### PR TITLE
Fix for adding tags with parameter nested. J 3.1.4

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -112,7 +112,7 @@ class JFormFieldTag extends JFormFieldList
 	 */
 	protected function getOptions()
 	{
-		if (!empty($this->value[0]) || $this->element['parent'])
+		if ($this->isNested || !empty($this->value[0]) || $this->element['parent'])
 		{
 			$published = $this->element['published']? $this->element['published'] : array(0,1);
 


### PR DESCRIPTION
With com_tag parameter set to nested it's not possible to add tags to a new ( or an old without tags) item.

Tracker item
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31585
