### PR TITLE
Bootstrap's clearfix

### DIFF
--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -117,7 +117,7 @@ else
 		<div class="container<?php if ($params->get('fluidContainer')) { echo "-fluid"; } ?>">
 			<!-- Header -->
 			<div class="header">
-				<div class="header-inner">
+				<div class="header-inner clearfix">
 					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>">
 						<img src="<?php echo $logo;?>" alt="<?php echo $sitename; ?>" />
 					</a>
@@ -133,7 +133,6 @@ else
 						}
 						?>
 					</div>
-					<div class="clearfix"></div>
 				</div>
 			</div>
 			<div class="navigation">

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -135,14 +135,13 @@ else
 		<div class="container<?php if ($this->params->get('fluidContainer')) { echo "-fluid"; } ?>">
 			<!-- Header -->
 			<div class="header">
-				<div class="header-inner">
+				<div class="header-inner clearfix">
 					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>">
 						<?php echo $logo;?> <?php if ($this->params->get('sitedescription')) { echo '<div class="site-description">'. htmlspecialchars($this->params->get('sitedescription')) .'</div>'; } ?>
 					</a>
 					<div class="header-search pull-right">
 						<jdoc:include type="modules" name="position-0" style="none" />
 					</div>
-					<div class="clearfix"></div>
 				</div>
 			</div>
 			<?php if ($this->countModules('position-1')): ?>


### PR DESCRIPTION
 is meant to wrap floated elements, not follow them.

This is a fix for the protostar template but there are still many more cases of this throughout joomla.

A partial fix for this: 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29439
