### PR TITLE
Fix broken module installation in Postgresql because of NULL constraint

### DIFF
--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -466,9 +466,11 @@ class JInstallerModule extends JAdapterInstance
 			$name = preg_replace('#[\*?]#', '', JText::_($this->get('name')));
 			$module = JTable::getInstance('module');
 			$module->set('title', $name);
+			$module->set('content', '');
 			$module->set('module', $this->get('element'));
 			$module->set('access', '1');
 			$module->set('showtitle', '1');
+			$module->set('params', '');
 			$module->set('client_id', $clientId);
 			$module->set('language', '*');
 


### PR DESCRIPTION
In Postgresql, if we have a column (TEXT NOT NULL) and we do not specify the column in INSERT, Postgresql will assume that column's value is NULL while MySQL will take it as empty string ''
