### PR TITLE
[#32035] Add package support for media folder

### DIFF
--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -250,6 +250,7 @@ class JInstallerAdapterPackage extends JAdapterInstance
 		}
 
 		// Parse optional tags
+		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
 
 		/*
@@ -518,6 +519,7 @@ class JInstallerAdapterPackage extends JAdapterInstance
 		}
 
 		// Remove any language files
+		$this->parent->removeFiles($xml->media);
 		$this->parent->removeFiles($xml->languages);
 
 		// Clean up manifest file after we're done if there were no errors


### PR DESCRIPTION
Actually package install adapters doesn't support:

``` XML


        css
        images
        js

```

This adds support for them like in components.

Issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32035
