### PR TITLE
Support non-mysql databases in stats module

### DIFF
--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -44,7 +44,7 @@ class ModStatsHelper
 			$i++;
 
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_MYSQL');
+			$rows[$i]->title = JText::_($db->name);
 			$rows[$i]->data	= $db->getVersion();
 			$i++;
 


### PR DESCRIPTION
This small change allows the module to report the version of non-mysql databases.
