### PR TITLE
Add conversion of "poster" attribute URL in SEF plugin

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -605,6 +605,42 @@ class JImage
 				imagejpeg($this->handle, $path, (array_key_exists('quality', $options)) ? $options['quality'] : 100);
 		}
 	}
+	
+	/**
+	 * Method to output the current image as a string.
+	 *
+	 * @param   integer  $type     The image type to save the file as.
+	 * @param   array    $options  The image type options to use in saving the file.
+	 *
+	 * @return  string
+	 *
+	 * @see     http://www.php.net/manual/image.constants.php
+	 * @since   11.3
+	 * @throws  LogicException
+	 */
+	public function toString($type = IMAGETYPE_JPEG, array $options = array())
+	{
+		// Make sure the resource handle is valid.
+		if (!$this->isLoaded())
+		{
+			throw new LogicException('No valid image was loaded.');
+		}
+
+		switch ($type)
+		{
+			case IMAGETYPE_GIF:
+				return imagegif($this->handle);
+				break;
+
+			case IMAGETYPE_PNG:
+				return imagepng($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 0);
+				break;
+
+			case IMAGETYPE_JPEG:
+			default:
+				return imagejpeg($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 100);
+		}
+	}
 
 	/**
 	 * Method to get an image filter instance of a specified type.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -625,21 +625,25 @@ class JImage
 		{
 			throw new LogicException('No valid image was loaded.');
 		}
+		
+		ob_start();
 
 		switch ($type)
 		{
 			case IMAGETYPE_GIF:
-				return imagegif($this->handle);
+				imagegif($this->handle);
 				break;
 
 			case IMAGETYPE_PNG:
-				return imagepng($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 0);
+				imagepng($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 0);
 				break;
 
 			case IMAGETYPE_JPEG:
 			default:
-				return imagejpeg($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 100);
+				imagejpeg($this->handle, null, (array_key_exists('quality', $options)) ? $options['quality'] : 100);
 		}
+		
+		return ob_get_clean();
 	}
 
 	/**

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -35,7 +35,7 @@ class plgSystemSef extends JPlugin
         $this->checkBuffer($buffer);
 
 		$protocols	= '[a-zA-Z0-9]+:'; //To check for all unknown protocals (a protocol must contain at least one alpahnumeric fillowed by :
-		$regex		= '#(src|href)="(?!/|'.$protocols.'|\#|\')([^"]*)"#m';
+		$regex		= '#(src|href|poster)="(?!/|'.$protocols.'|\#|\')([^"]*)"#m';
 		$buffer		= preg_replace($regex, "$1=\"$base\$2\"", $buffer);
         $this->checkBuffer($buffer);
 		$regex		= '#(onclick="window.open\(\')(?!/|'.$protocols.'|\#)([^/]+[^\']*?\')#m';


### PR DESCRIPTION
The SEF plugin does not convert the HTML5 poster attribute URL.

This commit adds the "poster" attribute to the regex alongside the "src and "href" attributes.

Tracker - http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27711
