### PR TITLE
Added ability to add attributes to the print-screen icon

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -250,7 +250,7 @@ abstract class JHtmlIcon
 		{
 			if ($legacy)
 			{
-				$text = JHtml::_('image', 'system/printButton.png', JText::_('JGLOBAL_PRINT'), null, true);
+				$text = JHtml::_('image', 'system/printButton.png', JText::_('JGLOBAL_PRINT'), $attribs, true);
 			}
 			else
 			{


### PR DESCRIPTION
For some reason, the attributes array was passed in but not used. It is now. At least for legacy users.
