### PR TITLE
[#28794] Redirect to homepage instead of 404 with SEF and URL rewrite enabled if no com_content on homepage

### DIFF
--- a/includes/router.php
+++ b/includes/router.php
@@ -232,7 +232,9 @@ class JRouterSite extends JRouter
 			}
 
 			if (!$found) {
-				$found = $menu->getDefault($lang_tag);
+				$found = new stdClass();
+				$found->id = 0;
+				$found->component = '';
 			}
 			else {
 				$route = substr($route, strlen($found->route));


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28794

Proposed fix for tracker issue #28794.
