### PR TITLE
Type check line 31, TemplatesHelper::getPositions

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit_positions.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_positions.php
@@ -28,7 +28,7 @@ foreach ($templates as $template)
 	$options = array();
 
 	$positions = TemplatesHelper::getPositions($clientId, $template);
-	foreach ($positions as $position)
+	if (is_array($positions)) foreach ($positions as $position)
 	{
 		$text = ModulesHelper::getTranslatedModulePosition($clientId, $template, $position) . ' [' . $position . ']';
 		$options[] = ModulesHelper::createOption($position, $text);


### PR DESCRIPTION
Dont know if you would call this a fix or not but checking if the $positions is an array removes the error displayed. I guess TemplatesHelper::getPositions doesnt allways return a proper result.
