### PR TITLE
UX "showon": Dynamic options in the Joomla Backend

### DIFF
--- a/administrator/components/com_config/models/forms/application.xml
+++ b/administrator/components/com_config/models/forms/application.xml
@@ -174,6 +174,7 @@
 			type="radio"
 			class="btn-group"
 			default="0"
+			onchange="Joomla.linkedoptions(this);"
 			label="COM_CONFIG_FIELD_FTP_ENABLE_LABEL"
 			description="COM_CONFIG_FIELD_FTP_ENABLE_DESC"
 			filter="integer">
@@ -189,6 +190,7 @@
 			label="COM_CONFIG_FIELD_FTP_HOST_LABEL"
 			description="COM_CONFIG_FIELD_FTP_HOST_DESC"
 			filter="string"
+			showon="ftp_enable:1"
 			size="14" />
 
 		<field
@@ -197,6 +199,7 @@
 			label="COM_CONFIG_FIELD_FTP_PORT_LABEL"
 			description="COM_CONFIG_FIELD_FTP_PORT_DESC"
 			filter="string"
+			showon="ftp_enable:1"
 			size="8" />
 
 		<field
@@ -205,6 +208,7 @@
 			label="COM_CONFIG_FIELD_FTP_USERNAME_LABEL"
 			description="COM_CONFIG_FIELD_FTP_USERNAME_DESC"
 			filter="string"
+			showon="ftp_enable:1"
 			autocomplete="off"
 			size="25" />
 
@@ -214,6 +218,7 @@
 			label="COM_CONFIG_FIELD_FTP_PASSWORD_LABEL"
 			description="COM_CONFIG_FIELD_FTP_PASSWORD_DESC"
 			filter="raw"
+			showon="ftp_enable:1"
 			autocomplete="off"
 			size="25" />
 
@@ -221,6 +226,7 @@
 			name="ftp_root"
 			type="text"
 			label="COM_CONFIG_FIELD_FTP_ROOT_LABEL"
+			showon="ftp_enable:1"
 			description="COM_CONFIG_FIELD_FTP_ROOT_DESC"
 			filter="string"
 			size="50" />
@@ -280,6 +286,7 @@
 			name="sendmail"
 			type="text"
 			default="/usr/sbin/sendmail"
+			showon="mailer:sendmail"
 			label="COM_CONFIG_FIELD_MAIL_SENDMAIL_PATH_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SENDMAIL_PATH_DESC"
 			filter="string"
@@ -290,6 +297,7 @@
 			type="radio"
 			class="btn-group"
 			default="0"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_AUTH_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_AUTH_DESC"
 			filter="integer">
@@ -303,6 +311,7 @@
 			name="smtpsecure"
 			type="list"
 			default="none"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_SECURE_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_SECURE_DESC"
 			filter="word">
@@ -318,6 +327,7 @@
 			name="smtpport"
 			type="text"
 			default="25"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_PORT_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_PORT_DESC"
 			required="true"
@@ -327,6 +337,7 @@
 		<field
 			name="smtpuser"
 			type="text"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_USERNAME_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_USERNAME_DESC"
 			filter="string"
@@ -336,6 +347,7 @@
 		<field
 			name="smtppass"
 			type="password"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_PASSWORD_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_PASSWORD_DESC"
 			filter="raw"
@@ -346,6 +358,7 @@
 			name="smtphost"
 			type="text"
 			default="localhost"
+			showon="mailer:smtp"
 			label="COM_CONFIG_FIELD_MAIL_SMTP_HOST_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_SMTP_HOST_DESC"
 			filter="string"

--- a/administrator/components/com_config/models/forms/application.xml
+++ b/administrator/components/com_config/models/forms/application.xml
@@ -174,7 +174,6 @@
 			type="radio"
 			class="btn-group"
 			default="0"
-			onchange="Joomla.linkedoptions(this);"
 			label="COM_CONFIG_FIELD_FTP_ENABLE_LABEL"
 			description="COM_CONFIG_FIELD_FTP_ENABLE_DESC"
 			filter="integer">

--- a/administrator/components/com_config/views/application/tmpl/default_cache.php
+++ b/administrator/components/com_config/views/application/tmpl/default_cache.php
@@ -8,35 +8,16 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_CACHE_SETTINGS'); ?></legend>
-			<?php
-			foreach ($this->form->getFieldset('cache') as $field):
-			?>
-				<div class="control-group">
-					<div class="control-label"><?php echo $field->label; ?></div>
-					<div class="controls"><?php echo $field->input; ?></div>
-				</div>
-			<?php
-			endforeach;
-			?>
-		<?php if (isset($this->data['cache_handler']) &&
-				$this->data['cache_handler'] == 'memcache' ||
-				$this->data['session_handler'] == 'memcache' ||
-				$this->data['cache_handler'] == 'memcached' ||
-				$this->data['session_handler'] == 'memcached'
-				) : ?>
 
-					<?php
-			foreach ($this->form->getFieldset('memcache') as $mfield):
-			?>
-				<div class="control-group">
-					<div class="control-label"><?php echo $mfield->label; ?></div>
-					<div class="controls"><?php echo $mfield->input; ?></div>
-				</div>
-			<?php
-			endforeach;
-			?>
-		<?php endif; ?>
-</fieldset>
+$this->name = JText::_('COM_CONFIG_CACHE_SETTINGS');
+$this->fieldsname = 'cache';
+if (isset($this->data['cache_handler']) &&
+	$this->data['cache_handler'] == 'memcache' ||
+	$this->data['session_handler'] == 'memcache' ||
+	$this->data['cache_handler'] == 'memcached' ||
+	$this->data['session_handler'] == 'memcached'
+	)
+{
+	$this->fieldsname .= ',memcache';
+}
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_cookie.php
+++ b/administrator/components/com_config/views/application/tmpl/default_cookie.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_COOKIE_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('cookie') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_COOKIE_SETTINGS');
+$this->fieldsname = 'cookie';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_database.php
+++ b/administrator/components/com_config/views/application/tmpl/default_database.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_DATABASE_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('database') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_DATABASE_SETTINGS');
+$this->fieldsname = 'database';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_debug.php
+++ b/administrator/components/com_config/views/application/tmpl/default_debug.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_DEBUG_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('debug') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_DEBUG_SETTINGS');
+$this->fieldsname = 'debug';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_filters.php
+++ b/administrator/components/com_config/views/application/tmpl/default_filters.php
@@ -8,14 +8,8 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-vertical">
-	<legend><?php echo JText::_('COM_CONFIG_TEXT_FILTER_SETTINGS'); ?></legend>
-	<p><?php echo JText::_('COM_CONFIG_TEXT_FILTERS_DESC'); ?></p>
-	<?php foreach ($this->form->getFieldset('filters') as $field) : ?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php endforeach; ?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_TEXT_FILTER_SETTINGS');
+$this->fieldsname = 'filters';
+$this->description = JText::_('COM_CONFIG_TEXT_FILTERS_DESC');
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_ftp.php
+++ b/administrator/components/com_config/views/application/tmpl/default_ftp.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_FTP_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('ftp') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_FTP_SETTINGS');
+$this->fieldsname = 'ftp';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_locale.php
+++ b/administrator/components/com_config/views/application/tmpl/default_locale.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_LOCATION_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('locale') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_LOCATION_SETTINGS');
+$this->fieldsname = 'locale';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_mail.php
+++ b/administrator/components/com_config/views/application/tmpl/default_mail.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_MAIL_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('mail') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_MAIL_SETTINGS');
+$this->fieldsname = 'mail';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_metadata.php
+++ b/administrator/components/com_config/views/application/tmpl/default_metadata.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_METADATA_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('metadata') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_METADATA_SETTINGS');
+$this->fieldsname = 'metadata';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_permissions.php
+++ b/administrator/components/com_config/views/application/tmpl/default_permissions.php
@@ -8,12 +8,9 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-vertical">
-	<legend><?php echo JText::_('COM_CONFIG_PERMISSION_SETTINGS'); ?></legend>
-	<?php foreach ($this->form->getFieldset('permissions') as $field) : ?>
-		<div class="control-group">
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php endforeach; ?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_PERMISSION_SETTINGS');
+$this->fieldsname = 'permissions';
+$this->formclass = 'form-vertical';
+$this->showlabel = false;
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_seo.php
+++ b/administrator/components/com_config/views/application/tmpl/default_seo.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_SEO_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('seo') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_SEO_SETTINGS');
+$this->fieldsname = 'seo';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_server.php
+++ b/administrator/components/com_config/views/application/tmpl/default_server.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_SERVER_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('server') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_SERVER_SETTINGS');
+$this->fieldsname = 'server';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_session.php
+++ b/administrator/components/com_config/views/application/tmpl/default_session.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_SESSION_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('session') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_SESSION_SETTINGS');
+$this->fieldsname = 'session';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_site.php
+++ b/administrator/components/com_config/views/application/tmpl/default_site.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_SITE_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('site') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_SITE_SETTINGS');
+$this->fieldsname = 'site';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/views/application/tmpl/default_system.php
+++ b/administrator/components/com_config/views/application/tmpl/default_system.php
@@ -8,17 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<fieldset class="form-horizontal">
-	<legend><?php echo JText::_('COM_CONFIG_SYSTEM_SETTINGS'); ?></legend>
-	<?php
-	foreach ($this->form->getFieldset('system') as $field):
-	?>
-		<div class="control-group">
-			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
-		</div>
-	<?php
-	endforeach;
-	?>
-</fieldset>
+
+$this->name = JText::_('COM_CONFIG_SYSTEM_SETTINGS');
+$this->fieldsname = 'system';
+echo JLayoutHelper::render('joomla.content.options_default', $this);

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_weblinks
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+JHtml::_('behavior.framework');
+?>
+<fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : 'form-horizontal'; ?>">
+	<legend><?php echo $displayData->name ?></legend>
+	<?php if (!empty($displayData->description)): ?>
+		<p><?php echo $displayData->description; ?></p>
+	<?php endif; ?>
+	<?php
+	$fieldsnames = explode(',', $displayData->fieldsname);
+	foreach($fieldsnames as $fieldname)
+	{
+		foreach ($displayData->form->getFieldset($fieldname) as $field)
+		{
+			$classnames = 'control-group';
+			$rel = '';
+			$showon = $displayData->form->getFieldAttribute($field->fieldname, 'showon');
+			if (!empty($showon))
+			{
+				JHtml::_('script', 'jui/cms.js', false, true);
+
+				$id = $displayData->form->getFormControl();
+				$showon = explode(':', $showon, 2);
+				$classnames .= ' showon_' . implode(' showon_', explode(',', $showon[1]));
+				$rel = ' rel="showon_' . $id . '['. $showon[0] . ']"';
+			}
+	?>
+		<div class="<?php echo $classnames; ?>"<?php echo $rel; ?>>
+			<?php if (!isset($displayData->showlabel) || $displayData->showlabel): ?>
+				<div class="control-label"><?php echo $field->label; ?></div>
+			<?php endif; ?>
+			<div class="controls"><?php echo $field->input; ?></div>
+		</div>
+	<?php
+		}
+	}
+?>
+</fieldset>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -27,6 +27,7 @@ JHtml::_('behavior.framework');
 			$showon = $displayData->form->getFieldAttribute($field->fieldname, 'showon');
 			if (!empty($showon))
 			{
+				JHtml::_('jquery.framework');
 				JHtml::_('script', 'jui/cms.js', false, true);
 
 				$id = $displayData->form->getFormControl();

--- a/media/jui/js/cms.js
+++ b/media/jui/js/cms.js
@@ -16,3 +16,33 @@ Joomla.setcollapse = function(url, name, height) {
         document.getElementById('container-collapse').innerHTML = '<div class="collapse fade" id="collapse-' + name + '"><iframe class="iframe" src="' + url + '" height="'+ height + '" width="100%"></iframe></div>';
     }
 }
+
+jQuery(document).ready(function($) {
+	var elements = {},
+		linkedoptions = function(element, target, checkType) {
+			var v = element.val(), id = element.attr('id');
+			if(checkType && !element.is(':checked'))
+				return;
+			$('[rel=\"showon_'+target+'\"]').each(function(){
+				var i = jQuery(this);
+				if(i.hasClass('showon_' + v))
+					i.show();
+				else
+					i.hide();
+			});
+		};
+	$('[rel^=\"showon_\"]').each(function(){
+		var el = $(this), target = el.attr('rel').replace('showon_', ''), targetEl = $('[name=\"' + target+'\"]');
+		if(!elements[target]) {
+			var targetType = targetEl.attr('type'), checkType = (targetType == 'checkbox' || targetType == 'radio');
+			targetEl.bind('change', function(){
+				linkedoptions( $(this), target, checkType);
+			}).bind('click', function(){
+				linkedoptions( $(this), target, checkType );
+			}).each(function(){
+				linkedoptions( $(this), target, checkType );
+			});
+			elements[target] = true;
+		}
+	});
+});

--- a/media/jui/js/cms.js
+++ b/media/jui/js/cms.js
@@ -17,32 +17,34 @@ Joomla.setcollapse = function(url, name, height) {
     }
 }
 
-jQuery(document).ready(function($) {
-	var elements = {},
-		linkedoptions = function(element, target, checkType) {
-			var v = element.val(), id = element.attr('id');
-			if(checkType && !element.is(':checked'))
-				return;
-			$('[rel=\"showon_'+target+'\"]').each(function(){
-				var i = jQuery(this);
-				if(i.hasClass('showon_' + v))
-					i.show();
-				else
-					i.hide();
-			});
-		};
-	$('[rel^=\"showon_\"]').each(function(){
-		var el = $(this), target = el.attr('rel').replace('showon_', ''), targetEl = $('[name=\"' + target+'\"]');
-		if(!elements[target]) {
-			var targetType = targetEl.attr('type'), checkType = (targetType == 'checkbox' || targetType == 'radio');
-			targetEl.bind('change', function(){
-				linkedoptions( $(this), target, checkType);
-			}).bind('click', function(){
-				linkedoptions( $(this), target, checkType );
-			}).each(function(){
-				linkedoptions( $(this), target, checkType );
-			});
-			elements[target] = true;
-		}
+if (jQuery) {
+	jQuery(document).ready(function($) {
+		var elements = {},
+			linkedoptions = function(element, target, checkType) {
+				var v = element.val(), id = element.attr('id');
+				if(checkType && !element.is(':checked'))
+					return;
+				$('[rel=\"showon_'+target+'\"]').each(function(){
+					var i = jQuery(this);
+					if (i.hasClass('showon_' + v))
+						i.show();
+					else
+						i.hide();
+				});
+			};
+		$('[rel^=\"showon_\"]').each(function(){
+			var el = $(this), target = el.attr('rel').replace('showon_', ''), targetEl = $('[name=\"' + target+'\"]');
+			if (!elements[target]) {
+				var targetType = targetEl.attr('type'), checkType = (targetType == 'checkbox' || targetType == 'radio');
+				targetEl.bind('change', function(){
+					linkedoptions( $(this), target, checkType);
+				}).bind('click', function(){
+					linkedoptions( $(this), target, checkType );
+				}).each(function(){
+					linkedoptions( $(this), target, checkType );
+				});
+				elements[target] = true;
+			}
+		});
 	});
-});
+}


### PR DESCRIPTION
Integration of the new feature made during the "Bug Squad" of the J&Beyond 2013 with Peter van Westen and myself.

The new feature allow to hide and show some elements in the configuration depending other configured elements. So the FTP options are not displayed if the FTP is not activated. Same thing for the SMTP/Sendmail options.
Different views in the configuration has been updated in order to use a new (generic) layout which support the "showon" option.
