### PR TITLE
Show Intro Text = Hide currently has no effect in Featured and Category menu items

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -144,7 +144,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 <?php endif; ?>
-<?php echo $this->item->event->beforeDisplayContent; ?> <?php echo $this->item->introtext; ?>
+<?php echo $this->item->event->beforeDisplayContent; ?>
+
+<?php if ($params->get('show_intro')) : ?>
+<?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($useDefList && ($info == 1 ||  $info == 2)) : ?>
 	<dl class="article-info muted">

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -144,7 +144,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 <?php endif; ?>
-<?php echo $this->item->event->beforeDisplayContent; ?> <?php echo $this->item->introtext; ?>
+<?php echo $this->item->event->beforeDisplayContent; ?>
+
+<?php if ($params->get('show_intro')) : ?>
+<?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($useDefList && ($info == 1 ||  $info == 2)) : ?>
 	<dl class="article-info muted">


### PR DESCRIPTION
This PR adds support of the article option parameter to control display of intro text, specifically hide, to Featured and Category Blog menu item types
