### PR TITLE
Login modules tips display

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -13,9 +13,6 @@ JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen');
 
-$document = JFactory::getDocument();
-$mainDirection = $document->direction == 'rtl' ? 'right' : 'left';
-$altDirection  = $document->direction == 'rtl' ? 'left' : 'right';
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="form-login" class="form-inline">
 	<fieldset class="loginform">
@@ -23,14 +20,14 @@ $altDirection  = $document->direction == 'rtl' ? 'left' : 'right';
 			<div class="controls">
 				<div class="input-prepend input-append">
 					<span class="add-on">
-						<i class="icon-user hasTooltip" data-placement="<?php echo $mainDirection; ?>" title="<?php echo JText::_('JGLOBAL_USERNAME'); ?>"></i>
+						<i class="icon-user hasTooltip" title="<?php echo JText::_('JGLOBAL_USERNAME'); ?>"></i>
 						<label for="mod-login-username" class="element-invisible">
 							<?php echo JText::_('JGLOBAL_USERNAME'); ?>
 						</label>
 					</span>
 					<input name="username" tabindex="1" id="mod-login-username" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15"/>
-					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind" class="btn width-auto hasTooltip" data-placement="<?php echo $altDirection; ?>" title="<?php echo JText::_('MOD_LOGIN_REMIND'); ?>">
-						<i class="icon-help" title="<?php echo JText::_('MOD_LOGIN_REMIND'); ?>"></i>
+					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_REMIND'); ?>">
+						<i class="icon-help"></i>
 					</a>
 				</div>
 			</div>
@@ -39,14 +36,14 @@ $altDirection  = $document->direction == 'rtl' ? 'left' : 'right';
 			<div class="controls">
 				<div class="input-prepend input-append">
 					<span class="add-on">
-						<i class="icon-lock hasTooltip" data-placement="<?php echo $mainDirection; ?>" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>"></i>
+						<i class="icon-lock hasTooltip" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>"></i>
 						<label for="mod-login-password" class="element-invisible">
 							<?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 						</label>
 					</span>
 					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"/>
-					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset" class="btn width-auto hasTooltip" data-placement="<?php echo $altDirection; ?>" title="<?php echo JText::_('MOD_LOGIN_RESET'); ?>">
-						<i class="icon-help" title="<?php echo JText::_('MOD_LOGIN_RESET'); ?>"></i>
+					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_RESET'); ?>">
+						<i class="icon-help"></i>
 					</a>
 				</div>
 			</div>
@@ -56,14 +53,14 @@ $altDirection  = $document->direction == 'rtl' ? 'left' : 'right';
 			<div class="controls">
 				<div class="input-prepend input-append">
 					<span class="add-on">
-						<i class="icon-star hasTooltip" data-placement="<?php echo $mainDirection; ?>" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>"></i>
+						<i class="icon-star hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>"></i>
 						<label for="mod-login-secretkey" class="element-invisible">
 							<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 						</label>
 					</span>
 					<input name="secretkey" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
-					<span class="btn width-auto hasTooltip" data-placement="<?php echo $altDirection; ?>" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
-						<i class="icon-help" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>"></i>
+					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
+						<i class="icon-help"></i>
 					</span>
 				</div>
 			</div>
@@ -74,7 +71,7 @@ $altDirection  = $document->direction == 'rtl' ? 'left' : 'right';
 				<div class="controls">
 					<div class="input-prepend">
 						<span class="add-on">
-							<i class="icon-comment hasTooltip" data-placement="<?php echo $mainDirection; ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGIN_LANGUAGE'); ?>"></i>
+							<i class="icon-comment hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGIN_LANGUAGE'); ?>"></i>
 							<label for="lang" class="element-invisible">
 								<?php echo JText::_('MOD_LOGIN_LANGUAGE'); ?>
 							</label>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -60,14 +60,14 @@ JHtml::_('bootstrap.tooltip');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend input-append">
 						<span class="add-on">
-							<span class="icon-star hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>"
+							<span class="icon-star hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>">
 							</span>
 								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
 						<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
-							<i class="icon-help"></i>
+							<span class="icon-help"></span>
 						</span>
 				</div>
 				<?php else: ?>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
+
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
 	<?php if ($params->get('pretext')) : ?>
@@ -24,7 +25,7 @@ JHtml::_('bootstrap.tooltip');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend">
 						<span class="add-on">
-							<span class="icon-user tip" title="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>"></span>
+							<span class="icon-user hasTooltip" title="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>"></span>
 							<label for="modlgn-username" class="element-invisible"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 						</span>
 						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>" />
@@ -40,7 +41,7 @@ JHtml::_('bootstrap.tooltip');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend">
 						<span class="add-on">
-							<span class="icon-lock tip" title="<?php echo JText::_('JGLOBAL_PASSWORD') ?>">
+							<span class="icon-lock hasTooltip" title="<?php echo JText::_('JGLOBAL_PASSWORD') ?>">
 							</span>
 								<label for="modlgn-passwd" class="element-invisible"><?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 							</label>
@@ -59,20 +60,20 @@ JHtml::_('bootstrap.tooltip');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend input-append">
 						<span class="add-on">
-							<span class="icon-star tip" title="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" data-placement="<?php echo $mainDirection; ?>">
+							<span class="icon-star hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>"
 							</span>
 								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
 						<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
-						<span class="btn width-auto hasTooltip" data-placement="<?php echo $altDirection; ?>" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
-							<i class="icon-help" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>"></i>
+						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
+							<i class="icon-help"></i>
 						</span>
 				</div>
 				<?php else: ?>
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
 					<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
-					<span class="btn width-auto hasTooltip" data-placement="<?php echo $altDirection; ?>" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
+					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>
 				<?php endif; ?>


### PR DESCRIPTION
This patch corrects 2 problems:
1. data-placement tag causes tips to be displayed out of the window.
2. Both booltstrap toolitps and browser "title" tips are displayed, or only broswer tips

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31961&start=0
