### PR TITLE
Fix [#31654] Browser Page Title Not Showing for Tagged Item Menu.

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -192,15 +192,7 @@ class TagsViewTag extends JViewLegacy
 			$this->params->set('page_subheading', $menu->title);
 		}
 
-		// If this is not a single tag menu item, set the page title to the menu item title
-		if (count($this->item) == 1)
-		{
-			$title = $this->item[0]->title;
-		}
-		else
-		{
-			$title = $this->state->params->get('page_title');
-		}
+		$title = $this->state->params->get('page_title');
 
 		if (empty($title))
 		{


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31654&start=0
