### PR TITLE
com_contact cat. list view

### DIFF
--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -26,6 +26,10 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 			<a href="<?php echo JRoute::_(ContactHelperRoute::getCategoryRoute($item->id));?>">
 			<?php echo $this->escape($item->title); ?>
 			</a>
+            <?php if ($this->params->get('show_cat_items_cat') == 1) :?>
+            <span class="badge badge-info pull-right" title="<?php echo JText::_('COM_CONTACT_COUNT'); ?>"><?php echo $item->numitems; ?></span>
+            <?php endif; ?>
+        </h4>
 			<?php if ($this->params->get('show_subcat_desc_cat') == 1) :?>
 				<?php if ($item->description) : ?>
 					<small class="category-desc">
@@ -34,10 +38,6 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 				<?php endif; ?>
 	        <?php endif; ?>
 
-			<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
-					<span class="badge badge-info pull-right" title="<?php echo JText::_('COM_CONTACT_COUNT'); ?>"><?php echo $item->numitems; ?></span>
-			<?php endif; ?>
-		</h4>
 		<?php if(count($item->getChildren()) > 0) :
 			$this->items[$item->id] = $item->getChildren();
 			$this->parent = $item;

--- a/components/com_contact/views/category/tmpl/default_children.php
+++ b/components/com_contact/views/category/tmpl/default_children.php
@@ -24,6 +24,10 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) :
 		<?php $class = ''; ?>
 			<h4 class="item-title"><a href="<?php echo JRoute::_(ContactHelperRoute::getCategoryRoute($child->id));?>">
 				<?php echo $this->escape($child->title); ?></a>
+                <?php if ($this->params->get('show_cat_items') == 1) :?>
+                    <span class="badge badge-info pull-right" title="<?php echo JText::_('COM_CONTACT_CAT_NUM'); ?>"><?php echo $child->numitems; ?></span>
+                    <?php endif; ?>
+            </h4>
 				<?php if ($this->params->get('show_subcat_desc') == 1) :?>
 					<?php if ($child->description) : ?>
 						<small class="category-desc">
@@ -31,10 +35,7 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) :
 						</small>
 					<?php endif; ?>
 	            <?php endif; ?>
-	            <?php if ($this->params->get('show_cat_items') == 1) :?>
-					<span class="badge badge-info pull-right" title="<?php echo JText::_('COM_CONTACT_CAT_NUM'); ?>"><?php echo $child->numitems; ?></span>
-				<?php endif; ?>
-			</h4>
+
             <?php if(count($child->getChildren()) > 0 ) :
 				$this->children[$child->id] = $child->getChildren();
 				$this->category = $child;

--- a/components/com_content/views/category/tmpl/default_children.php
+++ b/components/com_content/views/category/tmpl/default_children.php
@@ -49,10 +49,8 @@ $class = ' class="first"';
 				$this->children[$child->id] = $child->getChildren();
 				$this->category = $child;
 				$this->maxLevel--;
-				if ($this->maxLevel != 0) :
-					echo $this->loadTemplate('children');
-				endif;
-				$this->category = $child->getParent();
+				echo $this->loadTemplate('children');
+                $this->category = $child->getParent();
 				$this->maxLevel++;
 				?>
 			</div>


### PR DESCRIPTION
simple change to fix category item number badge alignment with category titles in com_contact category list views.
Problem seen here: http://s3.amazonaws.com/awesome_screenshot/755255?AWSAccessKeyId=0R7FMW7AXRVCYMAPTPR2&Expires=1347762135&Signature=So8FTnXEnUutiwYi%2BFRxz6titB0%3D
