### PR TITLE
Update input.php

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -597,7 +597,8 @@ class JFilterInput
 			$attrSubSet = explode('=', trim($attrSet[$i]), 2);
 
 			// Take the last attribute in case there is an attribute with no value
-			$attrSubSet[0] = array_pop(explode(' ', trim($attrSubSet[0])));
+			$attrSubSet_0 = explode(' ', trim($attrSubSet[0]));
+			$attrSubSet[0] = array_pop($attrSubSet_0);
 
 			// Remove all "non-regular" attribute names
 			// AND blacklisted attributes


### PR DESCRIPTION
The original code 
$attrSubSet[0] = array_pop(explode(' ', trim($attrSubSet[0]))); 
throws an Strict standards: Only variables should be passed by reference 
In array_pop the only parameter is an array passed by reference. The return value does not have any reference.
