### PR TITLE
Update default.php - infourl to open in new tab

### DIFF
--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -122,7 +122,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<td><?php echo $item->detailsurl ?>
 						<?php if (isset($item->infourl)) : ?>
 							<br />
-							<a href="<?php echo $item->infourl; ?>">
+							<a href="<?php echo $item->infourl; ?>" target="_blank">
 							<?php echo $this->escape($item->infourl); ?>
 							</a>
 						<?php endif; ?>


### PR DESCRIPTION
On line 125, placed 'target="_blank"' so that when an update has further information available, the user wishing to view the information isn't taken away from their website when clicking on the link.
