### PR TITLE
Duplicate parenthesis in Beez3 content/category layout override.

### DIFF
--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -125,7 +125,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php endif; ?>
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>">
+	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>">
 	<img
 		<?php if ($images->image_intro_caption):
 			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';

--- a/templates/beez3/html/com_content/featured/default_item.php
+++ b/templates/beez3/html/com_content/featured/default_item.php
@@ -130,7 +130,7 @@ $templateparams = $app->getTemplate(true)->params;
 
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="img-intro-"<?php echo htmlspecialchars($imgfloat); ?>">
+	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>">
 	<img
 		<?php if ($images->image_intro_caption):
 			echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';


### PR DESCRIPTION
Remove duplicate parenthesis.
