### PR TITLE
Probably typo in default value for $selector

### DIFF
--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -28,7 +28,7 @@ abstract class modLoginHelper
 		$languages = array();
 		$languages = JLanguageHelper::createLanguageList(null, JPATH_ADMINISTRATOR, false, true);
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
-		return JHtml::_('select.genericlist', $languages, 'lang', ' class="inputbox advandedSelect"', 'value', 'text', null);
+		return JHtml::_('select.genericlist', $languages, 'lang', ' class="inputbox advancedSelect"', 'value', 'text', null);
 	}
 
 	/**

--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -36,7 +36,7 @@ abstract class JHtmlFormbehavior
 	 *
 	 * @since   3.0
 	 */
-	public static function chosen($selector = '.advandedSelect', $debug = null)
+	public static function chosen($selector = '.advancedSelect', $debug = null)
 	{
 		if (isset(self::$loaded[__METHOD__][$selector]))
 		{


### PR DESCRIPTION
The default classname for the $selector should probably be named "advancedSelect" and not "advandedSelect". I guess it's a typo.
