### PR TITLE
Debug plugin system and empty object

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -304,6 +304,13 @@ class plgSystemDebug extends JPlugin
 						$entries = $o;
 						$display = false;
 					}
+					else
+					{
+						if (!method_exists($entries, '__toString'))
+						{
+							$entries = '<em>empty object</em>';
+						}
+					}
 				}
 
 				if (!$display)


### PR DESCRIPTION
Add a default value when the JArrayHelper::fromObject does not return a valid data.
The object might not have the __toString function so in some case there was a fatal error.
