### PR TITLE
fixed raw html in menu path

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -211,7 +211,7 @@ $sortFields = $this->getSortFields();
 						<div class="small" title="<?php echo $this->escape($item->path);?>">
 							<?php echo str_repeat('<span class="gtr">&mdash;</span>', $item->level - 1) ?>
 							<span title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
-								<?php echo $this->escape($item->item_type); ?></span>
+								<?php echo $item->item_type; ?></span>
 						</div>
 					</td>
 					<td class="center hidden-phone">


### PR DESCRIPTION
I use this in language sys file to show icon

``` ini
COM_COBALT="<i class="icon-puzzle"></i> Cobalt <b>8</b>"

CURLUSERLIST="<i class="icon-user"></i> User Articles"
CURLUSERLISTDESCR="list of user created articles or user homepage within the section"

CURLSYSNAME="Element type"
CURLSYSNAMEDESC="This field have to contain one of this values component, module, plugin or file."
```

I insert icon in to text and it it is shown

![image 2](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 12.50.59 PM.png)

And also when I start create new menu element

![image 1](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 12.51.42 PM.png)

But after I create it, it looks like this.

![image 3](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 12.50.33 PM.png)

It shows raw HTML. So i deleted `escape()`. Now it looks like this.

![image 4](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 12.50.08 PM.png)
