### PR TITLE
Incorrect if-test in JSession::get()

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -470,7 +470,7 @@ class JSession implements IteratorAggregate
 		// Add prefix to namespace to avoid collisions
 		$namespace = '__' . $namespace;
 
-		if ($this->_state !== 'active' && $this->_state !== 'expired')
+		if ($this->_state !== 'active')
 		{
 			// @TODO :: generated error here
 			$error = null;


### PR DESCRIPTION
The _state test in the "get" method is flawed.  Under normal session
operation, the _state is active, and pending logout or an expiration it will
remain active.  The if-test in question tests whether the session is not active
AND not expired, and upon evaluating to true will return NULL (I see there is a
note for a more robust error message in the future, but that doesn't help me
today).  Under normal operations, for example a user browsing the website, _state is active.
