### PR TITLE
Add publish date filters to weblinks module

### DIFF
--- a/modules/mod_weblinks/helper.php
+++ b/modules/mod_weblinks/helper.php
@@ -29,6 +29,7 @@ class modWeblinksHelper
 		$model->setState('list.limit', (int) $params->get('count', 5));
 
 		$model->setState('filter.state', 1);
+		$model->setState('filter.publish_date', true);
 		$model->setState('filter.archived', 0);
 		$model->setState('filter.approved', 1);
 


### PR DESCRIPTION
The weblink module was showing all weblinks and did not check for start or stop date.
This commit adds this filter.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29183

The same applies to Joomla 3.x branch.
PR for J!3.x: https://github.com/joomla/joomla-cms/pull/964
Tracker for J!3.x:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30505
