### PR TITLE
Fix static call to non-static method in JTags

### DIFF
--- a/libraries/cms/tags/tags.php
+++ b/libraries/cms/tags/tags.php
@@ -439,7 +439,7 @@ class JTags
 	{
 		if (!isset($explodedTypeAlias))
 		{
-			$explodedTypeAlias = self::explodedTypeAlias($typeAlias);
+			$explodedTypeAlias = $this->explodedTypeAlias($typeAlias);
 		}
 
 		$this->url = 'index.php?option=' . $explodedTypeAlias[0] . '&view=' . $explodedTypeAlias[1] . '&id=' . $id;
@@ -462,7 +462,7 @@ class JTags
 	{
 		if (!isset($explodedTypeAlias))
 		{
-			$explodedTypeAlias = self::explodeTypeAlias($typeAlias);
+			$explodedTypeAlias = $this->explodeTypeAlias($typeAlias);
 		}
 
 		$this->url = 'index.php&option=com_tags&view=tag&id=' . $id;


### PR DESCRIPTION
JTags::explodedTypeAlias is called statically in the class when the method is not marked as static and this would generate E_STRICT issues.
