### PR TITLE
Update default_item.php

### DIFF
--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -217,11 +217,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 			</dd>
 		<?php endif; ?>
 	</dl>
-
+		
+		<?php endif; ?>
 	<?php if ($this->params->get('show_tags', 1)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
-	<?php endif; ?>
 
 <?php endif; ?>
 


### PR DESCRIPTION
Make Tags appear when "Position of Article Info" is set to "Above" in "Featured Articles" menu.
Following http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31295
