### PR TITLE
Update behavior.php

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -804,7 +804,7 @@ abstract class JHtmlBehavior
 		}
 		// Include jQuery
 		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/tabs-state.js', true, true);
+		JHtml::_('script', 'system/tabs-state.js', false, true);
 		self::$loaded[__METHOD__] = true;
 	}
 }


### PR DESCRIPTION
Second parameter in `script` function should be now `false` for `tabstate` function. This is because this tabs-state.js requires JQuery not full Mootools framework. Setting this to `true` not only load Mootools when it is not required but also cause some conflicts if websites that depends on JQuery without noConflict.
