### PR TITLE
FOFModel::getTmpInstance() clears input before getItemList() is run [Tracker 32258]

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -55,7 +55,7 @@ class CpanelViewCpanel extends JViewLegacy
 			require_once JPATH_LIBRARIES . '/fof/include.php';
 		}
 
-		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel', array('input' => array('eid' => 700)));
+		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel')->eid(700);
 		$messages = $messages_model->getItemList();
 
 		$this->postinstall_message_count = count($messages);

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -34,11 +34,11 @@ class PostinstallModelMessages extends FOFModel
 		$db = $this->getDbo();
 
 		// Add a forced extension filtering to the list
-		$eid = $this->input->getInt('eid', 700);
+		$eid = $this->getState('eid', 700);
 		$query->where($db->qn('extension_id') . ' = ' . $db->q($eid));
 
 		// Force filter only enabled messages
-		$published = $this->input->getInt('published', 1);
+		$published = $this->getState('published', 1, 'int');
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));
 
 		return $query;


### PR DESCRIPTION
This PR fixes the [tracker item 32258](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32258) "FOFModel::getTmpInstance() clears input before getItemList() is run".

The problem was in the PostinstallModelMessages. It should use getState to read the eid and published state variables, not try to read them directly from the input object. Reading directly from the input is discouraged. The models act on their state, not the global application input. This is a fundamental tenant of the MVC architecture. My bad! I wrote some very bad code in that model.

This PR fixes the PostinstallModelMessages model and also modifies the call to it from CpanelViewCpanel to correctly set the state variable, exactly as proper MVC prescribes.
