### PR TITLE
Fix validation issue - add required="required"

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -556,6 +556,25 @@ abstract class JFormField
 
 		// Set the visibility.
 		$this->hidden = ($this->hidden || (string) $element['type'] == 'hidden');
+		
+		// Add the required class if the field is required.
+
+		$class = (string) $element ['class'];
+
+		if ($this->required)
+		{
+			if ($class)
+			{
+				if (strpos($class, 'required') === false)
+				{
+					$this->element ['class'] = $class . ' required';
+				}
+			}
+			else
+			{
+				$this->element ['class'] = 'required';
+			}
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Joomla 2.5 output

```
<input type="text" size="30" class="inputbox required" value="" id="jform_title" name="jformtitle" aria-required="true" required="required">
```

3.2. after recent changes

```
<input type="text" size="30" class="inputbox" value="" id="jform_title" name="jformtitle">
```

The above patch adds required back for fields that are marked required
