### PR TITLE
"404 Component not found" doesn't added to redirect component

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -771,7 +771,7 @@ abstract class JError
 			$document->setError($error);
 
 			@ob_end_clean();
-			$document->setTitle(JText::_('Error') . ': ' . $error->get('code'));
+			$document->setTitle(JText::_('Error') . ': ' . $error->getCode());
 			$data = $document->render(false, array('template' => $template, 'directory' => JPATH_THEMES, 'debug' => $config->get('debug')));
 
 			// Failsafe to get the error displayed.

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -33,6 +33,7 @@ class PlgSystemRedirect extends JPlugin
 
 		// Set the error handler for E_ERROR to be the class handleError method.
 		JError::setErrorHandling(E_ERROR, 'callback', array('PlgSystemRedirect', 'handleError'));
+		set_exception_handler(array('PlgSystemRedirect', 'handleError'));
 	}
 
 	public static function handleError(&$error)
@@ -51,7 +52,7 @@ class PlgSystemRedirect extends JPlugin
 			if ((strpos($current, 'mosConfig_') !== false) || (strpos($current, '=http://') !== false))
 			{
 				// Render the error page.
-				JError::customErrorPage($error);
+				JErrorPage::render($error);
 			}
 
 			// See if the current url exists in the database as a redirect.
@@ -111,13 +112,13 @@ class PlgSystemRedirect extends JPlugin
 					$db->execute();
 				}
 				// Render the error page.
-				JError::customErrorPage($error);
+				JErrorPage::render($error);
 			}
 		}
 		else
 		{
 			// Render the error page.
-			JError::customErrorPage($error);
+			JErrorPage::render($error);
 		}
 	}
 }


### PR DESCRIPTION
On some scenarios redirect plugin/component doesn't work as expected.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30990
