### PR TITLE
Removing eval() from JDocumentHTML->countModules

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -502,9 +502,9 @@ class JDocumentHTML extends JDocument
 				: count(JModuleHelper::getModules($name));
 		}
 
-		$str = 'return ' . implode(' ', $words) . ';';
+		$str = implode(' ', $words);
 
-		return eval($str);
+		return $str;
 	}
 
 	/**


### PR DESCRIPTION
Removing an unneeded eval() call in the countModules function.

Since it's the only place Joomla uses an eval() call, removing it would allow to disable eval() on server level for added security.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31081
