### PR TITLE
Fix for tabs changing positions in the Menu Selection interface

### DIFF
--- a/administrator/templates/bluestork/css/template.css
+++ b/administrator/templates/bluestork/css/template.css
@@ -648,7 +648,6 @@ dl.tabs dt {
 
 dl.tabs dt.open {
 	background: #F9F9F9;
-	border-bottom: 1px solid #F9F9F9;
 	z-index: 100;
 	color: #000;
 }


### PR DESCRIPTION
Slight CSS adjustment to resolve tabs changing positions in the Menu Selection interface of the Module Management screen.
