### PR TITLE
Error coding on attribute

### DIFF
--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -43,7 +43,7 @@ class JFormFieldUrl extends JFormFieldText
 		// Initialize some field attributes.
 		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$maxLength = $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		$class    = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '" ' : '" ';
+		$class    = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$readonly = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$required = $this->required ? ' required="required" aria-required="true"' : '';


### PR DESCRIPTION
if empty class, field got one alone ' " '

EG: < input name="jform[website]" id="jform_website" type="url" "="" value="" / >

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemBrowse&tracker_id=8103
