### PR TITLE
Fixed 'You Are Here' toggle

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 	<?php
 	if ($params->get('showHere', 1))
 	{
-		echo '<li class="active"><span class="divider icon-location hasTooltip" title="' . JText::_('MOD_BREADCRUMBS_HERE') . '"></span></li>';
+		echo '<li class="active"><span class="divider icon-location hasTooltip" title="' . JText::_('MOD_BREADCRUMBS_HERE') . '">' . JText::_('MOD_BREADCRUMBS_HERE') . '</span></li>';
 	}
 
 	// Get rid of duplicated entries on trail including home page when using multilanguage


### PR DESCRIPTION
Added additional JTEXT('MOD_BREADCRUMBS_HERE') to allow user to toggle whether 'You Are Here: ' is shown within the span or not.  The current release does not show the YAH text.
