### PR TITLE
[#31912] Generated passwords - longer and with special characters

### DIFF
--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -524,9 +524,9 @@ abstract class JUserHelper
 	 *
 	 * @since   11.1
 	 */
-	public static function genRandomPassword($length = 8)
+	public static function genRandomPassword($length = 10)
 	{
-		$salt = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+		$salt = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%+\/'!#$^?:.(){}[]~-_";
 		$base = strlen($salt);
 		$makepass = '';
 


### PR DESCRIPTION
By default, the generated password in Joomla! to 8 characters without any special characters (eg. $,%, @).

I suggest some improvement in security by default generate a 10-character password with special characters.

I applied a patch on Github.

Before sharing patch, it has been tested by me on the latest current version of Joomla 2.5 and 3 branches.

Test Procedure:
1 Create a new user account leaving the password field blank (send e-mail passwords must be enabled).
2 The generated password will not have any special characters - only letters and numbers.

and
1. Change password for @% + \ / '! # $ ^?:. () {} [] ~-_
2. Verify that you can log on.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31912
