### PR TITLE
[#30355] make tags list respect publish dates when filtering for published items

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -547,6 +547,11 @@ class JHelperTags
 
 			->where('m.tag_id IN (' . $tagId . ')')
 			->where('c.core_state IN (' . $stateFilter . ')');
+			if ($stateFilter == 1) {
+				$nowDate = $db->Quote(JFactory::getDate()->toSQL());
+				$query->where('(core_publish_up = ' . $nullDate . ' OR core_publish_up <= ' . $nowDate . ')');
+				$query->where('(core_publish_down = ' . $nullDate . ' OR core_publish_down >= ' . $nowDate . ')');
+			}
 
 		// Optionally filter on language
 		if (empty($language))


### PR DESCRIPTION
This adds filtering by state to the tagged items query.
Mark and I discussed and decided that filtering to just show published items makes the most sense a this time.

Tag some items and unpublish or trash one or more.
Before the patch, they would show.
After the patch they don't show.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30355
