### PR TITLE
 [#27476] Menu types view not sorted alphabetically

### DIFF
--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -156,6 +156,7 @@ class MenusModelMenutypes extends JModelLegacy
 			// Create the menu option for the component.
 			$o = new JObject;
 			$o->title		= (string) $menu['name'];
+			$o->type        = (string) $menu['name'];
 			$o->description	= (string) $menu['msg'];
 			$o->request		= array('option' => $component);
 
@@ -189,6 +190,7 @@ class MenusModelMenutypes extends JModelLegacy
 					// Create the menu option for the component.
 					$o = new JObject;
 					$o->title		= (string) $child['name'];
+					$o->type        = (string) $child['name'];
 					$o->description	= (string) $child['msg'];
 					$o->request		= array('option' => $component, (string) $optionsNode['var'] => (string) $child['value']);
 
@@ -199,6 +201,7 @@ class MenusModelMenutypes extends JModelLegacy
 					// Create the menu option for the component.
 					$o = new JObject;
 					$o->title		= (string) $child['name'];
+					$o->type        = (string) $child['name'];
 					$o->description	= (string) $child['msg'];
 					$o->request		= array('option' => $component);
 
@@ -268,6 +271,7 @@ class MenusModelMenutypes extends JModelLegacy
 											// Create the menu option for the component.
 											$o = new JObject;
 											$o->title		= (string) $child['name'];
+											$o->type        = (string) $child['name'];
 											$o->description	= (string) $child['msg'];
 											$o->request		= array('option' => $component, 'view' => $view, (string) $optionsNode['var'] => (string) $child['value']);
 
@@ -278,6 +282,7 @@ class MenusModelMenutypes extends JModelLegacy
 											// Create the menu option for the component.
 											$o = new JObject;
 											$o->title		= (string) $child['name'];
+											$o->type        = (string) $child['name'];
 											$o->description	= (string) $child['msg'];
 											$o->request		= array('option' => $component, 'view' => $view);
 
@@ -378,6 +383,7 @@ class MenusModelMenutypes extends JModelLegacy
 				// Create the menu option for the layout.
 				$o = new JObject;
 				$o->title		= ucfirst($layout);
+				$o->type        = ucfirst($layout);
 				$o->description	= '';
 				$o->request		= array('option' => $component, 'view' => $view);
 
@@ -411,6 +417,12 @@ class MenusModelMenutypes extends JModelLegacy
 							if (!empty($menu['title']))
 							{
 								$o->title = trim((string) $menu['title']);
+							}
+							
+							// Populate type if they exist.
+							if (!empty($menu['type']))
+							{
+								$o->type = trim((string) $menu['title']);
 							}
 
 							if (!empty($menu->message[0]))

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -31,12 +31,12 @@ $document = JFactory::getDocument();
 	<?php
 		$i = 0;
 		foreach ($this->types as $name => $list) : ?>
-		<?php echo JHtml::_('bootstrap.addSlide', 'collapseTypes', JText::_($name), 'collapse' . $i++); ?>
+		<?php echo JHtml::_('bootstrap.addSlide', 'collapseTypes', $name, 'collapse' . $i++); ?>
 			<ul class="nav nav-tabs nav-stacked">
 				<?php foreach ($list as $item) : ?>
 					<li>
 						<a class="choose_type" href="#" title="<?php echo JText::_($item->description); ?>"
-							onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => $item->title, 'request' => $item->request))); ?>')">
+							onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => $item->type, 'request' => $item->request))); ?>')">
 							<?php echo JText::_($item->title);?> <small class="muted"><?php echo JText::_($item->description); ?></small>
 						</a>
 					</li>
@@ -44,28 +44,4 @@ $document = JFactory::getDocument();
 			</ul>
 		<?php echo JHtml::_('bootstrap.endSlide'); ?>
 	<?php endforeach; ?>
-	<?php echo JHtml::_('bootstrap.addSlide', 'collapseTypes', JText::_('COM_MENUS_TYPE_SYSTEM'), 'collapse-system'); ?>
-		<ul class="nav nav-tabs nav-stacked">
-			<li><a class="choose_type" href="#" title="<?php echo JText::_('COM_MENUS_TYPE_EXTERNAL_URL_DESC'); ?>"
-					onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => 'url'))); ?>')">
-					<?php echo JText::_('COM_MENUS_TYPE_EXTERNAL_URL'); ?> <small class="muted"><?php echo JText::_('COM_MENUS_TYPE_EXTERNAL_URL_DESC'); ?></small>
-				</a>
-			</li>
-			<li><a class="choose_type" href="#" title="<?php echo JText::_('COM_MENUS_TYPE_ALIAS_DESC'); ?>"
-					onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => 'alias'))); ?>')">
-					<?php echo JText::_('COM_MENUS_TYPE_ALIAS'); ?> <small class="muted"><?php echo JText::_('COM_MENUS_TYPE_ALIAS_DESC'); ?></small>
-				</a>
-			</li>
-			<li><a class="choose_type" href="#" title="<?php echo JText::_('COM_MENUS_TYPE_SEPARATOR_DESC'); ?>"
-					onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => 'separator'))); ?>')">
-					<?php echo JText::_('COM_MENUS_TYPE_SEPARATOR'); ?> <small class="muted"><?php echo JText::_('COM_MENUS_TYPE_SEPARATOR_DESC'); ?></small>
-				</a>
-			</li>
-			<li><a class="choose_type" href="#" title="<?php echo JText::_('COM_MENUS_TYPE_HEADING_DESC'); ?>"
-					onclick="javascript:setmenutype('<?php echo base64_encode(json_encode(array('id' => $this->recordId, 'title' => 'heading'))); ?>')">
-					<?php echo JText::_('COM_MENUS_TYPE_HEADING'); ?> <small class="muted"><?php echo JText::_('COM_MENUS_TYPE_HEADING_DESC'); ?></small>
-				</a>
-			</li>
-		</ul>
-	<?php echo JHtml::_('bootstrap.endSlide'); ?>
 <?php echo JHtml::_('bootstrap.endAccordion'); ?>

--- a/administrator/components/com_menus/views/menutypes/view.html.php
+++ b/administrator/components/com_menus/views/menutypes/view.html.php
@@ -25,7 +25,47 @@ class MenusViewMenutypes extends JViewLegacy
 	{
 		$input = JFactory::getApplication()->input;
 		$this->recordId = $input->getInt('recordId');
-		$this->types    = $this->get('TypeOptions');
+		$types = $this->get('TypeOptions');
+		
+		//Adding System Links
+		$list = array();
+		$o = new JObject;
+		$o->title		= 'COM_MENUS_TYPE_EXTERNAL_URL';
+		$o->type 		= 'url';
+		$o->description	= 'COM_MENUS_TYPE_EXTERNAL_URL_DESC';
+		$o->request		= null;
+		$list[] = $o;
+		
+		$o = new JObject;
+		$o->title		= 'COM_MENUS_TYPE_ALIAS';
+		$o->type 		= 'alias';
+		$o->description	= 'COM_MENUS_TYPE_ALIAS_DESC';
+		$o->request		= null;
+		$list[] = $o;
+		
+		$o = new JObject;
+		$o->title		= 'COM_MENUS_TYPE_SEPARATOR';
+		$o->type 		= 'separator';
+		$o->description	= 'COM_MENUS_TYPE_SEPARATOR_DESC';
+		$o->request		= null;
+		$list[] = $o;
+		
+		$o = new JObject;
+		$o->title		= 'COM_MENUS_TYPE_HEADING';
+		$o->type 		= 'heading';
+		$o->description	= 'COM_MENUS_TYPE_HEADING_DESC';
+		$o->request		= null;
+		$list[] = $o;
+		$types['COM_MENUS_TYPE_SYSTEM'] = $list;
+		
+		// The list must be in alphabetic ordering based on label, JText::_(component_name)
+		$orderedtypes = array();
+		foreach($types as $name => $list) {
+			$orderedtypes[JText::_($name)] = $list;
+		}
+		ksort($orderedtypes);
+		
+		$this->types = $orderedtypes;
 
 		$this->addToolbar();
 


### PR DESCRIPTION
In the default.php the system links were handled separely. To be able to sort them I change the code and add a item->type to be able to support "the specific case of system links which title should be equals to url,alias,etc;..
