### PR TITLE
Fix problem with MySQL connections not being closed properly

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -82,7 +82,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 */
 	public function __destruct()
 	{
-		if (is_callable($this->connection, 'close'))
+		if (is_callable(array($this->connection, 'close')))
 		{
 			mysqli_close($this->connection);
 		}


### PR DESCRIPTION
Correct the syntax for the PHP is_callable() function in the JDatabaseDriverMysqli destructor method to ensure that MySQL connections are properly closed.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29916
