### PR TITLE
Fix type attributes not required in html5. Thanks @nternetinspired

### DIFF
--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -129,7 +129,7 @@ class JDocumentRendererHead extends JDocumentRenderer
 		foreach ($document->_styleSheets as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '"';
-			if (!is_null($strAttr['mime']) && !$document->isHtml5())
+			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || $strAttr['mime'] != 'text/css'))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}
@@ -169,7 +169,10 @@ class JDocumentRendererHead extends JDocumentRenderer
 		foreach ($document->_scripts as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
-			if (!is_null($strAttr['mime']) && !$document->isHtml5())
+			$defaultMimes = array(
+					'text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript'
+			);
+			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultMimes)))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -128,10 +128,14 @@ class JDocumentRendererHead extends JDocumentRenderer
 		// Generate stylesheet links
 		foreach ($document->_styleSheets as $strSrc => $strAttr)
 		{
-			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '" type="' . $strAttr['mime'] . '"';
+			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '"';
+			if (!is_null($strAttr['mime']) && !$document->isHtml5())
+			{
+				$buffer .= ' type="' . $strAttr['mime'] . '"';
+			}
 			if (!is_null($strAttr['media']))
 			{
-				$buffer .= ' media="' . $strAttr['media'] . '" ';
+				$buffer .= ' media="' . $strAttr['media'] . '"';
 			}
 			if ($temp = JArrayHelper::toString($strAttr['attribs']))
 			{
@@ -165,7 +169,7 @@ class JDocumentRendererHead extends JDocumentRenderer
 		foreach ($document->_scripts as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
-			if (!is_null($strAttr['mime']))
+			if (!is_null($strAttr['mime']) && !$document->isHtml5())
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}


### PR DESCRIPTION
Issue reported by @nternetinspired in the template9 branch:
https://github.com/Joomla3-Admin-template/joomla-cms/issues/114

To enable the html5 mode in the template use:

```
JFactory::getDocument()->setHtml5(true);
```

The type attributes will dissappear.

Issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32162&start=0
