### PR TITLE
setting up travis to NOT run on 2.5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+
+before_script:
+  - composer self-update
+  - pyrus channel-discover pear.phpunit.de
+  - pyrus install --force phpunit/DbUnit
+  - phpenv rehash
+  - mysql -e 'create database joomla_ut;'
+  - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
+  - psql -c 'create database joomla_ut;' -U postgres
+  - psql -d joomla_ut -a -f tests/unit/suites/database/stubs/postgresql.sql
+
+script:
+  - phpunit --configuration travisci-phpunit.xml
+
+branches:
+  except:
+    - 2.5.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,3 @@
-language: php
-
-php:
-  - 5.3
-  - 5.4
-
-before_script:
-  - composer self-update
-  - pyrus channel-discover pear.phpunit.de
-  - pyrus install --force phpunit/DbUnit
-  - phpenv rehash
-  - mysql -e 'create database joomla_ut;'
-  - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
-  - psql -c 'create database joomla_ut;' -U postgres
-  - psql -d joomla_ut -a -f tests/unit/suites/database/stubs/postgresql.sql
-
-script:
-  - phpunit --configuration travisci-phpunit.xml
-
 branches:
   except:
     - 2.5.x


### PR DESCRIPTION
any push to the 2.5 branch let travis fail because there isn't a travis configuration file and because of that the exclude for the 2.5.x branch does't work. I added a quite simple travis configuration for that situation
