### PR TITLE
Prevent tag from being displayed as an option as a parent of itself

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -129,6 +129,14 @@ class JFormFieldTag extends JFormFieldList
 			$query->where('a.id IN (' . implode(',', $values) . ')');
 		}
 
+		//Block the possibility to set a tag as it own parent
+		$id   = (int) $this->form->getValue('id', 0);
+		$name = (int) $this->form->getValue('name', '');
+		if ($name == 'com_tags.tag')
+		{
+			$query->where('a.id != ' . $db->quote($id));
+		}
+
 		// Filter language
 		if (!empty($this->element['language']))
 		{


### PR DESCRIPTION
Per http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30535
