### PR TITLE
exit the function if $paths is empty, not if it is not empty

### DIFF
--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -44,7 +44,7 @@ class MediaControllerFolder extends JController
 		$this->setRedirect($redirect);
 
 		// Just return if there's nothing to do
-		if (!empty($paths))
+		if (empty($paths))
 		{
 			return true;
 		}


### PR DESCRIPTION
Hmm. How did that ! get in there?
