### PR TITLE
Code inconsistency

### DIFF
--- a/administrator/components/com_banners/views/clients/view.html.php
+++ b/administrator/components/com_banners/views/clients/view.html.php
@@ -44,7 +44,7 @@ class BannersViewClients extends JViewLegacy
 		{
 			JError::raiseError(500, implode("\n", $errors));
 
-			return false;
+			return;
 		}
 
 		BannersHelper::addSubmenu('clients');


### PR DESCRIPTION
Methods declared 'void' must not return a value
Opened issue tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32641&start=0
