### PR TITLE
Making Finder plugins language aware

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -291,7 +291,7 @@ class PlgFinderCategories extends FinderIndexerAdapter
 		$class = $extension . 'HelperRoute';
 		if (class_exists($class) && method_exists($class, 'getCategoryRoute'))
 		{
-			$item->route = $class::getCategoryRoute($item->id);
+			$item->route = $class::getCategoryRoute($item->id, $item->language);
 		}
 		else
 		{

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -265,7 +265,7 @@ class PlgFinderContacts extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = ContactHelperRoute::getContactRoute($item->slug, $item->catslug);
+		$item->route = ContactHelperRoute::getContactRoute($item->slug, $item->catslug, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		// Get the menu title if it exists.

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -263,7 +263,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug);
+		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		// Get the menu title if it exists.

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -267,7 +267,7 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = NewsfeedsHelperRoute::getNewsfeedRoute($item->slug, $item->catslug);
+		$item->route = NewsfeedsHelperRoute::getNewsfeedRoute($item->slug, $item->catslug, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		/*

--- a/plugins/finder/weblinks/weblinks.php
+++ b/plugins/finder/weblinks/weblinks.php
@@ -259,7 +259,7 @@ class PlgFinderWeblinks extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = WeblinksHelperRoute::getWeblinkRoute($item->slug, $item->catslug);
+		$item->route = WeblinksHelperRoute::getWeblinkRoute($item->slug, $item->catslug, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		/*


### PR DESCRIPTION
com_finder currently does not take the language of an item into consideration when generating the URL for it and thus sometimes generates broken URLs. This patch adds the right parameter into the *HelperRoute calls.
