### PR TITLE
[#31166] fix Undefined property: JTableCorecontent::$metakey

### DIFF
--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -129,7 +129,7 @@ class JTableCorecontent extends JTable
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = JString::str_ireplace($bad_characters, "", $this->core_metakey);
 
 			// Create array using commas as delimiter
 			$keys = explode(',', $after_clean);


### PR DESCRIPTION
Notice: Undefined property: JTableCorecontent::$metakey in libraries/cms/table/corecontent.php on line 132

when
JTableCorecontent->check();
