### PR TITLE
SQL Portability Patches

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -99,7 +99,7 @@ class BannersHelper
 		$query->select('*');
 		$query->from('#__banners');
 		$query->where("'".$now."' >= ".$db->quoteName('reset'));
-		$query->where($db->quoteName('reset').' != '.$db->quote($nullDate).' AND '.$db->quoteName('reset').'!=NULL');
+		$query->where($db->quoteName('reset').' <> '.$db->quote($nullDate).' AND '.$db->quoteName('reset').'<> NULL');
 		$query->where('('.$db->quoteName('checked_out').' = 0 OR '.$db->quoteName('checked_out').' = '.(int) $db->Quote($user->id).')');
 		$db->setQuery((string)$query);
 		$rows = $db->loadObjectList();

--- a/administrator/components/com_banners/models/banners.php
+++ b/administrator/components/com_banners/models/banners.php
@@ -83,25 +83,23 @@ class BannersModelBanners extends JModelList
 		$db		= $this->getDbo();
 		$query	= $db->getQuery(true);
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id AS id, a.name AS name, a.alias AS alias,'.
-				'a.checked_out AS checked_out,'.
-				'a.checked_out_time AS checked_out_time, a.catid AS catid,' .
-				'a.clicks AS clicks, a.metakey AS metakey, a.sticky AS sticky,'.
-				'a.impmade AS impmade, a.imptotal AS imptotal,' .
-				'a.state AS state, a.ordering AS ordering,'.
-				'a.purchase_type as purchase_type,'.
-				'a.language, a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, ' .
+			'a.clicks, a.metakey, a.sticky, a.impmade, a.imptotal, a.state, ' .
+			'a.ordering, a.purchase_type, a.language, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from($db->quoteName('#__banners').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -148,7 +146,7 @@ class BannersModelBanners extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -132,21 +132,22 @@ class CategoriesModelCategories extends JModelList
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
 		$query->select(
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.alias, a.note, a.published, a.access' .
 				', a.checked_out, a.checked_out_time, a.created_user_id' .
-				', a.path, a.parent_id, a.level, a.lft, a.rgt' .
-				', a.language'
+				', a.path, a.parent_id, a.level, a.lft, a.rgt, ' . $a_language
 			)
 		);
 		$query->from('#__categories AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -167,7 +168,7 @@ class CategoriesModelCategories extends JModelList
 
 		// Filter on the level.
 		if ($level = $this->getState('filter.level')) {
-			$query->where('a.level <= '.(int) $level);
+			$query->where($query->qn('a.level') . ' <= ' . (int) $level);
 		}
 
 		// Filter by access level.
@@ -209,7 +210,7 @@ class CategoriesModelCategories extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -63,7 +63,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
-		$query->select('a.id AS value, a.title AS text, a.level, a.published');
+		$query->select('a.id AS value, a.title AS text, ' . $query->qn('a.level') . ', a.published');
 		$query->from('#__categories AS a');
 		$query->join('LEFT', $db->quoteName('#__categories').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
@@ -85,7 +85,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$query->where('NOT(a.lft >= p.lft AND a.rgt <= p.rgt)');
 
 			$rowQuery	= $db->getQuery(true);
-			$rowQuery->select('a.id AS value, a.title AS text, a.level, a.parent_id');
+			$rowQuery->select('a.id AS value, a.title AS text, ' $query->qn('a.level') . ', a.parent_id');
 			$rowQuery->from('#__categories AS a');
 			$rowQuery->where('a.id = ' . (int) $oldCat);
 			$db->setQuery($rowQuery);
@@ -103,7 +103,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$query->where('a.published IN (' . implode(',', $published) . ')');
 		}
 
-		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.extension, a.parent_id, a.published');
+		$query->group('a.id, a.title, ' . $query->qn('a.level') . ', a.lft, a.rgt, a.extension, a.parent_id, a.published');
 		$query->order('a.lft ASC');
 
 		// Get the options.

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -55,7 +55,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
-		$query->select('a.id AS value, a.title AS text, a.level');
+		$query->select('a.id AS value, a.title AS text, ' . $query->qn('a.level'));
 		$query->from('#__categories AS a');
 		$query->join('LEFT', $db->quoteName('#__categories').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
@@ -71,7 +71,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 				$query->where('NOT(a.lft >= p.lft AND a.rgt <= p.rgt)');
 
 				$rowQuery	= $db->getQuery(true);
-				$rowQuery->select('a.id AS value, a.title AS text, a.level, a.parent_id');
+				$rowQuery->select('a.id AS value, a.title AS text, ' . $query->qn('a.level') . ', a.parent_id');
 				$rowQuery->from('#__categories AS a');
 				$rowQuery->where('a.id = ' . (int) $id);
 				$db->setQuery($rowQuery);
@@ -79,7 +79,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 			}
 		}
 		$query->where('a.published IN (0,1)');
-		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.extension, a.parent_id');
+		$query->group('a.id, a.title, ' . $query->qn('a.level') . ', a.lft, a.rgt, a.extension, a.parent_id');
 		$query->order('a.lft ASC');
 
 		// Get the options.

--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -127,15 +127,18 @@ class ContactModelContacts extends JModelList
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, a.user_id' .
-				', a.published, a.access, a.created, a.created_by, a.ordering, a.featured, a.language'.
-				', a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, a.user_id, ' .
+			'a.published, a.access, a.created, a.created_by, a.ordering, a.featured, ' .
+			'a.language, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from('#__contact_details AS a');
 
 		// Join over the users for the linked user.
@@ -144,7 +147,7 @@ class ContactModelContacts extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -208,7 +211,7 @@ class ContactModelContacts extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where($a_language . ' = '.$db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -135,20 +135,23 @@ class ContentModelArticles extends JModelList
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
-				', a.state, a.access, a.created, a.created_by, a.ordering, a.featured, a.language, a.hits' .
-				', a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, ' .
+			'a.state, a.access, a.created, a.created_by, a.ordering, a.featured, ' .
+			'a.language, a.hits, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from('#__content AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -207,7 +210,7 @@ class ContentModelArticles extends JModelList
 
 		// Filter on the level.
 		if ($level = $this->getState('filter.level')) {
-			$query->where('c.level <= '.((int) $level + (int) $baselevel - 1));
+			$query->where($query->qn('c.level') . ' <= ' . ((int) $level + (int) $baselevel - 1));
 		}
 
 		// Filter by author
@@ -235,7 +238,7 @@ class ContentModelArticles extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -62,19 +62,22 @@ class ContentModelFeatured extends ContentModelArticles
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.state, a.access, a.created, a.hits,' .
-				'a.language, a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.state, ' .
+			'a.access, a.created, a.hits, a.language, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from('#__content AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the content table.
 		$query->select('fp.ordering');
@@ -122,7 +125,7 @@ class ContentModelFeatured extends ContentModelArticles
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_installer/models/fields/group.php
+++ b/administrator/components/com_installer/models/fields/group.php
@@ -44,7 +44,7 @@ class JFormFieldGroup extends JFormField
 		$query = $dbo->getQuery(true);
 		$query->select('DISTINCT folder');
 		$query->from('#__extensions');
-		$query->where('folder != '.$dbo->quote(''));
+		$query->where('folder <> '.$dbo->quote(''));
 		$query->order('folder');
 		$dbo->setQuery((string)$query);
 		$folders = $dbo->loadColumn();

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -72,15 +72,15 @@ class InstallerModelUpdate extends JModelList
 		$db		= $this->getDbo();
 		$query	= $db->getQuery(true);
 		// grab updates ignoring new installs
-		$query->select('*')->from('#__updates')->where('extension_id != 0');
+		$query->select('*')->from('#__updates')->where('extension_id <> 0');
 		$query->order($this->getState('list.ordering').' '.$this->getState('list.direction'));
 
 		// Filter by extension_id
 		if ($eid = $this->getState('filter.extension_id')) {
 			$query->where($db->nq('extension_id') . ' = ' . $db->q((int) $eid));
 		} else {
-			$query->where($db->nq('extension_id').' != '.$db->q(0));
-			$query->where($db->nq('extension_id').' != '.$db->q(700));
+			$query->where($db->nq('extension_id').' <> '.$db->q(0));
+			$query->where($db->nq('extension_id').' <> '.$db->q(700));
 		}
 
 		return $query;

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -99,6 +99,8 @@ abstract class multilangstatusHelper
 		$db		= JFactory::getDBO();
 		$query	= $db->getQuery(true);
 
+		$l_language = $db->quoteName('l.language');
+
 		// Select all fields from the languages table.
 		$query->select('a.*', 'l.home');
 		$query->select('a.published AS published');
@@ -107,8 +109,8 @@ abstract class multilangstatusHelper
 
 		// Select the language home pages
 		$query->select('l.home AS home');
-		$query->select('l.language AS home_language');
-		$query->join('LEFT', '#__menu  AS l  ON  l.language = a.lang_code AND l.home=1  AND l.language <> \'*\'' );
+		$query->select($l_language . ' AS home_language');
+		$query->join('LEFT', '#__menu  AS l  ON  ' . $l_language . ' = a.lang_code AND l.home=1  AND ' . $l_language . ' <> \'*\'' );
 		$query->select('e.enabled AS enabled');
 		$query->select('e.element AS element');
 		$query->join('LEFT', '#__extensions  AS e ON e.element = a.lang_code');
@@ -123,13 +125,15 @@ abstract class multilangstatusHelper
 	public static function getContacts()
 	{
 		$db = JFactory::getDBO();
+		$cd_language = $db->quoteName('cd.language');
+
 		$query = $db->getQuery(true);
-		$query->select('u.name, count(cd.language) as counted, MAX(cd.language='.$db->quote('*').') as all_languages');
+		$query->select('u.name, count(' . $cd_language . ') as counted, MAX(' . $cd_language . '='.$db->quote('*').') as all_languages');
 		$query->from('#__users AS u');
 		$query->leftJOIN('#__contact_details AS cd ON cd.user_id=u.id');
-		$query->leftJOIN('#__languages as l on cd.language=l.lang_code');
+		$query->leftJOIN('#__languages as l on ' . $cd_language . ' = l.lang_code');
 		$query->where('EXISTS (SELECT * from #__content as c where  c.created_by=u.id)');
-		$query->where('(l.published=1 or cd.language='.$db->quote('*').')');
+		$query->where('(l.published=1 or ' . $cd_language . ' = ' . $db->quote('*').')');
 		$query->where('cd.published=1');
 		$query->group('u.id');
 		$query->having('(counted !=' . count(JLanguageHelper::getLanguages()).' OR all_languages=1)');

--- a/administrator/components/com_languages/models/languages.php
+++ b/administrator/components/com_languages/models/languages.php
@@ -110,6 +110,8 @@ class LanguagesModelLanguages extends JModelList
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
 
+		$l_language = $db->quoteName('l.language');
+
 		// Select all fields from the languages table.
 		$query->select($this->getState('list.select', 'a.*', 'l.home'));
 		$query->from($db->quoteName('#__languages').' AS a');
@@ -120,7 +122,7 @@ class LanguagesModelLanguages extends JModelList
 		
 		// Select the language home pages
 		$query->select('l.home AS home');
-		$query->join('LEFT', $db->quoteName('#__menu') . ' AS l  ON  l.language = a.lang_code AND l.home=1  AND l.language <> ' . $db->quote('*'));
+		$query->join('LEFT', $db->quoteName('#__menu') . ' AS l  ON  ' . $l_language . ' = a.lang_code AND l.home=1  AND ' . $l_language . ' <> ' . $db->quote('*'));
 
 		// Filter on the published state.
 		$published = $this->getState('filter.published');

--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -123,21 +123,24 @@ class LoginModelLogin extends JModel
 
 		if (!($clean = $cache->get($cacheid))) {
 			$db	= JFactory::getDbo();
+			$m_module = $db->quoteName('m.module');
+			$m_position = $db->quoteName('m.position');
+			$m_language = $db->quoteName('m.language');
 
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.module, m.position, m.showtitle, m.params');
+			$query->select('m.id, m.title, ' . $m_module . ', ' . $m_position . ', m.showtitle, m.params');
 			$query->from('#__modules AS m');
-			$query->where('m.module =' . $db->Quote($module) .' AND m.client_id = 1');
+			$query->where($m_module . ' = ' . $db->Quote($module) . ' AND m.client_id = 1');
 
-			$query->join('LEFT', '#__extensions AS e ON e.element = m.module AND e.client_id = m.client_id');
+			$query->join('LEFT', '#__extensions AS e ON e.element = ' . $m_module . ' AND e.client_id = m.client_id');
 			$query->where('e.enabled = 1');
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('m.language IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
+				$query->where($m_language . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
-			$query->order('m.position, m.ordering');
+			$query->order($m_position . ', m.ordering');
 
 			// Set the query
 			$db->setQuery($query);

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -31,7 +31,7 @@ abstract class MenusHtmlMenus
 		$query->from('#__menu as m');
 		$query->leftJoin('#__menu_types as mt ON mt.menutype=m.menutype');
 		$query->where('m.id IN ('.implode(',', array_values($associations)).')');
-		$query->leftJoin('#__languages as l ON m.language=l.lang_code');
+		$query->leftJoin('#__languages as l ON ' . $query->qn('m.language') . ' = l.lang_code');
 		$query->select('l.image');
 		$query->select('l.title as language_title');
 		$db->setQuery($query);

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -137,7 +137,7 @@ class MenusHelper
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
-		$query->select('a.id AS value, a.title AS text, a.level, a.menutype, a.type, a.template_style_id, a.checked_out');
+		$query->select('a.id AS value, a.title AS text, ' . $query->qn('a.level') . ', a.menutype, a.type, a.template_style_id, a.checked_out');
 		$query->from('#__menu AS a');
 		$query->join('LEFT', $db->quoteName('#__menu').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
@@ -158,7 +158,7 @@ class MenusHelper
 			if (is_array($languages)) {
 				$languages = '(' . implode(',', array_map(array($db, 'quote'), $languages)) . ')';
 			}
-			$query->where('a.language IN ' . $languages);
+			$query->where($query->qn('a.language') . ' IN ' . $languages);
 		}
 
 		if (!empty($published)) {
@@ -166,8 +166,8 @@ class MenusHelper
 			$query->where('a.published IN ' . $published);
 		}
 
-		$query->where('a.published != -2');
-		$query->group('a.id, a.title, a.level, a.menutype, a.type, a.template_style_id, a.checked_out, a.lft');
+		$query->where('a.published <> -2');
+		$query->group('a.id, a.title, ' . $query->qn('a.level') . ', a.menutype, a.type, a.template_style_id, a.checked_out, a.lft');
 		$query->order('a.lft ASC');
 
 		// Get the options.
@@ -235,7 +235,7 @@ class MenusHelper
 		$query->innerJoin('#__associations as a2 ON a.key=a2.key');
 		$query->innerJoin('#__menu as m2 ON a2.id=m2.id');
 		$query->where('m.id='.(int)$pk);
-		$query->select('m2.language, m2.id');
+		$query->select($query->qn('m2.language') . ', m2.id');
 		$db->setQuery($query);
 		$menuitems = $db->loadObjectList('language');
 		// Check for a database error.

--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -55,7 +55,7 @@ class JFormFieldMenuOrdering extends JFormFieldList
 			$query->where('a.menutype = '.$db->quote($menuType));
 		}
 		else {
-			$query->where('a.menutype != '.$db->quote(''));
+			$query->where('a.menutype <> '.$db->quote(''));
 		}
 
 		$query->order('a.lft ASC');

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -39,7 +39,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
-		$query->select('a.id AS value, a.title AS text, a.level');
+		$query->select('a.id AS value, a.title AS text, ' . $query->qn('a.level'));
 		$query->from('#__menu AS a');
 		$query->join('LEFT', $db->quoteName('#__menu').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
@@ -47,7 +47,7 @@ class JFormFieldMenuParent extends JFormFieldList
 			$query->where('a.menutype = '.$db->quote($menuType));
 		}
 		else {
-			$query->where('a.menutype != '.$db->quote(''));
+			$query->where('a.menutype <> '.$db->quote(''));
 		}
 
 		// Prevent parenting to children of this item.
@@ -56,8 +56,8 @@ class JFormFieldMenuParent extends JFormFieldList
 			$query->where('NOT(a.lft >= p.lft AND a.rgt <= p.rgt)');
 		}
 
-		$query->where('a.published != -2');
-		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.menutype, a.parent_id, a.published');
+		$query->where('a.published <> -2');
+		$query->group('a.id, a.title, ' . $query->qn('a.level') . ', a.lft, a.rgt, a.menutype, a.parent_id, a.published');
 		$query->order('a.lft ASC');
 
 		// Get the options.

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -743,10 +743,12 @@ class MenusModelItem extends JModelAdmin
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
 
+		$a_position = $db->quoteName('a.position');
+
 		// Join on the module-to-menu mapping table.
 		// We are only interested if the module is displayed on ALL or THIS menu item (or the inverse ID number).
 		//sqlsrv changes for modulelink to menu manager
-		$query->select('a.id, a.title, a.position, a.published, map.menuid');
+		$query->select('a.id, a.title, ' . $a_position . ', a.published, map.menuid');
 		$case_when = ' (CASE WHEN ';
 		$case_when .= 'map2.menuid < 0 THEN map2.menuid ELSE NULL END) as ' . $db->qn('except');
 		$case_when .=$query->select( $case_when);
@@ -759,7 +761,7 @@ class MenusModelItem extends JModelAdmin
 		$query->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 		$query->where('a.published >= 0');
 		$query->where('a.client_id = 0');
-		$query->order('a.position, a.ordering');
+		$query->order($a_position . ', a.ordering');
 
 		$db->setQuery($query);
 		$result = $db->loadObjectList();

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -168,7 +168,10 @@ class MenusModelItems extends JModelList
 		$app	= JFactory::getApplication();
 
 		// Select all fields from the table.
-		$query->select($this->getState('list.select', 'a.id, a.menutype, a.title, a.alias, a.note, a.path, a.link, a.type, a.parent_id, a.level, a.published as apublished, a.component_id, a.ordering, a.checked_out, a.checked_out_time, a.browserNav, a.access, a.img, a.template_style_id, a.params, a.lft, a.rgt, a.home, a.language, a.client_id'));
+		$fields = $this->getState('list.select', 'a.id, a.menutype, a.title, a.alias, a.note, a.path, a.link, a.type, a.parent_id, a.level, a.component_id, a.ordering, a.checked_out, a.checked_out_time, a.browserNav, a.access, a.img, a.template_style_id, a.params, a.lft, a.rgt, a.home, a.language, a.client_id');
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($db->quoteName(trim($field)));
+		$query->select('a.published AS apublished');
 		$query->select('CASE a.type' .
 			' WHEN ' . $db->quote('component') . ' THEN a.published+2*(e.enabled-1) ' .
 			' WHEN ' . $db->quote('url') . ' THEN a.published+2 ' .
@@ -179,7 +182,7 @@ class MenusModelItems extends JModelList
 
 		// Join over the language
 		$query->select('l.title AS language_title, l.image as image');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $query->qn('a.language'));
 
 		// Join over the users.
 		$query->select('u.name AS editor');
@@ -258,12 +261,12 @@ class MenusModelItems extends JModelList
 
 		// Filter on the level.
 		if ($level = $this->getState('filter.level')) {
-			$query->where('a.level <= '.(int) $level);
+			$query->where($query->qn('a.level') . ' <= ' . (int) $level);
 		}
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = '.$db->quote($language));
+			$query->where($query->qn('a.language') . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -250,8 +250,8 @@ class MenusModelMenu extends JModelForm
 
 		$query = $db->getQuery(true);
 		$query->from('#__modules as a');
-		$query->select('a.id, a.title, a.params, a.position');
-		$query->where('module = '.$db->quote('mod_menu'));
+		$query->select('a.id, a.title, a.params, ' . $db->quoteName('a.position'));
+		$query->where($db->quoteName('module') . ' = '.$db->quote('mod_menu'));
 		$query->select('ag.title AS access_title');
 		$query->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 		$db->setQuery($query);

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -150,12 +150,14 @@ abstract class ModulesHelper
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
+		$m_module = $db->quoteName('m.module');
+
 		$query->select('element AS value, name AS text');
 		$query->from('#__extensions as e');
 		$query->where('e.client_id = '.(int)$clientId);
 		$query->where('type = '.$db->quote('module'));
-		$query->leftJoin('#__modules as m ON m.module=e.element AND m.client_id=e.client_id');
-		$query->where('m.module IS NOT NULL');
+		$query->leftJoin('#__modules as m ON ' . $m_module . ' = e.element AND m.client_id = e.client_id');
+		$query->where($m_module . ' IS NOT NULL');
 		$query->group('element,name');
 
 		$db->setQuery($query);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -1024,7 +1024,7 @@ class ModulesModelModule extends JModelAdmin
 		$query	= $db->getQuery(true);
 		$query->select('extension_id');
 		$query->from('#__extensions AS e');
-		$query->leftJoin('#__modules AS m ON e.element = m.module');
+		$query->leftJoin('#__modules AS m ON e.element = ' . $query->qn('m.module'));
 		$query->where('m.id = '.(int) $table->id);
 		$db->setQuery($query);
 

--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -81,7 +81,7 @@ class ModulesModelSelect extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.extension_id, a.name, a.element AS module'
+				'a.extension_id, a.name, a.element AS ' . $db->quoteName('module')
 			)
 		);
 		$query->from($db->quoteName('#__extensions').' AS a');

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -122,20 +122,22 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
-				'a.numarticles, a.cache_time, ' .
-				' a.published, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, a.numarticles, ' .
+			'a.cache_time, a.published, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from($db->quoteName('#__newsfeeds').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -192,7 +194,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -440,7 +440,7 @@ class TemplatesModelStyle extends JModelAdmin
 				$query->update('#__menu');
 				$query->set('template_style_id='.(int)$table->id);
 				$query->where('id IN ('.implode(',', $data['assigned']).')');
-				$query->where('template_style_id!='.(int) $table->id);
+				$query->where('template_style_id <> '.(int) $table->id);
 				$query->where('checked_out in (0,'.(int) $user->id.')');
 				$db->setQuery($query);
 				$db->query();

--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -210,10 +210,10 @@ class UsersModelDebugGroup extends JModelList
 			$levelEnd = $levelStart;
 		}
 		if ($levelStart > 0) {
-			$query->where('a.level >= '.$levelStart);
+			$query->where($query->qn('a.level') . ' >= ' . $levelStart);
 		}
 		if ($levelEnd > 0) {
-			$query->where('a.level <= '.$levelEnd);
+			$query->where($query->qn('a.level') . ' <= ' . $levelEnd);
 		}
 
 		// Filter the items over the component if set.

--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -73,7 +73,6 @@
 			class="inputbox"
 			label="COM_USERS_FIELD_REVIEW_TIME_LABEL"
 			description="COM_USERS_FIELD_REVIEW_TIME_DESC"
-			default="0000-00-00"
 			format="%Y-%m-%d"
 			/>
 

--- a/administrator/components/com_users/models/mail.php
+++ b/administrator/components/com_users/models/mail.php
@@ -104,7 +104,7 @@ class UsersModelMail extends JModelAdmin
 		$query	= $db->getQuery(true);
 		$query->select('email');
 		$query->from('#__users');
-		$query->where('id != '.(int) $user->get('id'));
+		$query->where('id <> '.(int) $user->get('id'));
 		if ($grp !== 0) {
 			if (empty($to)) {
 				$query->where('0');

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -298,8 +298,9 @@ class UsersModelUsers extends JModelList
 
 		if ($groupId || isset($groups))
 		{
+			$a_password = $query->qn('a.password');
 			$query->join('LEFT', '#__user_usergroup_map AS map2 ON map2.user_id = a.id');
-			$query->group('a.id,a.name,a.username,a.password,a.usertype,a.block,a.sendEmail,a.registerDate,a.lastvisitDate,a.activation,a.params,a.email');
+			$query->group('a.id, a.name, a.username, ' $a_password . ', a.usertype, a.block, a.sendEmail, a.registerDate, a.lastvisitDate, a.activation, a.params, a.email');
 
 			if ($groupId)
 			{

--- a/administrator/components/com_weblinks/models/weblinks.php
+++ b/administrator/components/com_weblinks/models/weblinks.php
@@ -125,21 +125,22 @@ class WeblinksModelWeblinks extends JModelList
 		$query	= $db->getQuery(true);
 		$user	= JFactory::getUser();
 
+		$a_language = $db->quoteName('a.language');
+
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
-				'a.hits,' .
-				'a.state, a.access, a.ordering,'.
-				'a.language, a.publish_up, a.publish_down'
-			)
+		$fields = $this->getState(
+			'list.select',
+			'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.hits, ' .
+			'a.state, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 		);
+		$fields = explode(',', $fields);
+		foreach ($fields as $field) $query->select($query->qn(trim($field)));
+
 		$query->from($db->quoteName('#__weblinks').' AS a');
 
 		// Join over the language
 		$query->select('l.title AS language_title');
-		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = a.language');
+		$query->join('LEFT', $db->quoteName('#__languages').' AS l ON l.lang_code = ' . $a_language);
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor');
@@ -192,7 +193,7 @@ class WeblinksModelWeblinks extends JModelList
 
 		// Filter on the language.
 		if ($language = $this->getState('filter.language')) {
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where($a_language . ' = ' . $db->quote($language));
 		}
 
 		// Add the list ordering clause.

--- a/administrator/modules/mod_logged/helper.php
+++ b/administrator/modules/mod_logged/helper.php
@@ -28,7 +28,7 @@ abstract class modLoggedHelper
 		$user = JFactory::getUser();
 		$query = $db->getQuery(true);
 
-		$query->select('s.time, s.client_id, u.id, u.name, u.username');
+		$query->select($query->qn('s.time') . ', s.client_id, u.id, u.name, u.username');
 		$query->from('#__session AS s');
 		$query->leftJoin('#__users AS u ON s.userid = u.id');
 		$query->where('s.guest = 0');

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -25,17 +25,19 @@ abstract class ModMenuHelper
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
+		$b_language = $db->quoteName('b.language');
+
 		$query->select('a.*, SUM(b.home) AS home');
 		$query->from('#__menu_types AS a');
-		$query->leftJoin('#__menu AS b ON b.menutype = a.menutype AND b.home != 0');
-		$query->select('b.language');
-		$query->leftJoin('#__languages AS l ON l.lang_code = language');
+		$query->leftJoin('#__menu AS b ON b.menutype = a.menutype AND b.home <> 0');
+		$query->select($b_language);
+		$query->leftJoin('#__languages AS l ON l.lang_code = ' . $b_language);
 		$query->select('l.image');
 		$query->select('l.sef');
 		$query->select('l.title_native');
 		$query->where('(b.client_id = 0 OR b.client_id IS NULL)');
 		//sqlsrv change
-		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native');
+		$query->group('a.id, a.menutype, a.description, a.title, b.menutype, ' . $b_language . ', l.image, l.sef, l.title_native');
 
 		$db->setQuery($query);
 

--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -159,7 +159,7 @@ class BannersModelBanners extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where($query->qn('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		$query->order('a.sticky DESC,'. ($randomise ? 'RAND()' : 'a.ordering'));

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -161,7 +161,7 @@ class ContactModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where($query->qn('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Set sortname ordering if selected

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -329,7 +329,8 @@ class ContactModelContact extends JModelForm
 				$query->order('a.state DESC, a.created DESC');
 				// filter per language if plugin published
 				if (JFactory::getApplication()->getLanguageFilter()) {
-					$query->where('a.language='.$db->quote(JFactory::getLanguage()->getTag()).' OR a.language='.$db->quote('*'));
+					$a_language = $db->quoteName('a.language');
+					$query->where($a_language . ' = ' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR ' . $a_language . ' = ' . $db->quote('*'));
 				}
 				if (is_numeric($published)) {
 					$query->where('a.state IN (1,2)');

--- a/components/com_contact/models/featured.php
+++ b/components/com_contact/models/featured.php
@@ -129,7 +129,7 @@ class ContactModelFeatured extends JModelList
 		$subquery .= 'WHERE parent.extension = ' . $db->quote('com_contact');
 		// Find any up-path categories that are not published
 		// If all categories are published, badcats.id will be null, and we just use the contact state
-		$subquery .= ' AND parent.published != 1 GROUP BY cat.id ';
+		$subquery .= ' AND parent.published <> 1 GROUP BY cat.id ';
 		// Select state to unpublished if up-path category is unpublished
 		$publishedWhere = 'CASE WHEN badcats.id is null THEN a.published ELSE 0 END';
 		$query->join('LEFT OUTER', '(' . $subquery . ') AS badcats ON badcats.id = c.id');
@@ -152,7 +152,7 @@ class ContactModelFeatured extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where($query->qn('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -310,7 +310,7 @@ class FinderModelSearch extends JModelList
 		}
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('l.language in ('.$db->quote(JFactory::getLanguage()->getTag()).','.$db->quote('*').')');
+			$query->where($query->qn('l.language') . ' IN (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 		// Push the data into cache.
 		$this->store($store, $query, false);

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -139,7 +139,7 @@ class NewsfeedsModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in ('.$db->Quote(JFactory::getLanguage()->getTag()).','.$db->Quote('*').')');
+			$query->where($query->qn('a.language) . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_weblinks/models/category.php
+++ b/components/com_weblinks/models/category.php
@@ -110,12 +110,12 @@ class WeblinksModelCategory extends JModelList
 		// Select required fields from the categories.
 		$query->select($this->getState('list.select', 'a.*'));
 		$query->from($db->quoteName('#__weblinks').' AS a');
+		$query->join('LEFT', '#__categories AS c ON c.id = a.catid');
 		$query->where('a.access IN ('.$groups.')');
 
 		// Filter by category.
 		if ($categoryId = $this->getState('category.id')) {
 			$query->where('a.catid = '.(int) $categoryId);
-			$query->join('LEFT', '#__categories AS c ON c.id = a.catid');
 			$query->where('c.access IN ('.$groups.')');
 
 			//Filter by published category
@@ -137,7 +137,7 @@ class WeblinksModelCategory extends JModelList
 			$query->where('a.state = '.(int) $state);
 		}
 		// do not show trashed links on the front-end
-		$query->where('a.state != -2');
+		$query->where('a.state <> -2');
 
 		// Filter by start and end dates.
 		$nullDate = $db->Quote($db->getNullDate());
@@ -151,7 +151,7 @@ class WeblinksModelCategory extends JModelList
 
 		// Filter by language
 		if ($this->getState('filter.language')) {
-			$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			$query->where($query->qn('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/includes/menu.php
+++ b/includes/menu.php
@@ -28,7 +28,8 @@ class JMenuSite extends JMenu
 		$app	= JApplication::getInstance('site');
 		$query	= $db->getQuery(true);
 
-		$query->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language');
+		$query->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type');
+		$query->select($db->quoteName('m.level') . ', ' . $db->quoteName('m.language'));
 		$query->select('m.browserNav, m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id');
 		$query->select('e.element as component');
 		$query->from('#__menu AS m');

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -287,6 +287,8 @@ class JCategories
 
 		$query = $db->getQuery(true);
 
+		$c_language = $db->quoteName('c.language');
+
 		// Right join with c for category
 		$query->select('c.*');
 		$case_when = ' CASE WHEN ';
@@ -320,7 +322,7 @@ class JCategories
 			$query->where('s.id=' . (int) $id);
 			if ($app->isSite() && $app->getLanguageFilter())
 			{
-				$query->leftJoin('#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt AND c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
+				$query->leftJoin('#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt AND ' . $c_language . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
 			}
 			else
 			{
@@ -331,13 +333,13 @@ class JCategories
 		{
 			if ($app->isSite() && $app->getLanguageFilter())
 			{
-				$query->where('c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+				$query->where($c_language . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 			}
 		}
 
 		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
 			'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-			' AND parent.published != 1 GROUP BY cat.id) ';
+			' AND parent.published <> 1 GROUP BY cat.id) ';
 		$query->leftJoin($subQuery . 'AS badcats ON badcats.id = c.id');
 		$query->where('badcats.id is null');
 
@@ -359,10 +361,11 @@ class JCategories
 		}
 
 		// Group by
-		$query->group('c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
- 			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-		 	c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
- 			c.path, c.published, c.rgt, c.title, c.modified_user_id');
+		$query->group('c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time, ' .
+ 			'c.created_time, c.created_user_id, c.description, c.extension, ' .
+			'c.hits, ' . $c_language . ', ' . $query->qn('c.level') . ', c.lft, ' .
+			'c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, ' .
+ 			'c.parent_id, c.path, c.published, c.rgt, c.title, c.modified_user_id');
 
 		// Get the results
 		$db->setQuery($query);

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -404,7 +404,7 @@ class JComponentHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
-		$query->select('extension_id AS id, element AS "option", params, enabled');
+		$query->select('extension_id AS id, element AS ' . $query->qn('option') . ', params, enabled');
 		$query->from('#__extensions');
 		$query->where($query->qn('type') . ' = ' . $db->quote('component'));
 		$query->where($query->qn('element') . ' = ' . $db->quote($option));

--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -303,14 +303,16 @@ abstract class JModuleHelper
 		if (!($clean = $cache->get($cacheid)))
 		{
 			$db = JFactory::getDbo();
+			$m_module =  $db->quoteName('m.module');
+			$m_position =  $db->quoteName('m.position');
 
 			$query = $db->getQuery(true);
-			$query->select('m.id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid');
+			$query->select('m.id, m.title, ' . $m_module . ', ' . $m_position . ', m.content, m.showtitle, m.params, mm.menuid');
 			$query->from('#__modules AS m');
 			$query->join('LEFT', '#__modules_menu AS mm ON mm.moduleid = m.id');
 			$query->where('m.published = 1');
 
-			$query->join('LEFT', '#__extensions AS e ON e.element = m.module AND e.client_id = m.client_id');
+			$query->join('LEFT', '#__extensions AS e ON e.element = ' . $m_module . ' AND e.client_id = m.client_id');
 			$query->where('e.enabled = 1');
 
 			$date = JFactory::getDate();
@@ -326,10 +328,10 @@ abstract class JModuleHelper
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter())
 			{
-				$query->where('m.language IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
+				$query->where($query->qn('m.language') . ' IN (' . $db->Quote($lang) . ',' . $db->Quote('*') . ')');
 			}
 
-			$query->order('m.position, m.ordering');
+			$query->order($m_position . ', m.ordering');
 
 			// Set the query
 			$db->setQuery($query);

--- a/libraries/joomla/database/table/menutype.php
+++ b/libraries/joomla/database/table/menutype.php
@@ -102,8 +102,8 @@ class JTableMenuType extends JTable
 			$query->select('id');
 			$query->from('#__menu');
 			$query->where('menutype=' . $this->_db->quote($table->menutype));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{
@@ -119,8 +119,8 @@ class JTableMenuType extends JTable
 			$query->from('#__modules');
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{
@@ -207,8 +207,8 @@ class JTableMenuType extends JTable
 			$query->from('#__modules');
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
-			$query->where('checked_out !=' . (int) $userId);
-			$query->where('checked_out !=0');
+			$query->where('checked_out <> ' . (int) $userId);
+			$query->where('checked_out <> 0');
 			$this->_db->setQuery($query);
 			if ($this->_db->loadRowList())
 			{

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -217,7 +217,7 @@ class JTableUser extends JTable
 		$query->select($this->_db->quoteName('id'));
 		$query->from($this->_db->quoteName('#__users'));
 		$query->where($this->_db->quoteName('username') . ' = ' . $this->_db->quote($this->username));
-		$query->where($this->_db->quoteName('id') . ' != ' . (int) $this->id);
+		$query->where($this->_db->quoteName('id') . ' <> ' . (int) $this->id);
 		$this->_db->setQuery($query);
 
 		$this->_db->setQuery($query);
@@ -233,7 +233,7 @@ class JTableUser extends JTable
 		$query->select($this->_db->quoteName('id'));
 		$query->from($this->_db->quoteName('#__users'));
 		$query->where($this->_db->quoteName('email') . ' = ' . $this->_db->quote($this->email));
-		$query->where($this->_db->quoteName('id') . ' != ' . (int) $this->id);
+		$query->where($this->_db->quoteName('id') . ' <> ' . (int) $this->id);
 		$this->_db->setQuery($query);
 		$xid = intval($this->_db->loadResult());
 		if ($xid && $xid != intval($this->id))

--- a/libraries/joomla/database/tablenested.php
+++ b/libraries/joomla/database/tablenested.php
@@ -133,7 +133,7 @@ class JTableNested extends JTable
 
 		// Get the path from the node to the root.
 		$query = $this->_db->getQuery(true);
-		$select = ($diagnostic) ? 'p.' . $k . ', p.parent_id, p.level, p.lft, p.rgt' : 'p.*';
+		$select = ($diagnostic) ? 'p.' . $k . ', p.parent_id, ' . $query->qn('p.level') . ', p.lft, p.rgt' : 'p.*';
 		$query->select($select);
 		$query->from($this->_tbl . ' AS n, ' . $this->_tbl . ' AS p');
 		$query->where('n.lft BETWEEN p.lft AND p.rgt');
@@ -173,7 +173,7 @@ class JTableNested extends JTable
 
 		// Get the node and children as a tree.
 		$query = $this->_db->getQuery(true);
-		$select = ($diagnostic) ? 'n.' . $k . ', n.parent_id, n.level, n.lft, n.rgt' : 'n.*';
+		$select = ($diagnostic) ? 'n.' . $k . ', n.parent_id, ' . $query->qn('n.level') . ', n.lft, n.rgt' : 'n.*';
 		$query->select($select);
 		$query->from($this->_tbl . ' AS n, ' . $this->_tbl . ' AS p');
 		$query->where('n.lft BETWEEN p.lft AND p.rgt');

--- a/libraries/joomla/html/html/category.php
+++ b/libraries/joomla/html/html/category.php
@@ -47,7 +47,7 @@ abstract class JHtmlCategory
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true);
 
-			$query->select('a.id, a.title, a.level');
+			$query->select('a.id, a.title, ' . $query->qn('a.level'));
 			$query->from('#__categories AS a');
 			$query->where('a.parent_id > 0');
 
@@ -107,7 +107,7 @@ abstract class JHtmlCategory
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true);
 
-			$query->select('a.id, a.title, a.level, a.parent_id');
+			$query->select('a.id, a.title, ' . $query->qn('a.level') . ', a.parent_id');
 			$query->from('#__categories AS a');
 			$query->where('a.parent_id > 0');
 

--- a/libraries/joomla/html/html/list.php
+++ b/libraries/joomla/html/html/list.php
@@ -246,7 +246,7 @@ abstract class JHtmlList
 		{
 			// Does not include registered users in the list
 			// @deprecated
-			$query->where('m.group_id != 2');
+			$query->where('m.group_id <> 2');
 		}
 
 		$query->select('u.id AS value, u.name AS text');

--- a/libraries/joomla/html/html/menu.php
+++ b/libraries/joomla/html/html/menu.php
@@ -77,7 +77,7 @@ abstract class JHtmlMenu
 			$menus = $db->loadObjectList();
 
 			$query->clear();
-			$query->select('a.id AS value, a.title AS text, a.level, a.menutype');
+			$query->select('a.id AS value, a.title AS text, ' . $query->qn('a.level') . ', a.menutype');
 			$query->from('#__menu AS a');
 			$query->where('a.parent_id > 0');
 			$query->where('a.type <> ' . $db->quote('url'));
@@ -188,7 +188,7 @@ abstract class JHtmlMenu
 			$query->from($db->quoteName('#__menu'));
 			$query->where($db->quoteName('menutype') . ' = ' . $db->quote($row->menutype));
 			$query->where($db->quoteName('parent_id') . ' = ' . (int) $row->parent_id);
-			$query->where($db->quoteName('published') . ' != -2');
+			$query->where($db->quoteName('published') . ' <> -2');
 			$query->order('ordering');
 			$order = JHtml::_('list.genericordering', $query);
 			$ordering = JHtml::_(

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -421,9 +421,9 @@ class JInstallerTemplate extends JAdapterInstance
 		}
 
 		// Set menu that assigned to the template back to default template
-		$query = 'UPDATE #__menu INNER JOIN #__template_styles' . ' ON #__template_styles.id = #__menu.template_style_id'
-			. ' SET #__menu.template_style_id = 0' . ' WHERE #__template_styles.template = ' . $db->Quote(strtolower($name))
-			. ' AND #__template_styles.client_id = ' . $db->Quote($clientId);
+		$query = 'UPDATE #__menu SET template_style_id = 0 WHERE template_style_id IN'
+			. '(SELECT id FROM #__template_styles WHERE #__template_styles.template = ' . $db->Quote(strtolower($name))
+			. ' AND #__template_styles.client_id = ' . $db->Quote($clientId) . ')';
 		$db->setQuery($query);
 		$db->Query();
 

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -143,7 +143,7 @@
 					multiple="true" size="5"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIAS_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIAS_DESC"
-					query="select distinct(created_by_alias) from #__content where created_by_alias != '' order by created_by_alias ASC"
+					query="select distinct(created_by_alias) from #__content where created_by_alias <> '' order by created_by_alias ASC"
 					key_field="created_by_alias" value_field="created_by_alias"
 				>
 					<option value="">JOPTION_SELECT_AUTHOR_ALIASES

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -35,10 +35,6 @@ abstract class modArticlesNewsHelper
 
 		$model->setState('filter.published', 1);
 
-		$model->setState('list.select', 'a.fulltext, a.id, a.title, a.alias, a.title_alias, a.introtext, a.state, a.catid, a.created, a.created_by, a.created_by_alias,' .
-			' a.modified, a.modified_by, a.publish_up, a.publish_down, a.images, a.urls, a.attribs, a.metadata, a.metakey, a.metadesc, a.access,' .
-			' a.hits, a.featured,' .
-			' LENGTH(a.fulltext) AS readmore');
 		// Access filter
 		$access = !JComponentHelper::getParams('com_content')->get('show_noauth');
 		$authorised = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -92,7 +92,7 @@ abstract class modRelatedItemsHelper
 					$query->from('#__content AS a');
 					$query->leftJoin('#__content_frontpage AS f ON f.content_id = a.id');
 					$query->leftJoin('#__categories AS cc ON cc.id = a.catid');
-					$query->where('a.id != ' . (int) $id);
+					$query->where('a.id <> ' . (int) $id);
 					$query->where('a.state = 1');
 					$query->where('a.access IN (' . $groups . ')');
           			$concat_string = $query->concatenate(array('","', ' REPLACE(a.metakey, ", ", ",")', ' ","'));
@@ -102,7 +102,7 @@ abstract class modRelatedItemsHelper
 
 					// Filter by language
 					if ($app->getLanguageFilter()) {
-						$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+						$query->where($query->qn('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 					}
 
 					$db->setQuery($query);

--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -48,9 +48,9 @@ class modWhosonlineHelper
 	static function getOnlineUserNames($params) {
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
-		$query->select('a.username, a.time, a.userid, a.usertype, a.client_id');
+		$query->select('a.username, ' . $query->qn('a.time') . ', a.userid, a.usertype, a.client_id');
 		$query->from('#__session AS a');
-		$query->where('a.userid != 0');
+		$query->where('a.userid <> 0');
 		$query->where('a.client_id = 0');
 		$query->group('a.userid');
 		$user = JFactory::getUser();

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -43,7 +43,7 @@ class plgAuthenticationJoomla extends JPlugin
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true);
 
-		$query->select('id, password');
+		$query->select('id, ' . $db->quoteName('password'));
 		$query->from('#__users');
 		$query->where('username=' . $db->Quote($credentials['username']));
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -123,7 +123,7 @@ class plgContentPagenavigation extends JPlugin
 						. ($canPublish ? '' : ' AND a.access = ' .(int)$row->access) . $xwhere);
 			$query->order($orderby);
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in ('.$db->quote($lang->getTag()).','.$db->quote('*').')');
+				$query->where($query->qn('a.language') . ' IN (' . $db->quote($lang->getTag()) . ',' . $db->quote('*') . ')');
 			}
 
 			$db->setQuery($query);

--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -349,7 +349,7 @@ class plgFinderCategories extends FinderIndexerAdapter
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.title, a.alias, a.description AS summary, a.extension');
 		$sql->select('a.created_user_id AS created_by, a.modified_time AS modified, a.modified_user_id AS modified_by');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.lft, a.parent_id, a.level');
+		$sql->select('a.metakey, a.metadesc, a.metadata, ' . $db->quoteName('a.language') . ', a.lft, a.parent_id, a.level');
 		$sql->select('a.created_time AS start_date, a.published AS state, a.access, a.params');
 
 		// Handle the alias CASE WHEN portion of the query

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -419,7 +419,7 @@ class plgFinderContacts extends FinderIndexerAdapter
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.name AS title, a.alias, a.con_position AS position, a.address, a.created AS start_date');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language');
+		$sql->select('a.metakey, a.metadesc, a.metadata, ' . $db->quoteName('a.language'));
 		$sql->select('a.sortname1, a.sortname2, a.sortname3');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('a.suburb AS city, a.state AS region, a.country, a.postcode AS zip');

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -349,7 +349,7 @@ class plgFinderContent extends FinderIndexerAdapter
 		$sql->select('a.id, a.title, a.alias, a.introtext AS summary, a.fulltext AS body');
 		$sql->select('a.state, a.catid, a.created AS start_date, a.created_by');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by, a.attribs AS params');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.access, a.version, a.ordering');
+		$sql->select('a.metakey, a.metadesc, a.metadata, ' . $db->quoteName('a.language') . ', a.access, a.version, a.ordering');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('c.title AS category, c.published AS cat_state, c.access AS cat_access');
 

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -342,7 +342,7 @@ class plgFinderNewsfeeds extends FinderIndexerAdapter
 		$sql->select('a.id, a.catid, a.name AS title, a.alias, a.link AS link');
 		$sql->select('a.published AS state, a.ordering, a.created AS start_date, a.params, a.access');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language');
+		$sql->select('a.metakey, a.metadesc, a.metadata, ' . $db->quoteName('a.language'));
 		$sql->select('a.created_by, a.created_by_alias, a.modified, a.modified_by');
 		$sql->select('c.title AS category, c.published AS cat_state, c.access AS cat_access');
 

--- a/plugins/finder/weblinks/weblinks.php
+++ b/plugins/finder/weblinks/weblinks.php
@@ -331,7 +331,7 @@ class plgFinderWeblinks extends FinderIndexerAdapter
 		// Check if we can use the supplied SQL query.
 		$sql = is_a($sql, 'JDatabaseQuery') ? $sql : $db->getQuery(true);
 		$sql->select('a.id, a.catid, a.title, a.alias, a.url AS link, a.description AS summary');
-		$sql->select('a.metakey, a.metadesc, a.metadata, a.language, a.access, a.ordering');
+		$sql->select('a.metakey, a.metadesc, a.metadata, ' . $db->quoteName('a.language') . ', a.access, a.ordering');
 		$sql->select('a.created_by_alias, a.modified, a.modified_by');
 		$sql->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date');
 		$sql->select('a.state AS state, a.ordering, a.access, a.approved, a.created AS start_date, a.params');

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -136,14 +136,14 @@ class plgSearchCategories extends JPlugin
 			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id.' END as slug';
-			$query->select('a.title, a.description AS text, "" AS created, "2" AS browsernav, a.id AS catid, ' . $case_when);
+			$query->select('a.title, a.description AS text, ' . $db->quote('') . ' AS created, ' . $db->quote('2') . ' AS browsernav, a.id AS catid, ' . $case_when);
 			$query->from('#__categories AS a');
 			$query->where('(a.title LIKE '. $text .' OR a.description LIKE '. $text .') AND a.published IN ('.implode(',', $state).') AND a.extension = \'com_content\''
 						.'AND a.access IN ('. $groups .')' );
 			$query->group('a.id');
 			$query->order($order);
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+				$query->where($db->quoteName('a.language') . ' IN (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/contacts/contacts.php
+++ b/plugins/search/contacts/contacts.php
@@ -97,6 +97,7 @@ class plgSearchContacts extends JPlugin
 				$order = 'a.name DESC';
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text	= $db->Quote('%'.$db->escape($text, true).'%', false);
 
 		$rows = array();
@@ -137,8 +138,8 @@ class plgSearchContacts extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -128,6 +128,7 @@ class plgSearchContent extends JPlugin
 
 		$rows = array();
 		$query	= $db->getQuery(true);
+		$q_lang = $db->quoteName('language');
 
 		// search articles
 		if ($sContent && $limit > 0)
@@ -151,7 +152,7 @@ class plgSearchContent extends JPlugin
 			$case_when1 .= $c_id.' END as catslug';
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created');
-			$query->select($query->concatenate(array('a.introtext', 'a.fulltext')).' AS text');
+			$query->select($query->concatenate(array($query->castAsChar('a.introtext'), $query->castAsChar('a.fulltext'))).' AS text');
 			$query->select('c.title AS section, '.$case_when.','.$case_when1.', '.'\'2\' AS browsernav');
 
 			$query->from('#__content AS a');
@@ -165,8 +166,8 @@ class plgSearchContent extends JPlugin
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);
@@ -222,8 +223,8 @@ class plgSearchContent extends JPlugin
 
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -75,6 +75,7 @@ class plgSearchNewsfeeds extends JPlugin
 			$state[]=2;
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text = trim($text);
 		if ($text == '') {
 			return array();
@@ -144,9 +145,9 @@ class plgSearchNewsfeeds extends JPlugin
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id.' END as catslug';
 
-			$query->select('a.name AS title, "" AS created, a.link AS text, ' . $case_when."," . $case_when1);
+			$query->select('a.name AS title, ' . $db->quote('') . ' AS created, a.link AS text, ' . $case_when."," . $case_when1);
 			$query->select($query->concatenate(array($db->Quote($searchNewsfeeds), 'c.title'), " / ").' AS section');
-			$query->select('"1" AS browsernav');
+			$query->select($db->quote('1') . ' AS browsernav');
 			$query->from('#__newsfeeds AS a');
 			$query->innerJoin('#__categories as c ON c.id = a.catid');
 			$query->where('('. $where .')' . 'AND a.published IN ('.implode(',', $state).') AND c.published = 1 AND c.access IN ('. $groups .')');
@@ -155,8 +156,8 @@ class plgSearchNewsfeeds extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);

--- a/plugins/search/weblinks/weblinks.php
+++ b/plugins/search/weblinks/weblinks.php
@@ -78,6 +78,7 @@ class plgSearchWeblinks extends JPlugin
 			$state[]=2;
 		}
 
+		$q_lang = $db->quoteName('language');
 		$text = trim($text);
 		if ($text == '') {
 			return array();
@@ -168,8 +169,8 @@ class plgSearchWeblinks extends JPlugin
 			// Filter by language
 			if ($app->isSite() && $app->getLanguageFilter()) {
 				$tag = JFactory::getLanguage()->getTag();
-				$query->where('a.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
-				$query->where('c.language in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('a.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
+				$query->where('c.' . $q_lang . ' in (' . $db->Quote($tag) . ',' . $db->Quote('*') . ')');
 			}
 
 			$db->setQuery($query, 0, $limit);


### PR DESCRIPTION
First set of patches to assist RDBMS portability as previously discussed on the general development list. This covers the following:
- Identifier quoting of SQL reserved words:
  - LANGUAGE
  - MODULE
  - OPTION
  - TIME
  - LEVEL
  - POSITION
- Identifier quoting of Virtuoso (and Oracle) reserved word:
  - PASSWORD
- Quoting of string literals in some places
- Correct use of non-standard != logic comparison operator to <>
- Casting of some long types used in SQL functions that may not support long types
- Fixed conditional join to categories in weblinks model (mod_weblinks seems to assume the categories table (aliased "c") is always present)
- Fixed duplication of column list in mod_articles_news helper

These changes are organised by front/admin then by component/module/plugin but squashed into single commits with respect to the categories of changes listed above. Given that none of the categories of changes are intended to alter any functional features, I hope that this is suitably divided and correct granularity for manual testing.

If preferred the commits are available unsquashed on separate branches under wdaniels/joomla-cms as indicated by the [branch-name] prefixes of the squashed commits messages where merged into this (sql92) branch.

These patches are relatively trivial and I do not believe to be contentious. Further patch sets I intend to raise for discussion on joomla platform/cms lists as appropriate.

NB: There remains RDBMS portability issues with the use of MySQL DATE_FORMAT function in mod_relateditems and mod_weblinks which require some further investigation. Also issues remain with quoting for the LIKE conditions in mod_relateditems. No doubt other issues also remain; this patch set is not intended to be exhaustive, even with respect to the identified issues.

[JoomlaCode #28391]
