### PR TITLE
Email subsystem blocked after upgrade to Joomla 3.2

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -76,7 +76,7 @@ class JMail extends PHPMailer
 	 */
 	public function Send()
 	{
-		if (JFactory::getConfig()->get('mailonline'))
+		if (JFactory::getConfig()->get('mailonline', 1))
 		{
 			if (($this->Mailer == 'mail') && !function_exists('mail'))
 			{


### PR DESCRIPTION
The mailonline option introduced in Joomla 3.2 lets websites  with email subsystem completely blocked. Even worse, sites owners don't ever know to have a problem.
Since the upgrade procedure doesn't set mailonline, when the mailer reads this value, it should default to "enabled".

issue tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32617&start=0
