### PR TITLE
Fix "where" clause for query on table "updates": integer column "client_id", use "0" instead of ""

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -646,7 +646,7 @@ ENDDATA;
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
 		$uid = $update->find(
-			array('element' => $element, 'type' => 'file', 'client_id' => '', 'folder' => '')
+			array('element' => $element, 'type' => 'file', 'client_id' => 0, 'folder' => '')
 		);
 
 		if ($uid)


### PR DESCRIPTION
Fix "invalid input syntax for integer" (PostgreSQL)

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29680
