### PR TITLE
Sql as 'option' type for JFormFieldList

### DIFF
--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('list');
+
 /**
  * Form Field class for the Joomla Platform.
  * Displays options as a list of check boxes.
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @see         JFormFieldCheckbox
  * @since       11.1
  */
-class JFormFieldCheckboxes extends JFormField
+class JFormFieldCheckboxes extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -92,46 +94,5 @@ class JFormFieldCheckboxes extends JFormField
 		$html[] = '</fieldset>';
 
 		return implode($html);
-	}
-
-	/**
-	 * Method to get the field options.
-	 *
-	 * @return  array  The field option objects.
-	 *
-	 * @since   11.1
-	 */
-	protected function getOptions()
-	{
-		$options = array();
-
-		foreach ($this->element->children() as $option)
-		{
-
-			// Only add <option /> elements.
-			if ($option->getName() != 'option')
-			{
-				continue;
-			}
-
-			// Create a new option object based on the <option /> element.
-			$tmp = JHtml::_(
-				'select.option', (string) $option['value'], trim((string) $option), 'value', 'text',
-				((string) $option['disabled'] == 'true')
-			);
-
-			// Set some option attributes.
-			$tmp->class = (string) $option['class'];
-
-			// Set some JavaScript option attributes.
-			$tmp->onclick = (string) $option['onclick'];
-
-			// Add the option object to the result set.
-			$options[] = $tmp;
-		}
-
-		reset($options);
-
-		return $options;
 	}
 }

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -99,14 +99,14 @@ class JFormFieldList extends JFormField
 					$result = $this->parseOptionSQL($option);
 					if (!empty($result))
 					{
-						$options += $result;
+						$options = array_merge($options, $result);
 					}
 					break;
 				case 'table':
 					$result = $this->parseOptionTable($option);
 					if (!empty($result))
 					{
-						$options += $result;
+						$options = array_merge($options, $result);
 					}
 					break;
 				case 'standard':

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('list');
+
 /**
  * Form Field class for the Joomla Platform.
  * Provides radio button inputs
@@ -18,7 +20,7 @@ defined('JPATH_PLATFORM') or die;
  * @link        http://www.w3.org/TR/html-markup/command.radio.html#command.radio
  * @since       11.1
  */
-class JFormFieldRadio extends JFormField
+class JFormFieldRadio extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -72,46 +74,5 @@ class JFormFieldRadio extends JFormField
 		$html[] = '</fieldset>';
 
 		return implode($html);
-	}
-
-	/**
-	 * Method to get the field options for radio buttons.
-	 *
-	 * @return  array  The field option objects.
-	 *
-	 * @since   11.1
-	 */
-	protected function getOptions()
-	{
-		$options = array();
-
-		foreach ($this->element->children() as $option)
-		{
-
-			// Only add <option /> elements.
-			if ($option->getName() != 'option')
-			{
-				continue;
-			}
-
-			// Create a new option object based on the <option /> element.
-			$tmp = JHtml::_(
-				'select.option', (string) $option['value'], trim((string) $option), 'value', 'text',
-				((string) $option['disabled'] == 'true')
-			);
-
-			// Set some option attributes.
-			$tmp->class = (string) $option['class'];
-
-			// Set some JavaScript option attributes.
-			$tmp->onclick = (string) $option['onclick'];
-
-			// Add the option object to the result set.
-			$options[] = $tmp;
-		}
-
-		reset($options);
-
-		return $options;
 	}
 }


### PR DESCRIPTION
Allows you to create `<option>` tags for `JFormFieldList` or any class that inherits from it which basically function exactly like `JFormFieldSQL`. This essentially makes `JFormFieldSQL` obsolete and adds its functionality to all classes that extend `JFormFieldList`. And, since it's built on top of #1115, that means you can create `checkbox` or `radiobutton` inputs based on SQL. 

An example of the `sql` field type from the wiki (http://docs.joomla.org/SQL_form_field_type) looks like this:

``` xml
<field name="title" type="sql" default="10" label="Select an article" query="SELECT id AS value, title FROM #__content" />
```

But could now be rewritten as:

``` xml
<field name="title" type="list" default="10" label="Select an article">
    <option type="sql" query="SELECT id AS value, title FROM #__content" />
</field>
```

Which might not seem better except you can also do this:

``` xml
<field name="title" type="checkboxes" label="Select some articles">
    <option type="sql" query="SELECT id AS value, title FROM #__content" />
</field>
```

Also, I've added this:

``` xml
<field name="title" type="checkboxes" label="Select some articles">
    <option type="sql" query="SELECT id AS value, title FROM #__content" >
        <query driver="mysqli" query="SELECT `id` AS `value`, `title` FROM `#__content`" />
        <query driver="sqlsrv" query="SELECT [id] AS [value], [title] FROM [#__content]" />
    </option>
</field>
```

Which makes it so that the `option`'s query will be used by default but, if there is a query for the specific database driver being used, that one will be used instead. 
