### PR TITLE
30599 bc break tabs

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -31,9 +31,9 @@ $fieldsets = $this->form->getFieldsets();
 </script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_admin&view=profile&layout=edit&id='.$this->item->id); ?>" method="post" name="adminForm" id="profile-form" class="form-validate form-horizontal" enctype="multipart/form-data">
-	<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'account')); ?>
+	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'account')); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'account', JText::_('COM_ADMIN_USER_ACCOUNT_DETAILS', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'account', JText::_('COM_ADMIN_USER_ACCOUNT_DETAILS', true)); ?>
 			<?php foreach ($this->form->getFieldset('user_details') as $field) : ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $field->label; ?></div>
@@ -48,7 +48,7 @@ $fieldsets = $this->form->getFieldsets();
 				continue;
 			endif;
 		?>
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $fieldset->name, JText::_($fieldset->label, true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', $fieldset->name, JText::_($fieldset->label, true)); ?>
 			<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
 				<?php if ($field->hidden) : ?>
 				<div class="control-group">

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -40,7 +40,7 @@ $fieldsets = $this->form->getFieldsets();
 					<div class="controls"><?php echo $field->input; ?></div>
 				</div>
 			<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php
 		foreach ($fieldsets as $fieldset) :
@@ -61,7 +61,7 @@ $fieldsets = $this->form->getFieldsets();
 				</div>
 				<?php endif; ?>
 			<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
 	<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -64,7 +64,7 @@ $fieldsets = $this->form->getFieldsets();
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
-	<?php echo JHtml::_('bootstrap.endPane'); ?>
+	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default.php
@@ -17,25 +17,25 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 	<div class="row-fluid">
 		<!-- Begin Content -->
 		<div class="span10">
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'site')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'site')); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'site', JText::_('COM_ADMIN_SYSTEM_INFORMATION', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'site', JText::_('COM_ADMIN_SYSTEM_INFORMATION', true)); ?>
 					<?php echo $this->loadTemplate('system'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'phpsettings', JText::_('COM_ADMIN_PHP_SETTINGS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'phpsettings', JText::_('COM_ADMIN_PHP_SETTINGS', true)); ?>
 					<?php echo $this->loadTemplate('phpsettings'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'config', JText::_('COM_ADMIN_CONFIGURATION_FILE', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'config', JText::_('COM_ADMIN_CONFIGURATION_FILE', true)); ?>
 					<?php echo $this->loadTemplate('config'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'directory', JText::_('COM_ADMIN_DIRECTORY_PERMISSIONS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'directory', JText::_('COM_ADMIN_DIRECTORY_PERMISSIONS', true)); ?>
 					<?php echo $this->loadTemplate('directory'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'phpinfo', JText::_('COM_ADMIN_PHP_INFORMATION', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'phpinfo', JText::_('COM_ADMIN_PHP_INFORMATION', true)); ?>
 					<?php echo $this->loadTemplate('phpinfo'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default.php
@@ -21,23 +21,23 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'site', JText::_('COM_ADMIN_SYSTEM_INFORMATION', true)); ?>
 					<?php echo $this->loadTemplate('system'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'phpsettings', JText::_('COM_ADMIN_PHP_SETTINGS', true)); ?>
 					<?php echo $this->loadTemplate('phpsettings'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'config', JText::_('COM_ADMIN_CONFIGURATION_FILE', true)); ?>
 					<?php echo $this->loadTemplate('config'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'directory', JText::_('COM_ADMIN_DIRECTORY_PERMISSIONS', true)); ?>
 					<?php echo $this->loadTemplate('directory'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'phpinfo', JText::_('COM_ADMIN_PHP_INFORMATION', true)); ?>
 					<?php echo $this->loadTemplate('phpinfo'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.endPane'); ?>
 		</div>

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default.php
@@ -39,7 +39,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 					<?php echo $this->loadTemplate('phpinfo'); ?>
 				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.endPane'); ?>
+			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 		</div>
 		<!-- End Content -->
 	</div>

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -50,9 +50,9 @@ JHtml::_('formbehavior.chosen', 'select');
 <div class="span10 form-horizontal">
 
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('COM_BANNERS_BANNER_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_BANNERS_BANNER_DETAILS', true)); ?>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('name'); ?>
@@ -131,7 +131,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				</div>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('COM_BANNERS_GROUP_LABEL_PUBLISHING_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_BANNERS_GROUP_LABEL_PUBLISHING_DETAILS', true)); ?>
 				<?php foreach ($this->form->getFieldset('publish') as $field) : ?>
 					<div class="control-group">
 						<div class="control-label">
@@ -144,7 +144,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endforeach; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'otherparams', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'otherparams', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS', true)); ?>
 				<?php foreach ($this->form->getFieldset('otherparams') as $field) : ?>
 					<div class="control-group">
 						<div class="control-label">
@@ -157,7 +157,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endforeach; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 				<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
 					<div class="control-group">
 						<div class="control-label">

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -129,7 +129,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						<?php echo $this->form->getInput('id'); ?>
 					</div>
 				</div>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_BANNERS_GROUP_LABEL_PUBLISHING_DETAILS', true)); ?>
 				<?php foreach ($this->form->getFieldset('publish') as $field) : ?>
@@ -142,7 +142,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'otherparams', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS', true)); ?>
 				<?php foreach ($this->form->getFieldset('otherparams') as $field) : ?>
@@ -155,7 +155,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 				<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
@@ -168,7 +168,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>
 	</fieldset>

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -170,7 +170,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endforeach; ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -27,8 +27,8 @@ $canDo	= BannersHelper::getActions();
 </script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_banners&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="client-form" class="form-validate form-horizontal">
-	<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'general')); ?>
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'general', empty($this->item->id) ? JText::_('COM_BANNERS_NEW_CLIENT', true) : JText::sprintf('COM_BANNERS_EDIT_CLIENT', $this->item->id, true)); ?>
+	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'general', empty($this->item->id) ? JText::_('COM_BANNERS_NEW_CLIENT', true) : JText::sprintf('COM_BANNERS_EDIT_CLIENT', $this->item->id, true)); ?>
 			<div class="row-fluid">
 				<div class="span6">
 					<?php if ($canDo->get('core.edit.state')) : ?>
@@ -115,7 +115,7 @@ $canDo	= BannersHelper::getActions();
 			</div>
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 			<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
 				<div class="control-group">
 					<?php if (!$field->hidden) : ?>

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -113,7 +113,7 @@ $canDo	= BannersHelper::getActions();
 					<?php endforeach; ?>
 				</div>
 			</div>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 			<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
@@ -128,7 +128,7 @@ $canDo	= BannersHelper::getActions();
 					</div>
 				</div>
 			<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 	<?php echo JHtml::_('bootstrap.endPane'); ?>
 

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -130,7 +130,7 @@ $canDo	= BannersHelper::getActions();
 			<?php endforeach; ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-	<?php echo JHtml::_('bootstrap.endPane'); ?>
+	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -160,7 +160,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 
-			<?php echo JHtml::_('bootstrap.endPane'); ?>
+			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 			<input type="hidden" name="task" value="" />
 			<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -73,7 +73,7 @@ JHtml::_('formbehavior.chosen', 'select');
 							<?php echo $this->form->getInput('extension'); ?>
 						</div>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CATEGORIES_FIELDSET_PUBLISHING', true)); ?>
 					<div class="control-group">
@@ -128,19 +128,19 @@ JHtml::_('formbehavior.chosen', 'select');
 							</div>
 						</div>
 					<?php endif; ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('CATEGORIES_FIELDSET_OPTIONS', true)); ?>
 					<fieldset>
 						<?php echo $this->loadTemplate('options'); ?>
 					</fieldset>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 					<fieldset>
 						<?php echo $this->loadTemplate('metadata'); ?>
 					</fieldset>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo $this->loadTemplate('extrafields'); ?>
 
@@ -149,7 +149,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						<fieldset>
 							<?php echo $this->loadTemplate('associations'); ?>
 						</fieldset>
-					<?php echo JHtml::_('bootstrap.endPanel'); ?>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 
 				<?php if ($this->canDo->get('core.admin')) : ?>
@@ -157,7 +157,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						<fieldset>
 							<?php echo $this->form->getInput('rules'); ?>
 						</fieldset>
-					<?php echo JHtml::_('bootstrap.endPanel'); ?>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 
 			<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -38,9 +38,9 @@ JHtml::_('formbehavior.chosen', 'select');
 	<div class="row-fluid">
 	<!-- Begin Content -->
 		<div class="span10 form-horizontal">
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'general')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'general', JText::_('COM_CATEGORIES_FIELDSET_DETAILS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'general', JText::_('COM_CATEGORIES_FIELDSET_DETAILS', true)); ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('title'); ?>
@@ -75,7 +75,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('COM_CATEGORIES_FIELDSET_PUBLISHING', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CATEGORIES_FIELDSET_PUBLISHING', true)); ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('id'); ?>
@@ -130,13 +130,13 @@ JHtml::_('formbehavior.chosen', 'select');
 					<?php endif; ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'options', JText::_('CATEGORIES_FIELDSET_OPTIONS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('CATEGORIES_FIELDSET_OPTIONS', true)); ?>
 					<fieldset>
 						<?php echo $this->loadTemplate('options'); ?>
 					</fieldset>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 					<fieldset>
 						<?php echo $this->loadTemplate('metadata'); ?>
 					</fieldset>
@@ -145,7 +145,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php echo $this->loadTemplate('extrafields'); ?>
 
 				<?php if ($this->assoc) : ?>
-					<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 						<fieldset>
 							<?php echo $this->loadTemplate('associations'); ?>
 						</fieldset>
@@ -153,7 +153,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endif; ?>
 
 				<?php if ($this->canDo->get('core.admin')) : ?>
-					<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'rules', JText::_('COM_CATEGORIES_FIELDSET_RULES', true)); ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'rules', JText::_('COM_CATEGORIES_FIELDSET_RULES', true)); ?>
 						<fieldset>
 							<?php echo $this->form->getInput('rules'); ?>
 						</fieldset>

--- a/administrator/components/com_categories/views/category/tmpl/edit_extrafields.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit_extrafields.php
@@ -31,6 +31,6 @@ defined('_JEXEC') or die;
 			<?php endforeach;?>
 			</fieldset>
 
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 	<?php endforeach; ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit_extrafields.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit_extrafields.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 		<?php $label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CATEGORIES_'.$name.'_FIELDSET_LABEL'; ?>
 		<?php if ($name != 'editorConfig' && $name != 'basic-limited') : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'attrib-'.$name, trim($label)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-'.$name, trim($label)); ?>
 			<fieldset>
 			<?php if (isset($fieldSet->description) && trim($fieldSet->description)) : ?>
 				<p class="tip"><?php echo $this->escape(JText::_($fieldSet->description));?></p>

--- a/administrator/components/com_config/views/application/tmpl/default.php
+++ b/administrator/components/com_config/views/application/tmpl/default.php
@@ -106,7 +106,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 
-				<?php echo JHtml::_('bootstrap.endPane'); ?>
+				<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 				<input type="hidden" name="task" value="" />
 				<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_config/views/application/tmpl/default.php
+++ b/administrator/components/com_config/views/application/tmpl/default.php
@@ -46,9 +46,9 @@ JHtml::_('formbehavior.chosen', 'select');
 		<!-- End Sidebar -->
 		<!-- Begin Content -->
 		<div class="span10">
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'page-site')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'page-site')); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-site', JText::_('JSITE', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-site', JText::_('JSITE', true)); ?>
 					<div class="row-fluid">
 						<div class="span6">
 							<?php echo $this->loadTemplate('site'); ?>
@@ -61,7 +61,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-system', JText::_('COM_CONFIG_SYSTEM', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-system', JText::_('COM_CONFIG_SYSTEM', true)); ?>
 					<div class="row-fluid">
 						<div class="span6">
 							<?php echo $this->loadTemplate('system'); ?>
@@ -74,7 +74,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-server', JText::_('COM_CONFIG_SERVER', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-server', JText::_('COM_CONFIG_SERVER', true)); ?>
 					<div class="row-fluid">
 						<div class="span6">
 							<?php echo $this->loadTemplate('server'); ?>
@@ -88,20 +88,20 @@ JHtml::_('formbehavior.chosen', 'select');
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-permissions', JText::_('COM_CONFIG_PERMISSIONS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-permissions', JText::_('COM_CONFIG_PERMISSIONS', true)); ?>
 					<div class="row-fluid">
 						<?php echo $this->loadTemplate('permissions'); ?>
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-filters', JText::_('COM_CONFIG_TEXT_FILTERS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-filters', JText::_('COM_CONFIG_TEXT_FILTERS', true)); ?>
 					<div class="row-fluid">
 						<?php echo $this->loadTemplate('filters'); ?>
 					</div>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 				<?php if ($this->ftp) : ?>
-					<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'page-ftp', JText::_('COM_CONFIG_FTP_SETTINGS', true)); ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-ftp', JText::_('COM_CONFIG_FTP_SETTINGS', true)); ?>
 						<?php echo $this->loadTemplate('ftplogin'); ?>
 					<?php echo JHtml::_('bootstrap.endPanel'); ?>
 				<?php endif; ?>

--- a/administrator/components/com_config/views/application/tmpl/default.php
+++ b/administrator/components/com_config/views/application/tmpl/default.php
@@ -59,7 +59,7 @@ JHtml::_('formbehavior.chosen', 'select');
 							<?php echo $this->loadTemplate('cookie'); ?>
 						</div>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-system', JText::_('COM_CONFIG_SYSTEM', true)); ?>
 					<div class="row-fluid">
@@ -72,7 +72,7 @@ JHtml::_('formbehavior.chosen', 'select');
 							<?php echo $this->loadTemplate('session'); ?>
 						</div>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-server', JText::_('COM_CONFIG_SERVER', true)); ?>
 					<div class="row-fluid">
@@ -86,24 +86,24 @@ JHtml::_('formbehavior.chosen', 'select');
 							<?php echo $this->loadTemplate('mail'); ?>
 						</div>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-permissions', JText::_('COM_CONFIG_PERMISSIONS', true)); ?>
 					<div class="row-fluid">
 						<?php echo $this->loadTemplate('permissions'); ?>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-filters', JText::_('COM_CONFIG_TEXT_FILTERS', true)); ?>
 					<div class="row-fluid">
 						<?php echo $this->loadTemplate('filters'); ?>
 					</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php if ($this->ftp) : ?>
 					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'page-ftp', JText::_('COM_CONFIG_FTP_SETTINGS', true)); ?>
 						<?php echo $this->loadTemplate('ftplogin'); ?>
-					<?php echo JHtml::_('bootstrap.endPanel'); ?>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 
 				<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -36,9 +36,9 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 		<!-- Begin contact -->
 		<div class="span10 form-horizontal">
 		<fieldset>
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_CONTACT_NEW_CONTACT', true) : JText::sprintf('COM_CONTACT_EDIT_CONTACT', $this->item->id, true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_CONTACT_NEW_CONTACT', true) : JText::sprintf('COM_CONTACT_EDIT_CONTACT', $this->item->id, true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('name'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('name'); ?></div>
@@ -69,7 +69,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 					<?php echo $this->form->getInput('misc'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('created_by'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('created_by'); ?></div>
@@ -122,7 +122,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'basic', JText::_('COM_CONTACT_CONTACT_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', JText::_('COM_CONTACT_CONTACT_DETAILS', true)); ?>
 
 				<p><?php echo empty($this->item->id) ? JText::_('COM_CONTACT_DETAILS', true) : JText::sprintf('COM_CONTACT_EDIT_DETAILS', $this->item->id, true); ?></p>
 
@@ -190,12 +190,12 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 
 			<?php echo $this->loadTemplate('params'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 					<?php echo $this->loadTemplate('metadata'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 			<?php if ($assoc) : ?>
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 					<?php echo $this->loadTemplate('associations'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endif; ?>

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -200,7 +200,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
-			<?php echo JHtml::_('bootstrap.endPane'); ?>
+			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 		</fieldset>
 		<input type="hidden" name="task" value="" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -67,7 +67,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 					<?php echo $this->form->getLabel('misc'); ?>
 				</div>
 					<?php echo $this->form->getInput('misc'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 				<div class="control-group">
@@ -120,7 +120,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 						</div>
 					</div>
 				<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', JText::_('COM_CONTACT_CONTACT_DETAILS', true)); ?>
 
@@ -186,18 +186,18 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 					<div class="control-label"><?php echo $this->form->getLabel('sortname3'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('sortname3'); ?></div>
 				</div>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo $this->loadTemplate('params'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 					<?php echo $this->loadTemplate('metadata'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($assoc) : ?>
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 					<?php echo $this->loadTemplate('associations'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 			<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_contact/views/contact/tmpl/edit_params.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit_params.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $fieldSets = $this->form->getFieldsets('params');
 foreach ($fieldSets as $name => $fieldSet) :
 	$paramstabs = 'params-' . $name;
-	echo JHtml::_('bootstrap.addPanel', 'myTab', $paramstabs, JText::_($fieldSet->label, true));
+	echo JHtml::_('bootstrap.addTab', 'myTab', $paramstabs, JText::_($fieldSet->label, true));
 
 	if (isset($fieldSet->description) && trim($fieldSet->description)) :
 		echo '<p class="alert alert-info">'.$this->escape(JText::_($fieldSet->description)).'</p>';

--- a/administrator/components/com_contact/views/contact/tmpl/edit_params.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit_params.php
@@ -24,5 +24,5 @@ foreach ($fieldSets as $name => $fieldSet) :
 				<div class="controls"><?php echo $field->input; ?></div>
 			</div>
 		<?php endforeach; ?>
-	<?php echo JHtml::_('bootstrap.endPanel'); ?>
+	<?php echo JHtml::_('bootstrap.endTab'); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -71,9 +71,9 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 	<div class="row-fluid">
 		<!-- Begin Content -->
 		<div class="span10 form-horizontal">
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'general')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'general', JText::_('COM_CONTENT_ARTICLE_DETAILS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'general', JText::_('COM_CONTENT_ARTICLE_DETAILS', true)); ?>
 					<fieldset class="adminform">
 						<div class="control-group form-inline">
 							<?php echo $this->form->getLabel('title'); ?> <?php echo $this->form->getInput('title'); ?> <?php echo $this->form->getLabel('catid'); ?> <?php echo $this->form->getInput('catid'); ?>
@@ -122,7 +122,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 
 				<?php // Do not show the publishing options if the edit form is configured not to. ?>
 					<?php  if ($params['show_publishing_options'] || ( $params['show_publishing_options'] = '' && !empty($editoroptions)) ) : ?>
-						<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('COM_CONTENT_FIELDSET_PUBLISHING', true)); ?>
+						<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CONTENT_FIELDSET_PUBLISHING', true)); ?>
 							<div class="row-fluid">
 								<div class="span6">
 									<div class="control-group">
@@ -215,7 +215,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 							<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 								<?php if ($name != 'editorConfig' && $name != 'basic-limited') : ?>
 									<?php $attribtabs = 'attrib-' . $name; ?>
-									<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $attribtabs, JText::_($fieldSet->label, true)); ?>
+									<?php echo JHtml::_('bootstrap.addTab', 'myTab', $attribtabs, JText::_($fieldSet->label, true)); ?>
 								<?php endif; ?>
 
 							<?php
@@ -256,7 +256,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 						// so that those fields always show to those wih permissions
 					?>
 					<?php if ($this->canDo->get('core.admin')):  ?>
-						<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'editor', JText::_('COM_CONTENT_SLIDER_EDITOR_CONFIG', true)); ?>
+						<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'editor', JText::_('COM_CONTENT_SLIDER_EDITOR_CONFIG', true)); ?>
 							<?php foreach ($this->form->getFieldset('editorConfig') as $field) : ?>
 								<div class="control-group">
 									<?php echo $field->label; ?>
@@ -268,18 +268,18 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 						<?php echo JHtml::_('bootstrap.endPanel'); ?>
 					<?php endif ?>
 
-					<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 							<?php echo $this->loadTemplate('metadata'); ?>
 					<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 					<?php if ($assoc) : ?>
-						<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+						<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 							<?php echo $this->loadTemplate('associations'); ?>
 						<?php echo JHtml::_('bootstrap.endPanel'); ?>
 					<?php endif; ?>
 
 					<?php if ($this->canDo->get('core.admin')) : ?>
-						<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'permissions', JText::_('COM_CONTENT_FIELDSET_RULES', true)); ?>
+						<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'permissions', JText::_('COM_CONTENT_FIELDSET_RULES', true)); ?>
 							<fieldset>
 								<?php echo $this->form->getInput('rules'); ?>
 							</fieldset>

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -286,7 +286,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif; ?>
 
-			<?php echo JHtml::_('bootstrap.endPane'); ?>
+			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="return" value="<?php echo $input->getCmd('return');?>" />

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -118,7 +118,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 							</div>
 						</div>
 					<?php endif; ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 				<?php // Do not show the publishing options if the edit form is configured not to. ?>
 					<?php  if ($params['show_publishing_options'] || ( $params['show_publishing_options'] = '' && !empty($editoroptions)) ) : ?>
@@ -207,7 +207,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 									<?php endif; ?>
 								</div>
 							</div>
-						<?php echo JHtml::_('bootstrap.endPanel'); ?>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php  endif; ?>
 
 					<?php if ($params['show_article_options'] || (( $params['show_article_options'] == '' && !empty($editoroptions) ))) : ?>
@@ -249,7 +249,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 								endif;
 							?>
 						<?php endforeach; ?>
-						<?php echo JHtml::_('bootstrap.endPanel'); ?>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif; ?>
 
 					<?php // We need to make a separate space for the configuration
@@ -265,17 +265,17 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 									</div>
 								</div>
 							<?php endforeach; ?>
-						<?php echo JHtml::_('bootstrap.endPanel'); ?>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif ?>
 
 					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 							<?php echo $this->loadTemplate('metadata'); ?>
-					<?php echo JHtml::_('bootstrap.endPanel'); ?>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 					<?php if ($assoc) : ?>
 						<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 							<?php echo $this->loadTemplate('associations'); ?>
-						<?php echo JHtml::_('bootstrap.endPanel'); ?>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif; ?>
 
 					<?php if ($this->canDo->get('core.admin')) : ?>
@@ -283,7 +283,7 @@ if (!empty($this->item->attribs['show_urls_images_backend']))
 							<fieldset>
 								<?php echo $this->form->getInput('rules'); ?>
 							</fieldset>
-						<?php echo JHtml::_('bootstrap.endPanel'); ?>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif; ?>
 
 			<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -38,7 +38,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					<div class="control-label"><?php echo $this->form->getLabel('map_count'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('map_count'); ?></div>
 				</div>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'params', JText::_('COM_FINDER_FILTER_FIELDSET_PARAMS', true)); ?>
 				<?php foreach ($this->form->getGroup('params') as $field) : ?>
@@ -49,7 +49,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						<div class="controls"><?php echo $field->input; ?></div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_FINDER_FILTER_FIELDSET_DETAILS', true)); ?>
 				<div class="control-group">
@@ -74,7 +74,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						<div class="controls"><?php echo $this->form->getInput('modified'); ?></div>
 					</div>
 				<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>
 	</fieldset>

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -76,7 +76,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<div id="finder-filter-window">

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -19,9 +19,9 @@ JHtml::_('formbehavior.chosen', 'select');
 <form action="<?php echo JRoute::_('index.php?option=com_finder&view=filter&layout=edit&filter_id=' . (int) $this->item->filter_id); ?>" method="post" name="adminForm" id="adminForm" class="form-validate form-horizontal">
 
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'basic')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'basic', JText::_('COM_FINDER_EDIT_FILTER', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', JText::_('COM_FINDER_EDIT_FILTER', true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('title'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('title'); ?></div>
@@ -40,7 +40,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				</div>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'params', JText::_('COM_FINDER_FILTER_FIELDSET_PARAMS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'params', JText::_('COM_FINDER_FILTER_FIELDSET_PARAMS', true)); ?>
 				<?php foreach ($this->form->getGroup('params') as $field) : ?>
 					<div class="control-group">
 						<?php if (!$field->hidden) : ?>
@@ -51,7 +51,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endforeach; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('COM_FINDER_FILTER_FIELDSET_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_FINDER_FILTER_FIELDSET_DETAILS', true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('created_by'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('created_by'); ?></div>

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -62,7 +62,7 @@ defined('_JEXEC') or die;
 						</ul>
 					</fieldset>
 
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'other', JText::_('COM_INSTALLER_MSG_DATABASE_INFO', true)); ?>
 				<div class="control-group" >
@@ -76,7 +76,7 @@ defined('_JEXEC') or die;
 						</ul>
 					</fieldset>
 				</div>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -27,14 +27,14 @@ defined('_JEXEC') or die;
 				<a class="close" data-dismiss="alert" href="#">&times;</a>
 				<?php echo JText::_('COM_INSTALLER_MSG_DATABASE_OK'); ?>
 			</div>
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'other')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'other')); ?>
 		<?php else : ?>
 			<div class="alert alert-error">
 				<a class="close" data-dismiss="alert" href="#">&times;</a>
 				<?php echo JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'); ?>
 			</div>
-			<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'problems')); ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'problems', JText::plural('COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL', $this->errorCount)); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'problems')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'problems', JText::plural('COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL', $this->errorCount)); ?>
 				<fieldset class="panelform">
 						<ul>
 						<?php if (!$this->filterParams) : ?>
@@ -64,7 +64,7 @@ defined('_JEXEC') or die;
 
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 		<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'other', JText::_('COM_INSTALLER_MSG_DATABASE_INFO', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'other', JText::_('COM_INSTALLER_MSG_DATABASE_INFO', true)); ?>
 				<div class="control-group" >
 					<fieldset class="panelform">
 						<ul>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -87,7 +87,7 @@ defined('_JEXEC') or die;
 					<input class="btn btn-primary" type="button" value="<?php echo JText::_('COM_INSTALLER_UPLOAD_AND_INSTALL'); ?>" onclick="Joomla.submitbutton()" />
 				</div>
 			</fieldset>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'directory', JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY', true)); ?>
 			<fieldset class="uploadform">
@@ -102,7 +102,7 @@ defined('_JEXEC') or die;
 					<input type="button" class="btn btn-primary" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton3()" />
 				</div>
 			</fieldset>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'url', JText::_('COM_INSTALLER_INSTALL_FROM_URL', true)); ?>
 			<fieldset class="uploadform">
@@ -117,12 +117,12 @@ defined('_JEXEC') or die;
 					<input type="button" class="btn btn-primary" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton4()" />
 				</div>
 			</fieldset>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php if ($this->ftp) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'ftp', JText::_('COM_INSTALLER_MSG_DESCFTPTITLE', true)); ?>
 				<?php echo $this->loadTemplate('ftp'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
 	<input type="hidden" name="type" value="" />

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -130,6 +130,6 @@ defined('_JEXEC') or die;
 	<input type="hidden" name="task" value="install.install" />
 	<?php echo JHtml::_('form.token'); ?>
 
-	<?php echo JHtml::_('bootstrap.endPane'); ?>
+	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 </form>
 </div>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -72,9 +72,9 @@ defined('_JEXEC') or die;
 		<?php echo $this->loadTemplate('message'); ?>
 	<?php endif; ?>
 
-	<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'upload')); ?>
+	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'upload')); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'upload', JText::_('COM_INSTALLER_UPLOAD_PACKAGE_FILE', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'upload', JText::_('COM_INSTALLER_UPLOAD_PACKAGE_FILE', true)); ?>
 			<fieldset class="uploadform">
 				<legend><?php echo JText::_('COM_INSTALLER_UPLOAD_PACKAGE_FILE'); ?></legend>
 				<div class="control-group">
@@ -89,7 +89,7 @@ defined('_JEXEC') or die;
 			</fieldset>
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'directory', JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'directory', JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY', true)); ?>
 			<fieldset class="uploadform">
 				<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY'); ?></legend>
 				<div class="control-group">
@@ -104,7 +104,7 @@ defined('_JEXEC') or die;
 			</fieldset>
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'url', JText::_('COM_INSTALLER_INSTALL_FROM_URL', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'url', JText::_('COM_INSTALLER_INSTALL_FROM_URL', true)); ?>
 			<fieldset class="uploadform">
 				<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_URL'); ?></legend>
 				<div class="control-group">
@@ -120,7 +120,7 @@ defined('_JEXEC') or die;
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 		<?php if ($this->ftp) : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'ftp', JText::_('COM_INSTALLER_MSG_DESCFTPTITLE', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'ftp', JText::_('COM_INSTALLER_MSG_DESCFTPTITLE', true)); ?>
 				<?php echo $this->loadTemplate('ftp'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 		<?php endif; ?>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -28,9 +28,9 @@ $canDo = LanguagesHelper::getActions();
 
 <form action="<?php echo JRoute::_('index.php?option=com_languages&layout=edit&lang_id='.(int) $this->item->lang_id); ?>" method="post" name="adminForm" id="language-form" class="form-validate form-horizontal">
 	<fieldset>
-	<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
 			<div class="control-group">
 				<div class="controls">
 					<?php if ($this->item->lang_id) : ?>
@@ -118,7 +118,7 @@ $canDo = LanguagesHelper::getActions();
 			</div>
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 			<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
 				<div class="control-group">
 					<?php if (!$field->hidden) : ?>
@@ -133,7 +133,7 @@ $canDo = LanguagesHelper::getActions();
 			<?php endforeach; ?>
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'site_name', JText::_('COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'site_name', JText::_('COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL', true)); ?>
 			<?php foreach ($this->form->getFieldset('site_name') as $field) : ?>
 				<div class="control-group">
 					<?php if (!$field->hidden) : ?>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -116,7 +116,7 @@ $canDo = LanguagesHelper::getActions();
 						<?php echo $this->form->getInput('lang_id'); ?>
 					</div>
 			</div>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS', true)); ?>
 			<?php foreach ($this->form->getFieldset('metadata') as $field) : ?>
@@ -131,7 +131,7 @@ $canDo = LanguagesHelper::getActions();
 					</div>
 				</div>
 			<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'site_name', JText::_('COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL', true)); ?>
 			<?php foreach ($this->form->getFieldset('site_name') as $field) : ?>
@@ -146,7 +146,7 @@ $canDo = LanguagesHelper::getActions();
 					</div>
 				</div>
 			<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 	<?php echo JHtml::_('bootstrap.endPane'); ?>
 	</fieldset>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -148,7 +148,7 @@ $canDo = LanguagesHelper::getActions();
 			<?php endforeach; ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-	<?php echo JHtml::_('bootstrap.endPane'); ?>
+	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -56,9 +56,9 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate form-horizontal">
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('COM_MENUS_ITEM_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_MENUS_ITEM_DETAILS', true)); ?>
 				<div class="row-fluid">
 					<div class="span6">
 						<div class="control-group">
@@ -253,18 +253,18 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				</div>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'options', JText::_('COM_MENUS_ADVANCED_FIELDSET_LABEL', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('COM_MENUS_ADVANCED_FIELDSET_LABEL', true)); ?>
 				<?php echo $this->loadTemplate('options'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 			<?php if ($assoc) : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endif; ?>
 
 			<?php if (!empty($this->modules)) : ?>
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'modules', JText::_('COM_MENUS_ITEM_MODULE_ASSIGNMENT', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'modules', JText::_('COM_MENUS_ITEM_MODULE_ASSIGNMENT', true)); ?>
 					<?php echo $this->loadTemplate('modules'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endif; ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -269,7 +269,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -251,22 +251,22 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 						</div>
 					</div>
 				</div>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('COM_MENUS_ADVANCED_FIELDSET_LABEL', true)); ?>
 				<?php echo $this->loadTemplate('options'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($assoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 			<?php if (!empty($this->modules)) : ?>
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'modules', JText::_('COM_MENUS_ITEM_MODULE_ASSIGNMENT', true)); ?>
 					<?php echo $this->loadTemplate('modules'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -81,7 +81,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				<?php endforeach; ?>
 			</div>
 
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 			<div class="control-group">
@@ -166,14 +166,14 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 				<div class="control-label"><?php echo $this->form->getLabel('xreference'); ?></div>
 				<div class="controls"><?php echo $this->form->getInput('xreference'); ?></div>
 			</div>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php $fieldSets = $this->form->getFieldsets('params'); ?>
 		<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 			<?php $paramstabs = 'params-' . $name; ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
 				<?php echo $this->loadTemplate('params'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
 		<?php $fieldSets = $this->form->getFieldsets('metadata'); ?>
@@ -181,13 +181,13 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 			<?php $metadatatabs = 'metadata-' . $name; ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
 				<?php echo $this->loadTemplate('metadata'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
 		<?php if ($assoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -37,9 +37,9 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 		<div class="span10 form-horizontal">
 
 	<fieldset>
-	<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_NEWSFEEDS_NEW_NEWSFEED', true) : JText::sprintf('COM_NEWSFEEDS_EDIT_NEWSFEED', $this->item->id, true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_NEWSFEEDS_NEW_NEWSFEED', true) : JText::sprintf('COM_NEWSFEEDS_EDIT_NEWSFEED', $this->item->id, true)); ?>
 			<div class="control-group">
 				<div class="control-label"><?php echo $this->form->getLabel('name'); ?></div>
 				<div class="controls"><?php echo $this->form->getInput('name'); ?></div>
@@ -83,7 +83,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 
 		<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 			<div class="control-group">
 				<div class="control-label"><?php echo $this->form->getLabel('alias'); ?></div>
 				<div class="controls"><?php echo $this->form->getInput('alias'); ?></div>
@@ -171,7 +171,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 		<?php $fieldSets = $this->form->getFieldsets('params'); ?>
 		<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 			<?php $paramstabs = 'params-' . $name; ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
 				<?php echo $this->loadTemplate('params'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 		<?php endforeach; ?>
@@ -179,13 +179,13 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 		<?php $fieldSets = $this->form->getFieldsets('metadata'); ?>
 		<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 			<?php $metadatatabs = 'metadata-' . $name; ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
 				<?php echo $this->loadTemplate('metadata'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 		<?php endforeach; ?>
 
 		<?php if ($assoc) : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 		<?php endif; ?>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -190,7 +190,7 @@ $assoc = isset($app->item_associations) ? $app->item_associations : 0;
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 		<input type="hidden" name="task" value="" />

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -106,7 +106,7 @@ $this->fieldsets = $this->form->getFieldsets('params');
 						<?php echo JText::_('COM_PLUGINS_XML_ERR'); ?>
 					</div>
 				<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo $this->loadTemplate('options'); ?>
 

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -110,7 +110,7 @@ $this->fieldsets = $this->form->getFieldsets('params');
 
 			<?php echo $this->loadTemplate('options'); ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -27,9 +27,9 @@ $this->fieldsets = $this->form->getFieldsets('params');
 
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&layout=edit&extension_id='.(int) $this->item->extension_id); ?>" method="post" name="adminForm" id="style-form" class="form-validate form-horizontal">
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('name'); ?>

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
@@ -33,6 +33,6 @@ foreach ($this->fieldsets as $name => $fieldset) :
 	<?php endforeach; ?>
 	<?php echo $hidden_fields; ?>
 
-<?php echo JHtml::_('bootstrap.endPanel'); ?>
+<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 <?php endforeach; ?>

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 foreach ($this->fieldsets as $name => $fieldset) :
 	$label = !empty($fieldset->label) ? JText::_($fieldset->label, true) : JText::_('COM_PLUGINS_'.$fieldset->name.'_FIELDSET_LABEL', true);
 	$optionsname = 'options-' . $fieldset->name;
-	echo JHtml::_('bootstrap.addPanel', 'myTab', $optionsname,  $label);
+	echo JHtml::_('bootstrap.addTab', 'myTab', $optionsname,  $label);
 	if (isset($fieldset->description) && trim($fieldset->description)) :
 		echo '<p class="tip">'.$this->escape(JText::_($fieldset->description)).'</p>';
 	endif;

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -28,9 +28,9 @@ JHtml::_('formbehavior.chosen', 'select');
 
 <form action="<?php echo JRoute::_('index.php?option=com_redirect&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="link-form" class="form-validate form-horizontal">
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'basic')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'basic', empty($this->item->id) ? JText::_('COM_REDIRECT_NEW_LINK', true) : JText::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', empty($this->item->id) ? JText::_('COM_REDIRECT_NEW_LINK', true) : JText::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id, true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('old_url'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('old_url'); ?></div>

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -59,7 +59,7 @@ JHtml::_('formbehavior.chosen', 'select');
 					<div class="control-label"><?php echo $this->form->getLabel('modified_date'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('modified_date'); ?></div>
 				</div>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>
 

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -61,7 +61,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				</div>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -103,7 +103,7 @@ $canDo = TemplatesHelper::getActions();
 				<?php endif; ?>
 			<?php endif;?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -88,18 +88,18 @@ $canDo = TemplatesHelper::getActions();
 				<?php else : ?>
 					<div class="alert alert-error"><?php echo JText::_('COM_TEMPLATES_ERR_XML'); ?></div>
 				<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('JOPTIONS', true)); ?>
 				<?php //get the menu parameters that are automatically set but may be modified.
 					echo $this->loadTemplate('options'); ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($user->authorise('core.edit', 'com_menu') && $this->item->client_id == 0):?>
 				<?php if ($canDo->get('core.edit.state')) : ?>
 					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'assignment', JText::_('COM_TEMPLATES_MENUS_ASSIGNMENT', true)); ?>
 						<?php echo $this->loadTemplate('assignment'); ?>
-					<?php echo JHtml::_('bootstrap.endPanel'); ?>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
 				<?php endif; ?>
 			<?php endif;?>
 

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -28,9 +28,9 @@ $canDo = TemplatesHelper::getActions();
 
 <form action="<?php echo JRoute::_('index.php?option=com_templates&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="style-form" class="form-validate form-horizontal">
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('JDETAILS', true)); ?>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('title'); ?>
@@ -90,14 +90,14 @@ $canDo = TemplatesHelper::getActions();
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'options', JText::_('JOPTIONS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'options', JText::_('JOPTIONS', true)); ?>
 				<?php //get the menu parameters that are automatically set but may be modified.
 					echo $this->loadTemplate('options'); ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 			<?php if ($user->authorise('core.edit', 'com_menu') && $this->item->client_id == 0):?>
 				<?php if ($canDo->get('core.edit.state')) : ?>
-					<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'assignment', JText::_('COM_TEMPLATES_MENUS_ASSIGNMENT', true)); ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'assignment', JText::_('COM_TEMPLATES_MENUS_ASSIGNMENT', true)); ?>
 						<?php echo $this->loadTemplate('assignment'); ?>
 					<?php echo JHtml::_('bootstrap.endPanel'); ?>
 				<?php endif; ?>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -84,7 +84,7 @@ $fieldsets = $this->form->getFieldsets();
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -35,9 +35,9 @@ $fieldsets = $this->form->getFieldsets();
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" class="form-validate form-horizontal" enctype="multipart/form-data">
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', JText::_('COM_USERS_USER_ACCOUNT_DETAILS', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_USERS_USER_ACCOUNT_DETAILS', true)); ?>
 				<?php foreach ($this->form->getFieldset('user_details') as $field) : ?>
 					<div class="control-group">
 						<div class="control-label">
@@ -51,7 +51,7 @@ $fieldsets = $this->form->getFieldsets();
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
 			<?php if ($this->grouplist) : ?>
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'groups', JText::_('COM_USERS_ASSIGNED_GROUPS', true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'groups', JText::_('COM_USERS_ASSIGNED_GROUPS', true)); ?>
 					<?php echo $this->loadTemplate('groups'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endif; ?>
@@ -62,7 +62,7 @@ $fieldsets = $this->form->getFieldsets();
 					continue;
 				endif;
 			?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $fieldset->name, JText::_($fieldset->label, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $fieldset->name, JText::_($fieldset->label, true)); ?>
 				<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
 					<?php if ($field->hidden) : ?>
 						<div class="control-group">

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -48,12 +48,12 @@ $fieldsets = $this->form->getFieldsets();
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($this->grouplist) : ?>
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'groups', JText::_('COM_USERS_ASSIGNED_GROUPS', true)); ?>
 					<?php echo $this->loadTemplate('groups'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 			<?php
@@ -81,7 +81,7 @@ $fieldsets = $this->form->getFieldsets();
 						</div>
 					<?php endif; ?>
 				<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endforeach; ?>
 
 		<?php echo JHtml::_('bootstrap.endPane'); ?>

--- a/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -147,7 +147,7 @@ JHtml::_('formbehavior.chosen', 'select');
 			<input type="hidden" name="task" value="" />
 			<?php echo JHtml::_('form.token'); ?>
 
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 		</fieldset>
 		</div>
 		<!-- End Weblinks -->

--- a/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -76,7 +76,7 @@ JHtml::_('formbehavior.chosen', 'select');
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 				<div class="control-group">
@@ -125,14 +125,14 @@ JHtml::_('formbehavior.chosen', 'select');
 						<div class="controls"><?php echo $this->form->getInput('hits'); ?></div>
 					</div>
 				<?php endif; ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php $fieldSets = $this->form->getFieldsets('params'); ?>
 			<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 				<?php $paramstabs = 'params-' . $name; ?>
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
 					<?php echo $this->loadTemplate('params'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endforeach; ?>
 
 			<?php $fieldSets = $this->form->getFieldsets('metadata'); ?>
@@ -140,7 +140,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php $metadatatabs = 'metadata-' . $name; ?>
 				<?php echo JHtml::_('bootstrap.addTab', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
 					<?php echo $this->loadTemplate('metadata'); ?>
-				<?php echo JHtml::_('bootstrap.endPanel'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endforeach; ?>
 
 

--- a/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -32,9 +32,9 @@ JHtml::_('formbehavior.chosen', 'select');
 		<div class="span10 form-horizontal">
 
 	<fieldset>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_WEBLINKS_NEW_WEBLINK', true) : JText::sprintf('COM_WEBLINKS_EDIT_WEBLINK', $this->item->id, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_WEBLINKS_NEW_WEBLINK', true) : JText::sprintf('COM_WEBLINKS_EDIT_WEBLINK', $this->item->id, true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('title'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('title'); ?></div>
@@ -78,7 +78,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php endforeach; ?>
 			<?php echo JHtml::_('bootstrap.endPanel'); ?>
 
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('alias'); ?></div>
 					<div class="controls"><?php echo $this->form->getInput('alias'); ?></div>
@@ -130,7 +130,7 @@ JHtml::_('formbehavior.chosen', 'select');
 			<?php $fieldSets = $this->form->getFieldsets('params'); ?>
 			<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 				<?php $paramstabs = 'params-' . $name; ?>
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', $paramstabs, JText::_($fieldSet->label, true)); ?>
 					<?php echo $this->loadTemplate('params'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endforeach; ?>
@@ -138,7 +138,7 @@ JHtml::_('formbehavior.chosen', 'select');
 			<?php $fieldSets = $this->form->getFieldsets('metadata'); ?>
 			<?php foreach ($fieldSets as $name => $fieldSet) : ?>
 				<?php $metadatatabs = 'metadata-' . $name; ?>
-				<?php echo JHtml::_('bootstrap.addPanel', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', $metadatatabs, JText::_($fieldSet->label, true)); ?>
 					<?php echo $this->loadTemplate('metadata'); ?>
 				<?php echo JHtml::_('bootstrap.endPanel'); ?>
 			<?php endforeach; ?>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -97,7 +97,7 @@ jimport('joomla.html.html.bootstrap');
 		<?php echo JHtml::_('bootstrap.endSlide'); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
@@ -118,7 +118,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
 		<?php endif; ?>
 			<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.endPanel'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 	<?php endif; ?>
@@ -145,7 +145,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
 	<?php endif; ?>
@@ -168,7 +168,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
 	<?php endif; ?>
@@ -204,7 +204,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.endPanel'); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
 	<?php endif; ?>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -213,6 +213,6 @@ jimport('joomla.html.html.bootstrap');
 		<?php echo JHtml::_('bootstrap.endAccordion'); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.endPane'); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<?php endif; ?>
 </div>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -58,14 +58,14 @@ jimport('joomla.html.html.bootstrap');
 		<?php echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'basic-details')); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.startPane', 'myTab', array('active' => 'basic-details')); ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic-details')); ?>
 	<?php endif; ?>
 
 	<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'basic-details', JText::_('COM_CONTACT_DETAILS', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic-details', JText::_('COM_CONTACT_DETAILS', true)); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'plain'):?>
 		<?php  echo '<h3>'. JText::_('COM_CONTACT_DETAILS').'</h3>';  ?>
@@ -106,7 +106,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'display-form', JText::_('COM_CONTACT_EMAIL_FORM', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-form', JText::_('COM_CONTACT_EMAIL_FORM', true)); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_EMAIL_FORM').'</h3>';  ?>
@@ -133,7 +133,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'display-articles', JText::_('JGLOBAL_ARTICLES', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-articles', JText::_('JGLOBAL_ARTICLES', true)); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>';  ?>
@@ -156,7 +156,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE', true)); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_PROFILE').'</h3>';  ?>
@@ -179,7 +179,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'display-misc', JText::_('COM_CONTACT_OTHER_INFORMATION', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-misc', JText::_('COM_CONTACT_OTHER_INFORMATION', true)); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_OTHER_INFORMATION').'</h3>';  ?>

--- a/components/com_contact/views/contact/tmpl/default_links.php
+++ b/components/com_contact/views/contact/tmpl/default_links.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_LINKS'), 'display-links'); ?>
 <?php endif; ?>
 <?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-	<?php echo JHtml::_('bootstrap.addPanel', 'myTab', 'display-links', JText::_('COM_CONTACT_LINKS', true)); ?>
+	<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-links', JText::_('COM_CONTACT_LINKS', true)); ?>
 <?php endif; ?>
 <?php if ($this->params->get('presentation_style') == 'plain'):?>
 	<?php echo '<h3>'. JText::_('COM_CONTACT_LINKS').'</h3>';  ?>

--- a/components/com_contact/views/contact/tmpl/default_links.php
+++ b/components/com_contact/views/contact/tmpl/default_links.php
@@ -50,5 +50,5 @@ defined('_JEXEC') or die;
 	<?php echo JHtml::_('bootstrap.endSlide'); ?>
 <?php endif; ?>
 <?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-	<?php echo JHtml::_('bootstrap.endPanel'); ?>
+	<?php echo JHtml::_('bootstrap.endTab'); ?>
 <?php endif; ?>

--- a/layouts/libraries/cms/html/bootstrap/addtab.php
+++ b/layouts/libraries/cms/html/bootstrap/addtab.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$id = empty($displayData['id']) ? '' : $displayData['id'];
+$active = empty($displayData['active']) ? '' : $displayData['active'];
+
+?>
+
+<div id="<?php echo $id; ?>" class="tab-pane<?php echo $active; ?>">

--- a/layouts/libraries/cms/html/bootstrap/addtabscript.php
+++ b/layouts/libraries/cms/html/bootstrap/addtabscript.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$selector = empty($displayData['selector']) ? '' : $displayData['selector'];
+$id = empty($displayData['id']) ? '' : $displayData['id'];
+$active = empty($displayData['active']) ? '' : $displayData['active'];
+$title = empty($displayData['title']) ? '' : $displayData['title'];
+
+
+echo "(function($){
+				$(document).ready(function() {
+					// Handler for .ready() called.
+					var tab = $('<li class=\"$active\"><a href=\"#$id\" data-toggle=\"tab\">$title</a></li>');
+					$('#" . $selector . "Tabs').append(tab);
+				});
+			})(jQuery);";

--- a/layouts/libraries/cms/html/bootstrap/endtab.php
+++ b/layouts/libraries/cms/html/bootstrap/endtab.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+?>
+
+</div>

--- a/layouts/libraries/cms/html/bootstrap/endtabset.php
+++ b/layouts/libraries/cms/html/bootstrap/endtabset.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+?>
+
+</div>

--- a/layouts/libraries/cms/html/bootstrap/index.html
+++ b/layouts/libraries/cms/html/bootstrap/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/layouts/libraries/cms/html/bootstrap/starttabset.php
+++ b/layouts/libraries/cms/html/bootstrap/starttabset.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$selector = empty($displayData['selector']) ? '' : $displayData['selector'];
+
+?>
+
+<ul class="nav nav-tabs" id="<?php echo $selector; ?>Tabs"></ul>
+<div class="tab-content" id="<?php echo $selector; ?>Content">

--- a/layouts/libraries/cms/html/bootstrap/starttabsetscript.php
+++ b/layouts/libraries/cms/html/bootstrap/starttabsetscript.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$selector = empty($displayData['selector']) ? '' : $displayData['selector'];
+
+echo "(function($){
+					$('#$selector a').click(function (e)
+					{
+						e.preventDefault();
+						$(this).tab('show');
+					});
+				})(jQuery);";

--- a/layouts/libraries/cms/html/index.html
+++ b/layouts/libraries/cms/html/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/layouts/libraries/cms/index.html
+++ b/layouts/libraries/cms/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/layouts/libraries/index.html
+++ b/layouts/libraries/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -45,9 +45,11 @@ abstract class JHtmlBootstrap
 		self::framework();
 
 		// Attach the alerts to the document
-		JFactory::getDocument()->addScriptDeclaration("(function($){
+		JFactory::getDocument()->addScriptDeclaration(
+			"(function($){
 				$('.$selector').alert();
-				})(jQuery);");
+				})(jQuery);"
+		);
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -85,9 +87,11 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach the carousel to document
-			JFactory::getDocument()->addScriptDeclaration("(function($){
+			JFactory::getDocument()->addScriptDeclaration(
+				"(function($){
 					$('.$selector').carousel($options);
-					})(jQuery);");
+					})(jQuery);"
+			);
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -117,9 +121,11 @@ abstract class JHtmlBootstrap
 		self::framework();
 
 		// Attach the dropdown to the document
-		JFactory::getDocument()->addScriptDeclaration("(function($){
+		JFactory::getDocument()->addScriptDeclaration(
+			"(function($){
 				$('.$selector').dropdown();
-				})(jQuery);");
+				})(jQuery);"
+		);
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -194,9 +200,11 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach the modal to document
-			JFactory::getDocument()->addScriptDeclaration("(function($){
+			JFactory::getDocument()->addScriptDeclaration(
+				"(function($){
 					$('#$selector').modal($options);
-					})(jQuery);");
+					})(jQuery);"
+			);
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -287,11 +295,12 @@ abstract class JHtmlBootstrap
 		$options = JHtml::getJSObject($opt);
 
 		// Attach the popover to the document
-		JFactory::getDocument()
-			->addScriptDeclaration("jQuery(document).ready(function()
+		JFactory::getDocument()->addScriptDeclaration(
+			"jQuery(document).ready(function()
 			{
 				jQuery('" . $selector . "').popover(" . $options . ");
-			});");
+			});"
+		);
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -325,9 +334,11 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach ScrollSpy to document
-			JFactory::getDocument()->addScriptDeclaration("(function($){
+			JFactory::getDocument()->addScriptDeclaration(
+				"(function($){
 					$('#$selector').scrollspy($options);
-					})(jQuery);");
+					})(jQuery);"
+			);
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -379,11 +390,12 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach tooltips to document
-			JFactory::getDocument()
-				->addScriptDeclaration("jQuery(document).ready(function()
+			JFactory::getDocument()->addScriptDeclaration(
+				"jQuery(document).ready(function()
 				{
 					jQuery('" . $selector . "').tooltip(" . $options . ");
-				});");
+				});"
+			);
 
 			// Set static array
 			self::$loaded[__METHOD__][$selector] = true;
@@ -424,9 +436,11 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach accordion to document
-			JFactory::getDocument()->addScriptDeclaration("(function($){
+			JFactory::getDocument()->addScriptDeclaration(
+				"(function($){
 					$('#$selector').collapse($options);
-				})(jQuery);");
+				})(jQuery);"
+			);
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -467,7 +481,9 @@ abstract class JHtmlBootstrap
 
 		$html = '<div class="accordion-group' . $class . '">'
 			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">' . $text . '</a></strong>'
+			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">'
+			. $text
+			. '</a></strong>'
 			. '</div>'
 			. '<div class="accordion-body collapse' . $in . '" id="' . $id . '">'
 			. '<div class="accordion-inner">';

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -465,8 +465,8 @@ abstract class JHtmlBootstrap
 		$in = (self::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
-		$html = '<div class="accordion-group' . $class . '">' 
-			. '<div class="accordion-heading">' 
+		$html = '<div class="accordion-group' . $class . '">'
+			. '<div class="accordion-heading">'
 			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">' . $text . '</a></strong>'
 			. '</div>'
 			. '<div class="accordion-body collapse' . $in . '" id="' . $id . '">'
@@ -511,23 +511,17 @@ abstract class JHtmlBootstrap
 
 			$options = JHtml::getJSObject($opt);
 
-			// Attach tooltips to document
+			// Attach tabs to document
 			JFactory::getDocument()
-				->addScriptDeclaration(
-					"(function($){
-					$('#$selector a').click(function (e)
-					{
-						e.preventDefault();
-						$(this).tab('show');
-					});
-				})(jQuery);");
+				->addScriptDeclaration(JLayoutHelper::render('libraries.cms.html.bootstrap.starttabsetscript', array('selector' => $selector)));
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
 			self::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
 		}
-		$html = '<ul class="nav nav-tabs" id="' . $selector . 'Tabs"></ul>';
-		$html .= '<div class="tab-content" id="' . $selector . 'Content">';
+
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.starttabset', array('selector' => $selector));
+
 		return $html;
 	}
 
@@ -540,7 +534,9 @@ abstract class JHtmlBootstrap
 	 */
 	public static function endTabSet()
 	{
-		return '</div>';
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endtabset');
+
+		return $html;
 	}
 
 	/**
@@ -556,20 +552,21 @@ abstract class JHtmlBootstrap
 	 */
 	public static function addTab($selector, $id, $title)
 	{
+		static $tabScriptLayout = null;
+		static $tabLayout = null;
+
+		$tabScriptLayout = is_null($tabScriptLayout) ? new JLayoutFile('libraries.cms.html.bootstrap.addtabscript') : $tabScriptLayout;
+		$tabLayout = is_null($tabLayout) ? new JLayoutFile('libraries.cms.html.bootstrap.addtab') : $tabLayout;
+
 		$active = (self::$loaded['JHtmlBootstrap::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
 		// Inject tab into UL
 		JFactory::getDocument()
-			->addScriptDeclaration(
-				"(function($){
-				$(document).ready(function() {
-					// Handler for .ready() called.
-					var tab = $('<li class=\"$active\"><a href=\"#$id\" data-toggle=\"tab\">$title</a></li>');
-					$('#" . $selector . "Tabs').append(tab);
-				});
-			})(jQuery);");
+		->addScriptDeclaration($tabScriptLayout->render(array('selector' => $selector,'id' => $id, 'active' => $active, 'title' => $title)));
 
-		return '<div id="' . $id . '" class="tab-pane' . $active . '">';
+		$html = $tabLayout->render(array('id' => $id, 'active' => $active));
+
+		return $html;
 	}
 
 	/**
@@ -581,7 +578,9 @@ abstract class JHtmlBootstrap
 	 */
 	public static function endTab()
 	{
-		return '</div>';
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endtab');
+
+		return $html;
 	}
 
 	/**

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -45,11 +45,9 @@ abstract class JHtmlBootstrap
 		self::framework();
 
 		// Attach the alerts to the document
-		JFactory::getDocument()->addScriptDeclaration(
-			"(function($){
+		JFactory::getDocument()->addScriptDeclaration("(function($){
 				$('.$selector').alert();
-				})(jQuery);"
-		);
+				})(jQuery);");
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -84,14 +82,12 @@ abstract class JHtmlBootstrap
 			$opt['interval'] = (isset($params['interval']) && ($params['interval'])) ? (int) $params['interval'] : 5000;
 			$opt['pause'] = (isset($params['pause']) && ($params['pause'])) ? $params['pause'] : 'hover';
 
-			$options = JHtml::getJSObject($opt);
+			$options = self::_getJSObject($opt);
 
 			// Attach the carousel to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
+			JFactory::getDocument()->addScriptDeclaration("(function($){
 					$('.$selector').carousel($options);
-					})(jQuery);"
-			);
+					})(jQuery);");
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -121,11 +117,9 @@ abstract class JHtmlBootstrap
 		self::framework();
 
 		// Attach the dropdown to the document
-		JFactory::getDocument()->addScriptDeclaration(
-			"(function($){
+		JFactory::getDocument()->addScriptDeclaration("(function($){
 				$('.$selector').dropdown();
-				})(jQuery);"
-		);
+				})(jQuery);");
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -158,7 +152,7 @@ abstract class JHtmlBootstrap
 		if ($debug === null)
 		{
 			$config = JFactory::getConfig();
-			$debug  = (boolean) $config->get('debug');
+			$debug = (boolean) $config->get('debug');
 		}
 
 		JHtml::_('script', 'jui/bootstrap.min.js', false, true, false, false, $debug);
@@ -194,17 +188,15 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['backdrop'] = (isset($params['backdrop']) && ($params['backdrop'])) ? (boolean) $params['backdrop'] : true;
 			$opt['keyboard'] = (isset($params['keyboard']) && ($params['keyboard'])) ? (boolean) $params['keyboard'] : true;
-			$opt['show']     = (isset($params['show']) && ($params['show'])) ? (boolean) $params['show'] : true;
-			$opt['remote']   = (isset($params['remote']) && ($params['remote'])) ? (boolean) $params['remote'] : '';
+			$opt['show'] = (isset($params['show']) && ($params['show'])) ? (boolean) $params['show'] : true;
+			$opt['remote'] = (isset($params['remote']) && ($params['remote'])) ? (boolean) $params['remote'] : '';
 
 			$options = JHtml::getJSObject($opt);
 
 			// Attach the modal to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
+			JFactory::getDocument()->addScriptDeclaration("(function($){
 					$('#$selector').modal($options);
-					})(jQuery);"
-			);
+					})(jQuery);");
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -240,7 +232,8 @@ abstract class JHtmlBootstrap
 
 		$html .= "<script>";
 		$html .= "jQuery('#" . $selector . "').on('show', function () {\n";
-		$html .= "document.getElementById('" . $selector . "-container').innerHTML = '<div class=\"modal-body\"><iframe class=\"iframe\" src=\"" . $params['url'] . "\" height=\"" . $params['height'] . "\" width=\"" . $params['width'] . "\"></iframe></div>" . $footer . "';\n";
+		$html .= "document.getElementById('" . $selector . "-container').innerHTML = '<div class=\"modal-body\"><iframe class=\"iframe\" src=\""
+			. $params['url'] . "\" height=\"" . $params['height'] . "\" width=\"" . $params['width'] . "\"></iframe></div>" . $footer . "';\n";
 		$html .= "});\n";
 		$html .= "</script>";
 
@@ -283,23 +276,22 @@ abstract class JHtmlBootstrap
 		self::framework();
 
 		$opt['animation'] = isset($params['animation']) ? $params['animation'] : null;
-		$opt['html']      = isset($params['html']) ? $params['html'] : null;
+		$opt['html'] = isset($params['html']) ? $params['html'] : null;
 		$opt['placement'] = isset($params['placement']) ? $params['placement'] : null;
-		$opt['selector']  = isset($params['selector']) ? $params['selector'] : null;
-		$opt['title']     = isset($params['title']) ? $params['title'] : null;
-		$opt['trigger']   = isset($params['trigger']) ? $params['trigger'] : 'hover';
-		$opt['content']   = isset($params['content']) ? $params['content'] : null;
-		$opt['delay']     = isset($params['delay']) ? $params['delay'] : null;
+		$opt['selector'] = isset($params['selector']) ? $params['selector'] : null;
+		$opt['title'] = isset($params['title']) ? $params['title'] : null;
+		$opt['trigger'] = isset($params['trigger']) ? $params['trigger'] : 'hover';
+		$opt['content'] = isset($params['content']) ? $params['content'] : null;
+		$opt['delay'] = isset($params['delay']) ? $params['delay'] : null;
 
 		$options = JHtml::getJSObject($opt);
 
 		// Attach the popover to the document
-		JFactory::getDocument()->addScriptDeclaration(
-			"jQuery(document).ready(function()
+		JFactory::getDocument()
+			->addScriptDeclaration("jQuery(document).ready(function()
 			{
 				jQuery('" . $selector . "').popover(" . $options . ");
-			});"
-		);
+			});");
 
 		self::$loaded[__METHOD__][$selector] = true;
 
@@ -333,11 +325,9 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach ScrollSpy to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
+			JFactory::getDocument()->addScriptDeclaration("(function($){
 					$('#$selector').scrollspy($options);
-					})(jQuery);"
-			);
+					})(jQuery);");
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -379,22 +369,21 @@ abstract class JHtmlBootstrap
 
 			// Setup options object
 			$opt['animation'] = (isset($params['animation']) && ($params['animation'])) ? (boolean) $params['animation'] : null;
-			$opt['html']      = (isset($params['html']) && ($params['html'])) ? (boolean) $params['html'] : null;
+			$opt['html'] = (isset($params['html']) && ($params['html'])) ? (boolean) $params['html'] : null;
 			$opt['placement'] = (isset($params['placement']) && ($params['placement'])) ? (string) $params['placement'] : null;
-			$opt['selector']  = (isset($params['selector']) && ($params['selector'])) ? (string) $params['selector'] : null;
-			$opt['title']     = (isset($params['title']) && ($params['title'])) ? (string) $params['title'] : null;
-			$opt['trigger']   = (isset($params['trigger']) && ($params['trigger'])) ? (string) $params['trigger'] : null;
-			$opt['delay']     = (isset($params['delay']) && ($params['delay'])) ? (int) $params['delay'] : null;
+			$opt['selector'] = (isset($params['selector']) && ($params['selector'])) ? (string) $params['selector'] : null;
+			$opt['title'] = (isset($params['title']) && ($params['title'])) ? (string) $params['title'] : null;
+			$opt['trigger'] = (isset($params['trigger']) && ($params['trigger'])) ? (string) $params['trigger'] : null;
+			$opt['delay'] = (isset($params['delay']) && ($params['delay'])) ? (int) $params['delay'] : null;
 
 			$options = JHtml::getJSObject($opt);
 
 			// Attach tooltips to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"jQuery(document).ready(function()
+			JFactory::getDocument()
+				->addScriptDeclaration("jQuery(document).ready(function()
 				{
 					jQuery('" . $selector . "').tooltip(" . $options . ");
-				});"
-			);
+				});");
 
 			// Set static array
 			self::$loaded[__METHOD__][$selector] = true;
@@ -435,11 +424,9 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach accordion to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
+			JFactory::getDocument()->addScriptDeclaration("(function($){
 					$('#$selector').collapse($options);
-				})(jQuery);"
-			);
+				})(jQuery);");
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -478,14 +465,12 @@ abstract class JHtmlBootstrap
 		$in = (self::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
-		$html = '<div class="accordion-group' . $class . '">'
-				. '<div class="accordion-heading">'
-				. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">'
-				. $text
-				. '</a></strong>'
-				. '</div>'
-				. '<div class="accordion-body collapse' . $in . '" id="' . $id . '">'
-				. '<div class="accordion-inner">';
+		$html = '<div class="accordion-group' . $class . '">' 
+			. '<div class="accordion-heading">' 
+			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">' . $text . '</a></strong>'
+			. '</div>'
+			. '<div class="accordion-body collapse' . $in . '" id="' . $id . '">'
+			. '<div class="accordion-inner">';
 
 		return $html;
 	}
@@ -510,9 +495,9 @@ abstract class JHtmlBootstrap
 	 *
 	 * @return  string
 	 *
-	 * @since   3.0
+	 * @since   3.1
 	 */
-	public static function startPane($selector = 'myTab', $params = array())
+	public static function startTabSet($selector = 'myTab', $params = array())
 	{
 		$sig = md5(serialize(array($selector, $params)));
 
@@ -527,15 +512,15 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Attach tooltips to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
+			JFactory::getDocument()
+				->addScriptDeclaration(
+					"(function($){
 					$('#$selector a').click(function (e)
 					{
 						e.preventDefault();
 						$(this).tab('show');
 					});
-				})(jQuery);"
-			);
+				})(jQuery);");
 
 			// Set static array
 			self::$loaded[__METHOD__][$sig] = true;
@@ -551,9 +536,9 @@ abstract class JHtmlBootstrap
 	 *
 	 * @return  string  HTML to close the pane
 	 *
-	 * @since   3.0
+	 * @since   3.1
 	 */
-	public static function endPane()
+	public static function endTabSet()
 	{
 		return '</div>';
 	}
@@ -567,22 +552,108 @@ abstract class JHtmlBootstrap
 	 *
 	 * @return  string  HTML to start a new panel
 	 *
-	 * @since   3.0
+	 * @since   3.1
 	 */
-	public static function addPanel($selector, $id, $title)
+	public static function addTab($selector, $id, $title)
 	{
-		$active = (self::$loaded['JHtmlBootstrap::startPane'][$selector]['active'] == $id) ? ' active' : '';
+		$active = (self::$loaded['JHtmlBootstrap::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
 		// Inject tab into UL
-		JFactory::getDocument()->addScriptDeclaration(
-			"(function($){
+		JFactory::getDocument()
+			->addScriptDeclaration(
+				"(function($){
 				$(document).ready(function() {
 					// Handler for .ready() called.
 					var tab = $('<li class=\"$active\"><a href=\"#$id\" data-toggle=\"tab\">$title</a></li>');
 					$('#" . $selector . "Tabs').append(tab);
 				});
-			})(jQuery);"
-		);
+			})(jQuery);");
+
+		return '<div id="' . $id . '" class="tab-pane' . $active . '">';
+	}
+
+	/**
+	 * Close the current tab content panel
+	 *
+	 * @return  string  HTML to close the pane
+	 *
+	 * @since   3.1
+	 */
+	public static function endTab()
+	{
+		return '</div>';
+	}
+
+	/**
+	 * Creates a tab pane
+	 *
+	 * @param   string  $selector  The pane identifier.
+	 * @param   array   $params    The parameters for the pane
+	 *
+	 * @return  string
+	 *
+	 * @since   3.0
+	 * @deprecated  4.0	Use JHtml::_('bootstrap.startTabSet') instead.
+	 */
+	public static function startPane($selector = 'myTab', $params = array())
+	{
+		$sig = md5(serialize(array($selector, $params)));
+		if (!isset(self::$loaded['JHtmlBootstrap::startTabSet'][$sig]))
+		{
+			// Include Bootstrap framework
+			self::framework();
+
+			// Setup options object
+			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
+
+			$options = JHtml::getJSObject($opt);
+
+			// Attach tooltips to document
+			JFactory::getDocument()
+				->addScriptDeclaration(
+					"(function($){
+			$('#$selector a').click(function (e)
+			{
+			e.preventDefault();
+			$(this).tab('show');
+		});
+		})(jQuery);");
+
+			// Set static array
+			self::$loaded['JHtmlBootstrap::startTabSet'][$sig] = true;
+			self::$loaded['JHtmlBootstrap::startTabSet'][$selector]['active'] = $opt['active'];
+		}
+
+		return '<div class="tab-content" id="' . $selector . 'Content">';
+	}
+
+	/**
+	 * Close the current tab pane
+	 *
+	 * @return  string  HTML to close the pane
+	 *
+	 * @since   3.0
+	 * @deprecated  4.0	Use JHtml::_('bootstrap.endTabSet') instead.
+	 */
+	public static function endPane()
+	{
+		return '</div>';
+	}
+
+	/**
+	 * Begins the display of a new tab content panel.
+	 *
+	 * @param   string  $selector  Identifier of the panel.
+	 * @param   string  $id        The ID of the div element
+	 *
+	 * @return  string  HTML to start a new panel
+	 *
+	 * @since   3.0
+	 * @deprecated  4.0 Use JHtml::_('bootstrap.addTab') instead.
+	 */
+	public static function addPanel($selector, $id)
+	{
+		$active = (self::$loaded['JHtmlBootstrap::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
 		return '<div id="' . $id . '" class="tab-pane' . $active . '">';
 	}
@@ -593,6 +664,7 @@ abstract class JHtmlBootstrap
 	 * @return  string  HTML to close the pane
 	 *
 	 * @since   3.0
+	 * @deprecated  4.0 Use JHtml::_('bootstrap.endTab') instead.
 	 */
 	public static function endPanel()
 	{

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -82,7 +82,7 @@ abstract class JHtmlBootstrap
 			$opt['interval'] = (isset($params['interval']) && ($params['interval'])) ? (int) $params['interval'] : 5000;
 			$opt['pause'] = (isset($params['pause']) && ($params['pause'])) ? $params['pause'] : 'hover';
 
-			$options = self::_getJSObject($opt);
+			$options = JHtml::getJSObject($opt);
 
 			// Attach the carousel to document
 			JFactory::getDocument()->addScriptDeclaration("(function($){

--- a/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
@@ -327,7 +327,7 @@ class JHtmlBootstrapTest extends TestCase
 	public function testEndPane()
 	{
 		$this->assertThat(
-			JHtml::_('bootstrap.endPane'),
+			JHtml::_('bootstrap.endTabSet'),
 			$this->equalTo('</div>')
 		);
 	}

--- a/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
@@ -352,7 +352,7 @@ class JHtmlBootstrapTest extends TestCase
 	public function testEndPanel()
 	{
 		$this->assertThat(
-			JHtml::_('bootstrap.endPanel'),
+			JHtml::_('bootstrap.endTab'),
 			$this->equalTo('</div>')
 		);
 	}

--- a/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/html/JHtmlBootstrapTest.php
@@ -258,6 +258,56 @@ class JHtmlBootstrapTest extends TestCase
 	}
 
 	/**
+	 * @todo   Implement testStartTabSet().
+	 */
+	public function testStartTabSet()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.'
+		);
+	}
+
+	/**
+	 * Tests the endTabSet method
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	public function testEndTabSet()
+	{
+		$this->assertThat(
+						JHtml::_('bootstrap.endTabSet'),
+						$this->equalTo('</div>')
+		);
+	}
+
+	/**
+	 * @todo   Implement testAddTab().
+	 */
+	public function testAddTab()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.'
+		);
+	}
+
+	/**
+	 * Tests the endTab method
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	public function testEndTab()
+	{
+		$this->assertThat(
+						JHtml::_('bootstrap.endTab'),
+						$this->equalTo('</div>')
+		);
+	}
+
+	/**
 	 * @todo   Implement testStartPane().
 	 */
 	public function testStartPane()


### PR DESCRIPTION
This is a propsed fix for http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30599

As the API was modified for JHtmlBootstrap::startPane and ::addPanel, the change reverts this back, and introduces new methods: startTabset, endTabSet, addTab and endTab. This new methods implements all the changes that were introduced recently in J 3.1, w/o interfering with pre-existing methods.

Where needed throughout the CMS, calls to JHtmlBootstrap::startPane have been changed to JHtmlBootstrap::startTabSet. Same for endPane, addPanel and endPanel.

Note that tabs html and javascript is now output through JLayout, so the tabs html and javascript can be overriden in templates.
