### PR TITLE
Don't timeout while download an update.

### DIFF
--- a/administrator/components/com_joomlaupdate/helpers/download.php
+++ b/administrator/components/com_joomlaupdate/helpers/download.php
@@ -355,7 +355,7 @@ class AdmintoolsHelperDownload
 		{
 			return $result;
 		}
-		elseif ( $result === true )
+		elseif ($result === true)
 		{
 			return $return;
 		}

--- a/administrator/components/com_joomlaupdate/helpers/download.php
+++ b/administrator/components/com_joomlaupdate/helpers/download.php
@@ -308,6 +308,9 @@ class AdmintoolsHelperDownload
 			return $result;
 		}
 
+		// If we can't find out the default timeout from php.ini, use 30 seconds.
+		$timeout = function_exists('ini_get') ? ini_get('max_execution_time') : 30;
+
 		// Try to download
 		$bytes = 0;
 		$result = true;
@@ -315,7 +318,11 @@ class AdmintoolsHelperDownload
 
 		while (!feof($ih) && $result)
 		{
-			set_time_limit(ini_get('max_execution_time'));
+			// Try to reset the time limit on each iteration so that we don't time out if the download takes too long.
+			if (function_exists('set_time_limit'))
+			{
+				set_time_limit($timeout);
+			}
 
 			$contents = fread($ih, 4096);
 

--- a/administrator/components/com_joomlaupdate/helpers/download.php
+++ b/administrator/components/com_joomlaupdate/helpers/download.php
@@ -315,6 +315,8 @@ class AdmintoolsHelperDownload
 
 		while (!feof($ih) && $result)
 		{
+			set_time_limit(ini_get('max_execution_time'));
+
 			$contents = fread($ih, 4096);
 
 			if ($contents === false)


### PR DESCRIPTION
Sometimes, if you're on a slow connection (or some other reason) you can timeout while downloading an update package. So, we should reset the time limit on each iteration of the download loop so that it's not so easy to timeout. 
