### PR TITLE
Fixed bug where countMenuChildren returned zero

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -493,6 +493,7 @@ class JDocumentHTML extends JDocument
 				$query->from('#__menu');
 				$query->where('parent_id = ' . $active->id);
 				$query->where('published = 1');
+				dbo->setQuery($query);
 				$children = $dbo->loadResult();
 			}
 			else


### PR DESCRIPTION
Fixes this error in the 2.5.x branch as well.

(And this time I mean it.)
