### PR TITLE
Notice error with advanced seo and featured articles

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -279,7 +279,7 @@ function ContentParseRoute($segments)
 	}
 
 	// we get the category id from the menu item and search from there
-	$id = $item->query['id'];
+	$id = isset($item->query['id']) ? (int)$item->query['id'] : 0;
 	$category = JCategories::getInstance('Content')->get($id);
 
 	if (!$category) {


### PR DESCRIPTION
If you activate the sef_advanced_link option (with a plugin or by temporary hardcode it in the router itself, see line 208) you get a notice error by following this steps:
1. Use an empty Joomla! installation for the best test environment (so other menu links will not "fix" the bug)
2. Create a com_content article
3. Set the article as "featured"
4. Go to the default frontpage home link
5. Click on the article
6. Notice: Undefined index: id in components\com_content\router.php on line 278
7. Apply pull request
8. Check again

Why do you get this notice error?
Because featured blog links have no "id" as request parameter.
