### PR TITLE
Getting Notices when adding new categories

### DIFF
--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -26,6 +26,7 @@
 	<field
 		name="parent_id"
 		type="categoryedit"
+		default="1"
 		label="COM_CATEGORIES_FIELD_PARENT_LABEL"
 		description="COM_CATEGORIES_FIELD_PARENT_DESC"
 		class="span12 small"/>


### PR DESCRIPTION
When adding new category, I noticed that I was getting a Notice on my PHP log.
The notice was because the publish_id field did not have any value.
So adding a default value to 1, will point the parent id category to root, what normally wood and the notice will stop
