### PR TITLE
JText: Changed conditional to make it easier to read

### DIFF
--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -65,7 +65,7 @@ class JText
 				$jsSafe = false;
 			}
 		}
-		if (!(strpos($string, ',') === false))
+		if (strpos($string, ','))
 		{
 			$test = substr($string, strpos($string, ','));
 			if (strtoupper($test) === $test)


### PR DESCRIPTION
I had serious problems understanding this conditional, so I simplified it a bit.

Old behavior:
1a. Check if there is a comma in the string. If not, return false.
2a. Compare that false to "false", resulting in "true".
3a. Negate that "true", resulting in false. Skip this block.

1b. Check if there is a comma in the string. If there is, return true.
2b. Compare that "true" against "false", resulting in "false".
3b. Negate that "false", resulting in true. Executing this block.

New behavior:
1a. Check if there is a comma in the string. If not or the comma is at the first position, return false or 0, which is both falsey. Skip this block.

1b. Check if there is a comma in the string. If there is and the comma is not at the first position, return an int > 0, which evaluates to true. Execute this block.

The only difference to before is, that you can't have a key with a leading comma. As far as I can see, this is never the case. At the same time, this code is a LOT more readable.
