### PR TITLE
Fix of copy template case where template name is same as a name in the path to the joomla instance

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -324,7 +324,7 @@ class TemplatesModelTemplate extends JModelForm
 
 		foreach ($files as $file)
 		{
-			$newFile = str_replace($oldName, $newName, $file);
+			$newFile = dirname($file).'/'.str_replace($oldName, $newName, basename($file));
 			$result = JFile::move($file, $newFile) && $result;
 		}
 


### PR DESCRIPTION
In the case where the path to the Joomla instance is the same as the template name, the `TemplatesModelTemplate->fixTemplateName` function replaces the old templates name in every location along the path not just in the ini file names.

This is just a simple fix to keep the directory path separate and only do the replace in the file name itself.
