### PR TITLE
Stop default handling of href in toolbar buttons

### DIFF
--- a/libraries/joomla/html/toolbar/button/confirm.php
+++ b/libraries/joomla/html/toolbar/button/confirm.php
@@ -47,7 +47,7 @@ class JButtonConfirm extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($msg, $name, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/joomla/html/toolbar/button/help.php
+++ b/libraries/joomla/html/toolbar/button/help.php
@@ -42,7 +42,7 @@ class JButtonHelp extends JButton
 		$class = $this->fetchIconClass('help');
 		$doTask = $this->_getCommand($ref, $com, $override, $component);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/joomla/html/toolbar/button/standard.php
+++ b/libraries/joomla/html/toolbar/button/standard.php
@@ -44,7 +44,7 @@ class JButtonStandard extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($text, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$i18n_text\n";


### PR DESCRIPTION
This will  make it possible to utilize the toolbar buttons in the frontend if the template specifies the <base> tag. With the current implementation, when the base tag is in effect it will navigate away from the page when toolbar buttons are clicked since it interprets href="#" relative to the base and disregards the query string.

For example, if I have a toolbar in index.php?option=com_foobar the href="#" attribute will refer to "index.php#" which will cause the browser to use the link and navigate away from the page using a GET as it is interpreted as a different page instead of submitting the form using Joomla.submitbutton('task'); and using a POST.

Without the <base> tag this is not an issue as  the href="#" attribute will refer to "index.php?option=com_foobar#" and the browser will recognize it as the "current" page.

So far i've found two possible solution to this to I just picked the one which I think is more clear.

``` html
<a href="#" onclick="$doTask; return false;">
<a href="#" onclick="event.preventDefault(); $doTask;">
```

Below is the example code used to generate the toolbar

``` php
<?php
jimport('joomla.html.toolbar');
$bar = JToolBar::getInstance('toolbar');
$bar->appendButton('Standard', 'new',  'New',  'new',  false);
?>
```

``` html
<form action="index.php?option=com_foobar" id="adminForm" name="adminForm" method="post">
        <div id="toolbar-box">
                <?php echo $bar->render(); ?>
        </div>
        <input type="hidden" name="task" value="" />
</form>
```
