### PR TITLE
Removes the class aliases for the DI package.

### DIFF
--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -79,6 +79,3 @@ JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'Banner
 JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'BannersTableClient', array('typeAlias' => 'com_banners.client'));
 JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'TagsTableTag', array('typeAlias' => 'com_tags.tag'));
 JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'UsersTableNote', array('typeAlias' => 'com_users.note'));
-
-// Register class name aliases to Framework classes
-require_once JPATH_LIBRARIES . '/framework/aliases.php';

--- a/libraries/framework/aliases.php
+++ b/libraries/framework/aliases.php
@@ -1,8 +1,0 @@
-<?php
-
-/**
- * Setup the class aliases for framework classes.
- */
-JLoader::registerAlias('JDiContainer', 'Joomla\\DI\\Container');
-JLoader::registerAlias('JDiContainerAwareInterface', 'Joomla\\DI\\ContainerAwareInterface');
-JLoader::registerAlias('JDiServiceProviderInterface', 'Joomla\\DI\\ServiceProviderInterface');

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -90,5 +90,3 @@ JLoader::register('JRules', JPATH_PLATFORM . '/legacy/access/rules.php');
 JLoader::register('JCli', JPATH_PLATFORM . '/legacy/application/cli.php');
 JLoader::register('JDaemon', JPATH_PLATFORM . '/legacy/application/daemon.php');
 JLoader::register('JApplication', JPATH_LIBRARIES . '/legacy/application/application.php');
-
-require_once JPATH_LIBRARIES . '/framework/aliases.php';

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -60,5 +60,3 @@ if (version_compare(PHP_VERSION, '5.4.0', '<'))
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/language/text.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');
-
-require_once JPATH_LIBRARIES . '/framework/aliases.php';


### PR DESCRIPTION
This PR removes the class alias file for the DI package from the framework. It is far better to teach developers the right way to deal with namespacing from day-one as this will open more opportunities for more of the Framework or other PSR-0 compatible code to be included in the CMS.
