### PR TITLE
Fixing similar tags module query

### DIFF
--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -74,16 +74,9 @@ abstract class ModTagssimilarHelper
 
 			$query->from($db->quoteName('#__contentitem_tag_map', 'm'));
 
-			$query->group($db->quoteName(array('m.core_content_id')));
-			if ($matchtype == 'all' && $tagCount > 0)
-			{
-				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  = ' . $tagCount);
-			}
-			elseif ($matchtype == 'half' && $tagCount > 0)
-			{
-				$tagCountHalf = ceil($tagCount / 2);
-				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  >= ' . $tagCountHalf);
-			}
+			$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON m.tag_id = t.id')
+				->join('INNER', $db->quoteName('#__ucm_content', 'cc') . ' ON m.core_content_id = cc.core_content_id')
+				->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias');
 
 			$query->where('t.access IN (' . $groups . ')');
 			$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
@@ -106,11 +99,18 @@ abstract class ModTagssimilarHelper
 				$query->where($db->quoteName('cc.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');
 			}
 
-			$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON m.tag_id = t.id')
-				->join('INNER', $db->quoteName('#__ucm_content', 'cc') . ' ON m.core_content_id = cc.core_content_id')
-				->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias')
+			$query->group($db->quoteName(array('m.core_content_id')));
+			if ($matchtype == 'all' && $tagCount > 0)
+			{
+				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  = ' . $tagCount);
+			}
+			elseif ($matchtype == 'half' && $tagCount > 0)
+			{
+				$tagCountHalf = ceil($tagCount / 2);
+				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  >= ' . $tagCountHalf);
+			}
 
-				->order($db->quoteName('count') . ' DESC');
+			$query->order($db->quoteName('count') . ' DESC');
 			$db->setQuery($query, 0, $maximum);
 			$results = $db->loadObjectList();
 

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -71,12 +71,10 @@ abstract class ModTagssimilarHelper
 					$db->quoteName('cc.core_language')
 					)
 			);
-			$query->group($db->quoteName(array('tag_id', 'm.content_item_id', 'm.type_alias', 't.access', 'ct.router')))
-				->from($db->quoteName('#__contentitem_tag_map', 'm'))
-				->having('t.access IN (' . $groups . ')')
-				->having($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')')
-				->having($db->quoteName('m.content_item_id') . ' <> ' . $id);
 
+			$query->from($db->quoteName('#__contentitem_tag_map', 'm'));
+
+			$query->group($db->quoteName(array('m.core_content_id')));
 			if ($matchtype == 'all' && $tagCount > 0)
 			{
 				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  = ' . $tagCount);
@@ -86,6 +84,12 @@ abstract class ModTagssimilarHelper
 				$tagCountHalf = ceil($tagCount / 2);
 				$query->having('COUNT( '  . $db->quoteName('tag_id') . ')  >= ' . $tagCountHalf);
 			}
+
+			$query->where('t.access IN (' . $groups . ')');
+			$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
+
+			// Don't show current item
+			$query->where('(' . $db->quoteName('m.content_item_id') . ' <> ' . $id . ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');
 
 			// Only return published tags
 			$query->where($db->quoteName('cc.core_state') . ' = 1 ');


### PR DESCRIPTION
Only group by m.core_content_id to avoid duplicates. Move "having" to "where", better to filter before grouping where it's possible.
Expanding the filter for the current item to also include the type_alias, otherwise items with the same id but from other extensions would be excluded as well.

This fixes two issues:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30609
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30603
