### PR TITLE
Fix RTL select issue including installation and modals

### DIFF
--- a/media/jui/css/chosen.css
+++ b/media/jui/css/chosen.css
@@ -127,7 +127,8 @@
 
 .chzn-container-single-nosearch .chzn-search input {
   position: absolute;
-  left: -9000px;
+  /* left: -9000px; JUI change: switch to top for rtl */
+  top: -9000px;
 }
 
 /* @group Multi Chosen */


### PR DESCRIPTION
Changed jquery's chosen.css file to go to top instead of left with the .chzn-container-single-nosearch .chzn-search input selector. Since this css file is loaded via jquery.php, it is loaded after the rtl css files in some cases. Therefore we need to do the fix within this file itself.
