### PR TITLE
Language Debug at the administrator login  [#31174] 

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6663,11 +6663,8 @@ body {
 }
 .view-login .container {
 	width: 300px;
-	position: absolute;
 	top: 50%;
 	left: 50%;
-	margin-top: -206px;
-	margin-left: -150px;
 }
 .view-login .navbar-fixed-bottom {
 	padding-left: 20px;
@@ -6900,9 +6897,6 @@ h6 {
 	color: #fff;
 }
 .container-main,
-#system-debug {
-	padding-bottom: 50px;
-}
 #status {
 	background: #EDEDED;
 	border-top: 1px solid #DDDDDD;


### PR DESCRIPTION
...  'Debug language ON and Debug System OFF' made a property appear and not in other configurations (f.e.: Debug System ON and Debug language OFF).

This affected to the display of main container view-login class. Some properties are overridden so the screen position of the debug container changes.

Relative on: [#31174] Language Debug at the administrator login
