### PR TITLE
[#30058] Quotes are not escaped in popup-manager.js

### DIFF
--- a/media/media/js/popup-imagemanager.js
+++ b/media/media/js/popup-imagemanager.js
@@ -98,7 +98,7 @@ var ImageManager = this.ImageManager = {
 		if (url != '') {
 			// Set alt attribute
 			if (alt != '') {
-				extra = extra + 'alt="'+alt+'" ';
+				extra = extra + 'alt="' + this.htmlEntities(alt) + '" ';
 			} else {
 				extra = extra + 'alt="" ';
 			}
@@ -106,11 +106,11 @@ var ImageManager = this.ImageManager = {
 			if (align != '') {
 				extra = extra + 'align="'+align+'" ';
 			}
-			// Set align attribute
+			// Set title attribute
 			if (title != '') {
-				extra = extra + 'title="'+title+'" ';
+				extra = extra + 'title="' + this.htmlEntities(title) + '" ';
 			}
-			// Set align attribute
+			// Set caption class
 			if (caption != '') {
 				extra = extra + 'class="caption" ';
 			}
@@ -214,7 +214,11 @@ var ImageManager = this.ImageManager = {
 	{
 		this._setFrameUrl();
 	},
-
+	
+	htmlEntities: function (str) {
+		return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	},
+	
 	_setFrameUrl: function(url)
 	{
 		if (url != null) {


### PR DESCRIPTION
This pull request adds new method htmlEntities to ImageManager class. This method is used to replace quotes and brackets in alt and title attributes of images, that are inserted with com_media>images modal. 
Link to tracker record: 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30058
