### PR TITLE
Add version note field to banner client edit form.

### DIFF
--- a/administrator/components/com_banners/models/forms/client.xml
+++ b/administrator/components/com_banners/models/forms/client.xml
@@ -33,6 +33,14 @@
 			<option value="2">JARCHIVED</option>
 			<option value="-2">JTRASHED</option>
 		</field>
+		
+		<field name="version_note"
+			type="text"
+			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
+			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			class="inputbox" size="45"
+			labelclass="control-label"
+		/>
 
 		<field name="purchase_type" type="list"
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL" description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"


### PR DESCRIPTION
Forgot to add version note to the Banners client form. This PR adds it.
