### PR TITLE
[28333] JFTP can not be installed on some PHP 5.3 due to "dl" function that is removed in PHP 5.3

### DIFF
--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -39,7 +39,7 @@ if (!defined("FTP_ASCII"))
 }
 
 // Is FTP extension loaded?  If not try to load it
-if (!extension_loaded('ftp'))
+if (!extension_loaded('ftp') && function_exists('dl'))
 {
 	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
 	{


### PR DESCRIPTION
Check if function dl exists before use it.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28333
