### PR TITLE
Can set the default mode for folder creation.

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -21,6 +21,32 @@ jimport('joomla.filesystem.path');
 abstract class JFolder
 {
 	/**
+	 * Default Directory Mode
+	 *
+	 * @var    integer
+	 */
+	protected static $dirmode = 0755;
+
+	/**
+	 * Get or set the default mode value.
+	 *
+	 * @param   integer  $mode  The new default mode value.
+	 *
+	 * @return  integer  The old default mode value.
+	 */
+	public static function mode($mode = null)
+	{
+		$old = self::$dirmode;
+
+		if (isset($mode))
+		{
+			self::$dirmode = (int) $mode;
+		}
+
+		return $old;
+	}
+
+	/**
 	 * Copy a folder.
 	 *
 	 * @param   string   $src          The path to the source folder.
@@ -167,10 +193,16 @@ abstract class JFolder
 	 *
 	 * @since   11.1
 	 */
-	public static function create($path = '', $mode = 0755)
+	public static function create($path = '', $mode = null)
 	{
 		$FTPOptions = JClientHelper::getCredentials('ftp');
 		static $nested = 0;
+
+		// Use the default mode if none specified.
+		if (!isset($mode))
+		{
+			$mode = self::$dirmode;
+		}
 
 		// Check to make sure the path valid and clean
 		$path = JPath::clean($path);


### PR DESCRIPTION
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32566&start=25

This adds a way for the default folder creation mode to be changed at run time. This way, if someone needs to use a different mode, they can write a small plugin which will set the default mode to whatever they prefer and this mode will be used when folders are created (in the media manager, for example). 
