### PR TITLE
XHTML: Unescaped Article Title in Category Blog "read more" Links

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -156,13 +156,13 @@ JHtml::core();
 					elseif ($readmore = $this->item->alternative_readmore) :
 						echo $readmore;
 						if ($params->get('show_readmore_title', 0) != 0) :
-						    echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+						    echo $this->escape(JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')));
 						endif;
 					elseif ($params->get('show_readmore_title', 0) == 0) :
 						echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
 					else :
 						echo JText::_('COM_CONTENT_READ_MORE');
-						echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+						echo $this->escape(JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')));
 					endif; ?></a>
 		</p>
 <?php endif; ?>


### PR DESCRIPTION
Article category blog layout produces invalid (X)HTML with reserved characters (e.g. ampersand &) not escaped in output of the "read more" link.

[JoomlaCode #28451]
