### PR TITLE
Creates Flex module chrome....

### DIFF
--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -144,7 +144,7 @@ function modChrome_outline($module, &$params, &$attribs)
  */
 function modChrome_flex($module, &$params, &$attribs)
 {
-	$moduleTag = $params->get('module_tag');
+	$moduleTag = $params->get('module_tag', 'h3');
 	
 	// we use this alot so declare it 
 	$moduleHeader = 'class="moduleheader';	

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -136,3 +136,69 @@ function modChrome_outline($module, &$params, &$attribs)
 	</div>
 	<?php
 }
+
+/*
+ * html5-Flex
+ * same as html5 but allows title area to have styling separate from title tag styling
+ *  resulting in moduletable, moduleheader, and text background all separetly stylable
+ */
+function modChrome_flex($module, &$params, &$attribs)
+{
+	$moduleTag = $params->get('module_tag');
+	
+	// we use this alot so declare it 
+	$moduleHeader = 'class="moduleheader';	
+	
+	// what tag do they want for wrapper 
+	$headerTag = htmlspecialchars($params->get('header_tag'));	
+	
+	// Get number of boostrap columns 
+	$bootstrapSize = $params->get('bootstrap_size');	
+	
+	// temporarily store header class in variable 
+	$headerClass = $params->get('header_class');	
+	
+	 // Create header class declaration 
+	$headerClass = !empty($headerClass) ? $moduleHeader . htmlspecialchars($headerClass) . '"' : $moduleHeader.'"';
+	 
+	 // Create module class declaration 
+	$moduleClass = !empty($bootstrapSize) ? ' span' . (int) $bootstrapSize . '' : '';
+	
+	// get module suffix 
+	$moduleClassSfx = htmlspecialchars($params->get('moduleclass_sfx')); 
+	
+	// don't create html if no module content 
+	if (!empty ($module->content))	
+	{
+		// Module wrapper 
+		$html  = "<{$moduleTag} class=\"moduletable{$moduleClassSfx}{$moduleClass}\">"; 
+
+		// don't display title if not requested 
+		if ((bool) $module->showtitle) 
+        {
+				// create tag and wrapper 
+				$html .= "<{$headerTag} {$headerClass}>";
+			
+					// Style the bar background for the title 
+					$html .= "<span {$moduleHeader}_txtbg\">";	
+	
+						// Title text 
+						$html .= $module->title;
+
+					// Close Title Background Style 
+					$html .= "</span>";	
+				
+				// Close Wrapper 
+				$html .= "</{$headerTag}>";	
+        }
+
+		// get content 
+		$html .= $module->content; 
+		
+		 // close module wrapper 
+		$html .= "</{$moduleTag}>";
+
+		// Display everything 
+		echo $html;
+	}
+}

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -153,16 +153,16 @@ function modChrome_flex($module, &$params, &$attribs)
 	$headerTag = htmlspecialchars($params->get('header_tag'));	
 	
 	// Get number of boostrap columns 
-	$bootstrapSize = $params->get('bootstrap_size');	
+	$bootstrapSize = (int) $params->get('bootstrap_size', '0');	
 	
 	// Temporarily store header class in variable 
-	$headerClass = $params->get('header_class');	
+	$headerClass = htmlspecialchars($params->get('header_class'));	
 	
 	 // Create header class declaration 
-	$headerClass = !empty($headerClass) ? $moduleHeader . htmlspecialchars($headerClass) . '"' : $moduleHeader.'"';
+	$headerClass = !empty($headerClass) ? $moduleHeader . $headerClass . '"' : $moduleHeader.'"';
 	 
 	 // Create module class declaration 
-	$moduleClass = !empty($bootstrapSize) ? ' span' . (int) $bootstrapSize . '' : '';
+	$moduleClass = !empty($bootstrapSize) ? ' span' . $bootstrapSize . '' : '';
 	
 	// Get module suffix 
 	$moduleClassSfx = htmlspecialchars($params->get('moduleclass_sfx')); 
@@ -175,7 +175,7 @@ function modChrome_flex($module, &$params, &$attribs)
 
 		// Don't display title if not requested 
 		if ((bool) $module->showtitle) 
-			{
+		{
 				// Create tag and wrapper 
 				$html .= "<{$headerTag} {$headerClass}>";
 			
@@ -190,7 +190,7 @@ function modChrome_flex($module, &$params, &$attribs)
 				
 				// Close Wrapper 
 				$html .= "</{$headerTag}>";	
-			}
+		}
 
 		// Get content 
 		$html .= $module->content; 

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -140,7 +140,7 @@ function modChrome_outline($module, &$params, &$attribs)
 /*
  * Html5-Flex
  * Same as html5 but allows title area to have styling separate from title tag styling
- *  resulting in moduletable, moduleheader, and text background all separately stylable
+ * resulting in moduletable, moduleheader, and text background all separately stylable
  */
 function modChrome_flex($module, &$params, &$attribs)
 {

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -138,24 +138,24 @@ function modChrome_outline($module, &$params, &$attribs)
 }
 
 /*
- * html5-Flex
- * same as html5 but allows title area to have styling separate from title tag styling
- *  resulting in moduletable, moduleheader, and text background all separetly stylable
+ * Html5-Flex
+ * Same as html5 but allows title area to have styling separate from title tag styling
+ *  resulting in moduletable, moduleheader, and text background all separately stylable
  */
 function modChrome_flex($module, &$params, &$attribs)
 {
 	$moduleTag = htmlspecialchars($params->get('module_tag', 'h3'));
 	
-	// we use this alot so declare it 
+	// We use this alot so declare it 
 	$moduleHeader = 'class="moduleheader';	
 	
-	// what tag do they want for wrapper 
+	// What tag do they want for wrapper 
 	$headerTag = htmlspecialchars($params->get('header_tag'));	
 	
 	// Get number of boostrap columns 
 	$bootstrapSize = $params->get('bootstrap_size');	
 	
-	// temporarily store header class in variable 
+	// Temporarily store header class in variable 
 	$headerClass = $params->get('header_class');	
 	
 	 // Create header class declaration 
@@ -164,19 +164,19 @@ function modChrome_flex($module, &$params, &$attribs)
 	 // Create module class declaration 
 	$moduleClass = !empty($bootstrapSize) ? ' span' . (int) $bootstrapSize . '' : '';
 	
-	// get module suffix 
+	// Get module suffix 
 	$moduleClassSfx = htmlspecialchars($params->get('moduleclass_sfx')); 
 	
-	// don't create html if no module content 
+	// Don't create html if no module content 
 	if (!empty ($module->content))	
 	{
 		// Module wrapper 
 		$html  = "<{$moduleTag} class=\"moduletable{$moduleClassSfx}{$moduleClass}\">"; 
 
-		// don't display title if not requested 
+		// Don't display title if not requested 
 		if ((bool) $module->showtitle) 
-        {
-				// create tag and wrapper 
+			{
+				// Create tag and wrapper 
 				$html .= "<{$headerTag} {$headerClass}>";
 			
 					// Style the bar background for the title 
@@ -190,12 +190,12 @@ function modChrome_flex($module, &$params, &$attribs)
 				
 				// Close Wrapper 
 				$html .= "</{$headerTag}>";	
-        }
+			}
 
-		// get content 
+		// Get content 
 		$html .= $module->content; 
 		
-		 // close module wrapper 
+		 // Close module wrapper 
 		$html .= "</{$moduleTag}>";
 
 		// Display everything 

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -144,7 +144,7 @@ function modChrome_outline($module, &$params, &$attribs)
  */
 function modChrome_flex($module, &$params, &$attribs)
 {
-	$moduleTag = $params->get('module_tag', 'h3');
+	$moduleTag = htmlspecialchars($params->get('module_tag', 'h3'));
 	
 	// we use this alot so declare it 
 	$moduleHeader = 'class="moduleheader';	

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -144,13 +144,13 @@ function modChrome_outline($module, &$params, &$attribs)
  */
 function modChrome_flex($module, &$params, &$attribs)
 {
-	$moduleTag = htmlspecialchars($params->get('module_tag', 'h3'));
+	$moduleTag = htmlspecialchars($params->get('module_tag', 'div'));
 	
 	// We use this alot so declare it 
 	$moduleHeader = 'class="moduleheader';	
 	
 	// What tag do they want for wrapper 
-	$headerTag = htmlspecialchars($params->get('header_tag'));	
+	$headerTag = htmlspecialchars($params->get('header_tag', 'h3'));	
 	
 	// Get number of boostrap columns 
 	$bootstrapSize = (int) $params->get('bootstrap_size', '0');	


### PR DESCRIPTION
modchrome_flex
same as html5 but allows title area to have styling separate from title tag styling resulting in moduletable, moduleheader, and text background all separably styleable
Image below gives you a rough idea of what would be possible using just 3 css element declarations..
.moduletable {}
.moduleheader{}
.moduleheader_txtbg

![capture](https://f.cloud.github.com/assets/1850089/1228684/dbfe8d42-27a8-11e3-8210-88fde51759f5.PNG)

While this could be a separate template override, due to its extreme flexibility and easy styling I think it would be universally usable ergo warranting inclusion in core.
