### PR TITLE
Removes emphatic elements

### DIFF
--- a/components/com_contact/views/category/tmpl/default_children.php
+++ b/components/com_contact/views/category/tmpl/default_children.php
@@ -34,9 +34,9 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) :
 
 			<?php if ($this->params->get('show_subcat_desc') == 1) : ?>
 				<?php if ($child->description) : ?>
-					<small class="category-desc">
+					<div class="category-desc">
 						<?php echo JHtml::_('content.prepare', $child->description, '', 'com_contact.category'); ?>
-					</small>
+					</div>
 				<?php endif; ?>
 			<?php endif; ?>
 

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -64,14 +64,14 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					</span>
 
 					<p>
-						<strong class="list-title">
+						<div class="list-title">
 							<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
 								<?php echo $item->name; ?></a>
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 							<?php endif; ?>
 
-						</strong><br/>
+						</div><br/>
 						<?php if ($this->params->get('show_position_headings')) : ?>
 								<?php echo $item->con_position; ?><br/>
 						<?php endif; ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -70,8 +70,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 							<?php endif; ?>
-
-						</div><br/>
+						</div>
 						<?php if ($this->params->get('show_position_headings')) : ?>
 								<?php echo $item->con_position; ?><br/>
 						<?php endif; ?>

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -26,7 +26,7 @@ $params = $this->params;
 					<?php endif; ?>
 				</h2>
 				<?php if ($params->get('show_author') && !empty($item->author )) : ?>
-					<small class="createdby">
+					<div class="createdby">
 					<?php $author = $item->author; ?>
 					<?php $author = ($item->created_by_alias ? $item->created_by_alias : $author); ?>
 						<?php if (!empty($item->contactid ) && $params->get('link_author') == true) : ?>
@@ -37,7 +37,7 @@ $params = $this->params;
 						<?php else :?>
 							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 						<?php endif; ?>
-					</small>
+					</div>
 				<?php endif; ?>
 			</div>
 		<?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')

--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -32,6 +32,6 @@ if (!empty($this->query->highlight) && empty($this->result->mime) && $this->para
 	</p>
 	<?php endif; ?>
 	<?php if ($this->params->get('show_url', 1)) : ?>
-	<small class="small result-url<?php echo $this->pageclass_sfx; ?>"><?php echo $base . JRoute::_($this->result->route); ?></small>
+	<div class="small result-url<?php echo $this->pageclass_sfx; ?>"><?php echo $base . JRoute::_($this->result->route); ?></div>
 	<?php endif; ?>
 </li>

--- a/components/com_newsfeeds/views/category/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/category/tmpl/default_items.php
@@ -52,10 +52,10 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					</span>
 				<?php  endif; ?>
 				<span class="list pull-left">
-					<strong class="list-title">
+					<div class="list-title">
 						<a href="<?php echo JRoute::_(NewsFeedsHelperRoute::getNewsfeedRoute($item->slug, $item->catid)); ?>">
 							<?php echo $item->name; ?></a>
-					</strong>
+					</div>
 				</span>
 				<?php if ($this->items[$i]->published == 0) : ?>
 					<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>

--- a/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/components/com_weblinks/views/category/tmpl/default_items.php
@@ -73,7 +73,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						</span>
 					<?php endif; ?>
 
-					<strong class="list-title">
+					<div class="list-title">
 						<?php if ($this->params->get('icons', 1) == 0) : ?>
 							 <?php echo JText::_('COM_WEBLINKS_LINK'); ?>
 						<?php elseif ($this->params->get('icons', 1) == 1) : ?>
@@ -126,7 +126,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 									break;
 							}
 						?>
-						</strong>
+						</div>
 						<?php $tagsData = $item->tags->getItemTags('com_weblinks.weblink', $item->id); ?>
 						<?php if ($this->params->get('show_tags', 1)) : ?>
 							<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>


### PR DESCRIPTION
small and strong are no longer presentational elements and should not be used in this context. They are emphatic elements used to 'voice' to elements and should not be used for stylistic purposes. 

If we want to make things smaller or larger that should be done with css.

As I removed strong the additional <br/ is no longer needed, as a div is a block level element.
