### PR TITLE
[imp] fast associated items management & use jlayouts to render them

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -138,7 +138,11 @@ class CategoriesHelper
 
 		foreach ($contentitems as $tag => $item)
 		{
-			$associations[$tag] = $item->id;
+			// Do not return itself as result
+			if ((int) $item->id != $pk)
+			{
+				$associations[$tag] = $item->id;
+			}
 		}
 
 		return $associations;

--- a/administrator/components/com_categories/helpers/html/categoriesadministrator.php
+++ b/administrator/components/com_categories/helpers/html/categoriesadministrator.php
@@ -18,44 +18,67 @@ JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_cat
 abstract class JHtmlCategoriesAdministrator
 {
 	/**
-	 * @param   int $catid	The category item id
+	 * Render the list of associated items
+	 *
+	 * @param   integer  $catid	     Category identifier to search its associations
+	 * @param   string   $extension  Category Extension
+	 *
+	 * @return  string  The language HTML
 	 */
 	public static function association($catid, $extension = 'com_content')
 	{
+		// Defaults
+		$html = '';
+
 		// Get the associations
-		$associations = CategoriesHelper::getAssociations($catid, $extension);
-
-		JArrayHelper::toInteger($associations);
-
-		// Get the associated categories
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('c.*')
-			->from('#__categories as c')
-			->where('c.id IN ('.implode(',', array_values($associations)).')')
-			->join('LEFT', '#__languages as l ON c.language=l.lang_code')
-			->select('l.image')
-			->select('l.title as language_title');
-		$db->setQuery($query);
-		$items = $db->loadObjectList('id');
-
-		// Check for a database error.
-		if ($error = $db->getErrorMsg())
+		if ($associations = CategoriesHelper::getAssociations($catid, $extension))
 		{
-			JError::raiseWarning(500, $error);
-			return false;
-		}
+			JArrayHelper::toInteger($associations);
 
-		// Construct html
-		$text = array();
-		foreach ($associations as $tag => $associated)
-		{
-			if ($associated != $catid)
+			// Get the associated categories
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('c.id, c.title')
+				->select('l.sef as lang_sef')
+				->from('#__categories as c')
+				->where('c.id IN (' . implode(',', array_values($associations)) . ')')
+				->join('LEFT', '#__languages as l ON c.language=l.lang_code')
+				->select('l.image')
+				->select('l.title as language_title');
+			$db->setQuery($query);
+
+			try
 			{
-				$text[] = JText::sprintf('COM_CATEGORIES_TIP_ASSOCIATED_LANGUAGE', JHtml::_('image', 'mod_languages/'.$items[$associated]->image.'.gif', $items[$associated]->language_title, array('title' => $items[$associated]->language_title), true), $items[$associated]->title);
+				$items = $db->loadObjectList('id');
 			}
+			catch (RuntimeException $e)
+			{
+				throw new Exception($e->getMessage(), 500);
+			}
+
+			if ($items)
+			{
+				foreach ($items as &$item)
+				{
+					$text = strtoupper($item->lang_sef);
+					$url = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . (int) $item->id . '&extension=' . $extension);
+					$tooltipParts = array(
+						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
+								$item->language_title,
+								array('title' => $item->language_title),
+								true
+						),
+						$item->title
+					);
+
+					$item->link = JHtml::_('tooltip', implode(' ', $tooltipParts), null, null, $text, $url, null, 'hasTip label label-association label-' . $item->lang_sef);
+				}
+			}
+
+			$html = JLayoutHelper::render('joomla.content.associations', $items);
 		}
-		return JHtml::_('tooltip', implode('<br />', $text), JText::_('COM_CATEGORIES_TIP_ASSOCIATION'), 'admin/icon-16-links.png');
+
+		return $html;
 	}
 
 }

--- a/administrator/components/com_contact/helpers/html/contact.php
+++ b/administrator/components/com_contact/helpers/html/contact.php
@@ -40,7 +40,8 @@ abstract class JHtmlContact
 			// Get the associated contact items
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->select('c.*')
+				->select('c.id, c.name as title')
+				->select('l.sef as lang_sef')
 				->from('#__contact_details as c')
 				->select('cat.title as category_title')
 				->join('LEFT', '#__categories as cat ON cat.id=c.catid')
@@ -61,25 +62,27 @@ abstract class JHtmlContact
 				return false;
 			}
 
-			$flags = array();
-
-			// Construct html
-			foreach ($associations as $tag => $associated)
+			if ($items)
 			{
-				if ($associated != $contactid)
+				foreach ($items as &$item)
 				{
-					$flags[] = JText::sprintf(
-						'COM_CONTACT_TIP_ASSOCIATED_LANGUAGE',
-						JHtml::_('image', 'mod_languages/' . $items[$associated]->image . '.gif',
-							$items[$associated]->language_title,
-							array('title' => $items[$associated]->language_title),
-							true
+					$text = strtoupper($item->lang_sef);
+					$url = JRoute::_('index.php?option=com_contact&task=contact.edit&id=' . (int) $item->id);
+					$tooltipParts = array(
+						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
+								$item->language_title,
+								array('title' => $item->language_title),
+								true
 						),
-						$items[$associated]->name, $items[$associated]->category_title
+						$item->title,
+						'(' . $item->category_title . ')'
 					);
+
+					$item->link = JHtml::_('tooltip', implode(' ', $tooltipParts), null, null, $text, $url, null, 'hasTip label label-association label-' . $item->lang_sef);
 				}
 			}
-			$html = JHtml::_('tooltip', implode('<br />', $flags), JText::_('COM_CONTACT_TIP_ASSOCIATION'), 'admin/icon-16-links.png');
+
+			$html = JLayoutHelper::render('joomla.content.associations', $items);
 		}
 
 		return $html;

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -12,13 +12,17 @@ defined('_JEXEC') or die;
 JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
 
 /**
+ * Content HTML helper
+ *
  * @package     Joomla.Administrator
  * @subpackage  com_content
+ *
+ * @since       3.0
  */
 abstract class JHtmlContentAdministrator
 {
 	/**
-	 * Get the associated language flags
+	 * Render the list of associated items
 	 *
 	 * @param   int  $articleid  The article item id
 	 *
@@ -32,7 +36,6 @@ abstract class JHtmlContentAdministrator
 		// Get the associations
 		if ($associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $articleid))
 		{
-
 			foreach ($associations as $tag => $associated)
 			{
 				$associations[$tag] = (int) $associated->id;
@@ -42,6 +45,7 @@ abstract class JHtmlContentAdministrator
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select('c.*')
+				->select('l.sef as lang_sef')
 				->from('#__content as c')
 				->select('cat.title as category_title')
 				->join('LEFT', '#__categories as cat ON cat.id=c.catid')
@@ -55,42 +59,44 @@ abstract class JHtmlContentAdministrator
 			{
 				$items = $db->loadObjectList('id');
 			}
-			catch (runtimeException $e)
+			catch (RuntimeException $e)
 			{
 				throw new Exception($e->getMessage(), 500);
-
-				return false;
 			}
 
-			$flags = array();
-
-			// Construct html
-			foreach ($associations as $tag => $associated)
+			if ($items)
 			{
-				if ($associated != $articleid)
+				foreach ($items as &$item)
 				{
-					$flags[] = JText::sprintf(
-						'COM_CONTENT_TIP_ASSOCIATED_LANGUAGE',
-						JHtml::_('image', 'mod_languages/' . $items[$associated]->image . '.gif',
-							$items[$associated]->language_title,
-							array('title' => $items[$associated]->language_title),
+					$text = strtoupper($item->lang_sef);
+					$url = JRoute::_('index.php?option=com_content&task=article.edit&id=' . (int) $item->id);
+					$tooltipParts = array(
+						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
+							$item->language_title,
+							array('title' => $item->language_title),
 							true
 						),
-						$items[$associated]->title, $items[$associated]->category_title
+						$item->title,
+						'(' . $item->category_title . ')'
 					);
+					$item->link = JHtml::_('tooltip', implode(' ', $tooltipParts), null, null, $text, $url, null, 'hasTip label label-association label-' . $item->lang_sef);
 				}
 			}
 
-			$html = JHtml::_('tooltip', implode('<br />', $flags), JText::_('COM_CONTENT_TIP_ASSOCIATION'), 'admin/icon-16-links.png');
-
+			$html = JLayoutHelper::render('joomla.content.associations', $items);
 		}
 
 		return $html;
 	}
 
 	/**
-	 * @param   int $value	The state value
-	 * @param   int $i
+	 * Show the feature/unfeature links
+	 *
+	 * @param   int      $value      The state value
+	 * @param   int      $i          Row number
+	 * @param   boolean  $canChange  Is user allowed to change?
+	 *
+	 * @return  string       HTML code
 	 */
 	public static function featured($value = 0, $i, $canChange = true)
 	{
@@ -103,15 +109,16 @@ abstract class JHtmlContentAdministrator
 		);
 		$state	= JArrayHelper::getValue($states, (int) $value, $states[1]);
 		$icon	= $state[0];
+
 		if ($canChange)
 		{
-			$html	= '<a href="#" onclick="return listItemTask(\'cb'.$i.'\',\''.$state[1].'\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="'.JText::_($state[3]).'"><i class="icon-'
-					. $icon.'"></i></a>';
+			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JText::_($state[3]) . '"><i class="icon-'
+					. $icon . '"></i></a>';
 		}
 		else
 		{
-			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="'.JText::_($state[2]).'"><i class="icon-'
-					. $icon.'"></i></a>';
+			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JText::_($state[2]) . '"><i class="icon-'
+					. $icon . '"></i></a>';
 		}
 
 		return $html;

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -22,42 +22,59 @@ abstract class MenusHtmlMenus
 	 */
 	public static function association($itemid)
 	{
+		// Defaults
+		$html = '';
+
 		// Get the associations
-		$associations = MenusHelper::getAssociations($itemid);
-
-		// Get the associated menu items
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('m.*')
-			->select('mt.title as menu_title')
-			->from('#__menu as m')
-			->join('LEFT', '#__menu_types as mt ON mt.menutype=m.menutype')
-			->where('m.id IN ('.implode(',', array_values($associations)).')')
-			->join('LEFT', '#__languages as l ON m.language=l.lang_code')
-			->select('l.image')
-			->select('l.title as language_title');
-		$db->setQuery($query);
-
-		try
+		if ($associations = MenusHelper::getAssociations($itemid))
 		{
-			$items = $db->loadObjectList('id');
-		}
-		catch (RuntimeException $e)
-		{
-			JError::raiseWarning(500, $e->getMessage());
-			return false;
-		}
+			// Get the associated menu items
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('m.id, m.title')
+				->select('l.sef as lang_sef')
+				->select('mt.title as menu_title')
+				->from('#__menu as m')
+				->join('LEFT', '#__menu_types as mt ON mt.menutype=m.menutype')
+				->where('m.id IN (' . implode(',', array_values($associations)) . ')')
+				->join('LEFT', '#__languages as l ON m.language=l.lang_code')
+				->select('l.image')
+				->select('l.title as language_title');
+			$db->setQuery($query);
 
-		// Construct html
-		$text = array();
-		foreach ($associations as $tag => $associated)
-		{
-			if ($associated != $itemid)
+			try
 			{
-				$text[] = JText::sprintf('COM_MENUS_TIP_ASSOCIATED_LANGUAGE', JHtml::_('image', 'mod_languages/' . $items[$associated]->image . '.gif', $items[$associated]->language_title, array('title' => $items[$associated]->language_title), true), $items[$associated]->title, $items[$associated]->menu_title);
+				$items = $db->loadObjectList('id');
 			}
+			catch (runtimeException $e)
+			{
+				throw new Exception($e->getMessage(), 500);
+			}
+
+			// Construct html
+			if ($items)
+			{
+				foreach ($items as &$item)
+				{
+					$text = strtoupper($item->lang_sef);
+					$url = JRoute::_('index.php?option=com_menus&task=item.edit&id=' . (int) $item->id);
+					$tooltipParts = array(
+						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
+							$item->language_title,
+							array('title' => $item->language_title),
+							true
+						),
+						$item->title,
+						'(' . $item->menu_title . ')'
+					);
+					$item->link = JHtml::_('tooltip', implode(' ', $tooltipParts), null, null, $text, $url, null, 'hasTip label label-association label-' . $item->lang_sef);
+				}
+			}
+
+			$html = JLayoutHelper::render('joomla.content.associations', $items);
 		}
-		return JHtml::_('tooltip', implode('<br />', $text), JText::_('COM_MENUS_TIP_ASSOCIATION'), 'admin/icon-16-links.png');
+
+		return $html;
 	}
 
 	/**

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -265,12 +265,16 @@ class MenusHelper
 		}
 		catch (RuntimeException $e)
 		{
-			JError::raiseWarning(500, $e->getMessage());
-			return false;
+			throw new Exception($e->getMessage(), 500);
 		}
+
 		foreach ($menuitems as $tag => $item)
 		{
-			$associations[$tag] = $item->id;
+			// Do not return itself as result
+			if ((int) $item->id != $pk)
+			{
+				$associations[$tag] = $item->id;
+			}
 		}
 		return $associations;
 	}

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3200,3 +3200,17 @@ table {
 .is-tagbox {
 	float: left;
 }
+
+/* Item associations */
+.item-associations {
+	margin: 0;
+}
+.item-associations li {
+	list-style: none;
+	display: inline-block;
+	margin: 0 0 3px 0;
+}
+.item-associations li a,
+table.adminlist .item-associations li a {
+	color: #ffffff;
+}

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3419,3 +3419,17 @@ table {
 .is-tagbox {
 	float: left;
 }
+
+/* Item associations */
+.item-associations {
+	margin: 0;
+}
+.item-associations li {
+	list-style: none;
+	display: inline-block;
+	margin: 0 0 3px 0;
+}
+.item-associations li a,
+table.adminlist .item-associations li a  {
+	color: #ffffff;
+}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6613,3 +6613,15 @@ ul.treeselect ul.dropdown-menu li {
 td.has-context {
 	height: 23px;
 }
+/* Item associations */
+.item-associations {
+	margin: 0;
+}
+.item-associations li {
+	list-style: none;
+	display: inline-block;
+	margin: 0 0 3px 0;
+}
+.item-associations li a {
+	color: #ffffff;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -679,3 +679,16 @@ td.has-context {
 	// Fixes difference in height between normal and hover on cell with context
 	height: 23px;
 }
+
+/* Item associations */
+.item-associations {
+	margin: 0;
+}
+.item-associations li {
+	list-style: none;
+	display: inline-block;
+	margin: 0 0 3px 0;
+}
+.item-associations li a {
+	color: #ffffff;
+}

--- a/layouts/joomla/content/associations.php
+++ b/layouts/joomla/content/associations.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$items = $displayData;
+
+if (!empty($items)) : ?>
+	<ul class="item-associations">
+		<?php foreach ($items as $id => $item) : ?>
+				<li>
+					<?php echo $item->link; ?>
+				</li>
+		<?php endforeach; ?>
+	</ul>
+<?php endif;

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -33,7 +33,6 @@ class JLanguageAssociations
 	 *
 	 * @since   3.1
 	 */
-
 	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid')
 	{
 		$associations = array();
@@ -75,7 +74,7 @@ class JLanguageAssociations
 				);
 		}
 
-		$query->where('c.id =' . (int) $id);
+		$query->where('c.' . $pk . ' = ' . (int) $id);
 
 		$db->setQuery($query);
 
@@ -83,18 +82,20 @@ class JLanguageAssociations
 		{
 			$items = $db->loadObjectList('language');
 		}
-		catch (runtimeException $e)
+		catch (RuntimeException $e)
 		{
 			throw new Exception($e->getMessage(), 500);
-
-			return false;
 		}
 
 		if ($items)
 		{
 			foreach ($items as $tag => $item)
 			{
-				$associations[$tag] = $item;
+				// Do not return itself as result
+				if ((int) $item->{$pk} != $id)
+				{
+					$associations[$tag] = $item;
+				}
 			}
 		}
 


### PR DESCRIPTION
Issue tracker item:

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30982
## Testing
### Enviroment
- Install aditional any aditional language through:
  <code>Extension > Language Manager > Install Language</code>
- In the plugin manager enable the plugin
  <code>System - Language Filter</code> and in the plugin <code>Basic options</code> enable <code>Item associations</code>
- Now for each type of content you will need to create one item for each language and link them through the <code>Associations</code> tab.
### Required tests
- [ ] **Content article list** in backend should show links to associated items and click in them should open them in edit mode.
- [ ] **Content category list** in backend should show links to associated items and click in them should open them in edit mode.
- [ ] **Contact list** in backend should show links to associated items and click in them should open them in edit mode.
- [ ] **Newsfeed list** in backend should show links to associated items and click in them should open them in edit mode.
- [ ] **Menu item list** in backend should show links to associated items and click in them should open them in edit mode.
- [ ] Run same test in both **Isis** and **Hathor** backend templates
