### PR TITLE
Error 404 when leaving K2 config box

### DIFF
--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -29,7 +29,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	{
 		$this->context = 'com_config.config.global';
 
-		$this->component = $this->input->getCmd();
+		$this->component = $this->input->getcmd('component');
 
 		$this->redirect = 'index.php?option=' . $this->component;
 

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -29,7 +29,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	{
 		$this->context = 'com_config.config.global';
 
-		$this->component = $this->input->getWord('component');
+		$this->component = $this->input->getVar('component');
 
 		$this->redirect = 'index.php?option=' . $this->component;
 

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -29,7 +29,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	{
 		$this->context = 'com_config.config.global';
 
-		$this->component = $this->input->getVar('component');
+		$this->component = $this->input->getCmd();
 
 		$this->redirect = 'index.php?option=' . $this->component;
 

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -29,7 +29,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	{
 		$this->context = 'com_config.config.global';
 
-		$this->component = $this->input->getcmd('component');
+		$this->component = $this->input->get('component');
 
 		$this->redirect = 'index.php?option=' . $this->component;
 


### PR DESCRIPTION
The function getWord deletes all digits from the variable and it is a problem for some components like k2 (ex : index.php?option=com_k).
