### PR TITLE
Improving module loading code in cpanel layout

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -38,22 +38,21 @@ $user = JFactory::getUser();
 </div>
 <?php endif; ?>
 <div class="row-fluid">
-	<div class="span3">
-		<div class="cpanel-links">
-			<?php
-			// Display the submenu position modules
-			$this->iconmodules = JModuleHelper::getModules('icon');
-			foreach ($this->iconmodules as $iconmodule)
-			{
-				$output = JModuleHelper::renderModule($iconmodule, array('style' => ''));
-				$params = new JRegistry;
-				$params->loadString($iconmodule->params);
-				echo $output;
-			}
-			?>
+	<?php $iconmodules = JModuleHelper::getModules('icon');
+	if ($iconmodules) : ?>
+		<div class="span3">
+			<div class="cpanel-links">
+				<?php
+				// Display the submenu position modules
+				foreach ($iconmodules as $iconmodule)
+				{
+					echo JModuleHelper::renderModule($iconmodule);
+				}
+				?>
+			</div>
 		</div>
-	</div>
-	<div class="span9">
+	<?php endif; ?>
+	<div class="span<?php echo ($iconmodules) ? 9 : 12; ?>">
 		<div class="row-fluid">
 			<?php
 			$spans = 0;
@@ -70,10 +69,7 @@ $user = JFactory::getUser();
 					echo '</div><div class="row-fluid">';
 					$spans = $bootstrapSize;
 				}
-				$output = JModuleHelper::renderModule($module, array('style' => 'well'));
-				$params = new JRegistry;
-				$params->loadString($module->params);
-				echo $output;
+				echo JModuleHelper::renderModule($module, array('style' => 'well'));
 			}
 			?>
 		</div>


### PR DESCRIPTION
I did two things
- Removed unneeded code mainly related to `$params`. That was probably some leftover code from long ago.
- Check if there is a module published on `icon` position. If there is no module published on this position, don't show blank space and let the other modules use this place instead.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32203
