### PR TITLE
Fix fatal error sending Contact Form

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JFormHelper::loadFieldClass('email');
+JFormHelper::loadRuleClass('email');
 
 /**
  * JFormRule for com_contact to make sure the E-Mail adress is not blocked.


### PR DESCRIPTION
Contact was calling JFormHelper::loadFieldClass('email'); instead of JFormHelper::loadRuleClass('email');
