### PR TITLE
Fixes bug in countMenuChildren which makes it always return 0

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -522,6 +522,7 @@ class JDocumentHTML extends JDocument
 				$query->from('#__menu');
 				$query->where('parent_id = ' . $active->id);
 				$query->where('published = 1');
+				$dbo->setQuery($query);
 				$children = $dbo->loadResult();
 			}
 			else


### PR DESCRIPTION
The query wasn't getting set before getting the results. Now it is. I'm resending it and closing the other, because it looked like some of my PR's were a little corrupted, and github makes recreating them so easy I figured I might as well touch every one of them again.

And Nick, my experiences interacting with Joomlacode issue tracker and submission process scarred me years ago. It has been several years (I may even still have a project or two on it that I haven't touched) so I'll accept that maybe it's changed for the better since, and sometime when I feel I can afford the time I may go back and try it again. But for right now, I'm here, the cms code is here, and jumping to another system that I neither like nor trust seems a needless waste of time. If that's what you need to have in order to fix a bug, I guess it'll have to wait until then.
