### PR TITLE
Featured view only processes content triggers on the first few articles in the list

### DIFF
--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -73,20 +73,16 @@ class ContentViewFeatured extends JView
 
 			$dispatcher = JDispatcher::getInstance();
 
-			// Ignore content plugins on links.
-			if ($i < $numLeading + $numIntro)
-			{
-				$item->introtext = JHtml::_('content.prepare', $item->introtext, '', 'com_content.featured');
+			$item->introtext = JHtml::_('content.prepare', $item->introtext, '', 'com_content.featured');
 
-				$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, 0));
-				$item->event->afterDisplayTitle = trim(implode("\n", $results));
+			$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, 0));
+			$item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-				$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_content.article', &$item, &$item->params, 0));
-				$item->event->beforeDisplayContent = trim(implode("\n", $results));
+			$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_content.article', &$item, &$item->params, 0));
+			$item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-				$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$item->params, 0));
-				$item->event->afterDisplayContent = trim(implode("\n", $results));
-			}
+			$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$item->params, 0));
+			$item->event->afterDisplayContent = trim(implode("\n", $results));
 		}
 
 		// Preprocess the breakdown of leading, intro and linked articles.


### PR DESCRIPTION
Due to the leading article and intro article usage in the IF statement surrounding the content triggers it results in only the first, for example, 5 articles being processed with triggers. If those triggers are used to alter the authors name for example then only the first 5 will actually change.
