### PR TITLE
Allow editor form to set editor mode

### DIFF
--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -52,6 +52,7 @@ class JFormFieldEditor extends JFormField
 		$assetField  = $this->element['asset_field'] ? (string) $this->element['asset_field'] : 'asset_id';
 		$authorField = $this->element['created_by_field'] ? (string) $this->element['created_by_field'] : 'created_by';
 		$asset       = $this->form->getValue($assetField) ? $this->form->getValue($assetField) : (string) $this->element['asset_id'];
+		$params      = (isset($this->element['mode'])) ? array('mode' => (int) $this->element['mode']) : array();
 
 		// Build the buttons array.
 		$buttons = (string) $this->element['buttons'];
@@ -78,7 +79,7 @@ class JFormFieldEditor extends JFormField
 			->display(
 			$this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $width, $height, $cols, $rows,
 			$buttons ? (is_array($buttons) ? array_merge($buttons, $hide) : $hide) : false, $this->id, $asset,
-			$this->form->getValue($authorField)
+			$this->form->getValue($authorField), $params
 		);
 	}
 


### PR DESCRIPTION
With this patch, if we create a new editor using JForm we can to set the mode (Simple = 0 , Advance = 1 , Extended = 2) using the JForm xml file
