### PR TITLE
Add class in bootstrap tabs

### DIFF
--- a/layouts/libraries/cms/html/bootstrap/starttabset.php
+++ b/layouts/libraries/cms/html/bootstrap/starttabset.php
@@ -10,8 +10,8 @@
 defined('_JEXEC') or die;
 
 $selector = empty($displayData['selector']) ? '' : $displayData['selector'];
-
+$class = empty($displayData['class']) ? '' : $displayData['class'];
 ?>
 
-<ul class="nav nav-tabs" id="<?php echo $selector; ?>Tabs"></ul>
+<ul class="nav nav-tabs <?php echo $class ?>" id="<?php echo $selector; ?>Tabs"></ul>
 <div class="tab-content" id="<?php echo $selector; ?>Content">

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -664,6 +664,7 @@ abstract class JHtmlBootstrap
 
 			// Setup options object
 			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
+			$opt['class'] = (isset($params['class']) && ($params['class'])) ? (string) $params['class'] : '';
 
 			$options = JHtml::getJSObject($opt);
 
@@ -676,7 +677,7 @@ abstract class JHtmlBootstrap
 			self::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
 		}
 
-		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.starttabset', array('selector' => $selector));
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.starttabset', array('selector' => $selector, 'class'=>$opt['class']));
 
 		return $html;
 	}


### PR DESCRIPTION
``` php
<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details','class'=>'pull-right')); ?>
```

Allow this feature in bootstrap tabs, more flexible and powerful combination with attribute class
