### PR TITLE
Adding CSS code for input-append and chosen select

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5518,6 +5518,24 @@ fieldset.radio.btn-group {
 .input-prepend .chzn-container-single .chzn-drop {
 	border-color: #ccc;
 }
+.input-append .chzn-container-single .chzn-single {
+	border-color: #ccc;
+	height: 26px;
+	-webkit-border-radius: 3px 0 0 3px;
+	-moz-border-radius: 3px 0 0 3px;
+	border-radius: 3px 0 0 3px;
+	-moz-box-shadow: none;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+}
+.input-append .chzn-container-active .chzn-single-with-drop {
+	-webkit-border-radius: 3px 0 0 3px;
+	-moz-border-radius: 3px 0 0 3px;
+	border-radius: 3px 0 0 3px;
+}
+.input-append .chzn-container-single .chzn-drop {
+	border-color: #ccc;
+}
 .input-prepend > .add-on,
 .input-append > .add-on {
 	vertical-align: top;


### PR DESCRIPTION
The CSS for the class "input-append" together with "chosen" selects was missing.
I took the one for the "input-prepend" class and changed the radius to be on the left side.
