### PR TITLE
Fix inline media preview height

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -173,9 +173,9 @@ class JFormFieldMedia extends JFormField
 			$previewImgEmpty = '<div id="' . $this->id . '_preview_empty"' . ($src ? ' style="display:none"' : '') . '>'
 				. JText::_('JLIB_FORM_MEDIA_PREVIEW_EMPTY') . '</div>';
 
-			$html[] = '<div class="media-preview add-on">';
 			if ($showAsTooltip)
 			{
+				$html[] = '<div class="media-preview add-on">';
 				$tooltip = $previewImgEmpty . $previewImg;
 				$options = array(
 					'title' => JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'),
@@ -183,13 +183,15 @@ class JFormFieldMedia extends JFormField
 					'class' => 'hasTipPreview'
 				);
 				$html[] = JHtml::tooltip($tooltip, $options);
+				$html[] = '</div>';
 			}
 			else
 			{
+				$html[] = '<div class="media-preview add-on" style="height:auto">';
 				$html[] = ' ' . $previewImgEmpty;
 				$html[] = ' ' . $previewImg;
+				$html[] = '</div>';
 			}
-			$html[] = '</div>';
 		}
 
 		$html[] = '	<input type="text" class="input-small" name="' . $this->name . '" id="' . $this->id . '" value="'


### PR DESCRIPTION
When using JFormFieldMedia with `preview="true"`, preview height is hardcoded to 18px by bootstrap.

`preview="tooltip"` is not affected.

Issue Tracker: [#31073](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31073)

---

_Before patch:_
![joomla_patch_formfieldmedia_before](https://f.cloud.github.com/assets/612953/600435/7c8c0c6e-cc67-11e2-8f5d-5dd7e3af11b8.png)

_After patch:_
![joomla_patch_formfieldmedia_after](https://f.cloud.github.com/assets/612953/600436/80a4d95c-cc67-11e2-9ea4-b2de19b04923.png)
