### PR TITLE
Deprecating X-Content-Encoded-By

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -390,7 +390,14 @@ class JApplicationWeb extends JApplicationBase
 
 				// Set the encoding headers.
 				$this->setHeader('Content-Encoding', $encoding);
-				$this->setHeader('X-Content-Encoded-By', 'Joomla');
+
+				/*
+				 * Header to be removed in 14.1 (Platform) & 3.5 (CMS)
+				 */
+				if ($this->get('MetaVersion'))
+				{
+					$this->setHeader('X-Content-Encoded-By', 'Joomla');
+				}
 
 				// Replace the output with the encoded data.
 				$this->setBody($gzdata);

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -391,9 +391,7 @@ class JApplicationWeb extends JApplicationBase
 				// Set the encoding headers.
 				$this->setHeader('Content-Encoding', $encoding);
 
-				/*
-				 * Header to be removed in 14.1 (Platform) & 3.5 (CMS)
-				 */
+				// Header will be removed at 4.0
 				if ($this->get('MetaVersion'))
 				{
 					$this->setHeader('X-Content-Encoded-By', 'Joomla');

--- a/libraries/joomla/environment/response.php
+++ b/libraries/joomla/environment/response.php
@@ -298,9 +298,7 @@ class JResponse
 
 		self::setHeader('Content-Encoding', $encoding);
 
-		/*
-		 * Header to be removed in 14.1 (Platform) & 3.5 (CMS)
-		 */
+		// Header will be removed at 4.0
 		if (JFactory::getConfig()->get('MetaVersion', 0) && defined('JVERSION'))
 		{
 			self::setHeader('X-Content-Encoded-By', 'Joomla! ' . JVERSION);

--- a/libraries/joomla/environment/response.php
+++ b/libraries/joomla/environment/response.php
@@ -297,7 +297,14 @@ class JResponse
 		$gzdata = gzencode($data, $level);
 
 		self::setHeader('Content-Encoding', $encoding);
-		self::setHeader('X-Content-Encoded-By', 'Joomla! 1.6');
+
+		/*
+		 * Header to be removed in 14.1 (Platform) & 3.5 (CMS)
+		 */
+		if (JFactory::getConfig()->get('MetaVersion', 0) && defined('JVERSION'))
+		{
+			self::setHeader('X-Content-Encoded-By', 'Joomla! ' . JVERSION);
+		}
 
 		return $gzdata;
 	}

--- a/tests/unit/suites/platform/application/JApplicationWebTest.php
+++ b/tests/unit/suites/platform/application/JApplicationWebTest.php
@@ -398,8 +398,7 @@ class JApplicationWebTest extends TestCase
 			TestReflection::getValue($this->class, 'response')->headers,
 			$this->equalTo(
 				array(
-					0 => array('name' => 'Content-Encoding', 'value' => 'gzip'),
-					1 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
+					0 => array('name' => 'Content-Encoding', 'value' => 'gzip')
 				)
 			),
 			'Checks the headers were set correctly.'
@@ -454,8 +453,7 @@ class JApplicationWebTest extends TestCase
 			TestReflection::getValue($this->class, 'response')->headers,
 			$this->equalTo(
 				array(
-					0 => array('name' => 'Content-Encoding', 'value' => 'deflate'),
-					1 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
+					0 => array('name' => 'Content-Encoding', 'value' => 'deflate')
 				)
 			),
 			'Checks the headers were set correctly.'


### PR DESCRIPTION
as per discussion [jgen: X-Content-Encoded-By](https://groups.google.com/group/joomla-dev-general/browse_frm/thread/8327413ffe009e07/)

Before patch when setting  _Gzip Page Compression: Yes_
`X-Content-Encoded-By:Joomla! 1.6`

After patch when setting _Gzip Page Compression: Yes_ + _Show Joomla! Version: Yes_
`X-Content-Encoded-By:Joomla! 3.0.3` (JVERSION)

Issue tracker: [#31080](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31080)

Discussion: [Joomla! General Development:   X-Content-Encoded-By](https://groups.google.com/group/joomla-dev-general/browse_frm/thread/8327413ffe009e07/)
