### PR TITLE
Add in Weblink Component Selenium Tests

### DIFF
--- a/tests/system/webdriver/Pages/Components/WeblinkEditPage.php
+++ b/tests/system/webdriver/Pages/Components/WeblinkEditPage.php
@@ -1,0 +1,101 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end menu items manager screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.0
+ */
+class WeblinkEditPage extends AdminEditPage
+{
+	/**
+	 * XPath string used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $waitForXpath =  "//form[@id='weblink-form']";
+
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $url = 'administrator/index.php?option=com_weblinks&view=weblink&layout=edit';
+
+	/**
+	 * Array of tabs present on this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $tabs = array('details', 'publishing', 'params-jbasic', 'metadata-jmetadata');
+
+	/**
+	 * Array of tab labels for this page
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	public $tabLabels = array('New Weblink', 'Publishing Options', 'Basic Options', 'Metadata Options');
+
+	/**
+	 * Array of all the field Details of the Edit page, along with the ID and tab value they are present on
+	 *
+	 * @var array
+	 * @since 3.0
+	 */
+	public $inputFields = array (
+			array('label' => 'Title', 'id' => 'jform_title', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'URL', 'id' => 'jform_url', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Category', 'id' => 'jform_catid', 'type' => 'select', 'tab' => 'details'),
+			//array('label' => 'Ordering', 'id' => 'jformordering', 'type' => 'select', 'tab' => 'details'),
+			array('label' => 'Description', 'id' => 'jform_description', 'type' => 'textarea', 'tab' => 'details'),
+			array('label' => 'First image', 'id' => 'jform_images_image_first', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Image Float', 'id' => 'jform_images_float_first', 'type' => 'select', 'tab' => 'details'),
+			array('label' => 'Alt text', 'id' => 'jform_images_image_first_alt', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Caption', 'id' => 'jform_images_image_first_caption', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Second image', 'id' => 'jform_images_image_second', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Image Float', 'id' => 'jform_images_float_second', 'type' => 'select', 'tab' => 'details'),
+			array('label' => 'Alt text', 'id' => 'jform_images_image_second_alt', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Caption', 'id' => 'jform_images_image_second_caption', 'type' => 'input', 'tab' => 'details'),
+			array('label' => 'Alias', 'id' => 'jform_alias', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'ID', 'id' => 'jform_id', 'type' => 'input', 'tab' => 'publishing'),
+			//array('label' => 'Created By', 'id' => 'jform_created_by_name', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Author\'s Alias', 'id' => 'jform_created_by_alias', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Created Date', 'id' => 'jform_created', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Start Publishing', 'id' => 'jform_publish_up', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Finish Publishing', 'id' => 'jform_publish_down', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Revision', 'id' => 'jform_version', 'type' => 'input', 'tab' => 'publishing'),
+			//array('label' => 'Modified by', 'id' => 'jform_modified_by_name', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Modified Date', 'id' => 'jform_modified', 'type' => 'input', 'tab' => 'publishing'),
+			array('label' => 'Target', 'id' => 'jform_params_target', 'type' => 'select', 'tab' => 'params-jbasic'),
+			array('label' => 'Width', 'id' => 'jform_params_width', 'type' => 'input', 'tab' => 'params-jbasic'),
+			array('label' => 'Height', 'id' => 'jform_params_height', 'type' => 'input', 'tab' => 'params-jbasic'),
+			array('label' => 'Count Clicks', 'id' => 'jform_params_count_clicks', 'type' => 'select', 'tab' => 'params-jbasic'),
+			array('label' => 'Meta Description', 'id' => 'jform_metadesc', 'type'=>'textarea', 'tab'=>'metadata-jmetadata'),
+			array('label' => 'Meta Keywords', 'id' => 'jform_metakey', 'type'=>'textarea', 'tab'=>'metadata-jmetadata'),
+			array('label' => 'External Reference', 'id' => 'jform_xreference', 'type'=>'input', 'tab'=>'metadata-jmetadata'),
+			array('label' => 'Robots', 'id' => 'jform_metadata_robots', 'type'=>'select', 'tab'=>'metadata-jmetadata'),
+			array('label' => 'Content Rights', 'id' => 'jform_metadata_rights', 'type'=>'input', 'tab'=>'metadata-jmetadata'),
+		);
+
+}
+

--- a/tests/system/webdriver/Pages/Components/WeblinkManagerPage.php
+++ b/tests/system/webdriver/Pages/Components/WeblinkManagerPage.php
@@ -1,0 +1,162 @@
+<?php
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+use SeleniumClient\WebElement;
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Page class for the back-end component weblink menu.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.1
+ */
+class WeblinkManagerPage extends AdminManagerPage
+{
+	/**
+	 * XPath string used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.1
+	 */
+	protected $waitForXpath =  "//ul/li/a[@href='index.php?option=com_weblinks']";
+
+	/**
+	 * URL used to uniquely identify this page
+	 *
+	 * @var    string
+	 * @since  3.1
+	 */
+	protected $url = 'administrator/index.php?option=com_weblinks';
+
+	/**
+	 * Array of filter id values for this page
+	 *
+	 * @var    array
+	 * @since  3.1
+	 */
+	public $filters = array(
+			'Select Status' => 'filter_state',
+			'Select Category' => 'filter_category_id',
+			'Select Access' => 'filter_access',
+			'Select Language' => 'filter_language',
+			'Select Tag' => 'filter_tag',
+			);
+
+	/**
+	 * Array of toolbar id values for this page
+	 *
+	 * @var    array
+	 * @since  3.1
+	 */
+	public $toolbar = array (
+			'New' => 'toolbar-new',
+			'Edit' => 'toolbar-edit',
+			'Publish' => 'toolbar-publish',
+			'Unpublish' => 'toolbar-unpublish',
+			'Archive' => 'toolbar-archive',
+			'Check In' => 'toolbar-check-in',
+			'Trash' => 'toolbar-trash',
+			'Empty Trash' => 'toolbar-delete',
+			'Batch' => 'toolbar-batch',
+			'Options' => 'toolbar-options',
+			'Help' => 'toolbar-help',
+			);
+
+	/**
+	 * Add a new Weblink item in the Weblink Manager: Component screen.
+	 *
+	 * @param string   $name          Test Weblink Name
+	 * @param array    $fields		  associative array of fields in the form label => value.
+	 *
+	 * @return  WeblinkManagerPage
+	 */
+	public function addWeblink($name='Test Weblink', $url, $fields)
+	{
+		$this->clickButton('toolbar-new');
+		$contactEditPage = $this->test->getPageObject('WeblinkEditPage');
+		$contactEditPage->setFieldValues(array('Title' => $name, 'URL' => $url));
+		if($fields) {
+			$contactEditPage->setFieldValues($fields);
+		}
+		$contactEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('WeblinkManagerPage');
+	}
+
+	/**
+	 * Edit a Weblink item in the Weblink Manager: Weblink Items screen.
+	 *
+	 * @param string   $name	   Weblink Title field
+	 * @param array    $fields     associative array of fields in the form label => value.
+	 *
+	 * @return  void
+	 */
+	public function editWeblink($name, $fields)
+	{
+		$this->clickItem($name);
+		$contactEditPage = $this->test->getPageObject('WeblinkEditPage');
+		$contactEditPage->setFieldValues($fields);
+		$contactEditPage->clickButton('toolbar-save');
+		$this->test->getPageObject('WeblinkManagerPage');
+		$this->searchFor();
+	}
+
+	/**
+	 * Get state  of a Weblink item in the Weblink Manager: Weblink Items screen.
+	 *
+	 * @param string   $name	   Weblink Title field
+	 *
+	 * @return  State of the Weblink //Published or Unpublished
+	 */
+	public function getState($name)
+	{
+		$result = false;
+		$row = $this->getRowNumber($name);
+		$text = $this->driver->findElement(By::xPath("//tbody/tr[" . $row . "]/td[3]/a"))->getAttribute(@onclick);
+		if (strpos($text, 'weblinks.unpublish') > 0)
+		{
+			$result = 'published';
+		}
+		if (strpos($text, 'weblinks.publish') > 0)
+		{
+			$result = 'unpublished';
+		}
+		return $result;
+	}
+
+	/**
+	 * Change state of a Weblink item in the Weblink Manager: Weblink Items screen.
+	 *
+	 * @param string   $name	   Weblink Title field
+	 * @param string   $state      State of the Weblink
+	 *
+	 * @return  void
+	 */
+	public function changeWeblinkState($name, $state = 'published')
+	{
+		$this->searchFor($name);
+		$this->checkAll();
+		if (strtolower($state) == 'published')
+		{
+			$this->clickButton('toolbar-publish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
+		elseif (strtolower($state) == 'unpublished')
+		{
+			$this->clickButton('toolbar-unpublish');
+			$this->driver->waitForElementUntilIsPresent(By::xPath($this->waitForXpath));
+		}
+		$this->searchFor();
+	}
+}

--- a/tests/system/webdriver/tests/components/WeblinkManager0001Test.php
+++ b/tests/system/webdriver/tests/components/WeblinkManager0001Test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the  Weblink: Add / Edit  Screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.1
+ */
+class WeblinkManager0001Test extends JoomlaWebdriverTestCase
+{
+	/**
+	 * The page class being tested.
+	 *
+	 * @var     weblinkManagerPage
+	 * @since   3.1
+	 */
+	protected $weblinkManagerPage = null;
+	
+	/**
+	 * Login to back end and navigate to menu Weblinks.
+	 *
+	 * @since   3.1
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->weblinkManagerPage = $cpPage->clickMenu('Weblinks', 'WeblinkManagerPage');
+	}
+
+	/**
+	 * Logout and close test.
+	 *
+	 * @since   3.1
+	 */
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getAllInputFields_ScreenDisplayed_EqualExpected()
+	{
+		$this->weblinkManagerPage->clickButton('toolbar-new');
+		$weblinkEditPage = $this->getPageObject('WeblinkEditPage');
+		$testElements = $weblinkEditPage->getAllInputFields(array('details', 'publishing', 'params-jbasic', 'metadata-jmetadata'));
+		$actualFields = array();
+		foreach ($testElements as $el)
+		{
+			$el->labelText = (substr($el->labelText, -2) == ' *') ? substr($el->labelText, 0, -2) : $el->labelText;
+			$actualFields[] = array('label' => $el->labelText, 'id' => $el->id, 'type' => $el->tag, 'tab' => $el->tab);
+		}
+		$this->assertEquals($weblinkEditPage->inputFields, $actualFields);
+		$weblinkEditPage->clickButton('toolbar-cancel');
+		$this->weblinkManagerPage = $this->getPageObject('WeblinkManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function constructor_OpenEditScreen_WeblinkEditOpened()
+	{
+		$this->weblinkManagerPage->clickButton('new');
+		$weblinkEditPage = $this->getPageObject('WeblinkEditPage');
+		$weblinkEditPage->clickButton('cancel');
+		$this->weblinkManagerPage = $this->getPageObject('WeblinkManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function getTabIds_ScreenDisplayed_EqualExpected()
+	{
+		$this->weblinkManagerPage->clickButton('toolbar-new');
+		$weblinkEditPage = $this->getPageObject('WeblinkEditPage');
+		$textArray = $weblinkEditPage->getTabIds();
+		$this->assertEquals($weblinkEditPage->tabs, $textArray, 'Weblink labels should match expected values.');
+		$weblinkEditPage->clickButton('toolbar-cancel');
+		$this->weblinkManagerPage = $this->getPageObject('WeblinkManagerPage');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addWeblink_WithFieldDefaults_WeblinkAdded()
+	{
+		$salt = rand();
+		$weblinkName = 'Weblink' . $salt;
+		$url='www.example.com';
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Test Weblink should not be present');
+		$this->weblinkManagerPage->addWeblink($weblinkName, $url, false);
+		$message = $this->weblinkManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Weblink successfully saved') >= 0, 'Weblink save should return success');
+		$this->assertEquals(10, $this->weblinkManagerPage->getRowNumber($weblinkName), 'Test Weblink should be in row 10');
+		$this->weblinkManagerPage->deleteItem($weblinkName);
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Test Weblink should not be present');
+	}
+	
+	/**
+	 * @test
+	 */
+	public function addWeblink_WithGivenFields_WeblinkAdded()
+	{
+		$salt = rand();
+		$weblinkName = 'Weblink' . $salt;
+		$url='www.example.com';
+		$alt='Alternative Text' . $salt;
+		$float='Right';
+		$caption='Sample Caption' . $salt;
+
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Test weblink should not be present');
+		$this->weblinkManagerPage->addWeblink($weblinkName, $url, array('Alt text' => $alt, 'Caption' => $caption, 'Image Float' => $float));
+		$message = $this->weblinkManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Weblink successfully saved') >= 0, 'Weblink save should return success');
+		$this->assertEquals(10, $this->weblinkManagerPage->getRowNumber($weblinkName), 'Test weblink should be in row 10');
+		$values = $this->weblinkManagerPage->getFieldValues('WeblinkEditPage', $weblinkName, array('Title', 'Alt text', 'Caption', 'Image Float'));
+		$this->assertEquals(array($weblinkName,$alt,$caption,$float), $values, 'Actual title, alt text, caption and image float should match expected');
+		$this->weblinkManagerPage->deleteItem($weblinkName);
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Test weblink should not be present');
+	}
+
+	/**
+	 * @test
+	 */
+	public function editWeblink_ChangeFields_FieldsChanged()
+	{
+		$salt = rand();
+		$weblinkName = 'Weblink' . $salt;
+		$url='www.example.com';
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Test weblink should not be present');
+		$this->weblinkManagerPage->addWeblink($weblinkName, $url, false);
+		$this->weblinkManagerPage->editWeblink($weblinkName, array('Alt text' => 'Alternative Text' . $salt, 'Caption' => 'Sample Caption' . $salt, 'Image Float' => 'Right'));
+		$values = $this->weblinkManagerPage->getFieldValues('WeblinkEditPage', $weblinkName, array('Alt text', 'Caption', 'Image Float'));
+		$this->weblinkManagerPage->deleteItem($weblinkName);
+	}
+	
+	/**
+	 * @test
+	 */
+	public function changeWeblinkState_ChangeEnabledUsingToolbar_EnabledChanged()
+	{
+		$salt = rand();
+		$weblinkName = 'Weblink' . $salt;
+		$url='www.example.com';
+		$this->weblinkManagerPage->addWeblink($weblinkName, $url, false);
+		$state = $this->weblinkManagerPage->getState($weblinkName);
+		$this->assertEquals('published', $state, 'Initial state should be published');
+		$this->weblinkManagerPage->changeWeblinkState($weblinkName, 'unpublished');
+		$state = $this->weblinkManagerPage->getState($weblinkName);
+		$this->assertEquals('unpublished', $state, 'State should be unpublished');
+		$this->weblinkManagerPage->deleteItem($weblinkName);
+	}
+}

--- a/tests/system/webdriver/tests/components/WeblinkManager0002Test.php
+++ b/tests/system/webdriver/tests/components/WeblinkManager0002Test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once 'JoomlaWebdriverTestCase.php';
+
+use SeleniumClient\By;
+use SeleniumClient\SelectElement;
+use SeleniumClient\WebDriver;
+use SeleniumClient\WebDriverWait;
+use SeleniumClient\DesiredCapabilities;
+
+/**
+ * This class tests the  Weblinks: Add / Edit  Screen.
+ *
+ * @package     Joomla.Test
+ * @subpackage  Webdriver
+ * @since       3.1
+ */
+class WeblinkManager0002Test extends JoomlaWebdriverTestCase
+{
+
+  /**
+	 * The page class being tested.
+	 *
+	 * @var     weblinkManagerPage
+	 * @since   3.1
+	 */
+	protected $weblinkManagerPage = null;
+
+	/**
+	 * Login to back end and navigate to menu Weblinks.
+	 *
+	 * @since   3.1
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+		$cpPage = $this->doAdminLogin();
+		$this->weblinkManagerPage = $cpPage->clickMenu('Weblinks', 'WeblinkManagerPage');
+	}
+
+	/**
+	 * Logout and close test.
+	 *
+	 * @since   3.1
+	 */
+	public function tearDown()
+	{
+		$this->doAdminLogout();
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function getFilters_GetListOfFilters_ShouldMatchExpected()
+	{
+		$actualIds = $this->weblinkManagerPage->getFilters();
+		$expectedIds = array_values($this->weblinkManagerPage->filters);
+		$this->assertEquals($expectedIds, $actualIds, 'Filter ids should match expected');
+	}
+
+	/**
+	 * @test
+	 */
+	public function setFilter_SetFilterValues_ShouldExecuteFilter()
+	{
+		$salt = rand();
+		$weblinkName = 'Test Filter' . $salt;
+		$url = 'www.example.com';
+		$this->weblinkManagerPage->addWeblink($weblinkName, $url, false);
+		$message = $this->weblinkManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Weblink successfully saved') >= 0, 'Weblink save should return success');
+		$test = $this->weblinkManagerPage->setFilter('filter_state', 'Unpublished');
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Weblink should not show');
+		$test = $this->weblinkManagerPage->setFilter('filter_state', 'Published');
+		$this->assertEquals(10, $this->weblinkManagerPage->getRowNumber($weblinkName), 'Weblink should be in row 10');
+		$this->weblinkManagerPage->deleteItem($weblinkName);
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName), 'Weblink should not be present');
+	}
+
+	/**
+	 * @test
+	 */
+	public function setFilter_TestFilters_ShouldFilterWeblinks()
+	{
+		$weblinkName_1 = 'Test Filter 1';
+		$weblinkName_2 = 'Test Filter 2';
+		$url = 'www.example.com';
+
+		$this->weblinkManagerPage->addWeblink($weblinkName_1, $url, false);
+		$message = $this->weblinkManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Weblink successfully saved') >= 0, 'Weblink save should return success');
+		$state = $this->weblinkManagerPage->getState($weblinkName_1);
+		$this->assertEquals('published', $state, 'Initial state should be published');
+
+
+		$this->weblinkManagerPage->addWeblink($weblinkName_2, $url, false);
+		$message = $this->weblinkManagerPage->getAlertMessage();
+		$this->assertTrue(strpos($message, 'Weblink successfully saved') >= 0, 'Weblink save should return success');
+		$state = $this->weblinkManagerPage->getState($weblinkName_2);
+		$this->assertEquals('published', $state, 'Initial state should be published');
+		$this->weblinkManagerPage->changeWeblinkState($weblinkName_2, 'unpublished');
+
+		$test = $this->weblinkManagerPage->setFilter('filter_state', 'Unpublished');
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName_1), 'Weblink should not show');
+		$this->assertEquals(1, $this->weblinkManagerPage->getRowNumber($weblinkName_2), 'Weblink should be in row 1');
+
+		$test = $this->weblinkManagerPage->setFilter('filter_state', 'Published');
+		$this->assertFalse($this->weblinkManagerPage->getRowNumber($weblinkName_2), 'Weblink should not show');
+		$this->assertEquals(10, $this->weblinkManagerPage->getRowNumber($weblinkName_1), 'Weblink should be in row 10');
+
+		$this->weblinkManagerPage->setFilter('Select Status', 'Select Status');
+		$this->weblinkManagerPage->deleteItem($weblinkName_1);
+		$this->weblinkManagerPage->deleteItem($weblinkName_2);
+	}
+
+}


### PR DESCRIPTION
This is me adapting the tags manager tests for the Weblinks Component. As with the contact components tests added earlier today selenium doesn't recognize some fields so I've commented those lines out rather than leave them out in their entirety. Not sure why they are not being 'seen'
