### PR TITLE
Avoid mixed-security warning when serving protostar templates over https with google fonts

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -87,7 +87,7 @@ else
 	if ($params->get('googleFont'))
 	{
 	?>
-		<link href='http://fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName');?>' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName');?>' rel='stylesheet' type='text/css'>
 	<?php
 	}
 	?>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -81,7 +81,7 @@ else
 	if ($params->get('googleFont'))
 	{
 	?>
-		<link href='http://fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName');?>' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName');?>' rel='stylesheet' type='text/css'>
 	<?php
 	}
 	?>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -89,7 +89,7 @@ else
 	if ($this->params->get('googleFont'))
 	{
 	?>
-		<link href='http://fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName');?>' rel='stylesheet' type='text/css' />
+		<link href='//fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName');?>' rel='stylesheet' type='text/css' />
 		<style type="text/css">
 			h1,h2,h3,h4,h5,h6,.site-title{
 				font-family: '<?php echo str_replace('+', ' ', $this->params->get('googleFontName'));?>', sans-serif;


### PR DESCRIPTION
This is done by changing the URL for the font style from http://
to a schema-less //.  In IE7 and IE8 this is known to cause the
stylesheet to be downloaded twice, but this stylesheet is only a
few bytes in size.
