### PR TITLE
Change the variable name on the submenu rendering to avoid conflicts

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -50,11 +50,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -43,14 +43,13 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
-					}
-				?>
+					}				?>
 				<hr />
 				<div class="filter-select">
 					<h4 class="page-header"><?php echo JText::_('JSEARCH_FILTER_LABEL');?></h4>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -40,11 +40,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -20,11 +20,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_cache/views/purge/tmpl/default.php
+++ b/administrator/components/com_cache/views/purge/tmpl/default.php
@@ -17,11 +17,11 @@ defined('_JEXEC') or die;
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -48,11 +48,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -18,11 +18,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_config/views/application/tmpl/default.php
+++ b/administrator/components/com_config/views/application/tmpl/default.php
@@ -30,11 +30,11 @@ JHtml::_('behavior.tooltip');
 				<?php echo $this->loadTemplate('navigation'); ?>
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -49,11 +49,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -50,11 +50,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -50,11 +50,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_finder/views/filters/tmpl/default.php
+++ b/administrator/components/com_finder/views/filters/tmpl/default.php
@@ -36,11 +36,11 @@ Joomla.submitbutton = function(pressbutton) {
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -47,11 +47,11 @@ Joomla.submitbutton = function(pressbutton) {
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -35,11 +35,11 @@ Joomla.submitbutton = function(pressbutton) {
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -17,12 +17,11 @@ defined('_JEXEC') or die;
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -29,12 +29,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -53,12 +53,11 @@ defined('_JEXEC') or die;
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -22,11 +22,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -29,12 +29,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -32,12 +32,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_installer/views/warnings/tmpl/default.php
+++ b/administrator/components/com_installer/views/warnings/tmpl/default.php
@@ -16,13 +16,12 @@ defined('_JEXEC') or die;
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module)
-				{
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
-
+					$params->loadString($submenumodule->params);
+					echo $output;
 				}
 			?>
 		</div>

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -26,11 +26,11 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					echo $this->loadTemplate('navigation');
 
 					// Display the submenu position modules
-					/* $this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					/* $this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					} */
 				?>

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -29,11 +29,11 @@ $saveOrder	= $listOrder == 'a.ordering';
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module) {
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -21,11 +21,11 @@ $listDirn		= $this->escape($this->state->get('list.direction')); ?>
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -50,11 +50,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -15,6 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 // Load the tooltip behavior.
 JHtml::_('behavior.tooltip');
 JHtml::_('behavior.multiselect');
+JHtml::_('behavior.modal');
 
 $uri = JUri::getInstance();
 $return = base64_encode($uri);
@@ -38,11 +39,11 @@ $modMenuId = (int) $this->get('ModMenuId');
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -47,11 +47,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -49,11 +49,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -47,11 +47,11 @@ $sortFields = $this->getSortFields();
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module) {
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -26,11 +26,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -25,11 +25,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module) {
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -27,11 +27,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div class="sidebar-nav">
 			<?php
 				// Display the submenu position modules
-				$this->modules = JModuleHelper::getModules('submenu');
-				foreach ($this->modules as $module) {
-					$output = JModuleHelper::renderModule($module);
+				$this->submenumodules = JModuleHelper::getModules('submenu');
+				foreach ($this->submenumodules as $submenumodule) {
+					$output = JModuleHelper::renderModule($submenumodule);
 					$params = new JRegistry;
-					$params->loadString($module->params);
+					$params->loadString($submenumodule->params);
 					echo $output;
 				}
 			?>

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -26,11 +26,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -26,11 +26,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -51,11 +51,11 @@ JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -29,11 +29,11 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -25,11 +25,11 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -27,11 +27,11 @@ $loggeduser = JFactory::getUser();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>

--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -46,11 +46,11 @@ $sortFields = $this->getSortFields();
 			<div class="sidebar-nav">
 				<?php
 					// Display the submenu position modules
-					$this->modules = JModuleHelper::getModules('submenu');
-					foreach ($this->modules as $module) {
-						$output = JModuleHelper::renderModule($module);
+					$this->submenumodules = JModuleHelper::getModules('submenu');
+					foreach ($this->submenumodules as $submenumodule) {
+						$output = JModuleHelper::renderModule($submenumodule);
 						$params = new JRegistry;
-						$params->loadString($module->params);
+						$params->loadString($submenumodule->params);
 						echo $output;
 					}
 				?>


### PR DESCRIPTION
$this->modules was already in use in some of the managers so switched it to $this->submenumodules in all the managers to avoid the conflicit.

JHtml::_('behavior.modal'); is also added to the menu manager so that the modal link to the modules will work
