### PR TITLE
query selects non-template extension elements.

### DIFF
--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -122,6 +122,7 @@ class TemplatesModelStyles extends JModelList
 		// Filter by extension enabled
 		$query->select('extension_id AS e_id');
 		$query->join('LEFT', '#__extensions AS e ON e.element = a.template');
+		$query->where('e.type = ' .$db->quote('template'));
 		$query->where('e.enabled = 1');
 
 		// Filter by template.


### PR DESCRIPTION
Scenario: Let's say I have a template 'atomic' and a set of 2 plugins (authentication/atomic, user/atomic).
Going to `Extensions > Template Manager > Styles` shows up 2 additional styles for 'atomic' template (which in fact are plugins with same name).

this appeared after migration 1.7 > 2.5 probably due to restructured query

duplicate of #93
