### PR TITLE
JTable::getInstance quits too easily

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -169,19 +169,17 @@ abstract class JTable extends JObject
 			// Search for the class file in the JTable include paths.
 			jimport('joomla.filesystem.path');
 
-			if ($path = JPath::find(JTable::addIncludePath(), strtolower($type) . '.php'))
+			$paths = JTable::addIncludePath();
+			$pathIndex = 0;
+			while (!class_exists($tableClass) && $pathIndex < count($paths))
 			{
-				// Import the class file.
-				include_once $path;
-
-				// If we were unable to load the proper class, raise a warning and return false.
-				if (!class_exists($tableClass))
+				if ($tryThis = JPath::find($paths[$pathIndex++], strtolower($type) . '.php'))
 				{
-					JError::raiseWarning(0, JText::sprintf('JLIB_DATABASE_ERROR_CLASS_NOT_FOUND_IN_FILE', $tableClass));
-					return false;
+					// Import the class file.
+					include_once $tryThis;
 				}
 			}
-			else
+			if (!class_exists($tableClass))
 			{
 				// If we were unable to find the class file in the JTable include paths, raise a warning and return false.
 				JError::raiseWarning(0, JText::sprintf('JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND', $type));


### PR DESCRIPTION
JTable::getInstance quit when the requested file was not found in the first file name matched, even though there may be more file names that match and which might contain the right class. This change keeps it going until it's checked _every_ matching file

This one we may want to talk about..there may be a better place and a better way to fix it. What happens is if you have two files that fit the name, but the first one doesn't have the right class, JTable quits without ever seeing the second one. I can see a discussion, though, about whether we want to enforce good naming conventions. It's an ideal vs real discussion.
