### PR TITLE
Update media/jui/js/icomoon-lte-ie7.js

### DIFF
--- a/media/jui/js/icomoon-lte-ie7.js
+++ b/media/jui/js/icomoon-lte-ie7.js
@@ -147,7 +147,7 @@ window.onload = function() {
 		}
 		c = el.className;
 		c = c.match(/icon-[^\s'"]+/);
-		if (c && icons[c[0]] != null) {
+		if (c && typeof icons[c[0]] != "undefined") {
 			addIcon(el, icons[c[0]]);
 		}
 	}

--- a/media/jui/js/icomoon-lte-ie7.js
+++ b/media/jui/js/icomoon-lte-ie7.js
@@ -146,8 +146,8 @@ window.onload = function() {
 			addIcon(el, attr);
 		}
 		c = el.className;
-		c = c.match(/icon-[^s'"]+/);
-		if (c) {
+		c = c.match(/icon-[^\s'"]+/);
+		if (c && icons[c[0]] != null) {
 			addIcon(el, icons[c[0]]);
 		}
 	}


### PR DESCRIPTION
Fixed broken javascript regular expression (whitespace instead of "s") and added a check, if the icon really exists in the icons array (or we get some strange empty span tags for example icon-white in the search button)
