### PR TITLE
Fix for *old* way of storing tags. B/C issue in J!3.1.2.

### DIFF
--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -314,6 +314,12 @@ abstract class JModelForm extends JModelLegacy
 			return false;
 		}
 
+		// Tags B/C break at 3.1.2
+		if (isset($data['metadata']['tags']) && !isset($data['tags']))
+		{
+			$data['tags'] = $data['metadata']['tags'];
+		}
+
 		return $data;
 	}
 }


### PR DESCRIPTION
This will fix the _old_ way of storing tags for 3rd party extensions and it will not do anything for those who store it the new way.

This commit is based on the solution Michael Babker used for his extension (see https://github.com/mbabker/Podcast-Manager/blob/master/com_podcastmanager/admin/models/podcast.php#L631), but taken to the legacy form model and adjusted so it doesn't interfere with extensions that don't need it.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31598
