### PR TITLE
Joomla CMS [#29069] Sort by Status does not work

### DIFF
--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -81,7 +81,7 @@ $sortFields = $this->getSortFields();
 					<input type="checkbox" name="checkall-toggle" value="" title="<?php echo JText::_('JGLOBAL_CHECK_ALL'); ?>" onclick="Joomla.checkAll(this)" />
 				</th>
 				<th width="5%" class="center">
-					<?php echo JText::_('JSTATUS'); ?>
+					<?php echo JHtml::_('grid.sort', 'JSTATUS', 'enabled', $listDirn, $listOrder); ?>
 				</th>
 				<th class="title">
 					<?php echo JHtml::_('grid.sort', 'COM_PLUGINS_NAME_HEADING', 'name', $listDirn, $listOrder); ?>


### PR DESCRIPTION
Link to the tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29069

The bug:
Sort by Status does not work.  I can't click on the Status column in plugin
manager or module manager to sort by that column.
