### PR TITLE
#31743 (for 2.5.x) Improve wording of failed authentication attempts

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_log.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_log.ini
@@ -5,6 +5,7 @@
 
 PLG_LOG_XML_DESCRIPTION="Provides System Logging"
 PLG_SYSTEM_LOG="System - Log"
-PLG_SYSTEM_LOG_FIELD_LOG_USERNAME_DESC="This option will log used user names when an authentication failed"
+PLG_SYSTEM_LOG_FIELD_LOG_USERNAME_DESC="This option will log used user names when authentication has failed"
 PLG_SYSTEM_LOG_FIELD_LOG_USERNAME_LABEL="Log user names"
-
+PLG_SYSTEM_LOG_FIELD_LOG_IPADDRESS_DESC="This option will log source IP addresses when authentication has failed"
+PLG_SYSTEM_LOG_FIELD_LOG_IPADDRESS_LABEL="Log IP addresses"

--- a/plugins/system/log/log.php
+++ b/plugins/system/log/log.php
@@ -31,12 +31,15 @@ class  plgSystemLog extends JPlugin
 
 			case JAuthentication::STATUS_FAILURE :
 			{
-				$errorlog['status']  = $response['type'] . " FAILURE: ";
-				if ($this->params->get('log_username', 0)) {
-					$errorlog['comment'] = $response['error_message'] . ' ("' . $response['username'] . '")';
+			$errorlog['status']  = $response['type'] . " FAILURE: ";
+			$errorlog['comment'] = $response['error_message'];
+				if ($this->params->get('log_username', 0) && $this->params->get('log_sourceip',0))
+				{
+					$errorlog['comment'] .= ' (username="' . $response['username'] . '",srcip=' . $_SERVER["REMOTE_ADDR"] . ')';
 				}
-				else {
-					$errorlog['comment'] = $response['error_message'];
+				elseif ($this->params->get('log_username', 0) && $this->params->get('log_sourceip',1))
+				{
+					$errorlog['comment'] .= ' (username="' . $response['username'] . '")';
 				}
 				$log->addEntry($errorlog);
 			}	break;

--- a/plugins/system/log/log.xml
+++ b/plugins/system/log/log.xml
@@ -28,6 +28,14 @@
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+                                <field name="log_sourceip" type="radio"
+                                        description="PLG_SYSTEM_LOG_FIELD_LOG_IPADDRESS_DESC"
+                                        label="PLG_SYSTEM_LOG_FIELD_LOG_IPADDRESS_LABEL"
+                                        default="0"
+                                >
+                                        <option value="0">JNO</option>
+                                        <option value="1">JYES</option>
+                                </field>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
Fixed earlier broken stuff. Tested.
