### PR TITLE
JMenu::getItems comments [2.5.x]

### DIFF
--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -222,8 +222,9 @@ class JMenu extends JObject
 	/**
 	 * Gets menu items by attribute
 	 *
-	 * @param   string   $attributes  The field name
-	 * @param   string   $values      The value of the field
+	 * @param   mixed    $attributes  The field name(s).
+	 * @param   mixed    $values      The value(s) of the field. If an array, need to match field names 
+	 *                                each attribute may have multiple values to lookup for.
 	 * @param   boolean  $firstonly   If true, only returns the first item found
 	 *
 	 * @return  array


### PR DESCRIPTION
Supersedes #1322

I missed, that same parameters should be updated in inheriting [JMenuSite](https://github.com/joomla/joomla-cms/blob/2.5.x/includes/menu.php#L68). But I didn't change these on PR for 3.x #1320 so will leave it like this.
