### PR TITLE
Banners Manager: Options is gone when filtering by a category

### DIFF
--- a/administrator/components/com_banners/views/banners/view.html.php
+++ b/administrator/components/com_banners/views/banners/view.html.php
@@ -141,7 +141,7 @@ class BannersViewBanners extends JViewLegacy
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($user->authorise('core.admin', 'com_banners'))
 		{
 			JToolbarHelper::preferences('com_banners');
 		}


### PR DESCRIPTION
Same issue and correction as done for Article Manager PR #2468

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32626&start=0
