### PR TITLE
Package media - J2.5

### DIFF
--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -207,6 +207,7 @@ class JInstallerPackage extends JAdapterInstance
 		}
 
 		// Parse optional tags
+		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
 
 		// Extension Registration
@@ -457,6 +458,7 @@ class JInstallerPackage extends JAdapterInstance
 		}
 
 		// Remove any language files
+		$this->parent->removeFiles($xml->media);
 		$this->parent->removeFiles($xml->languages);
 
 		// clean up manifest file after we're done if there were no errors


### PR DESCRIPTION
Actually package install adapters doesn't support:

``` XML


        css
        images
        js

```

This adds support for them like in components.
