### PR TITLE
Fix css gradient bug

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6060,6 +6060,7 @@ body {
 	background-image: -webkit-radial-gradient(circle,#165387,#142849);
 	background-image: -moz-radial-gradient(circle,#165387,#142849);
 	background-image: -o-radial-gradient(circle,#165387,#142849);
+	background-image: -ms-radial-gradient(center, circle farthest-side, #165387 0%, #142849 100%);
 	background-repeat: no-repeat;
 }
 .view-login .container {


### PR DESCRIPTION
In IE 10 the gradient background on the login-page won't display.
IE 8/9 does not support a gradient circle.
