### PR TITLE
When making a new context, base it on the old context.

### DIFF
--- a/administrator/components/com_joomlaupdate/helpers/download.php
+++ b/administrator/components/com_joomlaupdate/helpers/download.php
@@ -285,8 +285,9 @@ class AdmintoolsHelperDownload
 		// Open the URL for reading
 		if (function_exists('stream_context_create'))
 		{
-			$httpopts = array('user_agent' => 'Joomla/' . JVERSION);
-			$context = stream_context_create(array( 'http' => $httpopts ));
+			$opts = stream_context_get_options(stream_context_get_default());
+			$opts['http']['user_agent'] = 'Joomla/' . JVERSION;
+			$context = stream_context_create($opts);
 			$ih = @fopen($url, 'r', false, $context);
 		}
 		else


### PR DESCRIPTION
When creating a new context just to change the user agent, we need to preserve the other settings of the default context. Suppose you are running a site behind a proxy or something, you might have set your default context to deal with that (maybe via a custom plugin) and you won't want this downloader to undo that setting. 
