### PR TITLE
Regression fix: module article news show old news first

### DIFF
--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -62,7 +62,7 @@ abstract class ModArticlesNewsHelper
 		}
 		else
 		{
-			$model->setState('list.direction', 'ASC');
+			$model->setState('list.direction', 'DESC');
 		}
 
 		//	Retrieve Content


### PR DESCRIPTION
After updating to 3.2.0 module article news show old.
To really fix the issue reported: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28349&start=0

We should add desc/asc ordering in the menu while the current option should stay desc. Do not change the way it's currently work for backward compatibility.
