### PR TITLE
[#30997] Fix reordering of menus and categories.

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1227,17 +1227,8 @@ class JTableNested extends JTable
 			$query = $this->_db->getQuery(true)
 				->select($this->_tbl_key . ', alias')
 				->from($this->_tbl)
-				->where('parent_id = %d');
-
-			// If the table has an ordering field, use that for ordering.
-			if (property_exists($this, 'ordering'))
-			{
-				$query->order('parent_id, ordering, lft');
-			}
-			else
-			{
-				$query->order('parent_id, lft');
-			}
+				->where('parent_id = %d')
+				->order('lft');
 			$this->_cache['rebuild.sql'] = (string) $query;
 		}
 
@@ -1361,13 +1352,37 @@ class JTableNested extends JTable
 			// Validate arguments
 			if (is_array($idArray) && is_array($lft_array) && count($idArray) == count($lft_array))
 			{
-				for ($i = 0, $count = count($idArray); $i < $count; $i++)
+				if (count($idArray) > 100)
+				{
+					// No need for a big query when it's obvious that all rows were displayed for reordering.
+					$lftStart = 1;
+				}
+				else
+				{
+					$query->clear()
+						->select('MIN(lft)')
+						->from($this->_tbl)
+						->where($this->_tbl_key . ' IN (' . implode(', ', $idArray) . ')');
+					$this->_db->setQuery($query);
+					$lftStart = $this->_db->loadResult();
+
+					if (!$lftStart)
+					{
+						throw new UnexpectedValueException(sprintf('Invalid $idArray in %s', get_class($this)));
+					}
+					if ($this->_debug)
+					{
+						$this->_logtable(false);
+					}
+				}
+				asort($lft_array);
+				foreach (array_keys($lft_array) as $idNext)
 				{
 					// Do an update to change the lft values in the table for each id
 					$query->clear()
 						->update($this->_tbl)
-						->where($this->_tbl_key . ' = ' . (int) $idArray[$i])
-						->set('lft = ' . (int) $lft_array[$i]);
+						->where($this->_tbl_key . ' = ' . (int) $idArray[$idNext])
+						->set('lft = ' . (int) $lftStart++);
 
 					$this->_db->setQuery($query)->execute();
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30997

I have created patches for v3.1 and v2.5 that fix the problems described above.

In addition to fixing the above problems, the patches remove a bit of superfluous code in JTableNested::rebuild(), wherein, "If the table has an ordering field, use that for ordering."

In the case of v3.1, there are no nested tables with an ordering column, so the code clearly does nothing.

In the case of v2.5, the only nested table with an ordering column is #__menu, but v2.5 doesn't actually use the column for anything (it is filled with 0), so again, the code does nothing. However, there is or was a problem with JUpgrade putting data in the ordering column, causing rebuild() to sort incorrectly, resulting in problems when users tried to reorder menu items. Removing this code should help anyone still suffering from the problem.

Other older issues that I came across that might be related to this issue:

[#26655] *Ordering column issue for _menu table in sample_data.sql
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26655

[#26675] Menu ordering not working
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26675

[#28870] All #__menu_ordering rows reads 0
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28870

[#29379] Menu item re-ordering issue
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29379

[#29807] Order category/menu (JTableNested) doesn't work on pagination != 1
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29807

[#30872] Wrong sorting order on menuitems
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30872
