### PR TITLE
Fixing "urls" within TagsTableTag->bind()

### DIFF
--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -56,11 +56,11 @@ class TagsTableTag extends JTableNested
 			$array['metadata'] = (string) $registry;
 		}
 
-		if (isset($item->urls) && is_array($item->urls))
+		if (isset($array['urls'] && $array['urls'])
 		{
 			$registry = new JRegistry;
-			$registry->loadArray($item->urls);
-			$item->urls = (string) $registry;
+			$registry->loadArray($array['urls']);
+			$array['urls'] = (string) $registry;
 		}
 
 		if (isset($array['images']) && is_array($array['images']))


### PR DESCRIPTION
The "urls" are stored within $array['urls'], not within $item->urls ($item doesn't even exist in this context).
Thanks piotr_cz to notify in https://groups.google.com/d/msg/joomla-dev-cms/R8x3PcaL7nI/3N0I4_5KHCcJ

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30595
