### PR TITLE
Offline image overflow

### DIFF
--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -22,7 +22,7 @@ $app = JFactory::getApplication();
 <jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->getCfg('offline_image')) : ?>
-		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); ?>" />
+		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); width="400"?>" />
 		<?php endif; ?>
 		<h1>
 			<?php echo $app->getCfg('sitename'); ?>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -22,7 +22,7 @@ $app = JFactory::getApplication();
 <jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->getCfg('offline_image')) : ?>
-		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); width="400"?>" />
+		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); ?>" width="400" />
 		<?php endif; ?>
 		<h1>
 			<?php echo $app->getCfg('sitename'); ?>


### PR DESCRIPTION
In Offline page, when an offline image is set, If the image is wider than 400px, the image comes out from the edges of the central block.

A solution is to inform that the image must be less than 400px, or to force the width in HTML.
