### PR TITLE
Update tinymce.php

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -666,6 +666,21 @@ class PlgEditorTinymce extends JPlugin
 					relative_urls : $relative_urls,
 					remove_script_host : false,
 					document_base_url : \"" . JUri::root() . "\",
+					rel_list = [
+						{title: 'Alternate', value: 'alternate'},
+						{title: 'Author', value: 'author'},
+						{title: 'Bookmark', value: 'bookmark'},
+						{title: 'Help', value: 'help'},
+						{title: 'License', value: 'license'},
+						{title: 'Lightbox', value: 'lightbox'},
+						{title: 'Next', value: 'next'},
+						{title: 'No Follow', value: 'nofollow'},
+						{title: 'No Referrer', value: 'noreferrer'},
+						{title: 'Prefetch', value: 'prefetch'},
+						{title: 'Prev', value: 'prev'},
+						{title: 'Search', value: 'search'},
+						{title: 'Tag', value: 'tag'},
+					],
 					//Templates
 					" . $templates . "
 					// Layout


### PR DESCRIPTION
Joomla 3.2 after upgrade to TinyMce 4 does lack rel list for links when in extended mode. This change will make the list be displayed with predefined items (+ligthbox that is often used)
