### PR TITLE
deprecating JMail::getInstance()

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -55,15 +55,13 @@ class JMail extends PHPMailer
 	 * @return  JMail  The global JMail object
 	 *
 	 * @since   11.1
+	 * @deprecated  12.3 (Platform) & 4.0 (CMS)
 	 */
 	public static function getInstance($id = 'Joomla')
 	{
-		if (empty(self::$instances[$id]))
-		{
-			self::$instances[$id] = new JMail;
-		}
-
-		return self::$instances[$id];
+		JLog::add('JMail::getInstance is deprecated. Use a new JMail object every time instead.', JLog::WARNING, 'deprecated');
+		
+		return new JMail;
 	}
 
 	/**


### PR DESCRIPTION
Use 'new JMail' every time.

JMail::getInstance() currently re-uses an old object. If you send out several mails during one page load, you have to use new JMail objects, otherwise the recipient of the first mail will also get the second mail that you send with that object, since the list of recipients is not cleared after sending a mail.
