### PR TITLE
Login module does not display status button

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -132,10 +132,6 @@ JFactory::getDocument()->addScriptDeclaration($script);
 					'note'
 				);
 
-				if ((string) $this->item->xml->name == 'mod_login')
-				{
-					$this->fields = array_diff($this->fields, array('published', 'publish_up', 'publish_down'));
-				}
 				?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 			</div>


### PR DESCRIPTION
Fix issue #32431: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32431&start=0

The origin of this bug: https://github.com/joomla/joomla-cms/commit/6234151121a601d3659f2d4da9b2eab441699223#diff-76
