### PR TITLE
 Improve JModelLegacy::_getListCount() performance on JDatabaseQuery objects

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -303,20 +303,30 @@ abstract class JModelLegacy extends JObject
 	}
 
 	/**
-	 * Returns a record count for the query
+	 * Returns a record count for the query.
 	 *
-	 * @param   string  $query  The query.
+	 * @param   JDatabaseQuery|string  $query  The query.
 	 *
-	 * @return  integer  Number of rows for query
+	 * @return  integer  Number of rows for query.
 	 *
 	 * @since   12.2
 	 */
 	protected function _getListCount($query)
 	{
+		// Use fast COUNT(*) on JDatabaseQuery objects.
+		if ($query instanceof JDatabaseQuery) {
+			$query = clone $query;
+			$query->clear('select')->clear('order')->select('COUNT(*)');
+
+			$this->_db->setQuery($query);
+			return (int) $this->_db->loadResult();
+		}
+
+		// Otherwise fall back to inefficient way of counting all results.
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 
-		return $this->_db->getNumRows();
+		return (int) $this->_db->getNumRows();
 	}
 
 	/**

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -314,7 +314,8 @@ abstract class JModelLegacy extends JObject
 	protected function _getListCount($query)
 	{
 		// Use fast COUNT(*) on JDatabaseQuery objects.
-		if ($query instanceof JDatabaseQuery) {
+		if ($query instanceof JDatabaseQuery)
+		{
 			$query = clone $query;
 			$query->clear('select')->clear('order')->select('COUNT(*)');
 


### PR DESCRIPTION
Joomla currently uses unlimited query together with $db->getNumRows() to return total count. Unfortunately it has major performance penalty on large datasets, making queries very slow as @beat demonstrated in JAB13.

This pull request automatically optimizes all getListCount() calls to use COUNT(*) as long as JDatabaseQuery objects are used.
