### PR TITLE
Escape all backslashes (even when not explicitly required) 

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -279,10 +279,10 @@ class JDate extends DateTime
 		if ($translate)
 		{
 			// Do string replacements for date format options that can be translated.
-			$format = preg_replace('/(^|[^\\\])D/', "\\1" . self::DAY_ABBR, $format);
-			$format = preg_replace('/(^|[^\\\])l/', "\\1" . self::DAY_NAME, $format);
-			$format = preg_replace('/(^|[^\\\])M/', "\\1" . self::MONTH_ABBR, $format);
-			$format = preg_replace('/(^|[^\\\])F/', "\\1" . self::MONTH_NAME, $format);
+			$format = preg_replace('/(^|[^\\\\])D/', "\\1" . self::DAY_ABBR, $format);
+			$format = preg_replace('/(^|[^\\\\])l/', "\\1" . self::DAY_NAME, $format);
+			$format = preg_replace('/(^|[^\\\\])M/', "\\1" . self::MONTH_ABBR, $format);
+			$format = preg_replace('/(^|[^\\\\])F/', "\\1" . self::MONTH_NAME, $format);
 		}
 
 		// If the returned time should not be local use GMT.


### PR DESCRIPTION
because some IDEs (SublimeText) get confused.

This regexp is a bit confusing but it's mean to work like this:
Inside the `[]`, the first `\` (PHP string) escapes the second one and the third is literal. So this give us regexp like `/(^|[^\\])D/` in which the first one again (regexp) escapes the second one. 

Unfortunately, SublimeText (and maybe other editors) misinterpret the meaning of the third `\`. Of course they are wrong and I don't think it's a great idea to write code to appeal to wrongly behaving editors but I don't think there's any harm in this minor change. What will happen now is that the third `\`, instead of being literal, will escape the fourth one and we will still end up with a regexp like `/(^|[^\\])D/`. So there should be no change to functionality whatsoever. 
