### PR TITLE
 [#31573] "tags list" links article with incorrect item-id

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -212,8 +212,8 @@ abstract class ContactHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
-			|| ($active->component == 'com_tags'))
+		if ($active
+			&& ( !empty($app->scope) || $active->language == '*' || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -212,7 +212,8 @@ abstract class ContactHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
+			|| ($active->component == 'com_tags'))
 		{
 			return $active->id;
 		}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -227,9 +227,11 @@ abstract class ContentHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active &&
-			($active->component == 'com_content' && ($active->language == '*' || !JLanguageMultilang::isEnabled())) ||
-			($active->component == 'com_tags'))
+		// This code is also run for links in modules, hence the awkward test. Testing for app->scope ensures that
+		// links in for example the com_tags context fall back to the active menu-id. Similar testing is done in
+		// in helpers of com_contact, com_weblinks and com_newsfeed
+		if ($active
+			&& ( !empty($app->scope) || ( $active->component == 'com_content' && ($active->language == '*' || !JLanguageMultilang::isEnabled()))))
 		{
 			return $active->id;
 		}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -227,7 +227,9 @@ abstract class ContentHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && $active->component == 'com_content' && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active &&
+			($active->component == 'com_content' && ($active->language == '*' || !JLanguageMultilang::isEnabled())) ||
+			($active->component == 'com_tags'))
 		{
 			return $active->id;
 		}

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -217,7 +217,8 @@ abstract class NewsfeedsHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
+			|| ($active->component == 'com_tags'))
 		{
 			return $active->id;
 		}

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -217,8 +217,8 @@ abstract class NewsfeedsHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
-			|| ($active->component == 'com_tags'))
+		if ($active
+			&& ( !empty($app->scope) || $active->language == '*' || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -244,7 +244,8 @@ abstract class WeblinksHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
+			|| ($active->component == 'com_tags'))
 		{
 			return $active->id;
 		}

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -244,8 +244,8 @@ abstract class WeblinksHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled())
-			|| ($active->component == 'com_tags'))
+		if ($active
+			&& ( !empty($app->scope) || $active->language == '*' || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}


### PR DESCRIPTION
Articles, Contacts, Newsfeeds and weblinks that are NOT referenced (in)directly in any menu item now get the item-id of the "referencing" tags-items menu id.
They used to deafult to the "home" item for the menu with all (undesired modules displayed)

see for discussion
[#31573] "tags list" links article with incorrect item-id
