### PR TITLE
Added the trim() function to the URL that is used as the update

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -203,7 +203,7 @@ class JUpdaterCollection extends JUpdateAdapter
 	 */
 	public function findUpdate($options)
 	{
-		$url = $options['location'];
+		$url = trim($options['location']);
 		$this->_update_site_id = $options['update_site_id'];
 		if (substr($url, -4) != '.xml')
 		{

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -141,7 +141,7 @@ class JUpdaterExtension extends JUpdateAdapter
 	 */
 	public function findUpdate($options)
 	{
-		$url = $options['location'];
+		$url = trim($options['location']);
 		$this->_url = &$url;
 		$this->_update_site_id = $options['update_site_id'];
 		if (substr($url, -4) != '.xml')


### PR DESCRIPTION
source. A forgotten small whitespace after the URL in the XML file may
throw a confusing error message.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29791&tracker_id=29791
