### PR TITLE
Adds titles to anchors for accessibility win

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -40,7 +40,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<?php endif; ?>
 			<?php if ($params->get('show_title')) : ?>
 				<?php if ($params->get('link_titles') && !empty($this->item->readmore_link)) : ?>
-					<a href="<?php echo $this->item->readmore_link; ?>"> <?php echo $this->escape($this->item->title); ?></a>
+					<a href="<?php echo $this->item->readmore_link; ?>" title="<?php echo $this->escape($this->item->title); ?>"> <?php echo $this->escape($this->item->title); ?></a>
 				<?php else : ?>
 					<?php echo $this->escape($this->item->title); ?>
 				<?php endif; ?>
@@ -97,7 +97,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 				<dd class="parent-category-name">
 					<?php $title = $this->escape($this->item->parent_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'" title="'.$title.'">'.$title.'</a>';?>
 					<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
 						<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 					<?php else : ?>
@@ -108,7 +108,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<?php if ($params->get('show_category')) : ?>
 				<dd class="category-name">
 					<?php $title = $this->escape($this->item->category_title);
-					$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>';?>
+					$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '" title="'.$title.'">' . $title . '</a>';?>
 					<?php if ($params->get('link_category') && $this->item->catslug) : ?>
 						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 					<?php else : ?>

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -24,7 +24,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php if ($params->get('show_title')) : ?>
 	<h2 class="item-title">
 	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>"> <?php echo $this->escape($this->item->title); ?></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>" title="<?php echo $this->escape($this->item->title); ?>"> <?php echo $this->escape($this->item->title); ?></a>
 	<?php else : ?>
 		<?php echo $this->escape($this->item->title); ?>
 	<?php endif; ?>
@@ -79,7 +79,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 			<dd class="parent-category-name">
 				<?php $title = $this->escape($this->item->parent_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'" title="'.$title.'">'.$title.'</a>';?>
 				<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 				<?php else : ?>
@@ -91,7 +91,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		<?php if ($params->get('show_category')) : ?>
 			<dd class="category-name">
 				<?php $title = $this->escape($this->item->category_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
+				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'" title="'.$title.'">'.$title.'</a>';?>
 				<?php if ($params->get('link_category') && $this->item->catslug) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 				<?php else : ?>

--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -23,7 +23,7 @@ JHtml::_('behavior.framework');
 			<?php if ($params->get('show_title')) : ?>
 				<h2>
 					<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>" title="<?php echo $this->escape($displayData->title); ?>">
 						<?php echo $this->escape($displayData->title); ?></a>
 					<?php else : ?>
 						<?php echo $this->escape($displayData->title); ?>

--- a/layouts/joomla/content/blog_style_default_links.php
+++ b/layouts/joomla/content/blog_style_default_links.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($displayData->get('link_items') as $item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>" title="<?php echo $item->title; ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 ?>
 			<dd class="category-name">
 				<?php $title = $this->escape($displayData['item']->category_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)).'">'.$title.'</a>';?>
+				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)).'" title="'.$title.'">'.$title.'</a>';?>
 				<?php if ($displayData['params']->get('link_category') && $displayData['item']->catslug) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 				<?php else : ?>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 ?>
 			<dd class="parent-category-name">
 				<?php $title = $this->escape($displayData['item']->parent_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)).'">'.$title.'</a>';?>
+				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)).'" title="'.$title.'">'.$title.'</a>';?>
 				<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 				<?php else : ?>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -71,11 +71,11 @@ if ($this->params->get('logoFile'))
 }
 elseif ($this->params->get('sitetitle'))
 {
-	$logo = '<span class="site-title" title="'. $sitename .'">'. htmlspecialchars($this->params->get('sitetitle')) .'</span>';
+	$logo = '<span class="site-title">'. htmlspecialchars($this->params->get('sitetitle')) .'</span>';
 }
 else
 {
-	$logo = '<span class="site-title" title="'. $sitename .'">'. $sitename .'</span>';
+	$logo = '<span class="site-title">'. $sitename .'</span>';
 }
 ?>
 <!DOCTYPE html>
@@ -146,7 +146,7 @@ else
 			<!-- Header -->
 			<div class="header">
 				<div class="header-inner clearfix">
-					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>">
+					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>" title="<?php echo $sitename;?>">
 						<?php echo $logo;?> <?php if ($this->params->get('sitedescription')) { echo '<div class="site-description">'. htmlspecialchars($this->params->get('sitedescription')) .'</div>'; } ?>
 					</a>
 					<div class="header-search pull-right">
@@ -193,7 +193,7 @@ else
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : '');?>">
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
-			<p class="pull-right"><a href="#top" id="back-top"><?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?></a></p>
+			<p class="pull-right"><a href="#top" class="back-top" title="<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>"><?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?></a></p>
 			<p>&copy; <?php echo $sitename; ?> <?php echo date('Y');?></p>
 		</div>
 	</div>


### PR DESCRIPTION
For accessibility reasons anchors should always have titles. 

This is just a start but this commit adds anchor titles to linked article titles and category / parent category titles in article views, category and featured blog views, and to logo and back-top link in Protostar.

I would have loved to add titles to readmores as well but, with the access restrictions on those elements, I'm unsure how to best do that. 
