### PR TITLE
JComponentHelper::isEnabled returns true if the component doesn't exist

### DIFF
--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -39,13 +39,12 @@ class JComponentHelper
 	 * Get the component information.
 	 *
 	 * @param   string   $option  The component option.
-	 * @param   boolean  $strict  If set and the component does not exist, the enabled attribute will be set to false.
 	 *
 	 * @return  object   An object with the information for the component.
 	 *
 	 * @since   11.1
 	 */
-	public static function getComponent($option, $strict = false)
+	public static function getComponent($option)
 	{
 		if (!isset(self::$components[$option]))
 		{
@@ -53,11 +52,11 @@ class JComponentHelper
 			{
 				$result = self::$components[$option];
 			}
+			// The component is not installed => enabled = false.
 			else
 			{
 				$result = new stdClass;
-				$result->enabled = !$strict ? false : true;
-				$result->params = new JRegistry;
+				$result->enabled = false;
 			}
 		}
 		else
@@ -72,33 +71,31 @@ class JComponentHelper
 	 * Checks if the component is enabled
 	 *
 	 * @param   string   $option  The component option.
-	 * @param   boolean  $strict  If set and the component does not exist, false will be returned.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   11.1
 	 */
-	public static function isEnabled($option, $strict = false)
+	public static function isEnabled($option)
 	{
-		$result = self::getComponent($option, $strict);
+		$result = self::getComponent($option);
 
-		return ($result->enabled | JFactory::getApplication()->isAdmin());
+		return $result->enabled;
 	}
 
 	/**
 	 * Gets the parameter object for the component
 	 *
 	 * @param   string   $option  The option for the component.
-	 * @param   boolean  $strict  If set and the component does not exist, false will be returned
 	 *
 	 * @return  JRegistry  A JRegistry object.
 	 *
 	 * @see     JRegistry
 	 * @since   11.1
 	 */
-	public static function getParams($option, $strict = false)
+	public static function getParams($option)
 	{
-		$component = self::getComponent($option, $strict);
+		$component = self::getComponent($option);
 
 		return $component->params;
 	}

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -56,7 +56,7 @@ class JComponentHelper
 			else
 			{
 				$result = new stdClass;
-				$result->enabled = $strict ? false : true;
+				$result->enabled = !$strict ? false : true;
 				$result->params = new JRegistry;
 			}
 		}

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -57,6 +57,7 @@ class JComponentHelper
 			{
 				$result = new stdClass;
 				$result->enabled = false;
+				$result->params = new JRegistry;
 			}
 		}
 		else


### PR DESCRIPTION
You can see the issue here :

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28393

JComponentHelper::isEnabled('com_anycomponent') will aways return true if the component doesn't exists because in getComponent($option, $strict = false), $result->enabled was set to true for the default $strict = false value. (logic inversion).
