### PR TITLE
Update stream.php

### DIFF
--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -34,16 +34,16 @@ class JHttpTransportStream implements JHttpTransport
 	 */
 	public function __construct(JRegistry $options)
 	{
-		// Verify that fopen() is available.
-		if (!self::isSupported())
-		{
-			throw new RuntimeException('Cannot use a stream transport when fopen() is not available.');
-		}
-
 		// Verify that URLs can be used with fopen();
 		if (!ini_get('allow_url_fopen'))
 		{
 			throw new RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
+		}
+
+		// Verify that fopen() is available.
+		if (!self::isSupported())
+		{
+			throw new RuntimeException('Cannot use a stream transport when fopen() is not available.');
 		}
 
 		$this->options = $options;
@@ -211,6 +211,6 @@ class JHttpTransportStream implements JHttpTransport
 	 */
 	static public function isSupported()
 	{
-		return function_exists('fopen') && is_callable('fopen');
+		return function_exists('fopen') && is_callable('fopen') && ini_get('allow_url_fopen');
 	}
 }


### PR DESCRIPTION
Changed isSupported() method, now it returns false if allow_url_fopen is not set.

Testcase:
=> Allow fopen() and deactivate "allow_url_fopen" and activate CURL in your php.ini. Browse to the Joomla!-Updater:
=> Cannot use a stream transport when "allow_url_fopen" is disabled.
=> Apply patch
=> Try again, Joomla! should use CURL now
