### PR TITLE
MySQL(i) db collation check was not actually querying the database default collation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - pyrus channel-discover pear.phpunit.de
   - pyrus install --force phpunit/DbUnit
   - phpenv rehash
-  - mysql -e 'create database joomla_ut  DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;'
+  - mysql -e 'create database joomla_ut;'
   - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
   - psql -c 'create database joomla_ut;' -U postgres
   - psql -d joomla_ut -a -f tests/unit/suites/database/stubs/postgresql.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - pyrus channel-discover pear.phpunit.de
   - pyrus install --force phpunit/DbUnit
   - phpenv rehash
-  - mysql -e 'create database joomla_ut;'
+  - mysql -e 'create database joomla_ut  DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;'
   - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
   - psql -c 'create database joomla_ut;' -U postgres
   - psql -d joomla_ut -a -f tests/unit/suites/database/stubs/postgresql.sql

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -316,23 +316,32 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	{
 		$this->connect();
 
+		// Attempt to get the real Db colaltion.
+		$this->setQuery('SHOW VARIABLES LIKE "collation_database"');
 		try
 		{
+			$res = $this->loadObject();
 
-		}
-		catch (Exception $e)
-		{
-			$tables = $this->getTableList();
-
-			$this->setQuery('SHOW FULL COLUMNS FROM ' . $tables[0]);
-			$array = $this->loadAssocList();
-
-			foreach ($array as $field)
+			if (isset($res->Value))
 			{
-				if (!is_null($field['Collation']))
-				{
-					return $field['Collation'];
-				}
+				return $res->Value;
+			}
+		}
+		catch (RuntimeException $e)
+		{
+		}
+
+		// Fall back to querying the collation of the first db table.
+		$tables = $this->getTableList();
+
+		$this->setQuery('SHOW FULL COLUMNS FROM ' . $tables[0]);
+		$array = $this->loadAssocList();
+
+		foreach ($array as $field)
+		{
+			if (!is_null($field['Collation']))
+			{
+				return $field['Collation'];
 			}
 		}
 

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -316,16 +316,23 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	{
 		$this->connect();
 
-		$tables = $this->getTableList();
-
-		$this->setQuery('SHOW FULL COLUMNS FROM ' . $tables[0]);
-		$array = $this->loadAssocList();
-
-		foreach ($array as $field)
+		try
 		{
-			if (!is_null($field['Collation']))
+
+		}
+		catch (Exception $e)
+		{
+			$tables = $this->getTableList();
+
+			$this->setQuery('SHOW FULL COLUMNS FROM ' . $tables[0]);
+			$array = $this->loadAssocList();
+
+			foreach ($array as $field)
 			{
-				return $field['Collation'];
+				if (!is_null($field['Collation']))
+				{
+					return $field['Collation'];
+				}
 			}
 		}
 

--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -126,7 +126,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 	{
 		$this->assertThat(
 			self::$driver->getCollation(),
-			$this->equalTo('utf8_general_ci'),
+			$this->equalTo('utf8_unicode_ci'),
 			'Line:' . __LINE__ . ' The getCollation method should return the collation of the database.'
 		);
 	}

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -126,7 +126,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	{
 		$this->assertThat(
 			self::$driver->getCollation(),
-			$this->equalTo('utf8_general_ci'),
+			$this->equalTo('utf8_unicode_ci'),
 			'Line:' . __LINE__ . ' The getCollation method should return the collation of the database.'
 		);
 	}


### PR DESCRIPTION
This patch checks the actual db collation first, and if not found falls back to the previous method of querying the first db table's first column's collation.
Issue with the previous method is that if you had a table with a field whose collation was not the same as the db's default collation the method would return the wrong result.
