### PR TITLE
Adding checks to assert ->checked_out is set to JModelForm

### DIFF
--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -55,7 +55,7 @@ abstract class JModelForm extends JModelLegacy
 			}
 
 			// Check if this is the user having previously checked out the row.
-			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))
+			if (isset( $table->checked_out ) && $table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))
 			{
 				$this->setError(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'));
 				return false;


### PR DESCRIPTION
Fixing issue described in bug 30700 (http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30700), related to notices for unset properties of the $table object in JModelForm (libraries/legacy/model/form.php)
