### PR TITLE
[#28754] $route is already being converted to SEF by JRoute::_(), if there is an ...

### DIFF
--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -31,31 +31,17 @@ class ModFinderHelper
 	 */
 	public static function getGetFields($route = null, $paramItem = 0)
 	{
-		$fields = null;
+		$fields = array();
 		$uri = JUri::getInstance(JRoute::_($route));
 		$uri->delVar('q');
-		$elements = $uri->getQuery(true);
 
 		// Create hidden input elements for each part of the URI.
-		// Add the current menu id if it doesn't have one
-		foreach ($elements as $n => $v)
+		foreach ($uri->getQuery(true) as $n => $v)
 		{
-			if ($n == 'Itemid')
-			{
-				continue;
-			}
-
-			$fields .= '<input type="hidden" name="' . $n . '" value="' . $v . '" />';
+			$fields[] = '<input type="hidden" name="' . $n . '" value="' . $v . '" />';
 		}
 
-		/*
-		 * Figure out the Itemid value
-		 * First, check if the param is set.  If not, fall back to the Itemid from the JInput object
-		 */
-		$Itemid = $paramItem > 0 ? $paramItem : JFactory::getApplication()->input->getInt('Itemid');
-		$fields .= '<input type="hidden" name="Itemid" value="' . $Itemid . '" />';
-
-		return $fields;
+		return implode('', $fields);
 	}
 
 	/**


### PR DESCRIPTION
...Item id, it will be implicit in the URI, not part of the query string. So we don't need to care about it.

Also, prefer array implosion to string concatenation.

fix for this:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28754
