### PR TITLE
[#30463] Fixed closing div for compact list of tagged items

### DIFF
--- a/components/com_tags/views/tag/tmpl/list.php
+++ b/components/com_tags/views/tag/tmpl/list.php
@@ -48,3 +48,4 @@ $n = count($this->items);
 <?php endif; ?>
 
 <?php echo $this->loadTemplate('item'); ?>
+</div>

--- a/components/com_tags/views/tag/tmpl/list_item.php
+++ b/components/com_tags/views/tag/tmpl/list_item.php
@@ -90,7 +90,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					</tr>
 				<?php endforeach; ?>
 			</tbody>
-		</table></div>
+		</table>
 	<?php endif; ?>
 
 <?php endif; ?>


### PR DESCRIPTION
Added missing for compact list of tagged items.

See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30463
