### PR TITLE
 [#29567] UTF8 SEF URLs are caucing browser too many redirects failures

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -208,7 +208,7 @@ class ContentControllerArticle extends JControllerForm
 		}
 
 		if ($return) {
-			$append .= '&return='.base64_encode($return);
+			$append .= '&return='.base64_encode(urlencode($return));
 		}
 
 		return $append;
@@ -226,11 +226,11 @@ class ContentControllerArticle extends JControllerForm
 	{
 		$return = $this->input->get('return', null, 'base64');
 
-		if (empty($return) || !JUri::isInternal(base64_decode($return))) {
+		if (empty($return) || !JUri::isInternal(urldecode(base64_decode($return))) {
 			return JURI::base();
 		}
 		else {
-			return base64_decode($return);
+			return urldecode(base64_decode($return));
 		}
 	}
 

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -23,7 +23,7 @@ class JHtmlIcon
 	{
 		$uri = JURI::getInstance();
 
-		$url = 'index.php?option=com_content&task=article.add&return='.base64_encode($uri).'&a_id=0&catid=' . $category->id;
+		$url = 'index.php?option=com_content&task=article.add&return='.base64_encode(urlencode($uri)).'&a_id=0&catid=' . $category->id;
 
 		if ($params->get('show_icons')) {
 			$text = '<i class="icon-plus"></i> ' . JText::_('JNEW') . '&#160;';
@@ -101,7 +101,7 @@ class JHtmlIcon
 			return '<span class="hasTip" title="'.htmlspecialchars($tooltip, ENT_COMPAT, 'UTF-8').'">'.$button.'</span>';
 		}
 
-		$url	= 'index.php?option=com_content&task=article.edit&a_id='.$article->id.'&return='.base64_encode($uri);
+		$url	= 'index.php?option=com_content&task=article.edit&a_id='.$article->id.'&return='.base64_encode(urlencode($uri));
 
 		if ($article->state == 0) {
 					$overlib = JText::_('JUNPUBLISHED');

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -39,7 +39,7 @@ class ContentModelForm extends ContentModelArticle
 		$this->setState('article.catid', $app->input->getInt('catid'));
 
 		$return = $app->input->get('return', null, 'base64');
-		$this->setState('return_page', base64_decode($return));
+		$this->setState('return_page', urldecode(base64_decode($return)));
 
 		// Load the parameters.
 		$params	= $app->getParams();
@@ -129,6 +129,6 @@ class ContentModelForm extends ContentModelArticle
 	 */
 	public function getReturnPage()
 	{
-		return base64_encode($this->getState('return_page'));
+		return base64_encode(urlencode($this->getState('return_page')));
 	}
 }


### PR DESCRIPTION
This pull request addresses issue:
 [#29567] UTF8 SEF URLs are caucing browser too many redirects failures

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=11410&tracker_item_id=29567
