### PR TITLE
[#29302] Moving Accordion fix to bootstrap-extended

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5544,6 +5544,9 @@ fieldset.radio.btn-group {
 .btn-group .chzn-results {
 	white-space: normal;
 }
+.accordion-body.in:hover {
+	overflow: visible;
+}
 @font-face {
 	font-family: 'IcoMoon';
 	src: url('../../../../media/jui/fonts/IcoMoon.eot');

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -592,7 +592,9 @@ abstract class JHtmlBootstrap
 		// Load Bootstrap main CSS
 		if ($includeMainCss)
 		{
-			JHtml::_('stylesheet', 'media/jui/css/bootstrap.css', $attribs, false);
+			JHtml::_('stylesheet', 'media/jui/css/bootstrap.min.css', $attribs, false);
+			JHtml::_('stylesheet', 'media/jui/css/bootstrap-responsive.min.css', $attribs, false);
+			JHtml::_('stylesheet', 'media/jui/css/bootstrap-extended.css', $attribs, false);
 		}
 
 		// Load Bootstrap RTL CSS
@@ -600,8 +602,5 @@ abstract class JHtmlBootstrap
 		{
 			JHtml::_('stylesheet', 'media/jui/css/bootstrap-rtl.css', $attribs, false);
 		}
-
-		// Load Bootstrap CSS fixes
-		JHtml::_('stylesheet', 'media/cms/css/bootstrap.css', $attribs, false);
 	}
 }

--- a/media/cms/css/bootstrap.css
+++ b/media/cms/css/bootstrap.css
@@ -1,4 +1,0 @@
-/* Fix for #29223: ref: http://stackoverflow.com/questions/10959068/twitter-bootstrap-accordion-and-button-dropdown-overflow-issue */
-.accordion-body.in:hover {
-	overflow:visible;
-}

--- a/media/jui/css/bootstrap-extended.css
+++ b/media/jui/css/bootstrap-extended.css
@@ -434,3 +434,11 @@ fieldset.radio.btn-group {
 .width-auto {
   width: auto;
 }
+/* Chosen proper wrapping in Bootstrap btn-group */
+.btn-group .chzn-results {
+	white-space: normal;
+}
+/* Accordion overflow fix */
+.accordion-body.in:hover {
+	overflow:visible;
+}

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -424,3 +424,8 @@ fieldset.radio.btn-group {
 .btn-group .chzn-results {
 	white-space: normal;
 }
+
+/* Accordion overflow fix */
+.accordion-body.in:hover {
+	overflow:visible;
+}

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -5544,6 +5544,9 @@ fieldset.radio.btn-group {
 .btn-group .chzn-results {
 	white-space: normal;
 }
+.accordion-body.in:hover {
+	overflow: visible;
+}
 @font-face {
 	font-family: 'IcoMoon';
 	src: url('../../../media/jui/fonts/IcoMoon.eot');


### PR DESCRIPTION
This patch removes the need for an entire extra bootstrap.css file being load
for one style fix, and moves that style fix into
/media/jui/less/bootstrap-extended.less (and bootstrap-extended.css) which is
compiled into the template.css of Isis and Protostar

That extra file is also removed from being called in
/libraries/cms/html/bootstrap.php

Lastly, this patch adds extra files that are needed if you're not using LESS,
bootstrap-responsive.min.css and bootstrap-extended.css
