### PR TITLE
[#29572] Smart Search Error: Unknown column 'm.weight' in 'field list' when doing empty searches 

### DIFF
--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1142,9 +1142,12 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.ordering', 'l.list_price');
 				break;
 
-			default:
 			case ($order == 'relevance' && !empty($this->includedTerms)):
 				$this->setState('list.ordering', 'm.weight');
+				break;
+
+			default:
+				$this->setState('list.ordering', 'l.link_id');
 				break;
 		}
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29572

Fix tested by author + 2
