### PR TITLE
Tracker #29353 - Smart Search Module Not Using Selected Filter 

### DIFF
--- a/modules/mod_finder/mod_finder.php
+++ b/modules/mod_finder/mod_finder.php
@@ -42,7 +42,7 @@ This code intentionally commented
 $params->def('field_size', 20);
 
 // Get the route.
-$route = FinderHelperRoute::getSearchRoute($params->get('f', null));
+$route = FinderHelperRoute::getSearchRoute($params->get('searchfilter', null));
 
 // Load component language file.
 FinderHelperLanguage::loadComponentLanguage();


### PR DESCRIPTION
JoomlaCode Tracker URL:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29353

The Smart Search module was not using the selected filter in the getSearchRoutecall.It is referencing a non-existent parameter 'f' when the filter is contained inthe parameter 'searchfilter'
When a static filter is selected in the module parameters, no hidden input iscreated to specify the 'f' option. This results in the filter not being appliedduring the search.
Changed line 46 from:

$route = FinderHelperRoute::getSearchRoute($params->get('f', null));
To:
$route = FinderHelperRoute::getSearchRoute($params->get('searchfilter',null));

And the hidden input is created and the search takes the filter into accountand restricts results based on the static filter.
Note: other references to $params->get('f') were fixed in tracker item #27933 butthis one was missed.
