### PR TITLE
Setting consistent default values for `save_history`

### DIFF
--- a/administrator/components/com_banners/config.xml
+++ b/administrator/components/com_banners/config.xml
@@ -64,7 +64,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -92,7 +92,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -92,7 +92,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -90,7 +90,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -90,7 +90,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -158,7 +158,7 @@ class CategoriesViewCategory extends JViewLegacy
 		}
 		else
 		{
-			if ($componentParams->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($componentParams->get('save_history') && $user->authorise('core.edit'))
 			{
 				$typeAlias = $extension . '.category';
 				JToolbarHelper::versions($typeAlias, $this->item->id);

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -158,7 +158,7 @@ class CategoriesViewCategory extends JViewLegacy
 		}
 		else
 		{
-			if ($componentParams->get('save_history') && $user->authorise('core.edit'))
+			if ($componentParams->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				$typeAlias = $extension . '.category';
 				JToolbarHelper::versions($typeAlias, $this->item->id);

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -32,7 +32,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group btn-group-yesno"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -107,7 +107,7 @@ class ContactViewContact extends JViewLegacy
 				JToolbarHelper::save2copy('contact.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_contact.contact', $this->item->id);
 			}

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -107,7 +107,7 @@ class ContactViewContact extends JViewLegacy
 				JToolbarHelper::save2copy('contact.save2copy');
 			}
 
-			if ($this->state->params->get('save_history') && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_contact.contact', $this->item->id);
 			}

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -369,7 +369,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group btn-group-yesno"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -113,7 +113,7 @@ class ContentViewArticle extends JViewLegacy
 				JToolbarHelper::save2copy('article.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_content.article', $this->item->id);
 			}

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -19,7 +19,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group btn-group-yesno"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -90,7 +90,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_newsfeeds.newsfeed', $this->item->id);
 			}

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -19,7 +19,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -121,7 +121,7 @@ class TagsViewTag extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_tags.tag', $this->item->id);
 			}

--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -193,7 +193,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_users/views/note/view.html.php
+++ b/administrator/components/com_users/views/note/view.html.php
@@ -113,7 +113,7 @@ class UsersViewNote extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_users.note', $this->item->id);
 			}

--- a/administrator/components/com_weblinks/config.xml
+++ b/administrator/components/com_weblinks/config.xml
@@ -20,7 +20,7 @@
 			name="save_history"
 			type="radio"
 			class="btn-group btn-group-yesno"
-			default="1"
+			default="0"
 			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
 			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 			>

--- a/administrator/components/com_weblinks/views/weblink/view.html.php
+++ b/administrator/components/com_weblinks/views/weblink/view.html.php
@@ -83,7 +83,7 @@ class WeblinksViewWeblink extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_weblinks.weblink', $this->item->id);
 			}

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -59,7 +59,7 @@ if (!$editoroptions)
 					<span class="icon-cancel"></span>&#160;<?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
-			<?php if ($params->get('save_history')) : ?>
+			<?php if ($params->get('save_history', 0)) : ?>
 			<div class="btn-group">
 				<?php echo $this->form->getInput('contenthistory'); ?>
 			</div>
@@ -246,7 +246,7 @@ if (!$editoroptions)
 							<?php echo $this->form->getInput('tags'); ?>
 						</div>
 					</div>
-					<?php if ($params->get('save_history')) : ?>
+					<?php if ($params->get('save_history', 0)) : ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('version_note'); ?>

--- a/components/com_weblinks/views/form/tmpl/edit.php
+++ b/components/com_weblinks/views/form/tmpl/edit.php
@@ -46,7 +46,7 @@ $params = $this->state->get('params');
 					<span class="icon-cancel"></span> <?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
-			<?php if ($params->get('save_history')) : ?>
+			<?php if ($params->get('save_history', 0)) : ?>
 				<div class="btn-group">
 					<?php echo $this->form->getInput('contenthistory'); ?>
 				</div>
@@ -95,7 +95,7 @@ $params = $this->state->get('params');
 			</div>
 		</div>
 
-		<?php if ($params->get('save_history')) : ?>
+		<?php if ($params->get('save_history', 0)) : ?>
 			<div class="control-group">
 				<div class="control-label">
 					<?php echo $this->form->getLabel('version_note'); ?>


### PR DESCRIPTION
Setting the default values for `save_history` in all places to `0` so it is consistent.

We can't set it to `1` by default since we don't enable the feature on an update and the parameter also is used in global layout files which may be used by extensions who don't support versioning.

Based on an issue raised in the Google Groups:
https://groups.google.com/d/msg/joomlabugsquad/Bxtii_EPFdE/CAuLZdlpdvgJ

Related Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32347&start=0
