### PR TITLE
Displaying ordering fields

### DIFF
--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -101,9 +101,8 @@
 			label="COM_CONTENT_FIELD_VERSION_LABEL" size="6" description="COM_CONTENT_FIELD_VERSION_DESC"
 			readonly="true" filter="unset" />
 
-		<field name="ordering" type="text" label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC" class="inputbox" size="6"
-			default="0" />
+		<field name="ordering" type="ordering" label="JFIELD_ORDERING_LABEL"
+			description="JFIELD_ORDERING_DESC" class="inputbox" size="6" />
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -22,6 +22,7 @@ $fields = $displayData->get('fields') ?: array(
 	'featured',
 	'sticky',
 	'access',
+	'ordering',
 	'language',
 	'note',
 	'version_note'

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -105,7 +105,6 @@ abstract class JHtmlList
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
-			$items[$i]->text = JText::_($items[$i]->text);
 
 			if (JString::strlen($items[$i]->text) > $chop)
 			{


### PR DESCRIPTION
This patch reinstates the display of the ordering field for banners, contacts, newsfeeds, weblinks in the edit views.
It also adds it for articles and featured articles.

The reasoning is that it is impossible to order these items by drag and drop when the number of items is important or is displayed on multiple pages, and as well on mobile devices.

The patch includes a change to list.php as the items in the dropdown are shown untranslated (?? item ??)
That part could be taken off if it is thought that it could create B/C with 3pd extensions.
