### PR TITLE
Language in component folder

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -317,6 +317,8 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			$lang->load($component, JPATH_BASE, null, false, false);
 			$lang->load($component, JPATH_BASE, $lang->getDefault(), false, false);
+			$lang->load($component, JPATH_BASE . '/components/' . $component, null, false, false);
+			$lang->load($component, JPATH_BASE . '/components/' . $component, $lang->getDefault(), false, false);
 
 			if (!$form->loadFile($path, false))
 			{


### PR DESCRIPTION
Since joomla 1.7 language files can be put in the language folder inside the component. This was missing in the categories extension when loading extra fields.
