### PR TITLE
get rid of Notice 'Only variable references should be returned by reference'

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -233,7 +233,7 @@ class plgUserJoomla extends JPlugin
 	 * @return	object	A JUser object
 	 * @since	1.5
 	 */
-	protected function &_getUser($user, $options = array())
+	protected function _getUser($user, $options = array())
 	{
 		$instance = JUser::getInstance();
 		if ($id = intval(JUserHelper::getUserId($user['username'])))  {


### PR DESCRIPTION
php 5+, tested on php 5.3.0
