### PR TITLE
fix overflow hidden behaviour in permission tabs

### DIFF
--- a/media/jui/css/chosen.css
+++ b/media/jui/css/chosen.css
@@ -355,6 +355,14 @@
   color: #111 !important;
 }
 /* @end */
+/* fix overflow hidden behaviour in permission tabs */
+#page-permissions .tab-content, #permissions .tab-content {
+    overflow: hidden;
+}
+#page-permissions .chzn-drop, #permissions .chzn-drop {
+    position: relative;
+    top: 0!important;
+}
 
 /* @group Disabled Support */
 .chzn-disabled {


### PR DESCRIPTION
Please read bugtracker item

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30465

for further informations. 

This patch probably is not the best, but it is an answer to the problem, that dropdown fields become hidden.
