### PR TITLE
Fix jform labelclass property

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -270,7 +270,7 @@ abstract class JFormField
 	 * @var    mixed
 	 * @since  11.1
 	 */
-	protected $labelClass;
+	protected $labelclass;
 
 	/**
 	* The javascript onchange of the form field.
@@ -361,7 +361,7 @@ abstract class JFormField
 			case 'validate':
 			case 'value':
 			case 'class':
-			case 'labelClass':
+			case 'labelclass':
 			case 'size':
 			case 'onchange':
 			case 'onclick':
@@ -422,7 +422,7 @@ abstract class JFormField
 			case 'description':
 			case 'hint':
 			case 'value':
-			case 'labelClass':
+			case 'labelclass':
 			case 'onchange':
 			case 'onclick':
 			case 'validate':
@@ -533,7 +533,7 @@ abstract class JFormField
 		$this->group = $group;
 
 		$attributes = array(
-			'multiple', 'name', 'id', 'hint', 'class', 'description', 'labelClass', 'onchange',
+			'multiple', 'name', 'id', 'hint', 'class', 'description', 'labelclass', 'onchange',
 			'onclick', 'validate', 'pattern', 'default', 'required',
 			'disabled', 'readonly', 'autofocus', 'hidden', 'autocomplete', 'spellcheck',
 			'translateHint', 'translateLabel', 'translateDescription', 'size');
@@ -689,7 +689,7 @@ abstract class JFormField
 		// Build the class for the label.
 		$class = !empty($this->description) ? 'hasTooltip' : '';
 		$class = $this->required == true ? $class . ' required' : $class;
-		$class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
+		$class = !empty($this->labelclass) ? $class . ' ' . $this->labelclass : $class;
 
 		// Add the opening label tag and main attributes attributes.
 		$label .= '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '"';


### PR DESCRIPTION
The ability to set CSS class for form label is broken because of recent changes in this commit:

https://github.com/joomla/joomla-cms/commit/5696d944a6091fb70e80cc60dae95b7ad5aa0f34#diff-9d799c43096f42c965b28c44a8d8a8b1

Before this change, we use camelCase for JFormField property naming and lowercase for XML attribute, but the new change requires JFormField property name and XML attribute name to be exactly the same therefore it does not work.

This pull request attempts to fix this issue in a backward compatibility manner.
