### PR TITLE
Fixed [#28832] List field replacement in preprocessForm method

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -718,7 +718,7 @@ class JForm
 					{
 						$olddom = dom_import_simplexml($current);
 						$loadeddom = dom_import_simplexml($field);
-						$addeddom = $olddom->ownerDocument->importNode($loadeddom);
+						$addeddom = $olddom->ownerDocument->importNode($loadeddom, true);
 						$olddom->parentNode->replaceChild($addeddom, $olddom);
 						$loadeddom->parentNode->removeChild($loadeddom);
 					}


### PR DESCRIPTION
Setting 2nd parm for DOMDocument::importNode to true.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=28832

"If set to TRUE, this method will recursively import the subtree under the importedNode."
http://php.net/manual/en/domdocument.importnode.php
