### PR TITLE
[#30815] Check updates for extensions causes php errors

### DIFF
--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -20,6 +20,13 @@ jimport('joomla.updater.updateadapter');
 class JUpdaterExtension extends JUpdateAdapter
 {
 	/**
+	 * @var    stdClass
+	 * @since  12.1
+	 */
+	protected $currentUpdate;
+
+
+	/**
 	 * Start element parser callback.
 	 *
 	 * @param   object  $parser  The parser object.
@@ -44,11 +51,11 @@ class JUpdaterExtension extends JUpdateAdapter
 		switch ($name)
 		{
 			case 'UPDATE':
-				$this->current_update = JTable::getInstance('update');
-				$this->current_update->update_site_id = $this->updateSiteId;
-				$this->current_update->detailsurl = $this->_url;
-				$this->current_update->folder = "";
-				$this->current_update->client_id = 1;
+				$this->currentUpdate = JTable::getInstance('update');
+				$this->currentUpdate->update_site_id = $this->updateSiteId;
+				$this->currentUpdate->detailsurl = $this->_url;
+				$this->currentUpdate->folder = "";
+				$this->currentUpdate->client_id = 1;
 				break;
 
 			// Don't do anything
@@ -58,11 +65,11 @@ class JUpdaterExtension extends JUpdateAdapter
 				if (in_array($name, $this->updatecols))
 				{
 					$name = strtolower($name);
-					$this->current_update->$name = '';
+					$this->currentUpdate->$name = '';
 				}
 				if ($name == 'TARGETPLATFORM')
 				{
-					$this->current_update->targetplatform = $attrs;
+					$this->currentUpdate->targetplatform = $attrs;
 				}
 				break;
 		}
@@ -93,23 +100,23 @@ class JUpdaterExtension extends JUpdateAdapter
 
 				// Check that the product matches and that the version matches (optionally a regexp)
 				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
-				if ($product == $this->current_update->targetplatform['NAME']
-					&& preg_match('/' . $this->currentUpdate->targetplatform->version . '/', $ver->RELEASE)
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
+				if ($product == $this->currentUpdate->targetplatform['NAME']
+					&& preg_match('/' . $this->currentUpdate->targetplatform['VERSION'] . '/', $ver->RELEASE)
+					&& ((!isset($this->currentUpdate->targetplatform['min_dev_level'])) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform['min_dev_level'])
+					&& ((!isset($this->currentUpdate->targetplatform['max_dev_level'])) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform['max_dev_level']))
 				{
 					// Target platform isn't a valid field in the update table so unset it to prevent J! from trying to store it
-					unset($this->current_update->targetplatform);
+					unset($this->currentUpdate->targetplatform);
 					if (isset($this->latest))
 					{
-						if (version_compare($this->current_update->version, $this->latest->version, '>') == 1)
+						if (version_compare($this->currentUpdate->version, $this->latest->version, '>') == 1)
 						{
-							$this->latest = $this->current_update;
+							$this->latest = $this->currentUpdate;
 						}
 					}
 					else
 					{
-						$this->latest = $this->current_update;
+						$this->latest = $this->currentUpdate;
 					}
 				}
 				break;
@@ -141,7 +148,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		if (in_array($tag, $this->updatecols))
 		{
 			$tag = strtolower($tag);
-			$this->current_update->$tag .= $data;
+			$this->currentUpdate->$tag .= $data;
 		}
 	}
 


### PR DESCRIPTION
Fixed the following problem.
When browsing the Administrator dashboard:

PHP Notice:  Undefined property: JUpdaterExtension::$currentUpdate in libraries/joomla/updater/adapters/extension.php on line 97

PHP Notice:  Trying to get property of non-object in libraries/joomla/updater/adapters/extension.php on line 97

The two problems are on the same line, but they are due to different reasons.
