### PR TITLE
Checking article alias

### DIFF
--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -176,7 +176,12 @@ function ContactParseRoute($segments)
 			{
 				$db = JFactory::getDBO();
 				$query = $db->getQuery(true);
-				$query->select('c.id')->from($db->quoteName('#__contact_details').' AS c')->where('c.catid = '.$vars['catid'])->where('c.alias = '.$db->Quote($segment));
+				
+				$query->select('c.id');
+				$query->from('#__contact_details AS c');
+				$query->where('c.catid = '.$vars['catid']);
+				$query->where('c.alias = '.$db->Quote($segment));
+
 				$db->setQuery($query);
 				$nid = $db->loadResult();
 			} else {

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -175,7 +175,8 @@ function ContactParseRoute($segments)
 			if($advanced)
 			{
 				$db = JFactory::getDBO();
-				$query = 'SELECT id FROM #__contact_details WHERE catid = '.$vars['catid'].' AND alias = '.$db->Quote($segment);
+				$query = $db->getQuery(true);
+				$query->select('c.id')->from($db->quoteName('#__contact_details').' AS c')->where('c.catid = '.$vars['catid'])->where('c.alias = '.$db->Quote($segment));
 				$db->setQuery($query);
 				$nid = $db->loadResult();
 			} else {

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -76,12 +76,13 @@ function ContentBuildRoute(&$query)
 				// Make sure we have the id and the alias
 				if (strpos($query['id'], ':') === false) {
 					$db = JFactory::getDbo();
-					$aquery = $db->setQuery(
-						$db->getQuery(true)
-						->select('alias')
-						->from('#__content')
-						->where('id=' . (int) $query['id'])
-					);
+					$query = $db->getQuery(true);
+
+					$query->select('alias');
+					$query->from('#__content');
+					$query->where('id=' . (int) $query['id']);
+
+					$db->setQuery($query);
 					$alias = $db->loadResult();
 					$query['id'] = $query['id'].':'.$alias;
 				}
@@ -245,7 +246,11 @@ function ContentParseRoute($segments)
 			return $vars;
 		} else {
 			$query = $db->getQuery(true);
-			$query->select('c.alias')->from($db->quote('#__content').' AS c')->where('c.id = ' . (int) $id);
+
+			$query->select('c.alias');
+			$query->from('#__content AS c');
+			$query->where('c.id = ' . (int) $id);
+
 			$db->setQuery($query);
 			$article = $db->loadObject();
 			
@@ -285,7 +290,11 @@ function ContentParseRoute($segments)
 		
 		if ($article_id) {
 			$query = $db->getQuery(true);
-			$query->select('c.alias, c.catid')->from($db->quote('#__content').' AS c')->where('c.id = ' . (int) $article_id);
+
+			$query->select('c.alias, c.catid');
+			$query->from('#__content AS c')
+			$query->where('c.id = ' . (int) $article_id);
+
 			$db->setQuery($query);
 			$article = $db->loadObject();
 		
@@ -339,7 +348,12 @@ function ContentParseRoute($segments)
 		if ($found == 0) {
 			if ($advanced) {
 				$query = $db->getQuery(true);
-				$query->select('c.id')->from($db->quote('#__content').' AS c')->where('c.catid = ' . (int) $vars['catid'])->where('c.alias = '.$db->Quote($segment));
+
+				$query->select('c.id');
+				$query->from('#__content AS c')
+				$query->where('c.catid = ' . (int) $vars['catid'])
+				$query->where('c.alias = '.$db->Quote($segment));
+
 				$db->setQuery($query);
 				$cid = $db->loadResult();
 			} else {

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -244,10 +244,11 @@ function ContentParseRoute($segments)
 
 			return $vars;
 		} else {
-			$query = 'SELECT alias, catid FROM #__content WHERE id = ' . (int) $id;
+			$query = $db->getQuery(true);
+			$query->select('c.alias')->from($db->quote('#__content').' AS c')->where('c.id = ' . (int) $id);
 			$db->setQuery($query);
 			$article = $db->loadObject();
-
+			
 			if ($article) {
 				if ($article->alias == $alias) {
 					$vars['view'] = 'article';
@@ -255,14 +256,16 @@ function ContentParseRoute($segments)
 					$vars['id'] = (int) $id;
 
 					return $vars;
-				} else {
+				}
+				else 
+				{
 					JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
 					return $vars;
 				}
 			}
 		}
 	}
-
+	
 	// if there was more than one segment, then we can determine where the URL points to
 	// because the first segment will have the target category id prepended to it.  If the
 	// last segment has a number prepended, it is an article, otherwise, it is a category.
@@ -279,9 +282,10 @@ function ContentParseRoute($segments)
 			$vars['view'] = 'category';
 			$vars['id'] = $cat_id;
 		}
-
+		
 		if ($article_id) {
-			$query = 'SELECT alias, catid FROM #__content WHERE id = ' . (int) $article_id;
+			$query = $db->getQuery(true);
+			$query->select('c.alias, c.catid')->from($db->quote('#__content').' AS c')->where('c.id = ' . (int) $article_id);
 			$db->setQuery($query);
 			$article = $db->loadObject();
 		
@@ -291,7 +295,9 @@ function ContentParseRoute($segments)
 				$vars['id'] = (int) $id;
 
 				return $vars;
-			} else {
+			}
+			else 
+			{
 				JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
 				return $vars;
 			}
@@ -303,7 +309,7 @@ function ContentParseRoute($segments)
 	// we get the category id from the menu item and search from there
 	$id = $item->query['id'];
 	$category = JCategories::getInstance('Content')->get($id);
-
+	
 	if (!$category) {
 		JError::raiseError(404, JText::_('COM_CONTENT_ERROR_PARENT_CATEGORY_NOT_FOUND'));
 		return $vars;
@@ -332,8 +338,8 @@ function ContentParseRoute($segments)
 
 		if ($found == 0) {
 			if ($advanced) {
-				$db = JFactory::getDBO();
-				$query = 'SELECT id FROM #__content WHERE catid = '.$vars['catid'].' AND alias = '.$db->Quote($segment);
+				$query = $db->getQuery(true);
+				$query->select('c.id')->from($db->quote('#__content').' AS c')->where('c.catid = ' . (int) $vars['catid'])->where('c.alias = '.$db->Quote($segment));
 				$db->setQuery($query);
 				$cid = $db->loadResult();
 			} else {

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -255,6 +255,9 @@ function ContentParseRoute($segments)
 					$vars['id'] = (int) $id;
 
 					return $vars;
+				} else {
+					JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
+					return $vars;
 				}
 			}
 		}
@@ -275,6 +278,23 @@ function ContentParseRoute($segments)
 		} else {
 			$vars['view'] = 'category';
 			$vars['id'] = $cat_id;
+		}
+
+		if ($article_id) {
+			$query = 'SELECT alias, catid FROM #__content WHERE id = ' . (int) $article_id;
+			$db->setQuery($query);
+			$article = $db->loadObject();
+		
+			if ($article->alias == $alias) {
+				$vars['view'] = 'article';
+				$vars['catid'] = (int) $article->catid;
+				$vars['id'] = (int) $id;
+
+				return $vars;
+			} else {
+				JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
+				return $vars;
+			}
 		}
 
 		return $vars;

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -350,8 +350,8 @@ function ContentParseRoute($segments)
 				$query = $db->getQuery(true);
 
 				$query->select('c.id');
-				$query->from('#__content AS c')
-				$query->where('c.catid = ' . (int) $vars['catid'])
+				$query->from('#__content AS c');
+				$query->where('c.catid = '.(int) $vars['catid']);
 				$query->where('c.alias = '.$db->Quote($segment));
 
 				$db->setQuery($query);

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -173,7 +173,12 @@ function NewsfeedsParseRoute($segments)
 			{
 				$db = JFactory::getDBO();
 				$query = $db->getQuery(true);
-				$query->select('c.id')->from($db->quoteName('#__newsfeeds').' AS c')->where('c.catid = '.$vars['catid'])->where('c.alias = '.$db->Quote($segment));
+
+				$query->select('c.id');
+				$query->from('#__newsfeeds AS c');
+				$query->where('c.catid = '.$vars['catid']);
+				$query->where('c.alias = '.$db->Quote($segment));
+
 				$db->setQuery($query);
 				$nid = $db->loadResult();
 			} else {

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -172,7 +172,8 @@ function NewsfeedsParseRoute($segments)
 			if($advanced)
 			{
 				$db = JFactory::getDBO();
-				$query = 'SELECT id FROM #__newsfeeds WHERE catid = '.$vars['catid'].' AND alias = '.$db->Quote($segment);
+				$query = $db->getQuery(true);
+				$query->select('c.id')->from($db->quoteName('#__newsfeeds').' AS c')->where('c.catid = '.$vars['catid'])->where('c.alias = '.$db->Quote($segment));
 				$db->setQuery($query);
 				$nid = $db->loadResult();
 			} else {

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -175,11 +175,9 @@ function UsersParseRoute($segments)
 	if (is_numeric($userId)) {
 		// Get the package id from the packages table by alias.
 		$db = JFactory::getDbo();
-		$db->setQuery(
-			'SELECT '.$db->quoteName('id') .
-			' FROM '.$db->quoteName('#__users') .
-			' WHERE '.$db->quoteName('id').' = '.(int) $userId
-		);
+		$query = $db->getQuery(true);
+		$query->select('u.id')->from($db->quote('#__users').' AS u')->where('u.id = '.(int) $userId);
+		$db->setQuery($query);
 		$userId = $db->loadResult();
 	}
 

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -176,7 +176,11 @@ function UsersParseRoute($segments)
 		// Get the package id from the packages table by alias.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
-		$query->select('u.id')->from($db->quote('#__users').' AS u')->where('u.id = '.(int) $userId);
+
+		$query->select('u.id');
+		$query->from('#__users AS u');
+		$query->where('u.id = '.(int) $userId);
+
 		$db->setQuery($query);
 		$userId = $db->loadResult();
 	}

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -177,7 +177,8 @@ function WeblinksParseRoute($segments)
 		if ($found == 0) {
 			if ($advanced) {
 				$db = JFactory::getDBO();
-				$query = 'SELECT id FROM #__weblinks WHERE catid = '.$vars['id'].' AND alias = '.$db->Quote(str_replace(':', '-', $segment));
+				$query = $db->getQuery(true);
+				$query->select('c.id')->from($db->quoteName('#__weblinks').' AS c')->where('c.catid = '.$vars['id'])->where('c.alias = '.$db->Quote(str_replace(':', '-', $segment)));
 				$db->setQuery($query);
 				$id = $db->loadResult();
 			}

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -178,7 +178,12 @@ function WeblinksParseRoute($segments)
 			if ($advanced) {
 				$db = JFactory::getDBO();
 				$query = $db->getQuery(true);
-				$query->select('c.id')->from($db->quoteName('#__weblinks').' AS c')->where('c.catid = '.$vars['id'])->where('c.alias = '.$db->Quote(str_replace(':', '-', $segment)));
+
+				$query->select('c.id');
+				$query->from('#__weblinks AS c');
+				$query->where('c.catid = '.$vars['id']);
+				$query->where('c.alias = '.$db->Quote(str_replace(':', '-', $segment)));
+
 				$db->setQuery($query);
 				$id = $db->loadResult();
 			}


### PR DESCRIPTION
The Joomla router allows site visitors to create fake URLs.

For example, adding index.php/component/content/article/1-write-your-message-here, where "1" is the ID of the article, will produce a fake URL.  "write-your-mesage-here" can be changed by anyone to anything, including offensive words, and make it appear that the site owner/administrator has generated the URL pattern when that's not the case.

As another example, category URLs can also be manipulated.  In Joomla 2.5's default sample data, the following URL (which is about Joomla) :
index.php/using-joomla/extensions/components/content-component/article-category-list/24-joomla

can be manipulated to:
http://yoursite/joomla/using-joomla/extensions/components/content-component/lets-use/24-wordpress

Note that, in the above example, both "article-category-list" and "joomla" have been manipulated.

Having such alternative links could be detrimental for SEO if a malicious user creates malicious URLs.  Furthermore, a site's reputation could be tainted by a malicious link if it appears to be coming from the site itself.
