### PR TITLE
Undefined variable $catid

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -150,7 +150,7 @@ class BannersModelBanners extends JModelList
 						$condition2 .= " OR cl.metakey REGEXP '[[:<:]]" . $db->escape($keyword) . "[[:>:]]'";
 					}
 
-					if ($catid)
+					if ($categoryId)
 					{
 						$condition2 .= " OR cat.metakey REGEXP '[[:<:]]" . $db->escape($keyword) . "[[:>:]]'";
 					}


### PR DESCRIPTION
Variable $catid does not exist and that throws PHP notice. Replacing with correct category id variable $categoryId
