### PR TITLE
Default Error handling should be with custom error page as defined in

### DIFF
--- a/includes/framework.php
+++ b/includes/framework.php
@@ -38,7 +38,7 @@ require_once JPATH_LIBRARIES.'/import.legacy.php';
 
 JError::setErrorHandling(E_NOTICE, 'message');
 JError::setErrorHandling(E_WARNING, 'message');
-JError::setErrorHandling(E_ERROR, 'message', array('JError', 'customErrorPage'));
+JError::setErrorHandling(E_ERROR, 'callback', array('JError', 'customErrorPage'));
 
 // Botstrap the CMS libraries.
 require_once JPATH_LIBRARIES.'/cms.php';


### PR DESCRIPTION
The call to JError::setErrorHandling(E_ERROR, 'message', array('JError', 'customErrorPage')); found at the start of includes/framework si wrong, should be 'callback' instead of 'message' so that 404s are handled by the system default error page.
This is usually not visible by users, because the Redirect system plugin eventually calls JError::customErrorPage($error);

However, if that plugin is disabled, the the 404 error page complety breaks, displaying warning and notices, and no 404 error message at all

It appears problem was the same in J 2.5
