### PR TITLE
Content items have to be deletable even when their asset entry is missing

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -973,12 +973,6 @@ abstract class JTable extends JObject implements JObservableInterface
 					return false;
 				}
 			}
-			else
-			{
-				$this->setError($asset->getError());
-
-				return false;
-			}
 		}
 
 		// Delete the row by primary key.


### PR DESCRIPTION
This is related to this tracker item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32615&start=0

This commit removes the need to have an asset table entry to delete an item. If the item has no asset entry, it can still be deleted, there is no reason to abort it in that case.
