### PR TITLE
Fix JModel regex

### DIFF
--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -215,7 +215,7 @@ abstract class JModel extends JObject
 		{
 			$r = null;
 
-			if (!preg_match('/(.*)Model/i', get_class($this), $r))
+			if (!preg_match('/(^((?!Model).)*)Model/i', get_class($this), $r))
 			{
 				JError::raiseError(500, JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'));
 			}


### PR DESCRIPTION
The JModel regex that guesses option from model class name doesn't take
into account models that may end in the word "Model." ie: AutosModelModel

This new regex fixes that.
