### PR TITLE
Add jpeg support for PHP < 5.3 in Jimage

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -78,6 +78,10 @@ class JImage
 		{
 			$info = gd_info();
 			self::$formats[IMAGETYPE_JPEG] = ($info['JPEG Support']) ? true : false;
+			if (!self::$formats[IMAGETYPE_JPEG]) {
+				// If PHP < 5.3
+				self::$formats[IMAGETYPE_JPEG] = ($info['JPG Support']) ? true : false;
+			}
 			self::$formats[IMAGETYPE_PNG] = ($info['PNG Support']) ? true : false;
 			self::$formats[IMAGETYPE_GIF] = ($info['GIF Read Support']) ? true : false;
 		}


### PR DESCRIPTION
We currently cannot use JImage with jpeg images if PHP < 5.3, so I added the support for previous PHP version.
