### PR TITLE
[#31353] Default text for permissions in the global config is missing

### DIFF
--- a/administrator/components/com_config/models/forms/application.xml
+++ b/administrator/components/com_config/models/forms/application.xml
@@ -801,8 +801,7 @@
 		<field
 			name="rules"
 			type="rules"
-			label="FIELD_RULES_LABEL"
-			translate_label="false"
+			label="JCONFIG_PERMISSIONS_DESC"
 			validate="rules"
 			class="inputbox"
 			filter="rules">

--- a/administrator/components/com_config/views/application/tmpl/default_permissions.php
+++ b/administrator/components/com_config/views/application/tmpl/default_permissions.php
@@ -12,5 +12,4 @@ defined('_JEXEC') or die;
 $this->name = JText::_('COM_CONFIG_PERMISSION_SETTINGS');
 $this->fieldsname = 'permissions';
 $this->formclass = 'form-vertical';
-$this->showlabel = false;
 echo JLayoutHelper::render('joomla.content.options_default', $this);


### PR DESCRIPTION
Tracker: #31353
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31353
