### PR TITLE
Adding viewname to menuitems manager

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -83,41 +83,41 @@ class MenusViewItems extends JViewLegacy
 								if ($view = $xml->xpath('view[1]')) {
 									if (!empty($view[0]['title'])) {
 										$value .= ' » ' . JText::_(trim((string) $view[0]['title']));
-										$vars['layout'] = isset($vars['layout']) ? $vars['layout'] : 'default';
+									}
+									$vars['layout'] = isset($vars['layout']) ? $vars['layout'] : 'default';
 
-										// Attempt to load the layout xml file.
-										// If Alternative Menu Item, get template folder for layout file
-										if (strpos($vars['layout'], ':') > 0)
-										{
-											// Use template folder for layout file
-											$temp = explode(':', $vars['layout']);
-											$file = JPATH_SITE.'/templates/'.$temp[0].'/html/'.$item->componentname.'/'.$vars['view'].'/'.$temp[1].'.xml';
-											// Load template language file
-											$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, null, false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], null, false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, $lang->getDefault(), false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], $lang->getDefault(), false, false);
+									// Attempt to load the layout xml file.
+									// If Alternative Menu Item, get template folder for layout file
+									if (strpos($vars['layout'], ':') > 0)
+									{
+										// Use template folder for layout file
+										$temp = explode(':', $vars['layout']);
+										$file = JPATH_SITE.'/templates/'.$temp[0].'/html/'.$item->componentname.'/'.$vars['view'].'/'.$temp[1].'.xml';
+										// Load template language file
+										$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, null, false, false)
+										||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], null, false, false)
+										||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, $lang->getDefault(), false, false)
+										||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], $lang->getDefault(), false, false);
 
-										}
-										else
-										{
-											// Get XML file from component folder for standard layouts
-											$file = JPATH_SITE.'/components/'.$item->componentname.'/views/'.$vars['view'].'/tmpl/'.$vars['layout'].'.xml';
-										}
-										if (JFile::exists($file) && $xml = simplexml_load_file($file)) {
-											// Look for the first view node off of the root node.
-											if ($layout = $xml->xpath('layout[1]')) {
-												if (!empty($layout[0]['title'])) {
-													$value .= ' » ' . JText::_(trim((string) $layout[0]['title']));
-												}
-											}
-											if (!empty($layout[0]->message[0])) {
-												$item->item_type_desc = JText::_(trim((string) $layout[0]->message[0]));
+									}
+									else
+									{
+										// Get XML file from component folder for standard layouts
+										$file = JPATH_SITE.'/components/'.$item->componentname.'/views/'.$vars['view'].'/tmpl/'.$vars['layout'].'.xml';
+									}
+									if (JFile::exists($file) && $xml = simplexml_load_file($file)) {
+										// Look for the first view node off of the root node.
+										if ($layout = $xml->xpath('layout[1]')) {
+											if (!empty($layout[0]['title'])) {
+												$value .= ' » ' . JText::_(trim((string) $layout[0]['title']));
 											}
 										}
-										if (!isset($item->item_type_desc) && !empty($view[0]->message[0])) {
-											$item->item_type_desc = JText::_(trim((string) $view[0]->message[0]));
+										if (!empty($layout[0]->message[0])) {
+											$item->item_type_desc = JText::_(trim((string) $layout[0]->message[0]));
 										}
+									}
+									if (!isset($item->item_type_desc) && !empty($view[0]->message[0])) {
+										$item->item_type_desc = JText::_(trim((string) $view[0]->message[0]));
 									}
 								}
 								unset($xml);

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -82,6 +82,7 @@ class MenusViewItems extends JViewLegacy
 								// Look for the first view node off of the root node.
 								if ($view = $xml->xpath('view[1]')) {
 									if (!empty($view[0]['title'])) {
+										$value .= ' » ' . JText::_(trim((string) $view[0]['title']));
 										$vars['layout'] = isset($vars['layout']) ? $vars['layout'] : 'default';
 
 										// Attempt to load the layout xml file.
@@ -113,6 +114,9 @@ class MenusViewItems extends JViewLegacy
 											if (!empty($layout[0]->message[0])) {
 												$item->item_type_desc = JText::_(trim((string) $layout[0]->message[0]));
 											}
+										}
+										if (!isset($item->item_type_desc) && !empty($view[0]->message[0])) {
+											$item->item_type_desc = JText::_(trim((string) $view[0]->message[0]));
 										}
 									}
 								}

--- a/components/com_contact/views/category/metadata.xml
+++ b/components/com_contact/views/category/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Category">
-		<message><![CDATA[Choose a contact category layout.]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_contact/views/contact/metadata.xml
+++ b/components/com_contact/views/contact/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Contact">
-		<message><![CDATA[Choose a contact layout.]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_contact/views/featured/metadata.xml
+++ b/components/com_contact/views/featured/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Frontpage">
-		<message><![CDATA[TYPEFEATUREDCONTACTLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_content/views/archive/metadata.xml
+++ b/components/com_content/views/archive/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Archive">
-		<message><![CDATA[TYPEARCHLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_content/views/article/metadata.xml
+++ b/components/com_content/views/article/metadata.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view
-		title="Article">
-		<message><![CDATA[TYPEARTICLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_content/views/category/metadata.xml
+++ b/components/com_content/views/category/metadata.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view
-		title="Category">
-		<message><![CDATA[TYPECATEGLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_content/views/featured/metadata.xml
+++ b/components/com_content/views/featured/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Frontpage">
-		<message><![CDATA[TYPEFRONTLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_content/views/form/metadata.xml
+++ b/components/com_content/views/form/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Form">
-		<message><![CDATA[TYPEARTICLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_finder/views/search/metadata.xml
+++ b/components/com_finder/views/search/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="COM_FINDER_MENU_SEARCH_VIEW_TITLE">
-		<message><![CDATA[COM_FINDER_MENU_SEARCH_VIEW_TEXT]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_newsfeeds/views/category/metadata.xml
+++ b/components/com_newsfeeds/views/category/metadata.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="COM_NEWSFEEDS_CATEGORY_GROUP_LABEL">
-		<message>
-			<![CDATA[COM_NEWSFEEDS_CATEGORY_GROUP_DESC]]>
-		</message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_newsfeeds/views/newsfeed/metadata.xml
+++ b/components/com_newsfeeds/views/newsfeed/metadata.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="NEWSFEEDS_NEWSFEED_INDIVIDUAL_FEED_LABEL">
-		<message>
-			<![CDATA[NEWSFEEDS_NEWSFEED_INDIVIDUAL_FEED_DESC]]>
-		</message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_search/views/search/metadata.xml
+++ b/components/com_search/views/search/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Search">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_users/views/login/metadata.xml
+++ b/components/com_users/views/login/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Login">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_users/views/profile/metadata.xml
+++ b/components/com_users/views/profile/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Profile">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_users/views/registration/metadata.xml
+++ b/components/com_users/views/registration/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Registration">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_users/views/remind/metadata.xml
+++ b/components/com_users/views/remind/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Remind">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_users/views/reset/metadata.xml
+++ b/components/com_users/views/reset/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Reset">
-		<message><![CDATA[TYPESEARCHDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_weblinks/views/category/metadata.xml
+++ b/components/com_weblinks/views/category/metadata.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view title="Category">
-		<message><![CDATA[TYPECATEGORYDESC]]></message>
-	</view>
+	<view />
 </metadata>

--- a/components/com_weblinks/views/form/metadata.xml
+++ b/components/com_weblinks/views/form/metadata.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<view
-		title="Form">
-		<message><![CDATA[TYPEARTICLAYDESC]]></message>
-	</view>
+	<view />
 </metadata>


### PR DESCRIPTION
The "Menu Manager: Menu Items" view currently shows the "Menu Item Type" as 

> "component" » "layout"

This commit will add the viewname to it as set in the metadata.xml:

> "component" » "view" » "layout"

Interesting enough the code currently requires the file present and this title set, but doesn't use it. So it's probably just an oversight.

This commit will also use the "message" set in the metadata.xml as fallback for the item type description if there is no "message" set in the layout file.
