### PR TITLE
Corrected and extended backend usernames validation

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -184,7 +184,7 @@ class JTableUser extends JTable
 			return false;
 		}
 
-		if (preg_match("#[<>\"'%;()&]#i", $this->username) || strlen(utf8_decode($this->username)) < 2)
+		if (preg_match('#[<>"\'%;()&\\s\\\\]|\\.\\./#', $this->username) || strlen(utf8_decode($this->username)) < 2)
 		{
 			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_VALID_AZ09', 2));
 			return false;


### PR DESCRIPTION
Corrected backend username validation to ensure validation according to
the stated rules:

Please enter a valid username. No spaces, at least 2 characters and must
not contain the following characters: < > \ " ' % ; ( ) &

I'm not trimming the username and let the regex check for spaces.

Extended validation against the ../ as string this can be potentialy
used for exploits.

See tracker issue
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30586
