### PR TITLE
Adding viewname to the menu manager

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -82,6 +82,7 @@ class MenusViewItems extends JView
 								// Look for the first view node off of the root node.
 								if ($view = $xml->xpath('view[1]')) {
 									if (!empty($view[0]['title'])) {
+										$value .= ' » ' . JText::_(trim((string) $view[0]['title']));
 										$vars['layout'] = isset($vars['layout']) ? $vars['layout'] : 'default';
 
 										// Attempt to load the layout xml file.
@@ -113,6 +114,9 @@ class MenusViewItems extends JView
 											if (!empty($layout[0]->message[0])) {
 												$item->item_type_desc = JText::_(trim((string) $layout[0]->message[0]));
 											}
+										}
+										if (!isset($item->item_type_desc) && !empty($view[0]->message[0])){
+											$item->item_type_desc = JText::_(trim((string) $view[0]->message[0]));
 										}
 									}
 								}


### PR DESCRIPTION
Adding viewname to the menu manager like it was in Joomla 1.5 (component-name » view-name » layout-name). Currently it only shows component and layout name (component-name » layout-name), the view is missing. Also showing the view description in case no layout description is given.
Trackeritem: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27160
