### PR TITLE
Use IE=edge by default.

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -116,6 +116,9 @@ class JDocumentHTML extends JDocument
 
 		// Set default mime type and document metadata (meta data syncs with mime type by default)
 		$this->setMimeEncoding('text/html');
+
+		// Set default X-UA-Compatible to make sure IE uses the latest rendering mode
+		$this->setMetaData('X-UA-Compatible', 'IE=edge', true);
 	}
 
 	/**

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -142,6 +142,7 @@ class JDocumentHTML extends JDocument
 		$data['script']      = $this->_script;
 		$data['custom']      = $this->_custom;
 		$data['scriptText']  = JText::script();
+
 		return $data;
 	}
 
@@ -194,7 +195,6 @@ class JDocumentHTML extends JDocument
 	 */
 	public function mergeHeadData($data)
 	{
-
 		if (empty($data) || !is_array($data))
 		{
 			return;
@@ -213,6 +213,7 @@ class JDocumentHTML extends JDocument
 			foreach ($data['metaTags'] as $type1 => $data1)
 			{
 				$booldog = $type1 == 'http-equiv' ? true : false;
+
 				foreach ($data1 as $name2 => $data2)
 				{
 					$this->setMetaData($name2, $data2, $booldog);
@@ -373,12 +374,14 @@ class JDocumentHTML extends JDocument
 		}
 
 		$title = (isset($attribs['title'])) ? $attribs['title'] : null;
+
 		if (isset(parent::$_buffer[$type][$name][$title]))
 		{
 			return parent::$_buffer[$type][$name][$title];
 		}
 
 		$renderer = $this->loadRenderer($type);
+
 		if ($this->_caching == true && $type == 'modules')
 		{
 			$cache = JFactory::getCache('com_modules', '');
@@ -480,6 +483,7 @@ class JDocumentHTML extends JDocument
 		}
 
 		parent::render();
+
 		return $data;
 	}
 
@@ -496,6 +500,7 @@ class JDocumentHTML extends JDocument
 	{
 		$operators = '(\+|\-|\*|\/|==|\!=|\<\>|\<|\>|\<=|\>=|and|or|xor)';
 		$words = preg_split('# ' . $operators . ' #', $condition, null, PREG_SPLIT_DELIM_CAPTURE);
+
 		for ($i = 0, $n = count($words); $i < $n; $i += 2)
 		{
 			// Odd parts (modules)
@@ -527,6 +532,7 @@ class JDocumentHTML extends JDocument
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
+
 			if ($active)
 			{
 				$query = $db->getQuery(true)
@@ -578,9 +584,11 @@ class JDocumentHTML extends JDocument
 		// Try to find a favicon by checking the template and root folder
 		$path = $directory . '/';
 		$dirs = array($path, JPATH_BASE . '/');
+
 		foreach ($dirs as $dir)
 		{
 			$icon = $dir . 'favicon.ico';
+
 			if (file_exists($icon))
 			{
 				$path = str_replace(JPATH_BASE . '/', '', $dir);
@@ -666,6 +674,7 @@ class JDocumentHTML extends JDocument
 					$template_tags_last[$matches[0][$i]] = array('type' => $type, 'name' => $name, 'attribs' => $attribs);
 				}
 			}
+
 			// Reverse the last array so the jdocs are in forward order.
 			$template_tags_last = array_reverse($template_tags_last);
 


### PR DESCRIPTION
This patch fixes this issue: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32396&start=0

It's a template issue but, rather than fix it in the template, I'm fixing it in the HTML document class. Why?
1) Easy to override (for testing or whatever) without modifying any Joomla! files.
2) Future template writers need not be concerned with remember the tag.
3) 99.9% of all templates that will ever be created should want to use this setting anyway.
