### PR TITLE
Added New test to the TagManager Test Class 

### DIFF
--- a/tests/system/webdriver/Pages/Components/TagEditPage.php
+++ b/tests/system/webdriver/Pages/Components/TagEditPage.php
@@ -29,9 +29,9 @@ class TagEditPage extends AdminEditPage
 	 *
 	 * @var    string
 	 * @since  3.0
-	 */
+	 */  
 	protected $waitForXpath =  "//form[@id='item-form']";
-
+	
 	/**
 	 * URL used to uniquely identify this page
 	 *
@@ -39,7 +39,7 @@ class TagEditPage extends AdminEditPage
 	 * @since  3.0
 	 */
 	protected $url = 'administrator/index.php?option=com_tags&view=tag&layout=edit';
-
+	
 	/**
 	 * Array of tabs present on this page
 	 *
@@ -47,30 +47,41 @@ class TagEditPage extends AdminEditPage
 	 * @since  3.0
 	 */
 	public $tabs = array('general', 'publishing', 'metadata');
-
+	
 	/**
 	 * Array of tab labels for this page
 	 *
 	 * @var    array
 	 * @since  3.0
 	 */
-	 public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
-
+	public $tabLabels = array('Tag Details', 'Publishing Options', 'Metadata Options');
+	
 	/**
 	 * Array of all the field Details of the Edit page, along with the ID and tab value they are present on
 	 *
-	 * @var array
+	 * @var array		 
 	 * @since 3.0
 	 */
 	public $inputFields = array (
 			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'general'),
-			array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'general'),
-			array('label' => 'Access', 'id' => 'jform_access', 'type' => 'select', 'tab' => 'general'),
-			array('label' => 'Language', 'id' => 'jform_language', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Teaser image', 'id' => 'jform_images_image_intro', 'type' => 'input', 'tab' => 'general'),
+            array('label' => 'Float', 'id' => 'jform_images_float_intro', 'type' => 'select', 'tab' => 'general'),
+			array('label' => 'Alt', 'id' => 'jform_images_image_intro_alt', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Caption', 'id' => 'jform_images_image_intro_caption', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Full image', 'id' => 'jform_images_image_fulltext', 'type' => 'input', 'tab' => 'general'),
 			array('label' => 'Float', 'id' => 'jform_images_float_fulltext', 'type' => 'select', 'tab' => 'general'),
 			array('label' => 'Alt', 'id' => 'jform_images_image_fulltext_alt', 'type' => 'input', 'tab' => 'general'),
 			array('label' => 'Caption', 'id' => 'jform_images_image_fulltext_caption', 'type' => 'input', 'tab' => 'general'),
+			array('label' => 'Alias', 'id' => 'jform_alias', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'ID', 'id' => 'jform_id', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Author\'s Alias', 'id' => 'jform_created_by_alias', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Created Date', 'id' => 'jform_created_time', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Meta Description', 'id' => 'jform_metadesc', 'type'=>'textarea', 'tab'=>'metadata'),
+			array('label' => 'Meta Keywords', 'id' => 'jform_metakey', 'type'=>'textarea', 'tab'=>'metadata'),
+			array('label' => 'Author', 'id' => 'jform_metadata_author', 'type'=>'input', 'tab'=>'metadata'),
+			array('label' => 'Robots', 'id' => 'jform_metadata_robots', 'type'=>'select', 'tab'=>'metadata'),
 	);
-
+	
+	
 }
 

--- a/tests/system/webdriver/Pages/Components/TagManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/TagManagerPage.php
@@ -24,13 +24,13 @@ use SeleniumClient\WebElement;
  */
 class TagManagerPage extends AdminManagerPage
 {
-  	/**
+	/**
 	 * XPath string used to uniquely identify this page
 	 *
 	 * @var    string
 	 * @since  3.0
 	 */
-  	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
+	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_tags']";
 	
 	/**
 	 * URL used to uniquely identify this page
@@ -51,13 +51,13 @@ class TagManagerPage extends AdminManagerPage
 			'Select Access' => 'filter_access',
 			'Select Language' => 'filter_language',
 			);
-	
+			
 	/**
 	 * Array of toolbar id values for this page
 	 *
 	 * @var    array
 	 * @since  3.0
-	 */
+	 */	
 	public $toolbar = array (
 			'New' => 'toolbar-new',
 			'Edit' => 'toolbar-edit',
@@ -75,19 +75,23 @@ class TagManagerPage extends AdminManagerPage
 	/**
 	 * Add a new Tag item in the Tag Manager: Component screen.
 	 *
-	 * @param string   $title          Test Tag Name
+	 * @param string   $name          Test Tag Name
 	 * 
+	 * @param string   $caption 	  Caption of the test Image
+	 * 
+	 * @param string   $alt			  Alternative Caption for the Image
+	 * 
+	 * @param string   $float		  Position of the Image of the tag
 	 * 
 	 * @return  TagManagerPage
 	 */
-	public function addTag($name='Test Tag')
+	public function addTag($name='Test Tag', $caption='sample', $alt='Sample_Alt', $float='Use Global')
 	{
-		$new_name = $name . rand(1,100);
-		$login = "testing";
-		//echo $new_name; 
+		$new_name = $name;
+		$login = "testing"; 
 		$this->clickButton('toolbar-new');
 		$tagEditPage = $this->test->getPageObject('TagEditPage');
-		$tagEditPage->setFieldValues(array('Title' => $new_name));
+		$tagEditPage->setFieldValues(array('Title' => $name, 'Caption' => $caption, 'Alt'=>$alt,'Float'=>$float));
 		$tagEditPage->clickButton('toolbar-save');
 		$this->test->getPageObject('TagManagerPage');
 	}
@@ -96,7 +100,7 @@ class TagManagerPage extends AdminManagerPage
 	 * Edit a Tag item in the Tag Manager: Tag Items screen.
 	 *
 	 * @param string   $name	   Tag Title field
-	 * @param array    $fields         associative array of fields in the form label => value.
+	 * @param array    $fields     associative array of fields in the form label => value.
 	 *
 	 * @return  void
 	 */
@@ -107,6 +111,54 @@ class TagManagerPage extends AdminManagerPage
 		$tagEditPage->setFieldValues($fields);
 		$tagEditPage->clickButton('toolbar-save');
 		$this->test->getPageObject('TagManagerPage');
+		$this->searchFor();
+	}
+	
+	/**
+	 * Get state  of a Tag item in the Tag Manager: Tag Items screen.
+	 *
+	 * @param string   $name	   Tag Title field
+	 * 
+	 * @return  State of the Tag //Published or Unpublished
+	 */
+	public function getState($name)
+	{
+		$result = false;
+		$row = $this->getRowNumber($name);
+		$text = $this->driver->findElement(By::xPath("//tbody/tr[" . $row . "]/td[3]/a"))->getAttribute(@onclick);
+		if (strpos($text, 'tags.unpublish') > 0)
+		{
+			$result = 'published';
+		}
+		if (strpos($text, 'tags.publish') > 0)
+		{
+			$result = 'unpublished';
+		}
+		return $result;
+	}
+	
+	/**
+	 * Change state of a Tag item in the Tag Manager: Tag Items screen.
+	 *
+	 * @param string   $name	   Tag Title field
+	 * @param string   $state      State of the Tag
+	 *
+	 * @return  void
+	 */	
+	public function changeTagState($name, $state = 'published')
+	{
+		$this->searchFor($name);
+		$this->checkAll();
+		if (strtolower($state) == 'published')
+		{
+			$this->clickButton('toolbar-publish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
+		elseif (strtolower($state) == 'unpublished')
+		{
+			$this->clickButton('toolbar-unpublish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
 		$this->searchFor();
 	}
 

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -6,6 +6,7 @@
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
+
 require_once 'JoomlaWebdriverTestCase.php';
 
 use SeleniumClient\By;
@@ -23,14 +24,14 @@ use SeleniumClient\DesiredCapabilities;
  */
 class TagManager0001Test extends JoomlaWebdriverTestCase
 {
-  	/**
+	/**
 	 * The page class being tested.
 	 *
 	 * @var     TagManagerPage
 	 * @since   3.0
 	 */
-  	protected $tagManagerPage = null;
-
+	protected $tagManagerPage = null;
+	
 	/**
 	 * Login to back end and navigate to menu Tags.
 	 *
@@ -53,7 +54,26 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->doAdminLogout();
 		parent::tearDown();
 	}
-
+	
+	/**
+	 * @test
+	 */
+	public function getAllInputFields_ScreenDisplayed_EqualExpected()
+	{
+		$this->tagManagerPage->clickButton('toolbar-new');
+		$tagEditPage = $this->getPageObject('TagEditPage');
+		$testElements = $tagEditPage->getAllInputFields(array('general','publishing','metadata'));
+		$actualFields = array();
+		foreach ($testElements as $el)
+		{
+			$el->labelText = (substr($el->labelText, -2) == ' *') ? substr($el->labelText, 0, -2) : $el->labelText;
+			$actualFields[] = array('label' => $el->labelText, 'id' => $el->id, 'type' => $el->tag, 'tab' => $el->tab);
+		}
+		$this->assertEquals($tagEditPage->inputFields, $actualFields);
+		$tagEditPage->clickButton('toolbar-cancel');
+		$this->tagManagerPage = $this->getPageObject('TagManagerPage');
+	}
+	
 	/**
 	 * @test
 	 */
@@ -64,11 +84,24 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$tagEditPage->clickButton('cancel');
 		$this->tagManagerPage = $this->getPageObject('TagManagerPage');
 	}
-
+	
 	/**
 	 * @test
 	 */
-	public function addTag_WithGivenFields_TagAdded()
+	public function getTabIds_ScreenDisplayed_EqualExpected()
+	{
+		$this->tagManagerPage->clickButton('toolbar-new');
+		$tagEditPage = $this->getPageObject('TagEditPage');
+		$textArray = $tagEditPage->getTabIds();
+		$this->assertEquals($tagEditPage->tabs, $textArray, 'Tab labels should match expected values.');
+		$tagEditPage->clickButton('toolbar-cancel');
+		$this->tagManagerPage = $this->getPageObject('TagManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addTag_WithFieldDefaults_TagAdded()
 	{
 		$salt = rand();
 		$tagName = 'Tag' . $salt;
@@ -80,5 +113,58 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->tagManagerPage->deleteItem($tagName);
 		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test Tag should not be present');
 	}
+	
+	/**
+	 * @test
+	 */
+	public function addTag_WithGivenFields_TagAdded()
+	{
+		$salt = rand();
+		$tagName = 'Tag' . $salt;
+		$caption = 'Sample'. $salt;
+		$alt = 'alt' . $salt;
+		$float = 'Right'; //Other than the Default Value
 
+		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test tag should not be present');
+		$this->tagManagerPage->addTag($tagName,$caption,$alt,$float);
+		$message = $this->tagManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Tags successfully saved') >= 0, 'Tag save should return success');
+		$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be in row 1');
+		$values = $this->tagManagerPage->getFieldValues('TagEditPage', $tagName, array('Title', 'Caption'));
+		$this->assertEquals(array($tagName,$caption), $values, 'Actual name, caption should match expected');
+		$this->tagManagerPage->deleteItem($tagName);
+		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test tag should not be present');
+	}
+
+	/**
+	 * @test
+	 */
+	public function editTag_ChangeFields_FieldsChanged()
+	{
+		$salt = rand();
+		$tagName = 'Tag' . $salt;
+		$Caption = 'Caption' . $salt;
+		$alt = 'alt' . $salt;
+		$float = 'Right';
+		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test tag should not be present');
+		$this->tagManagerPage->addTag($tagName, $Caption, $alt, $float);
+		$this->tagManagerPage->editTag($tagName, array('Caption' => 'new_sample_Caption', 'Alt' => 'Sample_Alt'));
+		$values = $this->tagManagerPage->getFieldValues('tagEditPage', $tagName, array('Caption', 'Alt'));
+		$this->assertEquals(array('new_sample_Caption', 'Sample_Alt'), $values, 'Actual values should match expected');
+		$this->tagManagerPage->deleteItem($tagName);
+	}
+	
+	/**
+	 * @test
+	 */
+	public function changeTagState_ChangeEnabledUsingToolbar_EnabledChanged()
+	{
+		$this->tagManagerPage->addTag('Test Tag');
+		$state = $this->tagManagerPage->getState('Test Tag');
+		$this->assertEquals('published', $state, 'Initial state should be published');
+		$this->tagManagerPage->changeTagState('Test Tag', 'unpublished');
+		$state = $this->tagManagerPage->getState('Test Tag');
+		$this->assertEquals('unpublished', $state, 'State should be unpublished');
+		$this->tagManagerPage->deleteItem('Test Tag');
+	}	
 }


### PR DESCRIPTION
Added Four New tests to the Test class, TagManagerTest class now contains tests to Edit Tags, change state of a Tag, get all input fields, add a new Tag with given fields.
