### PR TITLE
Wrong default values for weblink icons in layout

### DIFF
--- a/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/components/com_weblinks/views/category/tmpl/default_items.php
@@ -74,11 +74,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<?php endif; ?>
 
 					<strong class="list-title">
-						<?php if ($this->params->get('icons') == 0) : ?>
+						<?php if ($this->params->get('icons', 1) == 0) : ?>
 							 <?php echo JText::_('COM_WEBLINKS_LINK'); ?>
-						<?php elseif ($this->params->get('icons') == 1) : ?>
+						<?php elseif ($this->params->get('icons', 1) == 1) : ?>
 							<?php if (!$this->params->get('link_icons')) : ?>
-								<?php echo JHtml::_('image', 'system/'.$this->params->get('link_icons', 'weblink.png'), JText::_('COM_WEBLINKS_LINK'), null, true); ?>
+								<?php echo JHtml::_('image', 'system/weblink.png', JText::_('COM_WEBLINKS_LINK'), null, true); ?>
 							<?php else: ?>
 								<?php echo '<img src="'.$this->params->get('link_icons').'" alt="'.JText::_('COM_WEBLINKS_LINK').'" />'; ?>
 							<?php endif; ?>


### PR DESCRIPTION
In the com_weblinks component settings, the default value for the "icons" is 1 (show icons), which is also states by the tooltip. However in the layoutfile the default value was zero (show text). This produced an unexpected behaviour as long as the settings were not saved.
This commit fixes this default value, showing the icon by default even when the settings aren't saved yet.
Also the check for "link_icons" was redundant if the parameter wasn't set. There is no need to check for something we already know isn't set :-)
