### PR TITLE
Fix memcached issue on Joomla 2.5.10

### DIFF
--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -314,7 +314,7 @@ class JCacheStorageMemcached extends JCacheStorage
 		$host = $config->get('memcache_server_host', 'localhost');
 		$port = $config->get('memcache_server_port', 11211);
 
-		$memcached = new Memcache;
+		$memcached = new Memcached;
 		$memcachedtest = @$memcached->addServer($host, $port);
 
 		if (!$memcachedtest)


### PR DESCRIPTION
When memcached php driver installed on the environment and you try to go to Joomla general configuration in back-end, you get page break. This is caused by wrong class name usage.
