### PR TITLE
fixe multiple select size

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6017,10 +6017,6 @@ body.site.fluid {
 .accordion-group {
 	background: #fff;
 }
-.select[multiple],
-select[size] {
-	height: 28px;
-}
 .site-title {
 	font-size: 40px;
 	line-height: 48px;


### PR DESCRIPTION
In the protostar template there is CSS in `template.css`

``` css
.select[multiple],
select[size] {
    height: 28px;
}
```

This is result in 

![im2](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 7.11.35 PM.png)

instead of

![im1](http://serhioromano.s3.amazonaws.com/tmp/Screen Shot 2012-10-02 at 7.12.22 PM.png)

I think if select is multiple, it is ok if it accept the size by `size="5"` attribute

I have deleted this part from the template.
