### PR TITLE
application mocks with fixed class names

### DIFF
--- a/tests/unit/core/mock/application/base.php
+++ b/tests/unit/core/mock/application/base.php
@@ -12,7 +12,7 @@
  * @package  Joomla.Test
  * @since    12.1
  */
-class TestMockApplicationWeb
+class TestMockApplicationBase
 {
 	/**
 	 * Creates and instance of the mock JApplicationBase object.

--- a/tests/unit/core/mock/application/cms.php
+++ b/tests/unit/core/mock/application/cms.php
@@ -59,6 +59,7 @@ class TestMockApplicationCms extends TestMockApplicationWeb
 			'getSession',
 			'getTemplate',
 			'initialiseApp',
+			'isAdmin',
 			'loadConfiguration',
 			'loadDispatcher',
 			'loadDocument',

--- a/tests/unit/core/mock/application/web.php
+++ b/tests/unit/core/mock/application/web.php
@@ -12,7 +12,7 @@
  * @package  Joomla.Test
  * @since    12.1
  */
-class TestMockApplicationWeb
+class TestMockApplicationWeb extends TestMockApplicationBase
 {
 	/**
 	 * Mock storage for the response body.


### PR DESCRIPTION
This fixes some class names of mock classes and adds a mocked method 'isAdmin' to the JApplicationCms mock.

A joomlacode tracker item has been added at http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32747&start=0
