### PR TITLE
Allow slash in cli input parameters filter

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -198,7 +198,7 @@ class JFilterInput
 				break;
 
 			case 'CMD':
-				$result = (string) preg_replace('/[^A-Z0-9_\.-]/i', '', $source);
+				$result = (string) preg_replace('/[^A-Z0-9_\.-\/]/i', '', $source);
 				$result = ltrim($result, '.');
 				break;
 


### PR DESCRIPTION
The problem is related to input filter when i try to get a filepath from cli parameters like:

./joomla-cli-aplication --file directory/file.csv

The current CMD filter remove the / slash
