### PR TITLE
Adding a space before the class

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -256,7 +256,7 @@ class JFormFieldMedia extends JFormField
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="input-small ' . $this->class . '"' : 'class="input-small"';
+		$attr .= !empty($this->class) ? ' class="input-small ' . $this->class . '"' : ' class="input-small"';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 
 		// Initialize JavaScript field attributes.


### PR DESCRIPTION
The media formfield is missing a space before the `class` attribute.

Tracker: 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32629&start=0
