### PR TITLE
2.5.x bug 30857

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -97,6 +97,7 @@ class JUpdaterCollection extends JUpdateAdapter
 	{
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
+
 		// Reset the data
 		if (isset($this->$tag))
 		{	

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -98,7 +98,11 @@ class JUpdaterCollection extends JUpdateAdapter
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
 		// Reset the data
-		eval('$this->' . $tag . '->_data = "";');
+		if (isset($this->$tag))
+		{	
+			$this->$tag->_data = "";
+		}
+		
 		switch ($name)
 		{
 			case 'CATEGORY':

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -35,7 +35,10 @@ class JUpdaterExtension extends JUpdateAdapter
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
 		// reset the data
-		eval('$this->' . $tag . '->_data = "";');
+		if (isset($this->$tag))
+		{
+			$this->$tag->_data = '';
+		}
 
 		switch ($name)
 		{


### PR DESCRIPTION
Removed 'eval' usage, added validation if tag is set in  libraries/joomla/updater/adapters/collection.php , like it's done in the master branch with 3.x ver
