### PR TITLE
Bug fix translation not needed

### DIFF
--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -54,7 +54,7 @@ class JToolbarButtonPopup extends JToolbarButton
 
 		// Store all data to the options array for use with JLayout
 		$options = array();
-		$options['name'] = trim(JText::_($name), '*?');
+		$options['name'] = $name;
 		$options['text'] = JText::_($text);
 		$options['title'] = JText::_($title);
 		$options['class'] = $this->fetchIconClass($name);


### PR DESCRIPTION
Remove the translation applied to a variable which is use as a javascript selector.
Bug report on Joomlacode : http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32225&start=0
