### PR TITLE
When triggering 'onContentBeforeSave', always pass three parameters

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -97,7 +97,7 @@ class MediaControllerFile extends JControllerLegacy
 			$dispatcher	= JEventDispatcher::getInstance();
 			$object_file = new JObject($file);
 			$object_file->filepath = $filepath;
-			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file));
+			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 
 			if (in_array(false, $result, true))
 			{

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -120,7 +120,7 @@ class MediaControllerFile extends JControllerLegacy
 
 			// Trigger the onContentBeforeSave event.
 			$object_file = new JObject($file);
-			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file));
+			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 
 			if (in_array(false, $result, true))
 			{

--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -184,7 +184,7 @@ class MediaControllerFolder extends JControllerLegacy
 				$object_file = new JObject(array('filepath' => $path));
 				JPluginHelper::importPlugin('content');
 				$dispatcher	= JEventDispatcher::getInstance();
-				$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file));
+				$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file, true));
 
 				if (in_array(false, $result, true))
 				{


### PR DESCRIPTION
 The third, $isNew, is required. I'm not sure if it really should be, but as it stands now, triggering this event without passing anything will result in a warning in PlgContentFinder and maybe some others. 
