### PR TITLE
Fixing JHtmlBootstrap tabs / panels

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -531,8 +531,9 @@ abstract class JHtmlBootstrap
 			self::$loaded[__METHOD__][$sig] = true;
 			self::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
 		}
-
-		return '<div class="tab-content" id="' . $selector . 'Content">';
+                $html = '<ul class="nav nav-tabs" id="' . $selector . 'Tabs"></ul>';
+		$html .= '<div class="tab-content" id="' . $selector . 'Content">';
+		return $html;
 	}
 
 	/**
@@ -552,15 +553,27 @@ abstract class JHtmlBootstrap
 	 *
 	 * @param   string  $selector  Identifier of the panel.
 	 * @param   string  $id        The ID of the div element
+	 * @param   string  $title     The title text for the new UL tab	
 	 *
 	 * @return  string  HTML to start a new panel
 	 *
 	 * @since   3.0
 	 */
-	public static function addPanel($selector, $id)
+	public static function addPanel($selector, $id, $title)
 	{
 		$active = (self::$loaded['JHtmlBootstrap::startPane'][$selector]['active'] == $id) ? ' active' : '';
 
+		// Inject tab into UL
+		JFactory::getDocument()->addScriptDeclaration(
+			"(function($){
+				$(document).ready(function() {
+					// Handler for .ready() called.
+					var tab = $('<li class=\"$active\"><a href=\"#$id\" data-toggle=\"tab\">$title</a></li>');
+					$('#".$selector."Tabs').append(tab);
+				});	
+			})(jQuery);"
+		);
+			
 		return '<div id="' . $id . '" class="tab-pane' . $active . '">';
 	}
 


### PR DESCRIPTION
add ul for tabs to the startPane function-- otherwise there's no controls
added javascript to addPanel function to inject new li tab into bootstrap tabs

joomlacode tracker link: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29786
