### PR TITLE
remove obsolete img border from tinymce.php (deprecated in html4, obsolete in html5)

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -421,7 +421,7 @@ class plgEditorTinymce extends JPlugin
 		if ($advimage)
 		{
 			$plugins[]	= 'advimage';
-			$elements[]	= 'img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name|style]';
+			$elements[]	= 'img[class|src|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name|style]';
 		}
 
 		// advlink


### PR DESCRIPTION
When inserting an image while using tinymce the element border="0" is automatically added to the html.

eg

<img border="0" src="/images/someting.png" alt="something">

it is even added if you specify a border in the insert image popup

<img src=/images/someting.png" alt="something" border="0" width="400" height="164" style="border: 10px solid black;" />

The border element was deprecated in HTML4 and is obsolete in HTML5.
