### PR TITLE
[#30752] J! Update component - > empty custom URL causes error, fix possible only in database

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -28,7 +28,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	 *
 	 * @return  void
 	 *
-	 * @since    2.5.4
+	 * @since    3.1.2
 	 */
 	public function applyUpdateSite()
 	{
@@ -51,9 +51,16 @@ class JoomlaupdateModelDefault extends JModelLegacy
 				$updateURL = 'http://update.joomla.org/core/test/list_test.xml';
 				break;
 
-			// "Custom"
+			// "Custom" if custom URL clear no chages
 			case 'custom':
-				$updateURL = $params->get('customurl', '');
+				if($params->get('customurl', '') != '')
+				{
+					$updateURL = $params->get('customurl', '');
+				}
+				else
+				{
+					return;
+				}
 				break;
 
 			// "Do not change"

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -28,7 +28,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	 *
 	 * @return  void
 	 *
-	 * @since    3.1.2
+	 * @since    2.5.4
 	 */
 	public function applyUpdateSite()
 	{
@@ -51,7 +51,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 				$updateURL = 'http://update.joomla.org/core/test/list_test.xml';
 				break;
 
-			// "Custom" if custom URL clear no chages
+			// "Custom" if custom URL empty no changes
 			case 'custom':
 				if($params->get('customurl', '') != '')
 				{


### PR DESCRIPTION
Tracker: #30752
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30752
