### PR TITLE
Corrected links in Contacts > List All Contact Categories

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -83,7 +83,7 @@ abstract class ContactHelperRoute
 
 			if ($item = self::_findItem($needles))
 			{
-				$link = 'index.php?Itemid='.$item;
+				$link .= '&Itemid='.$item;
 			}
 		}
 


### PR DESCRIPTION
The links generated in view categories of component com_contact link to the current page. The changed line removed all computed parameters in the link
