### PR TITLE
Fix children deletion on JTableCategory class

### DIFF
--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -209,7 +209,7 @@ class JTableCategory extends JTableNested
 	 */
 	public function delete($pk = null, $children = true)
 	{
-		$result = parent::delete($pk,$children);
+		$result = parent::delete($pk, $children);
 		$this->tagsHelper->typeAlias = $this->extension . '.category';
 		return $result && $this->tagsHelper->deleteTagData($this, $pk);
 	}

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -209,7 +209,7 @@ class JTableCategory extends JTableNested
 	 */
 	public function delete($pk = null, $children = true)
 	{
-		$result = parent::delete($pk);
+		$result = parent::delete($pk,$children);
 		$this->tagsHelper->typeAlias = $this->extension . '.category';
 		return $result && $this->tagsHelper->deleteTagData($this, $pk);
 	}


### PR DESCRIPTION
delete method from JTableCategory always delete children even if the parameter $children is set to false
