### PR TITLE
added JComponentTitle variable to JAdministrator

### DIFF
--- a/administrator/includes/application.php
+++ b/administrator/includes/application.php
@@ -20,6 +20,14 @@ defined('_JEXEC') or die;
 class JAdministrator extends JApplication
 {
 	/**
+	 * Component title
+	 *
+	 * @var     string
+	 * @since   3.0
+	 */
+	public $JComponentTitle = '';
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  An optional associative array of configuration settings.


### PR DESCRIPTION
This patch prevents PHP notices for cases when `JAdministrator::JComponentTitle` is not being set by component.

Issue tracker: [#31079](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31079)
