### PR TITLE
Feed module generates empty list for non-existing entries

### DIFF
--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -87,7 +87,11 @@ else
 	{ ?>
 	<ul>
 		<?php for  ($i = 0; $i < $params->get('rssitems', 5); $i++)
-		{  ?>
+		{
+			if( !$feed->offsetExists($i)) {
+				break;
+			}
+			?>
 			<?php
 				$uri = (!empty($feed[$i]->guid) || !is_null($feed[$i]->guid)) ? $feed[$i]->guid : $feed[$i]->uri;
 


### PR DESCRIPTION
When the number of items in the feed module is set to a higher number than the channel offers, the module will generate an empty list for these non existing entries.

J!Code item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30949
