### PR TITLE
Remove $moduleclass_sfx from <input> and <button> elements

### DIFF
--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -12,13 +12,13 @@ defined('_JEXEC') or die;
 <div class="search<?php echo $moduleclass_sfx ?>">
     <form action="<?php echo JRoute::_('index.php');?>" method="post" class="form-inline">
     		<?php
-				$output = '<label for="mod-search-searchword" class="element-invisible">' . $label . '</label> <input name="searchword" id="mod-search-searchword" maxlength="' . $maxlength . '"  class="inputbox'.$moduleclass_sfx.' search-query" type="text" size="' . $width . '" value="' . $text . '"  onblur="if (this.value==\'\') this.value=\'' . $text . '\';" onfocus="if (this.value==\'' . $text . '\') this.value=\'\';" />';
+				$output = '<label for="mod-search-searchword" class="element-invisible">' . $label . '</label> <input name="searchword" id="mod-search-searchword" maxlength="' . $maxlength . '"  class="inputbox search-query" type="text" size="' . $width . '" value="' . $text . '"  onblur="if (this.value==\'\') this.value=\'' . $text . '\';" onfocus="if (this.value==\'' . $text . '\') this.value=\'\';" />';
 
 				if ($button) :
 					if ($imagebutton) :
-						$button = ' <input type="image" value="' . $button_text . '" class="button' . $moduleclass_sfx.'" src="' . $img . '" onclick="this.form.searchword.focus();"/>';
+						$button = ' <input type="image" value="' . $button_text . '" class="button" src="' . $img . '" onclick="this.form.searchword.focus();"/>';
 					else :
-						$button = ' <button class="button' . $moduleclass_sfx . ' btn btn-primary" onclick="this.form.searchword.focus();">' . $button_text . '</button>';
+						$button = ' <button class="button btn btn-primary" onclick="this.form.searchword.focus();">' . $button_text . '</button>';
 					endif;
 				endif;
 


### PR DESCRIPTION
Removing the module class suffix from <input> and <button> elements in mod_search.

They're not needed for anything but it may well break layouts if a suffix is entered.
Also it's the only core module (I think) where it's applied to those elements. Normally it's only applied to the parent <div> where it makes sense as there is a specific module class.

This PR is based on a discussion in the JBS Google Group: 
https://groups.google.com/d/msg/joomlabugsquad/xCS5Npayc1M/h7G7FeiKo3UJ

TrackerItem: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30450
