### PR TITLE
Fix for JTableContenttype->save()

### DIFF
--- a/libraries/cms/table/contenttype.php
+++ b/libraries/cms/table/contenttype.php
@@ -50,14 +50,7 @@ class JTableContenttype extends JTable
 
 		if (empty($this->type_alias))
 		{
-			$this->type_alias = strtolower($this->type_title);
-		}
-
-		$this->type_alias = JApplication::stringURLSafe($this->type_alias);
-
-		if (trim(str_replace('-', '', $this->type_alias)) == '')
-		{
-			$this->type_alias = JFactory::getDate()->format("Y-m-d-H-i-s");
+			throw new UnexpectedValueException(sprintf('The type_alias is empty'));
 		}
 
 		return true;


### PR DESCRIPTION
Removing the checks and fallbacks for type_alias as they did not produce a valid type_alias. The type_alias needs to be "component.view" and has nothing to do with a regular alias.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30555
