### PR TITLE
Keeping open tab after page reload or save and not going back to first tab

### DIFF
--- a/administrator/components/com_admin/admin.php
+++ b/administrator/components/com_admin/admin.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 // No access check.
 

--- a/administrator/components/com_banners/banners.php
+++ b/administrator/components/com_banners/banners.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_banners'))
 {

--- a/administrator/components/com_categories/categories.php
+++ b/administrator/components/com_categories/categories.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 $input = JFactory::getApplication()->input;
 

--- a/administrator/components/com_config/config.php
+++ b/administrator/components/com_config/config.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 // Access checks are done internally because of different requirements for the two controllers.
 

--- a/administrator/components/com_contact/contact.php
+++ b/administrator/components/com_contact/contact.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_contact'))
 {

--- a/administrator/components/com_content/content.php
+++ b/administrator/components/com_content/content.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_content'))
 {

--- a/administrator/components/com_installer/installer.php
+++ b/administrator/components/com_installer/installer.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_installer'))
 {

--- a/administrator/components/com_languages/languages.php
+++ b/administrator/components/com_languages/languages.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_languages'))
 {

--- a/administrator/components/com_menus/menus.php
+++ b/administrator/components/com_menus/menus.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_menus'))
 {

--- a/administrator/components/com_modules/modules.php
+++ b/administrator/components/com_modules/modules.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_modules'))
 {

--- a/administrator/components/com_newsfeeds/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/newsfeeds.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_newsfeeds'))
 {

--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 {

--- a/administrator/components/com_tags/tags.php
+++ b/administrator/components/com_tags/tags.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 $input = JFactory::getApplication()->input;
 

--- a/administrator/components/com_templates/templates.php
+++ b/administrator/components/com_templates/templates.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_templates'))
 {

--- a/administrator/components/com_users/users.php
+++ b/administrator/components/com_users/users.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_users'))
 {

--- a/administrator/components/com_weblinks/weblinks.php
+++ b/administrator/components/com_weblinks/weblinks.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_weblinks'))
 {

--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.tabstate');
 
 require_once JPATH_COMPONENT.'/helpers/route.php';
 require_once JPATH_COMPONENT.'/helpers/query.php';

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -778,4 +778,29 @@ abstract class JHtmlBehavior
 			. ' Calendar._SMN = ' . json_encode($months_short) . ';'
 			. ' Calendar._TT = ' . json_encode($text) . ';';
 	}
+
+	/**
+	 * Add unobtrusive JavaScript support for a keeping tab state.
+	 *
+	 * Note that keeping tab state only work for inner tabs if the convension in accordance with the following example
+	 * parent tab = permissions
+	 * child tab = permission-<identifier>
+	 *
+	 * Each tab header "a" tag also should have a unique href attribute
+	 * 
+	 * @return  void
+	 *
+	 * @since   3.0
+	 */
+	public static function tabstate()
+	{
+		if (isset(self::$loaded[__METHOD__]))
+		{
+			return;
+		}
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/tabs-state.js', true, true);
+		self::$loaded[__METHOD__] = true;
+	}
 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -1,0 +1,42 @@
+/**
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * JavaScript behavior to allow selected tab to be remained after save or page reload
+ * keeping state in localstorage
+ */
+
+jQuery(function() {
+    
+    var loadTab = function() {
+        var $ = jQuery.noConflict();
+
+        jQuery(document).find('a[data-toggle="tab"]').on('click', function(e) {
+            // Store the selected tab href in localstorage
+            window.localStorage.setItem('tab-href', $(e.target).attr('href'));
+        });
+
+        var activateTab = function(href) {
+            var $el = $('a[data-toggle="tab"]a[href*=' + href + ']');
+            $el.tab('show');
+        }
+        if (localStorage.getItem('tab-href')) {
+            // Clean default tabs
+            $('a[data-toggle="tab"]').parent().removeClass('active');
+            var tabhref = localStorage.getItem('tab-href');
+            // Add active attribute for selected tab indicated by url
+            activateTab(tabhref);
+            // Check whether internal tab is selected (in format <tabname>-<id>)
+            var seperatorIndex = tabhref.indexOf('-');
+            if (seperatorIndex !== -1) {
+                var singular = tabhref.substring(0, seperatorIndex);
+                var plural = singular + "s";
+                activateTab(plural);
+            }
+        }
+    }
+    setTimeout(loadTab, 100);
+
+});


### PR DESCRIPTION
This is a fix to keep the table state even after save and reload and not to go back to the first tab

Note:
This PR does not include the usage of this function within different pages, and it needs to be selected out whether to use throughout the CMS or for specific pages.

To include the tab state save to a page, use the following include script
JHtml::_('behavior.tabstate');

@Tested for administrator section com_config
