### PR TITLE
Update mod_breatcrumbs/tmpl/default.php

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 	<?php
 	if ($params->get('showHere', 1))
 	{
-		echo '<li class="active"><span class="divider icon-location hasTooltip" title="' . JText::_('MOD_BREADCRUMBS_HERE') . '"></span></li>';
+		echo '<li class="active"><span class="divider icon-location hasTooltip" title="' . JText::_('MOD_BREADCRUMBS_HERE') . '">' . JText::_('MOD_BREADCRUMBS_HERE') . '</span></li>';
 	}
 
 	// Get rid of duplicated entries on trail including home page when using multilanguage


### PR DESCRIPTION
Bonjour.
Le module breadcrumbs n'affiche pas le text "Vous êtes ici" même si le module est paramétré pour l'afficher.
La correction l'affiche.

__
Eddy
