### PR TITLE
Update article.php

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/content.php';
+JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
 
 /**
  * Item Model for an Article.


### PR DESCRIPTION
Be able to extend class ContentModelArticle from another component.

If you try to include file JPATH_ADMINISTRATOR . '/components/com_content/models/article.php' from another component it fails because of definition in line 12: JPATH_COMPONENT_ADMINISTRATOR 

Line 12 of file: JPATH_ADMINISTRATOR . '/components/com_content/models/article.php'
try to include once content helper with definition JPATH_COMPONENT_ADMINISTRATOR. For that reason if you try to include it from another component it fails. That for sure does not allow other components to extend ContentModelArticle

Instead line 12 from:
require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/content.php';
it should be:
JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
The same problems apperas in version 3.1.5 and 3.2.0.alpha

All other models, except that use the correct inclusion.
