### PR TITLE
Wrong 'yes/no' class for grouped btn

### DIFF
--- a/plugins/user/joomla/joomla.xml
+++ b/plugins/user/joomla/joomla.xml
@@ -23,7 +23,7 @@
 
 			<fieldset name="basic">
 				<field name="strong_passwords" type="radio"
-					class="btn-group"
+					class="btn-group btn-group-yesno"
 					default="1"
 					description="PLG_USER_JOOMLA_FIELD_STRONG_PASSWORDS_DESC"
 					label="PLG_USER_JOOMLA_FIELD_STRONG_PASSWORDS_LABEL"


### PR DESCRIPTION
![before_plg_btn](https://f.cloud.github.com/assets/1972717/1416091/633dcfda-3f36-11e3-9f70-7354aa037527.png)

The group btn class for yes/no ‘Strong Passwords' buttons should be:
"btn-group btn-group-yesno"

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32445&start=0
