### PR TITLE
Update modules/mod_related_items/helper.php

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -95,8 +95,7 @@ abstract class modRelatedItemsHelper
 					$query->where('a.id != ' . (int) $id);
 					$query->where('a.state = 1');
 					$query->where('a.access IN (' . $groups . ')');
-          			$concat_string = $query->concatenate(array(',', 'REPLACE(a.metakey, ", ", ",")', ','));
-					$query->where('('.$concat_string.' LIKE "%'.implode('%" OR '.$concat_string.' LIKE "%', $likes).'%")'); //remove single space after commas in keywords)
+					$query->where('('.a.metakey.' LIKE "%'.implode('%" OR '.'"%', $likes).'%")');
 					$query->where('(a.publish_up = '.$db->Quote($nullDate).' OR a.publish_up <= '.$db->Quote($now).')');
 					$query->where('(a.publish_down = '.$db->Quote($nullDate).' OR a.publish_down >= '.$db->Quote($now).')');
 


### PR DESCRIPTION
# 

Module Articles - Related Articles Problem
And the Solutions
#31 January 2012
## 1.  INSTRUCTION

```
Please open:
Administrator->Extensions->Module Manager->Module Articles - Related Articles
```
## 2.  PROBLEM

```
This Mudule (mod_related_items) searching for related article items based on Meta Keywords.
But an error occure when we want to showing the Module at the Front-end.
The Mudule does not show up at all because there are some scripts error in our File.

For testing puspose, please create Article 1, Article 2, and Article 3,
with same Meta Keywords: ABC, DEF, GHI. The results should be as following:

*   Article 1 should display Article 2 and Article 3.
*   Article 2 should display Article 1 and Article 3.
*   Article 3 should display Article 1 and Article 2.

Then try to publish the module at the Front-end.
Then we will get our Module does not show up at all.
We only get empty space.
```
## 3.  SOLUTION

3.1 === Stage 1 of 4 ===
    Open file that have error in scripts.
    Please one File helper.php, at: http://localhost/modules/mod_related_items/helper.php
    Go to line: 98.

3.2 === Stage 2 of 4 ===
    Remove Unnecessary "$concat_string" Variable.
    Description:
    It is not necessary to use concatenate function around here.
    Because what we need is a Variable contains "a.metakey" only.
    As additional information, term "concatenate" is not registered in both MySQL and PHP.
    The function "concatenate" does not exist!.
    The registered function that existed in MySQL is: "CONCAT",
    so be aware that we must use "CONCAT" rather "concatenate".
    Also, present REPLACE Syntax for MySQL query not necessary at all.
    It is enough create a Variable contains "a.metakey" only.
    So, remove this $concat_string Variable and the rest.
    //$concat_string = $query->concatenate(array(',', 'REPLACE(a.metakey, ", ", ",")', ','));

3.3 === Stage 3 of 4 ===
    Create New Variable.
    Description:
    We are free to create or not create a new Variable that contains data: "a.metakey" only.
    Since we already have "a.metakey" that fulfill our needs.
    Here we create a Varible that contains data: "a.metakey".
    "a.metakey" refers to "metakey" field in "#__content" table.
    This new Variable is the newest of $concat_string Variable.
    $FieldMetaKey='a.metakey';

3.4 === Stage 4 of 4 ===
    Description:
    Remove Error Code and Repair It with Replace It with the True Code.
    These scripts have some errors. This make the Module at Front-End does not show-up.
    //$query->where('('.$concat_string.' LIKE "%'.implode('%" OR '.$concat_string.' LIKE "%', $likes).'%")');
    //$query->where('('.$FieldMetaKey.' LIKE "%'.implode('%" OR '.$concat_string.' LIKE "%', $likes).'%")');
    These are the newest scripts.
    Our Module will run smoothly at Front-End. "$.FieldMetaKey" and "' LIKE " was removed.
    $query->where('('.$FieldMetaKey.' LIKE "%'.implode('%" OR '.'"%', $likes).'%")');

```
Done.
Our Module should run smoothly at the Front-End.
```
## 4.  TESTING ENVIRONMENT

```
*   Joomla! 2.5.0 Stable [ Ember ] 24-Jan-2012 14:00 GMT
*   Internet Browser: Chrome 16.0.912.75
*   ApacheFriends XAMPP version 1.7.7
*   Apache 2.2.21
*   MySQL 5.5.16 (Community Server)
*   PHP 5.3.8 (VC9 X86 32bit thread safe) + PEAR
```
# 
