### PR TITLE
Update libraries/joomla/installer/installer.php

### DIFF
--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -1067,7 +1067,7 @@ class JInstaller extends JAdapter
 						// We have a version!
 						foreach ($files as $file)
 						{
-							if (version_compare($file, $version) > 0)
+							if (version_compare($file, $version) <= 0)
 							{
 								$buffer = file_get_contents($this->getPath('extension_root') . '/' . $schemapath . '/' . $file . '.sql');
 


### PR DESCRIPTION
Change Proposal for  [#30038] SQL files not processed by component update.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30038

From the PHP manual:
By default, version_compare() returns -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower.

So in my opinion the update should run once version_compare returns a value less or equal to 0 and not greater 0.
