### PR TITLE
Escaping  $app->getCfg('sitename') in Atomic and system template for good measure

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -159,30 +159,28 @@ endif; ?>
 
 <?php if ($params->get('access-view')):?>
 <?php  if (isset($images->image_fulltext) and !empty($images->image_fulltext)) : ?>
-<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-<div class="img-fulltext-<?php echo htmlspecialchars($imgfloat); ?>">
-<img
+    <?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
+    <img class="img-fulltext-<?php echo htmlspecialchars($imgfloat); ?>"
 	<?php if ($images->image_fulltext_caption):
 		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_fulltext_caption) .'"';
 	endif; ?>
 	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
-</div>
 <?php endif; ?>
-<?php
-if (!empty($this->item->pagination) AND $this->item->pagination AND !$this->item->paginationposition AND !$this->item->paginationrelative):
-	echo $this->item->pagination;
- endif;
-?>
+
+<?php if (!empty($this->item->pagination) AND $this->item->pagination AND !$this->item->paginationposition AND !$this->item->paginationrelative):
+	echo $this->item->pagination; ?>
+<?php endif;?>
+
 <?php echo $this->item->text; ?>
-<?php
-if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND!$this->item->paginationrelative):
+<?php if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND!$this->item->paginationrelative):
 	 echo $this->item->pagination;?>
 <?php endif; ?>
 
 <?php if (isset($urls) AND ((!empty($urls->urls_position)  AND ($urls->urls_position=='1')) OR ( $params->get('urls_position')=='1') )): ?>
 <?php echo $this->loadTemplate('links'); ?>
 <?php endif; ?>
-	<?php //optional teaser intro text for guests ?>
+
+<?php //optional teaser intro text for guests ?>
 <?php elseif ($params->get('show_noauth') == true and  $user->get('guest') ) : ?>
 	<?php echo $this->item->introtext; ?>
 	<?php //Optional link to let them register to see the whole article. ?>
@@ -209,10 +207,11 @@ if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item-
 		</p>
 	<?php endif; ?>
 <?php endif; ?>
-<?php
-if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND $this->item->paginationrelative):
+
+<?php if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND $this->item->paginationrelative):
 	 echo $this->item->pagination;?>
 <?php endif; ?>
 
 <?php echo $this->item->event->afterDisplayContent; ?>
 </div>
+

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -124,16 +124,16 @@ JHtml::core();
 <?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) :?>
  	</dl>
 <?php endif; ?>
+
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>">
-	<img
-		<?php if ($images->image_intro_caption):
-			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
-	</div>
+	<img class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>"
+	<?php if ($images->image_intro_caption):
+		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+	endif; ?>
+	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 <?php endif; ?>
+
 <?php echo $this->item->introtext; ?>
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -124,14 +124,11 @@ $canEdit	= $this->item->params->get('access-edit');
 
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-
-	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>">
-	<img
-		<?php if ($images->image_intro_caption):
-			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
-	</div>
+	<img class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>"
+	<?php if ($images->image_intro_caption):
+		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+	endif; ?>
+	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 <?php endif; ?>
 
 <?php echo $this->item->introtext; ?>

--- a/templates/atomic/index.php
+++ b/templates/atomic/index.php
@@ -43,7 +43,7 @@ $app = JFactory::getApplication();
 		<div class="container">
 			<hr class="space" />
 			<div class="joomla-header span-16 append-1">
-				<h1><?php echo $app->getCfg('sitename'); ?></h1>
+				<h1><?php echo htmlspecialchars($app->getCfg('sitename')); ?></h1>
 			</div>
 			<?php if($this->countModules('atomic-search')) : ?>
 				<div class="joomla-search span-7 last">
@@ -83,7 +83,7 @@ $app = JFactory::getApplication();
 
 			<div class="joomla-footer span-16 append-1">
 				<hr />
-				&copy;<?php echo date('Y'); ?> <?php echo $app->getCfg('sitename'); ?>
+				&copy;<?php echo date('Y'); ?> <?php echo htmlspecialchars($app->getCfg('sitename')); ?>
 			</div>
 		</div>
 	</body>

--- a/templates/beez5/html/com_content/article/default.php
+++ b/templates/beez5/html/com_content/article/default.php
@@ -158,17 +158,16 @@ if ($this->item->pagination && !$this->item->paginationposition && $this->item->
 <?php if( (isset($urls) AND ($urls->urls_position=='0'))   or ( $params->get('urls_position')=='0' AND ($urls->urls_position==""))     ): ?>
 	<?php echo $this->loadTemplate('links'); ?>
 <?php endif; ?>
-	<?php  if (isset($images->image_fulltext) and !empty($images->image_fulltext)) : ?>
+
+<?php  if (isset($images->image_fulltext) and !empty($images->image_fulltext)) : ?>
 	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	
-	<div class="img-fulltext-"<?php echo htmlspecialchars($imgfloat); ?>">
-	<img
-		<?php if ($images->image_fulltext_caption):
-			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_fulltext_caption) .'"';
-		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
-	</div>
-	<?php endif; ?>
+	<img class="img-fulltext-"<?php echo htmlspecialchars($imgfloat); ?>"
+	<?php if ($images->image_fulltext_caption):
+		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_fulltext_caption) .'"';
+	endif; ?>
+	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+<?php endif; ?>
+
 <?php
 if ($this->item->pagination && $this->item->paginationposition && $this->item->paginationrelative)
 	{

--- a/templates/beez5/html/com_content/category/blog_item.php
+++ b/templates/beez5/html/com_content/category/blog_item.php
@@ -128,16 +128,16 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) :?>
  	</dl>
 <?php endif; ?>
+
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>">
-	<img
-		<?php if ($images->image_intro_caption):
-			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
-	</div>
+	<img class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>"
+	<?php if ($images->image_intro_caption):
+		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+	endif; ?>
+	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 <?php endif; ?>
+
 <?php echo $this->item->introtext; ?>
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :

--- a/templates/beez5/html/com_content/featured/default_item.php
+++ b/templates/beez5/html/com_content/featured/default_item.php
@@ -135,13 +135,11 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>">
-	<img
-		<?php if ($images->image_intro_caption):
-			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
-	</div>
+	<img class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>"
+	<?php if ($images->image_intro_caption):
+		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+	endif; ?>
+	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 <?php endif; ?>
 
 <?php echo $this->item->introtext; ?>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -22,10 +22,10 @@ $app = JFactory::getApplication();
 <jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->getCfg('offline_image')) : ?>
-		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); ?>" />
+		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo htmlspecialchars($app->getCfg('sitename')); ?>" />
 		<?php endif; ?>
 		<h1>
-			<?php echo $app->getCfg('sitename'); ?>
+			<?php echo htmlspecialchars($app->getCfg('sitename')); ?>
 		</h1>
 	<?php if ($app->getCfg('display_offline_message', 1) == 1 && str_replace(' ', '', $app->getCfg('offline_message')) != ''): ?>
 		<p>


### PR DESCRIPTION
While not a high risk security issue, it is good measure to escape this data. If for no other reason, it would be consistent with Beez (in this respect) and a good example for those learning from these templates by analyzing their code.
