### PR TITLE
Update plugins/authentication/gmail/gmail.php

### DIFF
--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -80,7 +80,7 @@ class plgAuthenticationGMail extends JPlugin
 				$message = JText::_('JGLOBAL_AUTH_USER_BLACKLISTED');
 			}
 		} else {
-			$message = 'curl isn\'t insalled';
+			$message = 'curl isn\'t installed';
 		}
 		$response->type = 'GMail';
 		if ($success) {


### PR DESCRIPTION
Fixed misspelled word that shows up on administration login if gmail authentication fails.
