### PR TITLE
Offline template: remove "remember me" checkbox when plugin disabled 

### DIFF
--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -52,10 +52,12 @@ JHtml::_('bootstrap.framework');
 			<label for="passwd"><?php echo JText::_('JGLOBAL_PASSWORD') ?></label>
 			<input type="password" name="password" class="inputbox" size="18" alt="<?php echo JText::_('JGLOBAL_PASSWORD') ?>" id="passwd" />
 		</p>
+		<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
 		<p id="form-login-remember">
 			<label for="remember"><?php echo JText::_('JGLOBAL_REMEMBER_ME') ?></label>
 			<input type="checkbox" name="remember" class="inputbox" value="yes" alt="<?php echo JText::_('JGLOBAL_REMEMBER_ME') ?>" id="remember" />
 		</p>
+		<?php endif; ?>
 		<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGIN') ?>" />
 		<input type="hidden" name="option" value="com_users" />
 		<input type="hidden" name="task" value="user.login" />


### PR DESCRIPTION
See following bug report: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31716

Note: This is a take-over of the check for activation of the "remember" plugin from in \templates\atomic\html\mod_login\default.php on Joomla 2.5.14.

I tested it on Joomla 1.5, but can't test it on the current version, because I don't use it. While it seems from the code that the same (names) are still used in the current version, it still needs to be tested. I'm going to add a test procedure to the above bug report, for someone to test this quickly.
