### PR TITLE
[#32339] *Display of the ordering field when editing items

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -215,12 +215,6 @@ class ContentModelArticle extends JModelAdmin
 
 		// Increment the content version number.
 		$table->version++;
-
-		// Reorder the articles within the category so the new article is first
-		if (empty($table->id))
-		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
-		}
 	}
 
 	/**
@@ -536,6 +530,13 @@ class ContentModelArticle extends JModelAdmin
 					}
 				}
 			}
+
+			// Reorder the articles within the category so the new article is first
+			$table = $this->getTable();
+			$key = $table->getKeyName();
+			$pk = (!empty($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+			$table->load($pk);
+			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
 
 			return true;
 		}

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -101,9 +101,8 @@
 			label="COM_CONTENT_FIELD_VERSION_LABEL" size="6" description="COM_CONTENT_FIELD_VERSION_DESC"
 			readonly="true" filter="unset" />
 
-		<field name="ordering" type="text" label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC" size="6"
-			default="0" />
+		<field name="ordering" type="ordering" label="JFIELD_ORDERING_LABEL"
+			description="JFIELD_ORDERING_DESC" class="inputbox" size="6" />
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -930,12 +930,13 @@ class ModulesModelModule extends JModelAdmin
 		// Alter the title and published state for Save as Copy
 		if ($input->get('task') == 'save2copy')
 		{
-			$orig_data  = $input->post->get('jform', array(), 'array');
+			$orig_table = clone $this->getTable();
+			$orig_table->load((int) $input->getInt('id'));
+			$data['published'] = 0;
 
-			if ($data['title'] == $orig_data['title'])
+			if ($data['title'] == $orig_table->title)
 			{
 				$data['title'] .= ' ' . JText::_('JGLOBAL_COPY');
-				$data['published'] = 0;
 			}
 		}
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -931,10 +931,8 @@ class ModulesModelModule extends JModelAdmin
 		if ($input->get('task') == 'save2copy')
 		{
 			$orig_data  = $input->post->get('jform', array(), 'array');
-			$orig_table = clone $this->getTable();
-			$orig_table->load((int) $orig_data['id']);
 
-			if ($data['title'] == $orig_table->title)
+			if ($data['title'] == $orig_data['title'])
 			{
 				$data['title'] .= ' ' . JText::_('JGLOBAL_COPY');
 				$data['published'] = 0;

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -132,18 +132,6 @@ class ModulesViewModules extends JViewLegacy
 
 		JToolbarHelper::help('JHELP_EXTENSIONS_MODULE_MANAGER');
 
-		JHtmlSidebar::addEntry(
-			JText::_('JSITE'),
-			'index.php?option=com_modules&filter_client_id=0',
-			$this->state->get('filter.client_id') == 0
-		);
-
-		JHtmlSidebar::addEntry(
-			JText::_('JADMINISTRATOR'),
-			'index.php?option=com_modules&filter_client_id=1',
-			$this->state->get('filter.client_id') == 1
-		);
-
 		JHtmlSidebar::setAction('index.php?option=com_modules');
 
 		JHtmlSidebar::addFilter(

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -1,8 +1,8 @@
 <?php
 /**
- * @package		Joomla
- * @copyright	Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     Joomla
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  *
  * -------------------------------------------------------------------------
  * THIS SHOULD ONLY BE USED AS A LAST RESORT WHEN THE WEB INSTALLER FAILS
@@ -22,23 +22,22 @@ class JConfig {
 	public $offline_message = 'This site is down for maintenance.<br /> Please check back again soon.';
 	public $display_offline_message = '1';
 	public $offline_image = '';
-	public $sitename = 'Joomla!';				// Name of Joomla site
+	public $sitename = 'Joomla!';            // Name of Joomla site
 	public $editor = 'tinymce';
 	public $captcha = '0';
 	public $list_limit = '20';
-	public $root_user = '42';
 	public $access = '1';
 
 	/* Database Settings */
-	public $dbtype = 'mysql';					// Normally mysql
-	public $host = 'localhost';					// This is normally set to localhost
-	public $user = '';							// DB username
-	public $password = '';						// DB password
-	public $db = '';							// DB database name
-	public $dbprefix = 'jos_';					// Do not change unless you need to!
+	public $dbtype = 'mysqli';               // Normally mysqli
+	public $host = 'localhost';              // This is normally set to localhost
+	public $user = '';                       // DB username
+	public $password = '';                   // DB password
+	public $db = '';                         // DB database name
+	public $dbprefix = 'jos_';               // Do not change unless you need to!
 
 	/* Server Settings */
-	public $secret = 'FBVtggIk5lAzEU9H'; 		// Change this to something more secure
+	public $secret = 'FBVtggIk5lAzEU9H';     // Change this to something more secure
 	public $gzip = '0';
 	public $error_reporting = 'default';
 	public $helpurl = 'http://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}';
@@ -48,16 +47,16 @@ class JConfig {
 	public $ftp_pass = '';
 	public $ftp_root = '';
 	public $ftp_enable = '';
-	public $tmp_path = '/tmp';
-	public $log_path = '/var/logs';
-	public $live_site = ''; 					// Optional, Full url to Joomla install.
-	public $force_ssl = 0;						// Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
+	public $tmp_path = '/tmp';                // Please check with your host that this is the correct path to the temp directory. This path needs to be writable by Joomla!
+	public $log_path = '/var/logs';           // Please check with your host that this is the correct path to the logs directory. This path needs to be writable by Joomla!
+	public $live_site = '';                   // Optional, full url to Joomla install.
+	public $force_ssl = 0;                    // Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
 
 	/* Locale Settings */
 	public $offset = 'UTC';
 
 	/* Session settings */
-	public $lifetime = '15';					// Session time
+	public $lifetime = '15';                  // Session time
 	public $session_handler = 'database';
 
 	/* Mail Settings */

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -29,6 +29,7 @@ $fields = $displayData->get('fields') ?: array(
 	'featured',
 	'sticky',
 	'access',
+	'ordering',
 	'language',
 	'note',
 	'version_note'

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -105,7 +105,6 @@ abstract class JHtmlList
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
-			$items[$i]->text = JText::_($items[$i]->text);
 
 			if (JString::strlen($items[$i]->text) > $chop)
 			{

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -79,22 +79,24 @@ abstract class JHtmlList
 	/**
 	 * Returns an array of options
 	 *
-	 * @param   string   $query  SQL with 'ordering' AS value and 'name field' AS text
-	 * @param   integer  $chop   The length of the truncated headline
+	 * @param   string   $query         SQL with 'ordering' AS value and 'name field' AS text
+	 * @param   integer  $chop          The length of the truncated headline
+	 * @param   integer  $currentOrder  Order of the item
 	 *
 	 * @return  array  An array of objects formatted for JHtml list processing
 	 *
 	 * @since   1.5
 	 */
-	public static function genericordering($query, $chop = 30, $selectOrder = 0)
+	public static function genericordering($query, $chop = 30, $currentOrder = 0)
 	{
 		$db = JFactory::getDbo();
 		$options = array();
 		$db->setQuery($query);
 
 		$items = $db->loadObjectList();
+		$totalItems = count($items);
 
-		if (empty($items))
+		if ($totalItems == 0)
 		{
 			$options[] = JHtml::_('select.option', 1, JText::_('JOPTION_ORDER_FIRST'));
 
@@ -102,10 +104,10 @@ abstract class JHtmlList
 		}
 
 		$options[] = JHtml::_('select.option', 0, JText::_('JOPTION_ORDER_FIRST'));
+		$options[] = JHtml::_('select.option', $items[$totalItems - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
-		for ($i = 0, $n = count($items); $i < $n; $i++)
+		for ($i = 0; $i < $totalItems; ++$i)
 		{
-
 			if (JString::strlen($items[$i]->text) > $chop)
 			{
 				$text = JString::substr($items[$i]->text, 0, $chop) . "...";
@@ -115,10 +117,8 @@ abstract class JHtmlList
 				$text = $items[$i]->text;
 			}
 
-			$options[] = JHtml::_('select.option', ($items[$i]->value == $selectOrder ? $selectOrder : $items[$i]->value + 1), ($items[$i]->value + 1) / 2 . '. ' . $text);
+			$options[] = JHtml::_('select.option', $items[$i]->value + ($items[$i]->value < $currentOrder ? -1 : ($items[$i]->value > $currentOrder ? 1 : 0)), ($items[$i]->value + 1) / 2 . '. ' . $text);
 		}
-
-		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
 		return $options;
 	}

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -86,7 +86,7 @@ abstract class JHtmlList
 	 *
 	 * @since   1.5
 	 */
-	public static function genericordering($query, $chop = 30)
+	public static function genericordering($query, $chop = 30, $selectOrder = 0)
 	{
 		$db = JFactory::getDbo();
 		$options = array();
@@ -101,7 +101,7 @@ abstract class JHtmlList
 			return $options;
 		}
 
-		$options[] = JHtml::_('select.option', 0, '0 ' . JText::_('JOPTION_ORDER_FIRST'));
+		$options[] = JHtml::_('select.option', 0, JText::_('JOPTION_ORDER_FIRST'));
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
@@ -115,10 +115,10 @@ abstract class JHtmlList
 				$text = $items[$i]->text;
 			}
 
-			$options[] = JHtml::_('select.option', $items[$i]->value, $items[$i]->value . '. ' . $text);
+			$options[] = JHtml::_('select.option', ($items[$i]->value == $selectOrder ? $selectOrder : $items[$i]->value + 1), ($items[$i]->value + 1) / 2 . '. ' . $text);
 		}
 
-		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, ($items[$i - 1]->value + 1) . ' ' . JText::_('JOPTION_ORDER_LAST'));
+		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
 		return $options;
 	}
@@ -145,7 +145,7 @@ abstract class JHtmlList
 
 		if (empty($neworder))
 		{
-			$orders = JHtml::_('list.genericordering', $query);
+			$orders = JHtml::_('list.genericordering', $query, 30, (int) $selected);
 			$html = JHtml::_('select.genericlist', $orders, $name, array('list.attr' => $attribs, 'list.select' => (int) $selected));
 		}
 		else

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1388,12 +1388,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			if ($row->ordering >= 0)
 			{
 				// Only update rows that are necessary.
-				if ($row->ordering != $i + 1)
+				if ($row->ordering != $i*2 + 1)
 				{
 					// Update the row ordering field.
 					$query->clear()
 						->update($this->_tbl)
-						->set('ordering = ' . ($i + 1));
+						->set('ordering = ' . ($i*2 + 1));
 					$this->appendPrimaryKeys($query, $row);
 					$this->_db->setQuery($query);
 					$this->_db->execute();

--- a/tests/unit/suites/libraries/cms/response/JResponseJsonTest.php
+++ b/tests/unit/suites/libraries/cms/response/JResponseJsonTest.php
@@ -56,13 +56,11 @@ class JResponseJsonTest extends TestCase
 	 */
 	public function testSimpleSuccess()
 	{
-		ob_start();
-		echo new JResponseJson;
-		$output = ob_get_clean();
+		$output = new JResponseJson;
 
 		$response = json_decode($output);
 
-		$this->assertEquals(true, $response->success);
+		$this->assertTrue($response->success);
 	}
 
 	/**
@@ -78,15 +76,13 @@ class JResponseJsonTest extends TestCase
 		$data->value   = 5;
 		$data->average = 7.9;
 
-		ob_start();
-		echo new JResponseJson($data);
-		$output = ob_get_clean();
+		$output = new JResponseJson($data);
 
 		$response = json_decode($output);
 
-		$this->assertEquals(true, $response->success);
-		$this->assertEquals(5, $response->data->value);
-		$this->assertEquals(7.9, $response->data->average);
+		$this->assertTrue($response->success);
+		$this->assertSame(5, $response->data->value);
+		$this->assertSame(7.9, $response->data->average);
 	}
 
 	/**
@@ -101,14 +97,12 @@ class JResponseJsonTest extends TestCase
 	 */
 	public function testFailureWithException()
 	{
-		ob_start();
-		echo new JResponseJson(new Exception('This and that went wrong'));
-		$output = ob_get_clean();
+		$output = new JResponseJson(new Exception('This and that went wrong'));
 
 		$response = json_decode($output);
 
-		$this->assertEquals(false, $response->success);
-		$this->assertEquals('This and that went wrong', $response->message);
+		$this->assertFalse($response->success);
+		$this->assertSame('This and that went wrong', $response->message);
 	}
 
 	/**
@@ -127,16 +121,14 @@ class JResponseJsonTest extends TestCase
 		$data->value   = 6;
 		$data->average = 8.9;
 
-		ob_start();
-		echo new JResponseJson($data, 'Something went wrong', true);
-		$output = ob_get_clean();
+		$output = new JResponseJson($data, 'Something went wrong', true);
 
 		$response = json_decode($output);
 
-		$this->assertEquals(false, $response->success);
-		$this->assertEquals('Something went wrong', $response->message);
-		$this->assertEquals(6, $response->data->value);
-		$this->assertEquals(8.9, $response->data->average);
+		$this->assertFalse($response->success);
+		$this->assertSame('Something went wrong', $response->message);
+		$this->assertSame(6, $response->data->value);
+		$this->assertSame(8.9, $response->data->average);
 	}
 
 	/**
@@ -154,16 +146,14 @@ class JResponseJsonTest extends TestCase
 		$app->enqueueMessage('You should not do that', 'warning');
 		JFactory::$application = $app;
 
-		ob_start();
-		echo new JResponseJson(new Exception('A major error occured'));
-		$output = ob_get_clean();
+		$output = new JResponseJson(new Exception('A major error occured'));
 
 		$response = json_decode($output);
 
-		$this->assertEquals(false, $response->success);
-		$this->assertEquals('A major error occured', $response->message);
-		$this->assertEquals('This part was successful', $response->messages->message[0]);
-		$this->assertEquals('You should not do that', $response->messages->warning[0]);
+		$this->assertFalse($response->success);
+		$this->assertSame('A major error occured', $response->message);
+		$this->assertSame('This part was successful', $response->messages->message[0]);
+		$this->assertSame('You should not do that', $response->messages->warning[0]);
 	}
 
 	/**
@@ -184,15 +174,13 @@ class JResponseJsonTest extends TestCase
 		$app->enqueueMessage('You should not do that', 'warning');
 		JFactory::$application = $app;
 
-		ob_start();
-		echo new JResponseJson(new Exception('A major error occured'), null, false, true);
-		$output = ob_get_clean();
+		$output = new JResponseJson(new Exception('A major error occured'), null, false, true);
 
 		$response = json_decode($output);
 
-		$this->assertEquals(false, $response->success);
-		$this->assertEquals('A major error occured', $response->message);
-		$this->assertEquals(null, $response->messages);
+		$this->assertFalse($response->success);
+		$this->assertSame('A major error occured', $response->message);
+		$this->assertNull($response->messages);
 	}
 
 	/**
@@ -210,14 +198,12 @@ class JResponseJsonTest extends TestCase
 		$app->enqueueMessage('This one was also successful');
 		JFactory::$application = $app;
 
-		ob_start();
-		echo new JResponseJson;
-		$output = ob_get_clean();
+		$output = new JResponseJson;
 
 		$response = json_decode($output);
 
-		$this->assertEquals(true, $response->success);
-		$this->assertEquals('This part was successful', $response->messages->message[0]);
-		$this->assertEquals('This one was also successful', $response->messages->message[1]);
+		$this->assertTrue($response->success);
+		$this->assertSame('This part was successful', $response->messages->message[0]);
+		$this->assertSame('This one was also successful', $response->messages->message[1]);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -531,7 +531,6 @@ class JTableTest extends TestCaseDatabase
 		$object2->load(array('id1' => 25, 'id2' => 50));
 
 		$this->AssertEquals('5', $object2->checked_out);
-
 	}
 
 	/**
@@ -713,7 +712,8 @@ class JTableTest extends TestCaseDatabase
 
 		$object2->load(array('id1' => 25, 'id2' => 51));
 
-		$this->assertEquals(2, $object2->ordering, 'Elements did not get reordered');
+		// Now order is stored in the sequence 1,3,5,7,9...
+		$this->assertEquals(3, $object2->ordering, 'Elements did not get reordered');
 	}
 
 	/**


### PR DESCRIPTION
This patch reinstates the display of the ordering field for banners, contacts, newsfeeds, weblinks in the edit views.
It also adds it for articles and featured articles.

The reasoning is that it is impossible to order these items by drag and drop when the number of items is important or is displayed on multiple pages, and as well on mobile devices.

The patch includes a change to list.php as the items in the dropdown are shown untranslated (?? item ??) when debug is on.
That part of the patch could be taken off if it is thought that it could create B/C with 3pd extensions.

Note: As we do not have an ordering type for categories, ordering field display is not implemented here for categories.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32339
