### PR TITLE
helpsite url can't be localised at install time

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -446,10 +446,24 @@ final class InstallationApplicationWeb extends JApplicationCms
 			$options['language'] = 'en-GB';
 		}
 
+		// Check for custom helpurl
+		if (empty($forced['helpurl']))
+		{
+			$options['helpurl'] = 'http://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}';
+		}
+		else
+		{
+			$options['helpurl'] = $forced['helpurl'];
+		}
+
+		// Store helpurl in the session
+		$this->getSession()->set('setup.helpurl', $options['helpurl']);
+
 		// Set the language in the class
 		$this->config->set('language', $options['language']);
 		$this->config->set('debug_lang', $forced['debug']);
 		$this->config->set('sampledata', $forced['sampledata']);
+		$this->config->set('helpurl', $options['helpurl']);
 	}
 
 	/**

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -89,7 +89,7 @@ class InstallationModelConfiguration extends JModelBase
 		$registry->set('secret', JUserHelper::genRandomPassword(16));
 		$registry->set('gzip', 0);
 		$registry->set('error_reporting', 'default');
-		$registry->set('helpurl', 'http://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}');
+		$registry->set('helpurl', $options->helpurl);
 		$registry->set('ftp_host', isset($options->ftp_host) ? $options->ftp_host : '');
 		$registry->set('ftp_port', isset($options->ftp_host) ? $options->ftp_port : '');
 		$registry->set('ftp_user', (isset($options->ftp_save) && $options->ftp_save && isset($options->ftp_user)) ? $options->ftp_user : '');

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -54,6 +54,8 @@ class InstallationModelSetup extends JModelBase
 			$options['language'] = JFactory::getLanguage()->getTag();
 		}
 
+		$options['helpurl'] = $session->get('setup.helpurl', null);
+
 		// Merge the new setup options into the current ones and store in the session.
 		$options = array_merge($old, (array) $options);
 		$session->set('setup.options', $options);


### PR DESCRIPTION
Localised distributions can use the localise.xml file to force a default helpsite for new installs. This has been broken since 1.6.

To test: patch and add this url in installation/localise.xml, then install a clean Joomla

```
<helpurl>http://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}</helpurl>
```

If none set the joomla.org en-GB one will be used
