### PR TITLE
Update libraries/joomla/document/feed/renderer/rss.php

### DIFF
--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -72,7 +72,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		$feed = "<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">\n";
 		$feed .= "	<channel>\n";
 		$feed .= "		<title>" . $feed_title . "</title>\n";
-		$feed .= "		<description>" . $data->description . "</description>\n";
+    		$feed .= "              <description><![CDATA[" . $data->description . "]]></description>\n";
 		$feed .= "		<link>" . str_replace(' ', '%20', $url . $data->link) . "</link>\n";
 		$feed .= "		<lastBuildDate>" . htmlspecialchars($now->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
 		$feed .= "		<generator>" . $data->getGenerator() . "</generator>\n";


### PR DESCRIPTION
Fix for:
RSS feed gets corrupted when ampersand (&) or other escapable characters exist in Site Meta Description

Bug filed here:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29731

Bug also submitted (and now merged) to Joomla platform:
https://github.com/joomla/joomla-platform/pull/1716
https://github.com/joomla/joomla-platform/pull/1716.patch
https://github.com/joomla/joomla-platform/pull/1716.diff
