### PR TITLE
Removing duplicate class from the login button

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -61,7 +61,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php endif; ?>
 		<div id="form-login-submit" class="control-group">
 			<div class="controls">
-				<button type="submit" tabindex="0" name="Submit" class="btn btn-primary btn"><?php echo JText::_('JLOGIN') ?></button>
+				<button type="submit" tabindex="0" name="Submit" class="btn btn-primary"><?php echo JText::_('JLOGIN') ?></button>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
mod_login currently has the following CSS classes applied to the login button: "btn btn-primary btn". This commit removes the duplicate "btn" class.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30499
