### PR TITLE
Implementing class based component routers

### DIFF
--- a/components/com_banners/router.php
+++ b/components/com_banners/router.php
@@ -10,66 +10,76 @@
 defined('_JEXEC') or die;
 
 /**
- * @return  array  A named array
- * @return  array
+ * Routing class from com_banners
+ *
+ * @package     Joomla.Site
+ * @subpackage  com_banners
+ * @since       3.2
  */
-function BannersBuildRoute(&$query)
+class BannersRouter implements JComponentRouter
 {
-	$segments = array();
-
-	if (isset($query['task']))
+	/**
+	 * @return  array  A named array
+	 * @return  array
+	 */
+	public function build(&$query)
 	{
-		$segments[] = $query['task'];
-		unset($query['task']);
-	}
-	if (isset($query['id']))
-	{
-		$segments[] = $query['id'];
-		unset($query['id']);
-	}
+		$segments = array();
 
-	return $segments;
-}
-
-/**
- * @return  array  A named array
- * @param   array
- *
- * Formats:
- *
- * index.php?/banners/task/id/Itemid
- *
- * index.php?/banners/id/Itemid
- */
-function BannersParseRoute($segments)
-{
-	$vars = array();
-
-	// view is always the first element of the array
-	$count = count($segments);
-
-	if ($count)
-	{
-		$count--;
-		$segment = array_shift($segments);
-		if (is_numeric($segment))
+		if (isset($query['task']))
 		{
-			$vars['id'] = $segment;
+			$segments[] = $query['task'];
+			unset($query['task']);
 		}
-		else
+		if (isset($query['id']))
 		{
-			$vars['task'] = $segment;
+			$segments[] = $query['id'];
+			unset($query['id']);
 		}
+
+		return $segments;
 	}
 
-	if ($count)
+	/**
+	 * @return  array  A named array
+	 * @param   array
+	 *
+	 * Formats:
+	 *
+	 * index.php?/banners/task/id/Itemid
+	 *
+	 * index.php?/banners/id/Itemid
+	 */
+	public function parse(&$segments)
 	{
-		$segment = array_shift($segments);
-		if (is_numeric($segment))
-		{
-			$vars['id'] = $segment;
-		}
-	}
+		$vars = array();
 
-	return $vars;
+		// view is always the first element of the array
+		$count = count($segments);
+
+		if ($count)
+		{
+			$count--;
+			$segment = array_shift($segments);
+			if (is_numeric($segment))
+			{
+				$vars['id'] = $segment;
+			}
+			else
+			{
+				$vars['task'] = $segment;
+			}
+		}
+
+		if ($count)
+		{
+			$segment = array_shift($segments);
+			if (is_numeric($segment))
+			{
+				$vars['id'] = $segment;
+			}
+		}
+
+		return $vars;
+	}
 }

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -10,200 +10,210 @@
 defined('_JEXEC') or die;
 
 /**
- * Build the route for the com_contact component
+ * Routing class from com_contact
  *
- * @param   array  &$query  An array of URL arguments
- *
- * @return  array  The URL arguments to use to assemble the subsequent URL.
+ * @package     Joomla.Site
+ * @subpackage  com_contact
+ * @since       3.2
  */
-function ContactBuildRoute(&$query)
+class ContactRouter implements JComponentRouter
 {
-	$segments = array();
-
-	// get a menu item based on Itemid or currently active
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$params = JComponentHelper::getParams('com_contact');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	if (empty($query['Itemid']))
+	/**
+	 * Build the route for the com_contact component
+	 *
+	 * @param   array  &$query  An array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 */
+	public function build(&$query)
 	{
-		$menuItem = $menu->getActive();
-	}
-	else
-	{
-		$menuItem = $menu->getItem($query['Itemid']);
-	}
-	$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
-	$mId = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
+		$segments = array();
 
-	if (isset($query['view']))
-	{
-		$view = $query['view'];
-		if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_contact')
+		// get a menu item based on Itemid or currently active
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$params = JComponentHelper::getParams('com_contact');
+		$advanced = $params->get('sef_advanced_link', 0);
+
+		if (empty($query['Itemid']))
 		{
-			$segments[] = $query['view'];
-		}
-		unset($query['view']);
-	}
-
-	// are we dealing with a contact that is attached to a menu item?
-	if (isset($view) && ($mView == $view) and (isset($query['id'])) and ($mId == (int) $query['id']))
-	{
-		unset($query['view']);
-		unset($query['catid']);
-		unset($query['id']);
-		return $segments;
-	}
-
-	if (isset($view) and ($view == 'category' or $view == 'contact'))
-	{
-		if ($mId != (int) $query['id'] || $mView != $view)
-		{
-			if ($view == 'contact' && isset($query['catid']))
-			{
-				$catid = $query['catid'];
-			}
-			elseif (isset($query['id']))
-			{
-				$catid = $query['id'];
-			}
-			$menuCatid = $mId;
-			$categories = JCategories::getInstance('Contact');
-			$category = $categories->get($catid);
-			if ($category)
-			{
-				//TODO Throw error that the category either not exists or is unpublished
-				$path = array_reverse($category->getPath());
-
-				$array = array();
-				foreach ($path as $id)
-				{
-					if ((int) $id == (int) $menuCatid)
-					{
-						break;
-					}
-					if ($advanced)
-					{
-						list($tmp, $id) = explode(':', $id, 2);
-					}
-					$array[] = $id;
-				}
-				$segments = array_merge($segments, array_reverse($array));
-			}
-			if ($view == 'contact')
-			{
-				if ($advanced)
-				{
-					list($tmp, $id) = explode(':', $query['id'], 2);
-				}
-				else
-				{
-					$id = $query['id'];
-				}
-				$segments[] = $id;
-			}
-		}
-		unset($query['id']);
-		unset($query['catid']);
-	}
-
-	if (isset($query['layout']))
-	{
-		if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
-		{
-			if ($query['layout'] == $menuItem->query['layout'])
-			{
-
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getActive();
 		}
 		else
 		{
-			if ($query['layout'] == 'default')
-			{
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getItem($query['Itemid']);
 		}
-	}
+		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
+		$mId = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
 
-	return $segments;
-}
-
-/**
- * Parse the segments of a URL.
- *
- * @param   array  $segments  The segments of the URL to parse.
- *
- * @return  array  The URL attributes to be used by the application.
- */
-function ContactParseRoute($segments)
-{
-	$vars = array();
-
-	//Get the active menu item.
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$item = $menu->getActive();
-	$params = JComponentHelper::getParams('com_contact');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	// Count route segments
-	$count = count($segments);
-
-	// Standard routing for newsfeeds.
-	if (!isset($item))
-	{
-		$vars['view'] = $segments[0];
-		$vars['id'] = $segments[$count - 1];
-		return $vars;
-	}
-
-	// From the categories view, we can only jump to a category.
-	$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
-
-	$contactCategory = JCategories::getInstance('Contact')->get($id);
-
-	$categories = ($contactCategory) ? $contactCategory->getChildren() : array();
-	$vars['catid'] = $id;
-	$vars['id'] = $id;
-	$found = 0;
-	foreach ($segments as $segment)
-	{
-		$segment = $advanced ? str_replace(':', '-', $segment) : $segment;
-		foreach ($categories as $category)
+		if (isset($query['view']))
 		{
-			if ($category->slug == $segment || $category->alias == $segment)
+			$view = $query['view'];
+			if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_contact')
 			{
-				$vars['id'] = $category->id;
-				$vars['catid'] = $category->id;
-				$vars['view'] = 'category';
-				$categories = $category->getChildren();
-				$found = 1;
-				break;
+				$segments[] = $query['view'];
 			}
+			unset($query['view']);
 		}
-		if ($found == 0)
+
+		// are we dealing with a contact that is attached to a menu item?
+		if (isset($view) && ($mView == $view) and (isset($query['id'])) and ($mId == (int) $query['id']))
 		{
-			if ($advanced)
+			unset($query['view']);
+			unset($query['catid']);
+			unset($query['id']);
+			return $segments;
+		}
+
+		if (isset($view) and ($view == 'category' or $view == 'contact'))
+		{
+			if ($mId != (int) $query['id'] || $mView != $view)
 			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from('#__contact_details')
-					->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
-					->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
-				$db->setQuery($query);
-				$nid = $db->loadResult();
+				if ($view == 'contact' && isset($query['catid']))
+				{
+					$catid = $query['catid'];
+				}
+				elseif (isset($query['id']))
+				{
+					$catid = $query['id'];
+				}
+				$menuCatid = $mId;
+				$categories = JCategories::getInstance('Contact');
+				$category = $categories->get($catid);
+				if ($category)
+				{
+					//TODO Throw error that the category either not exists or is unpublished
+					$path = array_reverse($category->getPath());
+
+					$array = array();
+					foreach ($path as $id)
+					{
+						if ((int) $id == (int) $menuCatid)
+						{
+							break;
+						}
+						if ($advanced)
+						{
+							list($tmp, $id) = explode(':', $id, 2);
+						}
+						$array[] = $id;
+					}
+					$segments = array_merge($segments, array_reverse($array));
+				}
+				if ($view == 'contact')
+				{
+					if ($advanced)
+					{
+						list($tmp, $id) = explode(':', $query['id'], 2);
+					}
+					else
+					{
+						$id = $query['id'];
+					}
+					$segments[] = $id;
+				}
+			}
+			unset($query['id']);
+			unset($query['catid']);
+		}
+
+		if (isset($query['layout']))
+		{
+			if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
+			{
+				if ($query['layout'] == $menuItem->query['layout'])
+				{
+
+					unset($query['layout']);
+				}
 			}
 			else
 			{
-				$nid = $segment;
+				if ($query['layout'] == 'default')
+				{
+					unset($query['layout']);
+				}
 			}
-			$vars['id'] = $nid;
-			$vars['view'] = 'contact';
 		}
-		$found = 0;
+
+		return $segments;
 	}
-	return $vars;
+
+	/**
+	 * Parse the segments of a URL.
+	 *
+	 * @param   array  $segments  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
+
+		//Get the active menu item.
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$item = $menu->getActive();
+		$params = JComponentHelper::getParams('com_contact');
+		$advanced = $params->get('sef_advanced_link', 0);
+
+		// Count route segments
+		$count = count($segments);
+
+		// Standard routing for newsfeeds.
+		if (!isset($item))
+		{
+			$vars['view'] = $segments[0];
+			$vars['id'] = $segments[$count - 1];
+			return $vars;
+		}
+
+		// From the categories view, we can only jump to a category.
+		$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
+
+		$contactCategory = JCategories::getInstance('Contact')->get($id);
+
+		$categories = ($contactCategory) ? $contactCategory->getChildren() : array();
+		$vars['catid'] = $id;
+		$vars['id'] = $id;
+		$found = 0;
+		foreach ($segments as $segment)
+		{
+			$segment = $advanced ? str_replace(':', '-', $segment) : $segment;
+			foreach ($categories as $category)
+			{
+				if ($category->slug == $segment || $category->alias == $segment)
+				{
+					$vars['id'] = $category->id;
+					$vars['catid'] = $category->id;
+					$vars['view'] = 'category';
+					$categories = $category->getChildren();
+					$found = 1;
+					break;
+				}
+			}
+			if ($found == 0)
+			{
+				if ($advanced)
+				{
+					$db = JFactory::getDbo();
+					$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from('#__contact_details')
+						->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
+						->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
+					$db->setQuery($query);
+					$nid = $db->loadResult();
+				}
+				else
+				{
+					$nid = $segment;
+				}
+				$vars['id'] = $nid;
+				$vars['view'] = 'contact';
+			}
+			$found = 0;
+		}
+		return $vars;
+	}
 }

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -10,394 +10,404 @@
 defined('_JEXEC') or die;
 
 /**
- * Build the route for the com_content component
+ * Routing class from com_content
  *
- * @return  array  An array of URL arguments
- * @return  array  The URL arguments to use to assemble the subsequent URL.
- * @since    1.5
+ * @package     Joomla.Site
+ * @subpackage  com_content
+ * @since       3.2
  */
-function ContentBuildRoute(&$query)
+class ContentRouter implements JComponentRouter
 {
-	$segments = array();
-
-	// get a menu item based on Itemid or currently active
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$params = JComponentHelper::getParams('com_content');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	// we need a menu item.  Either the one specified in the query, or the current active one if none specified
-	if (empty($query['Itemid']))
+	/**
+	 * Build the route for the com_content component
+	 *
+	 * @return  array  An array of URL arguments
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 * @since    1.5
+	 */
+	public function build(&$query)
 	{
-		$menuItem = $menu->getActive();
-		$menuItemGiven = false;
-	}
-	else
-	{
-		$menuItem = $menu->getItem($query['Itemid']);
-		$menuItemGiven = true;
-	}
+		$segments = array();
 
-	// check again
-	if ($menuItemGiven && isset($menuItem) && $menuItem->component != 'com_content')
-	{
-		$menuItemGiven = false;
-		unset($query['Itemid']);
-	}
+		// get a menu item based on Itemid or currently active
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$params = JComponentHelper::getParams('com_content');
+		$advanced = $params->get('sef_advanced_link', 0);
 
-	if (isset($query['view']))
-	{
-		$view = $query['view'];
-	}
-	else
-	{
-		// we need to have a view in the query or it is an invalid URL
-		return $segments;
-	}
-
-	// are we dealing with an article or category that is attached to a menu item?
-	if (($menuItem instanceof stdClass) && $menuItem->query['view'] == $query['view'] && isset($query['id']) && $menuItem->query['id'] == (int) $query['id'])
-	{
-		unset($query['view']);
-
-		if (isset($query['catid']))
+		// we need a menu item.  Either the one specified in the query, or the current active one if none specified
+		if (empty($query['Itemid']))
 		{
-			unset($query['catid']);
-		}
-
-		if (isset($query['layout']))
-		{
-			unset($query['layout']);
-		}
-
-		unset($query['id']);
-
-		return $segments;
-	}
-
-	if ($view == 'category' || $view == 'article')
-	{
-		if (!$menuItemGiven)
-		{
-			$segments[] = $view;
-		}
-
-		unset($query['view']);
-
-		if ($view == 'article')
-		{
-			if (isset($query['id']) && isset($query['catid']) && $query['catid'])
-			{
-				$catid = $query['catid'];
-				// Make sure we have the id and the alias
-				if (strpos($query['id'], ':') === false)
-				{
-					$db = JFactory::getDbo();
-					$dbQuery = $db->getQuery(true)
-						->select('alias')
-						->from('#__content')
-						->where('id=' . (int) $query['id']);
-					$db->setQuery($dbQuery);
-					$alias = $db->loadResult();
-					$query['id'] = $query['id'] . ':' . $alias;
-				}
-			}
-			else
-			{
-				// we should have these two set for this view.  If we don't, it is an error
-				return $segments;
-			}
+			$menuItem = $menu->getActive();
+			$menuItemGiven = false;
 		}
 		else
 		{
-			if (isset($query['id']))
-			{
-				$catid = $query['id'];
-			}
-			else
-			{
-				// we should have id set for this view.  If we don't, it is an error
-				return $segments;
-			}
+			$menuItem = $menu->getItem($query['Itemid']);
+			$menuItemGiven = true;
 		}
 
-		if ($menuItemGiven && isset($menuItem->query['id']))
+		// check again
+		if ($menuItemGiven && isset($menuItem) && $menuItem->component != 'com_content')
 		{
-			$mCatid = $menuItem->query['id'];
+			$menuItemGiven = false;
+			unset($query['Itemid']);
+		}
+
+		if (isset($query['view']))
+		{
+			$view = $query['view'];
 		}
 		else
 		{
-			$mCatid = 0;
-		}
-
-		$categories = JCategories::getInstance('Content');
-		$category = $categories->get($catid);
-
-		if (!$category)
-		{
-			// we couldn't find the category we were given.  Bail.
+			// we need to have a view in the query or it is an invalid URL
 			return $segments;
 		}
 
-		$path = array_reverse($category->getPath());
-
-		$array = array();
-
-		foreach ($path as $id)
+		// are we dealing with an article or category that is attached to a menu item?
+		if (($menuItem instanceof stdClass) && $menuItem->query['view'] == $query['view'] && isset($query['id']) && $menuItem->query['id'] == (int) $query['id'])
 		{
-			if ((int) $id == (int) $mCatid)
+			unset($query['view']);
+
+			if (isset($query['catid']))
 			{
-				break;
+				unset($query['catid']);
 			}
 
-			list($tmp, $id) = explode(':', $id, 2);
-
-			$array[] = $id;
-		}
-
-		$array = array_reverse($array);
-
-		if (!$advanced && count($array))
-		{
-			$array[0] = (int) $catid . ':' . $array[0];
-		}
-
-		$segments = array_merge($segments, $array);
-
-		if ($view == 'article')
-		{
-			if ($advanced)
+			if (isset($query['layout']))
 			{
-				list($tmp, $id) = explode(':', $query['id'], 2);
+				unset($query['layout']);
+			}
+
+			unset($query['id']);
+
+			return $segments;
+		}
+
+		if ($view == 'category' || $view == 'article')
+		{
+			if (!$menuItemGiven)
+			{
+				$segments[] = $view;
+			}
+
+			unset($query['view']);
+
+			if ($view == 'article')
+			{
+				if (isset($query['id']) && isset($query['catid']) && $query['catid'])
+				{
+					$catid = $query['catid'];
+					// Make sure we have the id and the alias
+					if (strpos($query['id'], ':') === false)
+					{
+						$db = JFactory::getDbo();
+						$dbQuery = $db->getQuery(true)
+							->select('alias')
+							->from('#__content')
+							->where('id=' . (int) $query['id']);
+						$db->setQuery($dbQuery);
+						$alias = $db->loadResult();
+						$query['id'] = $query['id'] . ':' . $alias;
+					}
+				}
+				else
+				{
+					// we should have these two set for this view.  If we don't, it is an error
+					return $segments;
+				}
 			}
 			else
 			{
-				$id = $query['id'];
-			}
-			$segments[] = $id;
-		}
-		unset($query['id']);
-		unset($query['catid']);
-	}
-
-	if ($view == 'archive')
-	{
-		if (!$menuItemGiven)
-		{
-			$segments[] = $view;
-			unset($query['view']);
-		}
-
-		if (isset($query['year']))
-		{
-			if ($menuItemGiven)
-			{
-				$segments[] = $query['year'];
-				unset($query['year']);
-			}
-		}
-
-		if (isset($query['year']) && isset($query['month']))
-		{
-			if ($menuItemGiven)
-			{
-				$segments[] = $query['month'];
-				unset($query['month']);
-			}
-		}
-	}
-
-	// if the layout is specified and it is the same as the layout in the menu item, we
-	// unset it so it doesn't go into the query string.
-	if (isset($query['layout']))
-	{
-		if ($menuItemGiven && isset($menuItem->query['layout']))
-		{
-			if ($query['layout'] == $menuItem->query['layout'])
-			{
-				unset($query['layout']);
-			}
-		}
-		else
-		{
-			if ($query['layout'] == 'default')
-			{
-				unset($query['layout']);
-			}
-		}
-	}
-
-	return $segments;
-}
-
-/**
- * Parse the segments of a URL.
- *
- * @return  array  The segments of the URL to parse.
- *
- * @return  array  The URL attributes to be used by the application.
- * @since    1.5
- */
-function ContentParseRoute($segments)
-{
-	$vars = array();
-
-	//Get the active menu item.
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$item = $menu->getActive();
-	$params = JComponentHelper::getParams('com_content');
-	$advanced = $params->get('sef_advanced_link', 0);
-	$db = JFactory::getDbo();
-
-	// Count route segments
-	$count = count($segments);
-
-	// Standard routing for articles.  If we don't pick up an Itemid then we get the view from the segments
-	// the first segment is the view and the last segment is the id of the article or category.
-	if (!isset($item))
-	{
-		$vars['view'] = $segments[0];
-		$vars['id'] = $segments[$count - 1];
-
-		return $vars;
-	}
-
-	// if there is only one segment, then it points to either an article or a category
-	// we test it first to see if it is a category.  If the id and alias match a category
-	// then we assume it is a category.  If they don't we assume it is an article
-	if ($count == 1)
-	{
-		// we check to see if an alias is given.  If not, we assume it is an article
-		if (strpos($segments[0], ':') === false)
-		{
-			$vars['view'] = 'article';
-			$vars['id'] = (int) $segments[0];
-			return $vars;
-		}
-
-		list($id, $alias) = explode(':', $segments[0], 2);
-
-		// first we check if it is a category
-		$category = JCategories::getInstance('Content')->get($id);
-
-		if ($category && $category->alias == $alias)
-		{
-			$vars['view'] = 'category';
-			$vars['id'] = $id;
-
-			return $vars;
-		}
-		else
-		{
-			$query = 'SELECT alias, catid FROM #__content WHERE id = ' . (int) $id;
-			$db->setQuery($query);
-			$article = $db->loadObject();
-
-			if ($article)
-			{
-				if ($article->alias == $alias)
+				if (isset($query['id']))
 				{
-					$vars['view'] = 'article';
-					$vars['catid'] = (int) $article->catid;
-					$vars['id'] = (int) $id;
+					$catid = $query['id'];
+				}
+				else
+				{
+					// we should have id set for this view.  If we don't, it is an error
+					return $segments;
+				}
+			}
 
-					return $vars;
+			if ($menuItemGiven && isset($menuItem->query['id']))
+			{
+				$mCatid = $menuItem->query['id'];
+			}
+			else
+			{
+				$mCatid = 0;
+			}
+
+			$categories = JCategories::getInstance('Content');
+			$category = $categories->get($catid);
+
+			if (!$category)
+			{
+				// we couldn't find the category we were given.  Bail.
+				return $segments;
+			}
+
+			$path = array_reverse($category->getPath());
+
+			$array = array();
+
+			foreach ($path as $id)
+			{
+				if ((int) $id == (int) $mCatid)
+				{
+					break;
+				}
+
+				list($tmp, $id) = explode(':', $id, 2);
+
+				$array[] = $id;
+			}
+
+			$array = array_reverse($array);
+
+			if (!$advanced && count($array))
+			{
+				$array[0] = (int) $catid . ':' . $array[0];
+			}
+
+			$segments = array_merge($segments, $array);
+
+			if ($view == 'article')
+			{
+				if ($advanced)
+				{
+					list($tmp, $id) = explode(':', $query['id'], 2);
+				}
+				else
+				{
+					$id = $query['id'];
+				}
+				$segments[] = $id;
+			}
+			unset($query['id']);
+			unset($query['catid']);
+		}
+
+		if ($view == 'archive')
+		{
+			if (!$menuItemGiven)
+			{
+				$segments[] = $view;
+				unset($query['view']);
+			}
+
+			if (isset($query['year']))
+			{
+				if ($menuItemGiven)
+				{
+					$segments[] = $query['year'];
+					unset($query['year']);
+				}
+			}
+
+			if (isset($query['year']) && isset($query['month']))
+			{
+				if ($menuItemGiven)
+				{
+					$segments[] = $query['month'];
+					unset($query['month']);
 				}
 			}
 		}
-	}
 
-	// if there was more than one segment, then we can determine where the URL points to
-	// because the first segment will have the target category id prepended to it.  If the
-	// last segment has a number prepended, it is an article, otherwise, it is a category.
-	if (!$advanced)
-	{
-		$cat_id = (int) $segments[0];
-
-		$article_id = (int) $segments[$count - 1];
-
-		if ($article_id > 0)
+		// if the layout is specified and it is the same as the layout in the menu item, we
+		// unset it so it doesn't go into the query string.
+		if (isset($query['layout']))
 		{
-			$vars['view'] = 'article';
-			$vars['catid'] = $cat_id;
-			$vars['id'] = $article_id;
-		}
-		else
-		{
-			$vars['view'] = 'category';
-			$vars['id'] = $cat_id;
-		}
-
-		return $vars;
-	}
-
-	// we get the category id from the menu item and search from there
-	$id = $item->query['id'];
-	$category = JCategories::getInstance('Content')->get($id);
-
-	if (!$category)
-	{
-		JError::raiseError(404, JText::_('COM_CONTENT_ERROR_PARENT_CATEGORY_NOT_FOUND'));
-		return $vars;
-	}
-
-	$categories = $category->getChildren();
-	$vars['catid'] = $id;
-	$vars['id'] = $id;
-	$found = 0;
-
-	foreach ($segments as $segment)
-	{
-		$segment = str_replace(':', '-', $segment);
-
-		foreach ($categories as $category)
-		{
-			if ($category->alias == $segment)
+			if ($menuItemGiven && isset($menuItem->query['layout']))
 			{
-				$vars['id'] = $category->id;
-				$vars['catid'] = $category->id;
-				$vars['view'] = 'category';
-				$categories = $category->getChildren();
-				$found = 1;
-				break;
-			}
-		}
-
-		if ($found == 0)
-		{
-			if ($advanced)
-			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from('#__content')
-					->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
-					->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
-				$db->setQuery($query);
-				$cid = $db->loadResult();
+				if ($query['layout'] == $menuItem->query['layout'])
+				{
+					unset($query['layout']);
+				}
 			}
 			else
 			{
-				$cid = $segment;
+				if ($query['layout'] == 'default')
+				{
+					unset($query['layout']);
+				}
 			}
+		}
 
-			$vars['id'] = $cid;
+		return $segments;
+	}
 
-			if ($item->query['view'] == 'archive' && $count != 1)
-			{
-				$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
-				$vars['month'] = $segments[$count - 1];
-				$vars['view'] = 'archive';
-			}
-			else
+	/**
+	 * Parse the segments of a URL.
+	 *
+	 * @return  array  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 * @since    1.5
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
+
+		//Get the active menu item.
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$item = $menu->getActive();
+		$params = JComponentHelper::getParams('com_content');
+		$advanced = $params->get('sef_advanced_link', 0);
+		$db = JFactory::getDbo();
+
+		// Count route segments
+		$count = count($segments);
+
+		// Standard routing for articles.  If we don't pick up an Itemid then we get the view from the segments
+		// the first segment is the view and the last segment is the id of the article or category.
+		if (!isset($item))
+		{
+			$vars['view'] = $segments[0];
+			$vars['id'] = $segments[$count - 1];
+
+			return $vars;
+		}
+
+		// if there is only one segment, then it points to either an article or a category
+		// we test it first to see if it is a category.  If the id and alias match a category
+		// then we assume it is a category.  If they don't we assume it is an article
+		if ($count == 1)
+		{
+			// we check to see if an alias is given.  If not, we assume it is an article
+			if (strpos($segments[0], ':') === false)
 			{
 				$vars['view'] = 'article';
+				$vars['id'] = (int) $segments[0];
+				return $vars;
+			}
+
+			list($id, $alias) = explode(':', $segments[0], 2);
+
+			// first we check if it is a category
+			$category = JCategories::getInstance('Content')->get($id);
+
+			if ($category && $category->alias == $alias)
+			{
+				$vars['view'] = 'category';
+				$vars['id'] = $id;
+
+				return $vars;
+			}
+			else
+			{
+				$query = 'SELECT alias, catid FROM #__content WHERE id = ' . (int) $id;
+				$db->setQuery($query);
+				$article = $db->loadObject();
+
+				if ($article)
+				{
+					if ($article->alias == $alias)
+					{
+						$vars['view'] = 'article';
+						$vars['catid'] = (int) $article->catid;
+						$vars['id'] = (int) $id;
+
+						return $vars;
+					}
+				}
 			}
 		}
 
-		$found = 0;
-	}
+		// if there was more than one segment, then we can determine where the URL points to
+		// because the first segment will have the target category id prepended to it.  If the
+		// last segment has a number prepended, it is an article, otherwise, it is a category.
+		if (!$advanced)
+		{
+			$cat_id = (int) $segments[0];
 
-	return $vars;
+			$article_id = (int) $segments[$count - 1];
+
+			if ($article_id > 0)
+			{
+				$vars['view'] = 'article';
+				$vars['catid'] = $cat_id;
+				$vars['id'] = $article_id;
+			}
+			else
+			{
+				$vars['view'] = 'category';
+				$vars['id'] = $cat_id;
+			}
+
+			return $vars;
+		}
+
+		// we get the category id from the menu item and search from there
+		$id = $item->query['id'];
+		$category = JCategories::getInstance('Content')->get($id);
+
+		if (!$category)
+		{
+			JError::raiseError(404, JText::_('COM_CONTENT_ERROR_PARENT_CATEGORY_NOT_FOUND'));
+			return $vars;
+		}
+
+		$categories = $category->getChildren();
+		$vars['catid'] = $id;
+		$vars['id'] = $id;
+		$found = 0;
+
+		foreach ($segments as $segment)
+		{
+			$segment = str_replace(':', '-', $segment);
+
+			foreach ($categories as $category)
+			{
+				if ($category->alias == $segment)
+				{
+					$vars['id'] = $category->id;
+					$vars['catid'] = $category->id;
+					$vars['view'] = 'category';
+					$categories = $category->getChildren();
+					$found = 1;
+					break;
+				}
+			}
+
+			if ($found == 0)
+			{
+				if ($advanced)
+				{
+					$db = JFactory::getDbo();
+					$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from('#__content')
+						->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
+						->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
+					$db->setQuery($query);
+					$cid = $db->loadResult();
+				}
+				else
+				{
+					$cid = $segment;
+				}
+
+				$vars['id'] = $cid;
+
+				if ($item->query['view'] == 'archive' && $count != 1)
+				{
+					$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+					$vars['month'] = $segments[$count - 1];
+					$vars['view'] = 'archive';
+				}
+				else
+				{
+					$vars['view'] = 'article';
+				}
+			}
+
+			$found = 0;
+		}
+
+		return $vars;
+	}
 }

--- a/components/com_finder/router.php
+++ b/components/com_finder/router.php
@@ -10,101 +10,111 @@
 defined('_JEXEC') or die;
 
 /**
- * Method to build a SEF route.
+ * Routing class from com_finder
  *
- * @param   array  &$query  An array of route variables.
- *
- * @return  array  An array of route segments.
- *
- * @since   2.5
+ * @package     Joomla.Site
+ * @subpackage  com_finder
+ * @since       3.2
  */
-function FinderBuildRoute(&$query)
+class FinderRouter implements JComponentRouter
 {
-	static $menu;
-	$segments = array();
-
-	// Load the menu if necessary.
-	if (!$menu)
-	{
-		$menu = JFactory::getApplication('site')->getMenu();
-	}
-
-	/*
-	 * First, handle menu item routes first. When the menu system builds a
-	 * route, it only provides the option and the menu item id. We don't have
-	 * to do anything to these routes.
+	/**
+	 * Method to build a SEF route.
+	 *
+	 * @param   array  &$query  An array of route variables.
+	 *
+	 * @return  array  An array of route segments.
+	 *
+	 * @since   2.5
 	 */
-	if (count($query) === 2 && isset($query['Itemid']) && isset($query['option']))
+	public function build(&$query)
 	{
-		return $segments;
-	}
+		static $menu;
+		$segments = array();
 
-	/*
-	 * Next, handle a route with a supplied menu item id. All system generated
-	 * routes should fall into this group. We can assume that the menu item id
-	 * is the best possible match for the query but we need to go through and
-	 * see which variables we can eliminate from the route query string because
-	 * they are present in the menu item route already.
-	 */
-	if (!empty($query['Itemid']))
-	{
-		// Get the menu item.
-		$item = $menu->getItem($query['Itemid']);
-
-		// Check if the view matches.
-		if ($item && @$item->query['view'] === @$query['view'])
+		// Load the menu if necessary.
+		if (!$menu)
 		{
+			$menu = JFactory::getApplication('site')->getMenu();
+		}
+
+		/*
+		 * First, handle menu item routes first. When the menu system builds a
+		 * route, it only provides the option and the menu item id. We don't have
+		 * to do anything to these routes.
+		 */
+		if (count($query) === 2 && isset($query['Itemid']) && isset($query['option']))
+		{
+			return $segments;
+		}
+
+		/*
+		 * Next, handle a route with a supplied menu item id. All system generated
+		 * routes should fall into this group. We can assume that the menu item id
+		 * is the best possible match for the query but we need to go through and
+		 * see which variables we can eliminate from the route query string because
+		 * they are present in the menu item route already.
+		 */
+		if (!empty($query['Itemid']))
+		{
+			// Get the menu item.
+			$item = $menu->getItem($query['Itemid']);
+
+			// Check if the view matches.
+			if ($item && @$item->query['view'] === @$query['view'])
+			{
+				unset($query['view']);
+			}
+
+			// Check if the search query filter matches.
+			if ($item && @$item->query['f'] === @$query['f'])
+			{
+				unset($query['f']);
+			}
+
+			// Check if the search query string matches.
+			if ($item && @$item->query['q'] === @$query['q'])
+			{
+				unset($query['q']);
+			}
+
+			return $segments;
+		}
+
+		/*
+		 * Lastly, handle a route with no menu item id. Fortunately, we only need
+		 * to deal with the view as the other route variables are supposed to stay
+		 * in the query string.
+		 */
+		if (isset($query['view']))
+		{
+			// Add the view to the segments.
+			$segments[] = $query['view'];
 			unset($query['view']);
 		}
 
-		// Check if the search query filter matches.
-		if ($item && @$item->query['f'] === @$query['f'])
-		{
-			unset($query['f']);
-		}
-
-		// Check if the search query string matches.
-		if ($item && @$item->query['q'] === @$query['q'])
-		{
-			unset($query['q']);
-		}
-
 		return $segments;
 	}
 
-	/*
-	 * Lastly, handle a route with no menu item id. Fortunately, we only need
-	 * to deal with the view as the other route variables are supposed to stay
-	 * in the query string.
+	/**
+	 * Method to parse a SEF route.
+	 *
+	 * @param   array  $segments  An array of route segments.
+	 *
+	 * @return  array  An array of route variables.
+	 *
+	 * @since   2.5
 	 */
-	if (isset($query['view']))
+	public function parse(&$segments)
 	{
-		// Add the view to the segments.
-		$segments[] = $query['view'];
-		unset($query['view']);
+		$vars = array();
+
+		// Check if the view segment is set and it equals search or advanced.
+		if (@$segments[0] === 'search' || @$segments[0] === 'advanced')
+		{
+			$vars['view'] = $segments[0];
+		}
+
+		return $vars;
 	}
-
-	return $segments;
-}
-
-/**
- * Method to parse a SEF route.
- *
- * @param   array  $segments  An array of route segments.
- *
- * @return  array  An array of route variables.
- *
- * @since   2.5
- */
-function FinderParseRoute($segments)
-{
-	$vars = array();
-
-	// Check if the view segment is set and it equals search or advanced.
-	if (@$segments[0] === 'search' || @$segments[0] === 'advanced')
-	{
-		$vars['view'] = $segments[0];
-	}
-
-	return $vars;
 }

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -10,196 +10,206 @@
 defined('_JEXEC') or die;
 
 /**
- * Build the route for the com_newsfeeds component
+ * Routing class from com_newsfeeds
  *
- * @return  array  An array of URL arguments
- *
- * @return  array  The URL arguments to use to assemble the subsequent URL.
+ * @package     Joomla.Site
+ * @subpackage  com_newsfeeds
+ * @since       3.2
  */
-function NewsfeedsBuildRoute(&$query)
+class NewsfeedsRouter implements JComponentRouter
 {
-	$segments = array();
-
-	// get a menu item based on Itemid or currently active
-	$app	= JFactory::getApplication();
-	$menu	= $app->getMenu();
-	$params = JComponentHelper::getParams('com_newsfeeds');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	if (empty($query['Itemid']))
+	/**
+	 * Build the route for the com_newsfeeds component
+	 *
+	 * @return  array  An array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 */
+	public function build(&$query)
 	{
-		$menuItem = $menu->getActive();
-	}
-	else
-	{
-		$menuItem = $menu->getItem($query['Itemid']);
-	}
-	$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
-	$mId   = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
+		$segments = array();
 
-	if (isset($query['view']))
-	{
-		$view = $query['view'];
-		if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_newsfeeds')
+		// get a menu item based on Itemid or currently active
+		$app	= JFactory::getApplication();
+		$menu	= $app->getMenu();
+		$params = JComponentHelper::getParams('com_newsfeeds');
+		$advanced = $params->get('sef_advanced_link', 0);
+
+		if (empty($query['Itemid']))
 		{
-			$segments[] = $query['view'];
-		}
-		unset($query['view']);
-	}
-
-	// are we dealing with an newsfeed that is attached to a menu item?
-	if (isset($query['view']) && ($mView == $query['view']) and (isset($query['id'])) and ($mId == (int) $query['id']))
-	{
-		unset($query['view']);
-		unset($query['catid']);
-		unset($query['id']);
-		return $segments;
-	}
-
-	if (isset($view) and ($view == 'category' or $view == 'newsfeed'))
-	{
-		if ($mId != (int) $query['id'] || $mView != $view)
-		{
-			if ($view == 'newsfeed' && isset($query['catid']))
-			{
-				$catid = $query['catid'];
-			}
-			elseif (isset($query['id']))
-			{
-				$catid = $query['id'];
-			}
-			$menuCatid = $mId;
-			$categories = JCategories::getInstance('Newsfeeds');
-			$category = $categories->get($catid);
-			if ($category)
-			{
-				$path = $category->getPath();
-				$path = array_reverse($path);
-
-				$array = array();
-				foreach ($path as $id)
-				{
-					if ((int) $id == (int) $menuCatid)
-					{
-						break;
-					}
-					if ($advanced)
-					{
-						list($tmp, $id) = explode(':', $id, 2);
-					}
-					$array[] = $id;
-				}
-				$segments = array_merge($segments, array_reverse($array));
-			}
-			if ($view == 'newsfeed')
-			{
-				if ($advanced)
-				{
-					list($tmp, $id) = explode(':', $query['id'], 2);
-				}
-				else
-				{
-					$id = $query['id'];
-				}
-				$segments[] = $id;
-			}
-		}
-		unset($query['id']);
-		unset($query['catid']);
-	}
-
-	if (isset($query['layout']))
-	{
-		if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
-		{
-			if ($query['layout'] == $menuItem->query['layout'])
-			{
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getActive();
 		}
 		else
 		{
-			if ($query['layout'] == 'default')
-			{
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getItem($query['Itemid']);
 		}
-	}
+		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
+		$mId   = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
 
-	return $segments;
-}
-/**
- * Parse the segments of a URL.
- *
- * @return  array  The segments of the URL to parse.
- *
- * @return  array  The URL attributes to be used by the application.
- */
-function NewsfeedsParseRoute($segments)
-{
-	$vars = array();
-
-	//Get the active menu item.
-	$app	= JFactory::getApplication();
-	$menu	= $app->getMenu();
-	$item	= $menu->getActive();
-	$params = JComponentHelper::getParams('com_newsfeeds');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	// Count route segments
-	$count = count($segments);
-
-	// Standard routing for newsfeeds.
-	if (!isset($item))
-	{
-		$vars['view']	= $segments[0];
-		$vars['id']		= $segments[$count - 1];
-		return $vars;
-	}
-
-	// From the categories view, we can only jump to a category.
-	$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
-	$categories = JCategories::getInstance('Newsfeeds')->get($id)->getChildren();
-	$vars['catid'] = $id;
-	$vars['id'] = $id;
-	$found = 0;
-	foreach ($segments as $segment)
-	{
-		$segment = $advanced ? str_replace(':', '-', $segment) : $segment;
-		foreach ($categories as $category)
+		if (isset($query['view']))
 		{
-			if ($category->slug == $segment || $category->alias == $segment)
+			$view = $query['view'];
+			if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_newsfeeds')
 			{
-				$vars['id'] = $category->id;
-				$vars['catid'] = $category->id;
-				$vars['view'] = 'category';
-				$categories = $category->getChildren();
-				$found = 1;
-				break;
+				$segments[] = $query['view'];
 			}
+			unset($query['view']);
 		}
-		if ($found == 0)
+
+		// are we dealing with an newsfeed that is attached to a menu item?
+		if (isset($query['view']) && ($mView == $query['view']) and (isset($query['id'])) and ($mId == (int) $query['id']))
 		{
-			if ($advanced)
+			unset($query['view']);
+			unset($query['catid']);
+			unset($query['id']);
+			return $segments;
+		}
+
+		if (isset($view) and ($view == 'category' or $view == 'newsfeed'))
+		{
+			if ($mId != (int) $query['id'] || $mView != $view)
 			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from('#__newsfeeds')
-					->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
-					->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
-				$db->setQuery($query);
-				$nid = $db->loadResult();
+				if ($view == 'newsfeed' && isset($query['catid']))
+				{
+					$catid = $query['catid'];
+				}
+				elseif (isset($query['id']))
+				{
+					$catid = $query['id'];
+				}
+				$menuCatid = $mId;
+				$categories = JCategories::getInstance('Newsfeeds');
+				$category = $categories->get($catid);
+				if ($category)
+				{
+					$path = $category->getPath();
+					$path = array_reverse($path);
+
+					$array = array();
+					foreach ($path as $id)
+					{
+						if ((int) $id == (int) $menuCatid)
+						{
+							break;
+						}
+						if ($advanced)
+						{
+							list($tmp, $id) = explode(':', $id, 2);
+						}
+						$array[] = $id;
+					}
+					$segments = array_merge($segments, array_reverse($array));
+				}
+				if ($view == 'newsfeed')
+				{
+					if ($advanced)
+					{
+						list($tmp, $id) = explode(':', $query['id'], 2);
+					}
+					else
+					{
+						$id = $query['id'];
+					}
+					$segments[] = $id;
+				}
+			}
+			unset($query['id']);
+			unset($query['catid']);
+		}
+
+		if (isset($query['layout']))
+		{
+			if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
+			{
+				if ($query['layout'] == $menuItem->query['layout'])
+				{
+					unset($query['layout']);
+				}
 			}
 			else
 			{
-				$nid = $segment;
+				if ($query['layout'] == 'default')
+				{
+					unset($query['layout']);
+				}
 			}
-			$vars['id'] = $nid;
-			$vars['view'] = 'newsfeed';
 		}
-		$found = 0;
-	}
 
-	return $vars;
+		return $segments;
+	}
+	/**
+	 * Parse the segments of a URL.
+	 *
+	 * @return  array  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
+
+		//Get the active menu item.
+		$app	= JFactory::getApplication();
+		$menu	= $app->getMenu();
+		$item	= $menu->getActive();
+		$params = JComponentHelper::getParams('com_newsfeeds');
+		$advanced = $params->get('sef_advanced_link', 0);
+
+		// Count route segments
+		$count = count($segments);
+
+		// Standard routing for newsfeeds.
+		if (!isset($item))
+		{
+			$vars['view']	= $segments[0];
+			$vars['id']		= $segments[$count - 1];
+			return $vars;
+		}
+
+		// From the categories view, we can only jump to a category.
+		$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
+		$categories = JCategories::getInstance('Newsfeeds')->get($id)->getChildren();
+		$vars['catid'] = $id;
+		$vars['id'] = $id;
+		$found = 0;
+		foreach ($segments as $segment)
+		{
+			$segment = $advanced ? str_replace(':', '-', $segment) : $segment;
+			foreach ($categories as $category)
+			{
+				if ($category->slug == $segment || $category->alias == $segment)
+				{
+					$vars['id'] = $category->id;
+					$vars['catid'] = $category->id;
+					$vars['view'] = 'category';
+					$categories = $category->getChildren();
+					$found = 1;
+					break;
+				}
+			}
+			if ($found == 0)
+			{
+				if ($advanced)
+				{
+					$db = JFactory::getDbo();
+					$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from('#__newsfeeds')
+						->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
+						->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
+					$db->setQuery($query);
+					$nid = $db->loadResult();
+				}
+				else
+				{
+					$nid = $segment;
+				}
+				$vars['id'] = $nid;
+				$vars['view'] = 'newsfeed';
+			}
+			$found = 0;
+		}
+
+		return $vars;
+	}
 }

--- a/components/com_search/router.php
+++ b/components/com_search/router.php
@@ -10,31 +10,41 @@
 defined('_JEXEC') or die;
 
 /**
- * @param   array
- * @return  array
+ * Routing class from com_search
+ *
+ * @package     Joomla.Site
+ * @subpackage  com_search
+ * @since       3.2
  */
-function SearchBuildRoute(&$query)
+class SearchRouter implements JComponentRouter
 {
-	$segments = array();
-
-	if (isset($query['view']))
+	/**
+	 * @param   array
+	 * @return  array
+	 */
+	public function build(&$query)
 	{
-		unset($query['view']);
+		$segments = array();
+
+		if (isset($query['view']))
+		{
+			unset($query['view']);
+		}
+		return $segments;
 	}
-	return $segments;
-}
 
-/**
- * @param   array
- * @return  array
- */
-function SearchParseRoute($segments)
-{
-	$vars = array();
+	/**
+	 * @param   array
+	 * @return  array
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
 
-	$searchword	= array_shift($segments);
-	$vars['searchword'] = $searchword;
-	$vars['view'] = 'search';
+		$searchword	= array_shift($segments);
+		$vars['searchword'] = $searchword;
+		$vars['view'] = 'search';
 
-	return $vars;
+		return $vars;
+	}
 }

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -10,142 +10,152 @@
 defined('_JEXEC') or die;
 
 /**
- * Build the route for the com_tags component
+ * Routing class from com_tags
  *
- * @param   array  An array of URL arguments
- *
- * @return  array  The URL arguments to use to assemble the subsequent URL.
- *
- * @since   3.1
+ * @package     Joomla.Site
+ * @subpackage  com_tags
+ * @since       3.2
  */
-function TagsBuildRoute(&$query)
+class TagsRouter implements JComponentRouter
 {
-	$segments = array();
-
-	// Get a menu item based on Itemid or currently active
-	$app		= JFactory::getApplication();
-	$menu		= $app->getMenu();
-	$params		= JComponentHelper::getParams('com_tags');
-	$advanced	= $params->get('sef_advanced_link', 0);
-
-	// We need a menu item.  Either the one specified in the query, or the current active one if none specified
-	if (empty($query['Itemid'])) {
-		$menuItem = $menu->getActive();
-	}
-	else {
-		$menuItem = $menu->getItem($query['Itemid']);
-	}
-
-	$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
-	$mId   = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
-	if (is_array($mId))
+	/**
+	 * Build the route for the com_tags component
+	 *
+	 * @param   array  An array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.1
+	 */
+	public function build(&$query)
 	{
-		JArrayHelper::toInteger($mId);
-	}
+		$segments = array();
 
-	if (isset($query['view'])) {
-		$view = $query['view'];
+		// Get a menu item based on Itemid or currently active
+		$app		= JFactory::getApplication();
+		$menu		= $app->getMenu();
+		$params		= JComponentHelper::getParams('com_tags');
+		$advanced	= $params->get('sef_advanced_link', 0);
 
+		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid'])) {
-			$segments[] = $query['view'];
-		}
-		unset($query['view']);
-	}
-
-	// Are we dealing with a tag that is attached to a menu item?
-	if (isset($view) && ($mView == $view) and (isset($query['id'])) and ($mId == $query['id']))
-	{
-		unset($query['view']);
-		unset($query['id']);
-		return $segments;
-	}
-
-	if (isset($view) and $view == 'tag')
-	{
-		if ($mId != (int) $query['id'] || $mView != $view)
-		{
-			if ($view == 'tag') {
-				if ($advanced) {
-					list($tmp, $id) = explode(':', $query['id'], 2);
-				}
-				else {
-					$id = $query['id'];
-				}
-
-				$segments[] = $id;
-			}
-		}
-		unset($query['id']);
-	}
-
-	if (isset($query['layout'])) {
-		if (!empty($query['Itemid']) && isset($menuItem->query['layout'])) {
-			if ($query['layout'] == $menuItem->query['layout']) {
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getActive();
 		}
 		else {
-			if ($query['layout'] == 'default') {
-				unset($query['layout']);
-			}
+			$menuItem = $menu->getItem($query['Itemid']);
 		}
-	};
 
-	return $segments;
-}
-/**
- * Parse the segments of a URL.
- *
- * @param   array  The segments of the URL to parse.
- *
- * @return  array  The URL attributes to be used by the application.
- *
- * @since   3.1
- */
-function TagsParseRoute($segments)
-{
-	$vars = array();
+		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
+		$mId   = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
+		if (is_array($mId))
+		{
+			JArrayHelper::toInteger($mId);
+		}
 
-	//Get the active menu item.
-	$app	= JFactory::getApplication();
-	$menu	= $app->getMenu();
-	$item	= $menu->getActive();
+		if (isset($query['view'])) {
+			$view = $query['view'];
 
-	// Count route segments
-	$count = count($segments);
+			if (empty($query['Itemid'])) {
+				$segments[] = $query['view'];
+			}
+			unset($query['view']);
+		}
 
-	// Standard routing for tags.
-	if (!isset($item))
+		// Are we dealing with a tag that is attached to a menu item?
+		if (isset($view) && ($mView == $view) and (isset($query['id'])) and ($mId == $query['id']))
+		{
+			unset($query['view']);
+			unset($query['id']);
+			return $segments;
+		}
+
+		if (isset($view) and $view == 'tag')
+		{
+			if ($mId != (int) $query['id'] || $mView != $view)
+			{
+				if ($view == 'tag') {
+					if ($advanced) {
+						list($tmp, $id) = explode(':', $query['id'], 2);
+					}
+					else {
+						$id = $query['id'];
+					}
+
+					$segments[] = $id;
+				}
+			}
+			unset($query['id']);
+		}
+
+		if (isset($query['layout'])) {
+			if (!empty($query['Itemid']) && isset($menuItem->query['layout'])) {
+				if ($query['layout'] == $menuItem->query['layout']) {
+					unset($query['layout']);
+				}
+			}
+			else {
+				if ($query['layout'] == 'default') {
+					unset($query['layout']);
+				}
+			}
+		};
+
+		return $segments;
+	}
+	/**
+	 * Parse the segments of a URL.
+	 *
+	 * @param   array  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 *
+	 * @since   3.1
+	 */
+	public function parse(&$segments)
 	{
-		$vars['view']	= $segments[0];
-		$vars['id']		= $segments[$count - 1];
+		$vars = array();
+
+		//Get the active menu item.
+		$app	= JFactory::getApplication();
+		$menu	= $app->getMenu();
+		$item	= $menu->getActive();
+
+		// Count route segments
+		$count = count($segments);
+
+		// Standard routing for tags.
+		if (!isset($item))
+		{
+			$vars['view']	= $segments[0];
+			$vars['id']		= $segments[$count - 1];
+			return $vars;
+		}
+
+		// From the tags view, we can only jump to a tag.
+		$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
+
+		$found = 0;
+
+		/* TODO: Sort this code out. Makes no sense!
+		 * $found isn't used.
+		 * Indentation is all off
+		 * The foreach loop will always break in first itteration
+		 */
+		foreach($segments as $segment)
+		{
+			if ($found == 0)
+			{
+				$id = $segment;
+			}
+
+				$vars['id'] = $id;
+				$vars['view'] = 'tag';
+
+				break;
+		}
+
+		$found = 0;
+
 		return $vars;
 	}
-
-	// From the tags view, we can only jump to a tag.
-	$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
-
-	$found = 0;
-
-	/* TODO: Sort this code out. Makes no sense!
-	 * $found isn't used.
-	 * Indentation is all off
-	 * The foreach loop will always break in first itteration
-	 */
-	foreach($segments as $segment)
-	{
-		if ($found == 0)
-		{
-			$id = $segment;
-		}
-
-			$vars['id'] = $id;
-			$vars['view'] = 'tag';
-
-			break;
-	}
-
-	$found = 0;
-
-	return $vars;
 }

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -10,233 +10,243 @@
 defined('_JEXEC') or die;
 
 /**
- * Function to build a Users URL route.
+ * Routing class from com_users
  *
- * @return  array  The array of query string values for which to build a route.
- * @return  array  The URL route with segments represented as an array.
- * @since    1.5
+ * @package     Joomla.Site
+ * @subpackage  com_users
+ * @since       3.2
  */
-function UsersBuildRoute(&$query)
+class UsersRouter implements JComponentRouter
 {
-	// Declare static variables.
-	static $items;
-	static $default;
-	static $registration;
-	static $profile;
-	static $login;
-	static $remind;
-	static $resend;
-	static $reset;
-
-	$segments = array();
-
-	// Get the relevant menu items if not loaded.
-	if (empty($items))
+	/**
+	 * Function to build a Users URL route.
+	 *
+	 * @return  array  The array of query string values for which to build a route.
+	 * @return  array  The URL route with segments represented as an array.
+	 * @since    1.5
+	 */
+	public function build(&$query)
 	{
-		// Get all relevant menu items.
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu();
-		$items = $menu->getItems('component', 'com_users');
+		// Declare static variables.
+		static $items;
+		static $default;
+		static $registration;
+		static $profile;
+		static $login;
+		static $remind;
+		static $resend;
+		static $reset;
 
-		// Build an array of serialized query strings to menu item id mappings.
-		for ($i = 0, $n = count($items); $i < $n; $i++)
+		$segments = array();
+
+		// Get the relevant menu items if not loaded.
+		if (empty($items))
 		{
-			// Check to see if we have found the resend menu item.
-			if (empty($resend) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'resend'))
+			// Get all relevant menu items.
+			$app = JFactory::getApplication();
+			$menu = $app->getMenu();
+			$items = $menu->getItems('component', 'com_users');
+
+			// Build an array of serialized query strings to menu item id mappings.
+			for ($i = 0, $n = count($items); $i < $n; $i++)
 			{
-				$resend = $items[$i]->id;
+				// Check to see if we have found the resend menu item.
+				if (empty($resend) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'resend'))
+				{
+					$resend = $items[$i]->id;
+				}
+
+				// Check to see if we have found the reset menu item.
+				if (empty($reset) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'reset'))
+				{
+					$reset = $items[$i]->id;
+				}
+
+				// Check to see if we have found the remind menu item.
+				if (empty($remind) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'remind'))
+				{
+					$remind = $items[$i]->id;
+				}
+
+				// Check to see if we have found the login menu item.
+				if (empty($login) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'login'))
+				{
+					$login = $items[$i]->id;
+				}
+
+				// Check to see if we have found the registration menu item.
+				if (empty($registration) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'registration'))
+				{
+					$registration = $items[$i]->id;
+				}
+
+				// Check to see if we have found the profile menu item.
+				if (empty($profile) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'profile'))
+				{
+					$profile = $items[$i]->id;
+				}
 			}
 
-			// Check to see if we have found the reset menu item.
-			if (empty($reset) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'reset'))
+			// Set the default menu item to use for com_users if possible.
+			if ($profile)
 			{
-				$reset = $items[$i]->id;
+				$default = $profile;
 			}
-
-			// Check to see if we have found the remind menu item.
-			if (empty($remind) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'remind'))
+			elseif ($registration)
 			{
-				$remind = $items[$i]->id;
+				$default = $registration;
 			}
-
-			// Check to see if we have found the login menu item.
-			if (empty($login) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'login'))
+			elseif ($login)
 			{
-				$login = $items[$i]->id;
-			}
-
-			// Check to see if we have found the registration menu item.
-			if (empty($registration) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'registration'))
-			{
-				$registration = $items[$i]->id;
-			}
-
-			// Check to see if we have found the profile menu item.
-			if (empty($profile) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'profile'))
-			{
-				$profile = $items[$i]->id;
+				$default = $login;
 			}
 		}
 
-		// Set the default menu item to use for com_users if possible.
-		if ($profile)
+		if (!empty($query['view']))
 		{
-			$default = $profile;
+			switch ($query['view'])
+			{
+				case 'reset':
+					if ($query['Itemid'] = $reset)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+					break;
+
+				case 'resend':
+					if ($query['Itemid'] = $resend)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+					break;
+
+				case 'remind':
+					if ($query['Itemid'] = $remind)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+					break;
+
+				case 'login':
+					if ($query['Itemid'] = $login)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+					break;
+
+				case 'registration':
+					if ($query['Itemid'] = $registration)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+					break;
+
+				default:
+				case 'profile':
+					if (!empty($query['view']))
+					{
+						$segments[] = $query['view'];
+					}
+					unset ($query['view']);
+					if ($query['Itemid'] = $profile)
+					{
+						unset ($query['view']);
+					}
+					else
+					{
+						$query['Itemid'] = $default;
+					}
+
+					// Only append the user id if not "me".
+					$user = JFactory::getUser();
+					if (!empty($query['user_id']) && ($query['user_id'] != $user->id))
+					{
+						$segments[] = $query['user_id'];
+					}
+					unset ($query['user_id']);
+
+					break;
+			}
 		}
-		elseif ($registration)
+
+		return $segments;
+	}
+
+	/**
+	 * Function to parse a Users URL route.
+	 *
+	 * @return  array  The URL route with segments represented as an array.
+	 * @return  array  The array of variables to set in the request.
+	 * @since    1.5
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
+
+		// Only run routine if there are segments to parse.
+		if (count($segments) < 1)
 		{
-			$default = $registration;
+			return;
 		}
-		elseif ($login)
-		{
-			$default = $login;
-		}
-	}
 
-	if (!empty($query['view']))
-	{
-		switch ($query['view'])
-		{
-			case 'reset':
-				if ($query['Itemid'] = $reset)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-				break;
+		// Get the package from the route segments.
+		$userId = array_pop($segments);
 
-			case 'resend':
-				if ($query['Itemid'] = $resend)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-				break;
-
-			case 'remind':
-				if ($query['Itemid'] = $remind)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-				break;
-
-			case 'login':
-				if ($query['Itemid'] = $login)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-				break;
-
-			case 'registration':
-				if ($query['Itemid'] = $registration)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-				break;
-
-			default:
-			case 'profile':
-				if (!empty($query['view']))
-				{
-					$segments[] = $query['view'];
-				}
-				unset ($query['view']);
-				if ($query['Itemid'] = $profile)
-				{
-					unset ($query['view']);
-				}
-				else
-				{
-					$query['Itemid'] = $default;
-				}
-
-				// Only append the user id if not "me".
-				$user = JFactory::getUser();
-				if (!empty($query['user_id']) && ($query['user_id'] != $user->id))
-				{
-					$segments[] = $query['user_id'];
-				}
-				unset ($query['user_id']);
-
-				break;
-		}
-	}
-
-	return $segments;
-}
-
-/**
- * Function to parse a Users URL route.
- *
- * @return  array  The URL route with segments represented as an array.
- * @return  array  The array of variables to set in the request.
- * @since    1.5
- */
-function UsersParseRoute($segments)
-{
-	$vars = array();
-
-	// Only run routine if there are segments to parse.
-	if (count($segments) < 1)
-	{
-		return;
-	}
-
-	// Get the package from the route segments.
-	$userId = array_pop($segments);
-
-	if (!is_numeric($userId))
-	{
-		$vars['view'] = 'profile';
-		return $vars;
-	}
-
-	if (is_numeric($userId))
-	{
-		// Get the package id from the packages table by alias.
-		$db = JFactory::getDbo();
-		$db->setQuery(
-			'SELECT ' . $db->quoteName('id') .
-				' FROM ' . $db->quoteName('#__users') .
-				' WHERE ' . $db->quoteName('id') . ' = ' . (int) $userId
-		);
-		$userId = $db->loadResult();
-	}
-
-	// Set the package id if present.
-	if ($userId)
-	{
-		// Set the package id.
-		$vars['user_id'] = (int) $userId;
-
-		// Set the view to package if not already set.
-		if (empty($vars['view']))
+		if (!is_numeric($userId))
 		{
 			$vars['view'] = 'profile';
+			return $vars;
 		}
-	}
-	else
-	{
-		JError::raiseError(404, JText::_('JGLOBAL_RESOURCE_NOT_FOUND'));
-	}
 
-	return $vars;
+		if (is_numeric($userId))
+		{
+			// Get the package id from the packages table by alias.
+			$db = JFactory::getDbo();
+			$db->setQuery(
+				'SELECT ' . $db->quoteName('id') .
+					' FROM ' . $db->quoteName('#__users') .
+					' WHERE ' . $db->quoteName('id') . ' = ' . (int) $userId
+			);
+			$userId = $db->loadResult();
+		}
+
+		// Set the package id if present.
+		if ($userId)
+		{
+			// Set the package id.
+			$vars['user_id'] = (int) $userId;
+
+			// Set the view to package if not already set.
+			if (empty($vars['view']))
+			{
+				$vars['view'] = 'profile';
+			}
+		}
+		else
+		{
+			JError::raiseError(404, JText::_('JGLOBAL_RESOURCE_NOT_FOUND'));
+		}
+
+		return $vars;
+	}
 }

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -10,220 +10,230 @@
 defined('_JEXEC') or die;
 
 /**
- * Build the route for the com_weblinks component
+ * Routing class from com_weblinks
  *
- * @return  array  An array of URL arguments
- *
- * @return  array  The URL arguments to use to assemble the subsequent URL.
+ * @package     Joomla.Site
+ * @subpackage  com_weblinks
+ * @since       3.2
  */
-function WeblinksBuildRoute(&$query)
+class WeblinksRouter implements JComponentRouter
 {
-	$segments = array();
-
-	// get a menu item based on Itemid or currently active
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$params = JComponentHelper::getParams('com_weblinks');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	// we need a menu item.  Either the one specified in the query, or the current active one if none specified
-	if (empty($query['Itemid']))
+	/**
+	 * Build the route for the com_weblinks component
+	 *
+	 * @return  array  An array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 */
+	public function build(&$query)
 	{
-		$menuItem = $menu->getActive();
-	}
-	else
-	{
-		$menuItem = $menu->getItem($query['Itemid']);
-	}
+		$segments = array();
 
-	$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
-	$mId = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
+		// get a menu item based on Itemid or currently active
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$params = JComponentHelper::getParams('com_weblinks');
+		$advanced = $params->get('sef_advanced_link', 0);
 
-	if (isset($query['view']))
-	{
-		$view = $query['view'];
-
-		if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_weblinks')
+		// we need a menu item.  Either the one specified in the query, or the current active one if none specified
+		if (empty($query['Itemid']))
 		{
-			$segments[] = $query['view'];
+			$menuItem = $menu->getActive();
+		}
+		else
+		{
+			$menuItem = $menu->getItem($query['Itemid']);
 		}
 
-		// We need to keep the view for forms since they never have their own menu item
-		if ($view != 'form')
+		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
+		$mId = (empty($menuItem->query['id'])) ? null : $menuItem->query['id'];
+
+		if (isset($query['view']))
+		{
+			$view = $query['view'];
+
+			if (empty($query['Itemid']) || empty($menuItem) || $menuItem->component != 'com_weblinks')
+			{
+				$segments[] = $query['view'];
+			}
+
+			// We need to keep the view for forms since they never have their own menu item
+			if ($view != 'form')
+			{
+				unset($query['view']);
+			}
+		}
+
+		// are we dealing with an weblink that is attached to a menu item?
+		if (isset($query['view']) && ($mView == $query['view']) and (isset($query['id'])) and ($mId == (int) $query['id']))
 		{
 			unset($query['view']);
-		}
-	}
+			unset($query['catid']);
+			unset($query['id']);
 
-	// are we dealing with an weblink that is attached to a menu item?
-	if (isset($query['view']) && ($mView == $query['view']) and (isset($query['id'])) and ($mId == (int) $query['id']))
-	{
-		unset($query['view']);
-		unset($query['catid']);
-		unset($query['id']);
+			return $segments;
+		}
+
+		if (isset($view) and ($view == 'category' or $view == 'weblink'))
+		{
+			if ($mId != (int) $query['id'] || $mView != $view)
+			{
+				if ($view == 'weblink' && isset($query['catid']))
+				{
+					$catid = $query['catid'];
+				}
+				elseif (isset($query['id']))
+				{
+					$catid = $query['id'];
+				}
+
+				$menuCatid = $mId;
+				$categories = JCategories::getInstance('Weblinks');
+				$category = $categories->get($catid);
+
+				if ($category)
+				{
+					//TODO Throw error that the category either not exists or is unpublished
+					$path = $category->getPath();
+					$path = array_reverse($path);
+
+					$array = array();
+					foreach ($path as $id)
+					{
+						if ((int) $id == (int) $menuCatid)
+						{
+							break;
+						}
+
+						if ($advanced)
+						{
+							list($tmp, $id) = explode(':', $id, 2);
+						}
+
+						$array[] = $id;
+					}
+					$segments = array_merge($segments, array_reverse($array));
+				}
+
+				if ($view == 'weblink')
+				{
+					if ($advanced)
+					{
+						list($tmp, $id) = explode(':', $query['id'], 2);
+					}
+					else
+					{
+						$id = $query['id'];
+					}
+
+					$segments[] = $id;
+				}
+			}
+
+			unset($query['id']);
+			unset($query['catid']);
+		}
+
+		if (isset($query['layout']))
+		{
+			if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
+			{
+				if ($query['layout'] == $menuItem->query['layout'])
+				{
+					unset($query['layout']);
+				}
+			}
+			else
+			{
+				if ($query['layout'] == 'default')
+				{
+					unset($query['layout']);
+				}
+			}
+		}
 
 		return $segments;
 	}
 
-	if (isset($view) and ($view == 'category' or $view == 'weblink'))
+	/**
+	 * Parse the segments of a URL.
+	 *
+	 * @return  array  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 */
+	public function parse(&$segments)
 	{
-		if ($mId != (int) $query['id'] || $mView != $view)
+		$vars = array();
+
+		//Get the active menu item.
+		$app = JFactory::getApplication();
+		$menu = $app->getMenu();
+		$item = $menu->getActive();
+		$params = JComponentHelper::getParams('com_weblinks');
+		$advanced = $params->get('sef_advanced_link', 0);
+
+		// Count route segments
+		$count = count($segments);
+
+		// Standard routing for weblinks.
+		if (!isset($item))
 		{
-			if ($view == 'weblink' && isset($query['catid']))
-			{
-				$catid = $query['catid'];
-			}
-			elseif (isset($query['id']))
-			{
-				$catid = $query['id'];
-			}
+			$vars['view'] = $segments[0];
+			$vars['id'] = $segments[$count - 1];
+			return $vars;
+		}
 
-			$menuCatid = $mId;
-			$categories = JCategories::getInstance('Weblinks');
-			$category = $categories->get($catid);
+		// From the categories view, we can only jump to a category.
+		$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
 
-			if ($category)
+		$category = JCategories::getInstance('Weblinks')->get($id);
+
+		$categories = $category->getChildren();
+		$found = 0;
+
+		foreach ($segments as $segment)
+		{
+			foreach ($categories as $category)
 			{
-				//TODO Throw error that the category either not exists or is unpublished
-				$path = $category->getPath();
-				$path = array_reverse($path);
-
-				$array = array();
-				foreach ($path as $id)
+				if (($category->slug == $segment) || ($advanced && $category->alias == str_replace(':', '-', $segment)))
 				{
-					if ((int) $id == (int) $menuCatid)
-					{
-						break;
-					}
+					$vars['id'] = $category->id;
+					$vars['view'] = 'category';
+					$categories = $category->getChildren();
+					$found = 1;
 
-					if ($advanced)
-					{
-						list($tmp, $id) = explode(':', $id, 2);
-					}
-
-					$array[] = $id;
+					break;
 				}
-				$segments = array_merge($segments, array_reverse($array));
 			}
 
-			if ($view == 'weblink')
+			if ($found == 0)
 			{
 				if ($advanced)
 				{
-					list($tmp, $id) = explode(':', $query['id'], 2);
+					$db = JFactory::getDbo();
+					$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from('#__weblinks')
+						->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
+						->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote(str_replace(':', '-', $segment))));
+					$db->setQuery($query);
+					$id = $db->loadResult();
 				}
 				else
 				{
-					$id = $query['id'];
+					$id = $segment;
 				}
 
-				$segments[] = $id;
-			}
-		}
-
-		unset($query['id']);
-		unset($query['catid']);
-	}
-
-	if (isset($query['layout']))
-	{
-		if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
-		{
-			if ($query['layout'] == $menuItem->query['layout'])
-			{
-				unset($query['layout']);
-			}
-		}
-		else
-		{
-			if ($query['layout'] == 'default')
-			{
-				unset($query['layout']);
-			}
-		}
-	}
-
-	return $segments;
-}
-
-/**
- * Parse the segments of a URL.
- *
- * @return  array  The segments of the URL to parse.
- *
- * @return  array  The URL attributes to be used by the application.
- */
-function WeblinksParseRoute($segments)
-{
-	$vars = array();
-
-	//Get the active menu item.
-	$app = JFactory::getApplication();
-	$menu = $app->getMenu();
-	$item = $menu->getActive();
-	$params = JComponentHelper::getParams('com_weblinks');
-	$advanced = $params->get('sef_advanced_link', 0);
-
-	// Count route segments
-	$count = count($segments);
-
-	// Standard routing for weblinks.
-	if (!isset($item))
-	{
-		$vars['view'] = $segments[0];
-		$vars['id'] = $segments[$count - 1];
-		return $vars;
-	}
-
-	// From the categories view, we can only jump to a category.
-	$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
-
-	$category = JCategories::getInstance('Weblinks')->get($id);
-
-	$categories = $category->getChildren();
-	$found = 0;
-
-	foreach ($segments as $segment)
-	{
-		foreach ($categories as $category)
-		{
-			if (($category->slug == $segment) || ($advanced && $category->alias == str_replace(':', '-', $segment)))
-			{
-				$vars['id'] = $category->id;
-				$vars['view'] = 'category';
-				$categories = $category->getChildren();
-				$found = 1;
+				$vars['id'] = $id;
+				$vars['view'] = 'weblink';
 
 				break;
 			}
+
+			$found = 0;
 		}
 
-		if ($found == 0)
-		{
-			if ($advanced)
-			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from('#__weblinks')
-					->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
-					->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote(str_replace(':', '-', $segment))));
-				$db->setQuery($query);
-				$id = $db->loadResult();
-			}
-			else
-			{
-				$id = $segment;
-			}
-
-			$vars['id'] = $id;
-			$vars['view'] = 'weblink';
-
-			break;
-		}
-
-		$found = 0;
+		return $vars;
 	}
-
-	return $vars;
 }

--- a/components/com_wrapper/router.php
+++ b/components/com_wrapper/router.php
@@ -10,30 +10,40 @@
 defined('_JEXEC') or die;
 
 /**
- * @param   array
- * @return  array
+ * Routing class from com_wrapper
+ *
+ * @package     Joomla.Site
+ * @subpackage  com_wrapper
+ * @since       3.2
  */
-function WrapperBuildRoute(&$query)
+class WrapperRouter implements JComponentRouter
 {
-	$segments = array();
-
-	if (isset($query['view']))
+	/**
+	 * @param   array
+	 * @return  array
+	 */
+	public function build(&$query)
 	{
-		unset($query['view']);
+		$segments = array();
+
+		if (isset($query['view']))
+		{
+			unset($query['view']);
+		}
+
+		return $segments;
 	}
 
-	return $segments;
-}
+	/**
+	 * @param   array
+	 * @return  array
+	 */
+	public function parse(&$segments)
+	{
+		$vars = array();
 
-/**
- * @param   array
- * @return  array
- */
-function WrapperParseRoute($segments)
-{
-	$vars = array();
+		$vars['view'] = 'wrapper';
 
-	$vars['view'] = 'wrapper';
-
-	return $vars;
+		return $vars;
+	}
 }

--- a/libraries/cms/component/router.php
+++ b/libraries/cms/component/router.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @version		$Id$
+ * @package		Joomla.Site
+ * @subpackage	Component.Router
+ * @copyright	Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access
+defined('JPATH_PLATFORM') or die;
+
+interface JComponentRouter {
+	/**
+	 * Build method for URLs
+	 * 
+	 * @param array $query Array of query elements
+	 * 
+	 * @return array Array of URL segments
+	 */
+	public function build(&$query);
+	
+	/**
+	 * Parse method for URLs
+	 * 
+	 * @param array $segments Array of URL string-segments
+	 * 
+	 * @return array Associative array of query values
+	 */
+	public function parse(&$segments);
+}

--- a/libraries/cms/component/router/legacy.php
+++ b/libraries/cms/component/router/legacy.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @version		$Id$
+ * @package		Joomla.Site
+ * @subpackage	Component.Router
+ * @copyright	Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Defaultrouter for missing or legacy component routers
+ *
+ * @since 2.5
+ */
+class JComponentRouterLegacy implements JComponentRouter
+{
+	/**
+	 * Name of the component
+	 * 
+	 * @var string
+	 */
+	protected $component;
+	
+	/**
+	 * Constructor of JDefaultRouter
+	 * 
+	 * @param string $component Componentname without the com_ prefix this router should react upon
+	 */
+	public function __construct($component)
+	{
+		$this->component = $component;
+	}
+	
+	/**
+	 * Generic build function for missing or legacy component router
+	 * 
+	 * @param array $query Query-elements of the URL
+	 * 
+	 * @return array Array of segments of the URL
+	 */
+	public function build(&$query)
+	{
+		$function = $this->component.'BuildRoute';
+		if(function_exists($function)) {
+			$segments = $function($query);
+			$total = count($segments);
+			for ($i=0; $i<$total; $i++) {
+				$segments[$i] = str_replace(':', '-', $segments[$i]);
+			}
+			return $segments;
+		}
+		return array();
+	}
+
+	/**
+	 * Generic parse function for missing or legacy component router
+	 * 
+	 * @param array $segments Array of URL segments to parse
+	 * 
+	 * @return array Array of query elements
+	 */
+	public function parse(&$segments)
+	{
+		$function = $this->component.'ParseRoute';
+		if(function_exists($function)) {
+			$total = count($segments);
+			for ($i=0; $i<$total; $i++)  {
+				$segments[$i] = preg_replace('/-/', ':', $segments[$i], 1);
+			}
+
+			return $function($segments);
+		}
+		return array();
+	}
+}

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -19,6 +19,14 @@ defined('JPATH_BASE') or die;
 class JRouterSite extends JRouter
 {
 	/**
+	 * Component-router objects
+	 * 
+	 * @var    array
+	 * @since  3.2
+	 */
+	protected $componentRouters = array();
+	
+	/**
 	 * Function to convert a route to an internal URI
 	 *
 	 * @param   JUri  &$uri  The uri.
@@ -352,10 +360,7 @@ class JRouterSite extends JRouter
 			// Handle component	route
 			$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $this->_vars['option']);
 
-			// Use the component routing handler if it exists
-			$path = JPATH_SITE . '/components/' . $component . '/router.php';
-
-			if (file_exists($path) && count($segments))
+			if (count($segments))
 			{
 				// Cheap fix on searches
 				if ($component != 'com_search')
@@ -375,10 +380,8 @@ class JRouterSite extends JRouter
 					}
 				}
 
-				require_once $path;
-				$function = substr($component, 4) . 'ParseRoute';
-				$function = str_replace(array("-", "."), "", $function);
-				$vars = $function($segments);
+				$crouter = $this->getComponentRouter($component);
+				$vars = $crouter->parse($segments);
 
 				$this->setVars($vars);
 			}
@@ -439,39 +442,31 @@ class JRouterSite extends JRouter
 		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
 		$tmp       = '';
 		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
+		
+		$crouter = $this->getComponentRouter($component);
+		
+		$parts = $crouter->build($query);
 
-		// Use the component routing handler if it exists
-		$path = JPATH_SITE . '/components/' . $component . '/router.php';
-
-		// Use the custom routing handler if it exists
-		if (file_exists($path) && !empty($query))
+		// Encode the route segments
+		if ($component != 'com_search')
 		{
-			require_once $path;
-			$function = substr($component, 4) . 'BuildRoute';
-			$function = str_replace(array("-", "."), "", $function);
-			$parts    = $function($query);
-
-			// Encode the route segments
-			if ($component != 'com_search')
-			{
-				// Cheep fix on searches
-				$parts = $this->encodeSegments($parts);
-			}
-			else
-			{
-				// Fix up search for URL
-				$total = count($parts);
-
-				for ($i = 0; $i < $total; $i++)
-				{
-					// Urlencode twice because it is decoded once after redirect
-					$parts[$i] = urlencode(urlencode(stripcslashes($parts[$i])));
-				}
-			}
-
-			$result = implode('/', $parts);
-			$tmp    = ($result != "") ? $result : '';
+			// Cheep fix on searches
+			$parts = $this->encodeSegments($parts);
 		}
+		else
+		{
+			// Fix up search for URL
+			$total = count($parts);
+
+			for ($i = 0; $i < $total; $i++)
+			{
+				// Urlencode twice because it is decoded once after redirect
+				$parts[$i] = urlencode(urlencode(stripcslashes($parts[$i])));
+			}
+		}
+
+		$result = implode('/', $parts);
+		$tmp    = ($result != "") ? $result : '';
 
 		// Build the application route
 		$built = false;
@@ -654,5 +649,63 @@ class JRouterSite extends JRouter
 		}
 
 		return $uri;
+	}
+	
+	/**
+	 * Get component router
+	 * 
+	 * @param   string $component Name of the component including com_ prefix
+	 * 
+	 * @return  object The router of the component
+	 * 
+	 * @since   3.2
+	 */
+	public function getComponentRouter($component)
+	{
+		if(!isset($this->componentRouters[$component])) {
+			$compname = ucfirst(substr($component, 4));
+			if(!class_exists($compname.'Router')) {
+				// Use the component routing handler if it exists
+				$path = JPATH_SITE.'/components/'.$component.'/router.php';
+
+				// Use the custom routing handler if it exists
+				if (file_exists($path)) {
+					require_once $path;
+				}
+			}
+			$name = $compname.'Router';
+			if(class_exists($name)) {
+				$reflection = new ReflectionClass($name);
+				if(in_array('JComponentRouter', $reflection->getInterfaceNames())) {
+					$this->componentRouters[$component] = new $name();
+				}
+			}
+			if(!isset($this->componentRouters[$component])) {
+				$this->componentRouters[$component] = new JComponentRouterLegacy($compname);
+			}
+		}
+
+		return $this->componentRouters[$component];
+	}
+
+	/**
+	 * Set a router for a component
+	 * 
+	 * @param   string $component Componentname with com_ prefix
+	 * @param   object $router Componentrouter
+	 * 
+	 * @return  boolean True if the router was accepted, false if not
+	 * 
+	 * @since   3.2
+	 */
+	public function setComponentRouter($component, $router)
+	{
+		$reflection = new ReflectionClass($router);
+		if(in_array('JComponentRouter', $reflection->getInterfaceNames())) {
+			$this->componentRouters[$component] = $router;
+			return true;
+		} else {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
This implements classes for the component routers. Up till now the routers were based on two functions that the component had to provide, now a component should provide one class which extends from the JComponentRouter interface and provides the two methods build() and parse(). The benefit is, that developers now can extend from a base class and thus abstract some of the code out into those base classes. In a future PR, we can then implement a generic base class, which does most of the heavy lifting for the component routing.

Component developers now must simply wrap their routers in a class named <Componetname>Router, which implements the interface JComponentRouter. They can provide fallback functions that create an instance of that class and execute the build() or parse method. The code could look like this:

```
class ExampleRouter implements JComponentRouter
{
     public function build(&$query) {...}
     public function parse(&$segments){...}
}

function ExampleBuildRoute(&$query) {$router = new ExampleRouter; return $router->build($query);}
function ExampleParseRoute($segments) {$router = new ExampleRouter; return $router->parse($segments);}
```

That way, components can handle both the old and the new routers.

For legacy or missing routers, we have the JComponentRouterLegacy class, which wraps those old routers or provides an empty router in case the component does not provide one.
