### PR TITLE
Add new MVC classes from the Joomla platform

### DIFF
--- a/libraries/cms/component/base.php
+++ b/libraries/cms/component/base.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Controller
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Base Controller Class
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Controller
+ * @since       12.1
+ */
+abstract class JControllerBase
+{
+	/**
+	 * The application object.
+	 *
+	 * @var    JApplicationBase
+	 * @since  12.1
+	 */
+	protected $app;
+
+	/**
+	 * The input object.
+	 *
+	 * @var    JInput
+	 * @since  12.1
+	 */
+	protected $input;
+
+	/**
+	 * Instantiate the controller.
+	 *
+	 * @param   JInput            $input  The input object.
+	 * @param   JApplicationBase  $app    The application object.
+	 *
+	 * @since  12.1
+	 */
+	public function __construct(JInput $input = null, JApplicationBase $app = null)
+	{
+		// Setup dependencies.
+		$this->app = isset($app) ? $app : $this->loadApplication();
+		$this->input = isset($input) ? $input : $this->loadInput();
+	}
+
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean  True if controller finished execution, false if the controller did not
+	 *                   finish execution. A controller might return false if some precondition for
+	 *                   the controller to run has not been satisfied.
+	 *
+	 * @since   12.1
+	 * @throws  LogicException
+	 * @throws  RuntimeException
+	 */
+	abstract public function execute();
+
+	/**
+	 * Get the application object.
+	 *
+	 * @return  JApplicationBase  The application object.
+	 *
+	 * @since   12.1
+	 */
+	public function getApplication()
+	{
+		return $this->app;
+	}
+
+	/**
+	 * Get the input object.
+	 *
+	 * @return  JInput  The input object.
+	 *
+	 * @since   12.1
+	 */
+	public function getInput()
+	{
+		return $this->input;
+	}
+
+	/**
+	 * Serialize the controller.
+	 *
+	 * @return  string  The serialized controller.
+	 *
+	 * @since   12.1
+	 */
+	public function serialize()
+	{
+		return serialize($this->input);
+	}
+
+	/**
+	 * Unserialize the controller.
+	 *
+	 * @param   string  $input  The serialized controller.
+	 *
+	 * @return  JController  Supports chaining.
+	 *
+	 * @since   12.1
+	 * @throws  UnexpectedValueException if input is not the right class.
+	 */
+	public function unserialize($input)
+	{
+		// Setup dependencies.
+		$this->app = $this->loadApplication();
+
+		// Unserialize the input.
+		$this->input = unserialize($input);
+
+		if (!($this->input instanceof JInput))
+		{
+			throw new UnexpectedValueException(sprintf('%s::unserialize would not accept a `%s`.', get_class($this), gettype($this->input)));
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Load the application object.
+	 *
+	 * @return  JApplicationBase  The application object.
+	 *
+	 * @since   12.1
+	 */
+	protected function loadApplication()
+	{
+		return JFactory::getApplication();
+	}
+
+	/**
+	 * Load the input object.
+	 *
+	 * @return  JInput  The input object.
+	 *
+	 * @since   12.1
+	 */
+	protected function loadInput()
+	{
+		return $this->app->input;
+	}
+}

--- a/libraries/cms/model/base.php
+++ b/libraries/cms/model/base.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Base Model Class
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Model
+ * @since       12.1
+ */
+abstract class JModelBase
+{
+	/**
+	 * The model state.
+	 *
+	 * @var    JRegistry
+	 * @since  12.1
+	 */
+	protected $state;
+
+	/**
+	 * Instantiate the model.
+	 *
+	 * @param   JRegistry  $state  The model state.
+	 *
+	 * @since   12.1
+	 */
+	public function __construct(JRegistry $state = null)
+	{
+		// Setup the model.
+		$this->state = isset($state) ? $state : $this->loadState();
+	}
+
+	/**
+	 * Get the model state.
+	 *
+	 * @return  JRegistry  The state object.
+	 *
+	 * @since   12.1
+	 */
+	public function getState()
+	{
+		return $this->state;
+	}
+
+	/**
+	 * Set the model state.
+	 *
+	 * @param   JRegistry  $state  The state object.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function setState(JRegistry $state)
+	{
+		$this->state = $state;
+	}
+
+	/**
+	 * Load the model state.
+	 *
+	 * @return  JRegistry  The state object.
+	 *
+	 * @since   12.1
+	 */
+	protected function loadState()
+	{
+		return new JRegistry;
+	}
+}

--- a/libraries/cms/model/database.php
+++ b/libraries/cms/model/database.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Database Model Class
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Model
+ * @since       12.1
+ */
+abstract class JModelDatabase extends JModelBase
+{
+	/**
+	 * The database driver.
+	 *
+	 * @var    JDatabaseDriver
+	 * @since  12.1
+	 */
+	protected $db;
+
+	/**
+	 * Instantiate the model.
+	 *
+	 * @param   JRegistry        $state  The model state.
+	 * @param   JDatabaseDriver  $db     The database adpater.
+	 *
+	 * @since   12.1
+	 */
+	public function __construct(JRegistry $state = null, JDatabaseDriver $db = null)
+	{
+		parent::__construct($state);
+
+		// Setup the model.
+		$this->db = isset($db) ? $db : $this->loadDb();
+	}
+
+	/**
+	 * Get the database driver.
+	 *
+	 * @return  JDatabaseDriver  The database driver.
+	 *
+	 * @since   12.1
+	 */
+	public function getDb()
+	{
+		return $this->db;
+	}
+
+	/**
+	 * Set the database driver.
+	 *
+	 * @param   JDatabaseDriver  $db  The database driver.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function setDb(JDatabaseDriver $db)
+	{
+		$this->db = $db;
+	}
+
+	/**
+	 * Load the database driver.
+	 *
+	 * @return  JDatabaseDriver  The database driver.
+	 *
+	 * @since   12.1
+	 */
+	protected function loadDb()
+	{
+		return JFactory::getDbo();
+	}
+}

--- a/libraries/cms/view/base.php
+++ b/libraries/cms/view/base.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Base View Class
+ *
+ * @package     Joomla.Platform
+ * @subpackage  View
+ * @since       12.1
+ */
+abstract class JViewBase
+{
+	/**
+	 * The model object.
+	 *
+	 * @var    JModel
+	 * @since  12.1
+	 */
+	protected $model;
+
+	/**
+	 * Method to instantiate the view.
+	 *
+	 * @param   JModel  $model  The model object.
+	 *
+	 * @since  12.1
+	 */
+	public function __construct(JModel $model)
+	{
+		// Setup dependencies.
+		$this->model = $model;
+	}
+
+	/**
+	 * Method to escape output.
+	 *
+	 * @param   string  $output  The output to escape.
+	 *
+	 * @return  string  The escaped output.
+	 *
+	 * @see     JView::escape()
+	 * @since   12.1
+	 */
+	public function escape($output)
+	{
+		return $output;
+	}
+
+	/**
+	 * Method to render the view.
+	 *
+	 * @return  string  The rendered view.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	abstract public function render();
+}

--- a/libraries/cms/view/html.php
+++ b/libraries/cms/view/html.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+jimport('joomla.filesystem.path');
+
+/**
+ * Joomla Platform HTML View Class
+ *
+ * @package     Joomla.Platform
+ * @subpackage  View
+ * @since       12.1
+ */
+abstract class JViewHtml extends JViewBase
+{
+	/**
+	 * The view layout.
+	 *
+	 * @var    string
+	 * @since  12.1
+	 */
+	protected $layout = 'default';
+
+	/**
+	 * The paths queue.
+	 *
+	 * @var    SplPriorityQueue
+	 * @since  12.1
+	 */
+	protected $paths;
+
+	/**
+	 * Method to instantiate the view.
+	 *
+	 * @param   JModel            $model  The model object.
+	 * @param   SplPriorityQueue  $paths  The paths queue.
+	 *
+	 * @since   12.1
+	 */
+	public function __construct(JModel $model, SplPriorityQueue $paths = null)
+	{
+		parent::__construct($model);
+
+		// Setup dependencies.
+		$this->paths = isset($paths) ? $paths : $this->loadPaths();
+	}
+
+	/**
+	 * Magic toString method that is a proxy for the render method.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function __toString()
+	{
+		return $this->render();
+	}
+
+	/**
+	 * Method to escape output.
+	 *
+	 * @param   string  $output  The output to escape.
+	 *
+	 * @return  string  The escaped output.
+	 *
+	 * @see     JView::escape()
+	 * @since   12.1
+	 */
+	public function escape($output)
+	{
+		// Escape the output.
+		return htmlspecialchars($output, ENT_COMPAT, 'UTF-8');
+	}
+
+	/**
+	 * Method to get the view layout.
+	 *
+	 * @return  string  The layout name.
+	 *
+	 * @since   12.1
+	 */
+	public function getLayout()
+	{
+		return $this->layout;
+	}
+
+	/**
+	 * Method to get the layout path.
+	 *
+	 * @param   string  $layout  The layout name.
+	 *
+	 * @return  mixed  The layout file name if found, false otherwise.
+	 *
+	 * @since   12.1
+	 */
+	public function getPath($layout)
+	{
+		// Get the layout file name.
+		$file = JPath::clean($layout . '.php');
+
+		// Find the layout file path.
+		$path = JPath::find(clone($this->paths), $file);
+
+		return $path;
+	}
+
+	/**
+	 * Method to get the view paths.
+	 *
+	 * @return  SplPriorityQueue  The paths queue.
+	 *
+	 * @since   12.1
+	 */
+	public function getPaths()
+	{
+		return $this->paths;
+	}
+
+	/**
+	 * Method to render the view.
+	 *
+	 * @return  string  The rendered view.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function render()
+	{
+		// Get the layout path.
+		$path = $this->getPath($this->getLayout());
+
+		// Check if the layout path was found.
+		if (!$path)
+		{
+			throw new RuntimeException('Layout Path Not Found');
+		}
+
+		// Start an output buffer.
+		ob_start();
+
+		// Load the layout.
+		include $path;
+
+		// Get the layout contents.
+		$output = ob_get_clean();
+
+		return $output;
+	}
+
+	/**
+	 * Method to set the view layout.
+	 *
+	 * @param   string  $layout  The layout name.
+	 *
+	 * @return  JViewHtml  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function setLayout($layout)
+	{
+		$this->layout = $layout;
+
+		return $this;
+	}
+
+	/**
+	 * Method to set the view paths.
+	 *
+	 * @param   SplPriorityQueue  $paths  The paths queue.
+	 *
+	 * @return  JViewHtml  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function setPaths(SplPriorityQueue $paths)
+	{
+		$this->paths = $paths;
+
+		return $this;
+	}
+
+	/**
+	 * Method to load the paths queue.
+	 *
+	 * @return  SplPriorityQueue  The paths queue.
+	 *
+	 * @since   12.1
+	 */
+	protected function loadPaths()
+	{
+		return new SplPriorityQueue;
+	}
+}


### PR DESCRIPTION
This pull adds the new MVC classes (JControllerBase, JModelBase, JModelDatabase, JViewBase and JViewHtml) from the Joomla Platform without interfaces.  This gives extension developers the option of moving forward with the new concrete class names without generating backward compatibility issues revolving around the reassignment of JController, JModel and JView to interfaces.

Developers should note carefully that none of these new classes extend from JObject and should use autoloader rules to define where their classes can be found (no more addIncludePath type methods).
