### PR TITLE
'continue' used outside of loop context. Just return false instead.

### DIFF
--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -165,7 +165,7 @@ class MediaControllerFolder extends JController
 				if (in_array(false, $result, true)) {
 					// There are some errors in the plugins
 					JError::raiseWarning(100, JText::plural('COM_MEDIA_ERROR_BEFORE_SAVE', count($errors = $object_file->getErrors()), implode('<br />', $errors)));
-					continue;
+					return false;
 				}
 
 				JFolder::create($path);


### PR DESCRIPTION
Fix for this: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28630
