### PR TITLE
Improve $spans calculation in cPanel layout

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -59,6 +59,10 @@ $user = JFactory::getUser();
 				$params = new JRegistry;
 				$params->loadString($module->params);
 				$bootstrapSize = $params->get('bootstrap_size');
+				if (!$bootstrapSize)
+				{
+					$bootstrapSize = 12;
+				}
 				$spans += $bootstrapSize;
 				if ($spans > 12)
 				{


### PR DESCRIPTION
The cPanel layout calculates the `spans` to start a new line if it goes over 12. This works fine as long as `bootstrapSize` is not 0. If one or more module is set to 0, the design goes crazy because it doesn't start a new line, but the module is shown with full width.

This PR sets the bootstrapSize to 12 for the calculation so a new line is properly created.

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32446
