### PR TITLE
Removal of values that don't exist in the src when binding

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -460,6 +460,9 @@ abstract class JTable extends JObject
 				if (isset($src[$k]))
 				{
 					$this->$k = $src[$k];
+				}elseif(isset($this->$k)){
+					// Unset the value so it isn't saved to the database by accident
+					$this->$k = '';
 				}
 			}
 		}


### PR DESCRIPTION
Adjusted to clear the stored value from the object when binding if it doesn't exist in the source data

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28803
