### PR TITLE
Module save2copy dont work

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -893,7 +893,7 @@ class ModulesModelModule extends JModelAdmin
 		// Alter the title and published state for Save as Copy
 		if ($input->get('task') == 'save2copy')
 		{
-			$orig_data  = $this->input->post->get('jform', array(), 'array');
+			$orig_data  = $input->post->get('jform', array(), 'array');
 			$orig_table = clone($this->getTable());
 			$orig_table->load((int) $orig_data['id']);
 


### PR DESCRIPTION
(PHP Notice: Undefined property:ModulesModelModule::$input) > (Fatal error: Call to a member function get() on a non-object in .../administrator/components/com_modules/models/module.php on line 896)

On click 'Save as Copy' throws an error.
