### PR TITLE
Redirect back to article edit after version restore when editing article in front end.

### DIFF
--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -560,7 +560,7 @@ class JControllerForm extends JControllerLegacy
 		$recordId = $table->$key;
 
 		// To avoid data collisions the urlVar may be different from the primary key.
-		$urlVar = empty($this->urlVar) ? $key : $this->url;
+		$urlVar = empty($this->urlVar) ? $key : $this->urlVar;
 
 		// Access check.
 		if (!$this->allowEdit(array($key => $recordId), $key))


### PR DESCRIPTION
This PR fixes a bug in the redirect after restoring an article from history in the front end.
