### PR TITLE
RECAPTCHA_API_SERVER URL no longer accessible

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
  */
 class PlgCaptchaRecaptcha extends JPlugin
 {
-	const RECAPTCHA_API_SERVER = "http://api.recaptcha.net";
+	const RECAPTCHA_API_SERVER = "http://www.google.com/recaptcha/api";
 	const RECAPTCHA_API_SECURE_SERVER = "https://www.google.com/recaptcha/api";
 	const RECAPTCHA_VERIFY_SERVER = "api-verify.recaptcha.net";
 


### PR DESCRIPTION
Since yesterday http://api.recaptcha.net is not accessible. It must be replaced by http://www.google.com/recaptcha/api

Relevant bug: 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32574&start=0
