### PR TITLE
Cache returning incorrect content for Featured Articles (CMS#29686)

### DIFF
--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -71,10 +71,13 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
-		$model = $this->getModel('featured');
-		$categories = $model->getState('filter.frontpage.categories');
-		JRequest::setVar('categories', $categories);
-		$safeurlparams['categories'] = 'ARRAY';
+		if ($vName == 'featured')
+		{
+			$model = $this->getModel('featured');
+			$categories = $model->getState('filter.frontpage.categories');
+			JRequest::setVar('categories', $categories);
+			$safeurlparams['categories'] = 'ARRAY';
+		}
 
 		parent::display($cachable, $safeurlparams);
 

--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -71,6 +71,11 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
+		$model = $this->getModel('featured');
+		$categories = $model->getState('filter.frontpage.categories');
+		JRequest::setVar('categories', $categories);
+		$safeurlparams['categories'] = 'ARRAY';
+
 		parent::display($cachable, $safeurlparams);
 
 		return $this;


### PR DESCRIPTION
Fix for Joomla 2.5 - when cache is on, featured articles menu item doesn't filter categories currectly.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29686
