### PR TITLE
Add optional class param to accordion slider

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit_options.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_options.php
@@ -16,7 +16,9 @@ defined('_JEXEC') or die;
 
 	foreach ($fieldSets as $name => $fieldSet) :
 		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_MODULES_'.$name.'_FIELDSET_LABEL';
-		echo JHtml::_('bootstrap.addSlide', 'moduleOptions', JText::_($label), 'collapse' . $i++);
+		$class = isset($fieldSet->class) && !empty($fieldSet->class) ? $fieldSet->class : '';
+
+		echo JHtml::_('bootstrap.addSlide', 'moduleOptions', JText::_($label), 'collapse' . $i++, $class);
 			if (isset($fieldSet->description) && trim($fieldSet->description)) :
 				echo '<p class="tip">'.$this->escape(JText::_($fieldSet->description)).'</p>';
 			endif;

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -467,16 +467,18 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  Identifier of the accordion group.
 	 * @param   string  $text      Text to display.
 	 * @param   string  $id        Identifier of the slide.
+	 * @param   string  $class     Class of the accordion group.
 	 *
 	 * @return  string  HTML to add the slide
 	 *
 	 * @since   3.0
 	 */
-	public static function addSlide($selector, $text, $id)
+	public static function addSlide($selector, $text, $id, $class = '')
 	{
 		$in = (self::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
+		$class = (!empty($class)) ? ' ' . $class : '';
 
-		$html = '<div class="accordion-group">'
+		$html = '<div class="accordion-group' . $class . '">'
 				. '<div class="accordion-heading">'
 				. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">'
 				. $text


### PR DESCRIPTION
This is useful in module params for example. Now all module fieldset params are accordions. But we can't add specific classes to identifier. This is important to build more user-friendly params fieldsets. Sometimes our extensions can hide or show some fieldsets according some params. 
