### PR TITLE
class JFile not found

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -250,6 +250,7 @@ class TemplatesModelTemplate extends JModelLegacy
 		$newName = strtolower($this->getState('new_name'));
 		$oldName = $this->getTemplate()->element;
 
+		jimport('joomla.filesystem.file');
 		foreach ($files as $file)
 		{
 			$newFile = str_replace($oldName, $newName, $file);


### PR DESCRIPTION
I've found a bug when you try to copy a template and are using cache handler diff from "file".

the JFile class are not loaded and got a Fatal Error.

Report trackert link in joomlacode.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28985

Cheers,

Julio Pontes

Ps.: Need to check this on 1.5.X
Ps.: This patch its only for 2.5.X series
