### PR TITLE
Adding an Options button to the post-installation messages component [tracker 32317]

### DIFF
--- a/administrator/components/com_postinstall/toolbar.php
+++ b/administrator/components/com_postinstall/toolbar.php
@@ -38,5 +38,6 @@ class PostinstallToolbar extends FOFToolbar
 		}
 
 		JToolBarHelper::title(JText::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $extension_name));
+		JToolBarHelper::preferences($this->config['option'], 550, 875);
 	}
 }


### PR DESCRIPTION
This PR implements an Options button in com_postinstall (the post-installation messages component).
Reference: [Joomla! Tracker Item 32317](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32317&start=0)
