### PR TITLE
Move contact lookup outside of the Article and Articles Query (2.5.x)

### DIFF
--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -104,21 +104,6 @@ class ContentModelArticle extends JModelItem
 				$query->select('u.name AS author');
 				$query->join('LEFT', '#__users AS u on u.id = a.created_by');
 
-				// Get contact id
-				$subQuery = $db->getQuery(true);
-				$subQuery->select('MAX(contact.id) AS id');
-				$subQuery->from('#__contact_details AS contact');
-				$subQuery->where('contact.published = 1');
-				$subQuery->where('contact.user_id = a.created_by');
-
-				// Filter by language
-				if ($this->getState('filter.language'))
-				{
-					$subQuery->where('(contact.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') OR contact.language IS NULL)');
-				}
-
-				$query->select('(' . $subQuery . ') as contactid');
-
 				// Filter by language
 				if ($this->getState('filter.language'))
 				{
@@ -176,6 +161,8 @@ class ContentModelArticle extends JModelItem
 				if (((is_numeric($published)) || (is_numeric($archived))) && (($data->state != $published) && ($data->state != $archived))) {
 					return JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
 				}
+
+                $data->contactid = $this->getContactID($data->created_by);
 
 				// Convert parameter fields to objects.
 				$registry = new JRegistry;
@@ -244,6 +231,36 @@ class ContentModelArticle extends JModelItem
 
 		return $this->_item[$pk];
 	}
+
+    /**
+     * Retrieve Contact
+     *
+     * @param   int    $created_by
+     *
+     * @return  mixed|null|integer
+     */
+    protected function getContactID($created_by)
+    {
+        $db = JFactory::getDbo();
+        $query = $db->getQuery(true);
+        $query->clear();
+
+        $query->select('MAX(contact.id) AS contactid');
+        $query->from('#__contact_details AS contact');
+        $query->where('contact.published = 1');
+        $query->where('contact.user_id = ' . (int) $created_by);
+
+        if (JLanguageMultilang::isEnabled())
+        {
+            $query->where('(contact.language in '
+                . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
+                . ' OR contact.language IS NULL)');
+        }
+
+        $db->setQuery($query->__toString());
+
+        return $db->loadResult();
+    }
 
 	/**
 	 * Increment the hit counter for the article.

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -201,21 +201,6 @@ class ContentModelArticles extends JModelList
 		$query->join('LEFT', '#__users AS ua ON ua.id = a.created_by');
 		$query->join('LEFT', '#__users AS uam ON uam.id = a.modified_by');
 
-		// Get contact id
-		$subQuery = $db->getQuery(true);
-		$subQuery->select('MAX(contact.id) AS id');
-		$subQuery->from('#__contact_details AS contact');
-		$subQuery->where('contact.published = 1');
-		$subQuery->where('contact.user_id = a.created_by');
-
-		// Filter by language
-		if ($this->getState('filter.language'))
-		{
-			$subQuery->where('(contact.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') OR contact.language IS NULL)');
-		}
-
-		$query->select('(' . $subQuery . ') as contactid');
-
 		// Join over the categories to get parent category titles
 		$query->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias');
 		$query->join('LEFT', '#__categories as parent ON parent.id = c.parent_id');
@@ -585,6 +570,8 @@ class ContentModelArticles extends JModelList
 					$item->params->set('access-view', in_array($item->access, $groups) && in_array($item->category_access, $groups));
 				}
 			}
+
+            $item->contactid = $this->getContactID($item->created_by);
 		}
 
 		return $items;
@@ -593,4 +580,34 @@ class ContentModelArticles extends JModelList
 	{
 		return $this->getState('list.start');
 	}
+
+    /**
+     * Retrieve Contact
+     *
+     * @param   int    $created_by
+     *
+     * @return  mixed|null|integer
+     */
+    protected function getContactID($created_by)
+    {
+        $db = JFactory::getDbo();
+        $query = $db->getQuery(true);
+        $query->clear();
+
+        $query->select('MAX(contact.id) AS contactid');
+        $query->from('#__contact_details AS contact');
+        $query->where('contact.published = 1');
+        $query->where('contact.user_id = ' . (int) $created_by);
+
+        if (JLanguageMultilang::isEnabled())
+        {
+            $query->where('(contact.language in '
+                . '(' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ') '
+                . ' OR contact.language IS NULL)');
+        }
+
+        $db->setQuery($query->__toString());
+
+        return $db->loadResult();
+    }
 }


### PR DESCRIPTION
Fix the Contact Join problem for 2.5 (which is feature frozen) by removing the contact portion of the Article and Articles Query, and then adding the Contact ID lookup in the item resultset loop.

The 2.5.x change is very isolated, only impacts the model, and does not introduce a new feature for the plugin that is in 3.x or any layout changes.

This change fixes:
- The current SQL Server failure.
- Any duplicated content due to multiple contacts assigned to authors.
- Any dropped content due to no contact assigned to the author.

There are no BC issues.  
