### PR TITLE
The ModulesHelperXML class has not been used for years and years.

### DIFF
--- a/administrator/components/com_modules/helpers/xml.php
+++ b/administrator/components/com_modules/helpers/xml.php
@@ -9,17 +9,21 @@
 
 defined('_JEXEC') or die;
 
+JLog::add('ModulesHelperXML is deprecated. Do not use.', JLog::WARNING, 'deprecated');
+
 /**
  * Helper for parse XML module files
  *
  * @package     Joomla.Administrator
  * @subpackage  com_modules
  * @since       1.5
+ * @deprecated  3.2  Do not use.
  */
 class ModulesHelperXML
 {
 	/**
-	 * @since  1.5
+	 * @since       1.5
+	 * @deprecated  3.2  Do not use.
 	 */
 	public function parseXMLModuleFile(&$rows)
 	{


### PR DESCRIPTION
Looking through the history, it seems the last time this class was used was more than 3 years ago and should have been removed along with the old selecttype view.
