### PR TITLE
Updated php documentation for JMenu::getItems()

### DIFF
--- a/libraries/legacy/menu/menu.php
+++ b/libraries/legacy/menu/menu.php
@@ -229,8 +229,9 @@ class JMenu
 	/**
 	 * Gets menu items by attribute
 	 *
-	 * @param   string   $attributes  The field name
-	 * @param   string   $values      The value of the field
+	 * @param   mixed    $attributes  The field name(s).
+	 * @param   mixed    $values      The value(s) of the field. If an array, need to match field names 
+	 *                                each attribute may have multiple values to lookup for.
 	 * @param   boolean  $firstonly   If true, only returns the first item found
 	 *
 	 * @return  array


### PR DESCRIPTION
JMenu::getItems allows arrays as $attributes and $values.
Moreover, you may lookup multiple values. Please check my English :)

Tracker: [#31204](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31204)
