### PR TITLE
Custom html module "basic" options hard to find

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.xml
+++ b/administrator/modules/mod_custom/mod_custom.xml
@@ -24,7 +24,7 @@
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_ADMIN_CUSTOM" />
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="options" label="COM_MODULES_BASIC_FIELDSET_LABEL">
 				<field
 					name="prepare_content"
 					type="radio"

--- a/modules/mod_custom/mod_custom.xml
+++ b/modules/mod_custom/mod_custom.xml
@@ -25,7 +25,7 @@
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_CUSTOM_HTML" />
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="options" label="COM_MODULES_BASIC_FIELDSET_LABEL">
 				<field
 					name="prepare_content"
 					type="radio"


### PR DESCRIPTION
The Options are now displayed below the editor textarea and may not be seen by the user.
This patch adds a tab for them. 

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32401&start=0

![modcustomoptions](https://f.cloud.github.com/assets/869724/1391755/a759bcca-3c01-11e3-8355-3dab341d7e3b.png)
