### PR TITLE
fit overflowing offline image into offline login form

### DIFF
--- a/templates/system/css/offline.css
+++ b/templates/system/css/offline.css
@@ -24,6 +24,11 @@ img  {
 	padding: 20px;
 }
 
+#frame img {
+	max-width: 100%;
+	height: auto;
+}
+
 #frame form {
 	text-align: left;
 }


### PR DESCRIPTION
Was fixed in an prior version of Joomla! 2.5 but the error persists now again.

I have reopened the tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27824
