### PR TITLE
[#29875] fixed body tag output in Protostar for layout, task, itemid classes when not applicable

### DIFF
--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -110,11 +110,18 @@ else
 	<![endif]-->
 </head>
 
-<body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " ";?> <?php if ($params->get('fluidContainer')) { echo "fluid"; } ?>">
+<body class="site 
+<?php echo $option 
+	. ' view-' . $view
+	. ($layout ? ' layout-' . $layout : ' no-layout')
+	. ($task ? ' task-' . $task : ' no-task')
+	. ($itemid ? ' itemid-' . $itemid : '')
+	. ($params->get('fluidContainer') ? ' fluid' : '');
+?>">
 
 	<!-- Body -->
 	<div class="body">
-		<div class="container<?php if ($params->get('fluidContainer')) { echo "-fluid"; } ?>">
+		<div class="container<?php echo ($params->get('fluidContainer') ? ' fluid' : '');?>">
 			<!-- Header -->
 			<div class="header">
 				<div class="header-inner clearfix">
@@ -193,7 +200,7 @@ else
 	</div>
 	<!-- Footer -->
 	<div class="footer">
-		<div class="container<?php if ($params->get('fluidContainer')) { echo "-fluid"; } ?>">
+		<div class="container<?php echo ($params->get('fluidContainer') ? ' fluid' : '');?>">
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right"><a href="#top" id="back-top"><?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?></a></p>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -110,8 +110,7 @@ else
 	<![endif]-->
 </head>
 
-<body class="site 
-<?php echo $option 
+<body class="site <?php echo $option
 	. ' view-' . $view
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+// Getting params from template
+$params = JFactory::getApplication()->getTemplate(true)->params;
+
 $app = JFactory::getApplication();
 $doc = JFactory::getDocument();
 $this->language = $doc->language;
@@ -129,10 +132,18 @@ else
 	<![endif]-->
 </head>
 
-<body class="site <?php echo $option . " view-" . $view . ($layout ? " layout-" . $layout : " no-layout") . ($task ? " task-" . $task : " no-task") . ($itemid ? " itemid-" . $itemid : ""); ?> <?php if ($this->params->get('fluidContainer')) { echo "fluid"; } ?>">
+<body class="site 
+<?php echo $option 
+	. ' view-' . $view
+	. ($layout ? ' layout-' . $layout : ' no-layout')
+	. ($task ? ' task-' . $task : ' no-task')
+	. ($itemid ? ' itemid-' . $itemid : '')
+	. ($params->get('fluidContainer') ? ' fluid' : '');
+?>">
+
 	<!-- Body -->
 	<div class="body">
-		<div class="container<?php if ($this->params->get('fluidContainer')) { echo "-fluid"; } ?>">
+		<div class="container<?php echo ($params->get('fluidContainer') ? ' fluid' : '');?>">
 			<!-- Header -->
 			<div class="header">
 				<div class="header-inner clearfix">
@@ -180,7 +191,7 @@ else
 	</div>
 	<!-- Footer -->
 	<div class="footer">
-		<div class="container<?php if ($this->params->get('fluidContainer')) { echo "-fluid"; } ?>">
+		<div class="container<?php echo ($params->get('fluidContainer') ? ' fluid' : '');?>">
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right"><a href="#top" id="back-top"><?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?></a></p>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -132,8 +132,7 @@ else
 	<![endif]-->
 </head>
 
-<body class="site 
-<?php echo $option 
+<body class="site <?php echo $option
 	. ' view-' . $view
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -129,7 +129,7 @@ else
 	<![endif]-->
 </head>
 
-<body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " ";?> <?php if ($this->params->get('fluidContainer')) { echo "fluid"; } ?>">
+<body class="site <?php echo $option . " view-" . $view . ($layout ? " layout-" . $layout : " no-layout") . ($task ? " task-" . $task : " no-task") . ($itemid ? " itemid-" . $itemid : ""); ?> <?php if ($this->params->get('fluidContainer')) { echo "fluid"; } ?>">
 	<!-- Body -->
 	<div class="body">
 		<div class="container<?php if ($this->params->get('fluidContainer')) { echo "-fluid"; } ?>">


### PR DESCRIPTION
Protostar classes layout and task output incomplete if not layout or task. If no layout or task assigned, outputs: layout- and task- respectively. Also outputs itemid- on views that are not a menu item.

Added if/else to output 'layout-' or if not available 'no-layout'. Same for 'task-'. For itemid, if not a menu item, itemid- should not show up.

`<body class="site <?php echo $option . " view-" . $view . ($layout ? " layout-" . $layout : " no-layout") . ($task ? " task-" . $task : " no-task") . ($itemid ? " itemid-" . $itemid : ""); ?> <?php if ($this->params->get('fluidContainer')) { echo "fluid"; } ?>">`

Tracker item created at: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29858
