### PR TITLE
[#29767] fixes a bug in smart search categoryAccessChange.

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -419,7 +419,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 			$this->change((int) $item->id, 'access', $temp);
 
 			// Reindex the item
-			$this->reindex($row->id);
+			$this->reindex($item->id);
 		}
 	}
 


### PR DESCRIPTION
The current implementation will reindex the same category over and over in the
loop instead of the 'items' of the category.
Note that this function is buggy anyway in the way it handles the access level
for items and category with a 'max' (access level have no reason to be ordered by id !)

issue tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29767
