### PR TITLE
'com_contact' bad words fix

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -42,8 +42,11 @@ class JFormRuleContactEmail extends JFormRuleEmail
 		$banned = $params->get('banned_email');
 
 		foreach(explode(';', $banned) as $item){
-			if (JString::stristr($item, $value) !== false)
+			if ($item != '') {
+				if (JString::stristr($value, $item) !== false) {
 					return false;
+				}
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -36,8 +36,11 @@ class JFormRuleContactEmailMessage extends JFormRule
 		$banned = $params->get('banned_text');
 
 		foreach(explode(';', $banned) as $item){
-			if (JString::stristr($item, $value) !== false)
+			if ($item != '') {
+				if (JString::stristr($value, $item) !== false) {
 					return false;
+				}
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -36,8 +36,11 @@ class JFormRuleContactEmailSubject extends JFormRule
 		$banned = $params->get('banned_subject');
 
 		foreach(explode(';', $banned) as $item){
-			if (JString::stristr($item, $value) !== false)
+			if ($item != '') {
+				if (JString::stristr($value, $item) !== false) {
 					return false;
+				}
+			}
 		}
 
 		return true;

--- a/web.config.txt
+++ b/web.config.txt
@@ -3,7 +3,7 @@
    <system.webServer>
        <rewrite>
            <rules>
-               <rule name="Joomla! Rule 1" stopProcessing="true">
+               <rule name="Joomla!_Rule_1" stopProcessing="true">
                    <match url="^(.*)$" ignoreCase="false" />
                    <conditions logicalGrouping="MatchAny">
                        <add input="{QUERY_STRING}" pattern="base64_encode[^(]*\([^)]*\)" ignoreCase="false" />
@@ -13,7 +13,7 @@
                    </conditions>
                    <action type="CustomResponse" url="index.php" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
                </rule>
-               <rule name="Joomla! Rule 2">
+               <rule name="Joomla!_Rule_2">
                    <match url="(.*)" ignoreCase="false" />
                    <conditions logicalGrouping="MatchAll">
                      <add input="{URL}" pattern="^/index.php" ignoreCase="true" negate="true" />


### PR DESCRIPTION
This patch fixes 'com_contact' in that it does not obey the 'Banned Email, Banned Subject and Banned Text'.

A patch was submitted a submitted last year but for some reason it was
either reverted or not implemented.

Joomla Code tracker URL
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28368
