### PR TITLE
Fix #30241 Horizontal scroll appears when in edit articles caused by TAGs

### DIFF
--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -40,7 +40,7 @@
 
 		<field name="tags" type="tag"
 			label="JTAG" description="JTAG_DESC"
-			class="inputbox" multiple="true"
+			class="inputbox span12 small" multiple="true"
 		>
 		</field>
 


### PR DESCRIPTION
This Pull fixes bug reported here http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=30241 that was caused by tags addition
