### PR TITLE
explicit type check

### DIFF
--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -66,7 +66,7 @@ abstract class MediaHelper
 
 		$allowable = explode(',', $params->get('upload_extensions'));
 		$ignored = explode(',', $params->get('ignore_extensions'));
-		if ($format == '' || $format == false || (!in_array($format, $allowable) && !in_array($format, $ignored)))
+		if ($format == '' || $format === false || (!in_array($format, $allowable) && !in_array($format, $ignored)))
 		{
 			$err = 'COM_MEDIA_ERROR_WARNFILETYPE';
 			return false;


### PR DESCRIPTION
If $format = '', then the first check is included in the second.
Also, if a file extension "foo.0" were to be uploaded, ("0" == false) evaluates as true.
