### PR TITLE
[#32701] Fix errors Database=>Fix on MSSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.1.0.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.1.0.sql
@@ -14,7 +14,7 @@ ALTER TABLE [#__updates] ADD DEFAULT (N'') FOR [data];
 /****** Object:  Table [#__content_types] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__content_types](
+CREATE TABLE [#__content_types] (
 	[type_id] [bigint] IDENTITY(1,1) NOT NULL,
 	[type_title] [nvarchar](255) NOT NULL DEFAULT '',
 	[type_alias] [nvarchar](255) NOT NULL DEFAULT '',
@@ -62,7 +62,7 @@ SET IDENTITY_INSERT #__content_types  OFF;
 /****** Object:  Table [#__contentitem_tag_map] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__contentitem_tag_map](
+CREATE TABLE [#__contentitem_tag_map] (
 	[type_alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[core_content_id] [bigint] NOT NULL,
 	[content_item_id] [int] NOT NULL,
@@ -102,7 +102,7 @@ CREATE NONCLUSTERED INDEX [idx_core_content_id] ON [#__contentitem_tag_map]
 /****** Object:  Table [#__tags] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__tags](
+CREATE TABLE [#__tags] (
   [id] [int] IDENTITY(1,1) NOT NULL ,
   [parent_id] [bigint] NOT NULL DEFAULT '0',
   [lft] [int] NOT NULL DEFAULT '0',
@@ -186,7 +186,7 @@ SET IDENTITY_INSERT #__tags  OFF;
 /****** Object:  Table [#__ucm_base] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__ucm_base](
+CREATE TABLE [#__ucm_base] (
   [ucm_id] [bigint] IDENTITY(1,1) NOT NULL,
   [ucm_item_id] [bigint] NOT NULL,
   [ucm_type_id] [bigint] NOT NULL,
@@ -215,7 +215,7 @@ CREATE NONCLUSTERED INDEX [ucm_language_id] ON [#__ucm_base]
 /****** Object:  Table [#__ucm_content] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__ucm_content](
+CREATE TABLE [#__ucm_content] (
   [core_content_id] [bigint] IDENTITY(1,1) NOT NULL,
   [core_type_alias] [nvarchar](255) NOT NULL,
   [core_title] [nvarchar](255) NOT NULL DEFAULT '',

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.2.0.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.2.0.sql
@@ -75,7 +75,7 @@ SELECT 700, 'COM_CPANEL_MSG_EACCELERATOR_TITLE', 'COM_CPANEL_MSG_EACCELERATOR_BO
 UNION ALL
 SELECT 700, 'PLG_USER_JOOMLA_POSTINSTALL_STRONGPW_TITLE', 'PLG_USER_JOOMLA_POSTINSTALL_STRONGPW_TEXT', 'PLG_USER_JOOMLA_POSTINSTALL_STRONGPW_BTN', 'plg_user_joomla', 1, 'action', 'site://plugins/user/joomla/postinstall/actions.php', 'plguserjoomla_postinstall_action', 'site://plugins/user/joomla/postinstall/actions.php', 'plguserjoomla_postinstall_condition', '3.2.0', 1;
 
-CREATE TABLE [#__ucm_history](
+CREATE TABLE [#__ucm_history] (
   [version_id] [bigint] IDENTITY(1,1) NOT NULL,
   [ucm_item_id] [bigint] NOT NULL,
   [ucm_type_id] [bigint] NOT NULL,
@@ -107,7 +107,7 @@ ALTER TABLE [#__users] ADD [otpKey] [nvarchar](1000) NOT NULL DEFAULT '';
 
 ALTER TABLE [#__users] ADD [otep] [nvarchar](1000) NOT NULL DEFAULT '';
 
-CREATE TABLE [#__user_keys](
+CREATE TABLE [#__user_keys] (
   [id] [bigint] IDENTITY(1,1) NOT NULL,
   [user_id] [nvarchar](255) NOT NULL,
   [token] [nvarchar](255) NOT NULL,

--- a/libraries/cms/schema/changeitem/sqlsrv.php
+++ b/libraries/cms/schema/changeitem/sqlsrv.php
@@ -86,7 +86,7 @@ class JSchemaChangeitemSqlsrv extends JSchemaChangeitem
 
 		if ($command == 'CREATE TABLE')
 		{
-			$table = $wordArray[5];
+			$table = $wordArray[2];
 			$result = 'SELECT * FROM sys.TABLES WHERE NAME = ' . $this->fixQuote($table);
 			$this->queryType = 'CREATE_TABLE';
 			$this->msgElements = array($this->fixQuote($table));
@@ -140,6 +140,8 @@ class JSchemaChangeitemSqlsrv extends JSchemaChangeitem
 	 */
 	private function fixQuote($string)
 	{
+		$string = str_replace('[', '', $string);
+		$string = str_replace(']', '', $string);
 		$string = str_replace('`', '', $string);
 		$string = str_replace(';', '', $string);
 		$string = str_replace('#__', $this->db->getPrefix(), $string);


### PR DESCRIPTION
On a clean install Database=>Fix shouldn't produce discrepancies between database and definitions.
Due to the errors it doesn't show the versions and reports not existing tables. Using the wrong description and by mistake. Needs fixing statements in 3.1.0.sql and 3.2.0.sql

See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32701&start=0
