### PR TITLE
[29931] Problem with page_title in application.php

### DIFF
--- a/includes/application.php
+++ b/includes/application.php
@@ -380,7 +380,6 @@ final class JSite extends JApplication
 				$title = $temp->get('page_title', $title);
 			}
 
-			$params[$hash]->def('page_title', $title);
 			$params[$hash]->def('page_description', $description);
 			$params[$hash]->def('page_rights', $rights);
 			$params[$hash]->def('robots', $robots);


### PR DESCRIPTION
$params[$hash]->def('page_title', $title);

This causes a bug in the view form, causing the messages do not show the variable $head.

Example:

if (empty($this->item->id))
{
    $head = JText::_('COM_COMPONENT_FORM_SUBMIT_ITEM');
}
else
{
    $head = JText::_('COM_COMPONENT_FORM_EDIT_ITEM');
}

$title = $this->params->def('page_title', $head);

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29931
