### PR TITLE
[#29738] "Weblinks Hits Display when set to hide"

### DIFF
--- a/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/components/com_weblinks/views/category/tmpl/default_items.php
@@ -59,7 +59,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<?php else: ?>
 						<li class="cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>
-					<?php if ($this->params->get('list_show_hits', 1)) : ?>
+					<?php if ($this->params->get('show_link_hits', 1)) : ?>
 						<span class="list-hits badge badge-info pull-right">
 							<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
 						</span>


### PR DESCRIPTION
This is fix proposed by Glenn Arkell in this ticket:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29738
