### PR TITLE
[JUX2] [05] Automatically show toolbar buttons depending on selected items in table views (FR [#31862])

### DIFF
--- a/administrator/components/com_finder/views/filters/tmpl/default.php
+++ b/administrator/components/com_finder/views/filters/tmpl/default.php
@@ -9,8 +9,11 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
+JHtml::_('behavior.multiselect');
+JHtml::_('formbehavior.chosen', 'select');
+
+
 
 $user      = JFactory::getUser();
 $userId    = $user->get('id');

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
+JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.popover');
 

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -9,9 +9,9 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
+JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
+JHtml::_('behavior.multiselect');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -9,9 +9,9 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('bootstrap.tooltip');
 
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -10,9 +10,9 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
+JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('dropdown.init');
-JHtml::_('formbehavior.chosen', 'select');
 
 $user = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/media/system/js/multiselect.js
+++ b/media/system/js/multiselect.js
@@ -6,7 +6,7 @@
 /**
  * JavaScript behavior to allow shift select in administrator grids
  */
-(function() {
+(function($) {
 	Joomla = Joomla || {};
 
 	Joomla.JMultiSelect = new Class({
@@ -35,4 +35,25 @@
 			this.last = current;
 		}
 	});
-})();
+
+	$(document).ready(function (){
+		var selectActions = $('#toolbar').children('#toolbar-edit,#toolbar-publish,#toolbar-unpublish,#toolbar-featured,#toolbar-checkin,#toolbar-archive,#toolbar-trash,#toolbar-batch,#toolbar-remove,#toolbar-delete,#toolbar-default,#toolbar-unblock');
+		selectActions.hide();
+
+	    var multiCheckboxes = $('form#adminForm table.table-striped input[type=checkbox][onclick]');
+		multiCheckboxes.on('change', null, null, (function() {
+			var numberChecked = multiCheckboxes.filter(':checked').size();
+		    if (numberChecked > 0) {
+			    if (numberChecked == 1) {
+				    selectActions.fadeIn();
+			    } else {
+					selectActions.filter(':not(#toolbar-edit)').slideDown();
+				    selectActions.filter('#toolbar-edit').slideUp();
+			    }
+			} else {
+				selectActions.fadeOut();
+			}
+	    }));
+	});
+
+})(jQuery);

--- a/media/system/js/multiselect.js
+++ b/media/system/js/multiselect.js
@@ -37,22 +37,22 @@
 	});
 
 	$(document).ready(function (){
-		var selectActions = $('#toolbar').children('#toolbar-edit,#toolbar-publish,#toolbar-unpublish,#toolbar-featured,#toolbar-checkin,#toolbar-archive,#toolbar-trash,#toolbar-batch,#toolbar-remove,#toolbar-delete,#toolbar-default,#toolbar-unblock');
+		var selectActions = $('#toolbar').children('#toolbar-edit,#toolbar-publish,#toolbar-unpublish,#toolbar-featured,#toolbar-checkin,#toolbar-archive,#toolbar-trash,#toolbar-batch,#toolbar-remove,#toolbar-delete,#toolbar-copy,#toolbar-default,#toolbar-unblock');
 		selectActions.hide();
 
-	    var multiCheckboxes = $('form#adminForm table.table-striped input[type=checkbox][onclick]');
+	    var multiCheckboxes = $('form#adminForm table.table-striped input[type=checkbox]');
 		multiCheckboxes.on('change', null, null, (function() {
 			var numberChecked = multiCheckboxes.filter(':checked').size();
 		    if (numberChecked > 0) {
 			    if (numberChecked == 1) {
-				    selectActions.fadeIn();
+				    selectActions.fadeIn().prop('disabled', false);
 			    } else {
-					selectActions.filter(':not(#toolbar-edit)').slideDown();
-				    selectActions.filter('#toolbar-edit').slideUp();
+					selectActions.filter(':not(#toolbar-edit)').fadeIn().prop('disabled', false);
+				    selectActions.filter('#toolbar-edit').fadeOut().prop('disabled', true);
 			    }
 			} else {
-				selectActions.fadeOut();
-			}
+				selectActions.fadeOut().prop('disabled', true);
+		    }
 	    }));
 	});
 


### PR DESCRIPTION
This pull request allows to have a much cleaner toolbar for all table views. It also fixes a few inconsistent Javascript files loading orderings.

All toolbar buttons that only work when one or more items are selected, will only show up once at least one item is selected.

Buttons that only work on single items will only appear when one item is selected (and not be visible when no or more than one item is selected).

This is a pull request towards joomla-cms/master

Before checkmarking: http://awesomescreenshot.com/07d1qkel5d
![menu-2-left](https://f.cloud.github.com/assets/47402/1182037/6939065c-2212-11e3-8988-68f39b33e23b.png)

After checkmarking one: http://awesomescreenshot.com/08d1qkd8be : 
![menu-left](https://f.cloud.github.com/assets/47402/1182017/24c6171c-2212-11e3-96a7-ee81be07992d.png)

This replaces the old PR https://github.com/joomla-projects/joomla-cms/pull/53 done towards jux branch.

Related FR:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31862&start=25
