### PR TITLE
Fix icon display in protostar pagination

### DIFF
--- a/templates/protostar/html/pagination.php
+++ b/templates/protostar/html/pagination.php
@@ -177,7 +177,7 @@ function pagination_item_active(&$item)
 		$display = $item->text;
 	}
 
-	return "<li><a title=\"" . $item->text . "\" href=\"" . $item->link . "\" class=\"pagenav\">" . $item->text . "</a><li>";
+	return "<li><a title=\"" . $item->text . "\" href=\"" . $item->link . "\" class=\"pagenav\">" . $display . "</a><li>";
 }
 
 /**


### PR DESCRIPTION
change link text from "$item->text" to "$display" to display icons instead of text for active pagination items. ($display was not used for the output before)
