### PR TITLE
Escaping $app->getCfg('sitename') in Atomic and system template for good measure

### DIFF
--- a/templates/atomic/index.php
+++ b/templates/atomic/index.php
@@ -43,7 +43,7 @@ $app = JFactory::getApplication();
 		<div class="container">
 			<hr class="space" />
 			<div class="joomla-header span-16 append-1">
-				<h1><?php echo $app->getCfg('sitename'); ?></h1>
+				<h1><?php echo htmlspecialchars($app->getCfg('sitename')); ?></h1>
 			</div>
 			<?php if($this->countModules('atomic-search')) : ?>
 				<div class="joomla-search span-7 last">
@@ -83,7 +83,7 @@ $app = JFactory::getApplication();
 
 			<div class="joomla-footer span-16 append-1">
 				<hr />
-				&copy;<?php echo date('Y'); ?> <?php echo $app->getCfg('sitename'); ?>
+				&copy;<?php echo date('Y'); ?> <?php echo htmlspecialchars($app->getCfg('sitename')); ?>
 			</div>
 		</div>
 	</body>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -22,10 +22,10 @@ $app = JFactory::getApplication();
 <jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->getCfg('offline_image')) : ?>
-		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo $app->getCfg('sitename'); ?>" />
+		<img src="<?php echo $app->getCfg('offline_image'); ?>" alt="<?php echo htmlspecialchars($app->getCfg('sitename')); ?>" />
 		<?php endif; ?>
 		<h1>
-			<?php echo $app->getCfg('sitename'); ?>
+			<?php echo htmlspecialchars($app->getCfg('sitename')); ?>
 		</h1>
 	<?php if ($app->getCfg('display_offline_message', 1) == 1 && str_replace(' ', '', $app->getCfg('offline_message')) != ''): ?>
 		<p>


### PR DESCRIPTION
While not a high risk security issue, it is good measure to escape this data. If for no other reason, it would be consistent with Beez (in this respect) and a good example for those learning from these templates by analyzing their code.
