### PR TITLE
Form field type checkbox does not store unchecked - Proposed Fix

### DIFF
--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -58,7 +58,8 @@ class JFormFieldCheckbox extends JFormField
 		// Initialize JavaScript field attributes.
 		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
 
-		return '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
+		return '<input type="hidden" name="' . $this->name . '" value="" />'
+			. '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
 			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $required . ' />';
 	}
 }


### PR DESCRIPTION
This should fix the issue with checkbox form field element not storing the unchecked value into the database by adding an empty hidden element before the actual checkbox.
