### PR TITLE
Cookie should be delete onUserLogout

### DIFF
--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -72,7 +72,7 @@ class PlgSystemLogout extends JPlugin
 			$conf = JFactory::getConfig();
 			$cookie_domain 	= $conf->get('config.cookie_domain', '');
 			$cookie_path 	= $conf->get('config.cookie_path', '/');
-			setcookie($hash, true, time() + 86400, $cookie_path, $cookie_domain);
+			setcookie($hash, false, time() - 86400, $cookie_path, $cookie_domain);
 		}
 		return true;
 	}


### PR DESCRIPTION
After logout session cookie should be delete otherwise Varnish can't cache data or can't send cached data...
