### PR TITLE
Adding red colour to invalid fields

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1146,6 +1146,13 @@ select:focus:required:invalid:focus {
 	-moz-box-shadow: 0 0 6px #f8b9b7;
 	box-shadow: 0 0 6px #f8b9b7;
 }
+.invalid {
+	color: #b94a48;
+	border-color: #ee5f5b !important;
+}
+label.invalid {
+	color: #ee5f5b;
+}
 .form-actions {
 	padding: 17px 20px 18px;
 	margin-top: 18px;


### PR DESCRIPTION
This pull requests adds red colour to invalid fields in the new backend template as it was in previous templates.

Here is the tracker item for that:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29305
