### PR TITLE
Fix link issue in database query duplicate logging of debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1000,7 +1000,7 @@ class PlgSystemDebug extends JPlugin
 					{
 						if ($dup != $id)
 						{
-							$dups[] = '<a href="#dbg-query-' . ($dup + 1) . '">#' . ($dup + 1) . '</a>';
+							$dups[] = '<a href="'.JUri::getInstance()->toString().'#dbg-query-' . ($dup + 1) . '">#' . ($dup + 1) . '</a>';
 						}
 					}
 
@@ -1060,7 +1060,7 @@ class PlgSystemDebug extends JPlugin
 
 				foreach ($dups as $dup)
 				{
-					$links[] = '<a href="#dbg-query-' . ($dup + 1) . '">#' . ($dup + 1) . '</a>';
+					$links[] = '<a href="'.JUri::getInstance()->toString().'#dbg-query-' . ($dup + 1) . '">#' . ($dup + 1) . '</a>';
 				}
 
 				$html[] = '<div>' . JText::sprintf('PLG_DEBUG_QUERY_DUPLICATES_NUMBER', count($links)) . ': ' . implode('&nbsp; ', $links) . '</div>';


### PR DESCRIPTION
When enabling debug mode, if there are duplicated database queries, the linking using hash is incorrect, when clicking those hash links, it will return an URL with no query string

For example, the current URL:

http://abc.com/index.php/search?a=1&b=2&c=3

Clicking on those hash links will return

http://abc.com/index.php/search#abc
