### PR TITLE
Handling update exceptions

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -233,7 +233,18 @@ class JUpdaterCollection extends JUpdateAdapter
 
 		$http = JHttpFactory::getHttp();
 		$response = $http->get($url);
-		if (200 != $response->code)
+
+		// JHttp transport throws an exception when there's no reponse.
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $e)
+		{
+			$response = null;
+		}
+
+		if (!isset($reponse) || 200 != $response->code)
 		{
 			$query = $db->getQuery(true)
 				->update('#__update_sites')

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -244,7 +244,7 @@ class JUpdaterCollection extends JUpdateAdapter
 			$response = null;
 		}
 
-		if (!isset($reponse) || 200 != $response->code)
+		if (!isset($response) || 200 != $response->code)
 		{
 			$query = $db->getQuery(true)
 				->update('#__update_sites')

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.updater.updateadapter');
+
 /**
  * Extension class for updater
  *
@@ -171,8 +172,18 @@ class JUpdaterExtension extends JUpdateAdapter
 		$db = $this->parent->getDBO();
 
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
-		if (!empty($response->code) && 200 != $response->code)
+
+		// JHttp transport throws an exception when there's no reponse.
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $e)
+		{
+			$response = null;
+		}
+
+		if (!isset($response) || (!empty($response->code) && 200 != $response->code))
 		{
 			$query = $db->getQuery(true)
 				->update('#__update_sites')


### PR DESCRIPTION
When searching for updates one of the update site doesn't return response it causes whole JUpdater to crash: `0 - No Http response received`.

JUpdater has been switched from @fopen (Joomla 2.5) to JHttp (Joomla 3.0), which throws exceptions.

Issue tracker: [#29973](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29973)

Patch applies to Joomla 3.x
