### PR TITLE
get_html_translation_table default value has changed in PHP5.4

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -644,7 +644,8 @@ class JFilterInput
 		if (!is_array($ttr))
 		{
 			// Entity decode
-			$trans_tbl = get_html_translation_table(HTML_ENTITIES);
+			$trans_tbl = get_html_translation_table(HTML_ENTITIES, ENT_COMPAT, 'ISO-8859-1');
+
 			foreach ($trans_tbl as $k => $v)
 			{
 				$ttr[$v] = utf8_encode($k);


### PR DESCRIPTION
With PHP5.4 the default value is changed to utf8 so we need to define here the old default value to make sure that we have it working as before, see http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29944

new pull request because I closed https://github.com/joomla/joomla-cms/pull/1084 by accident
