### PR TITLE
Update no longer purges after each update, allowing multiple updates to run

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -166,7 +166,7 @@ class InstallerModelUpdate extends JModelList
 			$res = $this->install($update);
 
 			if ($res) {
-				$this->purge();
+				$instance->delete($uid);
 			}
 
 			$result = $res & $result;


### PR DESCRIPTION
Currently the update process purges the update table after every update. This means the updates are limited to one at a time, since the table is purged, and forces the updates to be refetched multiple times if multiple extensions need to be updated.

This change will only delete the specific row from the update table that was just installed instead of purging the entire table.
