### PR TITLE
Remove dependence on MooTools More in MooTools form validation

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -152,7 +152,7 @@ var JFormValidator = new Class({
 		}
 
 		// Run custom form validators if present
-		new Hash(this.custom).each(function(validator){
+		Object.each(this.custom, function(validator){
 			if (validator.exec() != true) {
 				valid = false;
 			}


### PR DESCRIPTION
Mootools validator does not load Mootools More since Joomla 3.0 but it is still using Hash object which is part of Mootools More.
There is a very simple fix.

Posted 5 months ago
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=30900
