### PR TITLE
[#29321] Fixed hiding items from dropdown menu in during assigning modules to pages

### DIFF
--- a/media/jui/js/treeselectmenu.jquery.js
+++ b/media/jui/js/treeselectmenu.jquery.js
@@ -53,6 +53,10 @@ jQuery(function($)
 		var text = $(this).val().toLowerCase();
 		$('.treeselect li').each(function()
 		{
+			if( $( this ).is( 'ul.dropdown-menu li' ) ) {
+				return;
+			}
+
 			if ($(this).text().toLowerCase().indexOf(text) == -1) {
 				$(this).hide();
 			}


### PR DESCRIPTION
Fixed issue with hiding items in dropdown menu when selecting pages for modul to display and using search feature

Here is the original ticket:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29321

There is also a need to generate new file treeselectmenu.jquery.min.js, but I dont know how, so If anybody can do it or post instructions in here.
