### PR TITLE
Fixing the issue 30642

### DIFF
--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -434,8 +434,8 @@ class TagsModelTag extends JModelAdmin
 		$table = $this->getTable();
 		while ($table->load(array('alias' => $alias, 'parent_id' => $parent_id)))
 		{
-		    $title = ($table->title != $title) ? $title : JString::increment($title);
-			$alias = ($table->alias != $alias) ? $alias : JString::increment($alias, 'dash');
+			$title = ($table->title != $title) ? $title : JString::increment($title);
+			$alias = JString::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -434,8 +434,8 @@ class TagsModelTag extends JModelAdmin
 		$table = $this->getTable();
 		while ($table->load(array('alias' => $alias, 'parent_id' => $parent_id)))
 		{
-			$title = JString::increment($title);
-			$alias = JString::increment($alias, 'dash');
+		    $title = ($table->title != $title) ? $title : JString::increment($title);
+			$alias = ($table->alias != $alias) ? $alias : JString::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);


### PR DESCRIPTION
Fix for creating a new Tag based on existing one, using "Save as Copy" appends a number even the new Title of the copy is different from the original. I did the following fix.

1) If the new Title is different from the copying source's one, the new Title will be saved as it is and if its same, it will generate an increment for the same Title.

2)Do the same for the Alias.

I have added the fix improvement with the second commit.
