### PR TITLE
fit offline overflow image

### DIFF
--- a/templates/system/css/offline.css
+++ b/templates/system/css/offline.css
@@ -24,6 +24,11 @@ img  {
 	padding: 20px;
 }
 
+#frame img {
+	max-width: 100%;
+	height: auto;
+}
+
 #frame form {
 	text-align: left;
 }


### PR DESCRIPTION
Was fixed for 2.5. But the issu exists again in 3.1.

Pls. see also:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30974
