### PR TITLE
[imp] use layouts for tinyMCE

### DIFF
--- a/layouts/joomla/tinymce/buttons.php
+++ b/layouts/joomla/tinymce/buttons.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$buttons = $displayData;
+
+// Load modal popup behavior
+JHtml::_('behavior.modal', 'a.modal-button');
+?>
+<div id="editor-xtd-buttons" class="btn-toolbar pull-left">
+	<div class="btn-toolbar">
+		<?php if ($buttons) : ?>
+			<?php foreach ($buttons as $button) : ?>
+				<?php echo JLayoutHelper::render('joomla.tinymce.buttons.button', $button); ?>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	</div>
+</div>

--- a/layouts/joomla/tinymce/buttons/button.php
+++ b/layouts/joomla/tinymce/buttons/button.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$button = $displayData;
+
+?>
+<?php if ($button->get('name')) : ?>
+	<?php
+		$class    = ($button->get('class')) ? $button->get('class') : null;
+		$class	 .= ($button->get('modal')) ? ' modal-button' : null;
+		$href     = ($button->get('link')) ? ' href="' . JUri::base() . $button->get('link') . '"' : null;
+		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : ' onclick="IeCursorFix(); return false;"';
+		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+	?>
+	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href . $onclick; ?> rel="<?php echo $button->get('options'); ?>">
+		<i class="icon-<?php echo $button->get('name'); ?>"></i> <?php echo $button->get('text'); ?>
+	</a>
+<?php endif;

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$data = $displayData;
+
+?>
+<textarea
+	name="<?php echo $data->name; ?>"
+	id="<?php echo $data->id; ?>"
+	cols="<?php echo $data->cols; ?>"
+	rows="<?php echo $data->rows; ?>"
+	style="width: <?php echo $data->width; ?>; height: <?php echo $data->width; ?>;"
+	class="mce_editable"
+>
+	<?php echo $data->content; ?>
+</textarea>

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -17,7 +17,7 @@ $data = $displayData;
 	id="<?php echo $data->id; ?>"
 	cols="<?php echo $data->cols; ?>"
 	rows="<?php echo $data->rows; ?>"
-	style="width: <?php echo $data->width; ?>; height: <?php echo $data->width; ?>;"
+	style="width: <?php echo $data->width; ?>; height: <?php echo $data->height; ?>;"
 	class="mce_editable"
 >
 	<?php echo $data->content; ?>

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$name = $displayData;
+
+?>
+<div class="toggle-editor btn-toolbar pull-right clearfix">
+	<div class="btn-group">
+		<a class="btn" href="#"
+			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
+			title="<?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>"
+		>
+			<i class="icon-eye"></i> <?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
+		</a>
+	</div>
+</div>

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -165,12 +165,12 @@ class PlgEditorTinymce extends JPlugin
 
 		if ($newlines)
 		{
-			// br
+			// Break
 			$forcenewline = "force_br_newlines : true, force_p_newlines : false, forced_root_block : '',";
 		}
 		else
 		{
-			// p
+			// Paragraph
 			$forcenewline = "force_br_newlines : false, force_p_newlines : true, forced_root_block : 'p',";
 		}
 
@@ -795,9 +795,19 @@ class PlgEditorTinymce extends JPlugin
 			$height .= 'px';
 		}
 
-		$editor  = '<textarea name="' . $name . '" id="' . $id .'" cols="' . $col .'" rows="' . $row . '" style="width: ' . $width . '; height:' . $height . ';" class="mce_editable">' . $content . "</textarea>\n" .
-		$this->_displayButtons($id, $buttons, $asset, $author) .
-		$this->_toogleButton($id);
+		// Data object for the layout
+		$textarea = new stdClass;
+		$textarea->name    = $name;
+		$textarea->id      = $id;
+		$textarea->cols    = $col;
+		$textarea->rows    = $row;
+		$textarea->width   = $width;
+		$textarea->height  = $height;
+		$textarea->content = $content;
+
+		$editor = JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
+		$editor .= $this->_displayButtons($id, $buttons, $asset, $author);
+		$editor .= $this->_toogleButton($id);
 
 		return $editor;
 	}
@@ -814,70 +824,45 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	private function _displayButtons($name, $buttons, $asset, $author)
 	{
-		// Load modal popup behavior
-		JHtml::_('behavior.modal', 'a.modal-button');
-
-		$args['name'] = $name;
-		$args['event'] = 'onGetInsertMethod';
-
 		$return = '';
-		$results[] = $this->update($args);
 
-		foreach ($results as $result)
+		$args = array(
+			'name'  => $name,
+			'event' => 'onGetInsertMethod'
+		);
+
+		$results = (array) $this->update($args);
+
+		if ($results)
 		{
-			if (is_string($result) && trim($result))
+			foreach ($results as $result)
 			{
-				$return .= $result;
+				if (is_string($result) && trim($result))
+				{
+					$return .= $result;
+				}
 			}
 		}
 
 		if (is_array($buttons) || (is_bool($buttons) && $buttons))
 		{
-			$results = $this->_subject->getButtons($name, $buttons, $asset, $author);
+			$buttons = $this->_subject->getButtons($name, $buttons, $asset, $author);
 
-			/*
-			 * This will allow plugins to attach buttons or change the behavior on the fly using AJAX
-			 */
-			$return .= "\n<div id=\"editor-xtd-buttons\" class=\"btn-toolbar pull-left\">\n";
-			$return .= "\n<div class=\"btn-toolbar\">\n";
-
-			foreach ($results as $button)
-			{
-				/*
-				 * Results should be an object
-				 */
-				if ( $button->get('name') )
-				{
-					$class		= ($button->get('class')) ? $button->get('class') : null;
-					$class		.= ($button->get('modal')) ? ' modal-button' : null;
-					$href		= ($button->get('link')) ? ' href="'.JUri::base().$button->get('link').'"' : null;
-					$onclick	= ($button->get('onclick')) ? ' onclick="'.$button->get('onclick').'"' : ' onclick="IeCursorFix(); return false;"';
-					$title      = ($button->get('title')) ? $button->get('title') : $button->get('text');
-					$return .= '<a class="' . $class . '" title="' . $title . '"' . $href . $onclick . ' rel="' . $button->get('options')
-						. '"><i class="icon-' . $button->get('name'). '"></i> ' . $button->get('text') . "</a>\n";
-				}
-			}
-
-			$return .= "</div>\n";
-			$return .= "</div>\n";
+			$return .= JLayoutHelper::render('joomla.tinymce.buttons', $buttons);
 		}
 
 		return $return;
 	}
 
 	/**
+	 * Get the toggle editor button
+	 *
+	 * @param   string  $name  Editor name
 	 *
 	 * @return  string
 	 */
 	private function _toogleButton($name)
 	{
-		$return  = '';
-		$return .= "\n<div class=\"toggle-editor btn-toolbar pull-right\">\n";
-		$return .= "<div class=\"btn-group\"><a class=\"btn\" href=\"#\" onclick=\"tinyMCE.execCommand('mceToggleEditor', false, '" . $name . "');return false;\" title=\"" . JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR') . '"><i class="icon-eye"></i> '.JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR')."</a></div>";
-		$return .= "</div>\n";
-
-		$return .= "<div class=\"clearfix\"></div>\n";
-
-		return $return;
+		return JLayoutHelper::render('joomla.tinymce.togglebutton', $name);
 	}
 }


### PR DESCRIPTION
tinyMCE editor markup is output in the plugin. That means that is not possible to override it in templates (for example) or in component views if someday my JLaoyuts improvements get merged ( https://github.com/joomla/joomla-cms/pull/1419 )

This PR adds layouts to solve that issue.

Issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32031
