### PR TITLE
[#28243] Fix for issue #28243 - remove the remember me option from the offline.php page (3.x)

### DIFF
--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -48,10 +48,6 @@ $app = JFactory::getApplication();
 			<label for="passwd"><?php echo JText::_('JGLOBAL_PASSWORD') ?></label>
 			<input type="password" name="password" class="inputbox" size="18" alt="<?php echo JText::_('JGLOBAL_PASSWORD') ?>" id="passwd" />
 		</p>
-		<p id="form-login-remember">
-			<label for="remember"><?php echo JText::_('JGLOBAL_REMEMBER_ME') ?></label>
-			<input type="checkbox" name="remember" class="inputbox" value="yes" alt="<?php echo JText::_('JGLOBAL_REMEMBER_ME') ?>" id="remember" />
-		</p>
 		<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGIN') ?>" />
 		<input type="hidden" name="option" value="com_users" />
 		<input type="hidden" name="task" value="user.login" />


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28243
As suggested by Brian Teeman and Dennis Hermatski, the correct
solution is to remove the « remember me » option from the offline.php page, as admin can be always auto-logged and forget that site is actually offline.
