### PR TITLE
Fix read/Save of specific attribute that are lost - Make consistent with...

### DIFF
--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -183,9 +183,9 @@ class ContentModelArticle extends JModelItem
 				// Convert parameter fields to objects.
 				$registry = new JRegistry;
 				$registry->loadString($data->attribs);
+				$data->attribs = $registry->toArray();
 
 				$data->params = clone $this->getState('params');
-				$data->params->merge($registry);
 
 				$registry = new JRegistry;
 				$registry->loadString($data->metadata);


### PR DESCRIPTION
... back-end Read/Write attributes

Fix the read/write saving of the article that lose the attributes that was uncompressed into the "params" field instead of the "attribs" field.

The fix consist in applying the same Read/Write processing than in the back-end.

For the test, it is required to create a plugin that store additional attributes into the article.

A regression test is probably required to verify the impact to remove the uncompress of the "attribs" into the "params" fields as this may impact the get_params() that does not contain any more the attribute.

Among the side effect of the bug was that the loadForm was not able to have the data correctly restored and available for processing. The attribs was not an object as expected.

Verify that when editing an article from the front-end that first the attributes are available in the plugin as an object.
The second test is to verify that the params is not destroyed or changed when nothing is modified (that was the case due to attributes that was uncompressed into the params and that might be save into params rather than into attribs)
Third, verify that when you modify a parameter of the article, only this parameter is updated and that other parameters are not affected.
