### PR TITLE
[#31549] JFile::makeSafe() allows spaces but com_media assumes it doesn't

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -61,7 +61,7 @@ class JFile
 	 */
 	public static function makeSafe($file)
 	{
-		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
+		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\-]#', '#^\.#');
 
 		return preg_replace($regex, '', $file);
 	}


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31549
