### PR TITLE
Update edit.php

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -103,6 +103,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 						</div>
 						<?php if ($this->item->type == 'url') : ?>
 							<?php $this->form->setFieldAttribute('link', 'readonly', 'false');?>
+							<?php $this->form->setFieldAttribute('link', 'required', 'true');?>
 							<div class="control-group">
 								<div class="control-label">
 									<?php echo $this->form->getLabel('link'); ?>


### PR DESCRIPTION
The "Link" field for menu item type External URL was not required. I added code here so that "Link" is only required for this menu item type. 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32021&start=0
