### PR TITLE
permit core classes override

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -147,7 +147,7 @@ abstract class JLoader
 				// Only register the class for autoloading if the file exists.
 				if (is_file($base . '/' . $path . '.php'))
 				{
-					self::$classes[strtolower($class)] = $base . '/' . $path . '.php';
+					self::register(strtolower($class), $base . '/' . $path . '.php',false);
 					$success = true;
 				}
 			}


### PR DESCRIPTION
with this modification it is possible to write plugins that overrides most joomla core classes, for example JAccess, with a simple plugins like

``` php
<?php
    defined('_JEXEC') or die;

    // include_once JPATH_SITE.'/overrides/access.php';
    JLoader::register('JAccess', JPATH_SITE.'/overrides/access.php');

?>
```
