### PR TITLE
Cleaning out old JRegistry->getValue()

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -205,8 +205,8 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		$basename = basename($packageURL);
 
 		// Find the path to the temp directory and the local package
-		$jreg = JFactory::getConfig();
-		$tempdir = $jreg->getValue('config.tmp_path');
+		$config = JFactory::getConfig();
+		$tempdir = $config->get('tmp_path');
 		$target = $tempdir . '/' . $basename;
 
 		// Do we have a cached file?
@@ -278,7 +278,8 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		}
 
 		// Get the package name
-		$tempdir = JFactory::getConfig()->getValue('config.tmp_path');
+		$config = JFactory::getConfig();
+		$tempdir = $config->get('tmp_path');
 		$file  = $tempdir . '/' . $basename;
 
 		$filesize = @filesize($file);
@@ -648,8 +649,9 @@ ENDDATA;
 	public function cleanUp()
 	{
 		// Remove the update package
-		$jreg = JFactory::getConfig();
-		$tempdir = $jreg->getValue('config.tmp_path');
+		$config = JFactory::getConfig();
+		$tempdir = $config->get('tmp_path');
+
 		$file = JFactory::getApplication()->getUserState('com_joomlaupdate.file', null);
 		$target = $tempdir.'/'.$file;
 		if (!@unlink($target))


### PR DESCRIPTION
Com_joomlaupdate model uses JRegistry->getValue which is removed.

Search this file for getValue:
https://github.com/joomla/joomla-cms/blob/master/administrator/components/com_joomlaupdate/models/default.php#L209

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29186
