### PR TITLE
getActiveFilters is passing zeros when filters are not active

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -135,7 +135,7 @@ class JModelList extends JModelLegacy
 			{
 				$filterName = 'filter.' . $filter;
 
-				if (property_exists($this->state, $filterName) && (!empty($this->state->{$filterName}) || is_numeric($this->state->{$filterName})))
+				if (property_exists($this->state, $filterName) && !empty($this->state->{$filterName}) || (is_numeric($this->state->{$filterName}) && $this->state->{$filterName} !== 0))
 				{
 					$activeFilters[$filter] = $this->state->get($filterName);
 				}


### PR DESCRIPTION
Articles filters in back-end are opened all the time, even if no search is performed. The filter status (show or hide) is detected in /layouts/joomla/searchtools/default.php from $data['view']->activeFilters.

It appeared that even when filters are empty 2 values are passed to activeFilters:
level=0
access=0

When this fix is applied the search filter is hidden until it's opened and an option is selected.
