### PR TITLE
Wrong classname was used. 

### DIFF
--- a/libraries/joomla/log/logger/callback.php
+++ b/libraries/joomla/log/logger/callback.php
@@ -19,10 +19,10 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Log
  * @since       12.2
  */
-class JLoggerCallback extends JLogLogger
+class JLogLoggerCallback extends JLogLogger
 {
 	/**
-	 * @var    callback  The function to call when an entry is added - should return True on success
+	 * @var    callable  The function to call when an entry is added - should return True on success
 	 * @since  12.2
 	 */
 	protected $callback;
@@ -46,7 +46,7 @@ class JLoggerCallback extends JLogLogger
 		}
 		else
 		{
-			throw new JLogException(JText::_('JLoggerCallback created without valid callback function.'));
+			throw new JLogException(JText::_('JLogLoggerCallback created without valid callback function.'));
 		}
 	}
 


### PR DESCRIPTION
This fix has already been implemented in the platform. I think it can be included in the cms before the next full platform update as it causes crashes in its current state.
