### PR TITLE
Publishing date instead of creation date in category feeds

### DIFF
--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -54,7 +54,7 @@ class ContentViewCategory extends JViewLegacy
 			// Get description, author and date
 			$description = ($params->get('feed_summary', 0) ? $row->introtext.$row->fulltext : $row->introtext);
 			$author = $row->created_by_alias ? $row->created_by_alias : $row->author;
-			@$date = ($row->created ? date('r', strtotime($row->created)) : '');
+			@$date = ($row->publish_up ? date('r', strtotime($row->publish_up)) : '');
 
 			// Load individual item creator class
 			$item 				= new JFeedItem;


### PR DESCRIPTION
I've changed the source for the date sent in category feeds from the creation date to the publishing date (this should match the <pubDate> tag better)
Please review.
