### PR TITLE
[32407] ^ [JUX] Remove sidebar on the places where search tools has been implemented

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -52,13 +52,11 @@ $sortFields = $this->getSortFields();
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
 <?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -43,13 +43,11 @@ $sortFields = $this->getSortFields();
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=clients'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
 <?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -50,12 +50,12 @@ $sortFields = $this->getSortFields();
 	}
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories'); ?>" method="post" name="adminForm" id="adminForm">
-	<?php if (!empty($this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
-			<?php echo $this->sidebar; ?>
-		</div>
-	<?php endif; ?>
-	<div id="j-main-container"<?php echo !empty($this->sidebar) ? ' class="span10"' : ''; ?>>
+<?php if (!empty( $this->sidebar)) : ?>
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
+		<?php echo $this->sidebar; ?>
+	</div>
+<?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -53,13 +53,11 @@ $assoc		= JLanguageAssociations::isEnabled();
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
 <?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -26,14 +26,12 @@ $saveOrder	= $listOrder == 'fp.ordering';
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=featured'); ?>" method="post" name="adminForm" id="adminForm">
-	<?php if (!empty( $this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
-			<?php echo $this->sidebar; ?>
-		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+<?php if (!empty( $this->sidebar)) : ?>
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
+		<?php echo $this->sidebar; ?>
+	</div>
+<?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -55,13 +55,11 @@ $assoc		= JLanguageAssociations::isEnabled();
 <?php // Set up the filter bar. ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
 <?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this), null, array('debug' => false));

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -37,14 +37,12 @@ $sortFields = $this->getSortFields();
 	}
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=users');?>" method="post" name="adminForm" id="adminForm">
-	<?php if (!empty( $this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
+<?php if (!empty( $this->sidebar)) : ?>
+	<div id="j-sidebar-container" class="hidden-desktop hidden-tablet">
 		<?php echo $this->sidebar; ?>
-		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+	</div>
+<?php endif;?>
+	<div id="j-main-container">
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));


### PR DESCRIPTION
This PR adds the extra feature proposed in the JUX code sprint after the creation of search tools. Hide the sidebar menu because we observed that the same options were in the top navigation menu. This makes all the available area usable for columns.

Previous with sidebar:
![jux-sidebar-shown](https://f.cloud.github.com/assets/1119272/1390133/ad9bd686-3be8-11e3-83d2-160a408f93ab.png)

Current without sidebar:
![jux-sidebar-hidden](https://f.cloud.github.com/assets/1119272/1390134/b620d982-3be8-11e3-91ac-c1cc93cdf8e8.png)

After talking with @brianteeman we decided to keep the menu for mobile devices where we think it's still useful:
![jux-sidebar-shown-mobile](https://f.cloud.github.com/assets/1119272/1390142/d0c4bb1e-3be8-11e3-96ab-705e941d2431.png)

If this is merged I'll add the extra managements while I integrate search tools before the release.
