### PR TITLE
Extending backend validation for usernames, introduced trimming

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -184,7 +184,10 @@ class JTableUser extends JTable
 			return false;
 		}
 
-		if (preg_match("#[<>\"'%;()&]#i", $this->username) || strlen(utf8_decode($this->username)) < 2)
+		$this->username = trim($this->username);
+		if (strlen(utf8_decode($this->username)) < 2
+			|| preg_match("#[<>\"'%;()&\s\\\]#i", $this->username)
+			|| preg_match("#\.\./#i", $this->username))
 		{
 			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_VALID_AZ09', 2));
 			return false;


### PR DESCRIPTION
Extended backend username validation and trimmed the username to ensure validation according to the stated rules:

Please enter a valid username. No spaces, at least 2 characters and must not contain the following characters: < > \ " ' % ; ( ) &

Also, added validation for potentially exploiting  usernames, such as user../etc/passwd/name.

See tracker issue http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30586
