### PR TITLE
Remove dependence on MooTools More in jQuery form validation

### DIFF
--- a/media/system/js/validate-jquery-uncompressed.js
+++ b/media/system/js/validate-jquery-uncompressed.js
@@ -105,7 +105,7 @@ var JFormValidator = function($) {
 			}
 		});
 		// Run custom form validators if present
-		new Hash(custom).each(function(validator) {
+		$.each(custom, function(key, validator) {
 			if (validator.exec() !== true) {
 				valid = false;
 			}


### PR DESCRIPTION
New jQuery validator still use Mootools More Hash object
