### PR TITLE
[31599] Deprecated JSubMenuHelper in mod_submenu

### DIFF
--- a/administrator/modules/mod_submenu/mod_submenu.php
+++ b/administrator/modules/mod_submenu/mod_submenu.php
@@ -9,9 +9,10 @@
 
 defined('_JEXEC') or die;
 
-$list    = JSubMenuHelper::getEntries();
-$filters = JSubMenuHelper::getFilters();
-$action  = JSubMenuHelper::getAction();
+// Initialise variables.
+$list    = JHtmlSidebar::getEntries();
+$filters = JHtmlSidebar::getFilters();
+$action  = JHtmlSidebar::getAction();
 
 $displayMenu    = count($list);
 $displayFilters = count($filters);
@@ -20,5 +21,6 @@ $hide = JFactory::getApplication()->input->getBool('hidemainmenu');
 
 if ($displayMenu || $displayFilters)
 {
+	// Render the module.
 	require JModuleHelper::getLayoutPath('mod_submenu', $params->get('layout', 'default'));
 }


### PR DESCRIPTION
Small correction in the submenu module that is using a deprecated class.

2013-07-28T22:11:05+00:00   WARNING deprecated  JSubMenuHelper::getEntries() is deprecated. Use JHtmlSidebar::getEntries() instead.
2013-07-28T22:11:05+00:00   WARNING deprecated  JSubMenuHelper::getFilters() is deprecated. Use JHtmlSidebar::getFilters() instead.
2013-07-28T22:11:05+00:00   WARNING deprecated  JSubMenuHelper::getAction() is deprecated. Use JHtmlSidebar::getAction() instead.
