### PR TITLE
Adding filters in back-end Installation Discover view for 3.x

### DIFF
--- a/administrator/components/com_installer/models/discover.php
+++ b/administrator/components/com_installer/models/discover.php
@@ -170,7 +170,6 @@ class InstallerModelDiscover extends InstallerModel
 			}
 
 			JArrayHelper::toInteger($eid);
-			$app    = JFactory::getApplication();
 			$failed = false;
 
 			foreach ($eid as $id)

--- a/administrator/components/com_installer/models/discover.php
+++ b/administrator/components/com_installer/models/discover.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/extension.php';
 
 /**
- * Installer Manage Model
+ * Installer Discover Model
  *
  * @package     Joomla.Administrator
  * @subpackage  com_installer
@@ -20,8 +20,6 @@ require_once __DIR__ . '/extension.php';
  */
 class InstallerModelDiscover extends InstallerModel
 {
-	protected $_context = 'com_installer.discover';
-
 	/**
 	 * Method to auto-populate the model state.
 	 *
@@ -32,15 +30,30 @@ class InstallerModelDiscover extends InstallerModel
 	 *
 	 * @return  void
 	 *
-	 * @since   1.6
+	 * @since   3.1
 	 */
 	protected function populateState($ordering = null, $direction = null)
 	{
 		$app = JFactory::getApplication();
+
+		// Load the filter state.
+		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+		$this->setState('filter.search', $search);
+
+		$clientId = $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', '');
+		$this->setState('filter.client_id', $clientId);
+
+		$categoryId = $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '');
+		$this->setState('filter.type', $categoryId);
+
+		$group = $this->getUserStateFromRequest($this->context . '.filter.group', 'filter_group', '');
+		$this->setState('filter.group', $group);
+
 		$this->setState('message', $app->getUserState('com_installer.message'));
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
+
 		parent::populateState('name', 'asc');
 	}
 
@@ -49,15 +62,42 @@ class InstallerModelDiscover extends InstallerModel
 	 *
 	 * @return  JDatabaseQuery  the database query
 	 *
-	 * @since   1.6
+	 * @since   3.1
 	 */
 	protected function getListQuery()
 	{
-		$db		= JFactory::getDbo();
-		$query = $db->getQuery(true)
+		$type   = $this->getState('filter.type');
+		$client = $this->getState('filter.client_id');
+		$group  = $this->getState('filter.group');
+
+		$query = JFactory::getDbo()->getQuery(true)
 			->select('*')
 			->from('#__extensions')
 			->where('state=-1');
+
+		if ($type)
+		{
+			$query->where('type=' . $this->_db->quote($type));
+		}
+
+		if ($client != '')
+		{
+			$query->where('client_id=' . (int) $client);
+		}
+
+		if ($group != '' && in_array($type, array('plugin', 'library', '')))
+		{
+			$query->where('folder=' . $this->_db->quote($group == '*' ? '' : $group));
+		}
+
+		// Filter by search in id
+		$search = $this->getState('filter.search');
+
+		if (!empty($search) && stripos($search, 'id:') === 0)
+		{
+			$query->where('extension_id = ' . (int) substr($search, 3));
+		}
+
 		return $query;
 	}
 
@@ -93,12 +133,14 @@ class InstallerModelDiscover extends InstallerModel
 			$key = implode(':', array($install->type, $install->element, $install->folder, $install->client_id));
 			$extensions[$key] = $install;
 		}
+
 		unset($installedtmp);
 
 		foreach ($results as $result)
 		{
 			// Check if we have a match on the element
 			$key = implode(':', array($result->type, $result->element, $result->folder, $result->client_id));
+
 			if (!array_key_exists($key, $extensions))
 			{
 				// Put it into the table
@@ -116,31 +158,37 @@ class InstallerModelDiscover extends InstallerModel
 	 */
 	public function discover_install()
 	{
-		$app = JFactory::getApplication();
+		$app       = JFactory::getApplication();
 		$installer = JInstaller::getInstance();
-		$eid = JRequest::getVar('cid', 0);
+		$eid       = JRequest::getVar('cid', 0);
+
 		if (is_array($eid) || $eid)
 		{
 			if (!is_array($eid))
 			{
 				$eid = array($eid);
 			}
+
 			JArrayHelper::toInteger($eid);
-			$app = JFactory::getApplication();
+			$app    = JFactory::getApplication();
 			$failed = false;
+
 			foreach ($eid as $id)
 			{
 				$result = $installer->discover_install($id);
+
 				if (!$result)
 				{
 					$failed = true;
 					$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_DISCOVER_INSTALLFAILED') . ': ' . $id);
 				}
 			}
+
 			$this->setState('action', 'remove');
 			$this->setState('name', $installer->get('name'));
 			$app->setUserState('com_installer.message', $installer->message);
 			$app->setUserState('com_installer.extension_message', $installer->get('extension_message'));
+
 			if (!$failed)
 			{
 				$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_DISCOVER_INSTALLSUCCESSFUL'));
@@ -166,14 +214,17 @@ class InstallerModelDiscover extends InstallerModel
 			->delete('#__extensions')
 			->where('state = -1');
 		$db->setQuery($query);
+
 		if ($db->execute())
 		{
 			$this->_message = JText::_('COM_INSTALLER_MSG_DISCOVER_PURGEDDISCOVEREDEXTENSIONS');
+
 			return true;
 		}
 		else
 		{
 			$this->_message = JText::_('COM_INSTALLER_MSG_DISCOVER_FAILEDTOPURGEEXTENSIONS');
+
 			return false;
 		}
 	}

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.multiselect');
+JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
@@ -34,6 +34,22 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
   	<?php if ($this->ftp) : ?>
   		<?php echo $this->loadTemplate('ftp'); ?>
   	<?php endif; ?>
+
+    <!-- Begin Filters -->
+    <div id="filter-bar" class="btn-toolbar">
+      <div class="btn-group pull-right hidden-phone">
+        <label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>
+        <?php echo $this->pagination->getLimitBox(); ?>
+      </div>
+      <div class="filter-search btn-group pull-left">
+        <input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_INSTALLER_FILTER_LABEL'); ?>" />
+      </div>
+      <div class="btn-group pull-left">
+        <button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
+        <button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+      </div>
+    </div>
+    <div class="clearfix"> </div>
 
   	<!-- Begin Content -->
   		<?php if (count($this->items)) : ?>

--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 include_once __DIR__ . '/../default/view.php';
 
 /**
- * Extension Manager Manage View
+ * Extension Manager Discover View
  *
  * @package     Joomla.Administrator
  * @subpackage  com_installer
@@ -44,7 +44,7 @@ class InstallerViewDiscover extends InstallerViewDefault
 	 *
 	 * @return  void
 	 *
-	 * @since   1.6
+	 * @since   3.1
 	 */
 	protected function addToolbar()
 	{
@@ -54,7 +54,28 @@ class InstallerViewDiscover extends InstallerViewDefault
 		JToolbarHelper::custom('discover.install', 'upload', 'upload', 'JTOOLBAR_INSTALL', true, false);
 		JToolbarHelper::custom('discover.refresh', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DISCOVER', false, false);
 		JToolbarHelper::divider();
-		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_DISCOVER');
+
+		JHtmlSidebar::setAction('index.php?option=com_installer&view=discover');
+
+		JHtmlSidebar::addFilter(
+			JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'),
+			'filter_client_id',
+			JHtml::_('select.options', array('0' => 'JSITE', '1' => 'JADMINISTRATOR'), 'value', 'text', $this->state->get('filter.client_id'), true)
+		);
+
+		JHtmlSidebar::addFilter(
+			JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'),
+			'filter_type',
+			JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true)
+		);
+
+		JHtmlSidebar::addFilter(
+			JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'),
+			'filter_group',
+			JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.group'), true)
+		);
+
+		parent::addToolbar();
 	}
 }


### PR DESCRIPTION
- It was very hard to find and install from discover view when having a large number of items. 
- I have added filters in discover view like we have in other Joomla! view.
- Here I have attached screen dump of the filters, 

![discover filter](https://f.cloud.github.com/assets/2002921/831300/31ba36f0-f1cb-11e2-921a-17612ca57687.png)
- **To test this PR**
  - Apply this patch https://github.com/joomla/joomla-cms/pull/1572.diff
  - Try to discover the items in installation/discover view.
  - Try to filter discover list with **any sting** and filter by **location**, **type** and **folder** using select box.
