### PR TITLE
Add publish date filters to weblinks module

### DIFF
--- a/modules/mod_weblinks/helper.php
+++ b/modules/mod_weblinks/helper.php
@@ -37,6 +37,7 @@ class ModWeblinksHelper
 		$model->setState('list.limit', (int) $params->get('count', 5));
 
 		$model->setState('filter.state', 1);
+		$model->setState('filter.publish_date', true);
 
 		// Access filter
 		$access = !JComponentHelper::getParams('com_weblinks')->get('show_noauth');


### PR DESCRIPTION
The weblink module was showing all weblinks and did not check for start or stop date.
This commit adds this filter.

The same can be patched in for J!2.5. Should I do a separate PR against the 2.5.x branch?

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29183 for J!2.5
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30505 for J!3.x
