### PR TITLE
Fixed #32545 :  BC issue: JApplication::redirect($url, $message) broken: Message not displayed after redirect: Affecting many extensions

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -915,13 +915,6 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	public function redirect($url, $moved = false)
 	{
-		// Persist messages if they exist.
-		if (count($this->_messageQueue))
-		{
-			$session = JFactory::getSession();
-			$session->set('application.queue', $this->_messageQueue);
-		}
-
 		// Handle B/C by checking if a message was passed to the method, will be removed at 4.0
 		if (func_num_args() > 1)
 		{
@@ -960,16 +953,16 @@ class JApplicationCms extends JApplicationWeb
 				// Enqueue the message
 				$this->enqueueMessage($message, $type);
 
-				// Persist messages if they exist.
-				if (count($this->_messageQueue))
-				{
-					$session = JFactory::getSession();
-					$session->set('application.queue', $this->_messageQueue);
-				}
-
 				// Reset the $moved variable
 				$moved = isset($args[3]) ? (boolean) $args[3] : false;
 			}
+		}
+
+		// Persist messages if they exist.
+		if (count($this->_messageQueue))
+		{
+			$session = JFactory::getSession();
+			$session->set('application.queue', $this->_messageQueue);
 		}
 
 		// Hand over processing to the parent now

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -960,6 +960,13 @@ class JApplicationCms extends JApplicationWeb
 				// Enqueue the message
 				$this->enqueueMessage($message, $type);
 
+				// Persist messages if they exist.
+				if (count($this->_messageQueue))
+				{
+					$session = JFactory::getSession();
+					$session->set('application.queue', $this->_messageQueue);
+				}
+
 				// Reset the $moved variable
 				$moved = isset($args[3]) ? (boolean) $args[3] : false;
 			}


### PR DESCRIPTION
The few lines from here:
https://github.com/joomla/joomla-cms/blob/master/libraries/legacy/application/application.php#L395

Have not been replicated to the backwards compatibility code that is being fixed by this PR.

Tracker issue item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32545

**This is really needed to be fixed in 3.2.0 stable as it affects many extensions that use extensively this redirect method and add messages to it.**

_Actually, it was very convenient, and the change of API of 3.2.0 and corresponding deprecation in 4.0 should be reconsidered in 3.2.1._
