### PR TITLE
[JUX2] [17] Move the Help and Options toolbar-buttons to the right where they belong (FR [#32054])

### DIFF
--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -9,6 +9,6 @@
 
 defined('_JEXEC') or die;
 ?>
-<div class="btn-wrapper" <?php echo $displayData['id']; ?>>
+<div class="btn-wrapper<?php echo $displayData['rightposition'] ? ' pull-right' : '' ?>" <?php echo $displayData['id']; ?>>
 	<?php echo $displayData['action']; ?>
 </div>

--- a/libraries/cms/toolbar/button.php
+++ b/libraries/cms/toolbar/button.php
@@ -37,6 +37,15 @@ abstract class JToolbarButton
 	protected $_parent = null;
 
 	/**
+	 * True If the button should have pull-right class (default: false)
+	 *
+	 * @var bool
+	 *
+	 * @since 3.2
+	 */
+	protected $rightPosition = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   object  $parent  The parent
@@ -85,6 +94,7 @@ abstract class JToolbarButton
 		$options = array();
 		$options['id'] = $id;
 		$options['action'] = $action;
+		$options['rightposition'] = $this->rightPosition;
 
 		$layout = new JLayoutFile('joomla.toolbar.base');
 

--- a/libraries/cms/toolbar/button/help.php
+++ b/libraries/cms/toolbar/button/help.php
@@ -24,6 +24,17 @@ class JToolbarButtonHelp extends JToolbarButton
 	protected $_name = 'Help';
 
 	/**
+	 * Constructor
+	 *
+	 * @param   object  $parent  The parent
+	 */
+	public function __construct($parent = null)
+	{
+		$this->rightPosition = true;
+		parent::__construct($parent);
+	}
+
+	/**
 	 * Fetches the button HTML code.
 	 *
 	 * @param   string   $type       Unused string.

--- a/libraries/cms/toolbar/button/link.php
+++ b/libraries/cms/toolbar/button/link.php
@@ -44,6 +44,11 @@ class JToolbarButtonLink extends JToolbarButton
 		$options['class'] = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($url);
 
+		if ($name == 'options')
+		{
+			$this->rightPosition = true;
+		}
+
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('joomla.toolbar.link');
 


### PR DESCRIPTION
 That was decided at JUX meeting too, now it's done, and it cleans up a lot the left side, especially in relation with dynamic buttons http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31862&start=25

Check before and after: Much cleaner:

Before: http://awesomescreenshot.com/08d1qkd8be : 
![menu-left](https://f.cloud.github.com/assets/47402/1182017/24c6171c-2212-11e3-96a7-ee81be07992d.png)

After: http://awesomescreenshot.com/0c81qke2f9
![menu-right](https://f.cloud.github.com/assets/47402/1182030/50801858-2212-11e3-8d02-39b6fe98f728.png)

And with the automatic dynamic buttons ( http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31862&start=25 / https://github.com/joomla/joomla-cms/pull/2029 ) it makes even more sense:

Before: http://awesomescreenshot.com/07d1qkel5d
![menu-2-left](https://f.cloud.github.com/assets/47402/1182037/6939065c-2212-11e3-8988-68f39b33e23b.png)

After: http://awesomescreenshot.com/0591qkegaa
![menu-2-right](https://f.cloud.github.com/assets/47402/1182045/8165be78-2212-11e3-9b95-6986d218edfa.png)

Related FR:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32054&start=0
