### PR TITLE
Problem when installing more than one extension

### DIFF
--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -505,6 +505,9 @@ class JInstaller extends JAdapter
 			{
 				if (method_exists($this->_adapters[$this->extension->type], 'discover_install'))
 				{
+					$this->setPath('source', null);
+					$this->manifest = null;
+
 					// Add the languages from the package itself
 					if (method_exists($this->_adapters[$this->extension->type], 'loadLanguage'))
 					{


### PR DESCRIPTION
Please see here for more information: https://github.com/elinw/joomla-cms/issues/29

I'm not sure whether to post this here or to the platform.

Problem is that some states are not reset after installing an extension via discover_install.
This way the same paths are used for the next extension, too.

Tracker issue:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30196
