### PR TITLE
Mod_feed template error when displaying feed title

### DIFF
--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -62,7 +62,7 @@ else
 		{
 			?>
 					<h2 class="<?php echo $direction; ?>">
-						<a href="<?php echo str_replace('&', '&amp', $feed->link); ?>" target="_blank">
+						<a href="<?php echo str_replace('&', '&amp', $feed->link->uri); ?>" target="_blank">
 						<?php echo $feed->title; ?></a>
 					</h2>
 			<?php


### PR DESCRIPTION
Not sure if this is indeed a bug or a problem related to the type of feed I'm
pointing at, but I am regularly getting a catchable fatal error when trying to
display a feed and the feed title option is set to 'show'. Line 65 of
mod_feed/tmpl/default.php is trying to echo a JFeedLink object where a string
is expected.

Tracker item here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=30445
