### PR TITLE
[#30215] (2.5) Fixed event dispatching inconsistencies on some models leading to incomp...

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -373,9 +373,10 @@ class CategoriesModelCategory extends JModelAdmin
 		$table = $this->getTable();
 		$pk = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
 		$isNew = true;
+		$context = $this->option . '.' . $this->name;
 
 		// Include the content plugins for the on save events.
-		JPluginHelper::importPlugin('content');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Load the row if saving an existing category.
 		if ($pk > 0)
@@ -420,7 +421,7 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		// Trigger the onContentBeforeSave event.
-		$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 		if (in_array(false, $result, true))
 		{
 			$this->setError($table->getError());
@@ -435,7 +436,7 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		// Trigger the onContentAfterSave event.
-		$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Rebuild the path for the category:
 		if (!$table->rebuildPath($table->id))

--- a/administrator/components/com_config/models/component.php
+++ b/administrator/components/com_config/models/component.php
@@ -18,22 +18,6 @@ jimport('joomla.application.component.modelform');
 class ConfigModelComponent extends JModelForm
 {
 	/**
-	 * The event to trigger before saving the data.
-	 *
-	 * @var    string
-	 * @since  2.5.10
-	 */
-	protected $event_before_save = 'onConfigurationBeforeSave';
-
-	/**
-	 * The event to trigger before deleting the data.
-	 *
-	 * @var    string
-	 * @since  2.5.10
-	 */
-	protected $event_after_save = 'onConfigurationAfterSave';
-
-	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.
@@ -84,8 +68,7 @@ class ConfigModelComponent extends JModelForm
 				'/config'
 			);
 
-		if (empty($form))
-		{
+		if (empty($form)) {
 			return false;
 		}
 
@@ -125,22 +108,18 @@ class ConfigModelComponent extends JModelForm
 	 */
 	public function save($data)
 	{
-		$dispatcher = JDispatcher::getInstance();
 		$table	= JTable::getInstance('extension');
-		$isNew = true;
 
 		$dispatcher = JDispatcher::getInstance();
 		$context = $this->option . '.' . $this->name;
 		JPluginHelper::importPlugin('extension');
 
 		// Save the rules.
-		if (isset($data['params']) && isset($data['params']['rules']))
-		{
+		if (isset($data['params']) && isset($data['params']['rules'])) {
 			$rules	= new JAccessRules($data['params']['rules']);
 			$asset	= JTable::getInstance('asset');
 
-			if (!$asset->loadByName($data['option']))
-			{
+			if (!$asset->loadByName($data['option'])) {
 				$root	= JTable::getInstance('asset');
 				$root->loadByName('root.1');
 				$asset->name = $data['option'];
@@ -149,8 +128,7 @@ class ConfigModelComponent extends JModelForm
 			}
 			$asset->rules = (string) $rules;
 
-			if (!$asset->check() || !$asset->store())
-			{
+			if (!$asset->check() || !$asset->store()) {
 				$this->setError($asset->getError());
 				return false;
 			}
@@ -161,8 +139,7 @@ class ConfigModelComponent extends JModelForm
 		}
 
 		// Load the previous Data
-		if (!$table->load($data['id']))
-		{
+		if (!$table->load($data['id'])) {
 			$this->setError($table->getError());
 			return false;
 		}
@@ -170,24 +147,13 @@ class ConfigModelComponent extends JModelForm
 		unset($data['id']);
 
 		// Bind the data.
-		if (!$table->bind($data))
-		{
+		if (!$table->bind($data)) {
 			$this->setError($table->getError());
 			return false;
 		}
 
 		// Check the data.
-		if (!$table->check())
-		{
-			$this->setError($table->getError());
-			return false;
-		}
-
-		// Trigger the oonConfigurationBeforeSave event.
-		$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, $table, $isNew));
-
-		if (in_array(false, $result, true))
-		{
+		if (!$table->check()) {
 			$this->setError($table->getError());
 			return false;
 		}
@@ -200,8 +166,7 @@ class ConfigModelComponent extends JModelForm
 		}
 
 		// Store the data.
-		if (!$table->store())
-		{
+		if (!$table->store()) {
 			$this->setError($table->getError());
 			return false;
 		}
@@ -211,9 +176,6 @@ class ConfigModelComponent extends JModelForm
 
 		// Clean the component cache.
 		$this->cleanCache('_system');
-
-		// Trigger the onConfigurationAfterSave event.
-		$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, $table, $isNew));
 
 		return true;
 	}

--- a/administrator/components/com_config/models/component.php
+++ b/administrator/components/com_config/models/component.php
@@ -110,6 +110,10 @@ class ConfigModelComponent extends JModelForm
 	{
 		$table	= JTable::getInstance('extension');
 
+		$dispatcher = JDispatcher::getInstance();
+		$context = $this->option . '.' . $this->name;
+		JPluginHelper::importPlugin('extension');
+
 		// Save the rules.
 		if (isset($data['params']) && isset($data['params']['rules'])) {
 			$rules	= new JAccessRules($data['params']['rules']);
@@ -154,11 +158,21 @@ class ConfigModelComponent extends JModelForm
 			return false;
 		}
 
+		$result = $dispatcher->trigger('onExtensionBeforeSave', array($context, &$table, false));
+		if (in_array(false, $result, true))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+
 		// Store the data.
 		if (!$table->store()) {
 			$this->setError($table->getError());
 			return false;
 		}
+
+		// Trigger the after save event.
+		$dispatcher->trigger('onExtensionAfterSave', array($context, &$table, false));
 
 		// Clean the component cache.
 		$this->cleanCache('_system');

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1078,10 +1078,15 @@ class MenusModelItem extends JModelAdmin
 	public function save($data)
 	{
 		// Initialise variables.
+		$dispatcher = JDispatcher::getInstance();
 		$pk		= (!empty($data['id'])) ? $data['id'] : (int)$this->getState('item.id');
 		$isNew	= true;
 		$db		= $this->getDbo();
 		$table	= $this->getTable();
+		$context = $this->option . '.' . $this->name;
+
+		// Include the plugins for the on save events.
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Load the row if saving an existing item.
 		if ($pk > 0) {
@@ -1147,11 +1152,22 @@ class MenusModelItem extends JModelAdmin
 			return false;
 		}
 
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
+		if (in_array(false, $result, true))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+
 		// Store the data.
 		if (!$table->store()) {
 			$this->setError($table->getError());
 			return false;
 		}
+
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Rebuild the tree path.
 		if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -33,16 +33,25 @@ class PluginsModelPlugin extends JModelAdmin
 	protected $_cache;
 
 	/**
-	 * @var		string	The event to trigger after saving the data.
-	 * @since	1.6
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *
+	 * @see     JController
+	 * @since   11.1
 	 */
-	protected $event_after_save = 'onExtensionAfterSave';
+	public function __construct($config = array())
+	{
+		$config = array_merge(array(
+			'event_after_delete'  => 'onExtensionAfterDelete',
+			'event_after_save'    => 'onExtensionAfterSave',
+			'event_before_delete' => 'onExtensionBeforeDelete',
+			'event_before_save'   => 'onExtensionBeforeSave',
+			'plugin_type'         => 'extension',
+			'event_change_state'  => 'onExtensionChangeState'), $config);
 
-	/**
-	 * @var		string	The event to trigger after before the data.
-	 * @since	1.6
-	 */
-	protected $event_before_save = 'onExtensionBeforeSave';
+		parent::__construct($config);
+	}
 
 	/**
 	 * Method to get the record form.
@@ -295,9 +304,6 @@ class PluginsModelPlugin extends JModelAdmin
 	 */
 	public function save($data)
 	{
-		// Load the extension plugin group.
-		JPluginHelper::importPlugin('extension');
-
 		// Setup type
 		$data['type'] = 'plugin';
 

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -37,6 +37,28 @@ class TemplatesModelStyle extends JModelAdmin
 	 */
 	private $_cache = array();
 
+    /**
+     * Constructor.
+     *
+     * @param   array  $config  An optional associative array of configuration settings.
+     *
+     * @see     JController
+     * @since   11.1
+     */
+    public function __construct($config = array())
+    {
+        $config = array_merge(array(
+            'event_after_delete'  => 'onExtensionAfterDelete',
+            'event_after_save'    => 'onExtensionAfterSave',
+            'event_before_delete' => 'onExtensionBeforeDelete',
+            'event_before_save'   => 'onExtensionBeforeSave',
+            'plugin_type'         => 'extension',
+            'event_change_state'  => 'onExtensionChangeState'), $config);
+
+        parent::__construct($config);
+    }
+
+
 	/**
 	 * Method to auto-populate the model state.
 	 *

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -67,9 +67,13 @@ class TemplatesModelStyle extends JModelAdmin
 	public function delete(&$pks)
 	{
 		// Initialise variables.
+		$dispatcher = JDispatcher::getInstance();
 		$pks	= (array) $pks;
 		$user	= JFactory::getUser();
 		$table	= $this->getTable();
+		$context = $this->option . '.' . $this->name;
+
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
@@ -85,10 +89,21 @@ class TemplatesModelStyle extends JModelAdmin
 					return false;
 				}
 
+				// Trigger the before delete event.
+				$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
+				if (in_array(false, $result, true))
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+
 				if (!$table->delete($pk)) {
 					$this->setError($table->getError());
 					return false;
 				}
+
+				// Trigger the after delete event.
+				$dispatcher->trigger($this->event_after_delete, array($context, $table));
 			}
 			else {
 				$this->setError($table->getError());
@@ -115,11 +130,16 @@ class TemplatesModelStyle extends JModelAdmin
 		// Initialise variables.
 		$user	= JFactory::getUser();
 		$db		= $this->getDbo();
+		$dispatcher = JDispatcher::getInstance();
+		$context = $this->option . '.' . $this->name;
 
 		// Access checks.
 		if (!$user->authorise('core.create', 'com_templates')) {
 			throw new Exception(JText::_('JERROR_CORE_CREATE_NOT_PERMITTED'));
 		}
+
+		// Include the extension plugins for the save events.
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		$table = $this->getTable();
 
@@ -136,9 +156,19 @@ class TemplatesModelStyle extends JModelAdmin
 				$m = null;
 				$table->title = $this->generateNewTitle(null, null, $table->title);
 
+				// Trigger the onExtensionBeforeSave event.
+				$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, true));
+				if (in_array(false, $result, true)) {
+					$this->setError($table->getError());
+					return false;
+				}
+
 				if (!$table->check() || !$table->store()) {
 					throw new Exception($table->getError());
 				}
+
+				// Trigger the onExtensionAfterSave event.
+				$dispatcher->trigger($this->event_after_save, array($context, &$table, true));
 			}
 			else {
 				throw new Exception($table->getError());
@@ -383,9 +413,10 @@ class TemplatesModelStyle extends JModelAdmin
 		$table		= $this->getTable();
 		$pk			= (!empty($data['id'])) ? $data['id'] : (int)$this->getState('style.id');
 		$isNew		= true;
+		$context = $this->option . '.' . $this->name;
 
 		// Include the extension plugins for the save events.
-		JPluginHelper::importPlugin('extension');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Load the row if saving an existing record.
 		if ($pk > 0) {
@@ -414,7 +445,7 @@ class TemplatesModelStyle extends JModelAdmin
 		}
 
 		// Trigger the onExtensionBeforeSave event.
-		$result = $dispatcher->trigger('onExtensionBeforeSave', array('com_templates.style', &$table, $isNew));
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 		if (in_array(false, $result, true)) {
 			$this->setError($table->getError());
 			return false;
@@ -472,7 +503,7 @@ class TemplatesModelStyle extends JModelAdmin
 		$this->cleanCache();
 
 		// Trigger the onExtensionAfterSave event.
-		$dispatcher->trigger('onExtensionAfterSave', array('com_templates.style', &$table, $isNew));
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		$this->setState('style.id', $table->id);
 

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -22,6 +22,18 @@ jimport('joomla.access.access');
  */
 class UsersModelUser extends JModelAdmin
 {
+	public function __construct($config = array())
+	{
+		$config = array_merge(array(
+			'event_after_delete'  => 'onUserAfterDelete',
+			'event_after_save'    => 'onUserAfterSave',
+			'event_before_delete' => 'onUserBeforeDelete',
+			'event_before_save'   => 'onUserBeforeSave',
+			'plugin_type'         => 'user'), $config);
+
+		parent::__construct($config);
+	}
+
 	/**
 	 * Returns a reference to the a Table object, always creating it.
 	 *
@@ -55,10 +67,10 @@ class UsersModelUser extends JModelAdmin
 
 		// Get the dispatcher and load the users plugins.
 		$dispatcher	= JDispatcher::getInstance();
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Trigger the data preparation event.
-		$results = $dispatcher->trigger('onContentPrepareData', array('com_users.user', $result));
+		$results = $dispatcher->trigger('onContentPrepareData', array($this->option . '.' . $this->name, $result));
 
 		return $result;
 	}
@@ -108,10 +120,10 @@ class UsersModelUser extends JModelAdmin
 		// TODO: Maybe this can go into the parent model somehow?
 		// Get the dispatcher and load the users plugins.
 		$dispatcher	= JDispatcher::getInstance();
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Trigger the data preparation event.
-		$results = $dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
+		$results = $dispatcher->trigger('onContentPrepareData', array($this->option . '.profile', $data));
 
 		// Check for errors encountered while preparing the data.
 		if (count($results) && in_array(false, $results, true))
@@ -219,7 +231,7 @@ class UsersModelUser extends JModelAdmin
 		$iAmSuperAdmin	= $user->authorise('core.admin');
 
 		// Trigger the onUserBeforeSave event.
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->plugin_type);
 		$dispatcher = JDispatcher::getInstance();
 
 		if (in_array($user->id, $pks))
@@ -244,7 +256,7 @@ class UsersModelUser extends JModelAdmin
 					$user_to_delete = JFactory::getUser($pk);
 
 					// Fire the onUserBeforeDelete event.
-					$dispatcher->trigger('onUserBeforeDelete', array($table->getProperties()));
+					$dispatcher->trigger($this->event_before_delete, array($table->getProperties()));
 
 					if (!$table->delete($pk))
 					{
@@ -254,7 +266,7 @@ class UsersModelUser extends JModelAdmin
 					else
 					{
 						// Trigger the onUserAfterDelete event.
-						$dispatcher->trigger('onUserAfterDelete', array($user_to_delete->getProperties(), true, $this->getError()));
+						$dispatcher->trigger($this->event_after_delete, array($user_to_delete->getProperties(), true, $this->getError()));
 					}
 				}
 				else
@@ -295,7 +307,7 @@ class UsersModelUser extends JModelAdmin
 		$table		= $this->getTable();
 		$pks		= (array) $pks;
 
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -343,8 +355,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onUserBeforeSave event.
-						$result = $dispatcher->trigger('onUserBeforeSave', array($old, false, $table->getProperties()));
+						// Trigger the before save event.
+						$result = $dispatcher->trigger($this->event_before_save, array($old, false, $table->getProperties()));
 						if (in_array(false, $result, true))
 						{
 							// Plugin will have to raise it's own error or throw an exception.
@@ -358,8 +370,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onAftereStoreUser event
-						$dispatcher->trigger('onUserAfterSave', array($table->getProperties(), false, true, null));
+						// Trigger the after save event
+						$dispatcher->trigger($this->event_after_save, array($table->getProperties(), false, true, null));
 					}
 					catch (Exception $e)
 					{
@@ -405,7 +417,7 @@ class UsersModelUser extends JModelAdmin
 		$table		= $this->getTable();
 		$pks		= (array) $pks;
 
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -436,8 +448,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onUserBeforeSave event.
-						$result = $dispatcher->trigger('onUserBeforeSave', array($old, false, $table->getProperties()));
+						// Trigger the before save event.
+						$result = $dispatcher->trigger($this->event_before_save, array($old, false, $table->getProperties()));
 						if (in_array(false, $result, true))
 						{
 							// Plugin will have to raise it's own error or throw an exception.
@@ -451,8 +463,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Fire the onAftereStoreUser event
-						$dispatcher->trigger('onUserAfterSave', array($table->getProperties(), false, true, null));
+						// Fire the after save event
+						$dispatcher->trigger($this->event_after_save, array($table->getProperties(), false, true, null));
 					}
 					catch (Exception $e)
 					{

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -69,6 +69,13 @@ abstract class JModelAdmin extends JModelForm
 	protected $event_change_state = null;
 
 	/**
+	 * The plugin type that will be loaded for triggering events.
+	 *
+	 * @var string
+	 */
+	protected $plugin_type = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -123,6 +130,15 @@ abstract class JModelAdmin extends JModelForm
 		elseif (empty($this->event_change_state))
 		{
 			$this->event_change_state = 'onContentChangeState';
+		}
+
+		if (isset($config['plugin_type']))
+		{
+			$this->plugin_type = $config['plugin_type'];
+		}
+		elseif (empty($this->plugin_type))
+		{
+			$this->plugin_type = 'content';
 		}
 
 		// Guess the JText message prefix. Defaults to the option.
@@ -642,8 +658,8 @@ abstract class JModelAdmin extends JModelForm
 		$pks = (array) $pks;
 		$table = $this->getTable();
 
-		// Include the content plugins for the on delete events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the on delete events.
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
@@ -657,7 +673,7 @@ abstract class JModelAdmin extends JModelForm
 
 					$context = $this->option . '.' . $this->name;
 
-					// Trigger the onContentBeforeDelete event.
+					// Trigger the before delete event.
 					$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
 					if (in_array(false, $result, true))
 					{
@@ -671,7 +687,7 @@ abstract class JModelAdmin extends JModelForm
 						return false;
 					}
 
-					// Trigger the onContentAfterDelete event.
+					// Trigger the after delete event.
 					$dispatcher->trigger($this->event_after_delete, array($context, $table));
 
 				}
@@ -841,8 +857,8 @@ abstract class JModelAdmin extends JModelForm
 		$table = $this->getTable();
 		$pks = (array) $pks;
 
-		// Include the content plugins for the change of state event.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the change of state event.
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -870,7 +886,7 @@ abstract class JModelAdmin extends JModelForm
 
 		$context = $this->option . '.' . $this->name;
 
-		// Trigger the onContentChangeState event.
+		// Trigger the change state event.
 		$result = $dispatcher->trigger($this->event_change_state, array($context, $pks, $value));
 
 		if (in_array(false, $result, true))
@@ -976,8 +992,8 @@ abstract class JModelAdmin extends JModelForm
 		$pk = (!empty($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
 		$isNew = true;
 
-		// Include the content plugins for the on save events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the on save events.
+		JPluginHelper::importPlugin($this->plugin_type);
 
 		// Allow an exception to be thrown.
 		try
@@ -1006,7 +1022,7 @@ abstract class JModelAdmin extends JModelForm
 				return false;
 			}
 
-			// Trigger the onContentBeforeSave event.
+			// Trigger the before save event.
 			$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, &$table, $isNew));
 			if (in_array(false, $result, true))
 			{
@@ -1024,7 +1040,7 @@ abstract class JModelAdmin extends JModelForm
 			// Clean the cache.
 			$this->cleanCache();
 
-			// Trigger the onContentAfterSave event.
+			// Trigger the after save event.
 			$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, &$table, $isNew));
 		}
 		catch (Exception $e)


### PR DESCRIPTION
# Reason

Incomplete API. We spotted inconsistencies on some component models which are not properly triggering events as expected. This results in an incomplete and inconsistent API for developers. 

For example in our case we would like to be able to keep track of extension events, which is currently not possible. 
# Problem

Some model’s methods are being overridden without calling their parent method. By not calling the parent the event dispatching process is being bypassed.
# Example

MenusModelItem::save does not trigger the before/after save events because it does not call its parent. 
# Patch

This patch includes the following fixes and enhancements: 
- This patch aims to solve the issue by properly taking care of the dispatching process on model actions.
- It also improves JModelAdmin a bit by reducing the amount of required code in some cases, e.g. extending JModelAdmin and wanting to trigger events on plugins other than content. 
- We also made sure that the correct events (content/extension) are being triggered on each action for each extension resource in order to preserve consistency. 
- Additionally event support was also added to com_config save actions.

Extreme care has been taken in order to provide full backwards compatibility. Patch has been tested extensively. 

As a side note, the same problem is present on J!3.0. We would be more than happy to port this patch into the new code base so that this gets fixed over there as well..

Thanks in advance for considering this patch.

Tracker ticket: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30215

The Joomlatools team.
http://www.joomlatools.com
