### PR TITLE
Deleting tag mappings after a tag is deleted

### DIFF
--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -194,9 +194,12 @@ class TagsTableTag extends JTableNested
 	 */
 	public function delete($pk = null, $children = false)
 	{
-		parent::delete($pk, $children);
-		$helper = new JHelperTags;
-		$helper->tagDeleteInstances($pk);
-		return;
+		$return = parent::delete($pk, $children);
+		if ($return)
+		{
+			$helper = new JHelperTags;
+			$helper->tagDeleteInstances($pk);
+		}
+		return $return;
 	}
 }

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -194,8 +194,9 @@ class TagsTableTag extends JTableNested
 	 */
 	public function delete($pk = null, $children = false)
 	{
-		return parent::delete($pk, $children);
+		parent::delete($pk, $children);
 		$helper = new JHelperTags;
 		$helper->tagDeleteInstances($pk);
+		return;
 	}
 }


### PR DESCRIPTION
The delete function returned before the related tag mappings were deleted resulting in the tag mapping not deleted.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30744
