### PR TITLE
Accordion fieldsets for template and category options like com_menus 

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -68,8 +68,6 @@ JHtml::_('behavior.keepalive');
 						<?php echo $this->form->getInput('description'); ?>
 					</div>
 				</div>
-			</div>
-			<div class="tab-pane" id="options">
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('extension'); ?>
@@ -78,46 +76,94 @@ JHtml::_('behavior.keepalive');
 						<?php echo $this->form->getInput('extension'); ?>
 					</div>
 				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('parent_id'); ?>
+
+				<div class="row-fluid">
+					<h4><?php echo JText::_('JDETAILS');?></h4>
+					<hr />
+
+					<div class="span6">
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('parent_id'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('parent_id'); ?>
+							</div>
+						</div>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('published'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('published'); ?>
+							</div>
+						</div>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('access'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('access'); ?>
+							</div>
+						</div>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('language'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('language'); ?>
+							</div>
+						</div>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('id'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('id'); ?>
+							</div>
+						</div>
 					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('parent_id'); ?>
+					<div class="span6">
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('created_user_id'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('created_user_id'); ?>
+							</div>
+						</div>
+						<?php if (intval($this->item->created_time)) : ?>
+							<div class="control-group">
+								<div class="control-label">
+									<?php echo $this->form->getLabel('created_time'); ?>
+								</div>
+								<div class="controls">
+									<?php echo $this->form->getInput('created_time'); ?>
+								</div>
+							</div>
+						<?php endif; ?>
+						<?php if ($this->item->modified_user_id) : ?>
+							<div class="control-group">
+								<div class="control-label">
+									<?php echo $this->form->getLabel('modified_user_id'); ?>
+								</div>
+								<div class="controls">
+									<?php echo $this->form->getInput('modified_user_id'); ?>
+								</div>
+							</div>
+							<div class="control-group">
+								<div class="control-label">
+									<?php echo $this->form->getLabel('modified_time'); ?>
+								</div>
+								<div class="controls">
+									<?php echo $this->form->getInput('modified_time'); ?>
+								</div>
+							</div>
+						<?php endif; ?>
 					</div>
 				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('published'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('published'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('access'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('access'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('language'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('language'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('id'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('id'); ?>
-					</div>
-				</div>
+			</div>
+			<div class="tab-pane" id="options">
 				<?php echo $this->loadTemplate('options'); ?>
 			</div>
 			<div class="tab-pane" id="metadata">
@@ -130,6 +176,7 @@ JHtml::_('behavior.keepalive');
 			<?php endif; ?>
 		</div>
 	</fieldset>
+
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_categories/views/category/tmpl/edit_options.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit_options.php
@@ -7,75 +7,41 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die; ?>
+defined('_JEXEC') or die;
+?>
+<?php
+	echo JHtml::_('bootstrap.startAccordion', 'categoryOptions', array('active' => 'collapse0'));
+	$fieldSets = $this->form->getFieldsets('params');
+	$i = 0;
 
-<div class="control-group">
-	<div class="control-label">
-		<?php echo $this->form->getLabel('created_user_id'); ?>
-	</div>
-	<div class="controls">
-		<?php echo $this->form->getInput('created_user_id'); ?>
-	</div>
-</div>
+	foreach ($fieldSets as $name => $fieldSet) :
+		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CATEGORIES_'.$name.'_FIELDSET_LABEL';
+		echo JHtml::_('bootstrap.addSlide', 'categoryOptions', JText::_($label), 'collapse' . $i++);
+			if (isset($fieldSet->description) && trim($fieldSet->description)) :
+				echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
+			endif;
+			?>
+				<?php foreach ($this->form->getFieldset($name) as $field) : ?>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $field->label; ?>
+						</div>
+						<div class="controls">
+							<?php echo $field->input; ?>
+						</div>
+					</div>
+				<?php endforeach; ?>
 
-<?php if (intval($this->item->created_time)) : ?>
-	<div class="control-group">
-		<div class="control-label">
-			<?php echo $this->form->getLabel('created_time'); ?>
-		</div>
-		<div class="controls">
-			<?php echo $this->form->getInput('created_time'); ?>
-		</div>
-	</div>
-<?php endif; ?>
-
-<?php if ($this->item->modified_user_id) : ?>
-	<div class="control-group">
-		<div class="control-label">
-			<?php echo $this->form->getLabel('modified_user_id'); ?>
-		</div>
-		<div class="controls">
-			<?php echo $this->form->getInput('modified_user_id'); ?>
-		</div>
-	</div>
-	<div class="control-group">
-		<div class="control-label">
-			<?php echo $this->form->getLabel('modified_time'); ?>
-		</div>
-		<div class="controls">
-			<?php echo $this->form->getInput('modified_time'); ?>
-		</div>
-	</div>
-<?php endif; ?>
-
-<?php $fieldSets = $this->form->getFieldsets('params');
-
-foreach ($fieldSets as $name => $fieldSet) :
-	$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CATEGORIES_'.$name.'_FIELDSET_LABEL';
-	if (isset($fieldSet->description) && trim($fieldSet->description)) :
-		echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
-	endif;
-	?>
-		<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-			<div class="control-group">
-				<div class="control-label">
-					<?php echo $field->label; ?>
-				</div>
-				<div class="controls">
-					<?php echo $field->input; ?>
-				</div>
-			</div>
-		<?php endforeach; ?>
-
-		<?php if ($name == 'basic'):?>
-			<div class="control-group">
-				<div class="control-label">
-					<?php echo $this->form->getLabel('note'); ?>
-				</div>
-				<div class="controls">
-					<?php echo $this->form->getInput('note'); ?>
-				</div>
-			</div>
-		<?php endif;?>
-
-<?php endforeach; ?>
+				<?php if ($name == 'basic'):?>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('note'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('note'); ?>
+						</div>
+					</div>
+				<?php endif;
+		echo JHtml::_('bootstrap.endSlide');
+	endforeach;
+echo JHtml::_('bootstrap.endAccordion');

--- a/administrator/components/com_templates/views/style/tmpl/edit_options.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_options.php
@@ -8,25 +8,29 @@
  */
 
 defined('_JEXEC') or die;
+?>
+<?php
+	echo JHtml::_('bootstrap.startAccordion', 'templatestyleOptions', array('active' => 'collapse0'));
+	$fieldSets = $this->form->getFieldsets('params');
+	$i = 0;
 
-$fieldSets = $this->form->getFieldsets('params');
-
-foreach ($fieldSets as $name => $fieldSet) :
-	$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_TEMPLATES_'.$name.'_FIELDSET_LABEL';
-		if (isset($fieldSet->description) && trim($fieldSet->description)) :
-			echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
-		endif;
-		?>
-		<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-			<div class="control-group">
-			<?php if (!$field->hidden) : ?>
-				<div class="control-label">
-					<?php echo $field->label; ?>
-				</div>
-			<?php endif; ?>
-				<div class="controls">
-					<?php echo $field->input; ?>
-				</div>
-			</div>
-		<?php endforeach; ?>
-<?php endforeach;  ?>
+	foreach ($fieldSets as $name => $fieldSet) :
+		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_TEMPLATES_'.$name.'_FIELDSET_LABEL';
+		echo JHtml::_('bootstrap.addSlide', 'templatestyleOptions', JText::_($label), 'collapse' . $i++);
+			if (isset($fieldSet->description) && trim($fieldSet->description)) :
+				echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
+			endif;
+			?>
+				<?php foreach ($this->form->getFieldset($name) as $field) : ?>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $field->label; ?>
+						</div>
+						<div class="controls">
+							<?php echo $field->input; ?>
+						</div>
+					</div>
+				<?php endforeach;
+		echo JHtml::_('bootstrap.endSlide');
+	endforeach;
+echo JHtml::_('bootstrap.endAccordion');

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -420,7 +420,7 @@ abstract class JHtmlBootstrap
 	 */
 	public static function endAccordion()
 	{
-		return '</div></div>';
+		return '</div>';
 	}
 
 	/**


### PR DESCRIPTION
Also included is a bootstrap.endAccordion markup fix. That destroies the layout (e.g. currently in the menu manger)

The pull request enables an accordion on category and template options. By default it looks like to make no sense, but if some extension extend fieldests with jform plugins then it will be mess.
