### PR TITLE
Bootstrap CSS styles loaded from (media/JUI/) for logged in users on front-end.

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -53,7 +53,6 @@ $moduleHtml = preg_replace(
 if ($count)
 {
 	// Load once booststrap tooltip and add stylesheet and javascript to head:
-	JHtml::_('bootstrap.loadCss', true, JFactory::getDocument()->getDirection());
 	JHtml::_('bootstrap.tooltip');
 	JHtml::_('bootstrap.popover');
 


### PR DESCRIPTION
The layout file used for the module frontend edit is loading Bootstrap CSS files using `JHtml::_('bootstrap.loadCss');`

This command should never be used in an extension as it WILL break templates, even Protostar.
