### PR TITLE
[#32064] Fix small issue with mod_menu (backend)

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -223,10 +223,10 @@ if ($user->authorise('core.manage', 'com_content'))
 	}
 
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured', 'class:featured'));
-	$menu->addSeparator();
 
 	if ($user->authorise('core.manage', 'com_media'))
 	{
+		$menu->addSeparator();
 		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MEDIA_MANAGER'), 'index.php?option=com_media', 'class:media'));
 	}
 


### PR DESCRIPTION
If not have access to com_media the menu display a wrong separator:

![menu user problem](https://f.cloud.github.com/assets/441774/1103562/cb4ab2d2-18b2-11e3-8e6d-c2d67f8d0774.png)

Tracker: #32064
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32064&start=0
