### PR TITLE
com_installer version compare for database schema fixed

### DIFF
--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -41,11 +41,11 @@ defined('_JEXEC') or die;
 							<li><?php echo JText::_('COM_INSTALLER_MSG_DATABASE_FILTER_ERROR'); ?>
 						<?php endif; ?>
 
-						<?php if (!(strncmp($this->schemaVersion, JVERSION, 5) === 0)) : ?>
+						<?php if (version_compare($this->schemaVersion, JVERSION) == -1) : ?>
 							<li><?php echo JText::sprintf('COM_INSTALLER_MSG_DATABASE_SCHEMA_ERROR', $this->schemaVersion, JVERSION); ?></li>
 						<?php endif; ?>
 
-						<?php if (($this->updateVersion != JVERSION)) : ?>
+						<?php if (version_compare($this->updateVersion, JVERSION) != 0) : ?>
 							<li><?php echo JText::sprintf('COM_INSTALLER_MSG_DATABASE_UPDATEVERSION_ERROR', $this->updateVersion, JVERSION); ?></li>
 						<?php endif; ?>
 

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -41,7 +41,7 @@ defined('_JEXEC') or die;
 							<li><?php echo JText::_('COM_INSTALLER_MSG_DATABASE_FILTER_ERROR'); ?>
 						<?php endif; ?>
 
-						<?php if (version_compare($this->schemaVersion, JVERSION) == -1) : ?>
+						<?php if (version_compare($this->schemaVersion, JVERSION) != 0) : ?>
 							<li><?php echo JText::sprintf('COM_INSTALLER_MSG_DATABASE_SCHEMA_ERROR', $this->schemaVersion, JVERSION); ?></li>
 						<?php endif; ?>
 

--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -44,7 +44,7 @@ class InstallerViewDatabase extends InstallerViewDefault
 		$this->pagination = $this->get('Pagination');
 		$this->errorCount = count($this->errors);
 
-		if (!(strncmp($this->schemaVersion, JVERSION, 5) === 0))
+		if (version_compare($this->schemaVersion, JVERSION) == -1)
 		{
 			$this->errorCount++;
 		}
@@ -52,7 +52,7 @@ class InstallerViewDatabase extends InstallerViewDefault
 		{
 			$this->errorCount++;
 		}
-		if (($this->updateVersion != JVERSION))
+		if (version_compare($this->updateVersion, JVERSION) != 0)
 		{
 			$this->errorCount++;
 		}

--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -44,7 +44,7 @@ class InstallerViewDatabase extends InstallerViewDefault
 		$this->pagination = $this->get('Pagination');
 		$this->errorCount = count($this->errors);
 
-		if (version_compare($this->schemaVersion, JVERSION) == -1)
+		if (version_compare($this->schemaVersion, JVERSION) != 0)
 		{
 			$this->errorCount++;
 		}


### PR DESCRIPTION
Here is the bug report: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32179

I don't know if this needs to be fixed in the fix() task of the installer, too. 
