### PR TITLE
Fix problems in the single contact custom rules

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -43,7 +43,7 @@ class JFormRuleContactEmail extends JFormRuleEmail
 		$banned = $params->get('banned_email');
 
 		foreach(explode(';', $banned) as $item){
-			if (JString::stristr($item, $value) !== false)
+			if (JString::stristr($value, $item) !== false)
 			{
 				return false;
 			}

--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -20,21 +20,22 @@ JFormHelper::loadRuleClass('email');
 class JFormRuleContactEmail extends JFormRuleEmail
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test for banned e-mail addresses
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
 	 * @param   mixed             $value     The form field value to validate.
 	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
 	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   object            $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   object            $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(SimpleXMLElement  $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
-		if(!parent::test($element, $value, $group, $input, $form)){
+		if(!parent::test($element, $value, $group, $input, $form))
+		{
 			return false;
 		}
 
@@ -43,7 +44,9 @@ class JFormRuleContactEmail extends JFormRuleEmail
 
 		foreach(explode(';', $banned) as $item){
 			if (JString::stristr($item, $value) !== false)
-					return false;
+			{
+				return false;
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -32,7 +32,7 @@ class JFormRuleContactEmail extends JFormRuleEmail
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(& $element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement  $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		if(!parent::test($element, $value, $group, $input, $form)){
 			return false;

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -20,17 +20,17 @@ class JFormRuleContactEmailMessage extends JFormRule
 	/**
 	 * Method to test for a valid color in hexadecimal.
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
 	 * @param   mixed             $value     The form field value to validate.
 	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
 	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   object            $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   object            $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(&$element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_text');

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -18,15 +18,15 @@ defined('_JEXEC') or die;
 class JFormRuleContactEmailMessage extends JFormRule
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test a message for banned words
 	 *
 	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
 	 * @param   mixed             $value     The form field value to validate.
 	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
 	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            $form     The form object for which the field is being tested.
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
@@ -35,9 +35,12 @@ class JFormRuleContactEmailMessage extends JFormRule
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_text');
 
-		foreach(explode(';', $banned) as $item){
+		foreach(explode(';', $banned) as $item)
+		{
 			if (JString::stristr($item, $value) !== false)
-					return false;
+			{
+				return false;
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -37,7 +37,7 @@ class JFormRuleContactEmailMessage extends JFormRule
 
 		foreach(explode(';', $banned) as $item)
 		{
-			if (JString::stristr($item, $value) !== false)
+			if (JString::stristr($value, $item) !== false)
 			{
 				return false;
 			}

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -37,7 +37,7 @@ class JFormRuleContactEmailSubject extends JFormRule
 
 		foreach(explode(';', $banned) as $item)
 		{
-			if (JString::stristr($item, $value) !== false)
+			if (JString::stristr($value, $item) !== false)
 			{
 				return false;
 			}

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -30,7 +30,7 @@ class JFormRuleContactEmailSubject extends JFormRule
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(&$element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_subject');

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -18,26 +18,29 @@ defined('_JEXEC') or die;
 class JFormRuleContactEmailSubject extends JFormRule
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test for a banned subject
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value     The form field value to validate.
-	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
-	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
-	 * @return  boolean  True if the value is valid, false otherwise.
+	 * @return  boolean  True if the value is valid, false otherwise
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_subject');
 
-		foreach(explode(';', $banned) as $item){
+		foreach(explode(';', $banned) as $item)
+		{
 			if (JString::stristr($item, $value) !== false)
-					return false;
+			{
+				return false;
+			}
 		}
 
 		return true;


### PR DESCRIPTION
1. The rules for banned email, text and subjects were not working due to a syntax error.
2. There were strict errors due to non matching signatures.
3. Some code style work

See

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28368
