### PR TITLE
Media manager Directory doesn't update while browsing folders

### DIFF
--- a/media/media/js/popup-imagemanager.js
+++ b/media/media/js/popup-imagemanager.js
@@ -55,6 +55,9 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
+				if ( typeof jQuery !== 'undefined' && folderlist.className.test( /\bchzn-done\b/ )) {
+					jQuery( this.folderlist ).trigger( 'liszt:updated' );
+				}
 				break;
 			}
 		}
@@ -130,6 +133,9 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
+				if ( typeof jQuery !== 'undefined' && folderlist.className.test( /\bchzn-done\b/ )) {
+					jQuery( this.folderlist ).trigger( 'liszt:updated' );
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
Reason: popup manager alters folderlist element value directly, doesn't trigger 'change' event. Need to update chosen.jquery state manually.

Solution:
jQuery( folderlist ).trigger('liszt:updated');

Note:
Cannot use `jQuery(this.folderlist).trigger('change');`, as this would cause a loop (element is listening to change event -> Maximum call stack size exceeded)

Issue tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29252
