### PR TITLE
2.5.x com finder nonarray

### DIFF
--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -72,6 +72,12 @@ class FinderViewSearch extends JViewLegacy
 		// Set the document link.
 		$this->document->link = JRoute::_($query->toURI());
 
+		// If we don't have any results, we are done.
+		if (empty($results))
+		{
+			return;
+		}
+
 		// Convert the results to feed entries.
 		foreach ($results as $result)
 		{

--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -31,6 +31,7 @@ class FinderViewSearch extends JViewLegacy
 	{
 		// Get the application
 		$app = JFactory::getApplication();
+
 		// Adjust the list limit to the feed limit.
 		$app->input->set('limit', $app->getCfg('feed_limit'));
 
@@ -98,7 +99,7 @@ class FinderViewSearch extends JViewLegacy
 				$item->category = $node->title;
 			}
 
-			// loads item info into rss array
+			// Loads item info into rss array.
 			$this->document->addItem($item);
 		}
 	}


### PR DESCRIPTION
This was already fixed for 3.x so this is the same fix for 2.5.x

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8549&tracker_item_id=30419
