### PR TITLE
Update libraries/joomla/cache/cache.php

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -636,9 +636,11 @@ class JCache extends JObject
 	{
 		$app = JFactory::getApplication();
 		// Get url parameters set by plugins
-		$registeredurlparams = $app->registeredurlparams;
-
-		if (empty($registeredurlparams))
+		if (!empty($app->registeredurlparams))
+		{
+			$registeredurlparams = $app->registeredurlparams;
+		}
+		else
 		{
 			/*
 			$registeredurlparams = new stdClass;


### PR DESCRIPTION
Fix to "$registeredurlparams not found".

This is the same solution as in the similar bug fix https://github.com/joomla/joomla-cms/commit/0cb249a858b8da5eb5bc16fef92dd9d8bf0ad5c5

There appear to be no further instances of this problem in the libraries subdirectory.
