### PR TITLE
[#32077] Smart Search toolbar broken in Hathor.

### DIFF
--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -67,7 +67,7 @@ class JToolbarButtonPopup extends JToolbarButton
 		$html[] = $layout->render($options);
 
 		// Place modal div and scripts in a new div
-		$html[] = '</div><div class="btn-group" style="width: 0; margin: 0">';
+		$html[] = '<div class="btn-group" style="width: 0; margin: 0">';
 
 		// Build the options array for the modal
 		$params = array();
@@ -84,6 +84,8 @@ class JToolbarButtonPopup extends JToolbarButton
 				. 'jQuery(\'#modal-' . $name . '\').on(\'hide\', function () {' . $onClose . ';});'
 				. '</script>';
 		}
+
+		$html[] = '</div>';
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32077&start=0&feedback=Item+is+now+being+monitored
