### PR TITLE
JMenu: Codestyle

### DIFF
--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -174,7 +174,7 @@ class JMenu
 	 *
 	 * @param   string  $language  The language code, default value of * means all.
 	 *
-	 * @return  object  The item object
+	 * @return  mixed  The item object or null when not found for given language
 	 *
 	 * @since   1.5
 	 */
@@ -190,7 +190,7 @@ class JMenu
 		}
 		else
 		{
-			return 0;
+			return null;
 		}
 	}
 

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -21,7 +21,7 @@ class JMenuSite extends JMenu
 	/**
 	 * Loads the entire menu table into memory.
 	 *
-	 * @return  array
+	 * @return  boolean  True on success, false on failure
 	 *
 	 * @since   1.5
 	 */
@@ -72,6 +72,8 @@ class JMenuSite extends JMenu
 
 			parse_str($url, $item->query);
 		}
+
+		return true;
 	}
 
 	/**
@@ -133,7 +135,7 @@ class JMenuSite extends JMenu
 	 *
 	 * @param   string  $language  The language code.
 	 *
-	 * @return  object  The item object
+	 * @return  mixed  The item object or null when not found for given language
 	 *
 	 * @since   1.6
 	 */
@@ -149,7 +151,7 @@ class JMenuSite extends JMenu
 		}
 		else
 		{
-			return 0;
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
- updated comments in docblock
- `$menu->getDefault()` now returns null in case of failure like other menu methods. This shouldn't affect anything, as return is evaluated using `is_object` in places noted below or not at all.
  - [JPatchwaySite](https://github.com/piotr-cz/joomla-cms/blob/master/libraries/cms/pathway/site.php#L40)
  - [JRouterSite](https://github.com/piotr-cz/joomla-cms/blob/master/libraries/cms/router/site.php#L155)

Issue tracker Item: [32222](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32222&start=0)
