### PR TITLE
Update installer php version check error message from 1.7 to 2.5 closes #119

### DIFF
--- a/installation/index.php
+++ b/installation/index.php
@@ -7,7 +7,7 @@
 
 // PHP 5 check
 if (version_compare(PHP_VERSION, '5.2.4', '<')) {
-	die('Your host needs to use PHP 5.2.4 or higher to run Joomla 1.7.');
+	die('Your host needs to use PHP 5.2.4 or higher to run Joomla 2.5.');
 }
 
 /**


### PR DESCRIPTION
index.php of the installer contains a version check for php. In the event it fails an error message is displayed. This commit changes the Joomla version number from 1.7 to 2.5
