### PR TITLE
Article Manager: Options is gone when filtering an category

### DIFF
--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -136,7 +136,7 @@ class ContentViewArticles extends JViewLegacy
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($user->authorise('core.admin', 'com_content'))
 		{
 			JToolbarHelper::preferences('com_content');
 		}


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32600&start=0
