### PR TITLE
Added a update mechanism for the Update component

### DIFF
--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -26,5 +26,8 @@
 			<language tag="en-GB">language/en-GB.com_joomlaupdate.sys.ini</language>
 		</languages>
 	</administration>
+	<updateservers>
+		<server type="extension" priority="1" name="Joomla! Update"><![CDATA[http://update.joomla.org/core/extensions/joomla/com_joomlaupdate.xml]]></server>
+	</updateservers>
 </extension>
 

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -27,7 +27,7 @@
 		</languages>
 	</administration>
 	<updateservers>
-		<server type="extension" priority="1" name="Joomla! Update"><![CDATA[http://update.joomla.org/core/extensions/joomla/com_joomlaupdate.xml]]></server>
+		<server type="extension" priority="1" name="Joomla! Update">http://update.joomla.org/core/extensions/joomla/com_joomlaupdate.xml</server>
 	</updateservers>
 </extension>
 


### PR DESCRIPTION
See:
https://groups.google.com/d/msg/joomla-dev-cms/2iuCF8bsA44/Nkec8TAKFV0J

The above code would allow us to have a fallback option to update the Joomla! Update component in case something goes drastically wrong with it.  Currently, there is not an xml at http://update.joomla.org/core/extensions/joomla/com_joomlaupdate.xml , but it's not needed since this would only be used on an as needed basis. 
