### PR TITLE
com_media: Auto-fill Image URL after upload

### DIFF
--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -98,7 +98,11 @@ class MediaControllerFile extends JController
 			{
 				// Trigger the onContentAfterSave event.
 				$dispatcher->trigger('onContentAfterSave', array('com_media.file', &$object_file, true));
-				$this->setMessage(JText::sprintf('COM_MEDIA_UPLOAD_COMPLETE', substr($file['filepath'], strlen(COM_MEDIA_BASE))));
+				// Get just the filepath
+				$filepath = substr($file['filepath'], strlen(COM_MEDIA_BASE));
+				$this->setMessage(JText::sprintf('COM_MEDIA_UPLOAD_COMPLETE', $filepath));
+				// Set the user state for the uploaded file path
+				JApplication::setUserState('filepath', COM_MEDIA_BASEPATH.$filepath);
 				return true;
 			}
 		}

--- a/administrator/components/com_media/media.php
+++ b/administrator/components/com_media/media.php
@@ -39,8 +39,11 @@ if (substr(strtolower($view), 0, 6) == "images" || $popup_upload == 1) {
 	$path = "image_path";
 }
 
-define('COM_MEDIA_BASE',	JPATH_ROOT.'/'.$params->get($path, 'images'));
-define('COM_MEDIA_BASEURL', JURI::root().$params->get($path, 'images'));
+$media_base = $params->get($path, 'images');
+
+define('COM_MEDIA_BASE',	JPATH_ROOT.'/'.$media_base);
+define('COM_MEDIA_BASEURL',	JURI::root().$media_base);
+define('COM_MEDIA_BASEPATH',	JURI::root(true).$media_base);
 
 // Include dependancies
 jimport('joomla.application.component.controller');

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -9,6 +9,8 @@
 // No direct access.
 defined('_JEXEC') or die;
 $user = JFactory::getUser();
+$filepath = JApplication::getUserState('filepath', null);
+JApplication::setUserState('filepath', null);
 ?>
 <script type='text/javascript'>
 var image_base_path = '<?php $params = JComponentHelper::getParams('com_media');
@@ -36,7 +38,7 @@ echo $params->get('image_path', 'images');?>/';
 		<table class="properties">
 			<tr>
 				<td><label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label></td>
-				<td><input type="text" id="f_url" value="" /></td>
+				<td><input type="text" id="f_url" value="<?php echo $filepath; ?>" /></td>
 				<?php if (!$this->state->get('field.id')):?>
 					<td><label for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label></td>
 					<td>


### PR DESCRIPTION
com_media is great, but uploading several images and having to find each one in the imagelist is a pain. This pull request addresses that issue by auto-filling the image url after successful upload via JApplication::setUserState() and JApplication::getUserState()

This solves tracker item - http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28624
