### PR TITLE
[#31974] Untranslated JLIB String at installation  

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -120,6 +120,7 @@ INSTL_INSTALLING_DATABASE="Creating database tables"
 INSTL_INSTALLING_SAMPLE="Installing sample data"
 INSTL_INSTALLING_CONFIG="Creating configuration File"
 INSTL_INSTALLING_EMAIL="Sending email to %s"
+JLIB_MAIL_FUNCTION_OFFLINE="The mail function has been temporarily disabled on this site, please try again later."
 
 ;Email
 INSTL_EMAIL_SUBJECT="Configuration Details: %s"


### PR DESCRIPTION
Tracker: #31974
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31974&start=0
