### PR TITLE
 use the correct json content-type header when sending json data 

### DIFF
--- a/components/com_finder/controllers/suggestions.json.php
+++ b/components/com_finder/controllers/suggestions.json.php
@@ -43,6 +43,9 @@ class FinderControllerSuggestions extends JControllerLegacy
 			$return = array();
 		}
 
+		// Use the correct json mime-type
+		header('Content-type: application/json');
+
 		// Send the response.
 		echo json_encode($return);
 		JFactory::getApplication()->close();

--- a/components/com_finder/controllers/suggestions.json.php
+++ b/components/com_finder/controllers/suggestions.json.php
@@ -44,7 +44,7 @@ class FinderControllerSuggestions extends JControllerLegacy
 		}
 
 		// Use the correct json mime-type
-		header('Content-type: application/json');
+		header('Content-Type: application/json');
 
 		// Send the response.
 		echo json_encode($return);


### PR DESCRIPTION
Shouldn't this be fixed at a lower level?

Anyway, a fix for this:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28690
