### PR TITLE
Make the Radio and Checkboxes field types subclasses of the List type so...

### DIFF
--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('list');
+
 /**
  * Form Field class for the Joomla Platform.
  * Displays options as a list of check boxes.
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @see         JFormFieldCheckbox
  * @since       11.1
  */
-class JFormFieldCheckboxes extends JFormField
+class JFormFieldCheckboxes extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -92,46 +94,5 @@ class JFormFieldCheckboxes extends JFormField
 		$html[] = '</fieldset>';
 
 		return implode($html);
-	}
-
-	/**
-	 * Method to get the field options.
-	 *
-	 * @return  array  The field option objects.
-	 *
-	 * @since   11.1
-	 */
-	protected function getOptions()
-	{
-		$options = array();
-
-		foreach ($this->element->children() as $option)
-		{
-
-			// Only add <option /> elements.
-			if ($option->getName() != 'option')
-			{
-				continue;
-			}
-
-			// Create a new option object based on the <option /> element.
-			$tmp = JHtml::_(
-				'select.option', (string) $option['value'], trim((string) $option), 'value', 'text',
-				((string) $option['disabled'] == 'true')
-			);
-
-			// Set some option attributes.
-			$tmp->class = (string) $option['class'];
-
-			// Set some JavaScript option attributes.
-			$tmp->onclick = (string) $option['onclick'];
-
-			// Add the option object to the result set.
-			$options[] = $tmp;
-		}
-
-		reset($options);
-
-		return $options;
 	}
 }

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('list');
+
 /**
  * Form Field class for the Joomla Platform.
  * Provides radio button inputs
@@ -18,7 +20,7 @@ defined('JPATH_PLATFORM') or die;
  * @link        http://www.w3.org/TR/html-markup/command.radio.html#command.radio
  * @since       11.1
  */
-class JFormFieldRadio extends JFormField
+class JFormFieldRadio extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -72,46 +74,5 @@ class JFormFieldRadio extends JFormField
 		$html[] = '</fieldset>';
 
 		return implode($html);
-	}
-
-	/**
-	 * Method to get the field options for radio buttons.
-	 *
-	 * @return  array  The field option objects.
-	 *
-	 * @since   11.1
-	 */
-	protected function getOptions()
-	{
-		$options = array();
-
-		foreach ($this->element->children() as $option)
-		{
-
-			// Only add <option /> elements.
-			if ($option->getName() != 'option')
-			{
-				continue;
-			}
-
-			// Create a new option object based on the <option /> element.
-			$tmp = JHtml::_(
-				'select.option', (string) $option['value'], trim((string) $option), 'value', 'text',
-				((string) $option['disabled'] == 'true')
-			);
-
-			// Set some option attributes.
-			$tmp->class = (string) $option['class'];
-
-			// Set some JavaScript option attributes.
-			$tmp->onclick = (string) $option['onclick'];
-
-			// Add the option object to the result set.
-			$options[] = $tmp;
-		}
-
-		reset($options);
-
-		return $options;
 	}
 }


### PR DESCRIPTION
... that getOptions() does not need to be repeated three times.

I realize that there is a minor difference between JFormFieldList::getOptions and the other two classes. But I reckon that it doesn't actually make any difference in practice. 

Also, in the past I would have sent this pull request to the platform but it seems to be closed. I don't really know what's going on, is there a newsletter I could subscribe to or something? Well, if this is inappropriate for CMS, I'll resubmit it elsewhere.  
