### PR TITLE
FIX REGRESSION In Cpanel modules widths due to buggy sample data set

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -56,7 +56,15 @@ $user = JFactory::getUser();
 				// Get module parameters
 				$params = new JRegistry;
 				$params->loadString($module->params);
-				$bootstrapSize = $params->get('bootstrap_size');
+				$bootstrapSize = (int) $params->get('bootstrap_size');
+
+				// Fix for bug of default 1 instead of 0 in default data set:
+				// https://github.com/joomla/joomla-cms/pull/2206/files#diff-8fb2f5a83bfb0c557be664644876f1adL102
+				if ($bootstrapSize < 2)
+				{
+					$bootstrapSize = 0;
+				}
+
 				$spans += $bootstrapSize;
 				if ($spans > 12)
 				{


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/2206/files#diff-8fb2f5a83bfb0c557be664644876f1adL102

has fixed @brianteeman has only fixed this regression bug for new sites. This fixes it for upgraded sites too.

Needs a test as I did this on github to help, without time to test right now. Additionally github seems to bug on mergestatus-check! So really test it before committing please.
