### PR TITLE
[#29417] sendMail automatically adds sender as replyTo (Joomla! 2.5.x)

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -417,7 +417,6 @@ class JMail extends PHPMailer
 	public function sendMail($from, $fromName, $recipient, $subject, $body, $mode = false, $cc = null, $bcc = null, $attachment = null,
 		$replyTo = null, $replyToName = null)
 	{
-		$this->setSender(array($from, $fromName));
 		$this->setSubject($subject);
 		$this->setBody($body);
 
@@ -446,6 +445,10 @@ class JMail extends PHPMailer
 		{
 			$this->addReplyTo(array($replyTo, $replyToName));
 		}
+
+		// Add sender to replyTo only if no replyTo received
+		$autoReplyTo = (empty($this->ReplyTo)) ? true : false;
+		$this->setSender(array($from, $fromName, $autoReplyTo));
 
 		return $this->Send();
 	}


### PR DESCRIPTION
Patch for Joomla 2.5.X

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29417

Already sent to Platform: 
joomla/joomla-platform#1564
