### PR TITLE
SQL92 RDBMS Portability

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -99,7 +99,7 @@ class BannersHelper
 		$query->select('*');
 		$query->from('#__banners');
 		$query->where("'".$now."' >= ".$db->quoteName('reset'));
-		$query->where($db->quoteName('reset').' != '.$db->quote($nullDate).' AND '.$db->quoteName('reset').'!=NULL');
+		$query->where($db->quoteName('reset').' <> '.$db->quote($nullDate).' AND '.$db->quoteName('reset').'<> NULL');
 		$query->where('('.$db->quoteName('checked_out').' = 0 OR '.$db->quoteName('checked_out').' = '.(int) $db->Quote($user->id).')');
 		$db->setQuery((string)$query);
 		$rows = $db->loadObjectList();

--- a/administrator/components/com_banners/models/banners.php
+++ b/administrator/components/com_banners/models/banners.php
@@ -81,6 +81,7 @@ class BannersModelBanners extends JModelList
 	{
 		// Initialise variables.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -94,14 +95,14 @@ class BannersModelBanners extends JModelList
 				'a.impmade AS impmade, a.imptotal AS imptotal,' .
 				'a.state AS state, a.ordering AS ordering,'.
 				'a.purchase_type as purchase_type,'.
-				'a.language, a.publish_up, a.publish_down'
+				'a.' . $q_lang . ', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from($db->quoteName('#__banners').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -148,7 +149,7 @@ class BannersModelBanners extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where('a.' . $q_lang . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -129,6 +129,7 @@ class CategoriesModelCategories extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
@@ -139,14 +140,14 @@ class CategoriesModelCategories extends JModelList
 				'a.id, a.title, a.alias, a.note, a.published, a.access' .
 				', a.checked_out, a.checked_out_time, a.created_user_id' .
 				', a.path, a.parent_id, a.level, a.lft, a.rgt' .
-				', a.language'
+				', a.' . $q_lang
 			)
 		);
 		$query->from('#__categories AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -209,7 +210,7 @@ class CategoriesModelCategories extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where('a.' . $q_lang . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause

--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -124,6 +124,7 @@ class ContactModelContacts extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
@@ -132,7 +133,7 @@ class ContactModelContacts extends JModelList
 			$this->getState(
 				'list.select',
 				'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, a.user_id' .
-				', a.published, a.access, a.created, a.created_by, a.ordering, a.featured, a.language'.
+				', a.published, a.access, a.created, a.created_by, a.ordering, a.featured, a.' . $q_lang .
 				', a.publish_up, a.publish_down'
 			)
 		);
@@ -144,7 +145,7 @@ class ContactModelContacts extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -208,7 +209,7 @@ class ContactModelContacts extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where('a.' . $q_lang . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -132,6 +132,7 @@ class ContentModelArticles extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
@@ -140,7 +141,7 @@ class ContentModelArticles extends JModelList
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
-				', a.state, a.access, a.created, a.created_by, a.ordering, a.featured, a.language, a.hits' .
+				', a.state, a.access, a.created, a.created_by, a.ordering, a.featured, a.' . $q_lang . ', a.hits' .
 				', a.publish_up, a.publish_down'
 			)
 		);
@@ -148,7 +149,7 @@ class ContentModelArticles extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -235,7 +236,7 @@ class ContentModelArticles extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where('a.' . $q_lang . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -60,6 +60,7 @@ class ContentModelFeatured extends ContentModelArticles
 	{
 		// Create a new query object.
 		$db = $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -67,14 +68,14 @@ class ContentModelFeatured extends ContentModelArticles
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.state, a.access, a.created, a.hits,' .
-				'a.language, a.publish_up, a.publish_down'
+				'a.' . $q_lang . ', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from('#__content AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the content table.
 		$query->select('fp.ordering');
@@ -122,7 +123,7 @@ class ContentModelFeatured extends ContentModelArticles
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where('a.' . $q_lang . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_installer/models/fields/group.php
+++ b/administrator/components/com_installer/models/fields/group.php
@@ -44,7 +44,7 @@ class JFormFieldGroup extends JFormField
 		$query = $dbo->getQuery(true);
 		$query->select('DISTINCT folder');
 		$query->from('#__extensions');
-		$query->where('folder != '.$dbo->quote(''));
+		$query->where('folder <> '.$dbo->quote(''));
 		$query->order('folder');
 		$dbo->setQuery((string)$query);
 		$folders = $dbo->loadColumn();

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -72,7 +72,7 @@ class InstallerModelUpdate extends JModelList
 		$db		= $this->getDbo();
 		$query	= $db->getQuery(true);
 		// grab updates ignoring new installs
-		$query->select('*')->from('#__updates')->where('extension_id != 0');
+		$query->select('*')->from('#__updates')->where('extension_id <> 0');
 		$query->order($this->getState('list.ordering').' '.$this->getState('list.direction'));
 
 		// Filter by extension_id

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -79,8 +79,8 @@ class InstallerModelUpdate extends JModelList
 		if ($eid = $this->getState('filter.extension_id')) {
 			$query->where($db->nq('extension_id') . ' = ' . $db->q((int) $eid));
 		} else {
-			$query->where($db->nq('extension_id').' != '.$db->q(0));
-			$query->where($db->nq('extension_id').' != '.$db->q(700));
+			$query->where($db->nq('extension_id').' <> '.$db->q(0));
+			$query->where($db->nq('extension_id').' <> '.$db->q(700));
 		}
 
 		return $query;

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -97,6 +97,7 @@ abstract class multilangstatusHelper
 	{
 		//check for combined status
 		$db		= JFactory::getDBO();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 
 		// Select all fields from the languages table.
@@ -107,8 +108,8 @@ abstract class multilangstatusHelper
 
 		// Select the language home pages
 		$query->select('l.home AS home');
-		$query->select('l.language AS home_language');
-		$query->join('LEFT', '#__menu  AS l  ON  l.language = a.lang_code AND l.home=1  AND l.language <> \'*\'' );
+		$query->select('l.' . $q_lang . ' AS home_language');
+		$query->join('LEFT', '#__menu  AS l  ON  l.' . $q_lang . ' = a.lang_code AND l.home=1  AND l.' . $q_lang . ' <> \'*\'' );
 		$query->select('e.enabled AS enabled');
 		$query->select('e.element AS element');
 		$query->join('LEFT', '#__extensions  AS e ON e.element = a.lang_code');
@@ -123,13 +124,14 @@ abstract class multilangstatusHelper
 	public static function getContacts()
 	{
 		$db = JFactory::getDBO();
+		$q_lang = $db->quoteName('language');
 		$query = $db->getQuery(true);
-		$query->select('u.name, count(cd.language) as counted, MAX(cd.language='.$db->quote('*').') as all_languages');
+		$query->select('u.name, count(cd.' . $q_lang . ') as counted, MAX(cd.' . $q_lang . '='.$db->quote('*').') as all_languages');
 		$query->from('#__users AS u');
 		$query->leftJOIN('#__contact_details AS cd ON cd.user_id=u.id');
-		$query->leftJOIN('#__languages as l on cd.language=l.lang_code');
+		$query->leftJOIN('#__languages as l on cd.' . $q_lang . '=l.lang_code');
 		$query->where('EXISTS (SELECT * from #__content as c where  c.created_by=u.id)');
-		$query->where('(l.published=1 or cd.language='.$db->quote('*').')');
+		$query->where('(l.published=1 or cd.' . $q_lang . '='.$db->quote('*').')');
 		$query->where('cd.published=1');
 		$query->group('u.id');
 		$query->having('(counted !=' . count(JLanguageHelper::getLanguages()).' OR all_languages=1)');

--- a/administrator/components/com_languages/models/languages.php
+++ b/administrator/components/com_languages/models/languages.php
@@ -108,6 +108,7 @@ class LanguagesModelLanguages extends JModelList
 	{
 		// Create a new query object.
 		$db = $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query = $db->getQuery(true);
 
 		// Select all fields from the languages table.
@@ -120,7 +121,7 @@ class LanguagesModelLanguages extends JModelList
 		
 		// Select the language home pages
 		$query->select('l.home AS home');
-		$query->join('LEFT', $db->quoteName('#__menu') . ' AS l  ON  l.language = a.lang_code AND l.home=1  AND l.language <> ' . $db->quote('*'));
+		$query->join('LEFT', $db->quoteName('#__menu') . ' AS l  ON  l.' . $q_lang . ' = a.lang_code AND l.home=1  AND l.' . $q_lang . ' <> ' . $db->quote('*'));
 
 		// Filter on the published state.
 		$published = $this->getState('filter.published');

--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -124,17 +124,18 @@ class LoginModelLogin extends JModel
 		if (!($clean = $cache->get($cacheid))) {
 			$db	= JFactory::getDbo();
 
+			$q_module = $db->quoteName('module');
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.module, m.position, m.showtitle, m.params');
+			$query->select('m.id, m.title, m.' . $q_module . ', m.position, m.showtitle, m.params');
 			$query->from('#__modules AS m');
-			$query->where('m.module =' . $db->Quote($module) .' AND m.client_id = 1');
+			$query->where('m.' . $q_module . ' = ' . $db->Quote($module) . ' AND m.client_id = 1');
 
-			$query->join('LEFT', '#__extensions AS e ON e.element = m.module AND e.client_id = m.client_id');
+			$query->join('LEFT', '#__extensions AS e ON e.element = m.' . $q_module . ' AND e.client_id = m.client_id');
 			$query->where('e.enabled = 1');
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('m.language IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
+				$query->where('m.' . $db->quoteName('language') . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
 			$query->order('m.position, m.ordering');

--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -123,10 +123,11 @@ class LoginModelLogin extends JModel
 
 		if (!($clean = $cache->get($cacheid))) {
 			$db	= JFactory::getDbo();
-
+			$q_pos = $db->quoteName('position');
 			$q_module = $db->quoteName('module');
+
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.' . $q_module . ', m.position, m.showtitle, m.params');
+			$query->select('m.id, m.title, m.' . $q_module . ', m.' . $q_pos . ', m.showtitle, m.params');
 			$query->from('#__modules AS m');
 			$query->where('m.' . $q_module . ' = ' . $db->Quote($module) . ' AND m.client_id = 1');
 
@@ -138,7 +139,7 @@ class LoginModelLogin extends JModel
 				$query->where('m.' . $db->quoteName('language') . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
-			$query->order('m.position, m.ordering');
+			$query->order('m.' . $q_pos . ', m.ordering');
 
 			// Set the query
 			$db->setQuery($query);

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -31,7 +31,7 @@ abstract class MenusHtmlMenus
 		$query->from('#__menu as m');
 		$query->leftJoin('#__menu_types as mt ON mt.menutype=m.menutype');
 		$query->where('m.id IN ('.implode(',', array_values($associations)).')');
-		$query->leftJoin('#__languages as l ON m.language=l.lang_code');
+		$query->leftJoin('#__languages as l ON m.' . $db->quoteName('language') . '=l.lang_code');
 		$query->select('l.image');
 		$query->select('l.title as language_title');
 		$db->setQuery($query);

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -158,7 +158,7 @@ class MenusHelper
 			if (is_array($languages)) {
 				$languages = '(' . implode(',', array_map(array($db, 'quote'), $languages)) . ')';
 			}
-			$query->where('a.language IN ' . $languages);
+			$query->where('a.' . $db->quoteName('language') . ' IN ' . $languages);
 		}
 
 		if (!empty($published)) {
@@ -235,7 +235,7 @@ class MenusHelper
 		$query->innerJoin('#__associations as a2 ON a.key=a2.key');
 		$query->innerJoin('#__menu as m2 ON a2.id=m2.id');
 		$query->where('m.id='.(int)$pk);
-		$query->select('m2.language, m2.id');
+		$query->select('m2.' . $db->quoteName('language') . ', m2.id');
 		$db->setQuery($query);
 		$menuitems = $db->loadObjectList('language');
 		// Check for a database error.

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -166,7 +166,7 @@ class MenusHelper
 			$query->where('a.published IN ' . $published);
 		}
 
-		$query->where('a.published != -2');
+		$query->where('a.published <> -2');
 		$query->group('a.id, a.title, a.level, a.menutype, a.type, a.template_style_id, a.checked_out, a.lft');
 		$query->order('a.lft ASC');
 

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -158,7 +158,7 @@ class MenusHelper
 			if (is_array($languages)) {
 				$languages = '(' . implode(',', array_map(array($db, 'quote'), $languages)) . ')';
 			}
-			$query->where('a.language IN ' . $languages);
+			$query->where('a.' . $db->quoteName('language') . ' IN ' . $languages);
 		}
 
 		if (!empty($published)) {
@@ -166,7 +166,7 @@ class MenusHelper
 			$query->where('a.published IN ' . $published);
 		}
 
-		$query->where('a.published != -2');
+		$query->where('a.published <> -2');
 		$query->group('a.id, a.title, a.level, a.menutype, a.type, a.template_style_id, a.checked_out, a.lft');
 		$query->order('a.lft ASC');
 
@@ -235,7 +235,7 @@ class MenusHelper
 		$query->innerJoin('#__associations as a2 ON a.key=a2.key');
 		$query->innerJoin('#__menu as m2 ON a2.id=m2.id');
 		$query->where('m.id='.(int)$pk);
-		$query->select('m2.language, m2.id');
+		$query->select('m2.' . $db->quoteName('language') . ', m2.id');
 		$db->setQuery($query);
 		$menuitems = $db->loadObjectList('language');
 		// Check for a database error.

--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -55,7 +55,7 @@ class JFormFieldMenuOrdering extends JFormFieldList
 			$query->where('a.menutype = '.$db->quote($menuType));
 		}
 		else {
-			$query->where('a.menutype != '.$db->quote(''));
+			$query->where('a.menutype <> '.$db->quote(''));
 		}
 
 		$query->order('a.lft ASC');

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -47,7 +47,7 @@ class JFormFieldMenuParent extends JFormFieldList
 			$query->where('a.menutype = '.$db->quote($menuType));
 		}
 		else {
-			$query->where('a.menutype != '.$db->quote(''));
+			$query->where('a.menutype <> '.$db->quote(''));
 		}
 
 		// Prevent parenting to children of this item.
@@ -56,7 +56,7 @@ class JFormFieldMenuParent extends JFormFieldList
 			$query->where('NOT(a.lft >= p.lft AND a.rgt <= p.rgt)');
 		}
 
-		$query->where('a.published != -2');
+		$query->where('a.published <> -2');
 		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.menutype, a.parent_id, a.published');
 		$query->order('a.lft ASC');
 

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -741,12 +741,14 @@ class MenusModelItem extends JModelAdmin
 	public function getModules()
 	{
 		$db = $this->getDbo();
+		$q_pos = $db->quoteName('position');
+
 		$query = $db->getQuery(true);
 
 		// Join on the module-to-menu mapping table.
 		// We are only interested if the module is displayed on ALL or THIS menu item (or the inverse ID number).
 		//sqlsrv changes for modulelink to menu manager
-		$query->select('a.id, a.title, a.position, a.published, map.menuid');
+		$query->select('a.id, a.title, a.' . $q_pos . ', a.published, map.menuid');
 		$case_when = ' (CASE WHEN ';
 		$case_when .= 'map2.menuid < 0 THEN map2.menuid ELSE NULL END) as ' . $db->qn('except');
 		$case_when .=$query->select( $case_when);
@@ -759,7 +761,7 @@ class MenusModelItem extends JModelAdmin
 		$query->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 		$query->where('a.published >= 0');
 		$query->where('a.client_id = 0');
-		$query->order('a.position, a.ordering');
+		$query->order('a.' . $q_pos . ', a.ordering');
 
 		$db->setQuery($query);
 		$result = $db->loadObjectList();

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -163,12 +163,13 @@ class MenusModelItems extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 		$app	= JFactory::getApplication();
 
 		// Select all fields from the table.
-		$query->select($this->getState('list.select', 'a.id, a.menutype, a.title, a.alias, a.note, a.path, a.link, a.type, a.parent_id, a.level, a.published as apublished, a.component_id, a.ordering, a.checked_out, a.checked_out_time, a.browserNav, a.access, a.img, a.template_style_id, a.params, a.lft, a.rgt, a.home, a.language, a.client_id'));
+		$query->select($this->getState('list.select', 'a.id, a.menutype, a.title, a.alias, a.note, a.path, a.link, a.type, a.parent_id, a.level, a.published as apublished, a.component_id, a.ordering, a.checked_out, a.checked_out_time, a.browserNav, a.access, a.img, a.template_style_id, a.params, a.lft, a.rgt, a.home, a.' . $q_lang . ', a.client_id'));
 		$query->select('CASE a.type' .
 			' WHEN ' . $db->quote('component') . ' THEN a.published+2*(e.enabled-1) ' .
 			' WHEN ' . $db->quote('url') . ' THEN a.published+2 ' .
@@ -179,7 +180,7 @@ class MenusModelItems extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title, l.image as image');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users.
 		$query->select('u.name AS editor');
@@ -263,7 +264,7 @@ class MenusModelItems extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where('a.' . $q_lang . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -251,7 +251,7 @@ class MenusModelMenu extends JModelForm
 		$query = $db->getQuery(true);
 		$query->from('#__modules as a');
 		$query->select('a.id, a.title, a.params, a.position');
-		$query->where('module = '.$db->quote('mod_menu'));
+		$query->where($db->quoteName('module') . ' = '.$db->quote('mod_menu'));
 		$query->select('ag.title AS access_title');
 		$query->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 		$db->setQuery($query);

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -250,7 +250,7 @@ class MenusModelMenu extends JModelForm
 
 		$query = $db->getQuery(true);
 		$query->from('#__modules as a');
-		$query->select('a.id, a.title, a.params, a.position');
+		$query->select('a.id, a.title, a.params, a.' . $db->quoteName('position'));
 		$query->where($db->quoteName('module') . ' = '.$db->quote('mod_menu'));
 		$query->select('ag.title AS access_title');
 		$query->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -148,14 +148,15 @@ abstract class ModulesHelper
 	public static function getModules($clientId)
 	{
 		$db		= JFactory::getDbo();
+		$q_module = $db->quoteName('module');
 		$query	= $db->getQuery(true);
 
 		$query->select('element AS value, name AS text');
 		$query->from('#__extensions as e');
 		$query->where('e.client_id = '.(int)$clientId);
 		$query->where('type = '.$db->quote('module'));
-		$query->leftJoin('#__modules as m ON m.module=e.element AND m.client_id=e.client_id');
-		$query->where('m.module IS NOT NULL');
+		$query->leftJoin('#__modules as m ON m.' . $q_module . '=e.element AND m.client_id=e.client_id');
+		$query->where('m.' . $q_module . ' IS NOT NULL');
 		$query->group('element,name');
 
 		$db->setQuery($query);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -1024,7 +1024,7 @@ class ModulesModelModule extends JModelAdmin
 		$query	= $db->getQuery(true);
 		$query->select('extension_id');
 		$query->from('#__extensions AS e');
-		$query->leftJoin('#__modules AS m ON e.element = m.module');
+		$query->leftJoin('#__modules AS m ON e.element = m.' . $db->quoteName('module'));
 		$query->where('m.id = '.(int) $table->id);
 		$db->setQuery($query);
 

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -203,13 +203,15 @@ class ModulesModelModules extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
+		$q_module = $db->quoteName('module');
 		$query	= $db->getQuery(true);
 
 		// Select the required fields from the table.
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.note, a.position, a.module, a.language,' .
+				'a.id, a.title, a.note, a.position, a.' . $q_module . ', a.' . $q_lang . ',' .
 				'a.checked_out, a.checked_out_time, a.published+2*(e.enabled-1) as published, a.access, a.ordering, a.publish_up, a.publish_down'
 			)
 		);
@@ -217,7 +219,7 @@ class ModulesModelModules extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -233,8 +235,8 @@ class ModulesModelModules extends JModelList
 
 		// Join over the extensions
 		$query->select('e.name AS name');
-		$query->join('LEFT', '#__extensions AS e ON e.element = a.module');
-		$query->group('a.id, a.title, a.note, a.position, a.module, a.language,a.checked_out,'.
+		$query->join('LEFT', '#__extensions AS e ON e.element = a.' . $q_module);
+		$query->group('a.id, a.title, a.note, a.position, a.' . $q_module . ', a.' . $q_lang . ', a.checked_out,'.
 						'a.checked_out_time, a.published, a.access, a.ordering,l.title, uc.name, ag.title, e.name,'.
 						'l.lang_code, uc.id, ag.id, mm.moduleid, e.element, a.publish_up, a.publish_down,e.enabled');
 
@@ -265,7 +267,7 @@ class ModulesModelModules extends JModelList
 		// Filter by module
 		$module = $this->getState('filter.module');
 		if ($module) {
-			$query->where('a.module = '.$db->Quote($module));
+			$query->where('a.' . $q_module . ' = '.$db->Quote($module));
 		}
 
 		// Filter by client.
@@ -290,7 +292,7 @@ class ModulesModelModules extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where('a.' . $q_lang . ' = ' . $db->quote($language));
 		}
 
 		//echo nl2br(str_replace('#__','jos_',$query));

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -148,7 +148,7 @@ class ModulesModelModules extends JModelList
 		}
 		else {
 			if ($ordering == 'ordering') {
-				$query->order('a.position ASC');
+				$query->order('a.' . $query->qn('position') . ' ASC');
 				$ordering = 'a.ordering';
 			}
 			if ($ordering == 'language_title') {
@@ -203,6 +203,7 @@ class ModulesModelModules extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_pos = $db->quoteName('position');
 		$q_lang = $db->quoteName('language');
 		$q_module = $db->quoteName('module');
 		$query	= $db->getQuery(true);
@@ -211,7 +212,7 @@ class ModulesModelModules extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.note, a.position, a.' . $q_module . ', a.' . $q_lang . ',' .
+				'a.id, a.title, a.note, a.' . $q_pos . ', a.' . $q_module . ', a.' . $q_lang . ',' .
 				'a.checked_out, a.checked_out_time, a.published+2*(e.enabled-1) as published, a.access, a.ordering, a.publish_up, a.publish_down'
 			)
 		);
@@ -236,7 +237,7 @@ class ModulesModelModules extends JModelList
 		// Join over the extensions
 		$query->select('e.name AS name');
 		$query->join('LEFT', '#__extensions AS e ON e.element = a.' . $q_module);
-		$query->group('a.id, a.title, a.note, a.position, a.' . $q_module . ', a.' . $q_lang . ', a.checked_out,'.
+		$query->group('a.id, a.title, a.note, a.' . $q_pos . ', a.' . $q_module . ', a.' . $q_lang . ', a.checked_out,'.
 						'a.checked_out_time, a.published, a.access, a.ordering,l.title, uc.name, ag.title, e.name,'.
 						'l.lang_code, uc.id, ag.id, mm.moduleid, e.element, a.publish_up, a.publish_down,e.enabled');
 
@@ -257,11 +258,11 @@ class ModulesModelModules extends JModelList
 		// Filter by position
 		$position = $this->getState('filter.position');
 		if ($position && $position != 'none') {
-			$query->where('a.position = '.$db->Quote($position));
+			$query->where('a.' . $q_pos . ' = '.$db->Quote($position));
 		}
 
 		elseif ($position == 'none') {
-			$query->where('a.position = '.$db->Quote(''));
+			$query->where('a.' . $q_pos . ' = '.$db->Quote(''));
 		}
 
 		// Filter by module

--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -81,7 +81,7 @@ class ModulesModelSelect extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.extension_id, a.name, a.element AS module'
+				'a.extension_id, a.name, a.element AS ' . $db->quoteName('module')
 			)
 		);
 		$query->from($db->quoteName('#__extensions').' AS a');

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -119,6 +119,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
@@ -128,14 +129,14 @@ class NewsfeedsModelNewsfeeds extends JModelList
 				'list.select',
 				'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
 				'a.numarticles, a.cache_time, ' .
-				' a.published, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
+				' a.published, a.access, a.ordering, a.' . $q_lang . ', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from($db->quoteName('#__newsfeeds').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -192,7 +193,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where('a.' . $q_lang . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -440,7 +440,7 @@ class TemplatesModelStyle extends JModelAdmin
 				$query->update('#__menu');
 				$query->set('template_style_id='.(int)$table->id);
 				$query->where('id IN ('.implode(',', $data['assigned']).')');
-				$query->where('template_style_id!='.(int) $table->id);
+				$query->where('template_style_id <> '.(int) $table->id);
 				$query->where('checked_out in (0,'.(int) $user->id.')');
 				$db->setQuery($query);
 				$db->query();

--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -73,7 +73,6 @@
 			class="inputbox"
 			label="COM_USERS_FIELD_REVIEW_TIME_LABEL"
 			description="COM_USERS_FIELD_REVIEW_TIME_DESC"
-			default="0000-00-00"
 			format="%Y-%m-%d"
 			/>
 

--- a/administrator/components/com_users/models/mail.php
+++ b/administrator/components/com_users/models/mail.php
@@ -104,7 +104,7 @@ class UsersModelMail extends JModelAdmin
 		$query	= $db->getQuery(true);
 		$query->select('email');
 		$query->from('#__users');
-		$query->where('id != '.(int) $user->get('id'));
+		$query->where('id <> '.(int) $user->get('id'));
 		if ($grp !== 0) {
 			if (empty($to)) {
 				$query->where('0');

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -299,7 +299,7 @@ class UsersModelUsers extends JModelList
 		if ($groupId || isset($groups))
 		{
 			$query->join('LEFT', '#__user_usergroup_map AS map2 ON map2.user_id = a.id');
-			$query->group('a.id,a.name,a.username,a.password,a.usertype,a.block,a.sendEmail,a.registerDate,a.lastvisitDate,a.activation,a.params,a.email');
+			$query->group('a.id,a.name,a.username,a.' . $db->quoteName('password') . ',a.usertype,a.block,a.sendEmail,a.registerDate,a.lastvisitDate,a.activation,a.params,a.email');
 
 			if ($groupId)
 			{

--- a/administrator/components/com_weblinks/models/weblinks.php
+++ b/administrator/components/com_weblinks/models/weblinks.php
@@ -122,6 +122,7 @@ class WeblinksModelWeblinks extends JModelList
 	{
 		// Create a new query object.
 		$db		= $this->getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
@@ -132,14 +133,14 @@ class WeblinksModelWeblinks extends JModelList
 				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
 				'a.hits,' .
 				'a.state, a.access, a.ordering,'.
-				'a.language, a.publish_up, a.publish_down'
+				'a.' . $q_lang . ', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from($db->quoteName('#__weblinks').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.' . $q_lang);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -192,7 +193,7 @@ class WeblinksModelWeblinks extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where('a.' . $q_lang . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/modules/mod_logged/helper.php
+++ b/administrator/modules/mod_logged/helper.php
@@ -28,7 +28,7 @@ abstract class modLoggedHelper
 		$user = JFactory::getUser();
 		$query = $db->getQuery(true);
 
-		$query->select('s.time, s.client_id, u.id, u.name, u.username');
+		$query->select('s.' . $db->quoteName('time') . ', s.client_id, u.id, u.name, u.username');
 		$query->from('#__session AS s');
 		$query->leftJoin('#__users AS u ON s.userid = u.id');
 		$query->where('s.guest = 0');

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -23,19 +23,20 @@ abstract class ModMenuHelper
 	public static function getMenus()
 	{
 		$db		= JFactory::getDbo();
+		$q_lang = $db->quoteName('language');
 		$query	= $db->getQuery(true);
 
 		$query->select('a.*, SUM(b.home) AS home');
 		$query->from('#__menu_types AS a');
-		$query->leftJoin('#__menu AS b ON b.menutype = a.menutype AND b.home != 0');
-		$query->select('b.language');
-		$query->leftJoin('#__languages AS l ON l.lang_code = language');
+		$query->leftJoin('#__menu AS b ON b.menutype = a.menutype AND b.home <> 0');
+		$query->select('b.' . $q_lang);
+		$query->leftJoin('#__languages AS l ON l.lang_code = ' . $q_lang);
 		$query->select('l.image');
 		$query->select('l.sef');
 		$query->select('l.title_native');
 		$query->where('(b.client_id = 0 OR b.client_id IS NULL)');
 		//sqlsrv change
-		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native');
+		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.' . $q_lang . ',l.image,l.sef,l.title_native');
 
 		$db->setQuery($query);
 

--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -159,7 +159,7 @@ class BannersModelBanners extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		$query->order('a.sticky DESC,'. ($randomise ? 'RAND()' : 'a.ordering'));

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -161,7 +161,7 @@ class ContactModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Set sortname ordering if selected

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -329,7 +329,8 @@ class ContactModelContact extends JModelForm
 				$query->order('a.state DESC, a.created DESC');
 				// filter per language if plugin published
 				if (JFactory::getApplication()->getLanguageFilter()) {
-					$query->where('a.language='.$db->quote(JFactory::getLanguage()->getTag()).' OR a.language='.$db->quote('*'));
+					$q_lang = $db->quoteName('language');
+					$query->where('a.' . $q_lang . '='.$db->quote(JFactory::getLanguage()->getTag()).' OR a.' . $q_lang . '='.$db->quote('*'));
 				}
 				if (is_numeric($published)) {
 					$query->where('a.state IN (1,2)');

--- a/components/com_contact/models/featured.php
+++ b/components/com_contact/models/featured.php
@@ -129,7 +129,7 @@ class ContactModelFeatured extends JModelList
 		$subquery .= 'WHERE parent.extension = ' . $db->quote('com_contact');
 		// Find any up-path categories that are not published
 		// If all categories are published, badcats.id will be null, and we just use the contact state
-		$subquery .= ' AND parent.published != 1 GROUP BY cat.id ';
+		$subquery .= ' AND parent.published <> 1 GROUP BY cat.id ';
 		// Select state to unpublished if up-path category is unpublished
 		$publishedWhere = 'CASE WHEN badcats.id is null THEN a.published ELSE 0 END';
 		$query->join('LEFT OUTER', '(' . $subquery . ') AS badcats ON badcats.id = c.id');
@@ -152,7 +152,7 @@ class ContactModelFeatured extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -77,6 +77,7 @@ class ContentModelArticle extends JModelItem
 
 			try {
 				$db = $this->getDbo();
+				$q_lang = $db->quoteName('language');
 				$query = $db->getQuery(true);
 
 				$query->select($this->getState(
@@ -89,7 +90,7 @@ class ContentModelArticle extends JModelItem
 				'CASE WHEN a.modified = 0 THEN a.created ELSE a.modified END as modified, ' .
 					'a.modified_by, a.checked_out, a.checked_out_time, a.publish_up, a.publish_down, ' .
 					'a.images, a.urls, a.attribs, a.version, a.parentid, a.ordering, ' .
-					'a.metakey, a.metadesc, a.access, a.hits, a.metadata, a.featured, a.language, a.xreference'
+					'a.metakey, a.metadesc, a.access, a.hits, a.metadata, a.featured, a.' . $q_lang . ', a.xreference'
 					)
 				);
 				$query->from('#__content AS a');
@@ -104,10 +105,10 @@ class ContentModelArticle extends JModelItem
 		
 				// Join on contact table
 				$subQuery = $db->getQuery(true);
-				$subQuery->select('contact.user_id, MAX(contact.id) AS id, contact.language');
+				$subQuery->select('contact.user_id, MAX(contact.id) AS id, contact.' . $q_lang);
 				$subQuery->from('#__contact_details AS contact');
 				$subQuery->where('contact.published = 1');
-				$subQuery->group('contact.user_id, contact.language');
+				$subQuery->group('contact.user_id, contact.' . $q_lang);
 				$query->select('contact.id as contactid' );
 				$query->join('LEFT', '(' . $subQuery . ') AS contact ON contact.user_id = a.created_by');
 				

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -154,6 +154,8 @@ class ContentModelArticles extends JModelList
 	{
 		// Create a new query object.
 		$db = $this->getDbo();
+		$q_lang = $db->quoteName('language');
+
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -206,10 +208,10 @@ class ContentModelArticles extends JModelList
 
 		// Join on contact table
 		$subQuery = $db->getQuery(true);
-		$subQuery->select('contact.user_id, MAX(contact.id) AS id, contact.language');
+		$subQuery->select('contact.user_id, MAX(contact.id) AS id, contact.' . $q_lang);
 		$subQuery->from('#__contact_details AS contact');
 		$subQuery->where('contact.published = 1');
-		$subQuery->group('contact.user_id, contact.language');
+		$subQuery->group('contact.user_id, contact.' . $q_lang);
 		$query->select('contact.id as contactid' );
 		$query->join('LEFT', '(' . $subQuery . ') AS contact ON contact.user_id = a.created_by');
 		
@@ -237,7 +239,7 @@ class ContentModelArticles extends JModelList
 		else {
 			// Find any up-path categories that are not published
 			// If all categories are published, badcats.id will be null, and we just use the article state
-			$subquery .= ' AND parent.published != 1 GROUP BY cat.id ';
+			$subquery .= ' AND parent.published <> 1 GROUP BY cat.id ';
 			// Select state to unpublished if up-path category is unpublished
 			$publishedWhere = 'CASE WHEN badcats.id is null THEN a.state ELSE 0 END';
 		}
@@ -455,8 +457,8 @@ class ContentModelArticles extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').')');
-			$query->where('(contact.language in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').') OR contact.language IS NULL)');
+			$query->where('a.' . $q_lang . ' in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').')');
+			$query->where('(contact.' . $q_lang . ' in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').') OR contact.' . $q_lang . ' IS NULL)');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -310,7 +310,7 @@ class FinderModelSearch extends JModelList
 		}
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('l.language in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').')');
+			$query->where('l.' . $db->quoteName('language') . ' in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').')');
 		}
 		// Push the data into cache.
 		$this->store($store, $query, false);

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -139,7 +139,7 @@ class NewsfeedsModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in ('.$db->Quote(JFactory::getLanguage()->getTag()).','.$db->Quote('*').')');
+			$query->where('a.' . $db->quoteName('language) . ' in ('.$db->Quote(JFactory::getLanguage()->getTag()).','.$db->Quote('*').')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_weblinks/models/category.php
+++ b/components/com_weblinks/models/category.php
@@ -137,7 +137,7 @@ class WeblinksModelCategory extends JModelList
 			$query->where('a.state = '.(int) $state);
 		}
 		// do not show trashed links on the front-end
-		$query->where('a.state != -2');
+		$query->where('a.state <> -2');
 
 		// Filter by start and end dates.
 		$nullDate = $db->Quote($db->getNullDate());
@@ -151,7 +151,7 @@ class WeblinksModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -28,7 +28,7 @@ class JMenuSite extends JMenu
 		$app	= JApplication::getInstance('site');
 		$query	= $db->getQuery(true);
 
-		$query->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language');
+		$query->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.' . $query->qn('language'));
 		$query->select('m.browserNav, m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id');
 		$query->select('e.element as component');
 		$query->from('#__menu AS m');

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -337,7 +337,7 @@ class JCategories
 
 		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
 			'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-			' AND parent.published != 1 GROUP BY cat.id) ';
+			' AND parent.published <> 1 GROUP BY cat.id) ';
 		$query->leftJoin($subQuery . 'AS badcats ON badcats.id = c.id');
 		$query->where('badcats.id is null');
 
@@ -359,9 +359,10 @@ class JCategories
 		}
 
 		// Group by
+		$q_lang = $db->quoteName('language');
 		$query->group('c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
- 			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-		 	c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
+ 			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.' . $q_lang . ',
+			c.level, c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
  			c.path, c.published, c.rgt, c.title, c.modified_user_id');
 
 		// Get the results

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -337,7 +337,7 @@ class JCategories
 
 		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
 			'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-			' AND parent.published != 1 GROUP BY cat.id) ';
+			' AND parent.published <> 1 GROUP BY cat.id) ';
 		$query->leftJoin($subQuery . 'AS badcats ON badcats.id = c.id');
 		$query->where('badcats.id is null');
 

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -359,9 +359,10 @@ class JCategories
 		}
 
 		// Group by
+		$q_lang = $db->quoteName('language');
 		$query->group('c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
- 			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-		 	c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
+ 			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.' . $q_lang . ',
+			c.level, c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
  			c.path, c.published, c.rgt, c.title, c.modified_user_id');
 
 		// Get the results

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -404,7 +404,7 @@ class JComponentHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
-		$query->select('extension_id AS id, element AS "option", params, enabled');
+		$query->select('extension_id AS id, element AS ' . $query->qn('option') . ', params, enabled');
 		$query->from('#__extensions');
 		$query->where($query->qn('type') . ' = ' . $db->quote('component'));
 		$query->where($query->qn('element') . ' = ' . $db->quote($option));

--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -303,14 +303,15 @@ abstract class JModuleHelper
 		if (!($clean = $cache->get($cacheid)))
 		{
 			$db = JFactory::getDbo();
+			$q_module =  $db->quoteName('module');
 
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid');
+			$query->select('m.id, m.title, m.' . $q_module . ', m.position, m.content, m.showtitle, m.params, mm.menuid');
 			$query->from('#__modules AS m');
 			$query->join('LEFT', '#__modules_menu AS mm ON mm.moduleid = m.id');
 			$query->where('m.published = 1');
 
-			$query->join('LEFT', '#__extensions AS e ON e.element = m.module AND e.client_id = m.client_id');
+			$query->join('LEFT', '#__extensions AS e ON e.element = m.' . $q_module . ' AND e.client_id = m.client_id');
 			$query->where('e.enabled = 1');
 
 			$date = JFactory::getDate();
@@ -326,7 +327,7 @@ abstract class JModuleHelper
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter())
 			{
-				$query->where('m.language IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
+				$query->where('m.' . $db->quoteName('language') . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
 			$query->order('m.position, m.ordering');

--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -303,10 +303,11 @@ abstract class JModuleHelper
 		if (!($clean = $cache->get($cacheid)))
 		{
 			$db = JFactory::getDbo();
+			$q_pos =  $db->quoteName('position');
 			$q_module =  $db->quoteName('module');
 
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.' . $q_module . ', m.position, m.content, m.showtitle, m.params, mm.menuid');
+			$query->select('m.id, m.title, m.' . $q_module . ', m.' . $q_pos . ', m.content, m.showtitle, m.params, mm.menuid');
 			$query->from('#__modules AS m');
 			$query->join('LEFT', '#__modules_menu AS mm ON mm.moduleid = m.id');
 			$query->where('m.published = 1');
@@ -330,7 +331,7 @@ abstract class JModuleHelper
 				$query->where('m.' . $db->quoteName('language') . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
-			$query->order('m.position, m.ordering');
+			$query->order('m.' . $q_pos . ', m.ordering');
 
 			// Set the query
 			$db->setQuery($query);

--- a/libraries/joomla/database/table/menutype.php
+++ b/libraries/joomla/database/table/menutype.php
@@ -102,8 +102,8 @@ class JTableMenuType extends JTable
 			$query->select('id');
 			$query->from('#__menu');
 			$query->where('menutype=' . $this->_db->quote($table->menutype));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{
@@ -119,8 +119,8 @@ class JTableMenuType extends JTable
 			$query->from('#__modules');
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{
@@ -207,8 +207,8 @@ class JTableMenuType extends JTable
 			$query->from('#__modules');
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -217,7 +217,7 @@ class JTableUser extends JTable
 		$query->select($this->_db->quoteName('id'));
 		$query->from($this->_db->quoteName('#__users'));
 		$query->where($this->_db->quoteName('username') . ' = ' . $this->_db->quote($this->username));
-		$query->where($this->_db->quoteName('id') . ' != ' . (int) $this->id);
+		$query->where($this->_db->quoteName('id') . ' <> ' . (int) $this->id);
 		$this->_db->setQuery($query);
 
 		$this->_db->setQuery($query);
@@ -233,7 +233,7 @@ class JTableUser extends JTable
 		$query->select($this->_db->quoteName('id'));
 		$query->from($this->_db->quoteName('#__users'));
 		$query->where($this->_db->quoteName('email') . ' = ' . $this->_db->quote($this->email));
-		$query->where($this->_db->quoteName('id') . ' != ' . (int) $this->id);
+		$query->where($this->_db->quoteName('id') . ' <> ' . (int) $this->id);
 		$this->_db->setQuery($query);
 		$xid = intval($this->_db->loadResult());
 		if ($xid && $xid != intval($this->id))

--- a/libraries/joomla/html/html/list.php
+++ b/libraries/joomla/html/html/list.php
@@ -246,7 +246,7 @@ abstract class JHtmlList
 		{
 			// Does not include registered users in the list
 			// @deprecated
-			$query->where('m.group_id != 2');
+			$query->where('m.group_id <> 2');
 		}
 
 		$query->select('u.id AS value, u.name AS text');

--- a/libraries/joomla/html/html/menu.php
+++ b/libraries/joomla/html/html/menu.php
@@ -188,7 +188,7 @@ abstract class JHtmlMenu
 			$query->from($db->quoteName('#__menu'));
 			$query->where($db->quoteName('menutype') . ' = ' . $db->quote($row->menutype));
 			$query->where($db->quoteName('parent_id') . ' = ' . (int) $row->parent_id);
-			$query->where($db->quoteName('published') . ' != -2');
+			$query->where($db->quoteName('published') . ' <> -2');
 			$query->order('ordering');
 			$order = JHtml::_('list.genericordering', $query);
 			$ordering = JHtml::_(

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -421,9 +421,9 @@ class JInstallerTemplate extends JAdapterInstance
 		}
 
 		// Set menu that assigned to the template back to default template
-		$query = 'UPDATE #__menu INNER JOIN #__template_styles' . ' ON #__template_styles.id = #__menu.template_style_id'
-			. ' SET #__menu.template_style_id = 0' . ' WHERE #__template_styles.template = ' . $db->Quote(strtolower($name))
-			. ' AND #__template_styles.client_id = ' . $db->Quote($clientId);
+		$query = 'UPDATE #__menu SET template_style_id = 0 WHERE template_style_id IN'
+			. '(SELECT id FROM #__template_styles WHERE #__template_styles.template = ' . $db->Quote(strtolower($name))
+			. ' AND #__template_styles.client_id = ' . $db->Quote($clientId) . ')';
 		$db->setQuery($query);
 		$db->Query();
 

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -143,7 +143,7 @@
 					multiple="true" size="5"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIAS_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIAS_DESC"
-					query="select distinct(created_by_alias) from #__content where created_by_alias != '' order by created_by_alias ASC"
+					query="select distinct(created_by_alias) from #__content where created_by_alias <> '' order by created_by_alias ASC"
 					key_field="created_by_alias" value_field="created_by_alias"
 				>
 					<option value="">JOPTION_SELECT_AUTHOR_ALIASES

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -92,7 +92,7 @@ abstract class modRelatedItemsHelper
 					$query->from('#__content AS a');
 					$query->leftJoin('#__content_frontpage AS f ON f.content_id = a.id');
 					$query->leftJoin('#__categories AS cc ON cc.id = a.catid');
-					$query->where('a.id != ' . (int) $id);
+					$query->where('a.id <> ' . (int) $id);
 					$query->where('a.state = 1');
 					$query->where('a.access IN (' . $groups . ')');
           			$concat_string = $query->concatenate(array('","', ' REPLACE(a.metakey, ", ", ",")', ' ","'));
@@ -102,7 +102,7 @@ abstract class modRelatedItemsHelper
 
 					// Filter by language
 					if ($app->getLanguageFilter()) {
-						$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+						$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 					}
 
 					$db->setQuery($query);

--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -50,7 +50,7 @@ class modWhosonlineHelper
 		$query	= $db->getQuery(true);
 		$query->select('a.username, a.time, a.userid, a.usertype, a.client_id');
 		$query->from('#__session AS a');
-		$query->where('a.userid != 0');
+		$query->where('a.userid <> 0');
 		$query->where('a.client_id = 0');
 		$query->group('a.userid');
 		$user = JFactory::getUser();

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -43,7 +43,7 @@ class plgAuthenticationJoomla extends JPlugin
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
-		$query->select('id, password');
+		$query->select('id, ' . $db->quoteName('password'));
 		$query->from('#__users');
 		$query->where('username=' . $db->Quote($credentials['username']));
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -123,7 +123,7 @@ class plgContentPagenavigation extends JPlugin
 						. ($canPublish ? '' : ' AND a.access = ' .(int)$row->access) . $xwhere);
 			$query->order($orderby);
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in ('.$db->quote($lang->getTag()).','.$db->quote('*').')');
+				$query->where('a.' . $db->quoteName('language') . ' in ('.$db->quote($lang->getTag()).','.$db->quote('*').')');
 			}
 
 			$db->setQuery($query);

--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -349,7 +349,7 @@ class plgFinderCategories extends FinderIndexerAdapter
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.title, a.alias, a.description AS summary, a.extension');
 		$sql->select('a.created_user_id AS created_by, a.modified_time AS modified, a.modified_user_id AS modified_by');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.lft, a.parent_id, a.level');
+		$sql->select('a.metakey, a.metadesc, a.metadata, a.' . $db->quoteName('language') . ', a.lft, a.parent_id, a.level');
 		$sql->select('a.created_time AS start_date, a.published AS state, a.access, a.params');
 
 		// Handle the alias CASE WHEN portion of the query

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -419,7 +419,7 @@ class plgFinderContacts extends FinderIndexerAdapter
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.name AS title, a.alias, a.con_position AS position, a.address, a.created AS start_date');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language');
+		$sql->select('a.metakey, a.metadesc, a.metadata, a.' . $db->quoteName('language'));
 		$sql->select('a.sortname1, a.sortname2, a.sortname3');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('a.suburb AS city, a.state AS region, a.country, a.postcode AS zip');

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -349,7 +349,7 @@ class plgFinderContent extends FinderIndexerAdapter
 		$sql->select('a.id, a.title, a.alias, a.introtext AS summary, a.fulltext AS body');
 		$sql->select('a.state, a.catid, a.created AS start_date, a.created_by');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by, a.attribs AS params');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.access, a.version, a.ordering');
+		$sql->select('a.metakey, a.metadesc, a.metadata, a.' . $db->quoteName('language') . ', a.access, a.version, a.ordering');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('c.title AS category, c.published AS cat_state, c.access AS cat_access');
 

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -342,7 +342,7 @@ class plgFinderNewsfeeds extends FinderIndexerAdapter
 		$sql->select('a.id, a.catid, a.name AS title, a.alias, a.link AS link');
 		$sql->select('a.published AS state, a.ordering, a.created AS start_date, a.params, a.access');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language');
+		$sql->select('a.metakey, a.metadesc, a.metadata, a.' . $db->quoteName('language'));
 		$sql->select('a.created_by, a.created_by_alias, a.modified, a.modified_by');
 		$sql->select('c.title AS category, c.published AS cat_state, c.access AS cat_access');
 

--- a/plugins/finder/weblinks/weblinks.php
+++ b/plugins/finder/weblinks/weblinks.php
@@ -331,7 +331,7 @@ class plgFinderWeblinks extends FinderIndexerAdapter
 		// Check if we can use the supplied SQL query.
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.catid, a.title, a.alias, a.url AS link, a.description AS summary');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.access, a.ordering');
+		$sql->select('a.metakey, a.metadesc, a.metadata, a.' . $db->quoteName('language') . ', a.access, a.ordering');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('a.state AS state, a.ordering, a.access, a.approved, a.created AS start_date, a.params');

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -136,14 +136,14 @@ class plgSearchCategories extends JPlugin
 			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id.' END as slug';
-			$query->select('a.title, a.description AS text, "" AS created, "2" AS browsernav, a.id AS catid, ' . $case_when);
+			$query->select('a.title, a.description AS text, ' . $db->quote('') . ' AS created, ' . $db->quote('2') . ' AS browsernav, a.id AS catid, ' . $case_when);
 			$query->from('#__categories AS a');
 			$query->where('(a.title LIKE '. $text .' OR a.description LIKE '. $text .') AND a.published IN ('.implode(',', $state).') AND a.extension = \'com_content\''
 						.'AND a.access IN ('. $groups .')' );
 			$query->group('a.id');
 			$query->order($order);
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $db->quoteName('language') . ' in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/contacts/contacts.php
+++ b/plugins/search/contacts/contacts.php
@@ -97,6 +97,7 @@ class plgSearchContacts extends JPlugin
 				$order = 'a.name DESC';
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text	= $db->Quote('%'.$db->escape($text, true).'%', false);
 
 		$rows = array();
@@ -137,8 +138,8 @@ class plgSearchContacts extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -128,6 +128,7 @@ class plgSearchContent extends JPlugin
 
 		$rows = array();
 		$query	= $db->getQuery(true);
+		$q_lang = $db->quoteName('language');
 
 		// search articles
 		if ($sContent && $limit > 0)
@@ -151,7 +152,7 @@ class plgSearchContent extends JPlugin
 			$case_when1 .= $c_id.' END as catslug';
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created');
-			$query->select($query->concatenate(array('a.introtext', 'a.fulltext')).' AS text');
+			$query->select($query->concatenate(array($query->castAsChar('a.introtext'), $query->castAsChar('a.fulltext'))).' AS text');
 			$query->select('c.title AS section, '.$case_when.','.$case_when1.', '.'\'2\' AS browsernav');
 
 			$query->from('#__content AS a');
@@ -165,8 +166,8 @@ class plgSearchContent extends JPlugin
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);
@@ -222,8 +223,8 @@ class plgSearchContent extends JPlugin
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -75,6 +75,7 @@ class plgSearchNewsfeeds extends JPlugin
 			$state[]=2;
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text = trim($text);
 		if ($text == '') {
 			return array();
@@ -144,9 +145,9 @@ class plgSearchNewsfeeds extends JPlugin
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id.' END as catslug';
 
-			$query->select('a.name AS title, "" AS created, a.link AS text, ' . $case_when."," . $case_when1);
+			$query->select('a.name AS title, ' . $db->quote('') . ' AS created, a.link AS text, ' . $case_when."," . $case_when1);
 			$query->select($query->concatenate(array($db->Quote($searchNewsfeeds), 'c.title'), " / ").' AS section');
-			$query->select('"1" AS browsernav');
+			$query->select($db->quote('1') . ' AS browsernav');
 			$query->from('#__newsfeeds AS a');
 			$query->innerJoin('#__categories as c ON c.id = a.catid');
 			$query->where('('. $where .')' . 'AND a.published IN ('.implode(',', $state).') AND c.published = 1 AND c.access IN ('. $groups .')');
@@ -155,8 +156,8 @@ class plgSearchNewsfeeds extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/weblinks/weblinks.php
+++ b/plugins/search/weblinks/weblinks.php
@@ -78,6 +78,7 @@ class plgSearchWeblinks extends JPlugin
 			$state[]=2;
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text = trim($text);
 		if ($text == '') {
 			return array();
@@ -168,8 +169,8 @@ class plgSearchWeblinks extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);


### PR DESCRIPTION
First set of patches to assist RDBMS portability as previously discussed on the general development list. This covers the following:
- Identifier quoting of SQL reserved words:
  - LANGUAGE
  - MODULE
  - OPTION
  - TIME
- Identifier quoting of Virtuoso reserved word:
  - PASSWORD
- Quoting of string literals in some places
- Correct use of non-standard != logic comparison operator to <> 
- Casting of some long types used in SQL functions that may not support long types

These changes are organised by front/admin then by component/module/plugin but squashed into single commits with respect to the categories of changes listed above. Given that none of the categories of changes are intended to alter any functional features, I hope that this is suitably divided and correct granularity for manual testing.

If preferred the commits are available unsquashed on separate branches under wdaniels/joomla-cms as indicated by the [branch-name] prefixes of the squashed commits messages where merged into this (sql92) branch.

These patches are relatively trivial and I do not believe to be contentious. Further patch sets I intend to raise for discussion on joomla platform/cms lists as appropriate.
