### PR TITLE
Removing MooTools dependencies from media/com_joomlaupdate section

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -56,6 +56,9 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		// Load mooTools
 		JHtml::_('behavior.framework', true);
 
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		
 		// Load our Javascript
 		$document = JFactory::getDocument();
 		$document->addScript('../media/com_joomlaupdate/default.js');

--- a/administrator/components/com_joomlaupdate/views/update/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/update/view.html.php
@@ -45,6 +45,9 @@ class JoomlaupdateViewUpdate extends JViewLegacy
 
 		// Load mooTools
 		JHtml::_('behavior.framework', true);
+		
+		// Include jQuery
+		JHtml::_('jquery.framework');
 
 		$updateScript = <<<ENDSCRIPT
 var joomlaupdate_password = '$password';

--- a/media/com_joomlaupdate/default.js
+++ b/media/com_joomlaupdate/default.js
@@ -1,27 +1,27 @@
-window.addEvent('domready', function () {
-	em = document.id('extraction_method');
-	if (em) {
-		em.addEvent('change', function () {
-			if (em.value == 'direct') {
-				document.id('row_ftp_hostname').style.display = 'none';
-				document.id('row_ftp_port').style.display = 'none';
-				document.id('row_ftp_username').style.display = 'none';
-				document.id('row_ftp_password').style.display = 'none';
-				document.id('row_ftp_directory').style.display = 'none';
-			} else {
-				document.id('row_ftp_hostname').style.display = 'table-row';
-				document.id('row_ftp_port').style.display = 'table-row';
-				document.id('row_ftp_username').style.display = 'table-row';
-				document.id('row_ftp_password').style.display = 'table-row';
-				document.id('row_ftp_directory').style.display = 'table-row';
-			}
-		});
-	}
+jQuery(function ($) {
+    $em = $('#extraction_method');
+    if ($em.length) {
+        $em.on('change', function () {
+            if ($em.val() === 'direct') {
+                document.getElementById('row_ftp_hostname').style.display = 'none';
+                document.getElementById('row_ftp_port').style.display = 'none';
+                document.getElementById('row_ftp_username').style.display = 'none';
+                document.getElementById('row_ftp_password').style.display = 'none';
+                document.getElementById('row_ftp_directory').style.display = 'none';
+            } else {
+                document.getElementById('row_ftp_hostname').style.display = 'table-row';
+                document.getElementById('row_ftp_port').style.display = 'table-row';
+                document.getElementById('row_ftp_username').style.display = 'table-row';
+                document.getElementById('row_ftp_password').style.display = 'table-row';
+                document.getElementById('row_ftp_directory').style.display = 'table-row';
+            }
+        });
+    }
 
-	$$('button.submit').addEvent('click', function() {
-		$$('div.download_message').setStyle('display', 'block');
-		var el = $$('div.joomlaupdate_spinner');
-		el.set('spinner', {class: 'joomlaupdate_spinner'});
-		el.spin();
-	})
+    $('button.submit').on('click', function() {
+        $('div.download_message').show();
+        var $el = $('div.joomlaupdate_spinner');
+        $el.attr('spinner', {class: 'joomlaupdate_spinner'});
+        $el.get(0).spin();
+    })
 });

--- a/media/com_joomlaupdate/update.js
+++ b/media/com_joomlaupdate/update.js
@@ -13,7 +13,7 @@ var joomlaupdate_progress_bar = null;
  */
 function dummy_error_handler(error)
 {
-	alert("ERROR:\n"+error);
+    alert("ERROR:\n"+error);
 }
 
 /**
@@ -25,83 +25,83 @@ function dummy_error_handler(error)
  */
 function doAjax(data, successCallback, errorCallback)
 {
-	var json = JSON.stringify(data);
-	if ( joomlaupdate_password.length > 0 )
-	{
-		json = AesCtr.encrypt( json, joomlaupdate_password, 128 );
-	}
-	var post_data = 'json='+encodeURIComponent(json);
+    var json = JSON.stringify(data);
+    if ( joomlaupdate_password.length > 0 )
+    {
+        json = AesCtr.encrypt( json, joomlaupdate_password, 128 );
+    }
+    var post_data = 'json='+encodeURIComponent(json);
 
 
-	var structure =
-	{
-		onSuccess: function(msg, responseXML)
-		{
-			// Initialize
-			var junk = null;
-			var message = "";
+    var structure =
+    {
+        onSuccess: function(msg, responseXML)
+        {
+            // Initialize
+            var junk = null;
+            var message = "";
 
-			// Get rid of junk before the data
-			var valid_pos = msg.indexOf('###');
-			if ( valid_pos == -1 ) {
-				// Valid data not found in the response
-				msg = 'Invalid AJAX data:\n' + msg;
-				if (joomlaupdate_error_callback != null)
-				{
-					joomlaupdate_error_callback(msg);
-				}
-				return;
-			} else if( valid_pos != 0 ) {
-				// Data is prefixed with junk
-				junk = msg.substr(0, valid_pos);
-				message = msg.substr(valid_pos);
-			}
-			else
-			{
-				message = msg;
-			}
-			message = message.substr(3); // Remove triple hash in the beginning
+            // Get rid of junk before the data
+            var valid_pos = msg.indexOf('###');
+            if ( valid_pos == -1 ) {
+                // Valid data not found in the response
+                msg = 'Invalid AJAX data:\n' + msg;
+                if (joomlaupdate_error_callback != null)
+                {
+                    joomlaupdate_error_callback(msg);
+                }
+                return;
+            } else if( valid_pos != 0 ) {
+                // Data is prefixed with junk
+                junk = msg.substr(0, valid_pos);
+                message = msg.substr(valid_pos);
+            }
+            else
+            {
+                message = msg;
+            }
+            message = message.substr(3); // Remove triple hash in the beginning
 
-			// Get of rid of junk after the data
-			var valid_pos = message.lastIndexOf('###');
-			message = message.substr(0, valid_pos); // Remove triple hash in the end
-			// Decrypt if required
-			if ( joomlaupdate_password.length > 0 )
-			{
-				try {
-					var data = JSON.parse(message);
-				} catch(err) {
-					message = AesCtr.decrypt(message, joomlaupdate_password, 128);
-				}
-			}
+            // Get of rid of junk after the data
+            var valid_pos = message.lastIndexOf('###');
+            message = message.substr(0, valid_pos); // Remove triple hash in the end
+            // Decrypt if required
+            if ( joomlaupdate_password.length > 0 )
+            {
+                try {
+                    var data = JSON.parse(message);
+                } catch(err) {
+                    message = AesCtr.decrypt(message, joomlaupdate_password, 128);
+                }
+            }
 
-			try {
-				var data = JSON.parse(message);
-			} catch(err) {
-				var msg = err.message + "\n<br/>\n<pre>\n" + message + "\n</pre>";
-				if (joomlaupdate_error_callback != null)
-				{
-					joomlaupdate_error_callback(msg);
-				}
-				return;
-			}
+            try {
+                var data = JSON.parse(message);
+            } catch(err) {
+                var msg = err.message + "\n<br/>\n<pre>\n" + message + "\n</pre>";
+                if (joomlaupdate_error_callback != null)
+                {
+                    joomlaupdate_error_callback(msg);
+                }
+                return;
+            }
 
-			// Call the callback function
-			successCallback(data);
-		},
-		onFailure: function(req) {
-			var message = 'AJAX Loading Error: '+req.statusText;
-			if (joomlaupdate_error_callback != null)
-			{
-				joomlaupdate_error_callback(msg);
-			}
-		}
-	};
+            // Call the callback function
+            successCallback(data);
+        },
+        onFailure: function(req) {
+            var message = 'AJAX Loading Error: '+req.statusText;
+            if (joomlaupdate_error_callback != null)
+            {
+                joomlaupdate_error_callback(msg);
+            }
+        }
+    };
 
-	var ajax_object = null;
-	structure.url = joomlaupdate_ajax_url;
-	ajax_object = new Request(structure);
-	ajax_object.send(post_data);
+    var ajax_object = null;
+    structure.url = joomlaupdate_ajax_url;
+    ajax_object = new Request(structure);
+    ajax_object.send(post_data);
 }
 
 /**
@@ -110,16 +110,16 @@ function doAjax(data, successCallback, errorCallback)
  */
 function pingUpdate()
 {
-	// Reset variables
-	joomlaupdate_stat_files = 0;
-	joomlaupdate_stat_inbytes = 0;
-	joomlaupdate_stat_outbytes = 0;
+    // Reset variables
+    joomlaupdate_stat_files = 0;
+    joomlaupdate_stat_inbytes = 0;
+    joomlaupdate_stat_outbytes = 0;
 
-	// Do AJAX post
-	var post = {task : 'ping'};
-	doAjax(post, function(data){
-		startUpdate(data);
-	});
+    // Do AJAX post
+    var post = {task : 'ping'};
+    doAjax(post, function(data){
+        startUpdate(data);
+    });
 }
 
 /**
@@ -128,15 +128,15 @@ function pingUpdate()
  */
 function startUpdate()
 {
-	// Reset variables
-	joomlaupdate_stat_files = 0;
-	joomlaupdate_stat_inbytes = 0;
-	joomlaupdate_stat_outbytes = 0;
+    // Reset variables
+    joomlaupdate_stat_files = 0;
+    joomlaupdate_stat_inbytes = 0;
+    joomlaupdate_stat_outbytes = 0;
 
-	var post = { task : 'startRestore' };
-	doAjax(post, function(data){
-		processUpdateStep(data);
-	});
+    var post = { task : 'startRestore' };
+    doAjax(post, function(data){
+        processUpdateStep(data);
+    });
 }
 
 /**
@@ -146,56 +146,56 @@ function startUpdate()
  */
 function processUpdateStep(data)
 {
-	if (data.status == false)
-	{
-		if (joomlaupdate_error_callback != null)
-		{
-			joomlaupdate_error_callback(data.message);
-		}
-	}
-	else
-	{
-		if (data.done)
-		{
-			joomlaupdate_factory = data.factory;
-			window.location = joomlaupdate_return_url;
-		}
-		else
-		{
-			// Add data to variables
-			joomlaupdate_stat_inbytes += data.bytesIn;
-			joomlaupdate_stat_percent = (joomlaupdate_stat_inbytes * 100) / joomlaupdate_totalsize;
-			
-			// Create progress bar once
-			if (joomlaupdate_progress_bar == null) 
-			{
-				joomlaupdate_progress_bar = new Fx.ProgressBar(document.id('progress'));
-			}
-			joomlaupdate_progress_bar.set(joomlaupdate_stat_percent);
-			joomlaupdate_stat_outbytes += data.bytesOut;
-			joomlaupdate_stat_files += data.files;
+    if (data.status == false)
+    {
+        if (joomlaupdate_error_callback != null)
+        {
+            joomlaupdate_error_callback(data.message);
+        }
+    }
+    else
+    {
+        if (data.done)
+        {
+            joomlaupdate_factory = data.factory;
+            window.location = joomlaupdate_return_url;
+        }
+        else
+        {
+            // Add data to variables
+            joomlaupdate_stat_inbytes += data.bytesIn;
+            joomlaupdate_stat_percent = (joomlaupdate_stat_inbytes * 100) / joomlaupdate_totalsize;
+            
+            // Create progress bar once
+            if (joomlaupdate_progress_bar == null) 
+            {
+                joomlaupdate_progress_bar = new Fx.ProgressBar(document.getElementById('progress'));
+            }
+            joomlaupdate_progress_bar.set(joomlaupdate_stat_percent);
+            joomlaupdate_stat_outbytes += data.bytesOut;
+            joomlaupdate_stat_files += data.files;
 
-			// Display data
-			document.getElementById('extpercent').innerHTML = new Number(joomlaupdate_stat_percent).formatPercentage(1);
-			document.getElementById('extbytesin').innerHTML = new Number(joomlaupdate_stat_inbytes).format();
-			document.getElementById('extbytesout').innerHTML = new Number(joomlaupdate_stat_outbytes).format();
-			document.getElementById('extfiles').innerHTML = new Number(joomlaupdate_stat_files).format(); 
+            // Display data
+            document.getElementById('extpercent').innerHTML = new Number(joomlaupdate_stat_percent).formatPercentage(1);
+            document.getElementById('extbytesin').innerHTML = new Number(joomlaupdate_stat_inbytes).format();
+            document.getElementById('extbytesout').innerHTML = new Number(joomlaupdate_stat_outbytes).format();
+            document.getElementById('extfiles').innerHTML = new Number(joomlaupdate_stat_files).format(); 
 
-			// Do AJAX post
-			post = {
-				task: 'stepRestore',
-				factory: data.factory
-			};
-			doAjax(post, function(data){
-				processUpdateStep(data);
-			});
-		}
-	}
+            // Do AJAX post
+            post = {
+                task: 'stepRestore',
+                factory: data.factory
+            };
+            doAjax(post, function(data){
+                processUpdateStep(data);
+            });
+        }
+    }
 }
 
-window.addEvent('domready', function() {
-	pingUpdate();
-	var el = $$('div.joomlaupdate_spinner');
-	el.set('spinner', {class: 'joomlaupdate_spinner'});
-	el.spin();
+jQuery(function($) {
+    pingUpdate();
+    var $el = $('div.joomlaupdate_spinner');
+    $el.attr('spinner', {class: 'joomlaupdate_spinner'});
+    $el.get(0).spin();
 });


### PR DESCRIPTION
Under GSoC 2013 MooTools to jQuery project this PR includes the MooTools dependency removed version of JS files included in media/com_joomlaupdate folder. The dependency with MooTools More (spinner) yet to exist where it requires to find a different plugin to replace it later.

Feature Tracker Item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32028&start=550
