### PR TITLE
Fixing the Postinstall message in cpanel

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -55,7 +55,7 @@ class CpanelViewCpanel extends JViewLegacy
 			require_once JPATH_LIBRARIES . '/fof/include.php';
 		}
 
-		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel', array('input' => array('eid' => 700)));
+		$messages_model = FOFModel::getAnInstance('Messages', 'PostinstallModel', array('input' => array('eid' => 700)));
 		$messages = $messages_model->getItemList();
 
 		$this->postinstall_message_count = count($messages);


### PR DESCRIPTION
`FOFModel::getTmpInstance` does reset the input before the actualy query is run. Thus the `eid` passed in the `input` array is not recognized.
It works in cPanel because it defaults to 700. If you change the eid number to some random value, you will see that the message still shows. But it shouldn't then.

Changing the call to `FOFModel::getAnInstance()` solves this.

It's possible that there are better fixes. It's just the first one I came up with.

This isn't a real issue in cPanel itself. Because of the intern default value it still works. I discovered it because I wanted to use the code to get messages for com_installer.
