### PR TITLE
Form order fix (Platform issue #1069)

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -712,11 +712,14 @@ class JForm
 				if ($current = $this->findField((string) $field['name'], implode('.', $groups)))
 				{
 
-					// If set to replace found fields remove it from the current definition.
+					// If set to replace found fields, replace the data and remove the field so we don't add it twice.
 					if ($replace)
 					{
-						$dom = dom_import_simplexml($current);
-						$dom->parentNode->removeChild($dom);
+						$olddom = dom_import_simplexml($current);
+						$loadeddom = dom_import_simplexml($field);
+						$addeddom = $olddom->ownerDocument->importNode($loadeddom);
+						$olddom->parentNode->replaceChild($addeddom, $olddom);
+						$loadeddom->parentNode->removeChild($loadeddom);
 					}
 					else
 					{

--- a/tests/unit/suite/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suite/libraries/joomla/form/JFormTest.php
@@ -1219,6 +1219,19 @@ class JFormTest extends JoomlaTestCase
 			$this->equalTo(1),
 			'Line:'.__LINE__.' The show_title in the params group has been replaced by show_abstract.'
 		);
+
+		$originalform = new JFormInspector('form1');
+		$originalform->load(JFormDataHelper::$loadDocument);
+		$originalset = $originalform->getXML()->xpath('/form/fields/field');
+		$set = $form->getXML()->xpath('/form/fields/field');
+		for ($i = 0; $i < count($originalset); $i++)
+		{
+			$this->assertThat(
+				(string) ($originalset[$i]->attributes()->name) == (string) ($set[$i]->attributes()->name),
+				$this->isTrue(),
+				'Line:'.__LINE__.' Replace should leave fields in the original order.'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This code causes JForm to replace fields in place when a new definition is loaded to replace the old definition. Duplicate fields will now remain in their original location rather than being moved to the end of the document.

https://github.com/joomla/joomla-platform/pull/1069
