### PR TITLE
Bugtracker #28333: JFTP call "DL" function that sometimes is removed by ...

### DIFF
--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -43,11 +43,17 @@ if (!extension_loaded('ftp'))
 {
 	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
 	{
-		@ dl('php_ftp.dll');
+		if ( function_exists( 'dl')) 
+		{
+   			@ dl('php_ftp.dll');
+   		}
 	}
 	else
 	{
-		@ dl('ftp.so');
+		if ( function_exists( 'dl')) 
+		{
+			@ dl('ftp.so');
+		}
 	}
 }
 if (!defined('FTP_NATIVE'))


### PR DESCRIPTION
...hosting environment and cause fatal error without message

The reason of the issue is due to the fact that the "dl" function is called event when FTP layer is not used.
As soon as a jimport load the FTP client somewhere it cause a fatal error that is hide due to the "@dl" that does not report error.

The fix consists in checking that function "dl" exists before calling it.

To reproduce it, you need to setup a server that does not contain the FTP module and that does not include the "dl" function.
Becarefull that most WAMP or similar include the FTP and dl in the core that can not be removed.
