### PR TITLE
Regarding issue tracker #29442 - Backport cURL support and related updater and installer fixes

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  HTTP
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * HTTP factory class.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  HTTP
+ * @since       12.1
+ */
+class JHttpFactory
+{
+	/**
+	 * method to recieve Http instance.
+	 *
+	 * @param   JRegistry  $options   Client options object.
+	 * @param   mixed      $adapters  Adapter (string) or queue of adapters (array) to use for communication.
+	 *
+	 * @return  JHttp      Joomla Http class
+	 *
+	 * @since   12.1
+	 */
+	public static function getHttp(JRegistry $options = null, $adapters = null)
+	{
+		if (empty($options))
+		{
+			$options = new JRegistry;
+		}
+		return new JHttp($options, self::getAvailableDriver($options, $adapters));
+	}
+
+	/**
+	 * Finds an available http transport object for communication
+	 *
+	 * @param   JRegistry  $options  Option for creating http transport object
+	 * @param   mixed      $default  Adapter (string) or queue of adapters (array) to use
+	 *
+	 * @return  JHttpTransport Interface sub-class
+	 *
+	 * @since   12.1
+	 */
+	public static function getAvailableDriver(JRegistry $options, $default = null)
+	{
+		if (is_null($default))
+		{
+			$availableAdapters = self::getHttpTransports();
+		}
+		else
+		{
+			settype($default, 'array');
+			$availableAdapters = $default;
+		}
+		// Check if there is available http transport adapters
+		if (!count($availableAdapters))
+		{
+			return false;
+		}
+		foreach ($availableAdapters as $adapter)
+		{
+			$class = 'JHttpTransport' . ucfirst($adapter);
+
+			if ($class::isSupported())
+			{
+				return new $class($options);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the http transport handlers
+	 *
+	 * @return  array  An array of available transport handlers
+	 *
+	 * @since   12.1
+	 */
+	public static function getHttpTransports()
+	{
+		$names = array();
+		$iterator = new DirectoryIterator(dirname(__FILE__) . '/transport');
+		foreach ($iterator as $file)
+		{
+			$fileName = $file->getFilename();
+
+			// Only load for php files.
+			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
+			if ($file->isFile() && substr($fileName, strrpos($fileName, '.') + 1) == 'php')
+			{
+				$names[] = substr($fileName, 0, strrpos($fileName, '.'));
+			}
+		}
+
+		return $names;
+	}
+}

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -180,4 +180,16 @@ class JHttpTransportCurl implements JHttpTransport
 
 		return $return;
 	}
+
+	/**
+	 * Method to check if HTTP transport cURL is available for use
+	 *
+	 * @return boolean true if available, else false
+	 *
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('curl_version') && curl_version();
+	}
 }

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -250,4 +250,16 @@ class JHttpTransportSocket implements JHttpTransport
 
 		return $this->connections[$key];
 	}
+
+	/**
+	 * method to check if http transport socket available for using
+	 *
+	 * @return bool true if available else false
+	 *
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('fsockopen') && is_callable('fsockopen');
+	}
 }

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -177,4 +177,16 @@ class JHttpTransportStream implements JHttpTransport
 
 		return $return;
 	}
+
+	/**
+	 * method to check if http transport stream available for using
+	 *
+	 * @return bool true if available else false
+	 *
+	 * @since   12.1
+	 */
+	static public function isSupported()
+	{
+		return function_exists('fopen') && is_callable('fopen');
+	}
 }

--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -47,7 +47,22 @@ abstract class JInstallerHelper
 		ini_set('user_agent', $version->getUserAgent('Installer'));
 
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
+
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $exc)
+		{
+			$response = null;
+		}
+
+		if (is_null($response))
+		{
+			JError::raiseWarning(42, JText::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $error));
+
+			return false;
+		}
 
 		if (302 == $response->code && isset($response->headers['Location']))
 		{

--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -46,23 +46,24 @@ abstract class JInstallerHelper
 		$version = new JVersion;
 		ini_set('user_agent', $version->getUserAgent('Installer'));
 
-		// Open the remote server socket for reading
-		$inputHandle = @ fopen($url, "r");
-		$error = strstr($php_errormsg, 'failed to open stream:');
-		if (!$inputHandle)
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+
+		if (302 == $response->code && isset($response->headers['Location']))
+		{
+			return self::downloadPackage($response->headers['Location']);
+		}
+		elseif (200 != $response->code)
 		{
 			JError::raiseWarning(42, JText::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $error));
+
 			return false;
 		}
 
-		$meta_data = stream_get_meta_data($inputHandle);
-		foreach ($meta_data['wrapper_data'] as $wrapper_data)
+		if (isset($response->headers['Content-Disposition']))
 		{
-			if (substr($wrapper_data, 0, strlen("Content-Disposition")) == "Content-Disposition")
-			{
-				$contentfilename = explode("\"", $wrapper_data);
-				$target = $contentfilename[1];
-			}
+			$contentfilename = explode("\"", $response->headers['Content-Disposition']);
+			$target = $contentfilename[1];
 		}
 
 		// Set the target path if not given
@@ -75,24 +76,8 @@ abstract class JInstallerHelper
 			$target = $config->get('tmp_path') . '/' . basename($target);
 		}
 
-		// Initialise contents buffer
-		$contents = null;
-
-		while (!feof($inputHandle))
-		{
-			$contents .= fread($inputHandle, 4096);
-			if ($contents === false)
-			{
-				JError::raiseWarning(44, JText::sprintf('JLIB_INSTALLER_ERROR_FAILED_READING_NETWORK_RESOURCES', $php_errormsg));
-				return false;
-			}
-		}
-
 		// Write buffer to file
-		JFile::write($target, $contents);
-
-		// Close file pointer resource
-		fclose($inputHandle);
+		JFile::write($target, $response->body);
 
 		// Restore error tracking to what it was before
 		ini_set('track_errors', $track_errors);

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -97,8 +97,13 @@ class JUpdaterCollection extends JUpdateAdapter
 	{
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
+
 		// Reset the data
-		eval('$this->' . $tag . '->_data = "";');
+		if (isset($this->$tag))
+		{
+			$this->$tag->_data = "";
+		}
+
 		switch ($name)
 		{
 			case 'CATEGORY':
@@ -205,12 +210,14 @@ class JUpdaterCollection extends JUpdateAdapter
 	{
 		$url = $options['location'];
 		$this->_update_site_id = $options['update_site_id'];
+
 		if (substr($url, -4) != '.xml')
 		{
 			if (substr($url, -1) != '/')
 			{
 				$url .= '/';
 			}
+
 			$url .= 'update.xml';
 		}
 
@@ -219,7 +226,10 @@ class JUpdaterCollection extends JUpdateAdapter
 		$this->updates = array();
 		$dbo = $this->parent->getDBO();
 
-		if (!($fp = @fopen($url, "r")))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+
+		if (200 != $response->code)
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');
@@ -231,6 +241,7 @@ class JUpdaterCollection extends JUpdateAdapter
 			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url), 'warning');
+
 			return false;
 		}
 
@@ -238,16 +249,15 @@ class JUpdaterCollection extends JUpdateAdapter
 		xml_set_object($this->xml_parser, $this);
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
 
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->body))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
-				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
-				return false;
-			}
+			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
+
+			return false;
 		}
+
 		// TODO: Decrement the bad counter if non-zero
 		return array('update_sites' => $this->update_sites, 'updates' => $this->updates);
 	}

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -227,9 +227,17 @@ class JUpdaterCollection extends JUpdateAdapter
 		$dbo = $this->parent->getDBO();
 
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
 
-		if (200 != $response->code)
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $exc)
+		{
+			$response = null;
+		}
+
+		if (is_null($response) || ($response->code != 200))
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -161,9 +161,17 @@ class JUpdaterExtension extends JUpdateAdapter
 		$dbo = $this->parent->getDBO();
 
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
 
-		if (200 != $response->code)
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $exc)
+		{
+			$response = null;
+		}
+
+		if (is_null($response) || ($response->code != 200))
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -34,8 +34,12 @@ class JUpdaterExtension extends JUpdateAdapter
 	{
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
-		// reset the data
-		eval('$this->' . $tag . '->_data = "";');
+
+		// Reset the data
+		if (isset($this->$tag))
+		{
+			$this->$tag->_data = "";
+		}
 
 		switch ($name)
 		{
@@ -144,6 +148,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		$url = $options['location'];
 		$this->_url = &$url;
 		$this->_update_site_id = $options['update_site_id'];
+
 		if (substr($url, -4) != '.xml')
 		{
 			if (substr($url, -1) != '/')
@@ -155,7 +160,10 @@ class JUpdaterExtension extends JUpdateAdapter
 
 		$dbo = $this->parent->getDBO();
 
-		if (!($fp = @fopen($url, "r")))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+
+		if (200 != $response->code)
 		{
 			$query = $dbo->getQuery(true);
 			$query->update('#__update_sites');
@@ -167,6 +175,7 @@ class JUpdaterExtension extends JUpdateAdapter
 			JLog::add("Error opening url: " . $url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), 'warning');
+
 			return false;
 		}
 
@@ -175,17 +184,17 @@ class JUpdaterExtension extends JUpdateAdapter
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
 		xml_set_character_data_handler($this->xml_parser, '_characterData');
 
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->body))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
-				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
-				return false;
-			}
+			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
+
+			return false;
 		}
+
 		xml_parser_free($this->xml_parser);
+
 		if (isset($this->latest))
 		{
 			if (isset($this->latest->client) && strlen($this->latest->client))
@@ -193,12 +202,14 @@ class JUpdaterExtension extends JUpdateAdapter
 				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, 1)->id;
 				unset($this->latest->client);
 			}
+
 			$updates = array($this->latest);
 		}
 		else
 		{
 			$updates = array();
 		}
+
 		return array('update_sites' => array(), 'updates' => $updates);
 	}
 }

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -293,8 +293,17 @@ class JUpdate extends JObject
 	public function loadFromXML($url)
 	{
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
-		if (200 != $response->code)
+
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $exc)
+		{
+			$response = null;
+		}
+
+		if (is_null($response) || ($response->code != 200))
 		{
 			// TODO: Add a 'mark bad' setting here somehow
 			JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -166,8 +166,12 @@ class JUpdate extends JObject
 	{
 		array_push($this->_stack, $name);
 		$tag = $this->_getStackLocation();
+
 		// Reset the data
-		eval('$this->' . $tag . '->_data = "";');
+		if (isset($this->$tag))
+		{
+			$this->$tag->_data = "";
+		}
 
 		switch ($name)
 		{
@@ -181,6 +185,10 @@ class JUpdate extends JObject
 			// For everything else there's...the default!
 			default:
 				$name = strtolower($name);
+				if (!isset($this->_current_update->$name))
+				{
+					$this->_current_update->$name = new stdClass;
+				}
 				$this->_current_update->$name->_data = '';
 				foreach ($attrs as $key => $data)
 				{
@@ -265,7 +273,12 @@ class JUpdate extends JObject
 		//$this->$tag->_data .= $data;
 		// Throw the data for this item together
 		$tag = strtolower($tag);
-		$this->_current_update->$tag->_data .= $data;
+
+		//$this->_current_update->$tag->_data .= $data;
+		if (isset($this->_current_update->$tag))
+		{
+			$this->_current_update->$tag->_data .= $data;
+		}
 	}
 
 	/**
@@ -279,7 +292,9 @@ class JUpdate extends JObject
 	 */
 	public function loadFromXML($url)
 	{
-		if (!($fp = @fopen($url, 'r')))
+		$http = JHttpFactory::getHttp();
+		$response = $http->get($url);
+		if (200 != $response->code)
 		{
 			// TODO: Add a 'mark bad' setting here somehow
 			JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
@@ -291,18 +306,16 @@ class JUpdate extends JObject
 		xml_set_element_handler($this->xml_parser, '_startElement', '_endElement');
 		xml_set_character_data_handler($this->xml_parser, '_characterData');
 
-		while ($data = fread($fp, 8192))
+		if (!xml_parse($this->xml_parser, $response->body))
 		{
-			if (!xml_parse($this->xml_parser, $data, feof($fp)))
-			{
-				die(
-					sprintf(
-						"XML error: %s at line %d", xml_error_string(xml_get_error_code($this->xml_parser)),
-						xml_get_current_line_number($this->xml_parser)
-					)
-				);
-			}
+			die(
+				sprintf(
+					"XML error: %s at line %d", xml_error_string(xml_get_error_code($this->xml_parser)),
+					xml_get_current_line_number($this->xml_parser)
+				)
+			);
 		}
+
 		xml_parser_free($this->xml_parser);
 		return true;
 	}

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -71,16 +71,9 @@ class JUpdater extends JAdapter
 	 */
 	public function findUpdates($eid = 0, $cacheTimeout = 0)
 	{
-		// Check if fopen is allowed
-		$result = ini_get('allow_url_fopen');
-		if (empty($result))
-		{
-			JError::raiseWarning('101', JText::_('JLIB_UPDATER_ERROR_COLLECTION_FOPEN'));
-			return false;
-		}
-
 		$dbo = $this->getDBO();
 		$retval = false;
+
 		// Push it into an array
 		if (!is_array($eid))
 		{


### PR DESCRIPTION
This pull request fixes a long standing Joomla! 2.5 issue which prevents any updates (core Joomla! and its extensions) from working on servers where URL fopen() wrappers are disabled. Moreover it fixes a related issue with installing extensions from URL on such servers.

The changes made are:
- Backport of JHttpFactory from Joomla! 3
- Modification of JUpdater and related classes to use JHttpFactory
- Removal of evil eval() code in JUpdater and related classes which caused the updater to not work at all on shared hosts which correctly and justifiably disallow the use of eval() for security reasons
- Modification of JInstallerHelper::downloadPackage to use JHttpFactory

This Pull Request does not have any backwards compatibility issues.
