### PR TITLE
Removing MooTools dependencies from libraries folder

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -58,46 +58,52 @@ class JFormFieldMedia extends JFormField
 		{
 			// Load the modal behavior script.
 			JHtml::_('behavior.modal');
-
+			// Include jQuery
+			JHtml::_('jquery.framework');
+		
 			// Build the script.
 			$script = array();
 			$script[] = '	function jInsertFieldValue(value, id) {';
-			$script[] = '		var old_value = document.id(id).value;';
+			$script[] = '		var $ = jQuery.noConflict();';
+			$script[] = '		var old_value = $("#" + id).val();';
 			$script[] = '		if (old_value != value) {';
-			$script[] = '			var elem = document.id(id);';
-			$script[] = '			elem.value = value;';
-			$script[] = '			elem.fireEvent("change");';
-			$script[] = '			if (typeof(elem.onchange) === "function") {';
-			$script[] = '				elem.onchange();';
+			$script[] = '			var $elem = $("#" + id);';
+			$script[] = '			$elem.val(value);';
+			$script[] = '			$elem.trigger("change");';
+			$script[] = '			if (typeof($elem.get(0).onchange) === "function") {';
+			$script[] = '				$elem.get(0).onchange();';
 			$script[] = '			}';
 			$script[] = '			jMediaRefreshPreview(id);';
 			$script[] = '		}';
 			$script[] = '	}';
 
 			$script[] = '	function jMediaRefreshPreview(id) {';
-			$script[] = '		var value = document.id(id).value;';
-			$script[] = '		var img = document.id(id + "_preview");';
-			$script[] = '		if (img) {';
+			$script[] = '		var $ = jQuery.noConflict();';
+			$script[] = '		var value = $("#" + id).val();';
+			$script[] = '		var $img = $("#" + id + "_preview");';
+			$script[] = '		if ($img.length) {';
 			$script[] = '			if (value) {';
 			$script[] = '				img.src = "' . JUri::root() . '" + value;';
-			$script[] = '				document.id(id + "_preview_empty").setStyle("display", "none");';
-			$script[] = '				document.id(id + "_preview_img").setStyle("display", "");';
+			$script[] = '				$("#" + id + "_preview_empty").hide();';
+			$script[] = '				$("#" + id + "_preview_img").show()';
 			$script[] = '			} else { ';
 			$script[] = '				img.src = ""';
-			$script[] = '				document.id(id + "_preview_empty").setStyle("display", "");';
-			$script[] = '				document.id(id + "_preview_img").setStyle("display", "none");';
+			$script[] = '				$("#" + id + "_preview_empty").show();';
+			$script[] = '				$("#" + id + "_preview_img").hide();';
 			$script[] = '			} ';
 			$script[] = '		} ';
 			$script[] = '	}';
 
 			$script[] = '	function jMediaRefreshPreviewTip(tip)';
 			$script[] = '	{';
-			$script[] = '		var img = tip.getElement("img.media-preview");';
-			$script[] = '		tip.getElement("div.tip").setStyle("max-width", "none");';
-			$script[] = '		var id = img.getProperty("id");';
+			$script[] = '		var $ = jQuery.noConflict();';
+			$script[] = '		var $tip = $(tip);';
+			$script[] = '		var $img = $tip.find("img.media-preview");';
+			$script[] = '		$tip.find("div.tip").css("max-width", "none");';
+			$script[] = '		var id = $img.attr("id");';
 			$script[] = '		id = id.substring(0, id.length - "_preview".length);';
 			$script[] = '		jMediaRefreshPreview(id);';
-			$script[] = '		tip.setStyle("display", "block");';
+			$script[] = '		$tip.show();';
 			$script[] = '	}';
 
 			// Add the script to the document head.

--- a/libraries/cms/form/field/moduleposition.php
+++ b/libraries/cms/form/field/moduleposition.php
@@ -62,7 +62,7 @@ class JFormFieldModulePosition extends JFormFieldText
 		// Build the script.
 		$script = array();
 		$script[] = '	function jSelectPosition_' . $this->id . '(name) {';
-		$script[] = '		document.id("' . $this->id . '").value = name;';
+		$script[] = '		document.getElementById("' . $this->id . '").value = name;';
 		$script[] = '		SqueezeBox.close();';
 		$script[] = '	}';
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -559,8 +559,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include MooTools framework
-		static::framework();
+		// Include jQuery
+		JHtml::_('jquery.framework');
 
 		$config = JFactory::getConfig();
 		$lifetime = ($config->get('lifetime') * 60000);
@@ -577,10 +577,10 @@ abstract class JHtmlBehavior
 		$document = JFactory::getDocument();
 		$script = '';
 		$script .= 'function keepAlive() {';
-		$script .= '	var myAjax = new Request({method: "get", url: "index.php"}).send();';
+		$script .= '	jQuery.get("index.php");';
 		$script .= '}';
-		$script .= ' window.addEvent("domready", function()';
-		$script .= '{ keepAlive.periodical(' . $refreshTime . '); }';
+		$script .= 'jQuery(function($)';
+		$script .= '{ setInterval(keepAlive, ' . $refreshTime . '); }';
 		$script .= ');';
 
 		$document->addScriptDeclaration($script);

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -238,19 +238,22 @@ abstract class JHtmlBehavior
 		$opt['onHide']    = (isset($params['onHide'])) ? '\\' . $params['onHide'] : null;
 
 		$options = JHtml::getJSObject($opt);
-
+		
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		
 		// Attach tooltips to document
 		JFactory::getDocument()->addScriptDeclaration(
-			"window.addEvent('domready', function() {
-			$$('$selector').each(function(el) {
-				var title = el.get('title');
+			"jQuery(function($) {
+			 $('$selector').each(function() {
+				var title = $(this).attr('title');
 				if (title) {
 					var parts = title.split('::', 2);
-					el.store('tip:title', parts[0]);
-					el.store('tip:text', parts[1]);
+					$(this).get(0).store('tip:title', parts[0]); // Depends on Mootools store which requires for Tips
+					$(this).get(0).store('tip:text', parts[1]);  // Depends on Mootools store which requires for Tips
 				}
 			});
-			var JTooltips = new Tips($$('$selector'), $options);
+			var JTooltips = new Tips($('$selector').get(), $options);
 		});"
 		);
 
@@ -321,22 +324,24 @@ abstract class JHtmlBehavior
 		$opt['onMove']        = (isset($params['onMove'])) ? $params['onMove'] : null;
 		$opt['onShow']        = (isset($params['onShow'])) ? $params['onShow'] : null;
 		$opt['onHide']        = (isset($params['onHide'])) ? $params['onHide'] : null;
+		
+		// Include jQuery
+		JHtml::_('jquery.framework');
 
 		if (isset($params['fullScreen']) && (bool) $params['fullScreen'])
 		{
-			$opt['size']      = array('x' => '\\window.getSize().x-80', 'y' => '\\window.getSize().y-80');
+			$opt['size']      = array('x' => '\\jQuery(window).width() - 80', 'y' => '\\jQuery(window).height() - 80');
 		}
 
 		$options = JHtml::getJSObject($opt);
-
+		
 		// Attach modal behavior to document
 		$document
 			->addScriptDeclaration(
 			"
-		window.addEvent('domready', function() {
-
+		jQuery(function($) {
 			SqueezeBox.initialize(" . $options . ");
-			SqueezeBox.assign($$('" . $selector . "'), {
+			SqueezeBox.assign($('" . $selector . "').get(), {
 				parse: 'rel'
 			});
 		});"
@@ -407,6 +412,9 @@ abstract class JHtmlBehavior
 			return;
 		}
 
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		
 		// Setup options object
 		$opt['div']   = (array_key_exists('div', $params)) ? $params['div'] : $id . '_tree';
 		$opt['mode']  = (array_key_exists('mode', $params)) ? $params['mode'] : 'folders';
@@ -433,7 +441,7 @@ abstract class JHtmlBehavior
 
 		$treeName = (array_key_exists('treeName', $params)) ? $params['treeName'] : '';
 
-		$js = '		window.addEvent(\'domready\', function(){
+		$js = '		jQuery(function(){
 			tree' . $treeName . ' = new MooTreeControl(' . $options . ',' . $rootNode . ');
 			tree' . $treeName . '.adopt(\'' . $id . '\');})';
 
@@ -660,7 +668,10 @@ abstract class JHtmlBehavior
 		// Include MooTools framework
 		static::framework();
 
-		$js = "window.addEvent('domready', function () {if (top == self) {document.documentElement.style.display = 'block'; }" .
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		
+		$js = "jQuery(function () {if (top == self) {document.documentElement.style.display = 'block'; }" .
 			" else {top.location = self.location; }});";
 		$document = JFactory::getDocument();
 		$document->addStyleDeclaration('html { display:none }');

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -315,30 +315,30 @@ abstract class JHtmlGrid
 
 		if (!$loaded)
 		{
+			
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		
 			// Build the behavior script.
 			$js = '
-		window.addEvent(\'domready\', function(){
-			actions = $$(\'a.move_up\');
-			actions.combine($$(\'a.move_down\'));
-			actions.combine($$(\'a.grid_true\'));
-			actions.combine($$(\'a.grid_false\'));
-			actions.combine($$(\'a.grid_trash\'));
-			actions.each(function(a){
-				a.addEvent(\'click\', function(){
+		jQuery(function($){
+			$actions = $(\'a.move_up, a.move_down, a.grid_true, a.grid_false, a.grid_trash\');
+			$actions.each(function(){
+				$(this).on(\'click\', function(){
 					args = JSON.decode(this.rel);
 					listItemTask(args.id, args.task);
 				});
 			});
-			$$(\'input.check-all-toggle\').each(function(el){
-				el.addEvent(\'click\', function(){
-					if (el.checked) {
-						document.id(this.form).getElements(\'input[type=checkbox]\').each(function(i){
-							i.checked = true;
+			$(\'input.check-all-toggle\').each(function(){
+				$(this).on(\'click\', function(){
+					if (this.checked) {
+						$(this).closest(\'form\').find(\'input[type=checkbox]\').each(function(){
+							this.checked = true;
 						})
 					}
 					else {
-						document.id(this.form).getElements(\'input[type=checkbox]\').each(function(i){
-							i.checked = false;
+						$(this).closest(\'form\').find(\'input[type=checkbox]\').each(function(){
+							this.checked = false;
 						})
 					}
 				});

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -633,7 +633,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::keepalive();
 		$this->assertEquals(
-			array('JHtmlBehavior::keepalive' => true, 'JHtmlBehavior::framework' => array('core' => true)),
+			array('JHtmlBehavior::keepalive' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}


### PR DESCRIPTION
Under GSoC MooTools to jQuery project, this PR removes the MooTools dependencies in several functions of the libraries/cms/form/field/media.php file. 
Note: MooTools dependencies are not removed from the functions that are related to media libraries loading since they are removed with the respective library (e.g switcher.js) MooTools dependency removal PR.

Feature Request Item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32029&start=550
