### PR TITLE
Article Manager shows the Name of the author without the link

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -241,7 +241,8 @@ $assoc		= isset($app->item_associations) ? $app->item_associations : 0;
 					<?php endif;?>
 					<td class="small hidden-phone">
 						<?php if ($item->created_by_alias) : ?>
-							<?php echo $this->escape($item->author_name); ?>
+							<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+							<?php echo $this->escape($item->author_name); ?></a>
 							<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
 						<?php else : ?>
 							<?php echo $this->escape($item->author_name); ?>


### PR DESCRIPTION
In the list of articles in Article Manager is shown the author Name, instead of the User Name.
This causes some difficulties in case of sites with many authors which may have duplicated Names (instead the User Name must be unique).
In Joomla 1.5 in the list of articles there was a useful link for each author, this pull request adds the link to the author edit page.
