### PR TITLE
Fixed height of the select element with multiple attribute.

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6,6 +6,7 @@ figure,
 footer,
 header,
 hgroup,
+main,
 nav,
 section {
 	display: block;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6025,10 +6025,6 @@ body.site.fluid {
 .accordion-group {
 	background: #fff;
 }
-.select[multiple],
-select[size] {
-	height: 28px;
-}
 .site-title {
 	font-size: 40px;
 	line-height: 48px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -97,9 +97,6 @@ body.site.fluid{
 .accordion-group {
 	background:#fff;
 }
-.select[multiple], select[size] {
-	height:28px;
-}
 /* Site Title (if no logo) */
 .site-title {
 	font-size: 40px;


### PR DESCRIPTION
[Issue tracking](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29424)

When you have multiple values attribute tyou expect that select will show you at least few values. And even when you set `size` attribute to your `<select>` element you expect it to how as many values as `size` sets.

In protstar template CSS set height to `28px` for amy multiple select elements with make then absolutely unusable.

Here is the select element before fix

![2013-05-09_15-08-51](https://f.cloud.github.com/assets/650741/482107/27d8d672-b888-11e2-97f2-a3277343a6a4.png)

and here is after fix

![2013-05-09_15-09-04](https://f.cloud.github.com/assets/650741/482108/32dd41f2-b888-11e2-9316-839639cb662e.png)
