### PR TITLE
The changing password process does not working

### DIFF
--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -171,10 +171,25 @@ class UsersModelReset extends JModelForm
 			return false;
 		}
 
+		// The Joomla user plugin allows you to use weaker passwords if necessary.
+		$joomlaPluginEnabled = JPluginHelper::isEnabled('user', 'joomla');
+
+		if ($joomlaPluginEnabled)
+		{
+			$userPlugin = JPluginHelper::getPlugin('user', 'joomla');
+			$userPluginParams = new JRegistry($userPlugin->params);
+			JPluginHelper::importPlugin('user', 'joomla');
+			$defaultEncryption = PlgUserJoomla::setDefaultEncryption($userPluginParams);
+		}
+		else
+		{
+			$defaultEncryption = 'bcrypt';
+		}
+		
 		// Generate the new password hash.
 		$salt = JUserHelper::genRandomPassword(32);
-		$crypted = JUserHelper::getCryptedPassword($data['password1'], $salt);
-		$password = $crypted . ':' . $salt;
+		$crypted = JUserHelper::getCryptedPassword($data['password1'], $salt, $defaultEncryption);
+		$password = (strpos($crypted, ':') > 0) ? $crypted : $crypted . ':' .$salt;
 
 		// Update the user object.
 		$user->password = $password;


### PR DESCRIPTION
The getCryptedPassword gives the salt value in the result if the encryption is sha256 or if the encryption is bcrypt (default value) and the use of strong encryption is set.

So in the processResetComplete function, if the code is :

$password = $crypted . ':' . $salt;

The salt value is set a second time when the encryption is sha256 or bcrypt and the user cannot connect with his new password. A simple solution is replace the line above by this line :

$password = (strpos($crypted, ':') > 0) ? $crypted : $crypted . ':' .$salt;

The processResetComplete function should be also set de the encryption param for the getCryptedPassword function.
