### PR TITLE
ACL getActions consistency improvements for all components

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -70,15 +70,14 @@ class BannersHelper
 
 		if (empty($categoryId)) {
 			$assetName = 'com_banners';
-			$level = 'component';
 		} else {
 			$assetName = 'com_banners.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 
-		$actions = JAccess::getActions('com_banners', $level);
+		$actions = JAccess::getActions('com_banners');
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -82,16 +82,15 @@ class CategoriesHelper
 
 		if (empty($categoryId)) {
 			$assetName = $component;
-			$level = 'component';
 		}
 		else {
 			$assetName = $component.'.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 
-		$actions = JAccess::getActions($component, $level);
+		$actions = JAccess::getActions($component);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name, $user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -60,20 +60,18 @@ class ContactHelper
 
 		if (empty($contactId) && empty($categoryId)) {
 			$assetName = 'com_contact';
-			$level = 'component';
 		}
 		elseif (empty($contactId)) {
 			$assetName = 'com_contact.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 		else {
 			$assetName = 'com_contact.contact.'.(int) $contactId;
-			$level = 'category';
 		}
 
-		$actions = JAccess::getActions('com_contact', $level);
+		$actions = JAccess::getActions('com_contact');
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -60,20 +60,18 @@ class ContentHelper
 
 		if (empty($articleId) && empty($categoryId)) {
 			$assetName = 'com_content';
-			$level = 'component';
 		}
 		elseif (empty($articleId)) {
 			$assetName = 'com_content.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 		else {
 			$assetName = 'com_content.article.'.(int) $articleId;
-			$level = 'article';
 		}
 
-		$actions = JAccess::getActions('com_content', $level);
+		$actions = JAccess::getActions('com_content');
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_finder/helpers/finder.php
+++ b/administrator/components/com_finder/helpers/finder.php
@@ -65,7 +65,7 @@ class FinderHelper
 		$result = new JObject;
 		$assetName = 'com_finder';
 
-		$actions = JAccess::getActions($assetName, 'component');
+		$actions = JAccess::getActions($assetName);
 
 		foreach ($actions as $action)
 		{

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -67,12 +67,12 @@ class InstallerHelper
 	{
 		$user	= JFactory::getUser();
 		$result	= new JObject;
-
 		$assetName = 'com_installer';
 
 		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
+++ b/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
@@ -29,7 +29,6 @@ class JoomlaupdateHelper
 	{
 		$user	= JFactory::getUser();
 		$result	= new JObject;
-
 		$assetName = 'com_joomlaupdate';
 
 		$actions = JAccess::getActions($assetName);

--- a/administrator/components/com_languages/helpers/languages.php
+++ b/administrator/components/com_languages/helpers/languages.php
@@ -58,7 +58,8 @@ class LanguagesHelper
 
 		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -35,11 +35,13 @@ abstract class ModulesHelper
 	{
 		$user	= JFactory::getUser();
 		$result	= new JObject;
+		$assetName = 'com_modules';
 
-		$actions = JAccess::getActions('com_modules');
+		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
-			$result->set($action->name, $user->authorise($action->name, 'com_modules'));
+		foreach ($actions as $action) 
+		{
+			$result->set($action->name, $user->authorise($action->name, $assetName));
 		}
 
 		return $result;

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -56,16 +56,15 @@ class NewsfeedsHelper
 
 		if (empty($categoryId)) {
 			$assetName = 'com_newsfeeds';
-			$level = 'component';
 		}
 		else {
 			$assetName = 'com_newsfeeds.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 
-		$actions = JAccess::getActions('com_newsfeeds', $level);
+		$actions = JAccess::getActions('com_newsfeeds');
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -41,7 +41,8 @@ class PluginsHelper
 
 		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_redirect/helpers/redirect.php
+++ b/administrator/components/com_redirect/helpers/redirect.php
@@ -41,7 +41,8 @@ class RedirectHelper
 
 		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -39,7 +39,8 @@ class SearchHelper
 
 		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -44,11 +44,13 @@ class TemplatesHelper
 	{
 		$user	= JFactory::getUser();
 		$result	= new JObject;
+		$assetName = 'com_templates';
 
-		$actions = JAccess::getActions('com_templates');
+		$actions = JAccess::getActions($assetName);
 
-		foreach ($actions as $action) {
-			$result->set($action->name, $user->authorise($action->name, 'com_templates'));
+		foreach ($actions as $action) 
+		{
+			$result->set($action->name, $user->authorise($action->name, $assetName));
 		}
 
 		return $result;

--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -86,12 +86,13 @@ class UsersHelper
 		{
 			$user = JFactory::getUser();
 			self::$actions = new JObject;
+			$assetName = 'com_users';
 
-			$actions = JAccess::getActions('com_users');
+			$actions = JAccess::getActions($assetName);
 
 			foreach ($actions as $action)
 			{
-				self::$actions->set($action->name, $user->authorise($action->name, 'com_users'));
+				self::$actions->set($action->name, $user->authorise($action->name, $assetName));
 			}
 		}
 

--- a/administrator/components/com_weblinks/helpers/weblinks.php
+++ b/administrator/components/com_weblinks/helpers/weblinks.php
@@ -55,15 +55,14 @@ class WeblinksHelper
 
 		if (empty($categoryId)) {
 			$assetName = 'com_weblinks';
-			$level = 'component';
 		} else {
 			$assetName = 'com_weblinks.category.'.(int) $categoryId;
-			$level = 'category';
 		}
 
-		$actions = JAccess::getActions('com_weblinks', $level);
+		$actions = JAccess::getActions('com_weblinks');
 
-		foreach ($actions as $action) {
+		foreach ($actions as $action) 
+		{
 			$result->set($action->name,	$user->authorise($action->name, $assetName));
 		}
 


### PR DESCRIPTION
This commit will improve the consistent use of the ACL API across the Joomla components. It also removes the level part of the getActions check for certain components. You want to have all component actions and not just of the specific section, and the component should contain all actions of the other sections of access.xml. Otherwise you might not be able to check for core.manage action to show the permission settings fieldset in an different section for example.
