### PR TITLE
Removing call to ModulesHelper from formfield ChromeStyle

### DIFF
--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -76,7 +76,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 		$moduleStyles = array();
 
 		$templates = array($this->getSystemTemplate());
-		$templates = array_merge($templates, ModulesHelper::getTemplates('site'));
+		$templates = array_merge($templates, $this->getTemplates());
 
 		foreach ($templates as $template)
 		{
@@ -117,4 +117,31 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 
 		return $template;
 	}
+
+	/**
+	 * Return a list of templates
+	 *
+	 * @return  array  List of templates
+	 *
+	 * @since   3.2.1
+	 */
+	protected function getTemplates()
+	{
+		$db = JFactory::getDbo();
+
+		// Get the database object and a new query object.
+		$query	= $db->getQuery(true);
+
+		// Build the query.
+		$query->select('element, name, enabled')
+			->from('#__extensions')
+			->where('client_id = 0')
+			->where('type = ' . $db->quote('template'));
+
+		// Set the query and load the templates.
+		$db->setQuery($query);
+		$templates = $db->loadObjectList('element');
+		return $templates;
+	}
+
 }


### PR DESCRIPTION
Currently the formfield `ChromeStyle` can only be used in the context of `com_modules` because it depends on the class `ModulesHelper` to fetch the installed templates.
If used outside of com_modules it results in a fatal error because the class isn't autoloaded.

This PR simply removes that call and does the database lookup in the formfield itself.

To test this you can change an existing form to use this formfield and see if it shows the list of available module chromstyles.
