### PR TITLE
Bugtracker #32702 - Menu type does not display components that have dire...

### DIFF
--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -215,7 +215,7 @@ class MenusModelMenutypes extends JModelLegacy
 		// Get the views for this component.
 		if (is_dir(JPATH_SITE . '/components/' . $component))
 		{
-			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s?]$', false, true);
+			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s]?$', false, true);
 		}
 		$path = '';
 
@@ -324,7 +324,7 @@ class MenusModelMenutypes extends JModelLegacy
 		// Get the views for this component.
 		if (is_dir(JPATH_SITE . '/components/' . $component))
 		{
-			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s?]$', false, true);
+			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s]?$', false, true);
 		}
 
 		if (!empty($folders[0]))

--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -215,7 +215,7 @@ class MenusModelMenutypes extends JModelLegacy
 		// Get the views for this component.
 		if (is_dir(JPATH_SITE . '/components/' . $component))
 		{
-			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, 'view', false, true);
+			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s?]$', false, true);
 		}
 		$path = '';
 
@@ -324,7 +324,7 @@ class MenusModelMenutypes extends JModelLegacy
 		// Get the views for this component.
 		if (is_dir(JPATH_SITE . '/components/' . $component))
 		{
-			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, 'view', false, true);
+			$folders = JFolder::folders(JPATH_SITE . '/components/' . $component, '^view[s?]$', false, true);
 		}
 
 		if (!empty($folders[0]))


### PR DESCRIPTION
...ctories that contain the word view

As explained in the bug tracker, when a component contain a directory name that contain the word "view" and that this directory is returned before the "/view" directory then the menu type does not display the component menu types.

The implementation consists to use the regular expression to just accept the word "view" with an optional S
All the other directory name that would contain the word view will be ignored (ie. viewer, myview, ...)
