### PR TITLE
[#30851] Administrator templates overrides for media manager are not wor...

### DIFF
--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -65,7 +65,6 @@ class MediaController extends JControllerLegacy
 
 		// Get/Create the view
 		$view = $this->getView($vName, $vType);
-		$view->addTemplatePath(JPATH_COMPONENT_ADMINISTRATOR.'/views/'.strtolower($vName).'/tmpl');
 
 		// Get/Create the model
 		if ($model = $this->getModel($mName))


### PR DESCRIPTION
...king

refs #645

removed $view->addTemplatePath(JPATH_COMPONENT_ADMINISTRATOR.'/views/'.strtolower($vName).'/tmpl');
and everything seems to work properly.
