### PR TITLE
administrator/mod_menu Bug! 'User Notes Category' the sub menu 'Add New Category' is linked to the user category and not to the user.notes category!

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -147,7 +147,7 @@ if ($user->authorise('core.manage', 'com_users'))
 	if ($createUser)
 	{
 		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users', 'class:newarticle')
+			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users.notes', 'class:newarticle')
 		);
 		$menu->getParent();
 	}


### PR DESCRIPTION
administrator/mod_menu Bug! 'User Notes Category' the sub menu 'Add New Category' is linked to the user category and not to the user.notes category

Greeting

Sebastian
