### PR TITLE
Remove default admin username on installation

### DIFF
--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -21,7 +21,6 @@
 
 		<field name="admin_user" type="text" id="admin_user" class="inputbox"
 			label="INSTL_ADMIN_USER_LABEL"
-			default=""
 			required="true"
 		/>
 

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -21,7 +21,7 @@
 
 		<field name="admin_user" type="text" id="admin_user" class="inputbox"
 			label="INSTL_ADMIN_USER_LABEL"
-			default="admin"
+			default=""
 			required="true"
 		/>
 


### PR DESCRIPTION
This is a part pull of #889 Joomla should not be recommending using "admin" as the default admin username during installation. This is giving a known credential which is 50% of the credentials needed for a site and so should be user generated and no default should be recommended. 

This is the pull request without any language file changes and so can be placed in Joomla 3.1.0
