### PR TITLE
Addition of The Page object class files for Tags and Test class files for the Tags components

### DIFF
--- a/tests/system/webdriver/Pages/Components/TagEditPage.php
+++ b/tests/system/webdriver/Pages/Components/TagEditPage.php
@@ -13,13 +13,37 @@ use SeleniumClient\WebElement;
  */
 class TagEditPage extends AdminEditPage
 {
-  protected $waitForXpath =  "//form[@id='item-form']";
+        /**
+	 * The field type.
+	 *
+	 * @waitforXpath 	string		Contains the Xpath for the Edit Tag Page Form 
+	 */
+        protected $waitForXpath =  "//form[@id='item-form']";
+	/**
+	 * The field type.
+	 *
+	 * @url 	string		Contains the URL for the Edit Tag Page 
+	 */
 	protected $url = 'administrator/index.php?option=com_tags&view=tag&layout=edit';
-	
+	/**
+	 * The field type.
+	 *
+	 * @tabs 	string array		Contains all the Tabs that are present on the Page 
+	 */
 	public $tabs = array('general', 'publishing', 'metadata');
-	
+	/**
+	 * The field type.
+	 *
+	 * @tabLabels 	string array		Contains all the labels of the Tabs that are present on the Page 
+	 */
 	public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
-
+	
+	/**
+	 * The field type.
+	 *
+	 * @inputFields 	string array		Contains all the field Details of the Edit page 
+	 */
+	
 	public $inputFields = array (
 			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'general'),
 			array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'general'),

--- a/tests/system/webdriver/Pages/Components/TagEditPage.php
+++ b/tests/system/webdriver/Pages/Components/TagEditPage.php
@@ -1,0 +1,35 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * Class for the back-end component panel
+ *
+ */
+class TagEditPage extends AdminEditPage
+{
+  protected $waitForXpath =  "//form[@id='item-form']";
+	protected $url = 'administrator/index.php?option=com_tags&view=tag&layout=edit';
+	
+	public $tabs = array('general', 'publishing', 'metadata');
+	
+	public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
+
+	public $inputFields = array (
+			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Access', 'id' => 'jform_access', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Language', 'id' => 'jform_language', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Float', 'id' => 'jform_images_float_fulltext', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Alt', 'id' => 'jform_images_image_fulltext_alt', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Caption', 'id' => 'jform_images_image_fulltext_caption', 'type' => 'input', 'tab' => 'general'),
+	);
+	
+	
+}
+

--- a/tests/system/webdriver/Pages/Components/TagManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/TagManagerPage.php
@@ -13,7 +13,17 @@ use SeleniumClient\WebElement;
  */
 class TagManagerPage extends AdminManagerPage
 {
-  protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
+        /**
+	 * The field type.
+	 *
+	 * @WaitForXpath 	string 		Contains the Xpath for the Page to be loaded
+	 */
+        protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
+	/**
+	 * The field type.
+	 *
+	 * @url 	string 		Contains the url for the Page to be loaded
+	 */
 	protected $url = 'administrator/index.php?option=com_tags';
 	
 	public $filters = array(
@@ -33,6 +43,16 @@ class TagManagerPage extends AdminManagerPage
 			'Options' => 'toolbar-options',
 			'Help' => 'toolbar-help',
 			);
+	
+	/**
+	 * Method to  add a Tag in the Components Fields.
+	 *
+	 * @param   $name  String  The Name of the Tag that we want to add.
+	 *
+	 * @return  null.
+	 *
+	 * 
+	 */
 	public function addTag($name='Test Tag')
 	{
 		$new_name = $name . rand(1,100);
@@ -45,6 +65,18 @@ class TagManagerPage extends AdminManagerPage
 		$TagEditPage->clickButton('toolbar-save');
 		$this->test->getPageObject('TagManagerPage');
 	}
+	/**
+	 * Method to  edit a existing  Tag in the Components Fields.
+	 *
+	 * @param   $name  String  The Name of the Tag that we want to edit.
+	 *
+	 * @param   $fields  String  The value of other fields that we want to change of the Tag.
+	 * 
+	 * @return  null.
+	 *
+	 * 
+	 */
+	
 	public function editTag($name, $fields)
 	{
 		$this->clickItem($name);
@@ -54,6 +86,15 @@ class TagManagerPage extends AdminManagerPage
 		$this->test->getPageObject('TagManagerPage');
 		$this->searchFor();
 	}
+	/**
+	 * Method to  delete a existing Tag in the Components Fields.
+	 *
+	 * @param   $name  String  The Name of the Tag that we want to delete.
+	 * 
+	 * @return  null.
+	 *
+	 * 
+	 */
 	public function deleteTag($name)
 	{
 		$this->searchFor($name);

--- a/tests/system/webdriver/Pages/Components/TagManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/TagManagerPage.php
@@ -1,0 +1,69 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * Class for the back-end Components screen.
+ *
+ */
+class TagManagerPage extends AdminManagerPage
+{
+  protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
+	protected $url = 'administrator/index.php?option=com_tags';
+	
+	public $filters = array(
+			'Select State' => 'filter_state',
+			'Select Access' => 'filter_access',
+			'Select Language' => 'filter_language',
+			);
+	public $toolbar = array (
+			'New' => 'toolbar-new',
+			'Edit' => 'toolbar-edit',
+			'Publish' => 'toolbar-publish',
+			'Unpublish' => 'toolbar-unpublish',
+			'Archive' => 'toolbar_archive',
+			'Check In' => 'toolbar_check_in',
+			'Trash' => 'toolbar_trash',
+			'Batch' => 'toolbar_batch',
+			'Options' => 'toolbar-options',
+			'Help' => 'toolbar-help',
+			);
+	public function addTag($name='Test Tag')
+	{
+		$new_name = $name . rand(1,100);
+		$login = "testing";
+		//echo $new_name; 
+		$this->clickButton('toolbar-new');
+		$TagEditPage = $this->test->getPageObject('TagEditPage');
+		//$TagEditPage->setFieldValue('Title',$new_name);	
+		$TagEditPage->setFieldValues(array('Title' => $new_name));
+		$TagEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('TagManagerPage');
+	}
+	public function editTag($name, $fields)
+	{
+		$this->clickItem($name);
+		$TagEditPage = $this->test->getPageObject('TagEditPage');
+		$TagEditPage->setFieldValues($fields);
+		$TagEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('TagManagerPage');
+		$this->searchFor();
+	}
+	public function deleteTag($name)
+	{
+		$this->searchFor($name);
+		$this->driver->findElement(By::name("checkall-toggle"))->click();
+		$this->driver->findElement(By::xPath(".//div[@id='toolbar-trash']/button"))->click();
+		//$this->clickButton('toolbar-trash');
+		$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		$this->searchFor();
+	}
+
+
+	
+}

--- a/tests/system/webdriver/Pages/System/AdminPage.php
+++ b/tests/system/webdriver/Pages/System/AdminPage.php
@@ -140,6 +140,7 @@ abstract class AdminPage
 			'Security Center'		=> 'http://developer.joomla.org/security.html',
 			'Developer Resources'	=> 'http://developer.joomla.org/',
 			'Joomla Shop'			=> 'http://shop.joomla.org/',
+			'Tags'				=>	'administrator/index.php?option=com_tags',
 	);
 
 

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -1,0 +1,65 @@
+<?php
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the Tag Components: Add / Edit Tag User Screens
+ * @author Mark
+ *
+ */
+class TagManager0001Test extends JoomlaWebdriverTestCase
+{
+  /**
+	 *
+	 * @var TagManagerPage
+	 */
+	protected $TagManagerPage = null;
+	
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->TagManagerPage = $cpPage->clickMenu('Tags', 'TagManagerPage');
+	}
+
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+	
+	/**
+	 * @test
+	 */
+	public function constructor_OpenEditScreen_TagEditOpened()
+	{
+		$this->TagManagerPage->clickButton('new');
+		$TagEditPage = $this->getPageObject('TagEditPage');
+		$TagEditPage->clickButton('cancel');
+		$this->TagManagerPage = $this->getPageObject('TagManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addTag_WithGivenFields_TagAdded()
+	{
+		$salt = rand();
+		$TagName = 'Tag' . $salt;
+		$this->assertFalse($this->TagManagerPage->getRowNumber($TagName), 'Test Tag should not be present');
+		$this->TagManagerPage->addTag($TagName);
+		$message = $this->TagManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Tag successfully saved') >= 0, 'Tag save should return success');
+		$this->assertEquals(2, $this->TagManagerPage->getRowNumber($TagName), 'Test Tag should be in row 2');
+		$this->TagManagerPage->deleteTag($TagName);
+		$this->assertFalse($this->TagManagerPage->getRowNumber($TagName), 'Test Tag should not be present');
+	}
+	
+	
+}

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -17,7 +17,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 {
   /**
 	 *
-	 * @var TagManagerPage
+	 * @var TagManagerPage String 
 	 */
 	protected $TagManagerPage = null;
 	
@@ -56,7 +56,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->TagManagerPage->addTag($TagName);
 		$message = $this->TagManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Tag successfully saved') >= 0, 'Tag save should return success');
-		$this->assertEquals(2, $this->TagManagerPage->getRowNumber($TagName), 'Test Tag should be in row 2');
+		$this->assertEquals(1, $this->TagManagerPage->getRowNumber($TagName), 'Test Tag should be in row 1');
 		$this->TagManagerPage->deleteTag($TagName);
 		$this->assertFalse($this->TagManagerPage->getRowNumber($TagName), 'Test Tag should not be present');
 	}

--- a/tests/system/webdriver/tests/phpunit.xml.dist
+++ b/tests/system/webdriver/tests/phpunit.xml.dist
@@ -7,6 +7,7 @@
 			<directory>extensions</directory>
 			<directory>menus</directory>
 			<directory>users</directory>
+			<directory>components</directory>
 		</testsuite>
 	</testsuites>
 	<logging>


### PR DESCRIPTION
I have Added Three Files and made minor changes in two other existing files, in the Pages folder I have added Two Page Class file 
1) TagEditPage.php
2) TagManagerPage.php

These two files contains the complete Page Object info for the edit and Manger Page for the Tag components in the CMS.

I have added one Test class file in the tests folder, file name is TagManager0001Test.php which contains the the test cases for Adding a new file and a simple GUI test.
