### PR TITLE
fix bug #27852

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  HTTP
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * HTTP factory class.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  HTTP
+ * @since       12.1
+ */
+class JHttpFactory
+{
+
+	/**
+	 * method to recieve Http instance.
+	 *
+	 * @param   JRegistry  $options   Client options object.
+	 * @param   mixed      $adapters  Adapter (string) or queue of adapters (array) to use for communication
+	 *
+	 * @return  JHttp      Joomla Http class
+	 * 
+	 * @since   12.1
+	 */
+	public static function getHttp(JRegistry $options = null, $adapters = null)
+	{
+		if (empty($options))
+		{
+			$options = new JRegistry;
+		}
+		return new JHttp($options, self::getAvailableDriver($options, $adapters));
+	}
+
+	/**
+	 * Finds an available http transport object for communication
+	 *
+	 * @param   JRegistery  $options  Option for creating http transport object
+	 * @param   mixed       $default  Adapter (string) or queue of adapters (array) to use
+	 *
+	 * @return  JHttpTransport Interface sub-class
+	 *
+	 * @since   12.1
+	 */
+	public static function getAvailableDriver(JRegistry $options, $default = null)
+	{
+		if (is_null($default))
+		{
+			$availableAdapters = self::getHttpTransports();
+		}
+		else
+		{
+			settype($default, 'array');
+			$availableAdapters = $default;
+		}
+		// Check if there is available http transport adapters
+		if (!count($availableAdapters))
+		{
+			return false;
+		}
+		foreach ($availableAdapters as $adapter)
+		{
+			$class = 'JHttpTransport' . ucfirst($adapter);
+			if (call_user_func_array(array($class, 'isSupported'), array()))
+			{
+				return new $class($options);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the http transport handlers
+	 *
+	 * @return  array    An array of available transport handlers
+	 *
+	 * @since   12.1
+	 * @todo make this function more generic cause the behaviour taken from cache (getStores)
+	 */
+	public static function getHttpTransports()
+	{
+		$names = array();
+		$iterator = new DirectoryIterator(__DIR__ . '/transport');
+		foreach ($iterator as $file)
+		{
+			$fileName = $file->getFilename();
+			// Only load for php files.
+			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
+			if ($file->isFile() && substr($fileName, strrpos($fileName, '.') + 1) == 'php')
+			{
+				$names[] = substr($fileName, 0, strrpos($fileName, '.'));
+			}
+		}
+
+		return $names;
+	}
+
+}

--- a/libraries/joomla/http/http.php
+++ b/libraries/joomla/http/http.php
@@ -43,7 +43,7 @@ class JHttp
 	public function __construct(JRegistry &$options = null, JHttpTransport $transport = null)
 	{
 		$this->options   = isset($options) ? $options : new JRegistry;
-		$this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+		$this->transport = isset($transport) ? $transport : JHttpFactory::getAvailableDriver($this->options);
 	}
 
 	/**
@@ -183,4 +183,5 @@ class JHttp
 	{
 		return $this->transport->request('TRACE', new JUri($url), null, $headers);
 	}
+
 }

--- a/libraries/joomla/http/transport.php
+++ b/libraries/joomla/http/transport.php
@@ -42,4 +42,13 @@ interface JHttpTransport
 	 * @since   11.3
 	 */
 	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null);
+
+	/**
+	 * method to check if http transport layer available for using
+	 * 
+	 * @return bool true if available else false
+	 * 
+	 * @since   12.1
+	 */
+	static public function isSupported();
 }

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -180,4 +180,16 @@ class JHttpTransportCurl implements JHttpTransport
 
 		return $return;
 	}
+
+	/**
+	 * method to check if http transport curl available for using
+	 * 
+	 * @return bool true if available else false
+	 * 
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('curl_version') && curl_version();
+	}
 }

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -40,7 +40,7 @@ class JHttpTransportSocket implements JHttpTransport
 	 */
 	public function __construct(JRegistry &$options)
 	{
-		if (!function_exists('fsockopen') || !is_callable('fsockopen'))
+		if (!self::isSupported())
 		{
 			throw new RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
 		}
@@ -232,6 +232,10 @@ class JHttpTransportSocket implements JHttpTransport
 			}
 		}
 
+		if (!is_numeric($timeout))
+		{
+			$timeout = ini_get("default_socket_timeout");
+		}
 		// Attempt to connect to the server.
 		$connection = fsockopen($host, $port, $errno, $err, $timeout);
 		if (!$connection)
@@ -250,4 +254,17 @@ class JHttpTransportSocket implements JHttpTransport
 
 		return $this->connections[$key];
 	}
+
+	/**
+	 * method to check if http transport socket available for using
+	 * 
+	 * @return bool true if available else false
+	 * 
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('fsockopen') && is_callable('fsockopen');
+	}
+
 }

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -35,7 +35,7 @@ class JHttpTransportStream implements JHttpTransport
 	public function __construct(JRegistry &$options)
 	{
 		// Verify that fopen() is available.
-		if (!function_exists('fopen') || !is_callable('fopen'))
+		if (!self::isSupported())
 		{
 			throw new RuntimeException('Cannot use a stream transport when fopen() is not available.');
 		}
@@ -176,5 +176,17 @@ class JHttpTransportStream implements JHttpTransport
 		}
 
 		return $return;
+	}
+
+	/**
+	 * method to check if http transport stream available for using
+	 * 
+	 * @return bool true if available else false
+	 * 
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('fopen') && is_callable('fopen');
 	}
 }

--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -38,7 +38,6 @@ abstract class JInstallerHelper
 		$config = JFactory::getConfig();
 
 		// Capture PHP errors
-		$php_errormsg = 'Error Unknown';
 		$track_errors = ini_get('track_errors');
 		ini_set('track_errors', true);
 
@@ -46,23 +45,18 @@ abstract class JInstallerHelper
 		$version = new JVersion;
 		ini_set('user_agent', $version->getUserAgent('Installer'));
 
-		// Open the remote server socket for reading
-		$inputHandle = @ fopen($url, "r");
-		$error = strstr($php_errormsg, 'failed to open stream:');
-		if (!$inputHandle)
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+		if (200 != $response->code)
 		{
-			JError::raiseWarning(42, JText::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $error));
+			JError::raiseWarning(42, JText::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $response->code));
 			return false;
 		}
 
-		$meta_data = stream_get_meta_data($inputHandle);
-		foreach ($meta_data['wrapper_data'] as $wrapper_data)
+		if ($response->headers['wrapper_data']['Content-Disposition'])
 		{
-			if (substr($wrapper_data, 0, strlen("Content-Disposition")) == "Content-Disposition")
-			{
-				$contentfilename = explode("\"", $wrapper_data);
-				$target = $contentfilename[1];
-			}
+			$contentfilename = explode("\"", $response->headers['wrapper_data']['Content-Disposition']);
+			$target = $contentfilename[1];
 		}
 
 		// Set the target path if not given
@@ -75,24 +69,8 @@ abstract class JInstallerHelper
 			$target = $config->get('tmp_path') . '/' . basename($target);
 		}
 
-		// Initialise contents buffer
-		$contents = null;
-
-		while (!feof($inputHandle))
-		{
-			$contents .= fread($inputHandle, 4096);
-			if ($contents === false)
-			{
-				JError::raiseWarning(44, JText::sprintf('JLIB_INSTALLER_ERROR_FAILED_READING_NETWORK_RESOURCES', $php_errormsg));
-				return false;
-			}
-		}
-
 		// Write buffer to file
-		JFile::write($target, $contents);
-
-		// Close file pointer resource
-		fclose($inputHandle);
+		JFile::write($target, $response->body);
 
 		// Restore error tracking to what it was before
 		ini_set('track_errors', $track_errors);

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -219,7 +219,9 @@ class JUpdaterCollection extends JUpdateAdapter
 		$this->updates = array();
 		$dbo = $this->parent->getDBO();
 
-		if (!($fp = @fopen($url, "r")))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+		if (200 != $response->code)
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');
@@ -237,16 +239,12 @@ class JUpdaterCollection extends JUpdateAdapter
 		$this->xml_parser = xml_parser_create('');
 		xml_set_object($this->xml_parser, $this);
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
-
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->body))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
-				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
-				return false;
-			}
+			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
+			return false;
 		}
 		// TODO: Decrement the bad counter if non-zero
 		return array('update_sites' => $this->update_sites, 'updates' => $this->updates);

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -155,7 +155,9 @@ class JUpdaterExtension extends JUpdateAdapter
 
 		$dbo = $this->parent->getDBO();
 
-		if (!($fp = @fopen($url, "r")))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+		if (!empty($response->code) && 200 != $response->code)
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');
@@ -175,15 +177,12 @@ class JUpdaterExtension extends JUpdateAdapter
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
 		xml_set_character_data_handler($this->xml_parser, '_characterData');
 
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->data))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
-				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
-				return false;
-			}
+			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
+			return false;
 		}
 		xml_parser_free($this->xml_parser);
 		if (isset($this->latest))

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -279,7 +279,9 @@ class JUpdate extends JObject
 	 */
 	public function loadFromXML($url)
 	{
-		if (!($fp = @fopen($url, 'r')))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+		if (200 != $response->code)
 		{
 			// TODO: Add a 'mark bad' setting here somehow
 			JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
@@ -291,17 +293,14 @@ class JUpdate extends JObject
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
 		xml_set_character_data_handler($this->xml_parser, '_characterData');
 
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->data))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				die(
-					sprintf(
-						"XML error: %s at line %d", xml_error_string(xml_get_error_code($this->xml_parser)),
-						xml_get_current_line_number($this->xml_parser)
-					)
-				);
-			}
+			die(
+				sprintf(
+					"XML error: %s at line %d", xml_error_string(xml_get_error_code($this->xml_parser)),
+					xml_get_current_line_number($this->xml_parser)
+				)
+			);
 		}
 		xml_parser_free($this->xml_parser);
 		return true;

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -71,13 +71,6 @@ class JUpdater extends JAdapter
 	 */
 	public function findUpdates($eid = 0, $cacheTimeout = 0)
 	{
-		// Check if fopen is allowed
-		$result = ini_get('allow_url_fopen');
-		if (empty($result))
-		{
-			JError::raiseWarning('101', JText::_('JLIB_UPDATER_ERROR_COLLECTION_FOPEN'));
-			return false;
-		}
 
 		$dbo = $this->getDBO();
 		$retval = false;
@@ -236,4 +229,5 @@ class JUpdater extends JAdapter
 		}
 		return false;
 	}
+
 }


### PR DESCRIPTION
This bug report manage to fix joomla update when stream http layer is off (allow_url_fopen disabled in php.ini).
The fix add other http layers to the joomla update (like curl).

more info: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27852
