### PR TITLE
[#31072] I think there should be set the pointer to the end as plugin indexing

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -203,7 +203,6 @@ class JEventDispatcher extends JObject
 				}
 			}
 
-			
 			$methods = array($observer['event']);
 		}
 		else

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -203,8 +203,7 @@ class JEventDispatcher extends JObject
 				}
 			}
 
-			$this->_observers[] = $observer;
-			end($this->_observers);
+			
 			$methods = array($observer['event']);
 		}
 		else
@@ -225,11 +224,11 @@ class JEventDispatcher extends JObject
 				}
 			}
 
-			$this->_observers[] = $observer;
 			$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
-			end($this->_observers);
 		}
 
+		$this->_observers[] = $observer;
+		end($this->_observers);
 		$key = key($this->_observers);
 
 		foreach ($methods as $method)

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -227,6 +227,7 @@ class JEventDispatcher extends JObject
 
 			$this->_observers[] = $observer;
 			$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
+			end($this->_observers);
 		}
 
 		$key = key($this->_observers);


### PR DESCRIPTION
will be unsynced with the methods array.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31072

When a custom plugin loaded by:
JPluginHelper::importPlugin('test', 'mytestplugin');

There is an indexing issue in JEventDispatcher::attach method. The $observer parameter is NOT array, so it skip into the else state and there is a missing end pointer setup on the $this->_observers array. So when the next step get out key($this->_observers), it gets the previous plugin index, which will result failer of the loaded plugin.

Old code:

$this->_observers[] = $observer;
$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));

The code should be like this:

$this->_observers[] = $observer;
$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
end($this->_observers);
