### PR TITLE
Showing correct access level in weblinks manager

### DIFF
--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -171,7 +171,7 @@ $sortFields = $this->getSortFields();
 						</div>
 					</td>
 					<td class="small hidden-phone">
-						<?php echo $this->escape($item->access); ?>
+						<?php echo $this->escape($item->access_level); ?>
 					</td>
 					<td class="center hidden-phone">
 						<?php echo $item->hits; ?>


### PR DESCRIPTION
Access Level in weblinnks manager is displaying as number
Changing ->access to ->access_level

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30596
