### PR TITLE
Simplify magic getters in third party API classes

### DIFF
--- a/libraries/joomla/facebook/facebook.php
+++ b/libraries/joomla/facebook/facebook.php
@@ -113,7 +113,7 @@ class JFacebook
 	 *
 	 * @param   JFacebookOAuth  $oauth    OAuth client.
 	 * @param   JRegistry       $options  Facebook options object.
-	 * @param   JFacebookHttp   $client   The HTTP client object.
+	 * @param   JHttp           $client   The HTTP client object.
 	 *
 	 * @since   13.1
 	 */
@@ -135,95 +135,23 @@ class JFacebook
 	 * @return  JFacebookObject  Facebook API object (status, user, friends etc).
 	 *
 	 * @since   13.1
+	 * @throws  InvalidArgumentException
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		$class = 'JFacebook' . ucfirst($name);
+
+		if (class_exists($class))
 		{
-			case 'user':
-				if ($this->user == null)
-				{
-					$this->user = new JFacebookUser($this->options, $this->client, $this->oauth);
-				}
-				return $this->user;
+			if (false == isset($this->$name))
+			{
+				$this->$name = new $class($this->options, $this->client, $this->oauth);
+			}
 
-			case 'status':
-				if ($this->status == null)
-				{
-					$this->status = new JFacebookStatus($this->options, $this->client, $this->oauth);
-				}
-				return $this->status;
-
-			case 'checkin':
-				if ($this->checkin == null)
-				{
-					$this->checkin = new JFacebookCheckin($this->options, $this->client, $this->oauth);
-				}
-				return $this->checkin;
-
-			case 'event':
-				if ($this->event == null)
-				{
-					$this->event = new JFacebookEvent($this->options, $this->client, $this->oauth);
-				}
-				return $this->event;
-
-			case 'group':
-				if ($this->group == null)
-				{
-					$this->group = new JFacebookGroup($this->options, $this->client, $this->oauth);
-				}
-				return $this->group;
-
-			case 'link':
-				if ($this->link == null)
-				{
-					$this->link = new JFacebookLink($this->options, $this->client, $this->oauth);
-				}
-				return $this->link;
-
-			case 'note':
-				if ($this->note == null)
-				{
-					$this->note = new JFacebookNote($this->options, $this->client, $this->oauth);
-				}
-				return $this->note;
-
-			case 'post':
-				if ($this->post == null)
-				{
-					$this->post = new JFacebookPost($this->options, $this->client, $this->oauth);
-				}
-				return $this->post;
-
-			case 'comment':
-				if ($this->comment == null)
-				{
-					$this->comment = new JFacebookComment($this->options, $this->client, $this->oauth);
-				}
-				return $this->comment;
-
-			case 'photo':
-				if ($this->photo == null)
-				{
-					$this->photo = new JFacebookPhoto($this->options, $this->client, $this->oauth);
-				}
-				return $this->photo;
-
-			case 'video':
-				if ($this->video == null)
-				{
-					$this->video = new JFacebookVideo($this->options, $this->client, $this->oauth);
-				}
-				return $this->video;
-
-			case 'album':
-				if ($this->album == null)
-				{
-					$this->album = new JFacebookAlbum($this->options, $this->client, $this->oauth);
-				}
-				return $this->album;
+			return $this->$name;
 		}
+
+		throw new InvalidArgumentException(sprintf('Argument %s produced an invalid class name: %s', $name, $class));
 	}
 
 	/**

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -140,116 +140,23 @@ class JGithub
 	 * @return  JGithubObject  GitHub API object (gists, issues, pulls, etc).
 	 *
 	 * @since   11.3
+	 * @throws  InvalidArgumentException
 	 */
 	public function __get($name)
 	{
-		if ($name == 'gists')
+		$class = 'JGithub' . ucfirst($name);
+
+		if (class_exists($class))
 		{
-			if ($this->gists == null)
+			if (false == isset($this->$name))
 			{
-				$this->gists = new JGithubGists($this->options, $this->client);
+				$this->$name = new $class($this->options, $this->client);
 			}
-			return $this->gists;
+
+			return $this->$name;
 		}
 
-		if ($name == 'issues')
-		{
-			if ($this->issues == null)
-			{
-				$this->issues = new JGithubIssues($this->options, $this->client);
-			}
-			return $this->issues;
-		}
-
-		if ($name == 'pulls')
-		{
-			if ($this->pulls == null)
-			{
-				$this->pulls = new JGithubPulls($this->options, $this->client);
-			}
-			return $this->pulls;
-		}
-
-		if ($name == 'refs')
-		{
-			if ($this->refs == null)
-			{
-				$this->refs = new JGithubRefs($this->options, $this->client);
-			}
-			return $this->refs;
-		}
-
-		if ($name == 'forks')
-		{
-			if ($this->forks == null)
-			{
-				$this->forks = new JGithubForks($this->options, $this->client);
-			}
-			return $this->forks;
-		}
-
-		if ($name == 'commits')
-		{
-			if ($this->commits == null)
-			{
-				$this->commits = new JGithubCommits($this->options, $this->client);
-			}
-			return $this->commits;
-		}
-
-		if ($name == 'milestones')
-		{
-			if ($this->milestones == null)
-			{
-				$this->milestones = new JGithubMilestones($this->options, $this->client);
-			}
-			return $this->milestones;
-		}
-
-		if ($name == 'statuses')
-		{
-			if ($this->statuses == null)
-			{
-				$this->statuses = new JGithubStatuses($this->options, $this->client);
-			}
-			return $this->statuses;
-		}
-
-		if ($name == 'account')
-		{
-			if ($this->account == null)
-			{
-				$this->account = new JGithubAccount($this->options, $this->client);
-			}
-			return $this->account;
-		}
-
-		if ($name == 'hooks')
-		{
-			if ($this->hooks == null)
-			{
-				$this->hooks = new JGithubHooks($this->options, $this->client);
-			}
-			return $this->hooks;
-		}
-
-		if ($name == 'users')
-		{
-			if ($this->users == null)
-			{
-				$this->users = new JGithubUsers($this->options, $this->client);
-			}
-			return $this->users;
-		}
-
-		if ($name == 'meta')
-		{
-			if ($this->meta == null)
-			{
-				$this->meta = new JGithubMeta($this->options, $this->client);
-			}
-			return $this->meta;
-		}
+		throw new InvalidArgumentException(sprintf('Argument %s produced an invalid class name: %s', $name, $class));
 	}
 
 	/**

--- a/libraries/joomla/linkedin/linkedin.php
+++ b/libraries/joomla/linkedin/linkedin.php
@@ -99,59 +99,23 @@ class JLinkedin
 	 * @return  JLinkedinObject  Linkedin API object (statuses, users, favorites, etc.).
 	 *
 	 * @since   13.1
+	 * @throws  InvalidArgumentException
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		$class = 'JLinkedin' . ucfirst($name);
+
+		if (class_exists($class))
 		{
-			case 'people':
-				if ($this->people == null)
-				{
-					$this->people = new JLinkedinPeople($this->options, $this->client, $this->oauth);
-				}
+			if (false == isset($this->$name))
+			{
+				$this->$name = new $class($this->options, $this->client, $this->oauth);
+			}
 
-				return $this->people;
-
-			case 'groups':
-				if ($this->groups == null)
-				{
-					$this->groups = new JLinkedinGroups($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->groups;
-
-			case 'companies':
-				if ($this->companies == null)
-				{
-					$this->companies = new JLinkedinCompanies($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->companies;
-
-			case 'jobs':
-				if ($this->jobs == null)
-				{
-					$this->jobs = new JLinkedinJobs($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->jobs;
-
-			case 'stream':
-				if ($this->stream == null)
-				{
-					$this->stream = new JLinkedinStream($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->stream;
-
-			case 'communications':
-				if ($this->communications == null)
-				{
-					$this->communications = new JLinkedinCommunications($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->communications;
+			return $this->$name;
 		}
+
+		throw new InvalidArgumentException(sprintf('Argument %s produced an invalid class name: %s', $name, $class));
 	}
 
 	/**

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -111,51 +111,23 @@ class JOpenstreetmap
 	 * @return  JOpenstreetmapObject  Openstreetmap API object
 	 *
 	 * @since   13.1
+	 * @throws  InvalidArgumentException
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		$class = 'JOpenstreetmap' . ucfirst($name);
+
+		if (class_exists($class))
 		{
-			case 'changesets':
-				if ($this->changesets == null)
-				{
-					$this->changesets = new JOpenstreetmapChangesets($this->options, $this->client, $this->oauth);
-				}
+			if (false == isset($this->$name))
+			{
+				$this->$name = new $class($this->options, $this->client, $this->oauth);
+			}
 
-				return $this->changesets;
-
-			case 'elements':
-				if ($this->elements == null)
-				{
-					$this->elements = new JOpenstreetmapElements($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->elements;
-
-			case 'gps':
-				if ($this->gps == null)
-				{
-					$this->gps = new JOpenstreetmapGps($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->gps;
-
-			case 'info':
-				if ($this->info == null)
-				{
-					$this->info = new JOpenstreetmapInfo($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->info;
-
-			case 'user':
-				if ($this->user == null)
-				{
-					$this->user = new JOpenstreetmapUser($this->options, $this->client, $this->oauth);
-				}
-
-				return $this->user;
+			return $this->$name;
 		}
+
+		throw new InvalidArgumentException(sprintf('Argument %s produced an invalid class name: %s', $name, $class));
 	}
 
 	/**

--- a/libraries/joomla/twitter/twitter.php
+++ b/libraries/joomla/twitter/twitter.php
@@ -113,7 +113,7 @@ class JTwitter
 	 *
 	 * @param   JTwitterOauth  $oauth    The oauth client.
 	 * @param   JRegistry      $options  Twitter options object.
-	 * @param   JTwitterHttp   $client   The HTTP client object.
+	 * @param   JHttp          $client   The HTTP client object.
 	 *
 	 * @since   12.3
 	 */
@@ -135,95 +135,23 @@ class JTwitter
 	 * @return  JTwitterObject  Twitter API object (statuses, users, favorites, etc.).
 	 *
 	 * @since   12.3
+	 * @throws  InvalidArgumentException
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		$class = 'JTwitter' . ucfirst($name);
+
+		if (class_exists($class))
 		{
-			case 'friends':
-				if ($this->friends == null)
-				{
-					$this->friends = new JTwitterFriends($this->options, $this->client, $this->oauth);
-				}
-				return $this->friends;
+			if (false == isset($this->$name))
+			{
+				$this->$name = new $class($this->options, $this->client, $this->oauth);
+			}
 
-			case 'help':
-				if ($this->help == null)
-				{
-					$this->help = new JTwitterHelp($this->options, $this->client, $this->oauth);
-				}
-				return $this->help;
-
-			case 'statuses':
-				if ($this->statuses == null)
-				{
-					$this->statuses = new JTwitterStatuses($this->options, $this->client, $this->oauth);
-				}
-				return $this->statuses;
-
-			case 'users':
-				if ($this->users == null)
-				{
-					$this->users = new JTwitterUsers($this->options, $this->client, $this->oauth);
-				}
-				return $this->users;
-
-			case 'search':
-				if ($this->search == null)
-				{
-					$this->search = new JTwitterSearch($this->options, $this->client, $this->oauth);
-				}
-				return $this->search;
-
-			case 'favorites':
-				if ($this->favorites == null)
-				{
-					$this->favorites = new JTwitterFavorites($this->options, $this->client, $this->oauth);
-				}
-				return $this->favorites;
-
-			case 'directMessages':
-				if ($this->directMessages == null)
-				{
-					$this->directMessages = new JTwitterDirectmessages($this->options, $this->client, $this->oauth);
-				}
-				return $this->directMessages;
-
-			case 'lists':
-				if ($this->lists == null)
-				{
-					$this->lists = new JTwitterLists($this->options, $this->client, $this->oauth);
-				}
-				return $this->lists;
-
-			case 'places':
-				if ($this->places == null)
-				{
-					$this->places = new JTwitterPlaces($this->options, $this->client, $this->oauth);
-				}
-				return $this->places;
-
-			case 'trends':
-				if ($this->trends == null)
-				{
-					$this->trends = new JTwitterTrends($this->options, $this->client, $this->oauth);
-				}
-				return $this->trends;
-
-			case 'block':
-				if ($this->block == null)
-				{
-					$this->block = new JTwitterBlock($this->options, $this->client, $this->oauth);
-				}
-				return $this->block;
-
-			case 'profile':
-				if ($this->profile == null)
-				{
-					$this->profile = new JTwitterProfile($this->options, $this->client, $this->oauth);
-				}
-				return $this->profile;
+			return $this->$name;
 		}
+
+		throw new InvalidArgumentException(sprintf('Argument %s produced an invalid class name: %s', $name, $class));
 	}
 
 	/**

--- a/tests/unit/suites/platform/facebook/JFacebookTest.php
+++ b/tests/unit/suites/platform/facebook/JFacebookTest.php
@@ -264,13 +264,11 @@ class JFacebookTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   13.1
+	 * @expectedException  InvalidArgumentException
 	 */
 	public function test__GetOther()
 	{
-		$this->assertThat(
-			$this->object->other,
-			$this->isNull()
-		);
+		$this->object->other;
 	}
 
 	/**

--- a/tests/unit/suites/platform/github/JGithubTest.php
+++ b/tests/unit/suites/platform/github/JGithubTest.php
@@ -235,13 +235,12 @@ class JGithubTest extends TestCase
 	 * @since  11.3
 	 *
 	 * @return void
+	 *
+	 * @expectedException  InvalidArgumentException
 	 */
 	public function test__GetFailure()
 	{
-		$this->assertThat(
-			$this->object->other,
-			$this->isNull()
-		);
+		$this->object->other;
 	}
 
 	/**

--- a/tests/unit/suites/platform/linkedin/JLinkedinTest.php
+++ b/tests/unit/suites/platform/linkedin/JLinkedinTest.php
@@ -167,13 +167,11 @@ class JLinkedinTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   13.1
+	 * @expectedException  InvalidArgumentException
 	 */
 	public function test__GetOther()
 	{
-		$this->assertThat(
-			$this->object->other,
-			$this->isNull()
-		);
+		$this->object->other;
 	}
 
 	/**

--- a/tests/unit/suites/platform/openstreetmap/JOpenstreetmapTest.php
+++ b/tests/unit/suites/platform/openstreetmap/JOpenstreetmapTest.php
@@ -150,13 +150,11 @@ class JOpenstreetmapTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   13.1
+	 * @expectedException  InvalidArgumentException
 	 */
 	public function test__GetOther()
 	{
-		$this->assertThat(
-				$this->object->other,
-				$this->isNull()
-		);
+		$this->object->other;
 	}
 
 	/**

--- a/tests/unit/suites/platform/twitter/JTwitterTest.php
+++ b/tests/unit/suites/platform/twitter/JTwitterTest.php
@@ -105,13 +105,11 @@ class JTwitterTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   12.3
+	 * @expectedException  InvalidArgumentException
 	 */
 	public function test__GetOther()
 	{
-		$this->assertThat(
-			$this->object->other,
-			$this->isNull()
-		);
+		$this->object->other;
 	}
 
 	/**


### PR DESCRIPTION
In working on the Framework, the `__get()` methods of the various third party API classes were simplified by not listing every possible object in the method and instead checking if the object's class exists, and if not, an exception is thrown.

These packages aren't implemented in the core, and the change for any third party implementers is that a failure goes from having no return to throwing an `InvalidArgumentException`.  Therefore, visual review and the unit tests passing will be sufficient for this PR.
