### PR TITLE
Smart Search does not remove old search phrases from the index when saving an article

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -323,6 +323,9 @@ abstract class FinderIndexerAdapter extends JPlugin
 		// Run the setup method.
 		$this->setup();
 
+		// Remove the old item.
+		$this->remove($id);
+
 		// Get the item.
 		$item = $this->getItem($id);
 


### PR DESCRIPTION
Smart Search does not remove old search phrases from the index when saving an article (or any content item actually).  This change fixes it.

See: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31055_
