### PR TITLE
Joomla! extension updates can't use update XML sources with URLs not ending in .xml

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -217,7 +217,16 @@ class JUpdaterCollection extends JUpdateAdapter
 	{
 		$url = $options['location'];
 		$this->updateSiteId = $options['update_site_id'];
-		if (substr($url, -4) != '.xml')
+
+
+		$appendExtension = false;
+
+		if (array_key_exists('append_extension', $options))
+		{
+			$appendExtension = $options['append_extension'];
+		}
+
+		if ($appendExtension && (substr($url, -4) != '.xml'))
 		{
 			if (substr($url, -1) != '/')
 			{
@@ -234,7 +243,7 @@ class JUpdaterCollection extends JUpdateAdapter
 		$http = JHttpFactory::getHttp();
 		$response = $http->get($url);
 
-		// JHttp transport throws an exception when there's no reponse.
+		// JHttp transport throws an exception when there's no response.
 		try
 		{
 			$response = $http->get($url);
@@ -246,6 +255,13 @@ class JUpdaterCollection extends JUpdateAdapter
 
 		if (!isset($response) || 200 != $response->code)
 		{
+			// If the URL is missing the .xml extension, try appending it and retry loading the update
+			if (!$appendExtension && (substr($url, -4) != '.xml'))
+			{
+				$options['append_extension'] = true;
+				return $this->findUpdate($options);
+			}
+
 			$query = $db->getQuery(true)
 				->update('#__update_sites')
 				->set('enabled = 0')
@@ -256,19 +272,31 @@ class JUpdaterCollection extends JUpdateAdapter
 			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url), 'warning');
+
 			return false;
 		}
 
 		$this->xmlParser = xml_parser_create('');
 		xml_set_object($this->xmlParser, $this);
 		xml_set_element_handler($this->xmlParser, '_startElement', '_endElement');
+
 		if (!xml_parse($this->xmlParser, $response->body))
 		{
+			// If the URL is missing the .xml extension, try appending it and retry loading the update
+			if (!$appendExtension && (substr($url, -4) != '.xml'))
+			{
+				$options['append_extension'] = true;
+				return $this->findUpdate($options);
+			}
+
 			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
+
 			return false;
 		}
+
 		// TODO: Decrement the bad counter if non-zero
 		return array('update_sites' => $this->update_sites, 'updates' => $this->updates);
 	}

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -160,7 +160,15 @@ class JUpdaterExtension extends JUpdateAdapter
 		$url = $options['location'];
 		$this->_url = &$url;
 		$this->updateSiteId = $options['update_site_id'];
-		if (substr($url, -4) != '.xml')
+
+		$appendExtension = false;
+
+		if (array_key_exists('append_extension', $options))
+		{
+			$appendExtension = $options['append_extension'];
+		}
+
+		if ($appendExtension && (substr($url, -4) != '.xml'))
 		{
 			if (substr($url, -1) != '/')
 			{
@@ -185,6 +193,13 @@ class JUpdaterExtension extends JUpdateAdapter
 
 		if (!isset($response) || (!empty($response->code) && 200 != $response->code))
 		{
+			// If the URL is missing the .xml extension, try appending it and retry loading the update
+			if (!$appendExtension && (substr($url, -4) != '.xml'))
+			{
+				$options['append_extension'] = true;
+				return $this->findUpdate($options);
+			}
+
 			$query = $db->getQuery(true)
 				->update('#__update_sites')
 				->set('enabled = 0')
@@ -195,6 +210,7 @@ class JUpdaterExtension extends JUpdateAdapter
 			JLog::add("Error opening url: " . $url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), 'warning');
+
 			return false;
 		}
 
@@ -205,12 +221,23 @@ class JUpdaterExtension extends JUpdateAdapter
 
 		if (!xml_parse($this->xmlParser, $response->body))
 		{
+			// If the URL is missing the .xml extension, try appending it and retry loading the update
+			if (!$appendExtension && (substr($url, -4) != '.xml'))
+			{
+				$options['append_extension'] = true;
+				return $this->findUpdate($options);
+			}
+
 			JLog::add("Error parsing url: " . $url, JLog::WARNING, 'updater');
+
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
+
 			return false;
 		}
+
 		xml_parser_free($this->xmlParser);
+
 		if (isset($this->latest))
 		{
 			if (isset($this->latest->client) && strlen($this->latest->client))
@@ -219,7 +246,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				{
 					$byName = false;
 
-					// <client> has to be 'administrator' or 'site', numeric values are depreceated. See http://docs.joomla.org/Design_of_JUpdate
+					// <client> has to be 'administrator' or 'site', numeric values are deprecated. See http://docs.joomla.org/Design_of_JUpdate
 					JLog::add(
 						'Using numeric values for <client> in the updater xml is deprecated. Use \'administrator\' or \'site\' instead.',
 						JLog::WARNING, 'deprecated'
@@ -229,15 +256,18 @@ class JUpdaterExtension extends JUpdateAdapter
 				{
 					$byName = true;
 				}
+
 				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
 				unset($this->latest->client);
 			}
+
 			$updates = array($this->latest);
 		}
 		else
 		{
 			$updates = array();
 		}
+
 		return array('update_sites' => array(), 'updates' => $updates);
 	}
 }


### PR DESCRIPTION
# Technical Details

**IMPORTANT**: See tracker item [32699](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32699)
## Bug analysis

When a developer specifies an update server for their extension in the XML manifest the URL must end in .xml. If it doesn't the findUpdate methods of JUpdaterCollection and JUpdaterExtension will append /update.xml and /extension.xml respectively. This is a problem in the following common cases:
- Update XML streams generated on-the-fly by PHP scripts.
- Update XML streams hosted on file hosting services such as Dropbox, SkyDrive etc where the URL may either need an authentication parameter or otherwise its last four characters not being .XML.
- Update XML streams hosted on Windows servers and having an extension of .XML (uppercase) or .Xml (mixed case).
- Update XML streams hosted on CDNs, requiring a special parameter to force-reload them.

In all those cases the developers would use an ugly workaround, appending a dummy query string parameter, e.g. &dummy=whatever.xml. Even though this approach works in most cases it is problematic in certain occasions, it's ugly and makes Joomla! look amateurish in its handling of update sources. It's even worse considering that if Joomla! thinks it can't load an update source it silently disables it, without any way for the user to enable it sort of editing the database.

Furthermore, the necessity of the URL ending in the exact character sequence ".xml" is not documented. Our documentation implies that any valid URL returning valid XML data should be accepted. Therefore the current behavior is a bug.
## Proposition

The findUpdate methods of JUpdaterCollection and JUpdaterExtension are modified to support one more option key in the $options array, called append_extension. By default this is false, meaning that these methods will not attempt to tuck the /update.xml or /extension.xml suffix to the URL. Instead they will try loading the provided URL. If the URL is not found or does not contain XML data they will append the /update.xml or /extension.xml suffix to the URL and retry loading it. If it still fails to load / doesn't contain XML data the update source will be silently disabled, exactly as it happens right now.
# Project management information
## Backwards compatibility issues

None. This solution is backwards compatible with all currently supported versions of Joomla!.
## Documentation burden

None. This solution actually makes the code adhere to the existing documentation.
# Information for extension developers

You can now use any URL in your XML manifests' updateserver tags. The URL does not have to end in .xml.
