### PR TITLE
[imp] Fields layouts: convert JFormFieldList

### DIFF
--- a/layouts/joomla/form/field/list.php
+++ b/layouts/joomla/form/field/list.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$data = (object) $displayData;
+
+$attributes = array();
+
+$attributes['id']            = $data->id;
+$attributes['class']         = !empty($data->class) ? (string) $data->class : null;
+$attributes['size']          = !empty($data->size) ? (int) $data->size : null;
+$attributes['multiple']      = $data->multiple ? 'multiple' : null;
+$attributes['required']      = $data->required ? 'required' : null;
+$attributes['aria-required'] = $data->required ? 'true' : null;
+$attributes['onchange']      = $data->element['onchange'] ? (string) $data->element['onchange'] : null;
+$attributes['autofocus']     = $data->autofocus ? ' autofocus' : null;
+
+if ((string) $data->element['readonly'] == 'true' || (string) $data->element['disabled'] == 'true')
+{
+	$attributes['disabled'] = 'disabled';
+}
+
+$renderedAttributes = null;
+
+if ($attributes)
+{
+	foreach ($attributes as $attribute => $value)
+	{
+		if (null !== $value)
+		{
+			$renderedAttributes .= ' ' . $attribute . '="' . (string) $value . '"';
+		}
+	}
+}
+
+$readOnly = ((string) $data->element['readonly'] == 'true');
+
+// If it's readonly the select will have no name
+$selectName = $readOnly ? '' : $data->name;
+?>
+
+<select name="<?php echo $selectName; ?>" <?php echo $renderedAttributes; ?>>
+	<?php if ($data->options) : ?>
+		<?php foreach ($data->options as $option) :?>
+				<option value="<?php echo $option->value; ?>" <?php if ($option->value == $data->value): ?>selected="selected"<?php endif; ?>>
+					<?php echo $option->text; ?>
+				</option>
+		<?php endforeach; ?>
+	<?php endif; ?>
+
+</select>
+<?php if ($readOnly) : ?>
+	<input type="hidden" name="<?php echo $data->name; ?>" value="<?php echo $data->value; ?>"/>
+<?php endif;

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -305,6 +305,13 @@ abstract class JFormField
 	protected static $generated_fieldname = '__field';
 
 	/**
+	 * Layout to render
+	 *
+	 * @var  string
+	 */
+	protected $layout;
+
+	/**
 	 * Method to instantiate the form field object.
 	 *
 	 * @param   JForm  $form  The form to attach to the form field object.

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -28,6 +28,13 @@ class JFormFieldList extends JFormField
 	protected $type = 'List';
 
 	/**
+	 * Layout to render
+	 *
+	 * @var  string
+	 */
+	protected $layout = 'joomla.form.field.list';
+
+	/**
 	 * Method to get the field input markup for a generic list.
 	 * Use the multiple attribute to enable multiselect.
 	 *
@@ -37,41 +44,24 @@ class JFormFieldList extends JFormField
 	 */
 	protected function getInput()
 	{
-		$html = array();
-		$attr = '';
+		$layout = !empty($this->element['layout']) ? $this->element['layout'] : $this->layout;
 
-		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$attr .= $this->multiple ? ' multiple' : '';
-		$attr .= $this->required ? ' required aria-required="true"' : '';
-		$attr .= $this->autofocus ? ' autofocus' : '';
-
-		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true' || (string) $this->disabled == '1'|| (string) $this->disabled == 'true')
-		{
-			$attr .= ' disabled="disabled"';
-		}
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
-
-		// Get the field options.
-		$options = (array) $this->getOptions();
-
-		// Create a read-only list (no name) with a hidden input to store the value.
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true')
-		{
-			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $this->value, $this->id);
-			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '"/>';
-		}
-		// Create a regular list.
-		else
-		{
-			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
-		}
-
-		return implode($html);
+		return JLayoutHelper::render(
+			$layout,
+			array(
+				'id'        => $this->id,
+				'element'   => $this->element,
+				'field'     => (array) $this,
+				'multiple'  => $this->multiple,
+				'name'      => $this->name,
+				'options'   => (array) $this->getOptions(),
+				'required'  => $this->required,
+				'value'     => $this->value,
+				'autofocus' => $this->autofocus,
+				'class'     => $this->class,
+				'size'      => $this->size
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32229

This opens the way to follow to start using layouts to render fields. This would allow override fields in templates i.e.

You can customise the layouts specifically also for a field instance with the `layout` attribute. Example:

``` xml
<field
    name="caching"
    type="list"
    default="2"
    label="COM_CONFIG_FIELD_CACHE_LABEL"
    description="COM_CONFIG_FIELD_CACHE_DESC"
    required="true"
    filter="integer"
    layout="field.mylayout"
    >
        <option value="0">COM_CONFIG_FIELD_VALUE_CACHE_OFF</option>
        <option value="1">COM_CONFIG_FIELD_VALUE_CACHE_CONSERVATIVE</option>
        <option value="2">COM_CONFIG_FIELD_VALUE_CACHE_PROGRESSIVE</option>
</field>
```

That will render a `list` field but instead of using the standard `joomla.form.field.list` it would use the layout `field.mylayout`. This is useful for example if we want to add some AJAX logic. Instead of creating our own field we just create a custom layout.

Also for the recent chosen issues this would allow us to add a class to every single select field (something not recommendable :D )
