### PR TITLE
because there isn't a THING like separator in bootstrap code removed

### DIFF
--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -8,9 +8,3 @@
  */
 
 defined('_JEXEC') or die;
-
-$class = $displayData['class'];
-$style = $displayData['style'];
-
-?>
-<div class="btn-group <?php echo $class; ?>"<?php echo $style; ?>></div>


### PR DESCRIPTION
The used bottom group was wrong because it is something different than a separator (or divider) and since there isn't a something like a separator we don't have HTML code for that.

related tracker item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31588
