### PR TITLE
Add ability to use scriptfile with packages

### DIFF
--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -91,14 +91,63 @@ class JInstallerPackage extends JAdapterInstance
 		$group = (string) $this->manifest->packagename;
 		if (!empty($group))
 		{
-			// TODO: Remark this location
-			$this->parent->setPath('extension_root', JPATH_ROOT . '/packages/' . implode(DS, explode('/', $group)));
+			$this->parent->setPath('extension_root', JPATH_MANIFESTS . '/packages/' . implode(DS, explode('/', $group)));
 		}
 		else
 		{
 			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_PACK', JText::_('JLIB_INSTALLER_' . strtoupper($this->route))));
 			return false;
 		}
+
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Installer Trigger Loading
+		 * ---------------------------------------------------------------------------------------------
+		 */
+		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
+		$this->scriptElement = $this->manifest->scriptfile;
+		$manifestScript = (string) $this->manifest->scriptfile;
+
+		if ($manifestScript)
+		{
+			$manifestScriptFile = $this->parent->getPath('source') . '/' . $manifestScript;
+
+			if (is_file($manifestScriptFile))
+			{
+				// load the file
+				include_once $manifestScriptFile;
+			}
+
+			// Set the class name
+			$classname = $element . 'InstallerScript';
+
+			if (class_exists($classname))
+			{
+				// create a new instance
+				$this->parent->manifestClass = new $classname($this);
+				// and set this so we can copy it later
+				$this->set('manifest_script', $manifestScript);
+				// Note: if we don't find the class, don't bother to copy the file
+			}
+		}
+
+		// run preflight if possible (since we know we're not an update)
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'preflight'))
+		{
+			if ($this->parent->manifestClass->preflight($this->route, $this) === false)
+			{
+				// Install failed, rollback changes
+				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_PACKAGE_INSTALL_CUSTOM_INSTALL_FAILURE'));
+
+				return false;
+			}
+		}
+
+		$msg = ob_get_contents(); // create msg object; first use here
+		ob_end_clean();
 
 		// Filesystem Processing Section
 
@@ -114,6 +163,7 @@ class JInstallerPackage extends JAdapterInstance
 		// Install all necessary files
 		if (count($this->manifest->files->children()))
 		{
+			$i = 0;
 			foreach ($this->manifest->files->children() as $child)
 			{
 				$file = $source . '/' . $child;
@@ -141,6 +191,14 @@ class JInstallerPackage extends JAdapterInstance
 					);
 					return false;
 				}
+				else
+				{
+					$results[$i] = array(
+						'name' => $tmpInstaller->manifest->name,
+						'result' => $tmpInstaller->install($package['dir'])
+					);
+				}
+				$i++;
 			}
 		}
 		else
@@ -187,6 +245,24 @@ class JInstallerPackage extends JAdapterInstance
 
 		// Finalization and Cleanup Section
 
+		// Start Joomla! 1.6
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, $this->route))
+		{
+			if ($this->parent->manifestClass->{$this->route}($this) === false)
+			{
+				// Install failed, rollback changes
+				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_FILE_INSTALL_CUSTOM_INSTALL_FAILURE'));
+
+				return false;
+			}
+		}
+
+		$msg .= ob_get_contents(); // append messages
+		ob_end_clean();
+
 		// Lastly, we will copy the manifest file to its appropriate place.
 		$manifest = array();
 		$manifest['src'] = $this->parent->getPath('manifest');
@@ -199,6 +275,49 @@ class JInstallerPackage extends JAdapterInstance
 				JText::sprintf('JLIB_INSTALLER_ABORT_PACK_INSTALL_COPY_SETUP', JText::_('JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES'))
 			);
 			return false;
+		}
+
+		// If there is a manifest script, let's copy it.
+		if ($this->get('manifest_script'))
+		{
+			// First, we have to create a folder for the script if one isn't present
+			$created = false;
+
+			if (!file_exists($this->parent->getPath('extension_root')))
+			{
+				JFolder::create($this->parent->getPath('extension_root'));
+			}
+
+			$path['src'] = $this->parent->getPath('source') . '/' . $this->get('manifest_script');
+			$path['dest'] = $this->parent->getPath('extension_root') . '/' . $this->get('manifest_script');
+
+			if (!file_exists($path['dest']) || $this->parent->getOverwrite())
+			{
+				if (!$this->parent->copyFiles(array($path)))
+				{
+					// Install failed, rollback changes
+					$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_PACKAGE_INSTALL_MANIFEST'));
+
+					return false;
+				}
+			}
+		}
+
+		// And now we run the postflight
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'postflight'))
+		{
+			$this->parent->manifestClass->postflight($this->route, $this, $results);
+		}
+
+		$msg .= ob_get_contents(); // append messages
+		ob_end_clean();
+
+		if ($msg != '')
+		{
+			$this->parent->set('extension_message', $msg);
 		}
 		return $row->extension_id;
 	}
@@ -277,6 +396,46 @@ class JInstallerPackage extends JAdapterInstance
 			JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_MANIFEST'));
 			return false;
 		}
+
+		// If there is an manifest class file, let's load it
+		$this->scriptElement = $manifest->scriptfile;
+		$manifestScript = (string) $manifest->scriptfile;
+
+		if ($manifestScript)
+		{
+			$manifestScriptFile = $this->parent->getPath('extension_root') . '/' . $manifestScript;
+
+			if (is_file($manifestScriptFile))
+			{
+				// Load the file
+				include_once $manifestScriptFile;
+			}
+
+			// Set the class name
+			$classname = $row->element . 'InstallerScript';
+
+			if (class_exists($classname))
+			{
+				// Create a new instance
+				$this->parent->manifestClass = new $classname($this);
+				// And set this so we can copy it later
+				$this->set('manifest_script', $manifestScript);
+
+				// Note: if we don't find the class, don't bother to copy the file
+			}
+		}
+
+		ob_start();
+		ob_implicit_flush(false);
+
+		// Run uninstall if possible
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'uninstall'))
+		{
+			$this->parent->manifestClass->uninstall($this);
+		}
+
+		$msg = ob_get_contents();
+		ob_end_clean();
 
 		$error = false;
 		foreach ($manifest->filelist as $extension)

--- a/libraries/joomla/installer/packagemanifest.php
+++ b/libraries/joomla/installer/packagemanifest.php
@@ -52,6 +52,11 @@ class JPackageManifest extends JObject
 	var $packagerurl = '';
 
 	/**
+	 * @var string scriptfile Scriptfile for the package
+	 */
+	protected $scriptfile = '';
+
+	/**
 	 * @var string update Update site for the package
 	 */
 	var $update = '';
@@ -119,6 +124,7 @@ class JPackageManifest extends JObject
 			$this->description = (string) $xml->description;
 			$this->packager = (string) $xml->packager;
 			$this->packagerurl = (string) $xml->packagerurl;
+			$this->scriptfile = (string) $xml->scriptfile;
 			$this->version = (string) $xml->version;
 
 			if (isset($xml->files->file) && count($xml->files->file))


### PR DESCRIPTION
To coincide with joomla/joomla-platform#237, this patches the CMS to allow for package extension types to use an install script.
