### PR TITLE
[#28052] Article page title can't be overwritten via content plugins

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -176,7 +176,7 @@ class ContentViewArticle extends JViewLegacy
 		if ($menu && ($menu->query['option'] != 'com_content' || $menu->query['view'] != 'article' || $id != $this->item->id))
 		{
 			// If this is not a single article menu item, set the page title to the article title
-			if ($this->item->title) {
+			if (($this->params->get('page_title') == $menu->title) || ($this->params->get('page_title') == $menu->params->get('page_title')) && $this->item->title) {
 				$title = $this->item->title;
 			}
 			$path = array(array('title' => $this->item->title, 'link' => ''));


### PR DESCRIPTION
The bug is that custom titles for articles set by a content plugin get overwritten with original article titles when the article has a parent category menu item. More info:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=28052
