### PR TITLE
Update libraries/joomla/installer/adapters/component.php

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -821,6 +821,8 @@ class JInstallerComponent extends JAdapterInstance
 
 		if ($this->manifest->update)
 		{
+			// Set the schema version to be the latest update version
+			$this->parent->setSchemaVersion($this->manifest->update->schemas, $eid);
 			$result = $this->parent->parseSchemaUpdates($this->manifest->update->schemas, $eid);
 
 			if ($result === false)


### PR DESCRIPTION
Change Proposal for  [#30038] SQL files not processed by component update.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30038

When the DB update should run during a component update, the Installer does not know the new version,
# __schemas table was not yet updated.

To solve this,
$this->parent->setSchemaVersion($this->manifest->update->schemas,
$eid); should be called
