### PR TITLE
Update template.css to Show Proper Underline on Quick Icons

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -203,6 +203,9 @@ a:focus {
 	color: #005580;
 	text-decoration: underline;
 }
+.span12 a:hover {
+    text-decoration: none;
+}
 .img-rounded {
 	-webkit-border-radius: 6px;
 	-moz-border-radius: 6px;
@@ -281,6 +284,9 @@ a:focus {
 }
 .span1 {
 	width: 60px;
+}
+.span12 span:hover {
+    text-decoration: underline;
 }
 .offset12 {
 	margin-left: 980px;


### PR DESCRIPTION
Makes the hover on Quick Icons links have a proper hover underline rather than one that sticks out to the left.

As seen in the JoomlaCode: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32045

Keep in mind, the GitHub addition is better than the first post on JoomlaCode.
