### PR TITLE
You can't have anonymous functions in 5.2

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -656,9 +656,10 @@ class JFilterInput extends JObject
 		}
 		$source = strtr($source, $ttr);
 		// Convert decimal
-		$source = preg_replace_callback('/&#(\d+);/m', function($m){return utf8_encode(chr($m[1]));}, $source); // decimal notation
+		$source = preg_replace_callback('/&#(\d+);/m', "callbackJFilterInputConvertDecimal", $source); // decimal notation
 		// Convert hex
-		$source = preg_replace_callback('/&#x([a-f0-9]+);/mi', function($m){return utf8_encode(chr('0x'.$m[1]));}, $source); // hex notation
+		$source = preg_replace_callback('/&#x([a-f0-9]+);/mi', "callbackJFilterInputConvertHex", $source); // hex notation
+
 		return $source;
 	}
 
@@ -745,5 +746,35 @@ class JFilterInput extends JObject
 			}
 		}
 		return $return;
+	}
+}
+
+if (! function_exists('callbackJFilterInputConvertDecimal'))
+{
+	/**
+	 * Decimal decode callback for JFilterInput::_decode.
+	 *
+	 * @param   $matches
+	 *
+	 * @return  string
+	 */
+	function callbackJFilterInputConvertDecimal($matches)
+	{
+		return utf8_encode(chr($matches[1]));
+	}
+}
+
+if (! function_exists('callbackJFilterInputConvertHex'))
+{
+	/**
+	 * Hex decode callback for JFilterInput::_decode.
+	 *
+	 * @param   $matches
+	 *
+	 * @return  string
+	 */
+	function callbackJFilterInputConvertHex($matches)
+	{
+		return utf8_encode(chr('0x' . $matches[1]));
 	}
 }


### PR DESCRIPTION
This PR was originally to fix the `E_DEPRECATED` that was thrown do to our usage of the `e` modifier in the `JFilterInput::_decode` method, but I saw that a fix for it has been merged. However, this fix utilizes anonymous functions, something that doesn't exist in PHP 5.2. Since Joomla 2.5 has a minimum requirement of 5.2, we cannot use anonymous functions in this case.

The original patch was merged on September 12th here - https://github.com/joomla/joomla-cms/commit/341512fbc68f66daaeca3c4b4ae2d403b66a40dc - thankfully we haven't had a release since then...
