### PR TITLE
Update sortablelist.js

### DIFF
--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -86,7 +86,7 @@
 
 					//serialize form then post to callback url
 					var formData = $('#' + formId).serialize();
-					formData = formData.replace('task', '');
+					formData = formData.replace('task=', '=');
 					$.post(saveOrderingUrl, formData);
 
 					//remove cloned checkboxes


### PR DESCRIPTION
Updated line 89 from 

formData = formData.replace('task', '');
to
formData = formData.replace('task=', '=');

because the former version causes issues if the extension developer has any form fields that contain the string "task" in it's name. So whenever we have a form field like "task_id" or something similar, the sortable functionality does not work, because the task field is not being removed from the POST data.

This change should fix this.
