### PR TITLE
Menu: Article Layout Selection

### DIFF
--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -227,6 +227,15 @@
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 		</field>
+
+		<field
+			name="layout" type="componentlayout"
+			label="JGLOBAL_FIELD_LAYOUT_LABEL"
+			description="JGLOBAL_FIELD_LAYOUT_DESC"
+			menuitems="true"
+			extension="com_content"
+			view="article"
+		/>
 		</fieldset>
 	</fields>
 </metadata>

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -69,9 +69,14 @@ class ContentViewArticle extends JView
 				// $item->params are the article params, $temp are the menu item params
 				// Merge so that the menu item params take priority
 				$item->params->merge($temp);
+
 				// Load layout from active query (in case it is an alternative menu item)
-				if (isset($active->query['layout'])) {
-					$this->setLayout($active->query['layout']);
+				// If not in active query check menu layout option
+				if ( isset( $active->query['layout'] ) ) {
+					$this->setLayout( $active->query['layout'] );
+				}
+				elseif ( $item->params->get( 'layout' ) ) {
+					$this->setLayout( $item->params->get( 'layout' ) );
 				}
 			}
 			else {


### PR DESCRIPTION
Found an issue in the Active Menu item where there was no way to choose a HTML override option for an article. If the article was a active menu and a layout override was chosen in the article it would not work. So a option was needed in the article menu to resolve this.

New option placed in the menu area for article selection called Choose Layout.
Updated logic to check for this new field in the view for com_content/view/article/

Signed-off-by: Steven steven@corephp.com
