### PR TITLE
Simplifying `modChrome_well`

### DIFF
--- a/administrator/templates/isis/html/modules.php
+++ b/administrator/templates/isis/html/modules.php
@@ -48,7 +48,7 @@ function modChrome_well($module, &$params, &$attribs)
 	if ($module->content)
 	{
 		$bootstrapSize  = (int) $params->get('bootstrap_size');
-		$moduleClass    = (!$bootstrapSize) ? ' span' . $bootstrapSize : '';
+		$moduleClass    = ($bootstrapSize) ? ' span' . $bootstrapSize : '';
 
 		echo '<div class="well well-small' . $moduleClass . '">';
 		echo '<h2 class="module-title nav-header">' . $module->title .'</h2>';

--- a/administrator/templates/isis/html/modules.php
+++ b/administrator/templates/isis/html/modules.php
@@ -47,22 +47,12 @@ function modChrome_well($module, &$params, &$attribs)
 {
 	if ($module->content)
 	{
-		$bootstrapSize  = $params->get('bootstrap_size');
-		$moduleClass    = !empty($bootstrapSize) ? ' span' . (int) $bootstrapSize . '' : '';
+		$bootstrapSize  = (int) $params->get('bootstrap_size');
+		$moduleClass    = (!$bootstrapSize) ? ' span' . $bootstrapSize : '';
 
-		if ( $moduleClass )
-		{
-			echo '<div class="' . $moduleClass . '">';
-		}
-
-		echo '<div class="well well-small">';
+		echo '<div class="well well-small' . $moduleClass . '">';
 		echo '<h2 class="module-title nav-header">' . $module->title .'</h2>';
 		echo $module->content;
 		echo '</div>';
-
-		if ( $moduleClass )
-		{
-			echo '</div>';
-		}
 	}
 }


### PR DESCRIPTION
Simplifying the module chrome `modChrome_well` in Isis template a bit by removing some unneeded code and a `<div>`
- Moved `(int)`to where we get the param instead of after the check
- Removed `empty()`as we set the variable the line above.
- Removed appending `. ''` because appending nothing doesn't do anything :)
- Removed the extra check and `<div>` for the `$moduleClass` and moved ìt into the regular `<div>`

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32447
