### PR TITLE
replaced deprecated option /e with callable function

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -664,7 +664,7 @@ class JFilterInput
 		$source = preg_replace_callback('/&#(\d+);/m', function($m){return utf8_encode(chr($m[1]));}, $source); // decimal notation
 
 		// Convert hex
-		$source = preg_replace('/&#x([a-f0-9]+);/mi', function($m){utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
+		$source = preg_replace('/&#x([a-f0-9]+);/mi', function($m){return utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
 		return $source;
 	}
 

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -661,10 +661,10 @@ class JFilterInput
 		$source = strtr($source, $ttr);
 
 		// Convert decimal
-		$source = preg_replace('/&#(\d+);/me', "utf8_encode(chr(\\1))", $source); // decimal notation
+		$source = preg_replace_callback('/&#(\d+);/m', function($m){return utf8_encode(chr($m[1]));}, $source); // decimal notation
 
 		// Convert hex
-		$source = preg_replace('/&#x([a-f0-9]+);/mei', "utf8_encode(chr(0x\\1))", $source); // hex notation
+		$source = preg_replace('/&#x([a-f0-9]+);/mi', function($m){utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
 		return $source;
 	}
 

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -664,7 +664,7 @@ class JFilterInput
 		$source = preg_replace_callback('/&#(\d+);/m', function($m){return utf8_encode(chr($m[1]));}, $source); // decimal notation
 
 		// Convert hex
-		$source = preg_replace('/&#x([a-f0-9]+);/mi', function($m){return utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
+		$source = preg_replace_callback('/&#x([a-f0-9]+);/mi', function($m){return utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
 		return $source;
 	}
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31197

option /e was marked as deprecated since PHP 5.5.0

> ( ! ) Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in  ~\libraries\joomla\filter\input.php on line 664

regards,
Yurii
