### PR TITLE
Fixing extension install from dynamic URLs

### DIFF
--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -57,9 +57,9 @@ abstract class JInstallerHelper
 			return false;
 		}
 
-		if (isset($response->headers['wrapper_data']['Content-Disposition']))
+		if (isset($response->headers['Content-Disposition']))
 		{
-			$contentfilename = explode("\"", $response->headers['wrapper_data']['Content-Disposition']);
+			$contentfilename = explode("\"", $response->headers['Content-Disposition']);
 			$target = $contentfilename[1];
 		}
 


### PR DESCRIPTION
Since the `JInstallerHelper::downloadPackage()` function now uses `JHttpFactory::getHttp()` instead of `stream_get_meta_data()`, the "Content-Dispositon" data is now stored directly in `$response->headers['Content-Disposition']` instead of `$response->headers['wrapper_data']['Content-Disposition']`.

Currently in Joomla 3.0.2, you can't install extensions directly from an URL if the URL points to a dynamic created link  with URL parameters (like in Akeeba Release System or CTransifex). This is because it doesn't detect a valid filename.

This commit fixes this.
