### PR TITLE
[#28956] No error message when saving a menu item with no title

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -35,13 +35,7 @@ JHtml::_('formbehavior.chosen', 'select');
 		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.id('item-form'))) {
 			Joomla.submitform(task, document.id('item-form'));
 		} else {
-			// special case for modal popups validation response
-			$$('#item-form .modal-value.invalid').each(function(field){
-				var idReversed = field.id.split("").reverse().join("");
-				var separatorLocation = idReversed.indexOf('_');
-				var name = idReversed.substr(separatorLocation).split("").reverse().join("")+'name';
-				document.id(name).addClass('invalid');
-			});
+		  alert('<?php echo $this->escape(JText::_('JGLOBAL_VALIDATION_FORM_FAILED'));?>');
 		}
 	}
 </script>


### PR DESCRIPTION
Replaced visual clue-only (adding "invalid" class) which was missing
from template anyway by simple alter box when trying to save a menu item
with an empty title
Note: template should have:
.invalid {
    color: red;
    font-weight: bold;
}

input.invalid {
    border: 1px solid red;
}
for the bad field(s) to be displayed. Also, I removed the JS to highlight invalid field, for consistency
