### PR TITLE
add JHtml::_('behavior.tabstate') to file config.php in administrator/co...

### DIFF
--- a/administrator/components/com_config/config.php
+++ b/administrator/components/com_config/config.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-
+JHtml::_('behavior.tabstate');
 // Access checks are done internally because of different requirements for the two controllers.
 
 // Tell the browser not to cache this page.

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -778,4 +778,29 @@ abstract class JHtmlBehavior
 			. ' Calendar._SMN = ' . json_encode($months_short) . ';'
 			. ' Calendar._TT = ' . json_encode($text) . ';';
 	}
+
+	/**
+	 * Add unobtrusive JavaScript support for a keeping tab state.
+	 *
+	 * Note that keeping tab state only work for inner tabs if the convension in accordance with the following example
+	 * parent tab = permissions
+	 * child tab = permission-<identifier>
+	 *
+	 * Each tab header "a" tag also should have a unique href attribute
+	 * 
+	 * @return  void
+	 *
+	 * @since   3.0
+	 */
+	public static function tabstate()
+	{
+		if (isset(self::$loaded[__METHOD__]))
+		{
+			return;
+		}
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/tabs-state.js', true, true);
+		self::$loaded[__METHOD__] = true;
+	}
 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -1,0 +1,42 @@
+/**
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * JavaScript behavior to allow selected tab to be remained after save or page reload
+ * keeping state in localstorage
+ */
+
+jQuery(function() {
+    
+    var loadTab = function() {
+        var $ = jQuery.noConflict();
+
+        jQuery(document).find('a[data-toggle="tab"]').on('click', function(e) {
+            // Store the selected tab href in localstorage
+            window.localStorage.setItem('tab-href', $(e.target).attr('href'));
+        });
+
+        var activateTab = function(href) {
+            var $el = $('a[data-toggle="tab"]a[href*=' + href + ']');
+            $el.tab('show');
+        }
+        if (localStorage.getItem('tab-href')) {
+            // Clean default tabs
+            $('a[data-toggle="tab"]').parent().removeClass('active');
+            var tabhref = localStorage.getItem('tab-href');
+            // Add active attribute for selected tab indicated by url
+            activateTab(tabhref);
+            // Check whether internal tab is selected (in format <tabname>-<id>)
+            var seperatorIndex = tabhref.indexOf('-');
+            if (seperatorIndex !== -1) {
+                var singular = tabhref.substring(0, seperatorIndex);
+                var plural = singular + "s";
+                activateTab(plural);
+            }
+        }
+    }
+    setTimeout(loadTab, 100);
+
+});


### PR DESCRIPTION
Add JHtml::_('behavior.tabstate') to file config.php in administrator/components/com_config/config.php

Fixed: Keep the table state even after save and reload and not to go back to the first tab
