### PR TITLE
Missing required second argument in array_diff

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -251,7 +251,7 @@ class JComponentHelper
 				// Remove white listed attributes from filter's default blacklist
 				if ($whiteListAttributes)
 				{
-					$filter->attrBlacklist = array_diff($filter->attrBlacklist);
+					$filter->attrBlacklist = array_diff($filter->attrBlacklist, $blackListAttributes);
 				}
 			}
 			// White lists take third precedence.


### PR DESCRIPTION
The $whiteListAttributes variable is missing on the comparison function.
