### PR TITLE
JLayoutFile improvements

### DIFF
--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -20,6 +20,68 @@ defined('JPATH_BASE') or die;
 class JLayoutBase implements JLayout
 {
 	/**
+	 * Options object
+	 *
+	 * @var  JRegistry
+	 */
+	protected $options = null;
+
+	/**
+	 * Set the options
+	 *
+	 * @param   mixed  $options  Array / JRegistry object with the options to load
+	 *
+	 * @return  JLayoutBase      An instance of itself for chaining
+	 */
+	public function bindOptions($options = null)
+	{
+		// Received JRegistry
+		if ($options instanceof JRegistry)
+		{
+			$this->options = $options;
+		}
+		elseif (is_array($options))
+		// Received array
+		{
+			$this->options = new JRegistry($options);
+		}
+		else
+		{
+			$this->options = new JRegistry;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Get the options
+	 *
+	 * @return  JRegistry  Object with the options
+	 */
+	public function getOptions()
+	{
+		// Always return a JRegistry instance
+		if (!($this->options instanceof JRegistry))
+		{
+			$this->resetOptions();
+		}
+
+		return $this->options;
+	}
+
+	/**
+	 * Function to empty all the options
+	 *
+	 * @return  JLayoutBase  An instance of itself for chaining
+	 */
+	public function resetOptions()
+	{
+		$this->options = new JRegistry;
+
+		return $this;
+	}
+
+	/**
 	 * Method to escape output.
 	 *
 	 * @param   string  $output  The output to escape.

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -27,6 +27,13 @@ class JLayoutBase implements JLayout
 	protected $options = null;
 
 	/**
+	 * Debug information messages
+	 *
+	 * @var  array
+	 */
+	protected $debugMessages = array();
+
+	/**
 	 * Set the options
 	 *
 	 * @param   mixed  $options  Array / JRegistry object with the options to load
@@ -94,6 +101,16 @@ class JLayoutBase implements JLayout
 	}
 
 	/**
+	 * Get the debug messages array
+	 *
+	 * @return  array
+	 */
+	public function getDebugMessages()
+	{
+		return $this->debugMessages;
+	}
+
+	/**
 	 * Method to render the layout.
 	 *
 	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
@@ -105,5 +122,27 @@ class JLayoutBase implements JLayout
 	public function render($displayData)
 	{
 		return '';
+	}
+
+	/**
+	 * Render the list of debug messages
+	 *
+	 * @return  string  Output text/HTML code
+	 */
+	public function renderDebugMessages()
+	{
+		return implode($this->debugMessages, "\n");
+	}
+
+	/**
+	 * Add a debug message to the debug messages array
+	 *
+	 * @param   string  $message  Message to save
+	 *
+	 * @return  void
+	 */
+	public function addDebugMessage($message)
+	{
+		$this->debugMessages[] = $message;
 	}
 }

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -33,7 +33,7 @@ class JLayoutBase implements JLayout
 	 *
 	 * @return  JLayoutBase      An instance of itself for chaining
 	 */
-	public function bindOptions($options = null)
+	public function setOptions($options = null)
 	{
 		// Received JRegistry
 		if ($options instanceof JRegistry)
@@ -76,9 +76,7 @@ class JLayoutBase implements JLayout
 	 */
 	public function resetOptions()
 	{
-		$this->options = new JRegistry;
-
-		return $this;
+		return $this->setOptions(null);
 	}
 
 	/**

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -57,7 +57,7 @@ class JLayoutFile extends JLayoutBase
 	public function __construct($layoutId, $basePath = null, $options = null)
 	{
 		// Initialise / Load options
-		$this->bindOptions($options);
+		$this->setOptions($options);
 
 		// Main properties
 		$this->setLayout($layoutId);

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -39,17 +39,33 @@ class JLayoutFile extends JLayoutBase
 	protected $fullPath = null;
 
 	/**
+	 * Paths to search for layouts
+	 *
+	 * @var  array
+	 */
+	protected $includePaths = array();
+
+	/**
 	 * Method to instantiate the file-based layout.
 	 *
 	 * @param   string  $layoutId  Dot separated path to the layout file, relative to base path
 	 * @param   string  $basePath  Base path to use when loading layout files
+	 * @param   mixed   $options   Optional custom options to load. JRegistry or array format
 	 *
 	 * @since   3.0
 	 */
-	public function __construct($layoutId, $basePath = null)
+	public function __construct($layoutId, $basePath = null, $options = null)
 	{
-		$this->layoutId = $layoutId;
-		$this->basePath = is_null($basePath) ? JPATH_ROOT . '/layouts' : rtrim($basePath, DIRECTORY_SEPARATOR);
+		// Initialise / Load options
+		$this->bindOptions($options);
+
+		// Main properties
+		$this->setLayout($layoutId);
+		$this->basePath = $basePath;
+
+		// Init Enviroment
+		$this->setComponent($this->options->get('component', 'auto'));
+		$this->setClient($this->options->get('client', 'auto'));
 	}
 
 	/**
@@ -63,6 +79,11 @@ class JLayoutFile extends JLayoutBase
 	 */
 	public function render($displayData)
 	{
+		if ($this->options->get('debug', false))
+		{
+			echo $this->debugInfo();
+		}
+
 		$layoutOutput = '';
 
 		// Check possible overrides, and build the full path to layout file
@@ -89,22 +110,282 @@ class JLayoutFile extends JLayoutBase
 	 */
 	protected function getPath()
 	{
-		jimport('joomla.filesystem.path');
+		JLoader::import('joomla.filesystem.path');
 
 		if (is_null($this->fullPath) && !empty($this->layoutId))
 		{
-			$rawPath = str_replace('.', '/', $this->layoutId) . '.php';
-			$fileName = basename($rawPath);
-			$filePath = dirname($rawPath);
+			// Refresh paths
+			$this->refreshIncludePaths();
 
-			$possiblePaths = array(
-				JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts/' . $filePath,
-				$this->basePath . '/' . $filePath
-			);
+			$rawPath  = str_replace('.', '/', $this->layoutId) . '.php';
 
-			$this->fullPath = JPath::find($possiblePaths, $fileName);
+			$this->fullPath = JPath::find($this->includePaths, $rawPath);
 		}
 
 		return $this->fullPath;
+	}
+
+	/**
+	 * Add one path to include in layout search. Proxy of addIncludePaths()
+	 *
+	 * @param   string  $path  The path to search for layouts
+	 *
+	 * @return  void
+	 */
+	public function addIncludePath($path)
+	{
+		$this->addIncludePaths($path);
+	}
+
+	/**
+	 * Add one or more paths to include in layout search
+	 *
+	 * @param   string  $paths  The path or array of paths to search for layouts
+	 *
+	 * @return  void
+	 */
+	public function addIncludePaths($paths)
+	{
+		if (!empty($paths))
+		{
+			if (is_array($paths))
+			{
+				$this->includePaths = array_unique(array_merge($paths, $this->includePaths));
+			}
+			else
+			{
+				array_unshift($this->includePaths, $paths);
+			}
+		}
+	}
+
+	/**
+	 * Dirty function to debug layout/path errors
+	 *
+	 * @return  void
+	 */
+	public function debugInfo()
+	{
+		$rawPath  = str_replace('.', '/', $this->layoutId) . '.php';
+
+		$html = "<pre>";
+		$html .= '<strong>Layout:</strong> ' . $this->layoutId . '<br />';
+		$html .= '<strong>RAW Layout path:</strong> ' . $rawPath . '<br>';
+		$html .= '<strong>includePaths:</strong> ';
+		$html .= print_r($this->includePaths, true);
+		$html .= '<strong>Checking paths:</strong> <br />';
+
+		if ($this->includePaths)
+		{
+			foreach ($this->includePaths as $path)
+			{
+				$file = $path . '/' . $rawPath;
+
+				if (!file_exists($file))
+				{
+					$html .= 'NOT exists: ' . $file . '<br />';
+				}
+				else
+				{
+					$html .= '<strong>EXISTS: ' . $file . '</strong><br />';
+					break;
+				}
+			}
+		}
+
+		$html .= "</pre>";
+
+		return $html;
+	}
+
+	/**
+	 * Validate that the active component is valid
+	 *
+	 * @param   string  $option  URL Option of the component. Example: com_content
+	 *
+	 * @return  boolean
+	 */
+	protected function validComponent($option = null)
+	{
+		// By default we will validate the active component
+		$component = ($option !== null) ? $option : $this->options->get('component', null);
+
+		if (!empty($component))
+		{
+			// Valid option format
+			if (substr_count($component, 'com_'))
+			{
+				// Latest check: component exists and is enabled
+				return JComponentHelper::isEnabled($component);
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Method to change the component where search for layouts
+	 *
+	 * @param   string  $option  URL Option of the component. Example: com_content
+	 *
+	 * @return  mixed            Component option string | null for none
+	 */
+	public function setComponent($option)
+	{
+		$component = null;
+
+		switch ((string) $option)
+		{
+			case 'none':
+				$component = null;
+				break;
+
+			case 'auto':
+				if (defined('JPATH_COMPONENT'))
+				{
+					$parts = explode('/', JPATH_COMPONENT);
+					$component = end($parts);
+				}
+				break;
+
+			default:
+				$component = $option;
+				break;
+		}
+
+		// Extra checks
+		if (!$this->validComponent($component))
+		{
+			$component = null;
+		}
+
+		$this->options->set('component', $component);
+
+		// Refresh include paths
+		$this->refreshIncludePaths();
+	}
+
+	/**
+	 * Function to initialise the application client
+	 *
+	 * @param   mixed  $client  Frontend: 'site' or 0 | Backend: 'admin' or 1
+	 *
+	 * @return  void
+	 */
+	public function setClient($client)
+	{
+		// Force string conversion to avoid unexpected states
+		switch ((string) $client)
+		{
+			case 'site':
+			case '0':
+				$client = 0;
+				break;
+
+			case 'admin':
+			case '1':
+				$client = 1;
+				break;
+
+			default:
+				$client = (int) JFactory::getApplication()->isAdmin();
+				break;
+		}
+
+		$this->options->set('client', $client);
+
+		// Refresh include paths
+		$this->refreshIncludePaths();
+	}
+
+	/**
+	 * Change the layout
+	 *
+	 * @param   string  $layoutId  Layout to render
+	 *
+	 * @return  void
+	 */
+	public function setLayout($layoutId)
+	{
+		$this->layoutId = $layoutId;
+		$this->fullPath = null;
+	}
+
+	/**
+	 * Refresh the list of include paths
+	 *
+	 * @return  void
+	 */
+	protected function refreshIncludePaths()
+	{
+		// Reset includePaths
+		$this->includePaths = array();
+
+		// (1 - lower priority) Frontend base layouts
+		$this->addIncludePaths(JPATH_ROOT . '/layouts');
+
+		// (2) Standard Joomla! layouts overriden
+		$this->addIncludePaths(JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts');
+
+		// Component layouts & overrides if exist
+		$component = $this->options->get('component', null);
+
+		if (!empty($component))
+		{
+			// (3) Component path
+			if ($this->options->get('client') == 0)
+			{
+				$this->addIncludePaths(JPATH_SITE . '/components/' . $component . '/layouts');
+			}
+			else
+			{
+				$this->addIncludePaths(JPATH_ADMINISTRATOR . '/components/' . $component . '/layouts');
+			}
+
+			// (4) Component template overrides path
+			$this->addIncludePath(JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts/' . $component);
+		}
+
+		// (5 - highest priority) Received a custom high priority path ?
+		if (!is_null($this->basePath))
+		{
+			$this->addIncludePath(rtrim($this->basePath, DIRECTORY_SEPARATOR));
+		}
+	}
+
+	/**
+	 * Change the debug mode
+	 *
+	 * @param   boolean  $debug  Enable / Disable debug
+	 *
+	 * @return  void
+	 */
+	public function setDebug($debug)
+	{
+		$this->options->set('debug', (boolean) $debug);
+	}
+
+	/**
+	 * Render a layout with the same include paths & options
+	 *
+	 * @param   object  $layoutId     Object which properties are used inside the layout file to build displayed output
+	 * @param   mixed   $displayData  Data to be rendered
+	 *
+	 * @return  string  The necessary HTML to display the layout
+	 *
+	 * @since   3.0
+	 */
+	public function sublayout($layoutId, $displayData)
+	{
+		// Sublayouts are searched in a subfolder with the name of the current layout
+		if (!empty($this->layoutId))
+		{
+			$layoutId = $this->layoutId . '.' . $layoutId;
+		}
+
+		$sublayout = new static($layoutId, $this->basePath, $this->options);
+		$sublayout->includePaths = $this->includePaths;
+
+		return $sublayout->render($displayData);
 	}
 }

--- a/libraries/cms/layout/helper.php
+++ b/libraries/cms/layout/helper.php
@@ -34,18 +34,19 @@ class JLayoutHelper
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
 	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
 	 * @param   string  $basePath     Base path to use when loading layout files
+	 * @param   mixed   $options      Optional custom options to load. JRegistry or array format
 	 *
 	 * @return  string
 	 *
 	 * @since   3.1
 	 */
-	public static function render($layoutFile, $displayData = null, $basePath = '')
+	public static function render($layoutFile, $displayData = null, $basePath = '', $options = null)
 	{
 		$basePath = empty($basePath) ? self::$defaultBasePath : $basePath;
 
 		// Make sure we send null to JLayoutFile if no path set
 		$basePath = empty($basePath) ? null : $basePath;
-		$layout = new JLayoutFile($layoutFile, $basePath);
+		$layout = new JLayoutFile($layoutFile, $basePath, $options);
 		$renderedLayout = $layout->render($displayData);
 
 		return $renderedLayout;


### PR DESCRIPTION
Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31352&start=0

This contribution tries to improve layouts usability for component developers without breaking B/C. New methods allow to:
- Allow devs to add an unlimited list of include paths with new functions: <code>addIncludePath()</code> & <code>addIncludePaths</code>
- Automatically search base layout overrides in the rendered component folder
- Automatically search overriden component layouts in the active template folder
- Add a sublayout function that inherits all the settings (except <code>$layoutId</code> &  <code>displayData</code> from the parent folder)
## Old method

With the old method a simple call like this:

``` PHP
$layout = new JLayoutFile('joomla.content.tags');
$layout->render($itemTags);
```

Will search for the layout in this folders (ordered by priority):

```
    [0] => templates/mytemplate/html/layouts
    [1] => layouts
```

You also could force a layout folder with:

``` PHP
$layout = new JLayoutFile('joomla.content.tags', JPATH_SITE . '/components/com_mycomponent/layouts');
$layout->render($itemTags);
```

Which would search for layouts in:

```
    [0] => templates/mytemplate/html/layouts
    [1] => components/com_mycomponent/layouts
```

That limits layout search to two folders and doesn't allow users to create layout overrides per component. 
## New method

Standard call (with default values shown) would be like:

``` PHP
JLayoutFile($layoutId, $basePath = null, $component = 'auto', $client = 'auto', $debug = false)
```

No B/C issues. Now let's use some examples to describe new features:
### 1. I want to customise the way that tags are shown in my component.

With the new functions you haven't to do anything. System will automatically search for layouts in the active component:

``` PHP
$layout = new JLayoutFile('joomla.content.tags');
$layout->render($itemTags);
```

Will search for layouts in this order:

```
    [0] => templates/mytemplate/html/layouts/com_mycomponent
    [1] => components/com_mycomponent/layouts
    [2] => templates/mytemplate/html/layouts
    [3] => layouts
```

That means that I can customise tags and also users can specifically override my customisation.
### 2. Wait I'm in a module that shows my component tags in any component

You can specify/force the component where you want to search for layouts

``` PHP
$layout = new JLayoutFile('joomla.content.tags', null, 'com_mycomponent');
$layout->render($itemTags);
```
### 3. But I want to show my tags in backend with the same frontend layout

You can also specify the client where you want to search for layouts:

``` PHP
$layout = new JLayoutFile('joomla.content.tags', null, 'com_mycomponent', 'site');
$layout->render($itemTags);
```
### 4. Why sublayouts?

I found that I needed to always use the same <code>includePaths</code> to render a lot of layouts. Let's say that we are on a plugin that creates an invoice. With sublayouts it's easy to allow users to customise exactly the part of the invoice the want. In the main file we will call something like:

``` PHP
$invoiceLayout = new JLayoutFile('invoice', null, 'com_mycomponent', 'site');
$invoiceLayout->render($invoiceData);
```

And then in the layout we can use:

``` PHP
// Render client information
echo $this->sublayout('invoice.client', $client);

// Render products lines
echo $this->sublayout('invoice.products', $products);
```

That will create a group of small layouts that clients can customise individually. For example to customise client information they just need to copy the file from:

<code>components/com_mycomponent/layouts/invoice/client.php</code>

to the template:

<code>templates/mytemplate/html/layouts/com_mycomponent/invoice/client.php</code>
### 5. Debug mode

As you may have noticed all this folders in the include path can cause you some headaches when any of them fails. When enabled debug mode will output something like this when the <code>render()</code> method is called:
![layouts_debug](https://f.cloud.github.com/assets/1119272/756072/d6d740a8-e5df-11e2-8c02-610e0beeb6c9.png)

You can also use <code>echo $layout->debugInfo(); </code> anytime.
### 6. Playground

I also added some new public available functions:

```
setComponent($component)
setClient($client)
setLayout($layoutId)
setDebug($debug)
```

They are mainly intended to be used internall but nothing prevents you to go crazy and do something like:

``` PHP
$layout = new JLayoutFile('invoice', null, 'com_mycomponent', 'site');
echo $layout->render($invoiceData);

// Crazy mode
$layout->setLayout('share');
$layout->setComponent('com_weblinks');
$layout->setClient('admin');
echo $layout->render($links);
```
### 7. Also available in fast layout mode

If you like to save lines of code you can use the <code>JLayoutHelper</code> which also includes the new features:

``` PHP
public static function render($layoutFile, $displayData = null, $basePath = '', $component = 'auto', $client = 'auto', $debug = false)
```

Some of the before examples in fast mode:

``` PHP
echo JLayoutHelper::render('joomla.content.tags', $itemTags, null, 'com_mycomponent', 'site')
echo JLayoutHelper::render('invoice', $invoiceData, null, 'com_mycomponent', 'site');
```
