### PR TITLE
Add bootstrap styling to overrides list

### DIFF
--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -37,7 +37,7 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 		</div>
 		<div class="clearfix"></div>
 
-		<table class="table table-striped">
+		<table class="adminlist table table-striped">
 			<thead>
 				<tr>
 					<th width="1%">

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -37,7 +37,7 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 		</div>
 		<div class="clearfix"></div>
 
-		<table id="overrideList" class="table table-striped">
+		<table class="table table-striped">
 			<thead>
 				<tr>
 					<th width="1%">

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -37,7 +37,7 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 		</div>
 		<div class="clearfix"></div>
 
-		<table class="adminlist">
+		<table id="overrideList" class="table table-striped">
 			<thead>
 				<tr>
 					<th width="1%">

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -37,7 +37,7 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 		</div>
 		<div class="clearfix"></div>
 
-		<table class="adminlist table table-striped">
+		<table class="table table-striped">
 			<thead>
 				<tr>
 					<th width="1%">


### PR DESCRIPTION
The list with overrides is currently not using the bootstrap markup, this patch fixes that.
