### PR TITLE
Joomla! Administration Login box has very SMALL margin at the bottom.

### DIFF
--- a/administrator/templates/bluestork/css/template.css
+++ b/administrator/templates/bluestork/css/template.css
@@ -1907,7 +1907,7 @@ a img.calendar {
 /* -- LOGIN STYLES ----------------------------- */
 
 .login {
-	margin: 50px auto 100px;
+	margin: 50px auto 100px !important;
 	width: 575px;
 }
 


### PR DESCRIPTION
margin-bottom: 100px in .login class doesn't work because #element-box with margin-bottom: 11px has higher priority.
