### PR TITLE
Add CONTRIBUTING.md file for GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+Contributing to the Joomla! CMS
+===============
+All contributions are welcome to be submitted for review for inclusion in the Joomla! CMS, but before they will be accepted, we ask that you follow these simple steps:
+
+1) Open an item on the Joomlacode tracker in the appropriate area.
+* CMS Bug Reports: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemBrowse&tracker_id=8103
+* CMS Feature Requests: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemBrowse&tracker_id=8549
+
+2) After submitting the item to the Joomlacode tracker, add a link to the Joomlacode tracker item and the GitHub issue or pull request.
+
+Please be patient as not all items will be tested immediately (remember, all bug testing for the Joomla! CMS is done by volunteers) and be receptive to feedback about your code.


### PR DESCRIPTION
Taking advantage of one of GitHub's new features, this adds a file for use on GitHub only with some simple instructions on contributing to the CMS.  See https://github.com/blog/1184-contributing-guidelines for its use.
