### PR TITLE
Fixed call to JClientFtp::getInstance() in download helper

### DIFF
--- a/administrator/components/com_joomlaupdate/helpers/download.php
+++ b/administrator/components/com_joomlaupdate/helpers/download.php
@@ -415,7 +415,7 @@ class AdmintoolsHelperDownload
 
 			// Connect the FTP client
 			$ftp = JClientFtp::getInstance(
-				$ftpOptions['host'], $ftpOptions['port'], null,
+				$ftpOptions['host'], $ftpOptions['port'], array(),
 				$ftpOptions['user'], $ftpOptions['pass']
 			);
 		}


### PR DESCRIPTION
Third arg needs to be array(), not null.
