### PR TITLE
[#31648] Wrong Color on Option Selection - Tags

### DIFF
--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -300,7 +300,7 @@
 			description="JGLOBAL_FILTER_FIELD_DESC"
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			>
-				<option value="hide">JHIDE</option>
+				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 		</field>
 


### PR DESCRIPTION
Components->Tags->Options->Shared Layout Options - Hide for Filter Field in green instead of red.
Line 303 changed value="hide" to value="0"
