### PR TITLE
Update helper.php

### DIFF
--- a/libraries/joomla/cache/storage/helper.php
+++ b/libraries/joomla/cache/storage/helper.php
@@ -65,7 +65,7 @@ class JCacheStorageHelper
 	 */
 	public function updateSize($size)
 	{
-		$this->size = number_format($this->size + $size, 2);
+		$this->size = number_format($this->size + $size, 2, '.', '');
 		$this->count++;
 	}
 }


### PR DESCRIPTION
Prevents thousands separator (",") from being used when total cache size exceeds 1mb.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31826
