### PR TITLE
 [#28120] XHTML 1.0 Transitional

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -144,7 +144,7 @@ class AdminModelSysInfo extends JModel
 			$output = preg_replace('#<hr />#', '', $output);
 			$output = str_replace('<div class="center">', '', $output);
 			$output = preg_replace('#<tr class="h">(.*)<\/tr>#', '<thead><tr class="h">$1</tr></thead><tbody>', $output);
-			$output = str_replace('</table>', '</tbody></table>', $output);
+			$output = preg_replace('#(<tbody>.*?)(?<!</tbody>)([ |\r|\n|\t]*</table>)#', '$1</tbody>$2', $output);
 			$output = str_replace('</div>', '', $output);
 			$output = str_replace("module_Zend Optimizer", "module_Zend_Optimizer", $output);
 			$this->php_info = $output;

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -146,6 +146,7 @@ class AdminModelSysInfo extends JModel
 			$output = preg_replace('#<tr class="h">(.*)<\/tr>#', '<thead><tr class="h">$1</tr></thead><tbody>', $output);
 			$output = str_replace('</table>', '</tbody></table>', $output);
 			$output = str_replace('</div>', '', $output);
+			$output = str_replace("module_Zend Optimizer", "module_Zend_Optimizer", $output);
 			$this->php_info = $output;
 		}
 		return $this->php_info;

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -143,7 +143,7 @@ class AdminModelSysInfo extends JModel
 			$output = preg_replace('#(\w),(\w)#', '\1, \2', $output);
 			$output = preg_replace('#<hr />#', '', $output);
 			$output = str_replace('<div class="center">', '', $output);
-			$output = preg_replace('#<tr class="h">(.*)<\/tr>#', '<thead><tr class="h">$1</tr></thead><tbody>', $output);
+			$output = preg_replace('#<tr class="h">(.*)<\/tr>([ |\r|\n|\t]*)(?>!</table>)#', '<thead><tr class="h">$1</tr>$2</thead><tbody>', $output);
 			$output = preg_replace('#(<tbody>.*?)(?<!</tbody>)([ |\r|\n|\t]*</table>)#', '$1</tbody>$2', $output);
 			$output = str_replace('</div>', '', $output);
 			$output = str_replace("module_Zend Optimizer", "module_Zend_Optimizer", $output);

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default_system.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default_system.php
@@ -85,6 +85,7 @@ defined('_JEXEC') or die;
 					<?php echo $this->info['version'];?>
 				</td>
 			</tr>
+			<tr>
 				<td>
 					<strong><?php echo JText::_('COM_ADMIN_PLATFORM_VERSION'); ?></strong>
 				</td>


### PR DESCRIPTION
I made some changes in administrator/components/com_admin/models/sysinfo.php.
if u check the html output of this page in w3c validator you get about 48 errors.
after changing the regex pattern line 146 and 147 and added a opening  tr tag at line in administrator/components/com_admin/views/sysinfo/tmpl/default_system.php i got zero errors.

check it :)

greetings from klaus 
