### PR TITLE
Admin app PHPCS cleanup & exemption changes

### DIFF
--- a/administrator/includes/defines.php
+++ b/administrator/includes/defines.php
@@ -8,12 +8,12 @@
 
 defined('_JEXEC') or die;
 
-//Global definitions.
-//Joomla framework path definitions.
+// Global definitions.
+// Joomla framework path definitions.
 $parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
 array_pop($parts);
 
-//Defines.
+// Defines.
 define('JPATH_ROOT',           implode(DIRECTORY_SEPARATOR, $parts));
 define('JPATH_SITE',          JPATH_ROOT);
 define('JPATH_CONFIGURATION', JPATH_ROOT);

--- a/administrator/includes/helper.php
+++ b/administrator/includes/helper.php
@@ -32,6 +32,7 @@ class JAdministratorHelper
 
 		$app->loadIdentity();
 		$user = $app->getIdentity();
+
 		if ($user->get('guest') || !$user->authorise('core.login.admin'))
 		{
 			$option = 'com_login';
@@ -43,6 +44,7 @@ class JAdministratorHelper
 		}
 
 		$app->input->set('option', $option);
+
 		return $option;
 	}
 }

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -33,6 +33,7 @@ abstract class JToolbarHelper
 	{
 		// Strip the extension.
 		$icons = explode(' ', $icon);
+
 		foreach ($icons as $i => $icon)
 		{
 			$icons[$i] = 'icon-48-' . preg_replace('#\.[^.]*$#', '', $icon);
@@ -105,7 +106,7 @@ abstract class JToolbarHelper
 	 * Writes a preview button for a given option (opens a popup window).
 	 *
 	 * @param   string  $url            The name of the popup file (excluding the file extension)
-	 * @param   bool    $updateEditors
+	 * @param   bool    $updateEditors  Unused
 	 *
 	 * @return  void
 	 *
@@ -116,7 +117,7 @@ abstract class JToolbarHelper
 		$bar = JToolbar::getInstance('toolbar');
 
 		// Add a preview button.
-		$bar->appendButton('Popup', 'preview', 'Preview', $url.'&task=preview');
+		$bar->appendButton('Popup', 'preview', 'Preview', $url . '&task=preview');
 	}
 
 	/**
@@ -422,11 +423,11 @@ abstract class JToolbarHelper
 	}
 
 	/**
-	 * Write a trash button that will move items to Trash Manager.
+	 * Writes a common 'trash' button for a list of records.
 	 *
 	 * @param   string  $task   An override for the task.
 	 * @param   string  $alt    An override for the alt text.
-	 * @param   bool    $check
+	 * @param   bool    $check  True to allow lists.
 	 *
 	 * @return  void
 	 *
@@ -557,11 +558,11 @@ abstract class JToolbarHelper
 	/**
 	 * Writes a configuration button and invokes a cancel operation (eg a checkin).
 	 *
-	 * @param   string  $component  The name of the component, eg, com_content.
-	 * @param   int     $height     The height of the popup. [UNUSED]
-	 * @param   int     $width      The width of the popup. [UNUSED]
-	 * @param   string  $alt        The name of the button.
-	 * @param   string  $path       An alternative path for the configuation xml relative to JPATH_SITE.
+	 * @param   string   $component  The name of the component, eg, com_content.
+	 * @param   integer  $height     The height of the popup. [UNUSED]
+	 * @param   integer  $width      The width of the popup. [UNUSED]
+	 * @param   string   $alt        The name of the button.
+	 * @param   string   $path       An alternative path for the configuation xml relative to JPATH_SITE.
 	 *
 	 * @return  void
 	 *
@@ -577,7 +578,12 @@ abstract class JToolbarHelper
 		$return = urlencode(base64_encode($uri));
 
 		// Add a button linking to config for component.
-		$bar->appendButton('Link', 'options', $alt, 'index.php?option=com_config&amp;view=component&amp;component=' . $component . '&amp;path=' . $path . '&amp;return=' . $return);
+		$bar->appendButton(
+			'Link',
+			'options',
+			$alt,
+			'index.php?option=com_config&amp;view=component&amp;component=' . $component . '&amp;path=' . $path . '&amp;return=' . $return
+		);
 	}
 }
 
@@ -620,9 +626,9 @@ abstract class JSubMenuHelper
 	/**
 	 * Method to add a menu item to submenu.
 	 *
-	 * @param   string	$name	 Name of the menu item.
-	 * @param   string	$link	 URL of the menu item.
-	 * @param   bool	$active  True if the item is active, false otherwise.
+	 * @param   string   $name    Name of the menu item.
+	 * @param   string   $link    URL of the menu item.
+	 * @param   boolean  $active  True if the item is active, false otherwise.
 	 *
 	 * @return  void
 	 *
@@ -652,10 +658,10 @@ abstract class JSubMenuHelper
 	/**
 	 * Method to add a filter to the submenu
 	 *
-	 * @param   string	$label      Label for the menu item.
-	 * @param   string	$name       name for the filter. Also used as id.
-	 * @param   string	$options    options for the select field.
-	 * @param   bool	$noDefault  Don't the label as the empty option
+	 * @param   string   $label      Label for the menu item.
+	 * @param   string   $name       name for the filter. Also used as id.
+	 * @param   string   $options    options for the select field.
+	 * @param   boolean  $noDefault  Don't the label as the empty option
 	 *
 	 * @return  void
 	 *

--- a/administrator/index.php
+++ b/administrator/index.php
@@ -25,12 +25,12 @@ if (file_exists(__DIR__ . '/defines.php'))
 if (!defined('_JDEFINES'))
 {
 	define('JPATH_BASE', __DIR__);
-	require_once JPATH_BASE.'/includes/defines.php';
+	require_once JPATH_BASE . '/includes/defines.php';
 }
 
-require_once JPATH_BASE.'/includes/framework.php';
-require_once JPATH_BASE.'/includes/helper.php';
-require_once JPATH_BASE.'/includes/toolbar.php';
+require_once JPATH_BASE . '/includes/framework.php';
+require_once JPATH_BASE . '/includes/helper.php';
+require_once JPATH_BASE . '/includes/toolbar.php';
 
 // Mark afterLoad in the profiler.
 JDEBUG ? $_PROFILER->mark('afterLoad') : null;

--- a/administrator/language/en-GB/en-GB.localise.php
+++ b/administrator/language/en-GB/en-GB.localise.php
@@ -19,64 +19,69 @@ abstract class En_GBLocalise
 	/**
 	 * Returns the potential suffixes for a specific number of items
 	 *
-	 * @param   int $count  The number of items.
+	 * @param   integer  $count  The number of items.
+	 *
 	 * @return  array  An array of potential suffixes.
+	 *
 	 * @since   1.6
 	 */
 	public static function getPluralSuffixes($count)
 	{
 		if ($count == 0)
 		{
-			$return = array('0');
+			return array('0');
 		}
 		elseif ($count == 1)
 		{
-			$return = array('1');
+			return array('1');
 		}
 		else
 		{
-			$return = array('MORE');
+			return array('MORE');
 		}
-		return $return;
 	}
+
 	/**
 	 * Returns the ignored search words
 	 *
 	 * @return  array  An array of ignored search words.
+	 *
 	 * @since   1.6
 	 */
 	public static function getIgnoredSearchWords()
 	{
-		$search_ignore = array();
-		$search_ignore[] = "and";
-		$search_ignore[] = "in";
-		$search_ignore[] = "on";
-		return $search_ignore;
+		return array('and', 'in', 'on');
 	}
+
 	/**
 	 * Returns the lower length limit of search words
 	 *
 	 * @return  integer  The lower length limit of search words.
+	 *
 	 * @since   1.6
 	 */
 	public static function getLowerLimitSearchWord()
 	{
 		return 3;
 	}
+
 	/**
 	 * Returns the upper length limit of search words
 	 *
 	 * @return  integer  The upper length limit of search words.
+	 *
 	 * @since   1.6
 	 */
 	public static function getUpperLimitSearchWord()
 	{
 		return 20;
 	}
+
 	/**
 	 * Returns the number of chars to display when searching
 	 *
 	 * @return  integer  The number of chars to display when searching.
+	 *
 	 * @since   1.6
 	 */
 	public static function getSearchDisplayedCharactersNumber()

--- a/administrator/modules/mod_feed/helper.php
+++ b/administrator/modules/mod_feed/helper.php
@@ -24,8 +24,10 @@ class ModFeedHelper
 	 * @param   JRegisty  $params  The parameters object.
 	 *
 	 * @return  JFeedReader|string  Return a JFeedReader object or a string message if error.
+	 *
+	 * @since   1.5
 	 */
-	static function getFeed($params)
+	public static function getFeed($params)
 	{
 		// Module params
 		$rssurl = $params->get('rssurl', '');
@@ -37,15 +39,7 @@ class ModFeedHelper
 			$feed   = new JFeedFactory;
 			$rssDoc = $feed->getFeed($rssurl);
 		}
-		catch (InvalidArgumentException $e)
-		{
-			return JText::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
-		}
-		catch (RunTimeException $e)
-		{
-			return JText::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
-		}
-		catch (LogicException $e)
+		catch (Exception $e)
 		{
 			return JText::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
 		}
@@ -54,6 +48,7 @@ class ModFeedHelper
 		{
 			return JText::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
 		}
+
 		return $rssDoc;
 	}
 }

--- a/administrator/modules/mod_latest/helper.php
+++ b/administrator/modules/mod_latest/helper.php
@@ -23,7 +23,7 @@ abstract class ModLatestHelper
 	/**
 	 * Get a list of articles.
 	 *
-	 * @param   JRegistry  $params  The module parameters.
+	 * @param   JRegistry  &$params  The module parameters.
 	 *
 	 * @return  mixed  An array of articles, or false on error.
 	 */

--- a/administrator/modules/mod_logged/helper.php
+++ b/administrator/modules/mod_logged/helper.php
@@ -21,9 +21,11 @@ abstract class ModLoggedHelper
 	/**
 	 * Get a list of logged users.
 	 *
-	 * @param   JRegistry  $params  The module parameters.
+	 * @param   JRegistry  &$params  The module parameters.
 	 *
 	 * @return  mixed  An array of users, or false on error.
+	 *
+	 * @throws  RuntimeException
 	 */
 	public static function getList(&$params)
 	{
@@ -42,9 +44,7 @@ abstract class ModLoggedHelper
 		}
 		catch (RuntimeException $e)
 		{
-			throw new RuntimeException($e->getMessage());
-
-			return false;
+			throw $e;
 		}
 
 		foreach ($results as $k => $result)

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -20,21 +20,22 @@ class JAdminCssMenu extends JObject
 {
 	/**
 	 * CSS string to add to document head
-	 * @var string
+	 *
+	 * @var  string
 	 */
 	protected $_css = null;
 
 	/**
 	 * Root node
 	 *
-	 * @var    object
+	 * @var  object
 	 */
 	protected $_root = null;
 
 	/**
 	 * Current working node
 	 *
-	 * @var    object
+	 * @var  object
 	 */
 	protected $_current = null;
 
@@ -85,11 +86,24 @@ class JAdminCssMenu extends JObject
 		$this->_current = &$this->_root;
 	}
 
+	/**
+	 * Method to add a separator node
+	 *
+	 * @return  void
+	 */
 	public function addSeparator()
 	{
 		$this->addChild(new JMenuNode(null, null, 'separator', false));
 	}
 
+	/**
+	 * Renders the menu
+	 *
+	 * @param   string  $id     CSS ID for the menu
+	 * @param   string  $class  CSS Class for the menu
+	 *
+	 * @return  void
+	 */
 	public function renderMenu($id = 'menu', $class = '')
 	{
 		$depth = 1;
@@ -121,11 +135,17 @@ class JAdminCssMenu extends JObject
 		if ($this->_css)
 		{
 			// Add style to document head
-			$doc = JFactory::getDocument();
-			$doc->addStyleDeclaration($this->_css);
+			JFactory::getDocument()->addStyleDeclaration($this->_css);
 		}
 	}
 
+	/**
+	 * Render the specified level
+	 *
+	 * @param   integer  $depth  The current depth
+	 *
+	 * @return  void
+	 */
 	public function renderLevel($depth)
 	{
 		// Build the CSS class suffix
@@ -151,15 +171,10 @@ class JAdminCssMenu extends JObject
 			$class = ' class="disabled"';
 		}
 
-		/*
-		 * Print the item
-		 */
+		// Print the item
 		echo "<li" . $class . ">";
 
-		/*
-		 * Print a link if it exists
-		 */
-
+		// Print a link if it exists
 		$linkClass = array();
 		$dataToggle = '';
 		$dropdownCaret = '';
@@ -190,7 +205,8 @@ class JAdminCssMenu extends JObject
 
 		if ($this->_current->link != null && $this->_current->target != null)
 		{
-			echo "<a" . $linkClass . " " . $dataToggle . " href=\"" . $this->_current->link . "\" target=\"" . $this->_current->target . "\" >" . $this->_current->title . $dropdownCaret . "</a>";
+			echo "<a" . $linkClass . " " . $dataToggle . " href=\"" . $this->_current->link . "\" target=\"" . $this->_current->target . "\" >"
+				. $this->_current->title . $dropdownCaret . "</a>";
 		}
 		elseif ($this->_current->link != null && $this->_current->target == null)
 		{
@@ -303,61 +319,84 @@ class JMenuNode extends JObject
 {
 	/**
 	 * Node Title
+	 *
+	 * @var  string
 	 */
 	public $title = null;
 
 	/**
 	 * Node Id
+	 *
+	 * @var  string
 	 */
 	public $id = null;
 
 	/**
 	 * Node Link
+	 *
+	 * @var  string
 	 */
 	public $link = null;
 
 	/**
 	 * Link Target
+	 *
+	 * @var  string
 	 */
 	public $target = null;
 
 	/**
 	 * CSS Class for node
+	 *
+	 * @var  string
 	 */
 	public $class = null;
 
 	/**
 	 * Active Node?
+	 *
+	 * @var  boolean
 	 */
 	public $active = false;
 
 	/**
 	 * Parent node
-	 * @var    object
+	 *
+	 * @var  JMenuNode
 	 */
 	protected $_parent = null;
 
 	/**
 	 * Array of Children
 	 *
-	 * @var    array
+	 * @var  array
 	 */
 	protected $_children = array();
 
+	/**
+	 * Constructor
+	 *
+	 * @param   string   $title      Node title
+	 * @param   string   $link       Node link
+	 * @param   string   $class      CSS Class for node
+	 * @param   boolean  $active     Active node
+	 * @param   string   $target     Link target
+	 * @param   string   $titleicon  Icon for the title
+	 */
 	public function __construct($title, $link = null, $class = null, $active = false, $target = null, $titleicon = null)
 	{
-		$this->title	= $titleicon ? $title . $titleicon : $title;
-		$this->link		= JFilterOutput::ampReplace($link);
-		$this->class	= $class;
-		$this->active	= $active;
+		$this->title  = $titleicon ? $title . $titleicon : $title;
+		$this->link   = JFilterOutput::ampReplace($link);
+		$this->class  = $class;
+		$this->active = $active;
 
 		$this->id = null;
 
 		if (!empty($link) && $link !== '#')
 		{
-			$uri = new JUri($link);
+			$uri   = new JUri($link);
 			$params = $uri->getQuery(true);
-			$parts = array();
+			$parts  = array();
 
 			foreach ($params as $value)
 			{
@@ -367,7 +406,7 @@ class JMenuNode extends JObject
 			$this->id = implode('-', $parts);
 		}
 
-		$this->target	= $target;
+		$this->target = $target;
 	}
 
 	/**
@@ -413,7 +452,7 @@ class JMenuNode extends JObject
 	/**
 	 * Get the children of this node
 	 *
-	 * @return  array    The children
+	 * @return  array  The children
 	 */
 	public function &getChildren()
 	{
@@ -423,7 +462,7 @@ class JMenuNode extends JObject
 	/**
 	 * Get the parent of this node
 	 *
-	 * @return  mixed   JMenuNode object with the parent or null for no parent
+	 * @return  mixed  JMenuNode object with the parent or null for no parent
 	 */
 	public function &getParent()
 	{

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -16,15 +16,11 @@ $showhelp = $params->get('showhelp', 1);
 $user = JFactory::getUser();
 $lang = JFactory::getLanguage();
 
-/**
- * Site SubMenu
-**/
-$menu->addChild(
-	new JMenuNode(JText::_('MOD_MENU_SYSTEM'), '#'), true
-);
-$menu->addChild(
-	new JMenuNode(JText::_('MOD_MENU_CONTROL_PANEL'), 'index.php', 'class:cpanel')
-);
+/*
+ * Site Submenu
+ */
+$menu->addChild(new JMenuNode(JText::_('MOD_MENU_SYSTEM'), '#'), true);
+$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CONTROL_PANEL'), 'index.php', 'class:cpanel'));
 
 $menu->addSeparator();
 
@@ -37,12 +33,10 @@ if ($user->authorise('core.admin'))
 $chm = $user->authorise('core.manage', 'com_checkin');
 $cam = $user->authorise('core.manage', 'com_cache');
 
-if ($chm || $cam )
+if ($chm || $cam)
 {
 	// Keep this for when bootstrap supports submenus?
-	/* $menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MAINTENANCE'), 'index.php?option=com_checkin', 'class:maintenance'), true
-	);*/
+	// $menu->addChild(new JMenuNode(JText::_('MOD_MENU_MAINTENANCE'), 'index.php?option=com_checkin', 'class:maintenance'), true);
 
 	if ($chm)
 	{
@@ -55,7 +49,6 @@ if ($chm || $cam )
 		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CLEAR_CACHE'), 'index.php?option=com_cache', 'class:clear'));
 		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_PURGE_EXPIRED_CACHE'), 'index.php?option=com_cache&view=purge', 'class:purge'));
 	}
-
 	// $menu->getParent();
 }
 
@@ -63,115 +56,92 @@ $menu->addSeparator();
 
 if ($user->authorise('core.admin'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_SYSTEM_INFORMATION'), 'index.php?option=com_admin&view=sysinfo', 'class:info')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_SYSTEM_INFORMATION'), 'index.php?option=com_admin&view=sysinfo', 'class:info'));
 }
 
 $menu->getParent();
 
-/**
+/*
  * Users Submenu
-**/
+ */
 if ($user->authorise('core.manage', 'com_users'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_USERS'), '#'), true
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_USERS'), '#'), true);
 	$createUser = $shownew && $user->authorise('core.create', 'com_users');
-	$createGrp = $user->authorise('core.admin', 'com_users');
+	$createGrp  = $user->authorise('core.admin', 'com_users');
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_USER_MANAGER'), 'index.php?option=com_users&view=users', 'class:user'), $createUser
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_USER_MANAGER'), 'index.php?option=com_users&view=users', 'class:user'), $createUser);
 
 	if ($createUser)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_USER'), 'index.php?option=com_users&task=user.add', 'class:newarticle')
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_USER'), 'index.php?option=com_users&task=user.add', 'class:newarticle'));
 		$menu->getParent();
 	}
 
 	if ($createGrp)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_GROUPS'), 'index.php?option=com_users&view=groups', 'class:groups'), $createUser
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_GROUPS'), 'index.php?option=com_users&view=groups', 'class:groups'), $createUser);
 
 		if ($createUser)
 		{
-			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_GROUP'), 'index.php?option=com_users&task=group.add', 'class:newarticle')
-			);
+			$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_GROUP'), 'index.php?option=com_users&task=group.add', 'class:newarticle'));
 			$menu->getParent();
 		}
 
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_LEVELS'), 'index.php?option=com_users&view=levels', 'class:levels'), $createUser
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_LEVELS'), 'index.php?option=com_users&view=levels', 'class:levels'), $createUser);
 
 		if ($createUser)
 		{
-			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_LEVEL'), 'index.php?option=com_users&task=level.add', 'class:newarticle')
-			);
+			$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_LEVEL'), 'index.php?option=com_users&task=level.add', 'class:newarticle'));
 			$menu->getParent();
 		}
 	}
 
 	$menu->addSeparator();
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTES'), 'index.php?option=com_users&view=notes', 'class:user-note'), $createUser
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTES'), 'index.php?option=com_users&view=notes', 'class:user-note'), $createUser);
 
 	if ($createUser)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_NOTE'), 'index.php?option=com_users&task=note.add', 'class:newarticle')
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_USERS_ADD_NOTE'), 'index.php?option=com_users&task=note.add', 'class:newarticle'));
 		$menu->getParent();
 	}
 
 	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_USERS_NOTE_CATEGORIES'), 'index.php?option=com_categories&view=categories&extension=com_users', 'class:category'), $createUser
+		new JMenuNode(
+			JText::_('MOD_MENU_COM_USERS_NOTE_CATEGORIES'), 'index.php?option=com_categories&view=categories&extension=com_users', 'class:category'),
+		$createUser
 	);
 
 	if ($createUser)
 	{
 		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users.notes', 'class:newarticle')
+			new JMenuNode(
+				JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_users.notes',
+				'class:newarticle'
+			)
 		);
 		$menu->getParent();
 	}
 
 	$menu->addSeparator();
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MASS_MAIL_USERS'), 'index.php?option=com_users&view=mail', 'class:massmail')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MASS_MAIL_USERS'), 'index.php?option=com_users&view=mail', 'class:massmail'));
 
 	$menu->getParent();
 }
 
-/**
+/*
  * Menus Submenu
-**/
+ */
 if ($user->authorise('core.manage', 'com_menus'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true);
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu);
 
 	if ($createMenu)
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit', 'class:newarticle')
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit', 'class:newarticle'));
 		$menu->getParent();
 	}
 
@@ -192,7 +162,9 @@ if ($user->authorise('core.manage', 'com_menus'))
 		}
 		elseif ($menuType->home > 1)
 		{
-			$titleicon = ' <span>'.JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, array('title' => JText::_('MOD_MENU_HOME_MULTIPLE')), true).'</span>';
+			$titleicon = ' <span>'
+				. JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, array('title' => JText::_('MOD_MENU_HOME_MULTIPLE')), true)
+				. '</span>';
 		}
 		else
 		{
@@ -200,22 +172,29 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 			if (!$image)
 			{
-				$titleicon = ' <span>' . JHtml::_('image', 'mod_languages/icon-16-language.png', $alt, array('title' => $menuType->title_native), true) . '</span>';
+				$image = JHtml::_('image', 'mod_languages/icon-16-language.png', $alt, array('title' => $menuType->title_native), true);
 			}
 			else
 			{
-				$titleicon = ' <span>' . JHtml::_('image', 'mod_languages/' . $menuType->image . '.gif', $alt, array('title' => $menuType->title_native), true) . '</span>';
+				$image = JHtml::_('image', 'mod_languages/' . $menuType->image . '.gif', $alt, array('title' => $menuType->title_native), true);
 			}
+
+			$titleicon = ' <span>' . $image . '</span>';
 		}
 
 		$menu->addChild(
-			new JMenuNode($menuType->title,	'index.php?option=com_menus&view=items&menutype='.$menuType->menutype, 'class:menu', null, null, $titleicon), $createMenu
+			new JMenuNode(
+				$menuType->title, 'index.php?option=com_menus&view=items&menutype=' . $menuType->menutype, 'class:menu', null, null, $titleicon
+			),
+			$createMenu
 		);
 
 		if ($createMenu)
 		{
 			$menu->addChild(
-				new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU_ITEM'), 'index.php?option=com_menus&view=item&layout=edit&menutype='.$menuType->menutype, 'class:newarticle')
+				new JMenuNode(
+					JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU_ITEM'), 'index.php?option=com_menus&view=item&layout=edit&menutype=' . $menuType->menutype,
+					'class:newarticle')
 			);
 			$menu->getParent();
 		}
@@ -223,42 +202,37 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->getParent();
 }
 
-/**
+/*
  * Content Submenu
-**/
+ */
 if ($user->authorise('core.manage', 'com_content'))
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT'), '#'), true
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT'), '#'), true);
 	$createContent = $shownew && $user->authorise('core.create', 'com_content');
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_ARTICLE_MANAGER'), 'index.php?option=com_content', 'class:article'), $createContent);
+
+	if ($createContent)
+	{
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_ARTICLE'), 'index.php?option=com_content&task=article.add', 'class:newarticle'));
+		$menu->getParent();
+	}
+
 	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_ARTICLE_MANAGER'), 'index.php?option=com_content', 'class:article'), $createContent
+		new JMenuNode(
+			JText::_('MOD_MENU_COM_CONTENT_CATEGORY_MANAGER'), 'index.php?option=com_categories&extension=com_content', 'class:category'),
+		$createContent
 	);
 
 	if ($createContent)
 	{
 		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_ARTICLE'), 'index.php?option=com_content&task=article.add', 'class:newarticle')
+			new JMenuNode(
+				JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_content', 'class:newarticle')
 		);
 		$menu->getParent();
 	}
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_CATEGORY_MANAGER'), 'index.php?option=com_categories&extension=com_content', 'class:category'), $createContent
-	);
-
-	if ($createContent)
-	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_NEW_CATEGORY'), 'index.php?option=com_categories&task=category.add&extension=com_content', 'class:newarticle')
-		);
-		$menu->getParent();
-	}
-
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured', 'class:featured')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured', 'class:featured'));
 	$menu->addSeparator();
 
 	if ($user->authorise('core.manage', 'com_media'))
@@ -269,9 +243,9 @@ if ($user->authorise('core.manage', 'com_content'))
 	$menu->getParent();
 }
 
-/**
+/*
  * Components Submenu
-**/
+ */
 
 // Get the authorised components and sub-menus.
 $components = ModMenuHelper::getComponents(true);
@@ -294,7 +268,6 @@ if ($components)
 			}
 
 			$menu->getParent();
-
 		}
 		else
 		{
@@ -305,9 +278,9 @@ if ($components)
 	$menu->getParent();
 }
 
-/**
+/*
  * Extensions Submenu
-**/
+ */
 $im = $user->authorise('core.manage', 'com_installer');
 $mm = $user->authorise('core.manage', 'com_modules');
 $pm = $user->authorise('core.manage', 'com_plugins');
@@ -347,28 +320,20 @@ if ($im || $mm || $pm || $tm || $lm)
 	$menu->getParent();
 }
 
-/**
+/*
  * Help Submenu
-**/
+ */
 if ($showhelp == 1)
 {
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP'), '#'), true
-	);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_JOOMLA'), 'index.php?option=com_admin&view=help', 'class:help')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP'), '#'), true);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_JOOMLA'), 'index.php?option=com_admin&view=help', 'class:help'));
 	$menu->addSeparator();
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM'), 'http://forum.joomla.org', 'class:help-forum', false, '_blank')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM'), 'http://forum.joomla.org', 'class:help-forum', false, '_blank'));
 
 	if ($forum_url = $params->get('forum_url'))
 	{
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM'), $forum_url, 'class:help-forum', false, '_blank')
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM'), $forum_url, 'class:help-forum', false, '_blank'));
 	}
 
 	$debug = $lang->setDebug(false);
@@ -377,37 +342,23 @@ if ($showhelp == 1)
 	{
 		$forum_url = 'http://forum.joomla.org/viewforum.php?f=' . (int) JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE');
 		$lang->setDebug($debug);
-		$menu->addChild(
-			new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM'), $forum_url, 'class:help-forum', false, '_blank')
-		);
+		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM'), $forum_url, 'class:help-forum', false, '_blank'));
 	}
 
 	$lang->setDebug($debug);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_DOCUMENTATION'), 'http://docs.joomla.org', 'class:help-docs', false, '_blank')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_DOCUMENTATION'), 'http://docs.joomla.org', 'class:help-docs', false, '_blank'));
 	$menu->addSeparator();
 
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_EXTENSIONS'), 'http://extensions.joomla.org', 'class:help-jed', false, '_blank')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_EXTENSIONS'), 'http://extensions.joomla.org', 'class:help-jed', false, '_blank'));
 	$menu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_TRANSLATIONS'), 'http://community.joomla.org/translations.html', 'class:help-trans', false, '_blank')
 	);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_RESOURCES'), 'http://resources.joomla.org', 'class:help-jrd', false, '_blank')
-	);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_COMMUNITY'), 'http://community.joomla.org', 'class:help-community', false, '_blank')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_RESOURCES'), 'http://resources.joomla.org', 'class:help-jrd', false, '_blank'));
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_COMMUNITY'), 'http://community.joomla.org', 'class:help-community', false, '_blank'));
 	$menu->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_SECURITY'), 'http://developer.joomla.org/security.html', 'class:help-security', false, '_blank')
 	);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_DEVELOPER'), 'http://developer.joomla.org', 'class:help-dev', false, '_blank')
-	);
-	$menu->addChild(
-		new JMenuNode(JText::_('MOD_MENU_HELP_SHOP'), 'http://shop.joomla.org', 'class:help-shop', false, '_blank')
-	);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_DEVELOPER'), 'http://developer.joomla.org', 'class:help-dev', false, '_blank'));
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_SHOP'), 'http://shop.joomla.org', 'class:help-shop', false, '_blank'));
 	$menu->getParent();
 }

--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -10,6 +10,8 @@
 defined('_JEXEC') or die;
 
 /**
+ * Helper class for admin stats module
+ *
  * @package     Joomla.Administrator
  * @subpackage  mod_stats_admin
  * @since       3.0
@@ -19,7 +21,7 @@ class ModStatsHelper
 	/**
 	 * Method to retrieve information about the site
 	 *
-	 * @param   JObject  $params  Params object
+	 * @param   JObject  &$params  Params object
 	 *
 	 * @return  array  Array containing site information
 	 *
@@ -38,6 +40,7 @@ class ModStatsHelper
 		$increase   = $params->get('increase');
 
 		$i = 0;
+
 		if ($serverinfo)
 		{
 			$rows[$i]        = new stdClass;

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -51,7 +51,7 @@ if ($task == 'edit' || $task == 'editA' || $input->getInt('hidemainmenu'))
 	$logoutLink = JRoute::_('index.php?option=com_login&task=logout&' . JSession::getFormToken() . '=1');
 }
 if ($params->get('show_logout', 1)) :
-	$output[] = '<div class="btn-group logout">' . ($hideLinks ? '' : '<a href="' . $logoutLink.'"><i class="icon-minus-2"></i> ') . JText::_('JLOGOUT') . ($hideLinks ? '' : '</a>') . '</div>';
+	$output[] = '<div class="btn-group logout">' . ($hideLinks ? '' : '<a href="' . $logoutLink . '"><i class="icon-minus-2"></i> ') . JText::_('JLOGOUT') . ($hideLinks ? '' : '</a>') . '</div>';
 endif;
 
 // Output the items.

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -31,7 +31,9 @@
  <rule ref="Generic.Files.LineEndings"/>
  <rule ref="Generic.Files.LineLength">
 	 <!-- These exceptions are temporary -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
@@ -120,14 +122,18 @@
 
  <rule ref="Joomla.Classes.MethodScope">
   <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.Commenting.FunctionComment">
   <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
@@ -138,7 +144,9 @@
 
  <rule ref="Joomla.Commenting.SingleComment">
   <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
@@ -150,14 +158,15 @@
  <rule ref="Joomla.Commenting.ClassComment">
   <!-- We exclude components and modules for now -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-  <exclude-pattern type="relative">administrator/modules/*</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.WhiteSpace.ConcatenationSpacing">
   <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
@@ -168,7 +177,9 @@
 
  <rule ref="Joomla.ControlStructures.ControlSignature">
   <!-- We only want this for libraries, languages and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>
@@ -193,7 +204,9 @@
 
  <rule ref="Joomla.ControlStructures.MultiLineCondition">
   <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/application.php</exclude-pattern>
+  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">plugins/*</exclude-pattern>
   <exclude-pattern type="relative">modules/*</exclude-pattern>


### PR DESCRIPTION
This PR fixes all reportable PHPCS issues in the admin app outside the `components` folder and `application.php` and `framework.php` files in the `includes` folder (as reported at http://mbabker.github.io/jcms-codestyle/).  In doing this, I've also changed the exceptions on the `administrator` folder so that only the files previously specified as not touched (and templates, which are permanently exempted from most rules) are still exempt from specified rules.
