### PR TITLE
Missing field in #__updates, causing 3rd-party extensions not to update

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -881,6 +881,7 @@ CREATE TABLE  `#__updates` (
   `version` varchar(10) default '',
   `data` text NOT NULL,
   `detailsurl` text NOT NULL,
+  `infourl` TEXT NOT NULL,
   PRIMARY KEY  (`update_id`)
 )  DEFAULT CHARSET=utf8 COMMENT='Available Updates';
 


### PR DESCRIPTION
Following should be added to a sql update script (e.g. joomla_update_173to174.sql)
# Fix for Extension Update bug

ALTER TABLE #__updates
ADD `infourl` TEXT NOT NULL, AFTER `detailsurl`;
