### PR TITLE
Removing some 'DS' constants and fixing a form-id to 'adminForm'

### DIFF
--- a/administrator/components/com_finder/models/fields/directories.php
+++ b/administrator/components/com_finder/models/fields/directories.php
@@ -83,7 +83,7 @@ class JFormFieldDirectories extends JFormFieldList
 		// Convert the values to options.
 		for ($i = 0, $c = count($values); $i < $c; $i++)
 		{
-			$options[] = JHtml::_('select.option', str_replace(JPATH_SITE . '/', '', $values[$i]), str_replace(JPATH_SITE . DS, '', $values[$i]));
+			$options[] = JHtml::_('select.option', str_replace(JPATH_SITE . '/', '', $values[$i]), str_replace(JPATH_SITE . '/', '', $values[$i]));
 		}
 
 		// Add a null option.

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.formvalidation');
 JHtml::_('behavior.keepalive');
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_finder&view=filter&layout=edit&filter_id=' . (int) $this->item->filter_id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php?option=com_finder&view=filter&layout=edit&filter_id=' . (int) $this->item->filter_id); ?>" method="post" name="adminForm" id="adminForm" class="form-validate">
 
 	<div class="width-60 fltlft">
 		<fieldset class="adminform">

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -231,7 +231,7 @@ class LanguagesModelOverrides extends JModelList
 		$app = JFactory::getApplication();
 
 		// Parse the override.ini file in oder to get the keys and strings
-		$filename = constant('JPATH_'.strtoupper($this->getState('filter.client'))).DS.'language'.DS.'overrides'.DS.$this->getState('filter.language').'.override.ini';
+		$filename = constant('JPATH_'.strtoupper($this->getState('filter.client'))).'/language/overrides/'.$this->getState('filter.language').'.override.ini';
 		$strings = LanguagesHelper::parseFile($filename);
 
 		// Unset strings that shall be deleted
@@ -251,7 +251,7 @@ class LanguagesModelOverrides extends JModelList
 		$registry = new JRegistry;
 		$registry->loadObject($strings);
 
-		$filename = constant('JPATH_'.strtoupper($this->getState('filter.client'))).DS.'language'.DS.'overrides'.DS.$this->getState('filter.language').'.override.ini';
+		$filename = constant('JPATH_'.strtoupper($this->getState('filter.client'))).'/language/overrides/'.$this->getState('filter.language').'.override.ini';
 
 		if (!JFile::write($filename, $registry->toString('INI')))
 		{


### PR DESCRIPTION
Three fixes:
- 'DS' constants found in language overrides model -- changed to '/'
- 'DS' constant found in finder formfield -- changed to '/'
- ID of search filters edit form was 'item-form' -- changed to 'adminForm'
