### PR TITLE
tinymce.php; template_list.js inclusion with file_get_contents over http

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -424,7 +424,7 @@ class PlgEditorTinymce extends JPlugin
 			if (JFile::exists(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js"))
 			{
 				// If using the legacy file we need to include and input the files the new way
-				$str = file_get_contents(JUri::root() . "media/editors/tinymce/templates/template_list.js");
+				$str = file_get_contents(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js");
 
 				// Find from one [ to the last ]
 				preg_match_all('/\[.*\]/', $str, $matches);


### PR DESCRIPTION
many low cost providers don't allow fopen over http. so you got an error and content edit does not work.
