### PR TITLE
Improve the appearance of codemirror 

### DIFF
--- a/media/editors/codemirror/css/codemirror.css
+++ b/media/editors/codemirror/css/codemirror.css
@@ -1,3 +1,17 @@
+.CodeMirror-wrapping {
+	/* Give some indication of the edge of the editor */
+	border: 1px solid #ddd;
+	/* Ensure that the width is correct whether padding for line numbers or not */
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+.CodeMirror-wrapping iframe {
+	/* Give the text area a slightly inset appearance */
+	box-shadow: inset 0 0 8px #ddd;	
+}
+
 .CodeMirror-line-numbers {
 	width: 2.2em;
 	color: #aaa;


### PR DESCRIPTION
by adding a border and using 'box-sizing: border-box;'

Fix for this: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29469
