### PR TITLE
 [#31368] jdoc:include tag fails on type "component" and "head" without space before "/>"

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -643,7 +643,7 @@ class JDocumentHTML extends JDocument
 	{
 		$matches = array();
 
-		if (preg_match_all('#<jdoc:include\ type="([^"]+)" (.*)\/>#iU', $this->_template, $matches))
+		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)\/>#iU', $this->_template, $matches))
 		{
 			$template_tags_first = array();
 			$template_tags_last = array();


### PR DESCRIPTION
Resolved [#31368] jdoc:include tag fails on type "component" and "head" without space before "/>"

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31368
