### PR TITLE
PosgreSQL: Error when saving  

### DIFF
--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -144,7 +144,7 @@ class JTableMenu extends JTableNested
 
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Menu', 'JTable', array('dbo' => $this->getDbo()));
-		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'client_id' => $this->client_id, 'language' => $this->language))
+		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'client_id' => (int)$this->client_id, 'language' => $this->language))
 			&& ($table->id != $this->id || $this->id == 0))
 		{
 			if ($this->menutype == $table->menutype)


### PR DESCRIPTION
When saving a menu item on Postgres, you receive a message like this:
JLIB_DATABASE_QUERY_FAILED SQL=SELECT \* FROM e3xoe_menu WHERE "alias"
= 'article#1' AND "parent_id" = '1' AND "client_id" = ''
AND "language" = '*'

See:

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29220
