### PR TITLE
Remove redundant svn $Id$ now that hosting is git based

### DIFF
--- a/components/com_contact/metadata.xml
+++ b/components/com_contact/metadata.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Id$ -->
-<metadata>
-</metadata>
+<metadata></metadata>


### PR DESCRIPTION
Simply remove a $Id$ from metadata.xml now that hosting is git based and no longer using svn:keywords
