### PR TITLE
[#32052] The fields "componentlayout" and "modulelayout" do not takes the class from XML 

### DIFF
--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -216,6 +216,7 @@ class JFormFieldComponentlayout extends JFormField
 
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 
 			// Prepare HTML code
 			$html = array();

--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -216,7 +216,14 @@ class JFormFieldComponentlayout extends JFormField
 
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+
+			// Check the class, and set default to the class "advancedSelect" if empty
+			$class = (string) $this->element['class'];
+			if(!$class)
+			{
+				$class = 'advancedSelect';
+			}
+			$attr .= ' class="' . $class . '"';
 
 			// Prepare HTML code
 			$html = array();

--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -216,14 +216,7 @@ class JFormFieldComponentlayout extends JFormField
 
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-
-			// Check the class, and set default to the class "advancedSelect" if empty
-			$class = (string) $this->element['class'];
-			if(!$class)
-			{
-				$class = 'advancedSelect';
-			}
-			$attr .= ' class="' . $class . '"';
+			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 
 			// Prepare HTML code
 			$html = array();

--- a/libraries/legacy/form/field/modulelayout.php
+++ b/libraries/legacy/form/field/modulelayout.php
@@ -177,6 +177,7 @@ class JFormFieldModulelayout extends JFormField
 			}
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 
 			// Prepare HTML code
 			$html = array();

--- a/libraries/legacy/form/field/modulelayout.php
+++ b/libraries/legacy/form/field/modulelayout.php
@@ -177,14 +177,7 @@ class JFormFieldModulelayout extends JFormField
 			}
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-
-			// Check the class, and set default to the class "advancedSelect" if empty
-			$class = (string) $this->element['class'];
-			if(!$class)
-			{
-				$class = 'advancedSelect';
-			}
-			$attr .= ' class="' . $class . '"';
+			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 
 			// Prepare HTML code
 			$html = array();

--- a/libraries/legacy/form/field/modulelayout.php
+++ b/libraries/legacy/form/field/modulelayout.php
@@ -177,7 +177,14 @@ class JFormFieldModulelayout extends JFormField
 			}
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+
+			// Check the class, and set default to the class "advancedSelect" if empty
+			$class = (string) $this->element['class'];
+			if(!$class)
+			{
+				$class = 'advancedSelect';
+			}
+			$attr .= ' class="' . $class . '"';
 
 			// Prepare HTML code
 			$html = array();


### PR DESCRIPTION
Joomla! Issue Tracker [[#32052] The fields "componentlayout" and "modulelayout" do not takes the class from XML ](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32052&start=0)
