### PR TITLE
Edit ".thumbnails > li" under "@media (max-width: 767px)"

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -4766,7 +4766,7 @@ a.badge:focus {
 		margin-left: 0;
 	}
 	.thumbnails > li {
-		float: none;
+		float: left;
 		margin-left: 0;
 	}
 	[class*="span"],


### PR DESCRIPTION
We have to changer "float:none" to "float:left" because it show images in one after one in media manager when user use:

To insert image in article -> When a user access media manager.
To insert image in Custom HTML -> When a user access media manager.
