### PR TITLE
IMplement the bugtracker #30935 that consists in computing the home page...

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -432,6 +432,13 @@ class PlgSystemLanguageFilter extends JPlugin
 		$menu = $app->getMenu();
 		if ($app->isSite() && $this->params->get('automatic_change', 1))
 		{
+			// Get menu home items
+			$homes = array();
+			foreach($menu->getMenu() as $item) {
+				if ($item->home) {
+					$homes[$item->language] = $item;
+				}
+			}
 			// Load associations
 			$assoc = isset($app->item_associations) ? $app->item_associations : 0;
 


### PR DESCRIPTION
... that is variable that was used without any assignment

The fix consists in a copy of the source code
It is inspired from the source present in Joomla 2.5.9
/module/mod_languages/helper.php line 23-29 that I copied as such in the plugin

To see the bug before, you need to use the language filter and run joomla in a debugger to see that $home is used without assignment.
The fix that can verified that the $home is correctly field.

This fix does not implement our remark concerning the fact that when a redirect page is present in the login, it is ignored.
