### PR TITLE
removed warning on update view

### DIFF
--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -25,7 +25,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<?php echo $this->loadTemplate('ftp'); ?>
 	<?php endif; ?>
 
-	<?php if (count($this->items)) : ?>
+	<?php if (!empty($this->items)) : ?>
 	<table class="adminlist" cellspacing="1">
 		<thead>
 			<tr>


### PR DESCRIPTION
Otherwise count(0) evaluates to true and that will trigger

Warning: Invalid argument supplied for foreach()
