### PR TITLE
Add include path for get Corecontent instance

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -255,7 +255,9 @@ class JHelperTags
 	{
 		$result = $this->unTagItem($contentItemId, $table);
 
+		JTable::addIncludePath(JPATH_PLATFORM . '/cms/table');
 		$ucmContentTable = JTable::getInstance('Corecontent');
+
 		return $result && $ucmContentTable->deleteByContentId($contentItemId);
 	}
 


### PR DESCRIPTION
Im trying to delete categories from CLI using JTableCategory class and JTable::getInstance('Corecontent'); return nothing. Addint the path solve the problem
