### PR TITLE
Allow all password rules to be checked before returning false

### DIFF
--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -91,6 +91,9 @@ class JFormRulePassword extends JFormRule
 
 		// We don't allow white space inside passwords
 		$valueTrim = trim($value);
+		
+		// Set a variable to check if any errors are made in password
+		$validPassword = true;
 
 		if (strlen($valueTrim) != $valueLength)
 		{
@@ -99,7 +102,7 @@ class JFormRulePassword extends JFormRule
 				'warning'
 				);
 
-			return false;
+			$validPassword = false;
 		}
 
 		// Minimum number of integers required
@@ -114,7 +117,7 @@ class JFormRulePassword extends JFormRule
 					'warning'
 				);
 
-				return false;
+				$validPassword = false;
 			}
 		}
 
@@ -130,7 +133,7 @@ class JFormRulePassword extends JFormRule
 					'warning'
 				);
 
-				return false;
+				$validPassword = false;
 			}
 		}
 
@@ -146,7 +149,7 @@ class JFormRulePassword extends JFormRule
 					'warning'
 			);
 
-				return false;
+				$validPassword = false;
 			}
 		}
 
@@ -160,10 +163,18 @@ class JFormRulePassword extends JFormRule
 					'warning'
 					);
 
-				return false;
+				$validPassword = false;
 			}
 		}
 
-		return true;
+		// If valid password is still true return true, else return false.
+		if ($validPassword == true)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
 	}
 }

--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -167,14 +167,12 @@ class JFormRulePassword extends JFormRule
 			}
 		}
 
-		// If valid password is still true return true, else return false.
-		if ($validPassword == true)
-		{
-			return true;
-		}
-		else
+		// If valid has violated any rules above return false.
+		if (!$validPassword)
 		{
 			return false;
 		}
+		
+		return true;
 	}
 }


### PR DESCRIPTION
This edits the password checking rule so that all violations of the rule are displayed to the user rather than just the first one in the 'if' statement

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31293
