### PR TITLE
Add in Contact Component Selenium Tests

### DIFF
--- a/tests/system/webdriver/Pages/Components/ContactEditPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactEditPage.php
@@ -1,0 +1,141 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end menu items manager screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
+ */
+class ContactEditPage extends AdminEditPage
+{
+	/**
+	 * XPath string used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $waitForXpath =  "//form[@id='item-form']";
+
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $url = 'administrator/index.php?option=com_contact&view=contact&layout=edit';
+
+	/**
+	 * Array of tabs present on this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $tabs = array('details', 'publishing', 'basic', 'params-jbasic', 'params-email', 'metadata');
+
+	/**
+	 * Array of tab labels for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $tabLabels = array('Edit Contact', 'Publishing Options', 'Contact Details', 'Display Options', 'Contact form', 'Metadata Options');
+
+	/**
+	 * Array of all the field Details of the Edit page, along with the ID and tab value they are present on
+	 *
+	 * @var array
+	 * @since 3.0
+	 */
+	public $inputFields = array (
+			array('label' => 'Name', 'id' => 'jform_name', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Alias', 'id' => 'jform_alias', 'type' => 'input', 'tab' => 'details'),
+            array('label' => 'Linked User', 'id' => 'jform_user_id', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Category', 'id' => 'jform_catid', 'type' => 'select', 'tab' => 'details'),
+			array('label' => 'Ordering', 'id' => 'jformordering', 'type' => 'select', 'tab' => 'details'),
+			array('label' => 'ID', 'id' => 'jform_id', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Miscellaneous Information', 'id' => 'jform_misc', 'type' => 'textarea', 'tab' => 'details'),
+			array('label' => 'Created by', 'id' => 'jform_created_by_name', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Created By Alias', 'id' => 'jform_created_by_alias', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Created date', 'id' => 'jform_created', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Start Publishing', 'id' => 'jform_publish_up', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Finish Publishing', 'id' => 'jform_publish_down', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Revision', 'id' => 'jform_version', 'type'=>'input', 'tab'=>'publishing'),
+			array('label' => 'Image', 'id' => 'jform_image', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Position', 'id' => 'jform_con_position', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Email', 'id' => 'jform_email_to', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Address', 'id' => 'jform_address', 'type'=>'textarea', 'tab'=>'basic'),
+			array('label' => 'City or Suburb', 'id' => 'jform_suburb', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'State or Province', 'id' => 'jform_state', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Country', 'id' => 'jform_country', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Telephone', 'id' => 'jform_telephone', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Mobile', 'id' => 'jform_mobile', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Fax', 'id' => 'jform_fax', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Website', 'id' => 'jform_webpage', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'First Sort Field', 'id' => 'jform_sortname1', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Second Sort Field', 'id' => 'jform_sortname2', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Third Sort Field', 'id' => 'jform_sortname3', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Show Category', 'id' => 'jform_params_show_contact_category', 'type'=>'radio', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Contact List', 'id' => 'jform_params_show_contact_list', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Display format', 'id' => 'jform_params_presentation_style', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Tags', 'id' => 'jform_params_show_tags', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Name', 'id' => 'jform_params_show_name', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Contact\'s Position', 'id' => 'jform_params_show_position', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Email', 'id' => 'jform_params_show_email', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Street Address', 'id' => 'jform_params_show_street_address', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'City or Suburb', 'id' => 'jform_params_show_suburb', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'State or County', 'id' => 'jform_params_show_state', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Postal Code', 'id' => 'jform_params_show_postcode', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Country', 'id' => 'jform_params_show_country', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Telephone', 'id' => 'jform_params_show_telephone', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Mobile Phone', 'id' => 'jform_params_show_mobile', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Fax', 'id' => 'jform_params_show_fax', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Webpage', 'id' => 'jform_params_show_webpage', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Misc. Information', 'id' => 'jform_params_show_misc', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Image', 'id' => 'jform_params_show_image', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'vCard', 'id' => 'jform_params_allow_vcard', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show User Articles', 'id' => 'jform_params_show_articles', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Profile', 'id' => 'jform_params_show_profile', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Links', 'id' => 'jform_params_show_links', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Link A Label', 'id' => 'jform_params_linka_name', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link A URL', 'id' => 'jform_params_linka', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link B Label', 'id' => 'jform_params_linkb_name', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link B URL', 'id' => 'jform_params_linkb', 'type'=>'input', 'tab'=>'params-jbasic'),			
+			array('label' => 'Link C Label', 'id' => 'jform_params_linkc_name', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link C URL', 'id' => 'jform_params_linkc', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link D Label', 'id' => 'jform_params_linkd_name', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link D URL', 'id' => 'jform_params_linkd', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link E Label', 'id' => 'jform_params_linke_name', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Link E URL', 'id' => 'jform_params_linke', 'type'=>'input', 'tab'=>'params-jbasic'),
+			array('label' => 'Alternative Layout', 'id' => 'jform_params_contact_layout', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Contact Form', 'id' => 'jform_params_show_email_form', 'type'=>'select', 'tab'=>'params-email'),
+			array('label' => 'Send Copy to Submitter', 'id' => 'jform_params_show_email_copy', 'type'=>'select', 'tab'=>'params-email'),
+			array('label' => 'Banned Email', 'id' => 'jform_params_banned_email', 'type'=>'textarea', 'tab'=>'params-email'),
+			array('label' => 'Banned Subject', 'id' => 'jform_params_banned_subject', 'type'=>'textarea', 'tab'=>'params-email'),
+			array('label' => 'Banned Text', 'id' => 'jform_params_banned_text', 'type'=>'textarea', 'tab'=>'params-email'),
+			array('label' => 'Session Check', 'id' => 'jform_params_validate_session', 'type'=>'select', 'tab'=>'params-email'),
+			array('label' => 'Custom Reply', 'id' => 'jform_params_custom_reply', 'type'=>'select', 'tab'=>'params-email'),	
+			array('label' => 'Contact Redirect', 'id' => 'jform_params_redirect', 'type'=>'input', 'tab'=>'params-email'),
+			array('label' => 'Meta Description', 'id' => 'jform_metadesc', 'type'=>'textarea', 'tab'=>'metadata'),
+			array('label' => 'Meta Keywords', 'id' => 'jform_metakey', 'type'=>'textarea', 'tab'=>'metadata'),
+			array('label' => 'Robots', 'id' => 'jform_metadata_robots', 'type'=>'select', 'tab'=>'metadata'),
+			array('label' => 'Rights', 'id' => 'jform_metadata_rights', 'type'=>'input', 'tab'=>'metadata'),
+		);
+
+}
+

--- a/tests/system/webdriver/Pages/Components/ContactEditPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactEditPage.php
@@ -81,7 +81,7 @@ class ContactEditPage extends AdminEditPage
 			array('label' => 'Email', 'id' => 'jform_email_to', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Address', 'id' => 'jform_address', 'type'=>'textarea', 'tab'=>'basic'),
 			array('label' => 'City or Suburb', 'id' => 'jform_suburb', 'type'=>'input', 'tab'=>'basic'),
-			//array('label' => 'State or Province', 'id' => 'jform_state', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'State or Province', 'id' => 'jform_state', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Postal / ZIP Code', 'id' => 'jform_postcode', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Country', 'id' => 'jform_country', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Telephone', 'id' => 'jform_telephone', 'type'=>'input', 'tab'=>'basic'),

--- a/tests/system/webdriver/Pages/Components/ContactEditPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactEditPage.php
@@ -30,7 +30,7 @@ class ContactEditPage extends AdminEditPage
 	 * @var    string
 	 * @since  3.0
 	 */
-	protected $waitForXpath =  "//form[@id='item-form']";
+	protected $waitForXpath =  "//form[@id='contact-form']";
 
 	/**
 	 * URL used to uniquely identify this page
@@ -65,23 +65,25 @@ class ContactEditPage extends AdminEditPage
 	public $inputFields = array (
 			array('label' => 'Name', 'id' => 'jform_name', 'type' => 'input', 'tab' => 'details'),
 			array('label' => 'Alias', 'id' => 'jform_alias', 'type' => 'input', 'tab' => 'details'),
-            array('label' => 'Linked User', 'id' => 'jform_user_id', 'type' => 'input', 'tab' => 'details'),
+            //array('label' => 'Linked User', 'id' => 'jform_user_id', 'type' => 'input', 'tab' => 'details'),
+            array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'details'),
 			array('label' => 'Category', 'id' => 'jform_catid', 'type' => 'select', 'tab' => 'details'),
-			array('label' => 'Ordering', 'id' => 'jformordering', 'type' => 'select', 'tab' => 'details'),
+			//array('label' => 'Ordering', 'id' => 'jformordering', 'type' => 'select', 'tab' => 'details'),
 			array('label' => 'ID', 'id' => 'jform_id', 'type' => 'input', 'tab' => 'details'),
 			array('label' => 'Miscellaneous Information', 'id' => 'jform_misc', 'type' => 'textarea', 'tab' => 'details'),
-			array('label' => 'Created by', 'id' => 'jform_created_by_name', 'type' => 'input', 'tab' => 'publishing'),
+			//array('label' => 'Created by', 'id' => 'jform_created_by_name', 'type' => 'input', 'tab' => 'publishing'),
 			array('label' => 'Created By Alias', 'id' => 'jform_created_by_alias', 'type' => 'input', 'tab' => 'publishing'),
 			array('label' => 'Created date', 'id' => 'jform_created', 'type'=>'input', 'tab'=>'publishing'),
 			array('label' => 'Start Publishing', 'id' => 'jform_publish_up', 'type'=>'input', 'tab'=>'publishing'),
 			array('label' => 'Finish Publishing', 'id' => 'jform_publish_down', 'type'=>'input', 'tab'=>'publishing'),
-			array('label' => 'Revision', 'id' => 'jform_version', 'type'=>'input', 'tab'=>'publishing'),
+			//array('label' => 'Revision', 'id' => 'jform_version', 'type'=>'input', 'tab'=>'publishing'),
 			array('label' => 'Image', 'id' => 'jform_image', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Position', 'id' => 'jform_con_position', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Email', 'id' => 'jform_email_to', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Address', 'id' => 'jform_address', 'type'=>'textarea', 'tab'=>'basic'),
 			array('label' => 'City or Suburb', 'id' => 'jform_suburb', 'type'=>'input', 'tab'=>'basic'),
-			array('label' => 'State or Province', 'id' => 'jform_state', 'type'=>'input', 'tab'=>'basic'),
+			//array('label' => 'State or Province', 'id' => 'jform_state', 'type'=>'input', 'tab'=>'basic'),
+			array('label' => 'Postal / ZIP Code', 'id' => 'jform_postcode', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Country', 'id' => 'jform_country', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Telephone', 'id' => 'jform_telephone', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Mobile', 'id' => 'jform_mobile', 'type'=>'input', 'tab'=>'basic'),
@@ -90,8 +92,8 @@ class ContactEditPage extends AdminEditPage
 			array('label' => 'First Sort Field', 'id' => 'jform_sortname1', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Second Sort Field', 'id' => 'jform_sortname2', 'type'=>'input', 'tab'=>'basic'),
 			array('label' => 'Third Sort Field', 'id' => 'jform_sortname3', 'type'=>'input', 'tab'=>'basic'),
-			array('label' => 'Show Category', 'id' => 'jform_params_show_contact_category', 'type'=>'radio', 'tab'=>'params-jbasic'),
-			array('label' => 'Show Contact List', 'id' => 'jform_params_show_contact_list', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Category', 'id' => 'jform_params_show_contact_category', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Show Contact List', 'id' => 'jform_params_show_contact_list', 'type'=>'fieldset', 'tab'=>'params-jbasic'),
 			array('label' => 'Display format', 'id' => 'jform_params_presentation_style', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Show Tags', 'id' => 'jform_params_show_tags', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Name', 'id' => 'jform_params_show_name', 'type'=>'select', 'tab'=>'params-jbasic'),
@@ -103,7 +105,7 @@ class ContactEditPage extends AdminEditPage
 			array('label' => 'Postal Code', 'id' => 'jform_params_show_postcode', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Country', 'id' => 'jform_params_show_country', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Telephone', 'id' => 'jform_params_show_telephone', 'type'=>'select', 'tab'=>'params-jbasic'),
-			array('label' => 'Mobile Phone', 'id' => 'jform_params_show_mobile', 'type'=>'select', 'tab'=>'params-jbasic'),
+			array('label' => 'Mobile phone', 'id' => 'jform_params_show_mobile', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Fax', 'id' => 'jform_params_show_fax', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Webpage', 'id' => 'jform_params_show_webpage', 'type'=>'select', 'tab'=>'params-jbasic'),
 			array('label' => 'Misc. Information', 'id' => 'jform_params_show_misc', 'type'=>'select', 'tab'=>'params-jbasic'),

--- a/tests/system/webdriver/Pages/Components/ContactEditPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactEditPage.php
@@ -65,8 +65,7 @@ class ContactEditPage extends AdminEditPage
 	public $inputFields = array (
 			array('label' => 'Name', 'id' => 'jform_name', 'type' => 'input', 'tab' => 'details'),
 			array('label' => 'Alias', 'id' => 'jform_alias', 'type' => 'input', 'tab' => 'details'),
-            //array('label' => 'Linked User', 'id' => 'jform_user_id', 'type' => 'input', 'tab' => 'details'),
-            array('label' => 'Status', 'id' => 'jform_published', 'type' => 'select', 'tab' => 'details'),
+            		//array('label' => 'Linked User', 'id' => 'jform_user_id', 'type' => 'input', 'tab' => 'details'),
 			array('label' => 'Category', 'id' => 'jform_catid', 'type' => 'select', 'tab' => 'details'),
 			//array('label' => 'Ordering', 'id' => 'jformordering', 'type' => 'select', 'tab' => 'details'),
 			array('label' => 'ID', 'id' => 'jform_id', 'type' => 'input', 'tab' => 'details'),

--- a/tests/system/webdriver/Pages/Components/ContactManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactManagerPage.php
@@ -1,0 +1,161 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end component contact menu.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
+ */
+class contactManagerPage extends AdminManagerPage
+{
+	/**
+	 * XPath string used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_contact']";
+
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $url = 'administrator/index.php?option=com_contact';
+
+	/**
+	 * Array of filter id values for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $filters = array(
+			'Select Status' => 'filter_published',
+			'Select Category' => 'filter_category_id',
+			'Select Access' => 'filter_access',
+			'Select Language' => 'filter_language',
+			'Select Tags' => 'filter_tag',
+			);
+
+	/**
+	 * Array of toolbar id values for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $toolbar = array (
+			'New' => 'toolbar-new',
+			'Edit' => 'toolbar-edit',
+			'Publish' => 'toolbar-publish',
+			'Unpublish' => 'toolbar-unpublish',
+			'Archive' => 'toolbar-archive',
+			'Check In' => 'toolbar-check-in',
+			'Trash' => 'toolbar-trash',
+			'Empty Trash' => 'toolbar-delete',
+			'Batch' => 'toolbar-batch',
+			'Options' => 'toolbar-options',
+			'Help' => 'toolbar-help',
+			);
+
+	/**
+	 * Add a new Contact item in the Contact Manager: Component screen.
+	 *
+	 * @param string   $name          Test Contact Name
+	 *
+	 * @return  ContactManagerPage
+	 */
+	public function addContact($name='Test Contact')
+	{
+		$new_name = $name;
+		$login = "testing";
+		$this->clickButton('toolbar-new');
+		$contactEditPage = $this->test->getPageObject('ContactEditPage');
+		$contactEditPage->setFieldValues(array('Name' => $name));
+		$contactEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('ContactManagerPage');
+	}
+
+	/**
+	 * Edit a Contact item in the Contact Manager: Contact Items screen.
+	 *
+	 * @param string   $name	   Contact Title field
+	 * @param array    $fields     associative array of fields in the form label => value.
+	 *
+	 * @return  void
+	 */
+	public function editContact($name, $fields)
+	{
+		$this->clickItem($name);
+		$contactEditPage = $this->test->getPageObject('ContactEditPage');
+		$contactEditPage->setFieldValues($fields);
+		$contactEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('ContactManagerPage');
+		$this->searchFor();
+	}
+
+	/**
+	 * Get state  of a Contact item in the Contact Manager: Contact Items screen.
+	 *
+	 * @param string   $name	   Contact Title field
+	 *
+	 * @return  State of the Contact //Published or Unpublished
+	 */
+	public function getState($name)
+	{
+		$result = false;
+		$row = $this->getRowNumber($name);
+		$text = $this->driver->findElement(By::xPath("//tbody/tr[" . $row . "]/td[3]/a"))->getAttribute(@onclick);
+		if (strpos($text, 'contact.unpublish') > 0)
+		{
+			$result = 'published';
+		}
+		if (strpos($text, 'contact.publish') > 0)
+		{
+			$result = 'unpublished';
+		}
+		return $result;
+	}
+
+	/**
+	 * Change state of a Contact item in the Contact Manager: Contact Items screen.
+	 *
+	 * @param string   $name	   Contact Title field
+	 * @param string   $state      State of the Contact
+	 *
+	 * @return  void
+	 */
+	public function changeContactState($name, $state = 'published')
+	{
+		$this->searchFor($name);
+		$this->checkAll();
+		if (strtolower($state) == 'published')
+		{
+			$this->clickButton('toolbar-publish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
+		elseif (strtolower($state) == 'unpublished')
+		{
+			$this->clickButton('toolbar-unpublish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
+		$this->searchFor();
+	}
+
+}

--- a/tests/system/webdriver/Pages/Components/ContactManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/ContactManagerPage.php
@@ -22,7 +22,7 @@ use SeleniumClient\WebElement;
  * @subpackage  Webdriver
  * @since       3.0
  */
-class contactManagerPage extends AdminManagerPage
+class ContactManagerPage extends AdminManagerPage
 {
 	/**
 	 * XPath string used to uniquely identify this page
@@ -78,16 +78,20 @@ class contactManagerPage extends AdminManagerPage
 	 * Add a new Contact item in the Contact Manager: Component screen.
 	 *
 	 * @param string   $name          Test Contact Name
+	 * @param array    $fields     associative array of fields in the form label => value.
 	 *
 	 * @return  ContactManagerPage
 	 */
-	public function addContact($name='Test Contact')
+	public function addContact($name='Test Contact', $fields)
 	{
 		$new_name = $name;
 		$login = "testing";
 		$this->clickButton('toolbar-new');
 		$contactEditPage = $this->test->getPageObject('ContactEditPage');
 		$contactEditPage->setFieldValues(array('Name' => $name));
+		if($fields) {
+			$contactEditPage->setFieldValues($fields);
+		}
 		$contactEditPage->clickButton('toolbar-save');
 		$this->test->getPageObject('ContactManagerPage');
 	}
@@ -122,11 +126,11 @@ class contactManagerPage extends AdminManagerPage
 		$result = false;
 		$row = $this->getRowNumber($name);
 		$text = $this->driver->findElement(By::xPath("//tbody/tr[" . $row . "]/td[3]/a"))->getAttribute(@onclick);
-		if (strpos($text, 'contact.unpublish') > 0)
+		if (strpos($text, 'contacts.unpublish') > 0)
 		{
 			$result = 'published';
 		}
-		if (strpos($text, 'contact.publish') > 0)
+		if (strpos($text, 'contacts.publish') > 0)
 		{
 			$result = 'unpublished';
 		}
@@ -157,5 +161,4 @@ class contactManagerPage extends AdminManagerPage
 		}
 		$this->searchFor();
 	}
-
 }

--- a/tests/system/webdriver/tests/components/ContactManager0001Test.php
+++ b/tests/system/webdriver/tests/components/ContactManager0001Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the  Contact: Add / Edit  Screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
+ */
+class ContactManager0001Test extends JoomlaWebdriverTestCase
+{
+	/**
+	 * The page class being tested.
+	 *
+	 * @var     contactManagerPage
+	 * @since   3.0
+	 */
+	protected $contactManagerPage = null;
+	
+	/**
+	 * Login to back end and navigate to menu Contact.
+	 *
+	 * @since   3.0
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->contactManagerPage = $cpPage->clickMenu('Contacts', 'contactManagerPage');
+	}
+
+	/**
+	 * Logout and close test.
+	 *
+	 * @since   3.0
+	 */
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getAllInputFields_ScreenDisplayed_EqualExpected()
+	{
+		$this->contactManagerPage->clickButton('toolbar-new');
+		$contactEditPage = $this->getPageObject('ContactEditPage');
+		$testElements = $contactEditPage->getAllInputFields(array('details', 'publishing', 'basic', 'params-jbasic', 'params-email', 'metadata'));
+		$actualFields = array();
+		foreach ($testElements as $el)
+		{
+			$el->labelText = (substr($el->labelText, -2) == ' *') ? substr($el->labelText, 0, -2) : $el->labelText;
+			$actualFields[] = array('label' => $el->labelText, 'id' => $el->id, 'type' => $el->contact, 'tab' => $el->tab);
+		}
+		$this->assertEquals($contactEditPage->inputFields, $actualFields);
+		$contactEditPage->clickButton('toolbar-cancel');
+		$this->contactManagerPage = $this->getPageObject('ContactManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function constructor_OpenEditScreen_ContactEditOpened()
+	{
+		$this->contactManagerPage->clickButton('new');
+		$contactEditPage = $this->getPageObject('ContactEditPage');
+		$contactEditPage->clickButton('cancel');
+		$this->contactManagerPage = $this->getPageObject('ContactManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getContactIds_ScreenDisplayed_EqualExpected()
+	{
+		$this->contactManagerPage->clickButton('toolbar-new');
+		$contactEditPage = $this->getPageObject('ContactEditPage');
+		$textArray = $contactEditPage->getTabIds();
+		$this->assertEquals($contactEditPage->tabs, $textArray, 'Contact labels should match expected values.');
+		$contactEditPage->clickButton('toolbar-cancel');
+		$this->contactManagerPage = $this->getPageObject('ContactManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addContact_WithFieldDefaults_ContactAdded()
+	{
+		$salt = rand();
+		$contactName = 'Contact' . $salt;
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test Contact should not be present');
+		$this->contactManagerPage->addContact($contactName);
+		$message = $this->contactManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
+		$this->assertEquals(1, $this->contactManagerPage->getRowNumber($contactName), 'Test Contact should be in row 2');
+		$this->contactManagerPage->deleteItem($contactName);
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test Contact should not be present');
+	}
+
+	/**
+	 * @test
+	 */
+	public function editContact_ChangeFields_FieldsChanged()
+	{
+		$salt = rand();
+		$contactName = 'Contact' . $salt;
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test contact should not be present');
+		$this->contactManagerPage->addContact($contactName);
+		$this->contactManagerPage->editContact($contactName);
+		$values = $this->contactManagerPage->getFieldValues('contactEditPage', $contactName);
+		$this->contactManagerPage->deleteItem($contactName);
+	}
+	
+	/**
+	 * @test
+	 */
+	public function changeContactState_ChangeEnabledUsingToolbar_EnabledChanged()
+	{
+		$this->contactManagerPage->addContact('Test Contact');
+		$state = $this->contactManagerPage->getState('Test Contact');
+		$this->assertEquals('published', $state, 'Initial state should be published');
+		$this->contactManagerPage->changeContactState('Test Contact', 'unpublished');
+		$state = $this->contactManagerPage->getState('Test Contact');
+		$this->assertEquals('unpublished', $state, 'State should be unpublished');
+		$this->contactManagerPage->deleteItem('Test Contact');
+	}	
+}

--- a/tests/system/webdriver/tests/components/ContactManager0001Test.php
+++ b/tests/system/webdriver/tests/components/ContactManager0001Test.php
@@ -20,7 +20,7 @@ use SeleniumClient\DesiredCapabilities;
  *
  * @package     Joomla.Test
  * @subpackage  Webdriver
- * @since       3.0
+ * @since       3.1
  */
 class ContactManager0001Test extends JoomlaWebdriverTestCase
 {
@@ -28,26 +28,26 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 	 * The page class being tested.
 	 *
 	 * @var     contactManagerPage
-	 * @since   3.0
+	 * @since   3.1
 	 */
 	protected $contactManagerPage = null;
 	
 	/**
-	 * Login to back end and navigate to menu Contact.
+	 * Login to back end and navigate to menu Contacts.
 	 *
-	 * @since   3.0
+	 * @since   3.1
 	 */
 	public function setUp()
 	{
 		parent::setUp();
 		$cpPage = $this->doAdminLogin();
-		$this->contactManagerPage = $cpPage->clickMenu('Contacts', 'contactManagerPage');
+		$this->contactManagerPage = $cpPage->clickMenu('Contacts', 'ContactManagerPage');
 	}
 
 	/**
 	 * Logout and close test.
 	 *
-	 * @since   3.0
+	 * @since   3.1
 	 */
 	public function tearDown()
 	{
@@ -67,7 +67,7 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 		foreach ($testElements as $el)
 		{
 			$el->labelText = (substr($el->labelText, -2) == ' *') ? substr($el->labelText, 0, -2) : $el->labelText;
-			$actualFields[] = array('label' => $el->labelText, 'id' => $el->id, 'type' => $el->contact, 'tab' => $el->tab);
+			$actualFields[] = array('label' => $el->labelText, 'id' => $el->id, 'type' => $el->tag, 'tab' => $el->tab);
 		}
 		$this->assertEquals($contactEditPage->inputFields, $actualFields);
 		$contactEditPage->clickButton('toolbar-cancel');
@@ -88,7 +88,7 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 	/**
 	 * @test
 	 */
-	public function getContactIds_ScreenDisplayed_EqualExpected()
+	public function getTabIds_ScreenDisplayed_EqualExpected()
 	{
 		$this->contactManagerPage->clickButton('toolbar-new');
 		$contactEditPage = $this->getPageObject('ContactEditPage');
@@ -106,12 +106,34 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 		$salt = rand();
 		$contactName = 'Contact' . $salt;
 		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test Contact should not be present');
-		$this->contactManagerPage->addContact($contactName);
+		$this->contactManagerPage->addContact($contactName, false);
 		$message = $this->contactManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
-		$this->assertEquals(1, $this->contactManagerPage->getRowNumber($contactName), 'Test Contact should be in row 2');
+		$this->assertEquals(5, $this->contactManagerPage->getRowNumber($contactName), 'Test Contact should be in row 5');
 		$this->contactManagerPage->deleteItem($contactName);
 		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test Contact should not be present');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addContact_WithGivenFields_ContactAdded()
+	{
+		$salt = rand();
+		$contactName = 'Contact' . $salt;
+		$address='10 Downing Street';
+		$city='London';
+		$country='England';
+
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test contact should not be present');
+		$this->contactManagerPage->addContact($contactName, array('Country' => $country, 'Address' => $address, 'City or Suburb' => $city));
+		$message = $this->contactManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
+		$this->assertEquals(5, $this->contactManagerPage->getRowNumber($contactName), 'Test test contact should be in row 5');
+		$values = $this->contactManagerPage->getFieldValues('ContactEditPage', $contactName, array('Name', 'Address', 'City or Suburb', 'Country'));
+		$this->assertEquals(array($contactName,$address,$city,$country), $values, 'Actual name, address, city and country should match expected');
+		$this->contactManagerPage->deleteItem($contactName);
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test contact should not be present');
 	}
 
 	/**
@@ -122,9 +144,9 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 		$salt = rand();
 		$contactName = 'Contact' . $salt;
 		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Test contact should not be present');
-		$this->contactManagerPage->addContact($contactName);
-		$this->contactManagerPage->editContact($contactName);
-		$values = $this->contactManagerPage->getFieldValues('contactEditPage', $contactName);
+		$this->contactManagerPage->addContact($contactName, false);
+		$this->contactManagerPage->editContact($contactName, array('Country' => 'England', 'Address' => '10 Downing Street', 'City or Suburb' => 'London'));
+		$values = $this->contactManagerPage->getFieldValues('ContactEditPage', $contactName, array('Country', 'Address', 'City or Suburb'));
 		$this->contactManagerPage->deleteItem($contactName);
 	}
 	
@@ -133,12 +155,14 @@ class ContactManager0001Test extends JoomlaWebdriverTestCase
 	 */
 	public function changeContactState_ChangeEnabledUsingToolbar_EnabledChanged()
 	{
-		$this->contactManagerPage->addContact('Test Contact');
-		$state = $this->contactManagerPage->getState('Test Contact');
+		$salt = rand();
+		$contactName = 'Contact' . $salt;
+		$this->contactManagerPage->addContact($contactName, false);
+		$state = $this->contactManagerPage->getState($contactName);
 		$this->assertEquals('published', $state, 'Initial state should be published');
-		$this->contactManagerPage->changeContactState('Test Contact', 'unpublished');
-		$state = $this->contactManagerPage->getState('Test Contact');
+		$this->contactManagerPage->changeContactState($contactName, 'unpublished');
+		$state = $this->contactManagerPage->getState($contactName);
 		$this->assertEquals('unpublished', $state, 'State should be unpublished');
-		$this->contactManagerPage->deleteItem('Test Contact');
+		$this->contactManagerPage->deleteItem($contactName);
 	}	
 }

--- a/tests/system/webdriver/tests/components/ContactManager0002Test.php
+++ b/tests/system/webdriver/tests/components/ContactManager0002Test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the  Tags: Add / Edit  Screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.1
+ */
+class ContactManager0002Test extends JoomlaWebdriverTestCase
+{
+
+  /**
+	 * The page class being tested.
+	 *
+	 * @var     contactManagerPage
+	 * @since   3.1
+	 */
+	protected $contactManagerPage = null;
+
+	/**
+	 * Login to back end and navigate to menu Contacts.
+	 *
+	 * @since   3.1
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->contactManagerPage = $cpPage->clickMenu('Contacts', 'ContactManagerPage');
+	}
+
+	/**
+	 * Logout and close test.
+	 *
+	 * @since   3.1
+	 */
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function getFilters_GetListOfFilters_ShouldMatchExpected()
+	{
+		$actualIds = $this->contactManagerPage->getFilters();
+		$expectedIds = array_values($this->contactManagerPage->filters);
+		$this->assertEquals($expectedIds, $actualIds, 'Filter ids should match expected');
+	}
+
+	/**
+	 * @test
+	 */
+	public function setFilter_SetFilterValues_ShouldExecuteFilter()
+	{
+		$salt = rand();
+		$contactName = 'Test Filter' . $salt;
+		$this->contactManagerPage->addContact($contactName, false);
+		$message = $this->contactManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
+		$test = $this->contactManagerPage->setFilter('filter_published', 'Unpublished');
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Contact should not show');
+		$test = $this->contactManagerPage->setFilter('filter_published', 'Published');
+		$this->assertEquals(8, $this->contactManagerPage->getRowNumber($contactName), 'Contact should be in row 8');
+		$this->contactManagerPage->deleteItem($contactName);
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName), 'Contact should not be present');
+	}
+
+	/**
+	 * @test
+	 */
+	public function setFilter_TestFilters_ShouldFilterContacts()
+	{
+		$tagName_1 = 'Test Filter 1';
+		$tagName_2 = 'Test Filter 2';
+
+		$this->contactManagerPage->addContact($tagName_1, false);
+		$message = $this->contactManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
+		$state = $this->contactManagerPage->getState($tagName_1);
+		$this->assertEquals('published', $state, 'Initial state should be published');
+
+
+		$this->contactManagerPage->addContact($tagName_2, false);
+		$message = $this->contactManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
+		$state = $this->contactManagerPage->getState($tagName_2);
+		$this->assertEquals('published', $state, 'Initial state should be published');
+		$this->contactManagerPage->changeContactState($tagName_2, 'unpublished');
+
+		$test = $this->contactManagerPage->setFilter('filter_published', 'Unpublished');
+		$this->assertFalse($this->contactManagerPage->getRowNumber($tagName_1), 'Contact should not show');
+		$this->assertEquals(1, $this->contactManagerPage->getRowNumber($tagName_2), 'Contact should be in row 1');
+
+		$test = $this->contactManagerPage->setFilter('filter_published', 'Published');
+		$this->assertFalse($this->contactManagerPage->getRowNumber($tagName_2), 'Contact should not show');
+		$this->assertEquals(8, $this->contactManagerPage->getRowNumber($tagName_1), 'Contact should be in row 8');
+
+		$this->contactManagerPage->setFilter('Select Status', 'Select Status');
+		$this->contactManagerPage->deleteItem($tagName_1);
+		$this->contactManagerPage->deleteItem($tagName_2);
+	}
+
+}

--- a/tests/system/webdriver/tests/components/ContactManager0002Test.php
+++ b/tests/system/webdriver/tests/components/ContactManager0002Test.php
@@ -16,7 +16,7 @@ use SeleniumClient\WebDriverWait;
 use SeleniumClient\DesiredCapabilities;
 
 /**
- * This class tests the  Tags: Add / Edit  Screen.
+ * This class tests the  Contact: Add / Edit  Screen.
  *
  * @package     Joomla.Test
  * @subpackage  Webdriver
@@ -89,34 +89,34 @@ class ContactManager0002Test extends JoomlaWebdriverTestCase
 	 */
 	public function setFilter_TestFilters_ShouldFilterContacts()
 	{
-		$tagName_1 = 'Test Filter 1';
-		$tagName_2 = 'Test Filter 2';
+		$contactName_1 = 'Test Filter 1';
+		$contactName_2 = 'Test Filter 2';
 
-		$this->contactManagerPage->addContact($tagName_1, false);
+		$this->contactManagerPage->addContact($contactName_1, false);
 		$message = $this->contactManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
-		$state = $this->contactManagerPage->getState($tagName_1);
+		$state = $this->contactManagerPage->getState($contactName_1);
 		$this->assertEquals('published', $state, 'Initial state should be published');
 
 
-		$this->contactManagerPage->addContact($tagName_2, false);
+		$this->contactManagerPage->addContact($contactName_2, false);
 		$message = $this->contactManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Contact successfully saved') >= 0, 'Contact save should return success');
-		$state = $this->contactManagerPage->getState($tagName_2);
+		$state = $this->contactManagerPage->getState($contactName_2);
 		$this->assertEquals('published', $state, 'Initial state should be published');
-		$this->contactManagerPage->changeContactState($tagName_2, 'unpublished');
+		$this->contactManagerPage->changeContactState($contactName_2, 'unpublished');
 
 		$test = $this->contactManagerPage->setFilter('filter_published', 'Unpublished');
-		$this->assertFalse($this->contactManagerPage->getRowNumber($tagName_1), 'Contact should not show');
-		$this->assertEquals(1, $this->contactManagerPage->getRowNumber($tagName_2), 'Contact should be in row 1');
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName_1), 'Contact should not show');
+		$this->assertEquals(1, $this->contactManagerPage->getRowNumber($contactName_2), 'Contact should be in row 1');
 
 		$test = $this->contactManagerPage->setFilter('filter_published', 'Published');
-		$this->assertFalse($this->contactManagerPage->getRowNumber($tagName_2), 'Contact should not show');
-		$this->assertEquals(8, $this->contactManagerPage->getRowNumber($tagName_1), 'Contact should be in row 8');
+		$this->assertFalse($this->contactManagerPage->getRowNumber($contactName_2), 'Contact should not show');
+		$this->assertEquals(8, $this->contactManagerPage->getRowNumber($contactName_1), 'Contact should be in row 8');
 
 		$this->contactManagerPage->setFilter('Select Status', 'Select Status');
-		$this->contactManagerPage->deleteItem($tagName_1);
-		$this->contactManagerPage->deleteItem($tagName_2);
+		$this->contactManagerPage->deleteItem($contactName_1);
+		$this->contactManagerPage->deleteItem($contactName_2);
 	}
 
 }


### PR DESCRIPTION
These are me adapting the tags manager tests for the Contact Component. They all pass (assuming #1160 is accepted - otherwise two will fail - +1 for tests finding bugs).

For the relevant people - does anyone know why selenium is failing to pick up some of the fields present? If you go into the array with all the fields in you'll see I've had to comment some of them out so that that particular test passes.
