### PR TITLE
Fixing notice in mod_breadcrumbs with multi-lang

### DIFF
--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -40,7 +40,7 @@ class ModBreadCrumbsHelper
 		{
 			$item = new stdClass;
 			$item->name = htmlspecialchars($params->get('homeText', JText::_('MOD_BREADCRUMBS_HOME')));
-			$item->link = JRoute::_('index.php?Itemid=' . $app->getMenu()->getDefault()->id);
+			$item->link = JRoute::_('index.php?Itemid=' . $app->getMenu()->getDefault(JFactory::getLanguage()->getTag())->id);
 			array_unshift($crumbs, $item);
 		}
 


### PR DESCRIPTION
This fixes a notice that is thrown in mod_breadcrumbs when we have a multi-language site without a default menu item for the language "All".
