### PR TITLE
Fix #31339 (Tags backwards-compatibility issue) through #31488 (a clean observer implmentation in JTable)

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -674,14 +674,14 @@ class CategoriesModelCategory extends JModelAdmin
 				$table->reset();
 				$table->load($pk);
 				$tags = array($value);
-				//$typeAlias = $table->get('tagsHelper')->typeAlias;
-				$typeAlias = $table->extension . '.category';
-				$table->get('tagsHelper')->typeAlias = $typeAlias;
 
-				$oldTags = $table->get('tagsHelper')->getTagIds($pk, $typeAlias);
-				$table->get('tagsHelper')->oldTags = $oldTags;
+				/**
+				 * @var  JTableObserverTags  $tagsObserver
+				 */
+				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
+				$result = $tagsObserver->setNewTags($tags, false);
 
-				if (!$table->get('tagsHelper')->postStoreProcess($table, $tags, false))
+				if (!$result)
 				{
 					$this->setError($table->getError());
 

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -16,14 +16,6 @@ defined('_JEXEC') or die;
 class ContactTableContact extends JTable
 {
 	/**
-	 * Helper object for storing and deleting tag information.
-	 *
-	 * @var    JHelperTags
-	 * @since  3.1
-	 */
-	protected $tagsHelper = null;
-
-	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  &$db  Database connector object
@@ -33,8 +25,9 @@ class ContactTableContact extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__contact_details', 'id', $db);
-		$this->tagsHelper = new JHelperTags;
-		$this->tagsHelper->typeAlias = 'com_contact.contact';
+
+		// Sets up the tags observer in $this
+		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_contact.contact');
 	}
 
 	/**
@@ -63,22 +56,6 @@ class ContactTableContact extends JTable
 		}
 
 		return parent::bind($array, $ignore);
-	}
-
-	/**
-	 * Override parent delete method to delete tags information.
-	 *
-	 * @param   integer  $pk  Primary key to delete.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   3.1
-	 * @throws  UnexpectedValueException
-	 */
-	public function delete($pk = null)
-	{
-		$result = parent::delete($pk);
-		return $result && $this->tagsHelper->deleteTagData($this, $pk);
 	}
 
 	/**
@@ -156,12 +133,8 @@ class ContactTableContact extends JTable
 			return false;
 		}
 
-		$this->tagsHelper->preStoreProcess($this);
-		$result = parent::store($updateNulls);
-
-		$this->newTags = isset($this->newTags) ? $this->newTags : array();
-		return $result && $this->tagsHelper->postStoreProcess($this, $this->newTags);
-		}
+		return parent::store($updateNulls);
+	}
 
 	/**
 	 * Overloaded check function

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -25,9 +25,6 @@ class ContactTableContact extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__contact_details', 'id', $db);
-
-		// Sets up the tags observer in $this
-		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_contact.contact');
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -23,9 +23,6 @@ class NewsfeedsTableNewsfeed extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__newsfeeds', 'id', $db);
-
-		// Sets up the tags observer in $this
-		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_newsfeeds.newsfeed');
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -16,14 +16,6 @@ defined('_JEXEC') or die;
 class NewsfeedsTableNewsfeed extends JTable
 {
 	/**
-	 * Helper object for storing and deleting tag information.
-	 *
-	 * @var    JHelperTags
-	 * @since  3.1
-	 */
-	protected $tagsHelper = null;
-
-	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  &$db  A database connector object
@@ -31,8 +23,9 @@ class NewsfeedsTableNewsfeed extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__newsfeeds', 'id', $db);
-		$this->tagsHelper = new JHelperTags;
-		$this->tagsHelper->typeAlias = 'com_newsfeeds.newsfeed';
+
+		// Sets up the tags observer in $this
+		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_newsfeeds.newsfeed');
 	}
 
 	/**
@@ -134,23 +127,6 @@ class NewsfeedsTableNewsfeed extends JTable
 	}
 
 	/**
-	 * Override parent delete method to delete tags information.
-	 *
-	 * @param   integer  $pk  Primary key to delete.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   3.1
-	 * @throws  UnexpectedValueException
-	 */
-	public function delete($pk = null)
-	{
-		$result = parent::delete($pk);
-		$this->tagsHelper->typeAlias = 'com_newsfeeds.newsfeed';
-		return $result && $this->tagsHelper->deleteTagData($this, $pk);
-	}
-
-	/**
 	 * Overriden JTable::store to set modified data.
 	 *
 	 * @param   boolean	 $updateNulls  True to update fields even if they are null.
@@ -193,11 +169,6 @@ class NewsfeedsTableNewsfeed extends JTable
 		// Save links as punycode.
 		$this->link = JStringPunycode::urlToPunycode($this->link);
 
-		$this->tagsHelper->typeAlias = 'com_newsfeeds.newsfeed';
-		$this->tagsHelper->preStoreProcess($this);
-		$result = parent::store($updateNulls);
-
-		$this->newTags = isset($this->newTags) ? $this->newTags : array();
-		return $result && $this->tagsHelper->postStoreProcess($this, $this->newTags);
+		return parent::store($updateNulls);
 	}
 }

--- a/administrator/components/com_weblinks/tables/weblink.php
+++ b/administrator/components/com_weblinks/tables/weblink.php
@@ -26,9 +26,6 @@ class WeblinksTableWeblink extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__weblinks', 'id', $db);
-
-		// Sets up the tags observer in $this
-		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_weblinks.weblink');
 	}
 
 	/**

--- a/administrator/components/com_weblinks/tables/weblink.php
+++ b/administrator/components/com_weblinks/tables/weblink.php
@@ -19,14 +19,6 @@ defined('_JEXEC') or die;
 class WeblinksTableWeblink extends JTable
 {
 	/**
-	 * Helper object for storing and deleting tag information.
-	 *
-	 * @var    JHelperTags
-	 * @since  3.1
-	 */
-	protected $tagsHelper = null;
-
-	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  &$db  A database connector object
@@ -35,8 +27,8 @@ class WeblinksTableWeblink extends JTable
 	{
 		parent::__construct('#__weblinks', 'id', $db);
 
-		$this->tagsHelper = new JHelperTags;
-		$this->tagsHelper->typeAlias = 'com_weblinks.weblink';
+		// Sets up the tags observer in $this
+		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_weblinks.weblink');
 	}
 
 	/**
@@ -132,11 +124,7 @@ class WeblinksTableWeblink extends JTable
 		// Convert IDN urls to punycode
 		$this->url = JStringPunycode::urlToPunycode($this->url);
 
-		$this->tagsHelper->preStoreProcess($this);
-		$result = parent::store($updateNulls);
-
-		$this->newTags = isset($this->newTags) ? $this->newTags : array();
-		return $result && $this->tagsHelper->postStoreProcess($this, $this->newTags);
+		return parent::store($updateNulls);
 	}
 
 	/**
@@ -207,22 +195,6 @@ class WeblinksTableWeblink extends JTable
 		}
 
 		return true;
-	}
-
-	/**
-	 * Override parent delete method to delete tags information.
-	 *
-	 * @param   integer  $pk  Primary key to delete.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   3.1
-	 * @throws  UnexpectedValueException
-	 */
-	public function delete($pk = null)
-	{
-		$result = parent::delete($pk);
-		return $result && $this->tagsHelper->deleteTagData($this, $pk);
 	}
 
 	/**

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -69,33 +69,35 @@ class TagsViewTag extends JViewLegacy
 				$itemElement->params->merge($temp);
 				$itemElement->params = (array) json_decode($itemElement->params);
 			}
-			foreach ($items as $itemElement)
+			if ($items !== false)
 			{
-				$itemElement->event = new stdClass;
-
-				// For some plugins.
-				!empty($itemElement->core_body)? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
-
-				$dispatcher = JEventDispatcher::getInstance();
-
-				JPluginHelper::importPlugin('content');
-				$dispatcher->trigger('onContentPrepare', array ('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
-
-				$results = $dispatcher->trigger('onContentAfterTitle', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
-				$itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
-
-				$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
-				$itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
-
-				$results = $dispatcher->trigger('onContentAfterDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
-				$itemElement->event->afterDisplayContent = trim(implode("\n", $results));
-
-				if ($itemElement->text)
+				foreach ($items as $itemElement)
 				{
-					$itemElement->core_body = $itemElement->text;
+					$itemElement->event = new stdClass;
+
+					// For some plugins.
+					!empty($itemElement->core_body)? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
+
+					$dispatcher = JEventDispatcher::getInstance();
+
+					JPluginHelper::importPlugin('content');
+					$dispatcher->trigger('onContentPrepare', array ('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
+
+					$results = $dispatcher->trigger('onContentAfterTitle', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
+					$itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
+
+					$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
+					$itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
+
+					$results = $dispatcher->trigger('onContentAfterDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
+					$itemElement->event->afterDisplayContent = trim(implode("\n", $results));
+
+					if ($itemElement->text)
+					{
+						$itemElement->core_body = $itemElement->text;
+					}
 				}
 			}
-
 		}
 
 		$this->state      = &$state;

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -58,3 +58,11 @@ JLoader::register('JInstallerPackage',  JPATH_PLATFORM . '/cms/installer/adapter
 JLoader::register('JInstallerPlugin',  JPATH_PLATFORM . '/cms/installer/adapter/plugin.php');
 JLoader::register('JInstallerTemplate',  JPATH_PLATFORM . '/cms/installer/adapter/template.php');
 JLoader::register('JExtension',  JPATH_PLATFORM . '/cms/installer/extension.php');
+
+// Register Observers:
+// Add Tags to Content, Contact, NewsFeeds, WebLinks and Categories: (this is the only link between them here!):
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'ContactTableContact', array('typeAlias' => 'com_contact.contact'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'NewsfeedsTableNewsfeed', array('typeAlias' => 'com_newsfeeds.newsfeed'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'WeblinksTableWeblink', array('typeAlias' => 'com_weblinks.weblink'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableCategory', array('typeAlias' => '{extension}.category'));

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -775,7 +775,7 @@ class JHelperTags
 		$newTable = clone $table;
 		$newTable->reset();
 		$key = $newTable->getKeyName();
-		$typeAlias = $newTable->get('tagsHelper')->typeAlias;
+		$typeAlias = $this->typeAlias;
 
 		$result = true;
 
@@ -834,7 +834,7 @@ class JHelperTags
 		$oldTable = clone $table;
 		$oldTable->reset();
 		$key = $oldTable->getKeyName();
-		$typeAlias = $oldTable->get('tagsHelper')->typeAlias;
+		$typeAlias = $this->typeAlias;
 
 		if ($oldTable->$key && $oldTable->load())
 		{
@@ -971,7 +971,7 @@ class JHelperTags
 	public function tagItem($ucmId, $table, $tags = array(), $replace = true)
 	{
 		$key = $table->get('_tbl_key');
-		$oldTags = $table->get('tagsHelper')->getTagIds((int) $table->$key, $table->get('tagsHelper')->typeAlias);
+		$oldTags = $this->getTagIds((int) $table->$key, $this->typeAlias);
 		$oldTags = explode(',', $oldTags);
 		$result = $this->unTagItem($ucmId, $table);
 

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -347,6 +347,9 @@ class JHelperTags
 	{
 		$result = $this->unTagItem($contentItemId, $table);
 
+		/**
+		 * @var JTableCorecontent $ucmContentTable
+		 */
 		$ucmContentTable = JTable::getInstance('Corecontent');
 
 		return $result && $ucmContentTable->deleteByContentId($contentItemId);
@@ -763,6 +766,11 @@ class JHelperTags
 	 */
 	public function postStoreProcess($table, $newTags = array(), $replace = true)
 	{
+		if (!empty($table->newTags) && empty($newTags))
+		{
+				$newTags = $table->newTags;
+		}
+
 		// If existing row, check to see if tags have changed.
 		$newTable = clone $table;
 		$newTable->reset();
@@ -784,6 +792,7 @@ class JHelperTags
 			{
 				// Process the tags
 				$rowdata = new JHelperContent;
+
 				$data = $rowdata->getRowData($table);
 				$ucmContentTable = JTable::getInstance('Corecontent');
 

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -760,7 +760,7 @@ class JHelperTags
 	 * @param   array    $newTags  Array of new tags
 	 * @param   boolean  $replace  Flag indicating if all exising tags should be replaced
 	 *
-	 * @return  null
+	 * @return  boolean
 	 *
 	 * @since   3.1
 	 */

--- a/libraries/joomla/observer/index.html
+++ b/libraries/joomla/observer/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -273,15 +273,22 @@ class JObserverMapper
 	 * Adds a mapping to observe $observerClass subjects with $observableClass observer/listener, attaching it on creation with $params
 	 * on $observableClass instance creations
 	 *
-	 * @param   string  $observerClass    The name of the observer class (implementing JObserverInterface)
-	 * @param   string  $observableClass  The name of the observable class (implementing JObservableInterface)
-	 * @param   array   $params           The params to give to the JObserverInterface::createObserver() function
+	 * @param   string         $observerClass    The name of the observer class (implementing JObserverInterface)
+	 * @param   string         $observableClass  The name of the observable class (implementing JObservableInterface)
+	 * @param   array|boolean  $params           The params to give to the JObserverInterface::createObserver() function, or false to remove mapping
 	 *
 	 * @return  void
 	 */
 	public static function addObserverClassToClass($observerClass, $observableClass, $params = array())
 	{
-		static::$observations[$observableClass][$observerClass] = $params;
+		if ($params !== false)
+		{
+			static::$observations[$observableClass][$observerClass] = $params;
+		}
+		else
+		{
+			unset(static::$observations[$observableClass][$observerClass]);
+		}
 	}
 
 	/**

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Table
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Observable Subject pattern interface for Joomla
+ *
+ * @package     Joomla
+ * @subpackage  Observer
+ * @link        http://docs.joomla.org/JObservableInterface
+ * @since       3.1.2
+ */
+interface JObservableInterface
+{
+	/**
+	 * Adds an observer to this JTable instance.
+	 * Ideally, this method should be called fron the constructor of JTableObserver
+	 * which should be instanciated by the constructor of $this.
+	 *
+	 * @param    JObserverInterface   $observer
+	 *
+	 * @return   void
+	 */
+	public function attachObserver(JObserverInterface $observer);
+
+}
+
+/**
+ * Observer pattern interface for Joomla
+ *
+ * @package     Joomla
+ * @subpackage  Observer
+ * @link        http://docs.joomla.org/JObserverInterface
+ * @since       3.1.2
+ */
+interface JObserverInterface
+{
+	/**
+	 * Creates the associated observer instance and attaches it to the $observableObject
+	 *
+	 * @param   JObservableInterface   $observableObject
+	 * @param   array                  $params
+	 *
+	 * @return  JObserverInterface
+	 */
+	public static function createObserver(JObservableInterface $observableObject, $params = array());
+}
+
+/**
+ * Observer mapping pattern implementation for Joomla
+ *
+ * @package     Joomla
+ * @subpackage  Observer
+ * @link        http://docs.joomla.org/JObserverMapper
+ * @since       3.1.2
+ */
+class JObserverMapper
+{
+	/**
+	 * The observed table
+	 *
+	 * @var   JTable
+	 */
+	protected $table;
+
+	protected static $observations = array();
+
+	/**
+	 * Constructor: Associates to $table $this observer
+	 *
+	 * @param   JTable   $table
+	 */
+	public function __construct(JTable $table)
+	{
+		$table->attachObserver($this);
+		$this->table = $table;
+	}
+
+	/**
+	 * Adds a mapping to observe $observerClass subjects with $observableClass observer/listener, attaching it on creation with $params
+	 * on $observableClass instance creations
+	 *
+	 * @param   string   $observerClass
+	 * @param   string   $observableClass
+	 * @param   array    $params
+	 *
+	 * @return  void
+	 */
+	public static function addObserverClassToClass($observerClass, $observableClass, $params = array())
+	{
+		static::$observations[$observableClass][$observerClass] = $params;
+	}
+
+	/**
+	 * Attaches all applicable observers to an $observableObject
+	 *
+	 * @param   JObservableInterface   $observableObject
+	 *
+	 * @return  void
+	 */
+	public static function attachAllObservers(JObservableInterface $observableObject)
+	{
+		$observableClass = get_class($observableObject);
+		while ($observableClass != false)
+		{
+			static::attachObserversToAnObservable($observableClass, $observableObject);
+			$observableClass = get_parent_class($observableClass);
+		}
+	}
+
+	/**
+	 * Internal method
+	 * Goes through mappings for a given observable class and attaches all corresponding observer classes to it.
+	 * It does check also for all parent classes as well.
+	 *
+	 * @param   string                 $observableClass
+	 * @param   JObservableInterface   $observableObject
+	 *
+	 * @return  void
+	 */
+	protected static function attachObserversToAnObservable($observableClass, JObservableInterface $observableObject)
+	{
+		if (isset(static::$observations[$observableClass]))
+		{
+			foreach (static::$observations[$observableClass] as $observerClass => $params)
+			{
+				static::attachObserverToObservable($observerClass, $observableObject, $params);
+			}
+		}
+	}
+
+	/**
+	 * Internal method
+	 * Attaches a observer to an observable subject
+	 *
+	 * @param   string                 $observerClass     (of type JObserverInterface)
+	 * @param   JObservableInterface   $observableObject
+	 * @param   array                  $params
+	 *
+	 * @return  void
+	 */
+	protected static function attachObserverToObservable($observerClass, JObservableInterface $observableObject, $params)
+	{
+		/**
+		 * @var JObserverInterface $observerClass
+		 */
+		$observerClass::createObserver($observableObject, $params);
+	}
+}
+

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -46,9 +46,9 @@ interface JObservableInterface
 	 * which should be instanciated by JObserverMapper.
 	 * The implementation of this function can use JObserverUpdater
 	 *
-	 * @param    JObserverInterface   $observer
+	 * @param   JObserverInterface  $observer  The observer to attach to $this observable subject
 	 *
-	 * @return   void
+	 * @return  void
 	 */
 	public function attachObserver(JObserverInterface $observer);
 }
@@ -95,8 +95,8 @@ interface JObserverInterface
 	/**
 	 * Creates the associated observer instance and attaches it to the $observableObject
 	 *
-	 * @param   JObservableInterface   $observableObject
-	 * @param   array                  $params
+	 * @param   JObservableInterface  $observableObject  The observable subject object
+	 * @param   array                 $params            Params for this observer
 	 *
 	 * @return  JObserverInterface
 	 */
@@ -116,14 +116,14 @@ interface JObserverUpdaterInterface
 	/**
 	 * Constructor
 	 *
-	 * @param   JObservableInterface   $observable
+	 * @param   JObservableInterface  $observable  The observable subject object
 	 */
 	public function __construct(JObservableInterface $observable);
 	/**
 	 * Adds an observer to the JObservableInterface instance updated by this
 	 * This method can be called fron JObservableInterface::attachObserver
 	 *
-	 * @param    JObserverInterface   $observer
+	 * @param   JObserverInterface  $observer  The observer object
 	 *
 	 * @return   void
 	 */
@@ -132,8 +132,8 @@ interface JObserverUpdaterInterface
 	/**
 	 * Call all observers for $event with $params
 	 *
-	 * @param   string   $event
-	 * @param   array    $params
+	 * @param   string  $event   Event name (function name in observer)
+	 * @param   array   $params  Params of event (params in observer function)
 	 *
 	 * @return  void
 	 */
@@ -142,9 +142,9 @@ interface JObserverUpdaterInterface
 	/**
 	 * Enable/Disable calling of observers (this is useful when calling parent:: function
 	 *
-	 * @param   boolean   $enabled
+	 * @param   boolean  $enabled  Enable (true) or Disable (false) the observer events
 	 *
-	 * @return  boolean   Returns old state
+	 * @return  boolean  Returns old state
 	 */
 	public function doCallObservers($enabled);
 }
@@ -175,7 +175,7 @@ class JObserverUpdater implements JObserverUpdaterInterface
 	/**
 	 * Constructor
 	 *
-	 * @param   JObservableInterface   $observable
+	 * @param   JObservableInterface  $observable  The observable subject object
 	 */
 	public function __construct(JObservableInterface $observable)
 	{
@@ -186,9 +186,9 @@ class JObserverUpdater implements JObserverUpdaterInterface
 	 * Adds an observer to the JObservableInterface instance updated by this
 	 * This method can be called fron JObservableInterface::attachObserver
 	 *
-	 * @param    JObserverInterface   $observer
+	 * @param   JObserverInterface  $observer  The observer object
 	 *
-	 * @return   void
+	 * @return  void
 	 */
 	public function attachObserver(JObserverInterface $observer)
 	{
@@ -198,10 +198,9 @@ class JObserverUpdater implements JObserverUpdaterInterface
 	/**
 	 * Gets the instance of the observer of class $observerClass
 	 *
-	 * @param    string          $observerClass
+	 * @param   string  $observerClass  The class name of the observer
 	 *
-	 * @return   JTableObserver|null
-	 *
+	 * @return  JTableObserver|null  The observer object of this class if any
 	 */
 	public function getObserverOfClass($observerClass)
 	{
@@ -209,14 +208,15 @@ class JObserverUpdater implements JObserverUpdaterInterface
 		{
 			return $this->observers[$observerClass];
 		}
+
 		return null;
 	}
 
 	/**
 	 * Call all observers for $event with $params
 	 *
-	 * @param   string   $event
-	 * @param   array    $params
+	 * @param   string  $event   Name of the event
+	 * @param   array   $params  Params of the event
 	 *
 	 * @return  void
 	 */
@@ -227,6 +227,7 @@ class JObserverUpdater implements JObserverUpdaterInterface
 			foreach ($this->observers as $observer)
 			{
 				$eventListener = array($observer, $event);
+
 				if (is_callable($eventListener))
 				{
 					call_user_func_array($eventListener, $params);
@@ -238,14 +239,15 @@ class JObserverUpdater implements JObserverUpdaterInterface
 	/**
 	 * Enable/Disable calling of observers (this is useful when calling parent:: function
 	 *
-	 * @param   boolean   $enabled
+	 * @param   boolean  $enabled  Enable (true) or Disable (false) the observer events
 	 *
-	 * @return  boolean   Returns old state
+	 * @return  boolean  Returns old state
 	 */
 	public function doCallObservers($enabled)
 	{
 		$oldState = $this->doCallObservers;
 		$this->doCallObservers = $enabled;
+
 		return $oldState;
 	}
 }
@@ -271,9 +273,9 @@ class JObserverMapper
 	 * Adds a mapping to observe $observerClass subjects with $observableClass observer/listener, attaching it on creation with $params
 	 * on $observableClass instance creations
 	 *
-	 * @param   string   $observerClass
-	 * @param   string   $observableClass
-	 * @param   array    $params
+	 * @param   string  $observerClass    The name of the observer class (implementing JObserverInterface)
+	 * @param   string  $observableClass  The name of the observable class (implementing JObservableInterface)
+	 * @param   array   $params           The params to give to the JObserverInterface::createObserver() function
 	 *
 	 * @return  void
 	 */
@@ -285,13 +287,14 @@ class JObserverMapper
 	/**
 	 * Attaches all applicable observers to an $observableObject
 	 *
-	 * @param   JObservableInterface   $observableObject
+	 * @param   JObservableInterface  $observableObject  The observable subject object
 	 *
 	 * @return  void
 	 */
 	public static function attachAllObservers(JObservableInterface $observableObject)
 	{
 		$observableClass = get_class($observableObject);
+
 		while ($observableClass != false)
 		{
 			// Attach applicable Observers for the class to the Observable subject:
@@ -306,6 +309,8 @@ class JObserverMapper
 					$observerClass::createObserver($observableObject, $params);
 				}
 			}
+
+			// Get parent class name (or false if none), and redo the above on it:
 			$observableClass = get_parent_class($observableClass);
 		}
 	}

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -119,6 +119,7 @@ interface JObserverUpdaterInterface
 	 * @param   JObservableInterface  $observable  The observable subject object
 	 */
 	public function __construct(JObservableInterface $observable);
+
 	/**
 	 * Adds an observer to the JObservableInterface instance updated by this
 	 * This method can be called fron JObservableInterface::attachObserver

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -1,13 +1,16 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Table
+ * @subpackage  Observer
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 defined('JPATH_PLATFORM') or die;
+
+// The 3 interfaces and 1 class below could be in their own file but will be used only after
+// JObserverMapper is autoloaded, so can stay here for now.
 
 /**
  * Observable Subject pattern interface for Joomla
@@ -20,16 +23,16 @@ defined('JPATH_PLATFORM') or die;
 interface JObservableInterface
 {
 	/**
-	 * Adds an observer to this JTable instance.
-	 * Ideally, this method should be called fron the constructor of JTableObserver
-	 * which should be instanciated by the constructor of $this.
+	 * Adds an observer to this JObservableInterface instance.
+	 * Ideally, this method should be called fron the constructor of JObserverInterface
+	 * which should be instanciated by JObserverMapper.
+	 * The implementation of this function can use JObserverUpdater
 	 *
 	 * @param    JObserverInterface   $observer
 	 *
 	 * @return   void
 	 */
 	public function attachObserver(JObserverInterface $observer);
-
 }
 
 /**
@@ -54,6 +57,153 @@ interface JObserverInterface
 }
 
 /**
+ * Observer updater pattern implementation for Joomla
+ *
+ * @package     Joomla
+ * @subpackage  Observer
+ * @link        http://docs.joomla.org/JObserverUpdater
+ * @since       3.1.2
+ */
+interface JObserverUpdaterInterface
+{
+	/**
+	 * Constructor
+	 *
+	 * @param   JObservableInterface   $observable
+	 */
+	public function __construct(JObservableInterface $observable);
+	/**
+	 * Adds an observer to the JObservableInterface instance updated by this
+	 * This method can be called fron JObservableInterface::attachObserver
+	 *
+	 * @param    JObserverInterface   $observer
+	 *
+	 * @return   void
+	 */
+	public function attachObserver(JObserverInterface $observer);
+
+	/**
+	 * Call all observers for $event with $params
+	 *
+	 * @param   string   $event
+	 * @param   array    $params
+	 *
+	 * @return  void
+	 */
+	public function update($event, $params);
+
+	/**
+	 * Enable/Disable calling of observers (this is useful when calling parent:: function
+	 *
+	 * @param   boolean   $enabled
+	 *
+	 * @return  boolean   Returns old state
+	 */
+	public function doCallObservers($enabled);
+}
+
+/**
+ * Observer updater pattern implementation for Joomla
+ *
+ * @package     Joomla
+ * @subpackage  Observer
+ * @link        http://docs.joomla.org/JObserverUpdater
+ * @since       3.1.2
+ */
+class JObserverUpdater implements JObserverUpdaterInterface
+{
+	/**
+	 * Generic JObserverInterface observers for this JObservableInterface
+	 *
+	 * @var    JObserverInterface[]
+	 */
+	protected $observers = array();
+
+	/**
+	 * Process observers (useful when a class extends significantly an observerved method, and calls observers itself
+	 * @var    boolean
+	 */
+	protected $doCallObservers = true;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   JObservableInterface   $observable
+	 */
+	public function __construct(JObservableInterface $observable)
+	{
+		// Not yet needed, but possible:  $this->observable = $observable;
+	}
+
+	/**
+	 * Adds an observer to the JObservableInterface instance updated by this
+	 * This method can be called fron JObservableInterface::attachObserver
+	 *
+	 * @param    JObserverInterface   $observer
+	 *
+	 * @return   void
+	 */
+	public function attachObserver(JObserverInterface $observer)
+	{
+		$this->observers[get_class($observer)] = $observer;
+	}
+
+	/**
+	 * Gets the instance of the observer of class $observerClass
+	 *
+	 * @param    string          $observerClass
+	 *
+	 * @return   JTableObserver|null
+	 *
+	 */
+	public function getObserverOfClass($observerClass)
+	{
+		if (isset($this->observers[$observerClass]))
+		{
+			return $this->observers[$observerClass];
+		}
+		return null;
+	}
+
+	/**
+	 * Call all observers for $event with $params
+	 *
+	 * @param   string   $event
+	 * @param   array    $params
+	 *
+	 * @return  void
+	 */
+	public function update($event, $params)
+	{
+		if ($this->doCallObservers)
+		{
+			foreach ($this->observers as $observer)
+			{
+				$eventListener = array($observer, $event);
+				if (is_callable($eventListener))
+				{
+					call_user_func_array($eventListener, $params);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Enable/Disable calling of observers (this is useful when calling parent:: function
+	 *
+	 * @param   boolean   $enabled
+	 *
+	 * @return  boolean   Returns old state
+	 */
+	public function doCallObservers($enabled)
+	{
+		$oldState = $this->doCallObservers;
+		$this->doCallObservers = $enabled;
+		return $oldState;
+	}
+}
+
+/**
  * Observer mapping pattern implementation for Joomla
  *
  * @package     Joomla
@@ -64,24 +214,11 @@ interface JObserverInterface
 class JObserverMapper
 {
 	/**
-	 * The observed table
+	 * Array: array( JObservableInterface_classname => array( JObserverInterface_classname => array( paramname => param, .... ) ) )
 	 *
-	 * @var   JTable
+	 * @var array[]
 	 */
-	protected $table;
-
 	protected static $observations = array();
-
-	/**
-	 * Constructor: Associates to $table $this observer
-	 *
-	 * @param   JTable   $table
-	 */
-	public function __construct(JTable $table)
-	{
-		$table->attachObserver($this);
-		$this->table = $table;
-	}
 
 	/**
 	 * Adds a mapping to observe $observerClass subjects with $observableClass observer/listener, attaching it on creation with $params

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -110,48 +110,20 @@ class JObserverMapper
 		$observableClass = get_class($observableObject);
 		while ($observableClass != false)
 		{
-			static::attachObserversToAnObservable($observableClass, $observableObject);
+			// Attach applicable Observers for the class to the Observable subject:
+			if (isset(static::$observations[$observableClass]))
+			{
+				foreach (static::$observations[$observableClass] as $observerClass => $params)
+				{
+					// Attach an Observer to the Observable subject:
+					/**
+					 * @var JObserverInterface $observerClass
+					 */
+					$observerClass::createObserver($observableObject, $params);
+				}
+			}
 			$observableClass = get_parent_class($observableClass);
 		}
-	}
-
-	/**
-	 * Internal method
-	 * Goes through mappings for a given observable class and attaches all corresponding observer classes to it.
-	 * It does check also for all parent classes as well.
-	 *
-	 * @param   string                 $observableClass
-	 * @param   JObservableInterface   $observableObject
-	 *
-	 * @return  void
-	 */
-	protected static function attachObserversToAnObservable($observableClass, JObservableInterface $observableObject)
-	{
-		if (isset(static::$observations[$observableClass]))
-		{
-			foreach (static::$observations[$observableClass] as $observerClass => $params)
-			{
-				static::attachObserverToObservable($observerClass, $observableObject, $params);
-			}
-		}
-	}
-
-	/**
-	 * Internal method
-	 * Attaches a observer to an observable subject
-	 *
-	 * @param   string                 $observerClass     (of type JObserverInterface)
-	 * @param   JObservableInterface   $observableObject
-	 * @param   array                  $params
-	 *
-	 * @return  void
-	 */
-	protected static function attachObserverToObservable($observerClass, JObservableInterface $observableObject, $params)
-	{
-		/**
-		 * @var JObserverInterface $observerClass
-		 */
-		$observerClass::createObserver($observableObject, $params);
 	}
 }
 

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -15,6 +15,24 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Observable Subject pattern interface for Joomla
  *
+ * To make a class and its inheriting classes observable:
+ * 1) add: implements JObservableInterface
+ *    to its class
+ *
+ * 2) at the end of the constructor, add:
+ * // Create observer updater and attaches all observers interested by $this class:
+ * $this->_observers = new JObserverUpdater($this);
+ * JObserverMapper::attachAllObservers($this);
+ *
+ * 3) add the function attachObserver below to your class to add observers using the JObserverUpdater class:
+ * 	public function attachObserver(JObserverInterface $observer)
+ * 	{
+ * 		$this->_observers->attachObserver($observer);
+ * 	}
+ *
+ * 4) in the methods that need to be observed, add, e.g. (name of event, params of event):
+ * 		$this->_observers->update('onBeforeLoad', array($keys, $reset));
+ *
  * @package     Joomla
  * @subpackage  Observer
  * @link        http://docs.joomla.org/JObservableInterface
@@ -37,6 +55,35 @@ interface JObservableInterface
 
 /**
  * Observer pattern interface for Joomla
+ *
+ * A class that wants to observe another class must:
+ *
+ * 1) Add: implements JObserverInterface
+ *    to its class
+ *
+ * 2) Implement a constructor, that can look like this:
+ * 	public function __construct(JObservableInterface $observableObject)
+ * 	{
+ * 	    $observableObject->attachObserver($this);
+ *  	$this->observableObject = $observableObject;
+ * 	}
+ *
+ * 3) and must implement the instanciator function createObserver() below, e.g. as follows:
+ * 	public static function createObserver(JObservableInterface $observableObject, $params = array())
+ * 	{
+ * 	    $observer = new self($observableObject);
+ *      $observer->... = $params['...']; ...
+ * 	    return $observer;
+ * 	}
+ *
+ * 4) Then add functions corresponding to the events to be observed,
+ *    E.g. to respond to event: $this->_observers->update('onBeforeLoad', array($keys, $reset));
+ *    following function is needed in the obser:
+ *  public function onBeforeLoad($keys, $reset) { ... }
+ *
+ * 5) Finally, the binding is made outside the observable and observer classes, using:
+ * JObserverMapper::addObserverClassToClass('ObserverClassname', 'ObservableClassname', array('paramName' => 'paramValue'));
+ * where the last array will be provided to the observer instanciator function createObserver.
  *
  * @package     Joomla
  * @subpackage  Observer

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -263,4 +263,3 @@ class JObserverMapper
 		}
 	}
 }
-

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -698,6 +698,15 @@ class JTableNested extends JTable
 	{
 		$k = $this->_tbl_key;
 
+		// Pre-processing by observers
+		if ($this->_callObservers)
+		{
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onBeforeStore($updateNulls, $k);
+			}
+		}
+
 		// @codeCoverageIgnoreStart
 		if ($this->_debug)
 		{
@@ -819,11 +828,15 @@ class JTableNested extends JTable
 		}
 
 		// Store the row to the database.
+		$oldCallObservers = $this->_callObservers;
+		$this->_callObservers = false;
 		if (!parent::store($updateNulls))
 		{
+			$this->_callObservers = $oldCallObservers;
 			$this->_unlock();
 			return false;
 		}
+		$this->_callObservers = $oldCallObservers;
 
 		// @codeCoverageIgnoreStart
 		if ($this->_debug)
@@ -834,6 +847,15 @@ class JTableNested extends JTable
 
 		// Unlock the table for writing.
 		$this->_unlock();
+
+		// Post-processing by observers
+		if ($this->_callObservers)
+		{
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onAfterStore($result);
+			}
+		}
 
 		return true;
 	}

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -853,6 +853,7 @@ class JTableNested extends JTable
 		{
 			foreach ($this->_observers as $observer)
 			{
+				$result = true;
 				$observer->onAfterStore($result);
 			}
 		}

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @link        http://docs.joomla.org/JTableObserver
  * @since       3.1.2
  */
-abstract class JTableObserver
+abstract class JTableObserver implements JObserverInterface
 {
 	/**
 	 * The observed table
@@ -33,7 +33,7 @@ abstract class JTableObserver
 	 */
 	public function __construct(JTable $table)
 	{
-		$table->addObserver($this);
+		$table->attachObserver($this);
 		$this->table = $table;
 	}
 

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -26,6 +26,11 @@ abstract class JTableObserver
 	 */
 	protected $table;
 
+	/**
+	 * Constructor: Associates to $table $this observer
+	 *
+	 * @param   JTable   $table
+	 */
 	public function __construct(JTable $table)
 	{
 		$table->addObserver($this);

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Table
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Table class supporting modified pre-order tree traversal behavior.
+ *
+ * @package     Joomla
+ * @subpackage  Table
+ * @link        http://docs.joomla.org/JTableObserver
+ * @since       3.1.2
+ */
+abstract class JTableObserver
+{
+	/**
+	 * The observed table
+	 *
+	 * @var   JTable
+	 */
+	protected $table;
+
+	public function __construct(JTable $table)
+	{
+		$table->addObserver($this);
+		$this->table = $table;
+	}
+
+	/**
+	 * Pre-processor for $table->load($id)
+	 *
+	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.  If not
+	 *                           set the instance property value is used.
+	 * @param   boolean  $reset  True to reset the default values before loading the new row.
+	 *
+	 * @return  void
+	 */
+	public function onBeforeLoad($keys, $reset)
+	{
+	}
+
+	/**
+	 * Post-processor for $table->load($id)
+	 *
+	 * @param   boolean   $result   The result of the load
+	 * @param   array     $row      The loaded (and already binded to $this->table) row of the database table
+	 *
+	 * @return  void
+	 */
+	public function onAfterLoad(&$result, $row)
+	{
+	}
+
+	/**
+	 * Pre-processor for $table->store($id)
+	 *
+	 * @param   boolean   $updateNulls   The result of the load
+	 * @param   string    $tableKey      The key of the table
+	 *
+	 * @return  void
+	 */
+	public function onBeforeStore($updateNulls, $tableKey)
+	{
+	}
+
+	/**
+	 * Post-processor for $table->store($id)
+	 *
+	 * @param   boolean   $result   The result of the load
+	 */
+	public function onAfterStore(&$result)
+	{
+	}
+}

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -29,7 +29,7 @@ abstract class JTableObserver implements JObserverInterface
 	/**
 	 * Constructor: Associates to $table $this observer
 	 *
-	 * @param   JTable   $table
+	 * @param   JTable  $table  Table to be observed
 	 */
 	public function __construct(JTable $table)
 	{
@@ -53,8 +53,8 @@ abstract class JTableObserver implements JObserverInterface
 	/**
 	 * Post-processor for $table->load($keys, $reset)
 	 *
-	 * @param   boolean   $result   The result of the load
-	 * @param   array     $row      The loaded (and already binded to $this->table) row of the database table
+	 * @param   boolean  &$result  The result of the load
+	 * @param   array    $row      The loaded (and already binded to $this->table) row of the database table
 	 *
 	 * @return  void
 	 */
@@ -65,8 +65,8 @@ abstract class JTableObserver implements JObserverInterface
 	/**
 	 * Pre-processor for $table->store($updateNulls)
 	 *
-	 * @param   boolean   $updateNulls   The result of the load
-	 * @param   string    $tableKey      The key of the table
+	 * @param   boolean  $updateNulls  The result of the load
+	 * @param   string   $tableKey     The key of the table
 	 *
 	 * @return  void
 	 */
@@ -77,16 +77,19 @@ abstract class JTableObserver implements JObserverInterface
 	/**
 	 * Post-processor for $table->store($updateNulls)
 	 *
-	 * @param   boolean   $result   The result of the store
+	 * @param   boolean  &$result  The result of the store
+	 *
+	 * @return  void
 	 */
 	public function onAfterStore(&$result)
 	{
 	}
+
 	/**
 	 * Pre-processor for $table->delete($pk)
 	 *
-	 * @param   mixed    $pk         An optional primary key value to delete.  If not set the instance property value is used.
-	 * @param   string   $tableKey   The normal key of the table
+	 * @param   mixed   $pk        An optional primary key value to delete.  If not set the instance property value is used.
+	 * @param   string  $tableKey  The normal key of the table
 	 *
 	 * @return  void
 	 *
@@ -99,7 +102,9 @@ abstract class JTableObserver implements JObserverInterface
 	/**
 	 * Post-processor for $table->delete($pk)
 	 *
-	 * @param   mixed    $pk         The deleted primary key value.
+	 * @param   mixed  $pk  The deleted primary key value.
+	 *
+	 * @return  void
 	 */
 	public function onAfterDelete($pk)
 	{

--- a/libraries/joomla/table/observer/index.html
+++ b/libraries/joomla/table/observer/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -54,7 +54,7 @@ class JTableObserverTags extends JTableObserver
 	 * @deprecated Never use this
 	 * @private
 	 */
-	public static $myThisForPregReplace;
+	public static $_myTableForPregreplaceOnly;
 
 	/**
 	 * Creates the associated observer instance and attaches it to the $observableObject
@@ -153,10 +153,10 @@ class JTableObserverTags extends JTableObserver
 	protected function parseTypeAlias()
 	{
 		// Needed for PHP < 5.4.0 as it's not passing context $this to closure function
-		static::$myThisForPregReplace = $this->table;
+		static::$_myTableForPregreplaceOnly = $this->table;
 
 		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/',
-			function($matches) { return JTableObserverTags::$myThisForPregReplace->{$matches[1]}; },
+			function($matches) { return JTableObserverTags::$_myTableForPregreplaceOnly->{$matches[1]}; },
 			$this->typeAliasPattern
 		);
 	}

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -77,6 +77,7 @@ class JTableObserverTags extends JTableObserver
 
 	/**
 	 * Creates the associated tags helper class instance
+	 * $typeAlias can be of the form "{variableName}.type", automatically replacing {variableName} with table-instance variables variableName
 	 *
 	 * @param   JTable   $table
 	 * @param   string   $typeAlias   The type alias (null if set after initial binding like in categories)
@@ -91,6 +92,13 @@ class JTableObserverTags extends JTableObserver
 		return $observer;
 	}
 
+	/**
+	 * Internal method
+	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName
+	 * Storing result into $this->tagsHelper->typeAlias
+	 *
+	 * @return void
+	 */
 	protected function parseTypeAlias()
 	{
 		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->table->{$matches[1]}; }, $this->typeAliasPattern);

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -47,6 +47,16 @@ class JTableObserverTags extends JTableObserver
 	protected $replaceTags = true;
 
 	/**
+	 * Not public, so marking private and deprecated, but needed internally in parseTypeAlias for
+	 * PHP < 5.4.0 as it's not passing context $this to closure function.
+	 *
+	 * @var JTableObserverTags
+	 * @deprecated Never use this
+	 * @private
+	 */
+	public static $myThisForPregReplace;
+
+	/**
 	 * Creates the associated observer instance and attaches it to the $observableObject
 	 * Creates the associated tags helper class instance
 	 * $typeAlias can be of the form "{variableName}.type", automatically replacing {variableName} with table-instance variables variableName
@@ -142,8 +152,11 @@ class JTableObserverTags extends JTableObserver
 	 */
 	protected function parseTypeAlias()
 	{
+		// Needed for PHP < 5.4.0 as it's not passing context $this to closure function
+		static::$myThisForPregReplace = $this;
+
 		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/',
-			function($matches) { return $this->table->{$matches[1]}; },
+			function($matches) { return static::$myThisForPregReplace->table->{$matches[1]}; },
 			$this->typeAliasPattern
 		);
 	}

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -51,8 +51,8 @@ class JTableObserverTags extends JTableObserver
 	 * Creates the associated tags helper class instance
 	 * $typeAlias can be of the form "{variableName}.type", automatically replacing {variableName} with table-instance variables variableName
 	 *
-	 * @param   JObservableInterface|JTable   $observableObject
-	 * @param   array                         $params  ( 'typeAlias' => $typeAlias )
+	 * @param   JObservableInterface|JTable  $observableObject  The subject object to be observed
+	 * @param   array                        $params            ( 'typeAlias' => $typeAlias )
 	 *
 	 * @return  JObserverInterface|JTableObserverTags
 	 */
@@ -71,8 +71,8 @@ class JTableObserverTags extends JTableObserver
 	/**
 	 * Pre-processor for $table->store($updateNulls)
 	 *
-	 * @param   boolean   $updateNulls   The result of the load
-	 * @param   string    $tableKey      The key of the table
+	 * @param   boolean  $updateNulls  The result of the load
+	 * @param   string   $tableKey     The key of the table
 	 *
 	 * @return  void
 	 */
@@ -86,7 +86,9 @@ class JTableObserverTags extends JTableObserver
 	 * Post-processor for $table->store($updateNulls)
 	 * You can change optional params newTags and replaceTags of tagsHelper with method setNewTagsToAdd
 	 *
-	 * @param   boolean   $result   The result of the load
+	 * @param   boolean  &$result  The result of the load
+	 *
+	 * @return  void
 	 */
 	public function onAfterStore(&$result)
 	{
@@ -103,8 +105,8 @@ class JTableObserverTags extends JTableObserver
 	/**
 	 * Pre-processor for $table->delete($pk)
 	 *
-	 * @param   mixed    $pk         An optional primary key value to delete.  If not set the instance property value is used.
-	 * @param   string   $tableKey   The normal key of the table
+	 * @param   mixed   $pk        An optional primary key value to delete.  If not set the instance property value is used.
+	 * @param   string  $tableKey  The normal key of the table
 	 *
 	 * @return  void
 	 *
@@ -116,18 +118,18 @@ class JTableObserverTags extends JTableObserver
 		$this->tagsHelper->deleteTagData($this->table, $pk);
 	}
 
-
 	/**
 	 * Sets the new tags to be added/replaced to the table row
 	 *
-	 * @param  array    $newTags
-	 * @param  boolean  $replaceTags
+	 * @param   array    $newTags      New tags to be added or replaced
+	 * @param   boolean  $replaceTags  Replace tags (true) or add them (false)
 	 *
-	 * @return boolean
+	 * @return  boolean
 	 */
 	public function setNewTags($newTags, $replaceTags)
 	{
 		$this->parseTypeAlias();
+
 		return $this->tagsHelper->postStoreProcess($this->table, $newTags, $replaceTags);
 	}
 
@@ -136,10 +138,13 @@ class JTableObserverTags extends JTableObserver
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName
 	 * Storing result into $this->tagsHelper->typeAlias
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function parseTypeAlias()
 	{
-		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->table->{$matches[1]}; }, $this->typeAliasPattern);
+		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/',
+			function($matches) { return $this->table->{$matches[1]}; },
+			$this->typeAliasPattern
+		);
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -111,18 +111,19 @@ class JTableObserverTags extends JTableObserver
 	}
 
 	/**
-	 * Sets the new tags to be added at the table's ->store() post-processing method
+	 * Sets the new tags to be added/replaced to the table row
 	 *
 	 * @param  array    $newTags
 	 * @param  boolean  $replaceTags
 	 *
-	 * @return void
+	 * @return boolean
 	 */
-	public function setNewTagsToAdd($newTags, $replaceTags)
+	public function setNewTags($newTags, $replaceTags)
 	{
-		$this->newTags = $newTags;
-		$this->replaceTags = $replaceTags;
+		$this->parseTypeAlias();
+		return $this->tagsHelper->postStoreProcess($this->table, $newTags, $replaceTags);
 	}
+
 	/**
 	 * Internal method
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -30,7 +30,7 @@ class JTableObserverTags extends JTableObserver
 	 * The pattern for this tag's TypeAlias
 	 * @var  string
 	 */
-	protected $typeAliasPattern;
+	protected $typeAliasPattern = null;
 
 	/**
 	 * Override for postStoreProcess param newTags, Set by setNewTagsToAdd, used by onAfterStore
@@ -45,6 +45,29 @@ class JTableObserverTags extends JTableObserver
 	 * @var boolean
 	 */
 	protected $replaceTags = true;
+
+	/**
+	 * Creates the associated observer instance and attaches it to the $observableObject
+	 * Creates the associated tags helper class instance
+	 * $typeAlias can be of the form "{variableName}.type", automatically replacing {variableName} with table-instance variables variableName
+	 *
+	 * @param   JObservableInterface|JTable   $observableObject
+	 * @param   array                         $params  ( 'typeAlias' => $typeAlias )
+	 *
+	 * @return  JObserverInterface|JTableObserverTags
+	 */
+	public static function createObserver(JObservableInterface $observableObject, $params = array())
+	{
+		$typeAlias = $params['typeAlias'];
+
+		$observer = new self($observableObject);
+
+		$observer->tagsHelper = new JHelperTags;
+		$observer->typeAliasPattern = $typeAlias;
+
+		return $observer;
+	}
+
 	/**
 	 * Pre-processor for $table->store($updateNulls)
 	 *
@@ -56,7 +79,7 @@ class JTableObserverTags extends JTableObserver
 	public function onBeforeStore($updateNulls, $tableKey)
 	{
 		$this->parseTypeAlias();
-		$this->tagsHelper->preStoreProcess($this->table, $this->newTags);
+		$this->tagsHelper->preStoreProcess($this->table);
 	}
 
 	/**
@@ -69,7 +92,7 @@ class JTableObserverTags extends JTableObserver
 	{
 		if ($result)
 		{
-			$result = $this->tagsHelper->postStoreProcess($this->table, $this->newTags, $this->replaceTags);
+			$result = $this->tagsHelper->postStoreProcess($this->table);
 
 			// Restore default values for the optional params:
 			$this->newTags = array();
@@ -93,22 +116,6 @@ class JTableObserverTags extends JTableObserver
 		$this->tagsHelper->deleteTagData($this->table, $pk);
 	}
 
-	/**
-	 * Creates the associated tags helper class instance
-	 * $typeAlias can be of the form "{variableName}.type", automatically replacing {variableName} with table-instance variables variableName
-	 *
-	 * @param   JTable   $table
-	 * @param   string   $typeAlias   The type alias (null if set after initial binding like in categories)
-	 *
-	 * @return  JTableObserverTags
-	 */
-	public static function observeTableWithTagsHelperOfTypeAlias($table, $typeAlias)
-	{
-		$observer = new self($table);
-		$observer->tagsHelper = new JHelperTags;
-		$observer->typeAliasPattern = $typeAlias;
-		return $observer;
-	}
 
 	/**
 	 * Sets the new tags to be added/replaced to the table row

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -153,10 +153,10 @@ class JTableObserverTags extends JTableObserver
 	protected function parseTypeAlias()
 	{
 		// Needed for PHP < 5.4.0 as it's not passing context $this to closure function
-		static::$myThisForPregReplace = $this;
+		static::$myThisForPregReplace = $this->table;
 
 		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/',
-			function($matches) { return JTableObserverTags::$myThisForPregReplace->table->{$matches[1]}; },
+			function($matches) { return JTableObserverTags::$myThisForPregReplace->{$matches[1]}; },
 			$this->typeAliasPattern
 		);
 	}

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -36,6 +36,7 @@ class JTableObserverTags extends JTableObserver
 	 */
 	public function onBeforeStore($updateNulls, $tableKey)
 	{
+		$this->parseTypeAlias();
 		$this->tagsHelper->preStoreProcess($this->table);
 	}
 
@@ -64,6 +65,7 @@ class JTableObserverTags extends JTableObserver
 	 */
 	public function onBeforeDelete($pk, $tableKey)
 	{
+		$this->parseTypeAlias();
 		$this->tagsHelper->deleteTagData($this->table, $pk);
 	}
 
@@ -81,5 +83,10 @@ class JTableObserverTags extends JTableObserver
 		$observer->tagsHelper = new JHelperTags;
 		$observer->tagsHelper->typeAlias = $typeAlias;
 		return $observer;
+	}
+
+	protected function parseTypeAlias()
+	{
+		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->{$matches[1]}; }, $this->tagsHelper->typeAlias);
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -17,48 +17,17 @@ defined('JPATH_PLATFORM') or die;
  * @link        http://docs.joomla.org/JTableObserver
  * @since       3.1.2
  */
-abstract class JTableObserver
+class JTableObserverTags extends JTableObserver
 {
 	/**
-	 * The observed table
+	 * Helper object for storing and deleting tag information associated with this table observer
 	 *
-	 * @var   JTable
+	 * @var  JHelperTags
 	 */
-	protected $table;
-
-	public function __construct(JTable $table)
-	{
-		$table->addObserver($this);
-		$this->table = $table;
-	}
+	protected $tagsHelper;
 
 	/**
-	 * Pre-processor for $table->load($id)
-	 *
-	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.  If not
-	 *                           set the instance property value is used.
-	 * @param   boolean  $reset  True to reset the default values before loading the new row.
-	 *
-	 * @return  void
-	 */
-	public function onBeforeLoad($keys, $reset)
-	{
-	}
-
-	/**
-	 * Post-processor for $table->load($id)
-	 *
-	 * @param   boolean   $result   The result of the load
-	 * @param   array     $row      The loaded (and already binded to $this->table) row of the database table
-	 *
-	 * @return  void
-	 */
-	public function onAfterLoad(&$result, $row)
-	{
-	}
-
-	/**
-	 * Pre-processor for $table->store($id)
+	 * Pre-processor for $table->store($updateNulls)
 	 *
 	 * @param   boolean   $updateNulls   The result of the load
 	 * @param   string    $tableKey      The key of the table
@@ -67,14 +36,50 @@ abstract class JTableObserver
 	 */
 	public function onBeforeStore($updateNulls, $tableKey)
 	{
+		$this->tagsHelper->preStoreProcess($this->table);
 	}
 
 	/**
-	 * Post-processor for $table->store($id)
+	 * Post-processor for $table->store($updateNulls)
 	 *
 	 * @param   boolean   $result   The result of the load
 	 */
 	public function onAfterStore(&$result)
 	{
+		if ($result)
+		{
+			$this->tagsHelper->postStoreProcess($this->table);
+		}
+	}
+
+	/**
+	 * Pre-processor for $table->delete($pk)
+	 *
+	 * @param   mixed    $pk         An optional primary key value to delete.  If not set the instance property value is used.
+	 * @param   string   $tableKey   The normal key of the table
+	 *
+	 * @return  void
+	 *
+	 * @throws  UnexpectedValueException
+	 */
+	public function onBeforeDelete($pk, $tableKey)
+	{
+		$this->tagsHelper->deleteTagData($this->table, $pk);
+	}
+
+	/**
+	 * Creates the associated tags helper class instance
+	 *
+	 * @param   JTable   $table
+	 * @param   string   $typeAlias   The type alias (null if set after initial binding like in categories)
+	 *
+	 * @return  JTableObserverTags
+	 */
+	public static function observeTableWithTagsHelperOfTypeAlias($table, $typeAlias)
+	{
+		$observer = new self($table);
+		$observer->tagsHelper = new JHelperTags;
+		$observer->tagsHelper->typeAlias = $typeAlias;
+		return $observer;
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -87,6 +87,6 @@ class JTableObserverTags extends JTableObserver
 
 	protected function parseTypeAlias()
 	{
-		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->{$matches[1]}; }, $this->tagsHelper->typeAlias);
+		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->table->{$matches[1]}; }, $this->tagsHelper->typeAlias);
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -27,6 +27,12 @@ class JTableObserverTags extends JTableObserver
 	protected $tagsHelper;
 
 	/**
+	 * The pattern for this tag's TypeAlias
+	 * @var  string
+	 */
+	protected $typeAliasPattern;
+
+	/**
 	 * Pre-processor for $table->store($updateNulls)
 	 *
 	 * @param   boolean   $updateNulls   The result of the load
@@ -81,12 +87,12 @@ class JTableObserverTags extends JTableObserver
 	{
 		$observer = new self($table);
 		$observer->tagsHelper = new JHelperTags;
-		$observer->tagsHelper->typeAlias = $typeAlias;
+		$observer->typeAliasPattern = $typeAlias;
 		return $observer;
 	}
 
 	protected function parseTypeAlias()
 	{
-		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->table->{$matches[1]}; }, $this->tagsHelper->typeAlias);
+		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/', function($matches) { return $this->table->{$matches[1]}; }, $this->typeAliasPattern);
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -33,6 +33,19 @@ class JTableObserverTags extends JTableObserver
 	protected $typeAliasPattern;
 
 	/**
+	 * Override for postStoreProcess param newTags, Set by setNewTagsToAdd, used by onAfterStore
+	 *
+	 * @var  array
+	 */
+	protected $newTags = array();
+
+	/**
+	 * Override for postStoreProcess param replaceTags. Set by setNewTagsToAdd, used by onAfterStore
+	 *
+	 * @var boolean
+	 */
+	protected $replaceTags = true;
+	/**
 	 * Pre-processor for $table->store($updateNulls)
 	 *
 	 * @param   boolean   $updateNulls   The result of the load
@@ -43,11 +56,12 @@ class JTableObserverTags extends JTableObserver
 	public function onBeforeStore($updateNulls, $tableKey)
 	{
 		$this->parseTypeAlias();
-		$this->tagsHelper->preStoreProcess($this->table);
+		$this->tagsHelper->preStoreProcess($this->table, $this->newTags);
 	}
 
 	/**
 	 * Post-processor for $table->store($updateNulls)
+	 * You can change optional params newTags and replaceTags of tagsHelper with method setNewTagsToAdd
 	 *
 	 * @param   boolean   $result   The result of the load
 	 */
@@ -55,7 +69,11 @@ class JTableObserverTags extends JTableObserver
 	{
 		if ($result)
 		{
-			$this->tagsHelper->postStoreProcess($this->table);
+			$result = $this->tagsHelper->postStoreProcess($this->table, $this->newTags, $this->replaceTags);
+
+			// Restore default values for the optional params:
+			$this->newTags = array();
+			$this->replaceTags = true;
 		}
 	}
 
@@ -92,6 +110,19 @@ class JTableObserverTags extends JTableObserver
 		return $observer;
 	}
 
+	/**
+	 * Sets the new tags to be added at the table's ->store() post-processing method
+	 *
+	 * @param  array    $newTags
+	 * @param  boolean  $replaceTags
+	 *
+	 * @return void
+	 */
+	public function setNewTagsToAdd($newTags, $replaceTags)
+	{
+		$this->newTags = $newTags;
+		$this->replaceTags = $replaceTags;
+	}
 	/**
 	 * Internal method
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -33,7 +33,7 @@ abstract class JTableObserver
 	}
 
 	/**
-	 * Pre-processor for $table->load($keys, $reset)
+	 * Pre-processor for $table->load($id)
 	 *
 	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.  If not
 	 *                           set the instance property value is used.
@@ -46,7 +46,7 @@ abstract class JTableObserver
 	}
 
 	/**
-	 * Post-processor for $table->load($keys, $reset)
+	 * Post-processor for $table->load($id)
 	 *
 	 * @param   boolean   $result   The result of the load
 	 * @param   array     $row      The loaded (and already binded to $this->table) row of the database table
@@ -58,7 +58,7 @@ abstract class JTableObserver
 	}
 
 	/**
-	 * Pre-processor for $table->store($updateNulls)
+	 * Pre-processor for $table->store($id)
 	 *
 	 * @param   boolean   $updateNulls   The result of the load
 	 * @param   string    $tableKey      The key of the table
@@ -70,33 +70,11 @@ abstract class JTableObserver
 	}
 
 	/**
-	 * Post-processor for $table->store($updateNulls)
+	 * Post-processor for $table->store($id)
 	 *
-	 * @param   boolean   $result   The result of the store
+	 * @param   boolean   $result   The result of the load
 	 */
 	public function onAfterStore(&$result)
-	{
-	}
-	/**
-	 * Pre-processor for $table->delete($pk)
-	 *
-	 * @param   mixed    $pk         An optional primary key value to delete.  If not set the instance property value is used.
-	 * @param   string   $tableKey   The normal key of the table
-	 *
-	 * @return  void
-	 *
-	 * @throws  UnexpectedValueException
-	 */
-	public function onBeforeDelete($pk, $tableKey)
-	{
-	}
-
-	/**
-	 * Post-processor for $table->delete($pk)
-	 *
-	 * @param   mixed    $pk         The deleted primary key value.
-	 */
-	public function onAfterDelete($pk)
 	{
 	}
 }

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -156,7 +156,7 @@ class JTableObserverTags extends JTableObserver
 		static::$myThisForPregReplace = $this;
 
 		$this->tagsHelper->typeAlias = preg_replace_callback('/{([^}]+)}/',
-			function($matches) { return static::$myThisForPregReplace->table->{$matches[1]}; },
+			function($matches) { return JTableObserverTags::$myThisForPregReplace->table->{$matches[1]}; },
 			$this->typeAliasPattern
 		);
 	}

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -814,6 +814,8 @@ abstract class JTable extends JObject
 		if ($this->_trackAssets)
 		{
 			// Get and the asset name.
+			$savedK = $this->$k;
+
 			$this->$k = $pk;
 			$name = $this->_getAssetName();
 			$asset = self::getInstance('Asset');
@@ -831,6 +833,8 @@ abstract class JTable extends JObject
 				$this->setError($asset->getError());
 				return false;
 			}
+
+			$this->$k = $savedK;
 		}
 
 		// Delete the row by primary key.

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -144,11 +144,11 @@ abstract class JTable extends JObject implements JObservableInterface
 	 * This method will be called fron the constructor of classes implementing JObserverInterface
 	 * which is instanciated by the constructor of $this with JObserverMapper::attachAllObservers($this)
 	 *
-	 * @param    JObserverInterface|JTableObserver   $observer
+	 * @param   JObserverInterface|JTableObserver  $observer  The observer object
 	 *
-	 * @return   void
+	 * @return  void
 	 *
-	 * @since    3.1.2
+	 * @since   3.1.2
 	 */
 	public function attachObserver(JObserverInterface $observer)
 	{
@@ -158,11 +158,11 @@ abstract class JTable extends JObject implements JObservableInterface
 	/**
 	 * Gets the instance of the observer of class $observerClass
 	 *
-	 * @param    string          $observerClass
+	 * @param   string  $observerClass  The observer class-name to return the object of
 	 *
-	 * @return   JTableObserver|null
+	 * @return  JTableObserver|null
 	 *
-	 * @since    3.1.2
+	 * @since   3.1.2
 	 */
 	public function getObserverOfClass($observerClass)
 	{

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -656,83 +656,83 @@ abstract class JTable extends JObject implements JObservableInterface
 			$result = $this->_db->insertObject($this->_tbl, $this, $this->_tbl_key);
 		}
 
+		// If the table is not set to track assets return true.
+		if ($this->_trackAssets)
+		{
+
+			if ($this->_locked)
+			{
+				$this->_unlock();
+			}
+
+			/*
+			 * Asset Tracking
+			 */
+
+			$parentId = $this->_getAssetParentId();
+			$name = $this->_getAssetName();
+			$title = $this->_getAssetTitle();
+
+			$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
+			$asset->loadByName($name);
+
+			// Re-inject the asset id.
+			$this->asset_id = $asset->id;
+
+			// Check for an error.
+			$error = $asset->getError();
+			if ($error)
+			{
+				$this->setError($error);
+				$result = false;
+			}
+			else
+			{
+				// Specify how a new or moved node asset is inserted into the tree.
+				if (empty($this->asset_id) || $asset->parent_id != $parentId)
+				{
+					$asset->setLocation($parentId, 'last-child');
+				}
+
+				// Prepare the asset to be stored.
+				$asset->parent_id = $parentId;
+				$asset->name = $name;
+				$asset->title = $title;
+
+				if ($this->_rules instanceof JAccessRules)
+				{
+					$asset->rules = (string) $this->_rules;
+				}
+
+				if (!$asset->check() || !$asset->store($updateNulls))
+				{
+					$this->setError($asset->getError());
+					$result = false;
+				}
+				else
+				{
+					// Create an asset_id or heal one that is corrupted.
+					if (empty($this->asset_id) || ($currentAssetId != $this->asset_id && !empty($this->asset_id)))
+					{
+						// Update the asset_id field in this table.
+						$this->asset_id = (int) $asset->id;
+
+						$query = $this->_db->getQuery(true)
+							->update($this->_db->quoteName($this->_tbl))
+							->set('asset_id = ' . (int) $this->asset_id)
+							->where($this->_db->quoteName($k) . ' = ' . (int) $this->$k);
+						$this->_db->setQuery($query);
+
+						$this->_db->execute();
+					}
+				}
+			}
+		}
+
 		// Implement JObservableInterface: Post-processing by observers
 		$this->_observers->update('onAfterStore', array(&$result));
 
-
-		// @TODO later: This trackAssets after here (and above too) could go into a observer post-processing method:
-
-		// If the table is not set to track assets return true.
-		if (!$this->_trackAssets)
-		{
-			return true;
-		}
-
-		if ($this->_locked)
-		{
-			$this->_unlock();
-		}
-
-		/*
-		 * Asset Tracking
-		 */
-
-		$parentId = $this->_getAssetParentId();
-		$name = $this->_getAssetName();
-		$title = $this->_getAssetTitle();
-
-		$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
-		$asset->loadByName($name);
-
-		// Re-inject the asset id.
-		$this->asset_id = $asset->id;
-
-		// Check for an error.
-		$error = $asset->getError();
-		if ($error)
-		{
-			$this->setError($error);
-			return false;
-		}
-
-		// Specify how a new or moved node asset is inserted into the tree.
-		if (empty($this->asset_id) || $asset->parent_id != $parentId)
-		{
-			$asset->setLocation($parentId, 'last-child');
-		}
-
-		// Prepare the asset to be stored.
-		$asset->parent_id = $parentId;
-		$asset->name = $name;
-		$asset->title = $title;
-
-		if ($this->_rules instanceof JAccessRules)
-		{
-			$asset->rules = (string) $this->_rules;
-		}
-
-		if (!$asset->check() || !$asset->store($updateNulls))
-		{
-			$this->setError($asset->getError());
-			return false;
-		}
-
-		// Create an asset_id or heal one that is corrupted.
-		if (empty($this->asset_id) || ($currentAssetId != $this->asset_id && !empty($this->asset_id)))
-		{
-			// Update the asset_id field in this table.
-			$this->asset_id = (int) $asset->id;
-
-			$query = $this->_db->getQuery(true)
-				->update($this->_db->quoteName($this->_tbl))
-				->set('asset_id = ' . (int) $this->asset_id)
-				->where($this->_db->quoteName($k) . ' = ' . (int) $this->$k);
-			$this->_db->setQuery($query);
-
-			$this->_db->execute();
-		}
-
-		return true;
+		return $result;
 	}
 
 	/**

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -22,7 +22,7 @@ jimport('joomla.filesystem.path');
  * @since       11.1
  * @tutorial	Joomla.Platform/jtable.cls
  */
-abstract class JTable extends JObject
+abstract class JTable extends JObject implements JObservableInterface
 {
 	/**
 	 * Include paths for searching for JTable classes.
@@ -138,6 +138,9 @@ abstract class JTable extends JObject
 		{
 			$this->access = (int) JFactory::getConfig()->get('access');
 		}
+
+		// Attaches all observers interested by $this class:
+		JObserverMapper::attachAllObservers($this);
 	}
 
 	/**
@@ -145,13 +148,13 @@ abstract class JTable extends JObject
 	 * Ideally, this method should be called fron the constructor of JTableObserver
 	 * which should be instanciated by the constructor of $this.
 	 *
-	 * @param    JTableObserver   $observer
+	 * @param    JObserverInterface|JTableObserver   $observer
 	 *
 	 * @return   void
 	 *
 	 * @since    3.1.2
 	 */
-	public function addObserver(JTableObserver $observer)
+	public function attachObserver(JObserverInterface $observer)
 	{
 		$this->_observers[get_class($observer)] = $observer;
 	}

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -89,6 +89,13 @@ abstract class JTable extends JObject
 	protected $_observers = array();
 
 	/**
+	 * Process observers (useful when a class extends significantly an observerved method, and calls observers itself
+	 * @var    boolean
+	 * @since  3.1.2
+	 */
+	protected $_callObservers = true;
+
+	/**
 	 * Object constructor to set table and key fields.  In most cases this will
 	 * be overridden by child classes to explicitly set the table and key fields
 	 * for a particular database table.
@@ -506,9 +513,12 @@ abstract class JTable extends JObject
 	public function load($keys = null, $reset = true)
 	{
 		// Pre-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onBeforeLoad($keys, $reset);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onBeforeLoad($keys, $reset);
+			}
 		}
 
 		if (empty($keys))
@@ -569,9 +579,12 @@ abstract class JTable extends JObject
 		}
 
 		// Post-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onAfterLoad($result, $row);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onAfterLoad($result, $row);
+			}
 		}
 
 		return $result;
@@ -612,9 +625,12 @@ abstract class JTable extends JObject
 		$k = $this->_tbl_key;
 
 		// Pre-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onBeforeStore($updateNulls, $k);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onBeforeStore($updateNulls, $k);
+			}
 		}
 
 		if (!empty($this->asset_id))
@@ -644,9 +660,12 @@ abstract class JTable extends JObject
 		}
 
 		// Post-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onAfterStore($result);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onAfterStore($result);
+			}
 		}
 
 		//@TODO: This trackAssets after here (and above too) should go into a observer post-processing method:
@@ -797,9 +816,12 @@ abstract class JTable extends JObject
 		$k = $this->_tbl_key;
 
 		// Pre-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onBeforeDelete($pk, $k);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onBeforeDelete($pk, $k);
+			}
 		}
 
 		$pk = (is_null($pk)) ? $this->$k : $pk;
@@ -847,9 +869,12 @@ abstract class JTable extends JObject
 		$this->_db->execute();
 
 		// Post-processing by observers
-		foreach ($this->_observers as $observer)
+		if ($this->_callObservers)
 		{
-			$observer->onAfterDelete($pk);
+			foreach ($this->_observers as $observer)
+			{
+				$observer->onAfterDelete($pk);
+			}
 		}
 
 		return true;

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -140,9 +140,9 @@ abstract class JTable extends JObject implements JObservableInterface
 
 	/**
 	 * Implement JObservableInterface:
-	 * Adds an observer to this JTable instance.
-	 * Ideally, this method should be called fron the constructor of JTableObserver
-	 * which should be instanciated by the constructor of $this.
+	 * Adds an observer to this instance.
+	 * This method will be called fron the constructor of classes implementing JObserverInterface
+	 * which is instanciated by the constructor of $this with JObserverMapper::attachAllObservers($this)
 	 *
 	 * @param    JObserverInterface|JTableObserver   $observer
 	 *

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -782,7 +782,7 @@ abstract class JTable extends JObject
 	}
 
 	/**
-	 * Override parent delete method to delete tags information.
+	 * Deletes this row in database (or if provided, the row of key $pk)
 	 *
 	 * @param   mixed  $pk  An optional primary key value to delete.  If not set the instance property value is used.
 	 *

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -142,7 +142,8 @@ abstract class JTable extends JObject
 
 	/**
 	 * Adds an observer to this JTable instance.
-	 * Ideally, this method should be called fron the constructor of JTableObserver.
+	 * Ideally, this method should be called fron the constructor of JTableObserver
+	 * which should be instanciated by the constructor of $this.
 	 *
 	 * @param    JTableObserver   $observer
 	 *
@@ -150,10 +151,29 @@ abstract class JTable extends JObject
 	 *
 	 * @since    3.1.2
 	 */
-	public function addObserver( JTableObserver $observer )
+	public function addObserver(JTableObserver $observer)
 	{
-		$this->_observers[] = $observer;
+		$this->_observers[get_class($observer)] = $observer;
 	}
+
+	/**
+	 * Gets the instance of the observer of class $observerClass
+	 *
+	 * @param    string          $observerClass
+	 *
+	 * @return   JTableObserver|null
+	 *
+	 * @since    3.1.2
+	 */
+	public function getObserverOfClass($observerClass)
+	{
+		if (isset($this->_observers[$observerClass]))
+		{
+			return $this->_observers[$observerClass];
+		}
+		return null;
+	}
+
 	/**
 	 * Get the columns from database table.
 	 *

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -795,6 +795,13 @@ abstract class JTable extends JObject
 	public function delete($pk = null)
 	{
 		$k = $this->_tbl_key;
+
+		// Pre-processing by observers
+		foreach ($this->_observers as $observer)
+		{
+			$observer->onBeforeDelete($pk, $k);
+		}
+
 		$pk = (is_null($pk)) ? $this->$k : $pk;
 
 		// If no primary key is given, return false.
@@ -834,6 +841,12 @@ abstract class JTable extends JObject
 
 		// Check for a database error.
 		$this->_db->execute();
+
+		// Post-processing by observers
+		foreach ($this->_observers as $observer)
+		{
+			$observer->onAfterDelete($pk);
+		}
 
 		return true;
 	}

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -567,24 +567,12 @@ abstract class JModelAdmin extends JModelForm
 				$table->load($pk);
 				$tags = array($value);
 
-				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 				/**
 				 * @var  JTableObserverTags  $tagsObserver
 				 */
-				$tagsObserver->setNewTagsToAdd($tags, false);
-				$result = true;
-				$tagsObserver->onAfterStore($result);
+				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
+				$result = $tagsObserver->setNewTags($tags, false);
 				if (!$result)
-/*
-				{
-
-				$typeAlias = $table->get('tagsHelper')->typeAlias;
-
-				$oldTags = $table->get('tagsHelper')->getTagIds($pk, $typeAlias);
-				$table->get('tagsHelper')->oldTags = $oldTags;
-
-				if (!$table->get('tagsHelper')->postStoreProcess($table, $tags, false))
-*/
 				{
 					$this->setError($table->getError());
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -566,12 +566,25 @@ abstract class JModelAdmin extends JModelForm
 				$table->reset();
 				$table->load($pk);
 				$tags = array($value);
+
+				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
+				/**
+				 * @var  JTableObserverTags  $tagsObserver
+				 */
+				$tagsObserver->setNewTagsToAdd($tags, false);
+				$result = true;
+				$tagsObserver->onAfterStore($result);
+				if (!$result)
+/*
+				{
+
 				$typeAlias = $table->get('tagsHelper')->typeAlias;
 
 				$oldTags = $table->get('tagsHelper')->getTagIds($pk, $typeAlias);
 				$table->get('tagsHelper')->oldTags = $oldTags;
 
 				if (!$table->get('tagsHelper')->postStoreProcess($table, $tags, false))
+*/
 				{
 					$this->setError($table->getError());
 

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -30,9 +30,6 @@ class JTableCategory extends JTableNested
 		parent::__construct('#__categories', 'id', $db);
 
 		$this->access = (int) JFactory::getConfig()->get('access');
-
-		// Sets up the tags observer in $this
-		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, '{extension}.category');
 	}
 
 	/**

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -39,7 +39,10 @@ class JTableCategory extends JTableNested
 		parent::__construct('#__categories', 'id', $db);
 
 		$this->access = (int) JFactory::getConfig()->get('access');
-		$this->tagsHelper = new JHelperTags;
+
+		// Sets up the tags observer in $this
+		$this->tagsHelper = JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, null);
+		;
 	}
 
 	/**
@@ -209,9 +212,8 @@ class JTableCategory extends JTableNested
 	 */
 	public function delete($pk = null, $children = true)
 	{
-		$result = parent::delete($pk);
 		$this->tagsHelper->typeAlias = $this->extension . '.category';
-		return $result && $this->tagsHelper->deleteTagData($this, $pk);
+		return parent::delete($pk);
 	}
 
 	/**
@@ -253,10 +255,7 @@ class JTableCategory extends JTableNested
 		}
 
 		$this->tagsHelper->typeAlias = $this->extension . '.category';
-		$this->tagsHelper->preStoreProcess($this);
-		$result = parent::store($updateNulls);
 
-		$this->newTags = isset($this->newTags) ? $this->newTags : array();
-		return $result && $this->tagsHelper->postStoreProcess($this, $this->newTags);
+		return parent::store($updateNulls);
 	}
 }

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -18,15 +18,6 @@ defined('JPATH_PLATFORM') or die;
  */
 class JTableCategory extends JTableNested
 {
-
-	/**
-	 * Helper object for storing and deleting tag information.
-	 *
-	 * @var    JHelperTags
-	 * @since  3.1
-	 */
-	protected $tagsHelper = null;
-
 	/**
 	 * Constructor
 	 *
@@ -41,8 +32,7 @@ class JTableCategory extends JTableNested
 		$this->access = (int) JFactory::getConfig()->get('access');
 
 		// Sets up the tags observer in $this
-		$this->tagsHelper = JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, null);
-		;
+		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, '{extension}.category');
 	}
 
 	/**
@@ -200,23 +190,6 @@ class JTableCategory extends JTableNested
 	}
 
 	/**
-	 * Override parent delete method to process tags
-	 *
-	 * @param   integer  $pk        The primary key of the node to delete.
-	 * @param   boolean  $children  True to delete child nodes, false to move them up a level.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   3.1
-	 * @throws  UnexpectedValueException
-	 */
-	public function delete($pk = null, $children = true)
-	{
-		$this->tagsHelper->typeAlias = $this->extension . '.category';
-		return parent::delete($pk);
-	}
-
-	/**
 	 * Overridden JTable::store to set created/modified and user id.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
@@ -253,8 +226,6 @@ class JTableCategory extends JTableNested
 
 			return false;
 		}
-
-		$this->tagsHelper->typeAlias = $this->extension . '.category';
 
 		return parent::store($updateNulls);
 	}

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -20,14 +20,6 @@ defined('JPATH_PLATFORM') or die;
 class JTableContent extends JTable
 {
 	/**
-	 * Helper object for storing and deleting tag information.
-	 *
-	 * @var    JHelperTags
-	 * @since  3.1
-	 */
-	protected $tagsHelper = null;
-
-	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object
@@ -38,8 +30,8 @@ class JTableContent extends JTable
 	{
 		parent::__construct('#__content', 'id', $db);
 
-		$this->tagsHelper = new JHelperTags;
-		$this->tagsHelper->typeAlias = 'com_content.article';
+		// Sets up the tags observer in $this
+		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_content.article');
 	}
 
 	/**
@@ -241,23 +233,6 @@ class JTableContent extends JTable
 	}
 
 	/**
-	 * Override parent delete method to delete tags information.
-	 *
-	 * @param   integer  $pk  Primary key to delete.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   3.1
-	 * @throws  UnexpectedValueException
-	 */
-	public function delete($pk = null)
-	{
-		$result = parent::delete($pk);
-		$this->tagsHelper->typeAlias = 'com_content.article';
-		return $result && $this->tagsHelper->deleteTagData($this, $pk);
-	}
-
-	/**
 	 * Overrides JTable::store to set modified data and user id.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
@@ -302,12 +277,7 @@ class JTableContent extends JTable
 			return false;
 		}
 
-		$this->tagsHelper->typeAlias = 'com_content.article';
-		$this->tagsHelper->preStoreProcess($this);
-		$result = parent::store($updateNulls);
-
-		$this->newTags = isset($this->newTags) ? $this->newTags : array();
-		return $result && $this->tagsHelper->postStoreProcess($this, $this->newTags);
+		return parent::store($updateNulls);
 	}
 
 	/**

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -30,8 +30,14 @@ class JTableContent extends JTable
 	{
 		parent::__construct('#__content', 'id', $db);
 
-		// Sets up the tags observer in $this
-		JTableObserverTags::observeTableWithTagsHelperOfTypeAlias($this, 'com_content.article');
+		// This is left here for reference:
+		//
+		// This would set up the tags observer in $this from here (so not entirely decoupled):
+		// JTableObserverTags::createObserver($this, array('typeAlias' => 'com_content.article'));
+		//
+		// But this makes the relation between content and tags completely external to Content as JTable is observable:
+		// So we are doing this only once in libraries/cms.php:
+		// JObserverFactory::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
 	}
 
 	/**


### PR DESCRIPTION
This pull request is an alternative implementation to the fix proposed in pull request 1452 ( https://github.com/joomla/joomla-cms/pull/1452 which was refered in #31339).

One line that shows the big advantage of this proposal easily understandable:

``` php
JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
```

is all what is needed to add the Tags feature to a JTableContent. Neither JTableContent nor JTable have after this PR any tags-specific code. This line is outside those 2 classes (here in cms.php), and such lines can be used to add tags to any class!

Detailed explanation of its benefits here for what it fixes:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31339

and here for its general advantages:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31488
