### PR TITLE
Add jui css files to the generatecss.php file

### DIFF
--- a/build/generatecss.php
+++ b/build/generatecss.php
@@ -49,6 +49,10 @@ class GenerateCss extends JApplicationCli
 	public function doExecute()
 	{
 		$templates = array(
+			JPATH_SITE . '/media/jui/less/bootstrap.less' => JPATH_SITE . '/media/jui/css/bootstrap.css',
+			JPATH_SITE . '/media/jui/less/responsive.less' => JPATH_SITE . '/media/jui/css/bootstrap-responsive.css',
+			JPATH_SITE . '/media/jui/less/bootstrap-rtl.less' => JPATH_SITE . '/media/jui/css/bootstrap-rtl.css',				
+			JPATH_SITE . '/media/jui/less/bootstrap-extended.less' => JPATH_SITE . '/media/jui/css/bootstrap-extended.css',				
 			JPATH_ADMINISTRATOR . '/templates/isis/less/template.less' => JPATH_ADMINISTRATOR . '/templates/isis/css/template.css',
 			JPATH_ADMINISTRATOR . '/templates/hathor/less/template.less' => JPATH_ADMINISTRATOR . '/templates/hathor/css/template.css',
 			JPATH_ADMINISTRATOR . '/templates/hathor/less/colour_blue.less' => JPATH_ADMINISTRATOR . '/templates/hathor/css/colour_blue.css',


### PR DESCRIPTION
If we have the generated css files in jui (which I think we should have) then we should add them to the list of files to be generated in the build.
