### PR TITLE
Overridable menu layouts using JLayouts

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -216,18 +216,18 @@ $sortFields = $this->getSortFields();
 					<td class="center hidden-phone">
 						<?php echo JHtml::_('banner.pinned', $item->sticky, $i, $canChange); ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $item->client_name;?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo JText::sprintf('COM_BANNERS_IMPRESSIONS', $item->impmade, $item->imptotal ? $item->imptotal : JText::_('COM_BANNERS_UNLIMITED'));?>
 					</td>
-					<td class="center small hidden-phone">
+					<td class="center hidden-phone">
 						<?php echo $item->clicks;?> -
 						<?php echo sprintf('%.2f%%', $item->impmade ? 100 * $item->clicks / $item->impmade : 0);?>
 					</td>
 
-					<td class="small nowrap hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php if ($item->language == '*'):?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>

--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -54,11 +54,9 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
-		<div id="filter-bar" class="btn-toolbar">
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
+	<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_BANNERS_SEARCH_IN_TITLE');?></label>
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_BANNERS_SEARCH_IN_TITLE'); ?>" />

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -47,10 +47,8 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_BANNERS_SEARCH_IN_TITLE');?></label>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -173,13 +173,13 @@ $sortFields = $this->getSortFields();
 								?>
 						</div>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $item->contact;?>
 					</td>
 					<td class="center hidden-phone">
 						<?php echo $item->nbanners; ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->purchase_type < 0):?>
 							<?php echo JText::sprintf('COM_BANNERS_DEFAULT', JText::_('COM_BANNERS_FIELD_VALUE_'.$params->get('purchase_type')));?>
 						<?php else:?>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -42,10 +42,8 @@ $sortFields = $this->getSortFields();
     <div id="j-sidebar-container" class="span2">
       <?php echo $this->sidebar; ?>
     </div>
-    <div id="j-main-container" class="span10">
-  <?php else : ?>
-    <div id="j-main-container">
-  <?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
   	<div id="filter-bar" class="btn-toolbar">
   		<div class="filter-search btn-group pull-left">
   			<label class="filter-hide-lbl" for="filter_begin"><?php echo JText::_('COM_BANNERS_BEGIN_LABEL'); ?></label>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -113,7 +113,7 @@ $sortFields = $this->getSortFields();
   				<td>
   					<?php echo $item->client_name;?>
   				</td>
-  				<td class="small hidden-phone">
+  				<td class="hidden-phone">
   					<?php echo $item->track_type == 1 ? JText::_('COM_BANNERS_IMPRESSION') : JText::_('COM_BANNERS_CLICK');?>
   				</td>
   				<td class="hidden-phone">

--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -20,10 +20,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
     <div id="j-sidebar-container" class="span2">
       <?php echo $this->sidebar; ?>
     </div>
-    <div id="j-main-container" class="span10">
-  <?php else : ?>
-    <div id="j-main-container">
-  <?php endif;?>
+  <?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
   	<table class="table table-striped">
   		<thead>
   			<tr>

--- a/administrator/components/com_cache/views/purge/tmpl/default.php
+++ b/administrator/components/com_cache/views/purge/tmpl/default.php
@@ -14,11 +14,9 @@ defined('_JEXEC') or die;
   <?php if (!empty( $this->sidebar)) : ?>
     <div id="j-sidebar-container" class="span2">
       <?php echo $this->sidebar; ?>
-    </div>  
-    <div id="j-main-container" class="span10">
-  <?php else : ?>
-    <div id="j-main-container">
-  <?php endif;?>
+    </div>
+  <?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
   	<fieldset>
   		<legend><?php echo JText::_('COM_CACHE_PURGE_EXPIRED_ITEMS'); ?></legend>
   		<p><?php echo JText::_('COM_CACHE_PURGE_INSTRUCTIONS'); ?></p>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -205,7 +205,7 @@ $sortFields = $this->getSortFields();
 							<?php endif; ?>
 						</span>
 						</td>
-						<td class="small hidden-phone">
+						<td class="hidden-phone">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
 						<?php if ($this->assoc) : ?>
@@ -215,7 +215,7 @@ $sortFields = $this->getSortFields();
 								<?php endif; ?>
 							</td>
 						<?php endif; ?>
-						<td class="small nowrap hidden-phone">
+						<td class="nowrap hidden-phone">
 							<?php if ($item->language == '*') : ?>
 								<?php echo JText::alt('JALL', 'language'); ?>
 							<?php else: ?>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -124,7 +124,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 							<?php echo $this->escape($item->title); ?>
 						</a>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
 					<td class="center nowrap">

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -55,10 +55,8 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC');?></label>

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -222,7 +222,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 							?>
 						</div>
 					</td>
-					<td align="small hidden-phone">
+					<td align="hidden-phone">
 						<?php if (!empty($item->linked_user)) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.$item->user_id);?>"><?php echo $item->linked_user;?></a>
 						<?php endif; ?>
@@ -230,7 +230,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 					<td class="center hidden-phone">
 						<?php echo JHtml::_('contact.featured', $item->featured, $i, $canChange); ?>
 					</td>
-					<td align="small hidden-phone">
+					<td align="hidden-phone">
 						<?php echo $item->access_level; ?>
 					</td>
 					<?php if ($assoc) : ?>
@@ -240,7 +240,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 						<?php endif; ?>
 					</td>
 					<?php endif;?>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->language == '*'):?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
@@ -31,7 +31,8 @@ if ($saveOrder)
 }
 
 $sortFields = $this->getSortFields();
-$assoc		= isset($app->item_associations) ? $app->item_associations : 0;
+$langs = isset($app->has_languages) ? $app->has_languages : 0;
+$assoc = isset($app->item_associations) ? $app->item_associations : 0;
 ?>
 <script type="text/javascript">
 	Joomla.orderTable = function()
@@ -39,12 +40,9 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
-		{
+		if (order != '<?php echo $listOrder; ?>') {
 			dirn = 'asc';
-		}
-		else
-		{
+		} else {
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, '');
@@ -52,10 +50,10 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 </script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles'); ?>" method="post" name="adminForm" id="adminForm">
-<?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
-		<?php echo $this->sidebar; ?>
-	</div>
+	<?php if (!empty($this->sidebar)) : ?>
+		<div id="j-sidebar-container" class="span2">
+			<?php echo $this->sidebar; ?>
+		</div>
 	<?php endif; ?>
 	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
@@ -64,8 +62,10 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" />
 			</div>
 			<div class="btn-group pull-left hidden-phone">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>">
+					<i class="icon-search"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();">
+					<i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
@@ -75,19 +75,25 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
 				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
 					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php if ($listDirn == 'asc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php if ($listDirn == 'desc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING');  ?></option>
+					<option value="asc" <?php if ($listDirn == 'asc')
+					{
+						echo 'selected="selected"';
+					} ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
+					<option value="desc" <?php if ($listDirn == 'desc')
+					{
+						echo 'selected="selected"';
+					} ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING'); ?></option>
 				</select>
 			</div>
 			<div class="btn-group pull-right">
 				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
 				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY');?></option>
+					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY'); ?></option>
 					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
 				</select>
 			</div>
 		</div>
-		<div class="clearfix"> </div>
+		<div class="clearfix"></div>
 
 		<table class="table table-striped" id="articleList">
 			<thead>
@@ -95,7 +101,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 					<th width="1%" class="nowrap center hidden-phone">
 						<?php echo JHtml::_('grid.sort', '<i class="icon-menu-2"></i>', 'a.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING'); ?>
 					</th>
-					<th width="1%" class="hidden-phone">
+					<th width="1%" class="hidden-phone center">
 						<?php echo JHtml::_('grid.checkall'); ?>
 					</th>
 					<th width="1%" style="min-width:55px" class="nowrap center">
@@ -104,167 +110,176 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 					<th>
 						<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 					</th>
+					<?php if ($langs) : ?>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
+					<?php if ($assoc) : ?>
+						<th width="10%" class="nowrap hidden-phone center">
+							<?php echo JHtml::_('grid.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
 					<th width="10%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('grid.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+						<?php echo JHtml::_('grid.sort', 'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 					</th>
-				<?php if ($assoc) : ?>
-					<th width="5%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
-					</th>
-				<?php endif;?>
 					<th width="10%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('grid.sort',  'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
-					</th>
-					<th width="5%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 					</th>
 					<th width="10%" class="nowrap hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
 					</th>
-					<th width="10%">
+					<th width="10%" class="center">
 						<?php echo JHtml::_('grid.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 					</th>
-					<th width="1%" class="nowrap hidden-phone">
+					<th width="1%" class="nowrap hidden-phone center">
 						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>
 			</thead>
 			<tbody>
-			<?php foreach ($this->items as $i => $item) :
-				$item->max_ordering = 0; //??
-				$ordering   = ($listOrder == 'a.ordering');
-				$canCreate  = $user->authorise('core.create',     'com_content.category.'.$item->catid);
-				$canEdit    = $user->authorise('core.edit',       'com_content.article.'.$item->id);
-				$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
-				$canEditOwn = $user->authorise('core.edit.own',   'com_content.article.'.$item->id) && $item->created_by == $userId;
-				$canChange  = $user->authorise('core.edit.state', 'com_content.article.'.$item->id) && $canCheckin;
-				?>
-				<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
-					<td class="order nowrap center hidden-phone">
-						<?php
-						$iconClass = '';
-						if (!$canChange)
-						{
-							$iconClass = ' inactive';
-						}
-						elseif (!$saveOrder)
-						{
-							$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
-						}
-						?>
-						<span class="sortable-handler<?php echo $iconClass ?>">
+				<?php foreach ($this->items as $i => $item) :
+					$item->max_ordering = 0; //??
+					$ordering = ($listOrder == 'a.ordering');
+					$canCreate = $user->authorise('core.create', 'com_content.category.' . $item->catid);
+					$canEdit = $user->authorise('core.edit', 'com_content.article.' . $item->id);
+					$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
+					$canEditOwn = $user->authorise('core.edit.own', 'com_content.article.' . $item->id) && $item->created_by == $userId;
+					$canChange = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+					?>
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
+						<td class="order nowrap center hidden-phone">
+							<?php
+							$iconClass = '';
+							if (!$canChange)
+							{
+								$iconClass = ' inactive';
+							}
+							elseif (!$saveOrder)
+							{
+								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
+							}
+							?>
+							<span class="sortable-handler<?php echo $iconClass ?>">
 							<i class="icon-menu"></i>
 						</span>
-						<?php if ($canChange && $saveOrder) : ?>
-							<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
-						<?php endif; ?>
-					</td>
-					<td class="center hidden-phone">
-						<?php echo JHtml::_('grid.id', $i, $item->id); ?>
-					</td>
-					<td class="center">
-						<div class="btn-group">
-							<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-							<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
-						</div>
-					</td>
-					<td class="nowrap has-context">
-						<div class="pull-left">
-							<?php if ($item->checked_out) : ?>
-								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+							<?php if ($canChange && $saveOrder) : ?>
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
 							<?php endif; ?>
-							<?php if ($item->language == '*'):?>
-								<?php $language = JText::alt('JALL', 'language'); ?>
-							<?php else:?>
-								<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-							<?php endif;?>
-							<?php if ($canEdit || $canEditOwn) : ?>
-								<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
-									<?php echo $this->escape($item->title); ?></a>
-							<?php else : ?>
-								<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
-							<?php endif; ?>
-							<div class="small">
-								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+						</td>
+						<td class="center hidden-phone">
+							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
+						</td>
+						<td class="center">
+							<div class="btn-group">
+								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 							</div>
-						</div>
-						<div class="pull-left">
-							<?php
+						</td>
+						<td class="nowrap has-context">
+							<div class="pull-left">
+								<?php if ($item->checked_out) : ?>
+									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+								<?php endif; ?>
+								<?php if ($canEdit || $canEditOwn) : ?>
+									<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+										<?php echo $this->escape($item->title); ?></a>
+								<?php else : ?>
+									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
+								<?php endif; ?>
+								<div class="small">
+									<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+								</div>
+							</div>
+							<div class="pull-left">
+								<?php
 								// Create dropdown items
 								JHtml::_('dropdown.edit', $item->id, 'article.');
 								JHtml::_('dropdown.divider');
-								if ($item->state) :
+								if ($item->state)
+								{
 									JHtml::_('dropdown.unpublish', 'cb' . $i, 'articles.');
-								else :
+								}
+								else
+								{
 									JHtml::_('dropdown.publish', 'cb' . $i, 'articles.');
-								endif;
+								}
 
-								if ($item->featured) :
+								if ($item->featured)
+								{
 									JHtml::_('dropdown.unfeatured', 'cb' . $i, 'articles.');
-								else :
+								}
+								else
+								{
 									JHtml::_('dropdown.featured', 'cb' . $i, 'articles.');
-								endif;
+								}
 
 								JHtml::_('dropdown.divider');
 
-								if ($archived) :
+								if ($archived)
+								{
 									JHtml::_('dropdown.unarchive', 'cb' . $i, 'articles.');
-								else :
+								}
+								else
+								{
 									JHtml::_('dropdown.archive', 'cb' . $i, 'articles.');
-								endif;
+								}
 
-								if ($item->checked_out) :
+								if ($item->checked_out)
+								{
 									JHtml::_('dropdown.checkin', 'cb' . $i, 'articles.');
-								endif;
+								}
 
-								if ($trashed) :
+								if ($trashed)
+								{
 									JHtml::_('dropdown.untrash', 'cb' . $i, 'articles.');
-								else :
+								}
+								else
+								{
 									JHtml::_('dropdown.trash', 'cb' . $i, 'articles.');
-								endif;
+								}
 
 								// Render dropdown list
 								echo JHtml::_('dropdown.render');
 								?>
-						</div>
-					</td>
-					<td class="small hidden-phone">
-						<?php echo $this->escape($item->access_level); ?>
-					</td>
-					<?php if ($assoc) : ?>
-					<td class="hidden-phone">
-						<?php if ($item->association) : ?>
-							<?php echo JHtml::_('contentadministrator.association', $item->id); ?>
+							</div>
+						</td>
+						<?php if ($langs) : ?>
+							<td class="hidden-phone">
+								<?php if ($item->language == '*'): ?>
+									<?php echo JText::alt('JALL', 'language'); ?>
+								<?php else: ?>
+									<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+								<?php endif; ?>
+							</td>
 						<?php endif; ?>
-					</td>
-					<?php endif;?>
-					<td class="small hidden-phone">
-						<?php if ($item->created_by_alias) : ?>
-							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
-							<?php echo $this->escape($item->author_name); ?></a>
-							<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
-						<?php else : ?>
-							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
-							<?php echo $this->escape($item->author_name); ?></a>
+						<?php if ($assoc) : ?>
+							<td class="hidden-phone center">
+								<?php if ($item->association) : ?>
+									<?php echo JHtml::_('contentadministrator.association', $item->id); ?>
+								<?php endif; ?>
+							</td>
 						<?php endif; ?>
-					</td>
-					<td class="small hidden-phone">
-						<?php if ($item->language == '*'):?>
-							<?php echo JText::alt('JALL', 'language'); ?>
-						<?php else:?>
-							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-						<?php endif;?>
-					</td>
-					<td class="nowrap small hidden-phone">
-						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</td>
-					<td class="center">
-						<?php echo (int) $item->hits; ?>
-					</td>
-					<td class="center hidden-phone">
-						<?php echo (int) $item->id; ?>
-					</td>
-				</tr>
+						<td class="hidden-phone">
+							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>">
+								<?php echo $this->escape($item->author_name); ?></a>
+							<?php if ($item->created_by_alias) : ?>
+								<div class="small">(<?php echo $this->escape($item->created_by_alias); ?>)</div>
+							<?php endif; ?>
+						</td>
+						<td class="hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="nowrap hidden-phone">
+							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+						</td>
+						<td class="center">
+							<?php echo (int) $item->hits; ?>
+						</td>
+						<td class="center hidden-phone">
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
 				<?php endforeach; ?>
 			</tbody>
 		</table>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -56,10 +56,8 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?></label>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -242,6 +242,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 								// Render dropdown list
 								echo JHtml::_('dropdown.render');
 								?>
+<<<<<<< HEAD
 							</div>
 						</td>
 						<?php if ($langs) : ?>
@@ -280,6 +281,47 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 							<?php echo (int) $item->id; ?>
 						</td>
 					</tr>
+=======
+						</div>
+					</td>
+					<td class="hidden-phone">
+						<?php echo $this->escape($item->access_level); ?>
+					</td>
+					<?php if ($assoc) : ?>
+					<td class="hidden-phone">
+						<?php if ($item->association) : ?>
+							<?php echo JHtml::_('contentadministrator.association', $item->id); ?>
+						<?php endif; ?>
+					</td>
+					<?php endif;?>
+					<td class="hidden-phone">
+						<?php if ($item->created_by_alias) : ?>
+							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+							<?php echo $this->escape($item->author_name); ?></a>
+							<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
+						<?php else : ?>
+							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+							<?php echo $this->escape($item->author_name); ?></a>
+						<?php endif; ?>
+					</td>
+					<td class="hidden-phone">
+						<?php if ($item->language == '*'):?>
+							<?php echo JText::alt('JALL', 'language'); ?>
+						<?php else:?>
+							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+						<?php endif;?>
+					</td>
+					<td class="nowrap hidden-phone">
+						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+					</td>
+					<td class="center">
+						<?php echo (int) $item->hits; ?>
+					</td>
+					<td class="center hidden-phone">
+						<?php echo (int) $item->id; ?>
+					</td>
+				</tr>
+>>>>>>> removes small classes from table cells
 				<?php endforeach; ?>
 			</tbody>
 		</table>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -31,10 +31,8 @@ $saveOrder	= $listOrder == 'fp.ordering';
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?></label>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -182,10 +182,10 @@ $saveOrder	= $listOrder == 'fp.ordering';
 							<?php echo $item->ordering; ?>
 						<?php endif; ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->created_by_alias) : ?>
 							<?php echo $this->escape($item->author_name); ?>
 							<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
@@ -193,14 +193,14 @@ $saveOrder	= $listOrder == 'fp.ordering';
 							<?php echo $this->escape($item->author_name); ?>
 						<?php endif; ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->language == '*'):?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>
 							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 						<?php endif;?>
 					</td>
-					<td class="nowrap small hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 					</td>
 					<td class="center hidden-phone">

--- a/administrator/components/com_finder/views/filters/tmpl/default.php
+++ b/administrator/components/com_finder/views/filters/tmpl/default.php
@@ -42,10 +42,8 @@ Joomla.submitbutton = function(pressbutton)
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_FINDER_FILTER_SEARCH_DESCRIPTION'); ?>" />

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -56,10 +56,8 @@ Joomla.submitbutton = function(pressbutton)
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_FINDER_FILTER_SEARCH_DESCRIPTION'); ?>" />

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -140,13 +140,13 @@ Joomla.submitbutton = function(pressbutton)
 							<i class="icon-calendar pull-right pop hasPopover" data-placement="left" title="<?php echo JText::_('JDETAILS');?>" data-content="<?php echo JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date);?>"></i>
 						<?php endif; ?>
 					</td>
-					<td class="small nowrap hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php
 						$key = FinderHelperLanguage::branchSingular($item->t_title);
 						echo $lang->hasKey($key) ? JText::_($key) : $item->t_title;
 						?>
 					</td>
-					<td class="small nowrap hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php echo JHtml::_('date', $item->indexdate, JText::_('DATE_FORMAT_LC4')); ?>
 					</td>
 				</tr>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -41,10 +41,8 @@ Joomla.submitbutton = function(pressbutton)
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_FINDER_FILTER_SEARCH_DESCRIPTION'); ?>" />

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -18,10 +18,8 @@ defined('_JEXEC') or die;
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+		<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<?php if ($this->errorCount === 0) : ?>
 			<div class="alert alert-info">
 				<a class="close" data-dismiss="alert" href="#">&times;</a>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -22,10 +22,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
     <div id="j-sidebar-container" class="span2">
       <?php echo $this->sidebar; ?>
     </div>
-    <div id="j-main-container" class="span10">
-  <?php else : ?>
-    <div id="j-main-container">
-  <?php endif;?>
+	<?php endif; ?>
+		<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
   	<?php if ($this->showMessage) : ?>
   		<?php echo $this->loadTemplate('message'); ?>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -62,10 +62,8 @@ defined('_JEXEC') or die;
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 	<!-- Render messages set by extension install scripts here -->
 	<?php if ($this->showMessage) : ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -77,16 +77,16 @@ $version = new JVersion;
 								<div class="small"><?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?></div>
 							<?php endif; ?>
 						</td>
-						<td class="center small">
+						<td class="center">
 							<?php echo $language->version; ?>
 						</td>
-						<td class="center small hidden-phone">
+						<td class="center hidden-phone">
 							<?php echo JText::_('COM_INSTALLER_TYPE_' . strtoupper($language->type)); ?>
 						</td>
-						<td class="small hidden-phone">
+						<td class="hidden-phone">
 							<?php echo $language->detailsurl; ?>
 						</td>
-						<td class="small hidden-phone">
+						<td class="hidden-phone">
 							<?php echo $language->update_id; ?>
 						</td>
 					</tr>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -26,10 +26,8 @@ $version = new JVersion;
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+		<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
 			<?php echo $this->loadTemplate('filter'); ?>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -22,10 +22,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 	<?php if ($this->showMessage) : ?>
 		<?php echo $this->loadTemplate('message'); ?>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -22,10 +22,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
 	<?php endif; ?>
+		<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 	<?php if ($this->showMessage) : ?>
 		<div class="alert alert-info">

--- a/administrator/components/com_installer/views/warnings/tmpl/default.php
+++ b/administrator/components/com_installer/views/warnings/tmpl/default.php
@@ -15,10 +15,8 @@ defined('_JEXEC') or die;
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+		<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 	<?php
 
 		if (!count($this->messages))

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -21,10 +21,8 @@ $clientId	= $this->state->get('filter.client_id', 0);
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 		<table class="table table-striped">
 			<thead>

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -29,10 +29,8 @@ $saveOrder	= $listOrder == 'a.ordering';
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_LANGUAGES_SEARCH_IN_TITLE'); ?>" />

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -22,10 +22,8 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar clearfix">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC'); ?>" />

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -232,17 +232,17 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 							<?php endif;?>
 						<?php endif; ?>
 					</td>
-				<td class="small hidden-phone">
+				<td class="hidden-phone">
 					<?php echo $this->escape($item->access_level); ?>
 				</td>
 				<?php if ($assoc):?>
-				<td class="small hidden-phone">
+				<td class="hidden-phone">
 					<?php if ($item->association):?>
 						<?php echo JHtml::_('MenusHtml.Menus.association', $item->id);?>
 						<?php endif;?>
 					</td>
 					<?php endif;?>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->language == ''):?>
 							<?php echo JText::_('JDEFAULT'); ?>
 						<?php elseif ($item->language == '*'):?>

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -55,10 +55,8 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC');?></label>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -39,10 +39,8 @@ $modMenuId = (int) $this->get('ModMenuId');
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_MENUS_MENU_SEARCH_FILTER');?></label>

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -26,10 +26,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_MESSAGES_SEARCH_IN_SUBJECT'); ?>" />

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -50,10 +50,8 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -205,7 +205,7 @@ $sortFields = $this->getSortFields();
 								?>
 						</div>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->position) : ?>
 							<span>
 								<?php echo $item->position; ?>
@@ -216,17 +216,17 @@ $sortFields = $this->getSortFields();
 							</span>
 						<?php endif; ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $item->name;?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $item->pages; ?>
 					</td>
 
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->language == ''):?>
 							<?php echo JText::_('JDEFAULT'); ?>
 						<?php elseif ($item->language == '*'):?>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -209,11 +209,11 @@ $sortFields = $this->getSortFields();
 					</td>
 					<td class="small hidden-phone">
 						<?php if ($item->position) : ?>
-							<span class="label label-info">
+							<span>
 								<?php echo $item->position; ?>
 							</span>
 						<?php else : ?>
-							<span class="label">
+							<span>
 								<?php echo JText::_('JNONE'); ?>
 							</span>
 						<?php endif; ?>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -55,10 +55,8 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC');?></label>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -218,7 +218,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 						</div>
 
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
 					<td class="center hidden-phone">
@@ -234,7 +234,7 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 						<?php endif; ?>
 					</td>
 					<?php endif;?>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php if ($item->language == '*'):?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -165,13 +165,13 @@ $sortFields = $this->getSortFields();
 								<?php echo $item->name; ?>
 						<?php endif; ?>
 					</td>
-					<td class="nowrap small hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php echo $this->escape($item->folder);?>
 					</td>
-					<td class="nowrap small hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php echo $this->escape($item->element);?>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
 					<td class="center hidden-phone">

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -102,13 +102,13 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 								<?php echo $this->escape(str_replace(JUri::root(), '', $item->old_url)); ?>
 						<?php endif; ?>
 					</td>
-					<td class="small">
+					<td>
 						<?php echo $this->escape($item->new_url); ?>
 					</td>
-					<td class="small">
+					<td>
 						<?php echo $this->escape($item->referer); ?>
 					</td>
-					<td class="small">
+					<td>
 						<?php echo JHtml::_('date', $item->created_date, JText::_('DATE_FORMAT_LC4')); ?>
 					</td>
 					<td class="center">

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -26,10 +26,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_REDIRECT_SEARCH_LINKS'); ?>" />

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -50,10 +50,8 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_TAGS_ITEMS_SEARCH_FILTER');?></label>

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -25,10 +25,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
 	<div id="filter-bar" class="btn-toolbar">
 		<div class="filter-search btn-group pull-left">

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -27,10 +27,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
     <div id="j-sidebar-container" class="span2">
       <?php echo $this->sidebar; ?>
     </div>
-    <div id="j-main-container" class="span10">
-  <?php else : ?>
-    <div id="j-main-container">
-  <?php endif;?>
+  <?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 
   	<div id="filter-bar" class="btn-toolbar">
   		<div class="filter-search btn-group pull-left">

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -23,10 +23,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_ASSETS'); ?>" />

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -22,10 +22,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_ASSETS'); ?>" />

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -70,10 +70,8 @@ JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_IN_GROUPS'); ?>" />

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -52,10 +52,8 @@ if ($saveOrder)
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_TITLE_LEVELS'); ?>" />

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -42,10 +42,8 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_IN_NOTE_TITLE'); ?>" />

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -42,10 +42,8 @@ $sortFields = $this->getSortFields();
 		<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 	<div id="filter-bar" class="btn-toolbar">
 		<div class="filter-search btn-group pull-left">
 			<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_USERS'); ?>" />

--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -50,10 +50,8 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
+	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('COM_WEBLINKS_SEARCH_IN_TITLE');?></label>

--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -170,13 +170,13 @@ $sortFields = $this->getSortFields();
 							<?php echo $this->escape($item->category_title); ?>
 						</div>
 					</td>
-					<td class="small hidden-phone">
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
 					<td class="center hidden-phone">
 						<?php echo $item->hits; ?>
 					</td>
-					<td class="small nowrap hidden-phone">
+					<td class="nowrap hidden-phone">
 						<?php if ($item->language == '*'):?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -17,165 +17,133 @@ $user = JFactory::getUser();
 $lang = JFactory::getLanguage();
 
 /**
- * Site SubMenu
-**/
-$menu->addChild(
-	new JMenuNode(JText::_('MOD_MENU_SYSTEM'), '#'), true
-);
-$menu->addChild(
-	new JMenuNode(JText::_('MOD_MENU_CONTROL_PANEL'), 'index.php', 'class:cpanel')
-);
-
-$menu->addSeparator();
+ * System submenu
+ */
+$systemMenu = new JMenuNode(JText::_('MOD_MENU_SYSTEM'), '#');
+$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_CONTROL_PANEL'), 'index.php'));
+$systemMenu->addSeparator();
 
 if ($user->authorise('core.admin'))
 {
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CONFIGURATION'), 'index.php?option=com_config', 'class:config'));
-	$menu->addSeparator();
+	$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_CONFIGURATION'), 'index.php?option=com_config'));
+	$systemMenu->addSeparator();
 }
 
-$chm = $user->authorise('core.manage', 'com_checkin');
+$chm = $user->authorise('core.admin', 'com_checkin');
 $cam = $user->authorise('core.manage', 'com_cache');
 
 if ($chm || $cam )
 {
-	// Keep this for when bootstrap supports submenus?
-	/* $menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MAINTENANCE'), 'index.php?option=com_checkin', 'class:maintenance'), true
-	);*/
-
 	if ($chm)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_GLOBAL_CHECKIN'), 'index.php?option=com_checkin', 'class:checkin'));
-		$menu->addSeparator();
+		$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_GLOBAL_CHECKIN'), 'index.php?option=com_checkin'));
+		$systemMenu->addSeparator();
 	}
 
 	if ($cam)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CLEAR_CACHE'), 'index.php?option=com_cache', 'class:clear'));
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_PURGE_EXPIRED_CACHE'), 'index.php?option=com_cache&view=purge', 'class:purge'));
+		$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_CLEAR_CACHE'), 'index.php?option=com_cache'));
+		$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_PURGE_EXPIRED_CACHE'), 'index.php?option=com_cache&view=purge'));
 	}
-
-	// $menu->getParent();
 }
 
-$menu->addSeparator();
+$systemMenu->addSeparator();
 
 if ($user->authorise('core.admin'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_SYSTEM_INFORMATION'), 'index.php?option=com_admin&view=sysinfo', 'class:info')
-	);
+	$systemMenu->addChild(new JMenuNode(JText::_('MOD_MENU_SYSTEM_INFORMATION'), 'index.php?option=com_admin&view=sysinfo'));
 }
 
-$menu->getParent();
+$menu->addChild($systemMenu);
 
 /**
- * Users Submenu
-**/
+ * Users submenu
+ */
 if ($user->authorise('core.manage', 'com_users'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_USERS'), '#'), true
-	);
-	$createUser = $shownew && $user->authorise('core.create', 'com_users');
-	$createGrp = $user->authorise('core.admin', 'com_users');
+	$userMenu = new JMenuNode(JText::_('MOD_MENU_COM_USERS_USERS'), '#');
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_USER_MANAGER'), 'index.php?option=com_users&view=users', 'class:user'), $createUser
-	);
+	$createUser = $shownew && $user->authorise('core.create', 'com_users');
+	$createGrp  = $user->authorise('core.admin', 'com_users');
+
+	$userManager = new JMenuNode(JText::_('MOD_MENU_COM_USERS_USER_MANAGER'), 'index.php?option=com_users&view=users');
 
 	if ($createUser)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_USER'), 'index.php?option=com_users&task=user.add', 'class:newarticle')
-		);
-		$menu->getParent();
+		$userManager->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_USER'), 'index.php?option=com_users&task=user.add'));
 	}
+
+	$userMenu->addChild($userManager, $createUser);
 
 	if ($createGrp)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_GROUPS'), 'index.php?option=com_users&view=groups', 'class:groups'), $createUser
-		);
+		$userGroups = new JMenuNode(JText::_('MOD_MENU_COM_USERS_GROUPS'), 'index.php?option=com_users&view=groups');
 
 		if ($createUser)
 		{
-			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_GROUP'), 'index.php?option=com_users&task=group.add', 'class:newarticle')
-			);
-			$menu->getParent();
+			$userGroups->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_GROUP'), 'index.php?option=com_users&task=group.add'));
 		}
 
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_LEVELS'), 'index.php?option=com_users&view=levels', 'class:levels'), $createUser
-		);
+		$userMenu->addChild($userGroups, $createUser);
+
+		$userLevels = new JMenuNode(JText::_('MOD_MENU_COM_USERS_LEVELS'), 'index.php?option=com_users&view=levels');
 
 		if ($createUser)
 		{
-			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_LEVEL'), 'index.php?option=com_users&task=level.add', 'class:newarticle')
-			);
-			$menu->getParent();
+			$userLevels->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_LEVEL'), 'index.php?option=com_users&task=level.add'));
 		}
+
+		$userMenu->addChild($userLevels, $createUser);
 	}
 
-	$menu->addSeparator();
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTES'), 'index.php?option=com_users&view=notes', 'class:user-note'), $createUser
-	);
+	$userMenu->addSeparator();
+
+	// Submenu: User Notes
+	$userNotes = new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTES'), 'index.php?option=com_users&view=notes');
 
 	if ($createUser)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_NOTE'), 'index.php?option=com_users&task=note.add', 'class:newarticle')
-		);
-		$menu->getParent();
+		$userNotes->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_NOTE'), 'index.php?option=com_users&task=note.add'));
 	}
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTE_CATEGORIES'), 'index.php?option=com_categories&view=categories&extension=com_users', 'class:category'), $createUser
-	);
+	$userMenu->addChild($userNotes, $createUser);
+
+	// Submenu: User Note categories
+	$userNoteCategories = new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTE_CATEGORIES'), 'index.php?option=com_categories&view=categories&extension=com_users');
 
 	if ($createUser)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users.notes', 'class:newarticle')
-		);
-		$menu->getParent();
+		$userNoteCategories->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users.notes'));
 	}
 
-	$menu->addSeparator();
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MASS_MAIL_USERS'), 'index.php?option=com_users&view=mail', 'class:massmail')
-	);
+	$userMenu->addChild($userNoteCategories, $createUser);
 
-	$menu->getParent();
+	$userMenu->addSeparator();
+	$userMenu->addChild(new JMenuNode(JText::_('MOD_MENU_MASS_MAIL_USERS'), 'index.php?option=com_users&view=mail'));
 }
 
+$menu->addChild($userMenu);
+
 /**
- * Menus Submenu
-**/
+ * Menus submenu
+ */
 if ($user->authorise('core.manage', 'com_menus'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true
-	);
+	$menusMenu = new JMenuNode(JText::_('MOD_MENU_MENUS'), '#');
+
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu
-	);
+	// Submenu: Menu manager
+	$menuManager = new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr');
 
 	if ($createMenu)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit', 'class:newarticle')
-		);
-		$menu->getParent();
+		$menuManager->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit'));
 	}
 
-	$menu->addSeparator();
+	$menusMenu->addChild($menuManager, $createMenu);
+
+	$menusMenu->addSeparator();
 
 	// Menu Types
 	foreach (ModMenuHelper::getMenus() as $menuType)
@@ -192,7 +160,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 		}
 		elseif ($menuType->home > 1)
 		{
-			$titleicon = ' <span>'.JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, array('title' => JText::_('MOD_MENU_HOME_MULTIPLE')), true).'</span>';
+			$titleicon = ' <span>' . JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, array('title' => JText::_('MOD_MENU_HOME_MULTIPLE')), true) . '</span>';
 		}
 		else
 		{
@@ -208,70 +176,60 @@ if ($user->authorise('core.manage', 'com_menus'))
 			}
 		}
 
-		$menu->addChild(
-			new JMenuNode($menuType->title,	'index.php?option=com_menus&view=items&menutype='.$menuType->menutype, 'class:menu', null, null, $titleicon), $createMenu
-		);
+		$dinamicMenu = new JMenuNode($menuType->title, 'index.php?option=com_menus&view=items&menutype=' . $menuType->menutype, '', null, null, $titleicon);
 
 		if ($createMenu)
 		{
-			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU_ITEM'), 'index.php?option=com_menus&view=item&layout=edit&menutype='.$menuType->menutype, 'class:newarticle')
-			);
-			$menu->getParent();
+			$dinamicMenu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU_ITEM'), 'index.php?option=com_menus&view=item&layout=edit&menutype=' . $menuType->menutype));
 		}
+
+		$menusMenu->addChild($dinamicMenu, $createMenu);
 	}
-	$menu->getParent();
+
+	$menu->addChild($menusMenu, true);
 }
 
 /**
- * Content Submenu
-**/
+ * Content submenu
+ */
 if ($user->authorise('core.manage', 'com_content'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT'), '#'), true
-	);
+	$contentMenu = new JMenuNode(JText::_('MOD_MENU_COM_CONTENT'), '#');
+
 	$createContent = $shownew && $user->authorise('core.create', 'com_content');
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_ARTICLE_MANAGER'), 'index.php?option=com_content', 'class:article'), $createContent
-	);
+	$articleManager = new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_ARTICLE_MANAGER'), 'index.php?option=com_content');
 
 	if ($createContent)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_ARTICLE'), 'index.php?option=com_content&task=article.add', 'class:newarticle')
-		);
-		$menu->getParent();
+		$articleManager->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_ARTICLE'), 'index.php?option=com_content&task=article.add'));
 	}
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_CATEGORY_MANAGER'), 'index.php?option=com_categories&extension=com_content', 'class:category'), $createContent
-	);
+	$contentMenu->addChild($articleManager, $createContent);
+
+	$categoryManager = new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_CATEGORY_MANAGER'), 'index.php?option=com_categories&extension=com_content');
 
 	if ($createContent)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_content', 'class:newarticle')
-		);
-		$menu->getParent();
+		$categoryManager->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_content'));
 	}
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured', 'class:featured')
-	);
-	$menu->addSeparator();
+	$contentMenu->addChild($categoryManager, $createContent);
+
+	$contentMenu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured'));
+	$contentMenu->addSeparator();
 
 	if ($user->authorise('core.manage', 'com_media'))
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MEDIA_MANAGER'), 'index.php?option=com_media', 'class:media'));
+		$contentMenu->addChild(new JMenuNode(JText::_('MOD_MENU_MEDIA_MANAGER'), 'index.php?option=com_media', 'class:media'));
 	}
 
-	$menu->getParent();
+	$menu->addChild($contentMenu, true);
 }
+
 
 /**
  * Components Submenu
-**/
+ */
 
 // Get the authorised components and sub-menus.
 $components = ModMenuHelper::getComponents(true);
@@ -279,35 +237,30 @@ $components = ModMenuHelper::getComponents(true);
 // Check if there are any components, otherwise, don't render the menu
 if ($components)
 {
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COMPONENTS'), '#'), true);
+	$componentsMenu = new JMenuNode(JText::_('MOD_MENU_COMPONENTS'), '#');
 
-	foreach ($components as &$component)
+	foreach ($components as $component)
 	{
+		$componentMenu = new JMenuNode($component->text, $component->link, $component->img);
+
 		if (!empty($component->submenu))
 		{
 			// This component has a db driven submenu.
-			$menu->addChild(new JMenuNode($component->text, $component->link, $component->img), true);
-
 			foreach ($component->submenu as $sub)
 			{
-				$menu->addChild(new JMenuNode($sub->text, $sub->link, $sub->img));
+				$componentMenu->addChild(new JMenuNode($sub->text, $sub->link, $sub->img));
 			}
 
-			$menu->getParent();
-
-		}
-		else
-		{
-			$menu->addChild(new JMenuNode($component->text, $component->link, $component->img));
+			$componentsMenu->addChild($componentMenu, true);
 		}
 	}
 
-	$menu->getParent();
+	$menu->addChild($componentsMenu, true);
 }
 
 /**
  * Extensions Submenu
-**/
+ */
 $im = $user->authorise('core.manage', 'com_installer');
 $mm = $user->authorise('core.manage', 'com_modules');
 $pm = $user->authorise('core.manage', 'com_plugins');
@@ -316,57 +269,56 @@ $lm = $user->authorise('core.manage', 'com_languages');
 
 if ($im || $mm || $pm || $tm || $lm)
 {
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_EXTENSIONS'), '#'), true);
+	$extensionsMenu = new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_EXTENSIONS'), '#');
 
 	if ($im)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_EXTENSION_MANAGER'), 'index.php?option=com_installer', 'class:install'));
-		$menu->addSeparator();
+		$extensionsMenu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_EXTENSION_MANAGER'), 'index.php?option=com_installer', 'class:install'));
+		$extensionsMenu->addSeparator();
 	}
 
 	if ($mm)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_MODULE_MANAGER'), 'index.php?option=com_modules', 'class:module'));
+		$extensionsMenu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_MODULE_MANAGER'), 'index.php?option=com_modules', 'class:module'));
 	}
 
 	if ($pm)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_PLUGIN_MANAGER'), 'index.php?option=com_plugins', 'class:plugin'));
+		$extensionsMenu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_PLUGIN_MANAGER'), 'index.php?option=com_plugins', 'class:plugin'));
 	}
 
 	if ($tm)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_TEMPLATE_MANAGER'), 'index.php?option=com_templates', 'class:themes'));
+		$extensionsMenu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_TEMPLATE_MANAGER'), 'index.php?option=com_templates', 'class:themes'));
 	}
 
 	if ($lm)
 	{
-		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_LANGUAGE_MANAGER'), 'index.php?option=com_languages', 'class:language'));
+		$extensionsMenu->addChild(new JMenuNode(JText::_('MOD_MENU_EXTENSIONS_LANGUAGE_MANAGER'), 'index.php?option=com_languages', 'class:language'));
 	}
 
-	$menu->getParent();
+	$menu->addChild($extensionsMenu, true);
 }
 
 /**
  * Help Submenu
-**/
+ */
 if ($showhelp == 1)
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP'), '#'), true
-	);
-	$menu->addChild(
+	$helpMenu = new JMenuNode(JText::_('MOD_MENU_HELP'), '#');
+
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_JOOMLA'), 'index.php?option=com_admin&view=help', 'class:help')
 	);
-	$menu->addSeparator();
+	$helpMenu->addSeparator();
 
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM'), 'http://forum.joomla.org', 'class:help-forum', false, '_blank')
 	);
 
 	if ($forum_url = $params->get('forum_url'))
 	{
-		$menu->addChild(
+		$helpMenu->addChild(
 			new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM'), $forum_url, 'class:help-forum', false, '_blank')
 		);
 	}
@@ -377,37 +329,38 @@ if ($showhelp == 1)
 	{
 		$forum_url = 'http://forum.joomla.org/viewforum.php?f=' . (int) JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE');
 		$lang->setDebug($debug);
-		$menu->addChild(
+		$helpMenu->addChild(
 			new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM'), $forum_url, 'class:help-forum', false, '_blank')
 		);
 	}
 
 	$lang->setDebug($debug);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_DOCUMENTATION'), 'http://docs.joomla.org', 'class:help-docs', false, '_blank')
 	);
-	$menu->addSeparator();
+	$helpMenu->addSeparator();
 
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_EXTENSIONS'), 'http://extensions.joomla.org', 'class:help-jed', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_TRANSLATIONS'), 'http://community.joomla.org/translations.html', 'class:help-trans', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_RESOURCES'), 'http://resources.joomla.org', 'class:help-jrd', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_COMMUNITY'), 'http://community.joomla.org', 'class:help-community', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_SECURITY'), 'http://developer.joomla.org/security.html', 'class:help-security', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_DEVELOPER'), 'http://developer.joomla.org', 'class:help-dev', false, '_blank')
 	);
-	$menu->addChild(
+	$helpMenu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_SHOP'), 'http://shop.joomla.org', 'class:help-shop', false, '_blank')
 	);
-	$menu->getParent();
+
+	$menu->addChild($helpMenu, true);
 }

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -125,8 +125,10 @@ class PlgSystemLanguageFilter extends JPlugin
 
 	public function onAfterInitialise()
 	{
+		$languages = JLanguageHelper::getLanguages('lang_code');
 		$app = JFactory::getApplication();
-		$app->item_associations = $this->params->get('item_associations', 0);
+		$app->has_languages = count($languages) > 1;
+		$app->item_associations = $app->has_languages ? $this->params->get('item_associations', 0) : 0;
 
 		if ($app->isSite())
 		{
@@ -140,7 +142,6 @@ class PlgSystemLanguageFilter extends JPlugin
 			$router->attachParseRule(array($this, 'parseRule'));
 
 			// Adding custom site name
-			$languages = JLanguageHelper::getLanguages('lang_code');
 			if (isset($languages[self::$tag]) && $languages[self::$tag]->sitename)
 			{
 				JFactory::getConfig()->set('sitename', $languages[self::$tag]->sitename);


### PR DESCRIPTION
Backend menus markup was not overridable.

I moved the JMenuNode (that was inside the administrator mod_menu) to the cms library and improved it to manage attributes. This way the library is available for every extension.

I also added JLayouts for the common used bootstrap menus:
- dropdown
- tabs
- tabs-stacked
- pills
- pills-stacked
- list

Also created two joomla basic menu layouts.

Now administrator mod_menu default layout displays:

```
$layout = new JLayoutFile('bootstrap.menu.dropdown');
echo  $layout->render($menu);
```

That file can be easily overriden for example in hathor to use:

```
$layout = new JLayoutFile('joomla.menu');
echo  $layout->render($menu);
```

Anywhere in the site we now can display a menu. 
## Sample menu creation

```
$menu = new JMenuParent;
$submenu = new JMenuNode('Hello world', 'index.php');
$submenu->addChild(new JMenuNode('Hello2 world', 'index.php'));
$submenu->addChild(new JMenuNode('Hello3 world', 'index.php'));
$menu->addChild($submenu);
$menu->addChild(new JMenuNode('Hello4 world', 'index.php'));

$layout = new JLayoutFile('bootstrap.menu.tabs');
echo  $layout->render($menu);
```
