### PR TITLE
Changed moduleclass suffix to textarea - Issue 30592

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.xml
+++ b/administrator/modules/mod_custom/mod_custom.xml
@@ -48,7 +48,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_feed/mod_feed.xml
+++ b/administrator/modules/mod_feed/mod_feed.xml
@@ -116,7 +116,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -79,7 +79,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -53,7 +53,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_login/mod_login.xml
+++ b/administrator/modules/mod_login/mod_login.xml
@@ -49,7 +49,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -34,7 +34,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -36,7 +36,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -68,7 +68,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -42,7 +42,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.xml
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.xml
@@ -80,7 +80,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/administrator/modules/mod_status/mod_status.xml
+++ b/administrator/modules/mod_status/mod_status.xml
@@ -71,7 +71,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_submenu/mod_submenu.xml
+++ b/administrator/modules/mod_submenu/mod_submenu.xml
@@ -34,7 +34,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_title/mod_title.xml
+++ b/administrator/modules/mod_title/mod_title.xml
@@ -33,7 +33,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_toolbar/mod_toolbar.xml
+++ b/administrator/modules/mod_toolbar/mod_toolbar.xml
@@ -33,7 +33,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/administrator/modules/mod_version/mod_version.xml
+++ b/administrator/modules/mod_version/mod_version.xml
@@ -59,7 +59,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_archive/mod_articles_archive.xml
+++ b/modules/mod_articles_archive/mod_articles_archive.xml
@@ -39,7 +39,7 @@
 					label="JFIELD_ALT_LAYOUT_LABEL"
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 
-				<field name="moduleclass_sfx" type="text"
+				<field name="moduleclass_sfx" type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -107,7 +107,7 @@
 				<option value="5">JH5</option>
 			</field>
 
-			<field name="moduleclass_sfx" type="text"
+			<field name="moduleclass_sfx" type="textarea" rows="3"
 				label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 				description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -426,7 +426,7 @@
 				<field name="layout" type="modulelayout"
 					label="JFIELD_ALT_LAYOUT_LABEL" description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 
-				<field name="moduleclass_sfx" type="text"
+				<field name="moduleclass_sfx" type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -103,7 +103,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -159,7 +159,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_articles_popular/mod_articles_popular.xml
+++ b/modules/mod_articles_popular/mod_articles_popular.xml
@@ -74,7 +74,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -121,7 +121,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.xml
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.xml
@@ -83,7 +83,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_custom/mod_custom.xml
+++ b/modules/mod_custom/mod_custom.xml
@@ -51,7 +51,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_feed/mod_feed.xml
+++ b/modules/mod_feed/mod_feed.xml
@@ -117,7 +117,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_finder/mod_finder.xml
+++ b/modules/mod_finder/mod_finder.xml
@@ -63,7 +63,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					default=""
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />

--- a/modules/mod_footer/mod_footer.xml
+++ b/modules/mod_footer/mod_footer.xml
@@ -33,7 +33,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_languages/mod_languages.xml
+++ b/modules/mod_languages/mod_languages.xml
@@ -120,7 +120,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -119,7 +119,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_menu/mod_menu.xml
+++ b/modules/mod_menu/mod_menu.xml
@@ -121,7 +121,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_random_image/mod_random_image.xml
+++ b/modules/mod_random_image/mod_random_image.xml
@@ -63,7 +63,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_related_items/mod_related_items.xml
+++ b/modules/mod_related_items/mod_related_items.xml
@@ -49,7 +49,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_search/mod_search.xml
+++ b/modules/mod_search/mod_search.xml
@@ -117,7 +117,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_stats/mod_stats.xml
+++ b/modules/mod_stats/mod_stats.xml
@@ -79,7 +79,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_syndicate/mod_syndicate.xml
+++ b/modules/mod_syndicate/mod_syndicate.xml
@@ -66,7 +66,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -67,7 +67,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -61,7 +61,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_users_latest/mod_users_latest.xml
+++ b/modules/mod_users_latest/mod_users_latest.xml
@@ -57,7 +57,7 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 

--- a/modules/mod_weblinks/mod_weblinks.xml
+++ b/modules/mod_weblinks/mod_weblinks.xml
@@ -138,7 +138,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_whosonline/mod_whosonline.xml
+++ b/modules/mod_whosonline/mod_whosonline.xml
@@ -51,7 +51,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -112,7 +112,7 @@
 					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
 				<field
 					name="moduleclass_sfx"
-					type="text"
+					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field


### PR DESCRIPTION
Changed moduleclass suffix field to textarea to allow more room given the number of suffixes users use nowadays
