### PR TITLE
fix for protocol-agnostic embedded URLs in content

### DIFF
--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -244,7 +244,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 	public function _relToAbs($text)
 	{
 		$base = JUri::base();
-		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
+		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data|\/\/)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
 
 		return $text;
 	}


### PR DESCRIPTION
Recently, YouTube changed the embed URLs provided, so that they are protocol agnostic;

&lt;iframe width="560" height="315" src="//www.youtube.com/embed/bRdOBbluWgc" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;

While &lt;iframes&gt; are, indeed, disallowed in _most_ cases, the concept of a protocol-agnostic URL is not new, and continues to rise in prominence.

This fix should prevent URLs like the one shown above, from having JURI::base() concatenated to the beginning.
