### PR TITLE
[#32698] Avoid loading tabs-state.js in com_content frontend

### DIFF
--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -8,7 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.tabstate');
 
 require_once JPATH_COMPONENT.'/helpers/route.php';
 require_once JPATH_COMPONENT.'/helpers/query.php';


### PR DESCRIPTION
tabs-state.js is not currently needed in any of the com_content frontend views. If at some point in the future it does become needed, it should be loaded in the individual views, not in the controller.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32698
