### PR TITLE
[#32523] Update some wrong Docblock packages for phpDocumentor

### DIFF
--- a/administrator/components/com_config/controller/application/display.php
+++ b/administrator/components/com_config/controller/application/display.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 /**
  * Base Display Controller
  *
- * @package     Joomla.Libraries
- * @subpackage  controller
+ * @package     Joomla.Administrator
+ * @subpackage  com_config
  * @since       3.2
  * @note        Needed for front end view
  */

--- a/administrator/components/com_config/controller/component/display.php
+++ b/administrator/components/com_config/controller/component/display.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 /**
  * Base Display Controller
  *
- * @package     Joomla.Libraries
- * @subpackage  controller
+ * @package     Joomla.Administrator
+ * @subpackage  com_config
  * @since       3.2
  * @note        Needed for front end view
  */

--- a/cli/deletefiles.php
+++ b/cli/deletefiles.php
@@ -42,7 +42,7 @@ $lang->load('files_joomla.sys', JPATH_SITE, null, false, false)
 /**
  * A command line cron job to attempt to remove files that should have been deleted at update.
  *
- * @package  Joomla.CLI
+ * @package  Joomla.Cli
  * @since    3.0
  */
 class DeletefilesCli extends JApplicationCli

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -54,9 +54,9 @@ $lang->load('finder_cli', JPATH_SITE, null, false, false)
 /**
  * A command line cron job to run the Finder indexer.
  *
- * @package     Joomla.CLI
- * @subpackage  com_finder
- * @since       2.5
+ * @package  Joomla.Cli
+ *
+ * @since    2.5
  */
 class FinderCli extends JApplicationCli
 {

--- a/cli/garbagecron.php
+++ b/cli/garbagecron.php
@@ -30,7 +30,7 @@ require_once JPATH_LIBRARIES . '/cms.php';
 /**
  * Cron job to trash expired cache data
  *
- * @package  Joomla.CLI
+ * @package  Joomla.Cli
  * @since    2.5
  */
 class GarbageCron extends JApplicationCli

--- a/cli/update_cron.php
+++ b/cli/update_cron.php
@@ -40,7 +40,7 @@ require_once JPATH_CONFIGURATION . '/configuration.php';
  * This script will fetch the update information for all extensions and store
  * them in the database, speeding up your administrator.
  *
- * @package  Joomla.CLI
+ * @package  Joomla.Cli
  * @since    2.5
  */
 class Updatecron extends JApplicationCli

--- a/components/com_config/controller/cancel.php
+++ b/components/com_config/controller/cancel.php
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Cancel Controller
  *
  * @package     Joomla.Libraries
- * @subpackage  Controller
+ * @subpackage  com_config
  * @since       3.2
  */
 class ConfigControllerCancel extends JControllerBase

--- a/components/com_config/controller/canceladmin.php
+++ b/components/com_config/controller/canceladmin.php
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Cancel Controller for Admin
  *
  * @package     Joomla.Libraries
- * @subpackage  Controller
+ * @subpackage  com_config
  * @since       3.2
  */
 class ConfigControllerCanceladmin extends ConfigControllerCancel

--- a/components/com_config/controller/cmsbase.php
+++ b/components/com_config/controller/cmsbase.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die('Restricted access');
 /**
  * Base Display Controller
  *
- * @package     Joomla.Libraries
- * @subpackage  controller
+ * @package     Joomla.Site
+ * @subpackage  com_config
  * @since       3.2
 */
 class ConfigControllerCmsbase extends JControllerBase

--- a/components/com_config/controller/display.php
+++ b/components/com_config/controller/display.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die('Restricted access');
 /**
  * Base Display Controller
  *
- * @package     Joomla.Libraries
- * @subpackage  controller
+ * @package     Joomla.Site
+ * @subpackage  com_config
  * @since       3.2
 */
 class ConfigControllerDisplay extends JControllerBase

--- a/components/com_config/controller/helper.php
+++ b/components/com_config/controller/helper.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die('Restricted access');
 /**
  * Helper class for controllers
  *
- * @package     Joomla.Libraries
- * @subpackage  controller
+ * @package     Joomla.Site
+ * @subpackage  com_config
  * @since       3.2
 */
 class ConfigControllerHelper

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.CMS
+ * @package     Joomla.Cms
  * @subpackage  Layout
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.

--- a/layouts/joomla/edit/item_title.php
+++ b/layouts/joomla/edit/item_title.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.CMS
+ * @package     Joomla.Cms
  * @subpackage  Layout
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.

--- a/layouts/joomla/edit/title_alias.php
+++ b/layouts/joomla/edit/title_alias.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.CMS
+ * @package     Joomla.Cms
  * @subpackage  Layout
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  helper
+ * @subpackage  Language
  *
  * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
Update some wrong packages and subpackages of layout, libraries and com_config controller docblock.

And added subpackage to every FOF files that phpDocumentor can make them categorize.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32523&start=0
