### PR TITLE
32348 - Hide the content-history version icons by default when upgrading from 3.1.5

### DIFF
--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -92,7 +92,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -90,7 +90,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -107,7 +107,7 @@ class ContactViewContact extends JViewLegacy
 				JToolbarHelper::save2copy('contact.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_contact.contact', $this->item->id);
 			}

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -113,7 +113,7 @@ class ContentViewArticle extends JViewLegacy
 				JToolbarHelper::save2copy('article.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_content.article', $this->item->id);
 			}

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -90,7 +90,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_newsfeeds.newsfeed', $this->item->id);
 			}

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -121,7 +121,7 @@ class TagsViewTag extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_tags.tag', $this->item->id);
 			}

--- a/administrator/components/com_users/views/note/view.html.php
+++ b/administrator/components/com_users/views/note/view.html.php
@@ -113,7 +113,7 @@ class UsersViewNote extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_users.note', $this->item->id);
 			}

--- a/administrator/components/com_weblinks/views/weblink/view.html.php
+++ b/administrator/components/com_weblinks/views/weblink/view.html.php
@@ -83,7 +83,7 @@ class WeblinksViewWeblink extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 1) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_weblinks.weblink', $this->item->id);
 			}


### PR DESCRIPTION
The issue is that the version icons still appear, even though content history is off by default when upgrading from Joomla 3.1.5. The simple solution is to hide the icons by default if the feature is not enabled.

Special thanks to Michael for helping me find the code for the change and also for bouncing my idea(s) off of him for advice.

For more info, see discussions at:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32348

and:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32332
