### PR TITLE
patch for [#28409] Smart Search gives fatal error when searching with stemmer enabled

### DIFF
--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -14,6 +14,7 @@ define('FINDER_PATH_INDEXER', JPATH_ADMINISTRATOR . '/components/com_finder/help
 JLoader::register('FinderIndexerHelper', FINDER_PATH_INDEXER . '/helper.php');
 JLoader::register('FinderIndexerQuery', FINDER_PATH_INDEXER . '/query.php');
 JLoader::register('FinderIndexerResult', FINDER_PATH_INDEXER . '/result.php');
+JLoader::register('FinderIndexerStemmer', FINDER_PATH_INDEXER . '/stemmer.php');
 
 jimport('joomla.application.component.modellist');
 

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1204,7 +1204,7 @@ class FinderModelSearch extends JModelList
 			case ($order == 'relevance' && !empty($this->includedTerms)):
 				$this->setState('list.ordering', 'm.weight');
 				break;
-				
+
 			default:
 				$this->setState('list.ordering', 'l.link_id');
 				break;

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1201,9 +1201,12 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.ordering', 'l.list_price');
 				break;
 
-			default:
 			case ($order == 'relevance' && !empty($this->includedTerms)):
 				$this->setState('list.ordering', 'm.weight');
+				break;
+				
+			default:
+				$this->setState('list.ordering', 'l.link_id');
 				break;
 		}
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28409

3 people confirmed that the suggested fix worked.
