### PR TITLE
Added support for multiple tabs with options in the template styles manager

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit_options.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_options.php
@@ -34,6 +34,9 @@ defined('_JEXEC') or die;
 			<?php endif; ?>
 		<?php endforeach; ?>
 		<?php echo $hidden_fields; ?>
-
-		<?php echo '</div>'; // .tab-pane div ?>
+		
+		<?php 
+			// Closing the .tab-pane div
+			echo '</div>'; 
+		?>
 	<?php endforeach; ?>

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -15,6 +15,8 @@ JHtml::_('behavior.formvalidation');
 JHtml::_('behavior.keepalive');
 $user = JFactory::getUser();
 $canDo = TemplatesHelper::getActions();
+$fieldsets = $this->form->getFieldsets('params');
+
 ?>
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
@@ -29,7 +31,14 @@ $canDo = TemplatesHelper::getActions();
 	<fieldset>
 		<ul class="nav nav-tabs">
 			<li class="active"><a href="#details" data-toggle="tab"><?php echo JText::_('JDETAILS');?></a></li>
-			<li><a href="#options" data-toggle="tab"><?php echo JText::_('JOPTIONS');?></a></li>
+			
+			<?php if (count($fieldsets)) : ?>
+				<?php foreach ($fieldsets as $fieldset) : ?>
+					<?php $label = !empty($fieldset->label) ? JText::_($fieldset->label) : JText::_('COM_TEMPLATES_'.$fieldset->name.'_FIELDSET_LABEL');?>
+					<li><a href="#options-<?php echo $fieldset->name; ?>" data-toggle="tab"><?php echo $label ?></a></li>
+				<?php endforeach; ?>
+			<?php endif; ?>
+			
 			<?php if ($user->authorise('core.edit', 'com_menu') && $this->item->client_id == 0):?>
 				<?php if ($canDo->get('core.edit.state')) : ?>
 						<li><a href="#assignment" data-toggle="tab"><?php echo JText::_('COM_TEMPLATES_MENUS_ASSIGNMENT');?></a></li>
@@ -97,10 +106,10 @@ $canDo = TemplatesHelper::getActions();
 					<div class="alert alert-error"><?php echo JText::_('COM_TEMPLATES_ERR_XML'); ?></div>
 				<?php endif; ?>
 			</div>
-			<div class="tab-pane" id="options">
+			
 				<?php //get the menu parameters that are automatically set but may be modified.
 					echo $this->loadTemplate('options'); ?>
-			</div>
+					
 			<?php if ($user->authorise('core.edit', 'com_menu') && $this->item->client_id == 0):?>
 				<?php if ($canDo->get('core.edit.state')) : ?>
 					<div class="tab-pane" id="assignment">

--- a/administrator/components/com_templates/views/style/tmpl/edit_options.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_options.php
@@ -9,12 +9,14 @@
 
 defined('_JEXEC') or die;
 
-$fieldSets = $this->form->getFieldsets('params');
+$fieldsets = $this->form->getFieldsets('params');
 
-foreach ($fieldSets as $name => $fieldSet) :
-	$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_TEMPLATES_'.$name.'_FIELDSET_LABEL';
-		if (isset($fieldSet->description) && trim($fieldSet->description)) :
-			echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
+foreach ($fieldsets as $name => $fieldset) :
+	echo '<div class="tab-pane" id="options-'.$name.'">';
+	
+	$label = !empty($fieldset->label) ? $fieldset->label : 'COM_TEMPLATES_'.$name.'_FIELDSET_LABEL';
+		if (isset($fieldset->description) && trim($fieldset->description)) :
+			echo '<p class="tip">'.$this->escape(JText::_($fieldset->description)).'</p>';
 		endif;
 		?>
 		<?php foreach ($this->form->getFieldset($name) as $field) : ?>
@@ -29,4 +31,6 @@ foreach ($fieldSets as $name => $fieldSet) :
 				</div>
 			</div>
 		<?php endforeach; ?>
+		
+	<?php echo '</div>'; // .tab-pane div ?>
 <?php endforeach;  ?>

--- a/administrator/components/com_templates/views/style/tmpl/edit_options.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_options.php
@@ -32,5 +32,8 @@ foreach ($fieldsets as $name => $fieldset) :
 			</div>
 		<?php endforeach; ?>
 		
-	<?php echo '</div>'; // .tab-pane div ?>
+	<?php 
+		// closing the .tab-pane div 
+		echo '</div>'; 
+	?>
 <?php endforeach;  ?>


### PR DESCRIPTION
Earlier the template style edit page showed always all options in the
one "Options" tab. Implementation is based on the edit view from the
com_modules manager.
