### PR TITLE
solved "Fatal error: Call to undefined method PHPUnit_Util_Filter::addDirectoryToFilter()" that happens if PHPUnit version 3.5 or newer is used

### DIFF
--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -55,7 +55,15 @@ require_once JPATH_LIBRARIES.'/import.php';
 require_once JPATH_BASE.'/libraries/joomla/session/session.php';
 
 // Exclude all of the tests from code coverage reports
-PHPUnit_Util_Filter::addDirectoryToFilter(JPATH_BASE . '/tests');
+if (method_exists('PHPUnit_Util_Filter', 'addDirectoryToFilter'))
+{
+	PHPUnit_Util_Filter::addDirectoryToFilter(JPATH_BASE . '/tests');
+}
+else
+{
+	$codeCoverageFilter = new PHP_CodeCoverage_Filter;
+	$codeCoverageFilter->addDirectoryToBlacklist(JPATH_BASE . '/tests');
+}
 
 // Set error handling.
 JError::setErrorHandling(E_NOTICE, 'ignore');


### PR DESCRIPTION
Method PHPUnit_Util_Filter::addDirectoryToFilter() was removed in PHPUnit 3.5 (https://github.com/sebastianbergmann/phpunit/commit/150341273801b55392d0bde99fc7be60f5a5c15d).
