### PR TITLE
Fixing tags formfield when editing an item with the same id as an assigned tag

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -129,15 +129,6 @@ class JFormFieldTag extends JFormFieldList
 			$query->where('a.id IN (' . implode(',', $values) . ')');
 		}
 
-		// Block the possibility to set a tag as it own parent
-		$id   = (int) $this->form->getValue('id', 0);
-		$name = (int) $this->form->getValue('name', '');
-
-		if ($name == 'com_tags.tag')
-		{
-			$query->where('a.id != ' . $db->quote($id));
-		}
-
 		// Filter language
 		if (!empty($this->element['language']))
 		{
@@ -170,6 +161,19 @@ class JFormFieldTag extends JFormFieldList
 		catch (RuntimeException $e)
 		{
 			return false;
+		}
+
+		// Block the possibility to set a tag as it own parent
+		if ($this->form->getName() == 'com_tags.tag')
+		{
+			$id   = (int) $this->form->getValue('id', 0);
+			foreach ($options as $option)
+			{
+				if ($option->value == $id)
+				{
+					$option->disable = true;
+				}
+			}
 		}
 
 		// Merge any additional options in the XML definition.


### PR DESCRIPTION
## Introduction

Currently when you assign a tag to an item with the same id as the tag, the tag will be correctly assigned, but the formfield will not show it.
This is due to an incorrect check in the formfield which is supposed to block the currently edited tag from being selected as its parent tag. The check currently uses a wrong call to get the name of the form, and then casts the result to int which results in the check returning true always. Thus removing the currently edited `id` from the tags list even if we are not editing a tag but an article or anything.
## Test instructions
1. Edit an article and assign a tag with the same id. After saving the tag will not show up anymore in the field. In an installation with default testing sample data this would be for example the article `Articles Category Module` with the `Green` tag assigned.
2. Apply PR
3. Verify in the article that the tag will now show
4. Verify in the tag edit form that the tag will still either not be shown or shown greyed out as a disabled option
## What this PR does
- Changing `(int) $this->form->getValue('name', '');` to `$this->form->getName();` to correctly get the name of the form
- Changing from excluding the `$id` from the query to disable the option in the list. Currently there will be no difference at all as chosen does not show disabled options. However if chosen is disabled, or when we update chosen (see https://github.com/joomla/joomla-cms/pull/2228) it will be shown as greyed out option instead. It will still not be possible to select it but it will show. This will be helpful especially if the tag is already a parent of a nother tag, as the tree structure will be correct. You can see that when you look at the `Green` tag in the sample testing data which has a child `Lime`. If you edit the `Green` tag, it currently looks as if `Lime` is a child of `Yellow` instead.
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32779
