### PR TITLE
Missing parameter handling in magic proxy methods for name quotes

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -430,7 +430,7 @@ abstract class JDatabase implements JDatabaseInterface
 				break;
 			case 'nq':
 			case 'qn':
-				return $this->quoteName($args[0]);
+				return $this->quoteName($args[0], isset($args[1]) ? $args[1] : null);
 				break;
 		}
 	}


### PR DESCRIPTION
Background here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=27951
and here: https://github.com/joomla/joomla-platform/pull/821
