### PR TITLE
fix parsing schemas with mysqli driver type

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1064,8 +1064,16 @@ class JInstaller extends JAdapter
 				foreach ($schemapaths as $entry)
 				{
 					$attrs = $entry->attributes();
+					
+					//assuming that the type is a mandatory attribute but if it is not mandatory then there should be a discussion for it.
+					$uDriver = strtolower($attrs['type']);
+		
+					if ($uDriver == 'mysqli')
+					{
+						$uDriver = 'mysql';
+					}
 
-					if ($attrs['type'] == $dbDriver)
+					if ($uDriver == $dbDriver)
 					{
 						$schemapath = $entry;
 						break;


### PR DESCRIPTION
Update to fix the problem of parsing schemas when the user insert a schemapath with type=mysqli because the old version not support this choice even if the type "mysqli" is supported in the install and uninstall.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32351
