### PR TITLE
JFactory::createDocument always creates HTML documents.

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -697,10 +697,12 @@ abstract class JFactory
 	{
 		$lang = self::getLanguage();
 
+		$type = JRequest::getWord('format', 'html');
+
 		$attributes = array('charset' => 'utf-8', 'lineend' => 'unix', 'tab' => '  ', 'language' => $lang->getTag(),
 			'direction' => $lang->isRTL() ? 'rtl' : 'ltr');
 
-		return JDocument::getInstance('html', $attributes);
+		return JDocument::getInstance($type, $attributes);
 	}
 
 	/**


### PR DESCRIPTION
Fixing the "format" URL parameter. Bug was introduced when the depreceated "no_html" was removed.
Now it is no longer possible to create other document types using "&format=raw".
This PR brings back this function but doesn't reintroduce the "no_html" parameter.
