### PR TITLE
JTable::load() should always return false if row wasn't loaded

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -492,7 +492,8 @@ abstract class JTable extends JObject
 			// If empty primary key there's is no need to load anything
 			if (empty($keyValue))
 			{
-				return true;
+				// Row not found, return false.
+				return false;
 			}
 
 			$keys = array($keyName => $keyValue);


### PR DESCRIPTION
Current version of JTable::load(null) returns true if table key is either null or 0. This contradicts the method documentation which says that false is returned if the row wasn't found (from the database).

```
// Initialize any table instance (with id as primary key) and run:
$table->id = 0;
$success = $table->load();
var_dump($success); // true (should be false)
$table->id = 9999999;
$success = $table->load();
var_dump($success); // false
```
