### PR TITLE
Improve ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
-*~
-/.project
-/.settings
-/.buildpath
+# IDE & System Related Files #
+.buildpath
+.project
+.settings
+.DS_Store
+.idea
+
+# Local System Files (i.e. cache, logs, etc.) #
+/administrator/cache
+/cache
+/logs
+/tmp
 /configuration.php
+/.htaccess
+/web.config
+
+# Test Related Files #
+/phpunit.xml

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+# Ignore test report folders so they do not push to the repo #
+/coverage
+/logs
+/pdepend


### PR DESCRIPTION
This is an improved .gitignore structure to better ensure we aren't accidentally pushing files to the repository that we don't want unless explicitly overriding at commit.  This adds the cache, logs, and tmp folders, ignores a customized phpunit.xml (used for unit testing), .htaccess, or web.config file, and adds a .gitignore to the build folder to ignore the folders that reports get generated into.
