### PR TITLE
Fixing Tag view if core_access is not set

### DIFF
--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Site
- * @subpackage  com_tagsxc v
+ * @subpackage  com_tags
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -60,28 +60,26 @@ $n = count($this->items);
 
 	<ul class="category list-striped list-condensed">
 		<?php foreach ($items as $i => $item) : ?>
-			<?php if ((!empty($item->core_access)) && in_array($item->core_access, $this->user->getAuthorisedViewLevels())) : ?>
-				<?php if ($item->core_state == 0) : ?>
-					<li class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
-				<?php else: ?>
-					<li class="cat-list-row<?php echo $i % 2; ?>" >
-					<h3>
-						<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
-							<?php echo $this->escape($item->core_title); ?>
-						</a>
-					</h3>
-				<?php endif; ?>
-				<?php $images  = json_decode($item->core_images);?>
-				<?php if ($this->params->get('tag_list_show_item_image', 1) == 1 && !empty($images->image_intro)) :?>
-					<img src="<?php echo htmlspecialchars($images->image_intro);?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>">
-				<?php endif; ?>
-				<?php if ($this->params->get('tag_list_show_item_description', 1)) : ?>
-					<span class="tag-body">
-						<?php echo JHtml::_('string.truncate', $item->core_body, $this->params->get('tag_list_item_maximum_characters')); ?>
-					</span>
-				<?php endif; ?>
-					</li>
-			<?php endif;?>
+			<?php if ($item->core_state == 0) : ?>
+				<li class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
+			<?php else: ?>
+				<li class="cat-list-row<?php echo $i % 2; ?>" >
+				<h3>
+					<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
+						<?php echo $this->escape($item->core_title); ?>
+					</a>
+				</h3>
+			<?php endif; ?>
+			<?php $images  = json_decode($item->core_images);?>
+			<?php if ($this->params->get('tag_list_show_item_image', 1) == 1 && !empty($images->image_intro)) :?>
+				<img src="<?php echo htmlspecialchars($images->image_intro);?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>">
+			<?php endif; ?>
+			<?php if ($this->params->get('tag_list_show_item_description', 1)) : ?>
+				<span class="tag-body">
+					<?php echo JHtml::_('string.truncate', $item->core_body, $this->params->get('tag_list_item_maximum_characters')); ?>
+				</span>
+			<?php endif; ?>
+				</li>
 			<div class="clearfix"></div>
 		<?php endforeach; ?>
 	</ul>

--- a/components/com_tags/views/tag/tmpl/list_items.php
+++ b/components/com_tags/views/tag/tmpl/list_items.php
@@ -78,11 +78,9 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<tr class="cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>
 						<td headers="categorylist_header_title" class="list-title">
-							<?php if (in_array($item->core_access, $this->user->getAuthorisedViewLevels())) : ?>
-								<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
-									<?php echo $this->escape($item->core_title); ?>
-								</a>
-							<?php endif; ?>
+							<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
+								<?php echo $this->escape($item->core_title); ?>
+							</a>
 							<?php if ($item->core_state == 0) : ?>
 								<span class="list-published label label-warning">
 									<?php echo JText::_('JUNPUBLISHED'); ?>

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -397,7 +397,7 @@ class JHelperTags
 		$query->where('m.type_alias IN (' . $typeAliases . ')');
 
 		$groups = implode(',', $user->getAuthorisedViewLevels());
-		$query->where('c.core_access IN (' . $groups . ')')
+		$query->where('c.core_access IN (' . $groups . ') OR c.core_access = 0')
 			->group('m.type_alias, m.content_item_id, m.core_content_id');
 
 		// Use HAVING if matching all tags and we are matching more than one tag.


### PR DESCRIPTION
3rd party extension may have tagged items without an access column. Those are saved into #__ucm_content with access = 0.
Currently they show in the similar tag module, but not in the tag view.

This PR fixes this.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30588
