### PR TITLE
Fix Strict warning `Attribute already exists`

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -341,7 +341,7 @@ abstract class JFormField
 			}
 			else
 			{
-				$this->element->addAttribute('class', 'required');
+				$this->element['class'] = 'required';
 			}
 		}
 


### PR DESCRIPTION
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30446

**Test Instructions**
1. Crate new JFormField with class = "" and required = true

``` PHP
$form = new JForm('');
$addForm = new SimpleXMLElement('<form />');
$field = $addForm->addChild('field');
$field->addAttribute('name', 'test');
$field->addAttribute('type', 'text');
$field->addAttribute('class', "");
$field->addAttribute('required', 1);
$form->load($addForm, false);
```
1. Print out the form

``` PHP
print_r($form->getLabel('test'));
```
1. see

```
Warning: SimpleXMLElement::addAttribute() [simplexmlelement.addattribute]: Attribute already exists in \libraries\joomla\form\field.php on line 344
```
