### PR TITLE
Fixing Module Class Suffix in mod_menu

### DIFF
--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -19,7 +19,7 @@ $active	= $menu->getActive();
 $active_id = isset($active) ? $active->id : $menu->getDefault()->id;
 $path	= isset($active) ? $active->tree : array();
 $showAll	= $params->get('showAllChildren');
-$class_sfx	= htmlspecialchars($params->get('class_sfx'));
+$class_sfx	= htmlspecialchars($params->get('moduleclass_sfx'));
 
 if(count($list)) {
 	require JModuleHelper::getLayoutPath('mod_menu', $params->get('layout', 'default'));


### PR DESCRIPTION
Tracker item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31247

The problem has been found in joomla 2.5, but it looks like the same problem is also present in the Joomla 3.x 

mod_menu.xml file contains two fields:

<field
name="class_sfx"
type="text"
label="MOD_MENU_FIELD_CLASS_LABEL" ...

<field
name="moduleclass_sfx"
type="textarea" rows="3"
label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL" ...

but the second field is not used in the module.
