### PR TITLE
Modal behavior missing for user notes view

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -101,11 +101,12 @@ class JHtmlUsers
 		}
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
+		
+		$html  = '<a class="btn btn-micro hasTooltip" href="' . JRoute::_('index.php?option=com_users&view=notes&filter_search=uid:' . (int)$userId) . '" ';
+		$html .= 'title="' . $title . '"><i class="icon icon-filter text-info"></i></a>';
 
-		return '<a class="modal"'
-			. ' href="' . JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId) . '"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
-			. '<span class="label label-info"><i class="icon-drawer-2"></i>' . $title . '</span></a>';
+		return $html;
+
 	}
 
 	/**

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
+JHtml::_('behavior.modal');
 JHtml::_('dropdown.init');
 JHtml::_('formbehavior.chosen', 'select');
 


### PR DESCRIPTION
If a user note is set, the "Display note" link, that uses the modal css class, is broken because the modal behavior is not set.
