### PR TITLE
Fix the $app that is not initialize in case of errors

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -121,7 +121,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$asset->check() || !$asset->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					JFactory::getApplication()->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
 
 					return;
 				}
@@ -153,7 +153,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$extension->check() || !$extension->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					JFactory::getApplication()->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
 
 					return;
 				}


### PR DESCRIPTION
Some error may generate a fatal PHP error due to the fact that the $app is not initialized.

So we replaced the $app that is not initialized by its normal value JFactory::getApplication() to avoid initializing the $app when this is not required.
