### PR TITLE
Grouped uppercase class name letters

### DIFF
--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -469,7 +469,7 @@ class JViewLegacy extends JObject
 			}
 
 			$lastPart = substr($classname, $viewpos + 4);
-			$pathParts = explode(' ', JStringNormalise::fromCamelCase($lastPart));
+			$pathParts = explode(' ', JStringNormalise::fromCamelCase($lastPart, true));
 
 			if (!empty($pathParts[1]))
 			{

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -469,7 +469,7 @@ class JViewLegacy extends JObject
 			}
 
 			$lastPart = substr($classname, $viewpos + 4);
-			$pathParts = explode(' ', JStringNormalise::fromCamelCase($lastPart, true));
+			$pathParts = JStringNormalise::fromCamelCase($lastPart, true);
 
 			if (!empty($pathParts[1]))
 			{


### PR DESCRIPTION
Refering to the patch https://github.com/joomla/joomla-cms/commit/0414f0ffddcb0ad80b232adfdcd434dd0a36787e the JViewLegacy name loader was changed for the "new MVC". This breaks classes like: ExampleViewSEO. The getName() returns "s" instead of "seo". This patch fixed that behavior:

ExampleViewSEO => seo
ExampleViewApplicationHtml => application
