### PR TITLE
[imp] Add the option to set the default language to the active language

### DIFF
--- a/components/com_users/models/forms/sitelang.xml
+++ b/components/com_users/models/forms/sitelang.xml
@@ -2,12 +2,13 @@
 <form>
 	<fields name="params">
 		<fieldset name="params" label="COM_USERS_SETTINGS_FIELDSET_LABEL">
-			<field name="language" type="language" 
+			<field name="language" type="language"
 				client="site"
 				description="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_DESC"
 				label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
 				required="true"
 				filter="cmd"
+				default="site"
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_users/models/forms/sitelang.xml
+++ b/components/com_users/models/forms/sitelang.xml
@@ -8,7 +8,7 @@
 				label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
 				required="true"
 				filter="cmd"
-				default="site"
+				default="active"
 			/>
 		</fieldset>
 	</fields>

--- a/libraries/joomla/form/fields/language.php
+++ b/libraries/joomla/form/fields/language.php
@@ -53,7 +53,6 @@ class JFormFieldLanguage extends JFormFieldList
 			JLanguageHelper::createLanguageList($this->value, constant('JPATH_' . strtoupper($client)), true, true)
 		);
 
-
 		// Set the default value active language
 		if ($langParams = JComponentHelper::getParams('com_languages'))
 		{
@@ -69,6 +68,12 @@ class JFormFieldLanguage extends JFormFieldList
 				case 'backend':
 				case '1':
 					$this->value = $langParams->get('administrator', 'en-GB');
+					break;
+				case 'active':
+				case 'auto':
+					$lang = JFactory::getLanguage();
+					$this->value = $lang->getTag();
+					break;
 				default:
 				break;
 			}

--- a/libraries/joomla/form/fields/language.php
+++ b/libraries/joomla/form/fields/language.php
@@ -41,6 +41,7 @@ class JFormFieldLanguage extends JFormFieldList
 	{
 		// Initialize some field attributes.
 		$client = (string) $this->element['client'];
+
 		if ($client != 'site' && $client != 'administrator')
 		{
 			$client = 'site';
@@ -51,6 +52,27 @@ class JFormFieldLanguage extends JFormFieldList
 			parent::getOptions(),
 			JLanguageHelper::createLanguageList($this->value, constant('JPATH_' . strtoupper($client)), true, true)
 		);
+
+
+		// Set the default value active language
+		if ($langParams = JComponentHelper::getParams('com_languages'))
+		{
+			switch ((string) $this->value)
+			{
+				case 'site':
+				case 'frontend':
+				case '0':
+					$this->value = $langParams->get('site', 'en-GB');
+					break;
+				case 'admin':
+				case 'administrator':
+				case 'backend':
+				case '1':
+					$this->value = $langParams->get('administrator', 'en-GB');
+				default:
+				break;
+			}
+		}
 
 		return $options;
 	}


### PR DESCRIPTION
This adds the option to set the default language for a language field to the default frontend or backen language. Basically it adds the option to use:

<code>default="site"</code>
<code>default="administrator"</code>
<code>default="active"</code>

This also changes frontend user registration to use the automatically detected 
language. Before it was selecting the first language.

It also allows devs to store a dynamic reference to the active language. For exampe if you want to always store the active frontend language you can save "site" and you always get the active language. Without this you would, for example, store en-GB and then if the language is changed you will keep getting en-GB.

Example loading of frontend active language:

``` XML
            <field name="language" type="language"
                client="site"
                description="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_DESC"
                label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
                required="true"
                filter="cmd"
                default="site"
            />
```

Example loading of backend active language:

``` XML
            <field name="language" type="language"
                client="site"
                description="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_DESC"
                label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
                required="true"
                filter="cmd"
                default="administrator"
            />
```

Example loading of automatically detected language:

``` XML
            <field name="language" type="language"
                client="site"
                description="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_DESC"
                label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
                required="true"
                filter="cmd"
                default="active"
            />
```

You can reference frontend active language with:
<code>'site', 'frontend', '0'</code>

You can reference backend active language with:
<code>'admin', 'administrator', 'backend', '1'</code>

You can reference automaically detected language with:
<code>"active", "auto"</code>
