### PR TITLE
Improvement and bugfix of validate-uncompressed.js

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -78,10 +78,19 @@ var JFormValidator = new Class({
 				if (el.hasClass('validate')) {
 					el.onclick = function(){return document.formvalidator.isValid(this.form);};
 				}
-			} else {
+			}
+			else if (document.id(el).get('tag') == 'fieldset') {
+				if (el.hasClass('radio') || el.hasClass('checkboxes')) {
+					el.getElements('input').each(function(elCh){
+						elCh.parent = el;
+						elCh.addEvent('change', function(){return document.formvalidator.validate(this.parent);});
+					});
+				}
+			}
+			else {
 				el.addEvent('blur', function(){return document.formvalidator.validate(this);});
 				if (el.hasClass('validate-email') && Browser.Features.inputemail) {
-					el.type = 'email';
+					try { el.type = 'email'; } catch (e){}
 				}
 			}
 		});
@@ -99,17 +108,11 @@ var JFormValidator = new Class({
 
 		// If the field is required make sure it has a value
 		if (el.hasClass('required')) {
-			if (el.get('tag')=='fieldset' && (el.hasClass('radio') || el.hasClass('checkboxes'))) {
-				for(var i=0;;i++) {
-					if (document.id(el.get('id')+i)) {
-						if (document.id(el.get('id')+i).checked) {
-							break;
-						}
-					}
-					else {
-						this.handleResponse(false, el);
-						return false;
-					}
+			// Check if any radio or checkbox is selected in fieldset
+			if (el.get('tag') == 'fieldset' && (el.hasClass('radio') || el.hasClass('checkboxes'))) {
+				if (!el.getElements('input:checked').length) {
+					this.handleResponse(false, el);
+					return false;
 				}
 			}
 			else if (!(el.get('value'))) {
@@ -152,7 +155,7 @@ var JFormValidator = new Class({
 		}
 
 		// Run custom form validators if present
-		new Hash(this.custom).each(function(validator){
+		Object.each(this.custom, function(validator){
 			if (validator.exec() != true) {
 				valid = false;
 			}


### PR DESCRIPTION
Below is description of my changes in order as they appear in the code.
1. Improvement: I have added event to validate radio and checkboxes like text field just after change. Now you have to submit form to validate those fields.
2. bugfix: I have put field type change into try-catch because it cause errors in IE8 and 7 on some site. 
   It is not a bug, but it will protect validator from other errors in 3-rd part extensions.
3. Improvement: I have made simpler usage of radio and checkboxes validation. So far it was too
   complicated. Now it is still backward compatible.
   I have also added validation of multiple select list. Such field you can create with core field type of list and without this fix it would not validate as required.
4. bugfix: Fix of usage Hash object in isValid method which is part of mootools-more which is not being loaded with validator since J!3.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=26114
