### PR TITLE
[#29864] Many properties missing when triggering onContentPrepare

### DIFF
--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -74,6 +74,9 @@ class ContentViewCategory extends JViewLegacy
 		$numIntro	= $params->def('num_intro_articles', 4);
 		$numLinks	= $params->def('num_links', 4);
 
+		$dispatcher = JDispatcher::getInstance();
+		JPluginHelper::importPlugin('content');
+		
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
@@ -87,10 +90,9 @@ class ContentViewCategory extends JViewLegacy
 
 			$item->event = new stdClass();
 
-			$dispatcher = JDispatcher::getInstance();
-
-			$item->introtext = JHtml::_('content.prepare', $item->introtext, '', 'com_content.category');
-
+			$item->text	 = $item->introtext;
+			$dispatcher->trigger('onContentPrepare', array('com_content.category', &$item, &$item->params, 0));
+			
 			$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, 0));
 			$item->event->afterDisplayTitle = trim(implode("\n", $results));
 

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -55,6 +55,9 @@ class ContentViewFeatured extends JViewLegacy
 		$numIntro = $params->def('num_intro_articles', 4);
 		$numLinks = $params->def('num_links', 4);
 
+		$dispatcher = JDispatcher::getInstance();
+		JPluginHelper::importPlugin('content');
+		
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($items as $i => & $item)
 		{
@@ -68,9 +71,8 @@ class ContentViewFeatured extends JViewLegacy
 
 			$item->event = new stdClass();
 
-			$dispatcher = JDispatcher::getInstance();
-
-			$item->introtext = JHtml::_('content.prepare', $item->introtext, '', 'com_content.featured');
+			$item->text  = $item->introtext;
+			$dispatcher->trigger('onContentPrepare', array('com_content.featured', &$item, &$item->params, 0));
 
 			$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, 0));
 			$item->event->afterDisplayTitle = trim(implode("\n", $results));


### PR DESCRIPTION
Joomla! Content (com_content) views "Featured" and "Category," when the system triggers onContentPrepare, provide only intro text.
But many "Content Plugins" need more than the intro text. So I made a few changes, and now the system provides full object.

Here you are a link to the record on Joomla! code tracker.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29864
