### PR TITLE
Support JSON response in Internet Explorer < 10

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -97,15 +97,27 @@ if (!is_null($error))
 switch ($format)
 {
 	case 'json':
-		header('Content-Type: application/json');
+		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) 
+		{
+			JResponse::setHeader('Content-Type', 'application/json');
+		} 
+		else 
+		{
+			JResponse::setHeader('Content-Type', 'text/plain'); // Internet Explorer < 10
+		}
+		JResponse::toString();
 		echo json_encode($results);
 		$app->close();
 		break;
+		
 	case 'debug':
+		JResponse::toString();
 		echo '<pre>' . print_r($results, true) . '</pre>';
 		$app->close();
 		break;
+		
 	default:
+		JResponse::toString();
 		echo is_array($results) ? implode($results) : $results;
 		// Emulates format=raw by closing $app
 		$app->close();


### PR DESCRIPTION
Internet Explorer older than 10 does not accept
Content-Type: application/json
and would start to download it.
But this one would work for older IE and all new browsers
Content-Type: text/plain

When you send ajax request by jQuery just set header:

``` JavaScript
$.ajax({
    url: ...,
    dataType: 'json',
    headers: {
        Accept: 'application/json'
    },
    accept: 'application/json'
}).done(function(data, textStatus, jqXHR) {
    ...
});
```

and then server would respond with:
Content-Type: application/json

Also we should use

``` php
JResponse::toString();
```

because in ajax method on server side there might be set some other headers by

``` php
JResponse::setHeader(...);
```
