### PR TITLE
Argument 1 passed to JHttpTransportStream::getResponse() must be an array

### DIFF
--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -133,7 +133,20 @@ class JHttpTransportStream implements JHttpTransport
 		// Close the stream.
 		fclose($stream);
 
-		return $this->getResponse($metadata['wrapper_data'], $content);
+		if (isset($metadata['wrapper_data']['headers']))
+		{
+			$headers = $metadata['wrapper_data']['headers'];
+		}
+		elseif (isset($metadata['wrapper_data']))
+		{
+			$headers = $metadata['wrapper_data'];
+		}
+		else
+		{
+			$headers = array();
+		}
+
+		return $this->getResponse($headers, $content);
 	}
 
 	/**


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32578
