### PR TITLE
Addition of The Page object class files for Tags and Test class files for the Tags components

### DIFF
--- a/tests/system/webdriver/Pages/Components/TagEditPage.php
+++ b/tests/system/webdriver/Pages/Components/TagEditPage.php
@@ -1,0 +1,57 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * Class for the back-end component panel
+ *
+ */
+class TagEditPage extends AdminEditPage
+{
+  /**
+	 * The field type.
+	 *
+	 * @waitforXpath 	string		Contains the Xpath for the Edit Tag Page Form 
+	 */
+	protected $waitForXpath =  "//form[@id='item-form']";
+	/**
+	 * The field type.
+	 *
+	 * @url 	string		Contains the URL for the Edit Tag Page 
+	 */
+	protected $url = 'administrator/index.php?option=com_tags&view=tag&layout=edit';
+	/**
+	 * The field type.
+	 *
+	 * @tabLabels 	string array		Contains all the labels of the Tabs that are present on the Page 
+	 */	
+	public $tabs = array('general', 'publishing', 'metadata');
+	/**
+	 * The field type.
+	 *
+	 * @tabLabels 	string array		Contains all the labels of the Tabs that are present on the Page 
+	 */
+	public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
+	/**
+	 * The field type.
+	 *
+	 * @inputFields 	string array		Contains all the field Details of the Edit page 
+	 */
+	public $inputFields = array (
+			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Access', 'id' => 'jform_access', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Language', 'id' => 'jform_language', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Float', 'id' => 'jform_images_float_fulltext', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Alt', 'id' => 'jform_images_image_fulltext_alt', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Caption', 'id' => 'jform_images_image_fulltext_caption', 'type' => 'input', 'tab' => 'general'),
+	);
+	
+	
+}
+

--- a/tests/system/webdriver/Pages/Components/TagEditPage.php
+++ b/tests/system/webdriver/Pages/Components/TagEditPage.php
@@ -8,39 +8,59 @@ use SeleniumClient\DesiredCapabilities;
 use SeleniumClient\WebElement;
 
 /**
- * Class for the back-end component panel
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
  *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end menu items manager screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
  */
 class TagEditPage extends AdminEditPage
 {
-  /**
-	 * The field type.
-	 *
-	 * @waitforXpath 	string		Contains the Xpath for the Edit Tag Page Form 
-	 */
-	protected $waitForXpath =  "//form[@id='item-form']";
 	/**
-	 * The field type.
+	 * XPath string used to uniquely identify this page
 	 *
-	 * @url 	string		Contains the URL for the Edit Tag Page 
+	 * @var    string
+	 * @since  3.0
+	 */  
+	protected $waitForXpath =  "//form[@id='item-form']";
+	
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
 	 */
 	protected $url = 'administrator/index.php?option=com_tags&view=tag&layout=edit';
+	
 	/**
-	 * The field type.
+	 * Array of tabs present on this page
 	 *
-	 * @tabLabels 	string array		Contains all the labels of the Tabs that are present on the Page 
-	 */	
-	public $tabs = array('general', 'publishing', 'metadata');
-	/**
-	 * The field type.
-	 *
-	 * @tabLabels 	string array		Contains all the labels of the Tabs that are present on the Page 
+	 * @var    array
+	 * @since  3.0
 	 */
-	public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
+	public $tabs = array('general', 'publishing', 'metadata');
+	
 	/**
-	 * The field type.
+	 * Array of tab labels for this page
 	 *
-	 * @inputFields 	string array		Contains all the field Details of the Edit page 
+	 * @var    array
+	 * @since  3.0
+	 */
+	 public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
+	
+	/**
+	 * Array of all the field Details of the Edit page, along with the ID and tab value they are present on
+	 *
+	 * @var array		 
+	 * @since 3.0
 	 */
 	public $inputFields = array (
 			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'general'),

--- a/tests/system/webdriver/Pages/Components/TagManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/TagManagerPage.php
@@ -8,31 +8,56 @@ use SeleniumClient\DesiredCapabilities;
 use SeleniumClient\WebElement;
 
 /**
- * Class for the back-end Components screen.
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
  *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end component tags menu.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
  */
 class TagManagerPage extends AdminManagerPage
 {
-  /**
-	 * The field type.
+  	/**
+	 * XPath string used to uniquely identify this page
 	 *
-	 * @WaitForXpath 	string 		Contains the Xpath for the Page to be loaded
+	 * @var    string
+	 * @since  3.0
 	 */
-    
-	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
-	/**
-	 * The field type.
-	 *
-	 * @url 	string 		Contains the url for the Page to be loaded
-	 */
+  	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
 	
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
 	protected $url = 'administrator/index.php?option=com_tags';
 	
+	/**
+	 * Array of filter id values for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
 	public $filters = array(
 			'Select Status' => 'filter_published',
 			'Select Access' => 'filter_access',
 			'Select Language' => 'filter_language',
 			);
+	
+	/**
+	 * Array of toolbar id values for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
 	public $toolbar = array (
 			'New' => 'toolbar-new',
 			'Edit' => 'toolbar-edit',
@@ -46,14 +71,14 @@ class TagManagerPage extends AdminManagerPage
 			'Options' => 'toolbar-options',
 			'Help' => 'toolbar-help',
 			);
+			
 	/**
-	 * Method to  add a Tag in the Components Fields.
+	 * Add a new Tag item in the Tag Manager: Component screen.
 	 *
-	 * @param   $name  String  The Name of the Tag that we want to add.
-	 *
-	 * @return  null.
-	 *
+	 * @param string   $title          Test Tag Name
 	 * 
+	 * 
+	 * @return  TagManagerPage
 	 */
 	public function addTag($name='Test Tag')
 	{
@@ -66,16 +91,14 @@ class TagManagerPage extends AdminManagerPage
 		$tagEditPage->clickButton('toolbar-save');
 		$this->test->getPageObject('TagManagerPage');
 	}
+	
 	/**
-	 * Method to  edit a existing  Tag in the Components Fields.
+	 * Edit a Tag item in the Tag Manager: Tag Items screen.
 	 *
-	 * @param   $name  String  The Name of the Tag that we want to edit.
+	 * @param string   $name	   Tag Title field
+	 * @param array    $fields         associative array of fields in the form label => value.
 	 *
-	 * @param   $fields  String  The value of other fields that we want to change of the Tag.
-	 * 
-	 * @return  null.
-	 *
-	 * 
+	 * @return  void
 	 */
 	public function editTag($name, $fields)
 	{

--- a/tests/system/webdriver/Pages/Components/TagManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/TagManagerPage.php
@@ -1,0 +1,91 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * Class for the back-end Components screen.
+ *
+ */
+class TagManagerPage extends AdminManagerPage
+{
+  /**
+	 * The field type.
+	 *
+	 * @WaitForXpath 	string 		Contains the Xpath for the Page to be loaded
+	 */
+    
+	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
+	/**
+	 * The field type.
+	 *
+	 * @url 	string 		Contains the url for the Page to be loaded
+	 */
+	
+	protected $url = 'administrator/index.php?option=com_tags';
+	
+	public $filters = array(
+			'Select Status' => 'filter_published',
+			'Select Access' => 'filter_access',
+			'Select Language' => 'filter_language',
+			);
+	public $toolbar = array (
+			'New' => 'toolbar-new',
+			'Edit' => 'toolbar-edit',
+			'Publish' => 'toolbar-publish',
+			'Unpublish' => 'toolbar-unpublish',
+			'Archive' => 'toolbar-archive',
+			'Check In' => 'toolbar-check-in',
+			'Trash' => 'toolbar-trash',
+			'Empty Trash' => 'toolbar-delete',
+			'Batch' => 'toolbar-batch',
+			'Options' => 'toolbar-options',
+			'Help' => 'toolbar-help',
+			);
+	/**
+	 * Method to  add a Tag in the Components Fields.
+	 *
+	 * @param   $name  String  The Name of the Tag that we want to add.
+	 *
+	 * @return  null.
+	 *
+	 * 
+	 */
+	public function addTag($name='Test Tag')
+	{
+		$new_name = $name . rand(1,100);
+		$login = "testing";
+		//echo $new_name; 
+		$this->clickButton('toolbar-new');
+		$tagEditPage = $this->test->getPageObject('TagEditPage');
+		$tagEditPage->setFieldValues(array('Title' => $new_name));
+		$tagEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('TagManagerPage');
+	}
+	/**
+	 * Method to  edit a existing  Tag in the Components Fields.
+	 *
+	 * @param   $name  String  The Name of the Tag that we want to edit.
+	 *
+	 * @param   $fields  String  The value of other fields that we want to change of the Tag.
+	 * 
+	 * @return  null.
+	 *
+	 * 
+	 */
+	public function editTag($name, $fields)
+	{
+		$this->clickItem($name);
+		$tagEditPage = $this->test->getPageObject('TagEditPage');
+		$tagEditPage->setFieldValues($fields);
+		$tagEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('TagManagerPage');
+		$this->searchFor();
+	}
+
+	
+}

--- a/tests/system/webdriver/Pages/System/AdminPage.php
+++ b/tests/system/webdriver/Pages/System/AdminPage.php
@@ -140,6 +140,7 @@ abstract class AdminPage
 			'Security Center'		=> 'http://developer.joomla.org/security.html',
 			'Developer Resources'	=> 'http://developer.joomla.org/',
 			'Joomla Shop'			=> 'http://shop.joomla.org/',
+			'Tags'			=>	'administrator/index.php?option=com_tags',
 	);
 
 

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -1,0 +1,65 @@
+<?php
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the Tag Components: Add / Edit Tag User Screens
+ * @author Mark
+ *
+ */
+class TagManager0001Test extends JoomlaWebdriverTestCase
+{
+  /**
+	 *
+	 * @var tagManagerPage String 
+	 */
+	protected $tagManagerPage = null;
+	
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->tagManagerPage = $cpPage->clickMenu('Tags', 'TagManagerPage');
+	}
+
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+	
+	/**
+	 * @test
+	 */
+	public function constructor_OpenEditScreen_TagEditOpened()
+	{
+		$this->tagManagerPage->clickButton('new');
+		$tagEditPage = $this->getPageObject('TagEditPage');
+		$tagEditPage->clickButton('cancel');
+		$this->tagManagerPage = $this->getPageObject('TagManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addTag_WithGivenFields_TagAdded()
+	{
+		$salt = rand();
+		$tagName = 'Tag' . $salt;
+		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test Tag should not be present');
+		$this->tagManagerPage->addTag($tagName);
+		$message = $this->tagManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Tag successfully saved') >= 0, 'Tag save should return success');
+		$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test Tag should be in row 2');
+		$this->tagManagerPage->deleteItem($tagName);
+		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test Tag should not be present');
+	}
+	
+	
+}

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -1,5 +1,11 @@
 <?php
-
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
 require_once 'JoomlaWebdriverTestCase.php';
 
 use SeleniumClient\By;
@@ -9,25 +15,39 @@ use SeleniumClient\WebDriverWait;
 use SeleniumClient\DesiredCapabilities;
 
 /**
- * This class tests the Tag Components: Add / Edit Tag User Screens
- * @author Mark
+ * This class tests the  Tags: Add / Edit  Screen.
  *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
  */
 class TagManager0001Test extends JoomlaWebdriverTestCase
 {
-  /**
+  	/**
+	 * The page class being tested.
 	 *
-	 * @var tagManagerPage String 
+	 * @var     TagManagerPage
+	 * @since   3.0
 	 */
-	protected $tagManagerPage = null;
+  	protected $tagManagerPage = null;
 	
+	/**
+	 * Login to back end and navigate to menu Tags.
+	 *
+	 * @since   3.0
+	 */
 	public function setUp()
 	{
 		parent::setUp();
 		$cpPage = $this->doAdminLogin();
 		$this->tagManagerPage = $cpPage->clickMenu('Tags', 'TagManagerPage');
 	}
-
+	
+	/**
+	 * Logout and close test.
+	 *
+	 * @since   3.0
+	 */
 	public function tearDown()
 	{
 		$this->doAdminLogout();

--- a/tests/system/webdriver/tests/phpunit.xml.dist
+++ b/tests/system/webdriver/tests/phpunit.xml.dist
@@ -7,6 +7,7 @@
 			<directory>extensions</directory>
 			<directory>menus</directory>
 			<directory>users</directory>
+			<directory>components</directory>
 		</testsuite>
 	</testsuites>
 	<logging>


### PR DESCRIPTION
I have Added Three Files and made minor changes in two other existing files, in the Pages folder I have added Two Page Class file 
1) TagEditPage.php
2) TagManagerPage.php

These two files contains the complete Page Object info for the edit and Manger Page for the Tag components in the CMS.

I have added one Test class file in the tests folder, file name is TagManager0001Test.php which contains the the test cases for Adding a new file and a simple GUI test.
