### PR TITLE
Update blog.php

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -43,7 +43,11 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers');
 	</div>
 <?php endif; ?>
 
-
+<?php if (empty($this->lead_items) && empty($this->link_items) && empty($this->intro_items)) : ?>
+	<?php if ($this->params->get('show_no_articles', 1)) : ?>
+		<p><?php echo JText::_('COM_CONTENT_NO_ARTICLES'); ?></p>
+	<?php endif; ?>
+<?php endif; ?>
 
 <?php $leadingcount=0 ; ?>
 <?php if (!empty($this->lead_items)) : ?>


### PR DESCRIPTION
Empty category blog did not show 'COM_CONTENT_NO_ARTICLES' message.
Ref. http://forum.joomla.org/viewtopic.php?f=624&t=723468
Fix in ~\components\com_content\views\category\tmpl\blog.php:
 5 lines added at line no. 46; checks 'show_no_articles' param as well.
