### PR TITLE
Fixcount: Fixed bug #31455: Regression on #31278: Improve counting of results in querie

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -140,6 +140,10 @@ class JDatabaseQueryElement
  * @method      string  q()   q($text, $escape = true)  Alias for quote method
  * @method      string  qn()  qs($name, $as = null)     Alias for quoteName method
  * @method      string  e()   e($text, $extra = false)   Alias for escape method
+ * @property-read   JDatabaseQueryElement  $type
+ * @property-read   JDatabaseQueryElement  $select
+ * @property-read   JDatabaseQueryElement  $group
+ * @property-read   JDatabaseQueryElement  $having
  */
 abstract class JDatabaseQuery
 {
@@ -382,8 +386,8 @@ abstract class JDatabaseQuery
 				break;
 
 			case 'unionAll':
-					$query .= (string) $this->unionAll;
-					break;
+				$query .= (string) $this->unionAll;
+				break;
 
 			case 'delete':
 				$query .= (string) $this->delete;
@@ -878,6 +882,8 @@ abstract class JDatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
+	 * @throws  RuntimeException
+	 *
 	 * @since   11.1
 	 */
 	public function from($tables, $subQueryAlias = null)
@@ -1033,18 +1039,6 @@ abstract class JDatabaseQuery
 	}
 
 	/**
-	 * Gets the columns of the GROUP clause of the query
-	 *
-	 * @return  array   (array of strings: string[])
-	 *
-	 * @since   CMS 3.1.2
-	 */
-	public function getGroup()
-	{
-		return (is_null($this->group) ? array() : $this->group->getElements());
-	}
-
-	/**
 	 * A conditions to the HAVING clause of the query.
 	 *
 	 * Usage:
@@ -1070,18 +1064,6 @@ abstract class JDatabaseQuery
 		}
 
 		return $this;
-	}
-
-	/**
-	 * Gets the columns of the HAVING clause of the query
-	 *
-	 * @return  array   (array of strings: string[])
-	 *
-	 * @since   CMS 3.1.2
-	 */
-	public function getHaving()
-	{
-		return (is_null($this->having) ? array() : $this->having->getElements());
 	}
 
 	/**

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -101,7 +101,7 @@ class JDatabaseQueryElement
 	/**
 	 * Gets the elements of this element.
 	 *
-	 * @return  string
+	 * @return  array
 	 *
 	 * @since   11.1
 	 */
@@ -1033,6 +1033,18 @@ abstract class JDatabaseQuery
 	}
 
 	/**
+	 * Gets the columns of the GROUP clause of the query
+	 *
+	 * @return  array   (array of strings: string[])
+	 *
+	 * @since   CMS 3.1.2
+	 */
+	public function getGroup()
+	{
+		return (is_null($this->group) ? array() : $this->group->getElements());
+	}
+
+	/**
 	 * A conditions to the HAVING clause of the query.
 	 *
 	 * Usage:
@@ -1058,6 +1070,18 @@ abstract class JDatabaseQuery
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Gets the columns of the HAVING clause of the query
+	 *
+	 * @return  array   (array of strings: string[])
+	 *
+	 * @since   CMS 3.1.2
+	 */
+	public function getHaving()
+	{
+		return (is_null($this->having) ? array() : $this->having->getElements());
 	}
 
 	/**

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -314,8 +314,11 @@ abstract class JModelLegacy extends JObject
 	 */
 	protected function _getListCount($query)
 	{
-		// Use fast COUNT(*) on JDatabaseQuery objects if there no GROUP BY clause:
-		if ($query instanceof JDatabaseQuery && count($query->getGroup()) == 0 && count($query->getHaving()) == 0)
+		// Use fast COUNT(*) on JDatabaseQuery objects if there no GROUP BY or HAVING clause:
+		if ($query instanceof JDatabaseQuery
+			&& $query->type == 'select'
+			&& $query->group === null
+			&& $query->having === null)
 		{
 			$query = clone $query;
 			$query->clear('select')->clear('order')->select('COUNT(*)');

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -314,8 +314,8 @@ abstract class JModelLegacy extends JObject
 	 */
 	protected function _getListCount($query)
 	{
-		// Use fast COUNT(*) on JDatabaseQuery objects.
-		if ($query instanceof JDatabaseQuery)
+		// Use fast COUNT(*) on JDatabaseQuery objects if there no GROUP BY clause:
+		if ($query instanceof JDatabaseQuery && count($query->getGroup()) == 0 && count($query->getHaving()) == 0)
 		{
 			$query = clone $query;
 			$query->clear('select')->clear('order')->select('COUNT(*)');


### PR DESCRIPTION
Added condition that query that gets modified with COUNT(*) instead of loading all rows must not have any GROUP BY nor HAVING statement (and be of type 'select').

That fixes the bug #31455 : http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31455
Which is a regression of fix #31278 : http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31278
