### PR TITLE
Show Intro Text = Hide currently has no effect in Featured and Category menu items

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -134,7 +134,10 @@ JHtml::_('behavior.framework');
 		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 	</div>
 <?php endif; ?>
+
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -134,7 +134,9 @@ $canEdit	= $this->item->params->get('access-edit');
 	</div>
 <?php endif; ?>
 
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :


### PR DESCRIPTION
This PR adds support of the article option parameter to control display of intro text, specifically hide, to Featured and Category Blog menu item types
