### PR TITLE
getComponentsWithConfig for Custom Components

### DIFF
--- a/administrator/components/com_config/helper/component.php
+++ b/administrator/components/com_config/helper/component.php
@@ -29,7 +29,7 @@ class ConfigHelperComponent
 	{
 		$db = JFactory::getDBO();
 		$query = $db->getQuery(true);
-		$query->select('name');
+		$query->select('element');
 		$query->from('#__extensions');
 		$query->where('type = ' . $db->quote('component'));
 		$query->where('enabled = 1');


### PR DESCRIPTION
getComponentsWithConfig does not work for custom components at the moment because the column 'name' is used in the database query instead of column 'element'.

Here is the tracker item for that:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29307
