### PR TITLE
Wrong client name of mod_stats_admin

### DIFF
--- a/administrator/modules/mod_stats_admin/mod_stats_admin.xml
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.xml
@@ -2,7 +2,7 @@
 <extension
 	type="module"
 	version="3.0"
-	client="admin"
+	client="administrator"
 	method="upgrade">
 	<name>mod_stats_admin</name>
 	<author>Joomla! Project</author>


### PR DESCRIPTION
Due to the wrong name there are PHP notices when installing the module via discover_install.
