### PR TITLE
Update loadmodule.php

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -97,7 +97,7 @@ class PlgContentLoadmodule extends JPlugin
 				}
 
 				$module = trim($matchesmodlist[0]);
-				$name   = trim($matchesmodlist[1]);
+				$name   = htmlspecialchars_decode(trim($matchesmodlist[1]));
 				$stylemod  = trim($matchesmodlist[2]);
 				// $match[0] is full pattern match, $match[1] is the module,$match[2] is the title
 				$output = $this->_loadmod($module, $name, $stylemod);


### PR DESCRIPTION
Following: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31280

Loadmodule does not support htmlspecialchars when passing a title.  This is
because the article is saved with htmlspecialchars.  The module title needs to
be decoded before matching.

plugins/content/loadmodule/loadmodule.php
line 100 <<
$name   = trim($matchesmodlist[1])

> > $name   = htmlspecialchars_decode(trim($matchesmodlist[1]))
