### PR TITLE
allow text-based inputs to handle "multiple"

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -570,7 +570,20 @@ abstract class JFormField
 		// If the field should support multiple values add the final array segment.
 		if ($this->multiple)
 		{
-			$name .= '[]';
+			switch (strtolower((string)$this->element['type']))
+			{
+				case 'text':
+				case 'textarea':
+				case 'email':
+				case 'password':
+				case 'radio':
+				case 'calendar':
+				case 'editor':
+				case 'hidden':
+					break;
+				default:
+					$name .= '[]';
+			}
 		}
 
 		return $name;


### PR DESCRIPTION
Several types of input fields have not been handling the "multiple" attribute.  This attribute causes the fields to store their values as an array instead of as a string.  But this fields expect a string when they attempt to load a value from the database.  As a result, the field displays no value.  The "multiple" attribute is needed at least for textarea and email so that validation can anticipate multiple values.  This solution stops the addition of '[]' to the input field's name if it belongs to one of these text-based field types.
