### PR TITLE
Bug fix 1.7.3: SQL error when saving a module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *~
 
+/.settings
+/.project
+/.buildpath
+/configuration.php
+/logs/*
+/cache/*

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -631,11 +631,10 @@ class ModulesModelModule extends JModelAdmin
 				// );
 
 				$query->clear();
-				$query->insert('#__modules_menu');			
+				$query->insert('#__modules_menu');
 				$query->columns('moduleid');
 				$query->columns('menuid');
-				$query->values((int)$table->id);
-				$query->values(0);
+				$query->values((int) $table->id . ', 0');
 				$db->setQuery((string)$query);
 				if (!$db->query()) {
 					$this->setError($db->getErrorMsg());


### PR DESCRIPTION
Saving a module produces an SQL error due to incorrect usage of the query builder.  JDatabaseQuery::values takes a whole tuple of values or an array of tuples (which differs from the columns method which can add to the list of columns with subsequent calls).

Patch also adds some other common files to .gitignore.

NOTE: Error is occurring against the master git platform, not Joomla's copy of `/libraries/joomla/`.
