### PR TITLE
can work in php 5.5.0

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.0.3.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.0.3.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "#__associations" ALTER COLUMN id TYPE INT(11);
+ALTER TABLE "#__associations" ALTER COLUMN id TYPE INT;

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -261,7 +261,7 @@ class JInstallerAdapterLanguage extends JAdapterInstance
 
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
-		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'client_id' => '', 'folder' => ''));
+		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'folder' => ''));
 
 		if ($uid)
 		{

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -653,10 +653,24 @@ class JFilterInput
 		$source = strtr($source, $ttr);
 
 		// Convert decimal
-		$source = preg_replace('/&#(\d+);/me', "utf8_encode(chr(\\1))", $source); // decimal notation
+		
+		if (version_compare(phpversion(), '5.5.0', '<')) {
+			$source = preg_replace('/&#(\d+);/me', "utf8_encode(chr(\\1))", $source); // decimal notation
+		}
+		else
+		{
+			$source = preg_replace_callback ('/&#(\d+);/m', function ($match) { return utf8_encode(chr($match[1]));}, $source); // decimal notation
+		}
+		
 
 		// Convert hex
-		$source = preg_replace('/&#x([a-f0-9]+);/mei', "utf8_encode(chr(0x\\1))", $source); // hex notation
+		if (version_compare(phpversion(), '5.5.0', '<')) {
+			$source = preg_replace('/&#x([a-f0-9]+);/mei', "utf8_encode(chr(0x\\1))", $source); // hex notation
+		}
+		else
+		{
+			$source = preg_replace_callback('/&#x([a-f0-9]+);/mi',  function ($match) {utf8_encode(chr("0x".$match[1]));}, $source); // hex notation
+		}
 		return $source;
 	}
 

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -657,8 +657,6 @@ class JFilterInput
 
 		// Convert hex
 		$source = preg_replace_callback('/&#x([a-f0-9]+);/mi', function($m){return utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
-
-
 		return $source;
 	}
 


### PR DESCRIPTION
in php 5.5.0 the preg_replace()  /e modifier is deprecated. Use preg_replace_callback() instead.
