### PR TITLE
Add no-repeat for system message background icons

### DIFF
--- a/administrator/templates/bluestork/css/template.css
+++ b/administrator/templates/bluestork/css/template.css
@@ -1890,6 +1890,7 @@ a img.calendar {
 }
 
 /* -- SYSTEM MESSAGE STYLES ----------------------------- */
+#system-message dd ul {background-repeat:no-repeat}
 
 #system-message dd.message ul {
 	background-image: url(../images/notice-info.png);


### PR DESCRIPTION
System error messages in Bluestork need background-repeat:no-repeat on line #1893 of template.css
