### PR TITLE
ContentBuildRoute does not remove layout if link attached to menu item

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -51,6 +51,10 @@ function ContentBuildRoute(&$query)
 		if (isset($query['catid'])) {
 			unset($query['catid']);
 		}
+		
+		if (isset($query['layout'])) {
+			unset($query['layout']);
+		}
 
 		unset($query['id']);
 


### PR DESCRIPTION
In components/com_content/router.php the layout is not removed from the query if the link is attached to a menu item.

This may result in links like index.php/extensions?layout=blog, where the original link was something like index.php?option=com_content&view=category&layout=blog&id=20&Itemid=527
