### PR TITLE
403 has more sense that 404

### DIFF
--- a/administrator/components/com_installer/installer.php
+++ b/administrator/components/com_installer/installer.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_installer'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	return JError::raiseWarning(403, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
 $controller	= JControllerLegacy::getInstance('Installer');


### PR DESCRIPTION
404 is for non existing file.
403 is for page that need authorization.
