### PR TITLE
Correct usage behavior.modal with custom selector

### DIFF
--- a/libraries/joomla/html/behavior.php
+++ b/libraries/joomla/html/behavior.php
@@ -324,20 +324,26 @@ abstract class JHtmlBehavior
 			$opt['size']      = array('x' => '\\window.getSize().x-80', 'y' => '\\window.getSize().y-80');
 		}
 
-		$options = JHtml::getJSObject($opt);
+		$js = array();
+		$js[] = 'window.addEvent("domready", function() {';
+		if (!sizeof(self::$loaded[__METHOD__])) 
+		{
+			$options = JHtml::getJSObject($opt);
+
+			$js[] = '    SqueezeBox.initialize(' . $options . ');';
+			$js[] = '    SqueezeBox.assign($$("' . $selector . '"), {parse: "rel"});';
+		}
+		else
+		{
+			$opt['parse'] = isset($params['parse']) ? $params['parse'] : 'rel';
+			$options = JHtml::getJSObject($opt);
+			
+			$js[] = '    SqueezeBox.assign($$("' . $selector . '"), ' . $options . ');';
+		}
+		$js[] = '});';
 
 		// Attach modal behavior to document
-		$document
-			->addScriptDeclaration(
-			"
-		window.addEvent('domready', function() {
-
-			SqueezeBox.initialize(" . $options . ");
-			SqueezeBox.assign($$('" . $selector . "'), {
-				parse: 'rel'
-			});
-		});"
-		);
+		$document->addScriptDeclaration(implode("\r\n", $js));
 
 		// Set static array
 		self::$loaded[__METHOD__][$sig] = true;


### PR DESCRIPTION
When you use in Joomla
JHTML::_('behavior.modal');
and
JHTML::_('behavior.modal', 'a.test', array('parse' => false, 'fullScreen'=> true));

it would initialize SqueezeBox twice
and it would also create twice HTML tags: div#sbox-overlay and div#sbox-window

Here is one of many cases when it would not work correct.
When you try to run JavaScript 

SqueezeBox.open($('element'), {
   onOpen: function(){
      $('element_container').inject( $('sbox-content') );
   }
});

then it would insert HTML to first copy of SqueezeBox
but second copy of SqueezeBox would be opened with empty content.

SqueezeBox is not a class but a single instance of object which use static IDs.
This correction will prevent from loading HTML code twice.
