### PR TITLE
Add JHtml Tabs deprecation

### DIFF
--- a/libraries/joomla/html/tabs.php
+++ b/libraries/joomla/html/tabs.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  HTML
  * @since       11.2
+ * @deprecated	13.2
  */
 abstract class JHtmlTabs
 {
@@ -75,6 +76,8 @@ abstract class JHtmlTabs
 	protected static function _loadBehavior($group, $params = array())
 	{
 		static $loaded = array();
+		
+		JLog::add('JHtml tabs is deprecated, use bootstrap tabs instead.', JLog::WARNING, 'deprecated');
 
 		if (!array_key_exists((string) $group, $loaded))
 		{


### PR DESCRIPTION
Add in deprecation of subpackage and JLog to mark as deprecated. See google groups discussion here:

https://groups.google.com/forum/?fromgroups=#!topic/joomla-dev-cms/H6IRbyvnP1I

'Feature' request here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30456

Would be nice to get this into 3.1 so people have as much time as possible to get moved across!
