### PR TITLE
Removed htmlspecialchars to prevent redirect to invalid URLs

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -385,7 +385,7 @@ class JApplication extends JApplicationBase
 		// so we will output a javascript redirect statement.
 		if (headers_sent())
 		{
-			echo "<script>document.location.href='" . htmlspecialchars($url) . "';</script>\n";
+			echo "<script>document.location.href='" . $url . "';</script>\n";
 		}
 		else
 		{

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -385,7 +385,7 @@ class JApplication extends JApplicationBase
 		// so we will output a javascript redirect statement.
 		if (headers_sent())
 		{
-			echo "<script>document.location.href='" . $url . "';</script>\n";
+			echo "<script>document.location.href='" . str_replace("'","&apos;",$url) . "';</script>\n";
 		}
 		else
 		{
@@ -396,7 +396,7 @@ class JApplication extends JApplicationBase
 			{
 				// MSIE type browser and/or server cause issues when url contains utf8 character,so use a javascript redirect method
 				echo '<html><head><meta http-equiv="content-type" content="text/html; charset=' . $document->getCharset() . '" />'
-					. '<script>document.location.href=\'' . htmlspecialchars($url) . '\';</script></head></html>';
+					. '<script>document.location.href=\'' . str_replace("'","&apos;",$url) . '\';</script></head></html>';
 			}
 			else
 			{


### PR DESCRIPTION
Tracker item http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30354

htmlspecialchars is being run on URLs when HTTP headers can't be used for redirect, leading to invalid URLs
