### PR TITLE
JError::customErrorPage doesn't work well

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -52,7 +52,7 @@ class PlgSystemRedirect extends JPlugin
 			if ((strpos($current, 'mosConfig_') !== false) || (strpos($current, '=http://') !== false))
 			{
 				// Render the error page.
-				JErrorPage::render($error);
+				JError::customErrorPage($error);
 			}
 
 			// See if the current url exists in the database as a redirect.
@@ -112,13 +112,13 @@ class PlgSystemRedirect extends JPlugin
 					$db->execute();
 				}
 				// Render the error page.
-				JErrorPage::render($error);
+				JError::customErrorPage($error);
 			}
 		}
 		else
 		{
 			// Render the error page.
-			JErrorPage::render($error);
+			JError::customErrorPage($error);
 		}
 	}
 }


### PR DESCRIPTION
This is fix for regression caused by PR #1212 (bug #30990):
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30990
The method JError::customErrorPage doesn't show the error page well.
