### PR TITLE
com_contact: Fix PHP strict warnings on sending email

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -20,30 +20,37 @@ JFormHelper::loadRuleClass('email');
 class JFormRuleContactEmail extends JFormRuleEmail
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test for banned e-mail addresses
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value     The form field value to validate.
-	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
-	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   object            $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   object            $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(& $element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
-		if (!parent::test($element, $value, $group, $input, $form)){
+		if(!parent::test($element, $value, $group, $input, $form))
+		{
 			return false;
 		}
 
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_email');
 
-		foreach (explode(';', $banned) as $item) {
-			if (JString::stristr($item, $value) !== false)
+		if ($banned)
+		{
+			foreach(explode(';', $banned) as $item)
+			{
+				if (JString::stristr($value, $item) !== false)
+				{
 					return false;
+				}
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -18,26 +18,32 @@ defined('_JEXEC') or die;
 class JFormRuleContactEmailMessage extends JFormRule
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test a message for banned words
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value     The form field value to validate.
-	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
-	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(&$element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_text');
 
-		foreach (explode(';', $banned) as $item) {
-			if (JString::stristr($item, $value) !== false)
+		if ($banned)
+		{
+			foreach(explode(';', $banned) as $item)
+			{
+				if (JString::stristr($value, $item) !== false)
+				{
 					return false;
+				}
+			}
 		}
 
 		return true;

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_contact
  *
- * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -18,26 +18,32 @@ defined('_JEXEC') or die;
 class JFormRuleContactEmailSubject extends JFormRule
 {
 	/**
-	 * Method to test for a valid color in hexadecimal.
+	 * Method to test for a banned subject
 	 *
-	 * @param   SimpleXMLElement  &$element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value     The form field value to validate.
-	 * @param   string            $group     The field name group control value. This acts as as an array container for the field.
-	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                       full field name would end up being "bar[foo]".
-	 * @param   object            &$input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   object            &$form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
-	 * @return  boolean  True if the value is valid, false otherwise.
+	 * @return  boolean  True if the value is valid, false otherwise
 	 */
-	public function test(&$element, $value, $group = null, &$input = null, &$form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_subject');
 
-		foreach (explode(';', $banned) as $item) {
-			if (JString::stristr($item, $value) !== false)
+		if ($banned)
+		{
+			foreach(explode(';', $banned) as $item)
+			{
+				if (JString::stristr($value, $item) !== false)
+				{
 					return false;
+				}
+			}
 		}
 
 		return true;


### PR DESCRIPTION
When sending an email (that uses JFormRuleContact\* Rules), PHP strict error appears:

`Strict standards: Declaration of JFormRuleContactEmail::test() should be compatible with JFormRule::test(SimpleXMLElement $element, $value, $group = NULL, JRegistry $input = NULL, JForm $form = NULL)`

Issue tracker: [#29107](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29107)

There was a PR by @elinw: #523, but it has been closed.
