### PR TITLE
Joomla! Update fails on hosts with an unwritable logs directory

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -31,7 +31,15 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
 		$user = JFactory::getUser();
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, JVERSION), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, JVERSION), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
+
 
 		$this->_applyCredentials();
 
@@ -45,7 +53,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			JFactory::getApplication()->setUserState('com_joomlaupdate.file', $file);
 			$url = 'index.php?option=com_joomlaupdate&task=update.install';
-			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $file), JLog::INFO, 'Update');
+			try
+			{
+				JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $file), JLog::INFO, 'Update');
+			}
+			catch (Exception $e)
+			{
+				// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+			}
 		}
 		else
 		{
@@ -69,7 +84,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_INSTALL'), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_INSTALL'), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
 
 		$this->_applyCredentials();
 
@@ -93,7 +115,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
 		$this->_applyCredentials();
 
 		$model = $this->getModel('Default');
@@ -116,7 +145,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
 		$this->_applyCredentials();
 
 		$model = $this->getModel('Default');
@@ -125,7 +161,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		$url = 'index.php?option=com_joomlaupdate&layout=complete';
 		$this->setRedirect($url);
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -284,7 +284,14 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	protected function downloadPackage($url, $target)
 	{
 		JLoader::import('helpers.download', JPATH_COMPONENT_ADMINISTRATOR);
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $packageURL), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $packageURL), JLog::INFO, 'Update');
+		}
+		catch (Exception $e)
+		{
+			// Do nothing; the logs directory is probably not writeable (usually Plesk-based hosts)
+		}
 		$result = AdmintoolsHelperDownload::download($url, $target);
 
 		if (!$result)

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -2059,6 +2059,7 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 	 */
 	public function isIgnoredDirectory($shortFilename)
 	{
+		return false;
 		if (substr($shortFilename, -1) == '/')
 		{
 			$check = substr($shortFilename, 0, -1);
@@ -2796,12 +2797,677 @@ class AKPostprocFTP extends AKAbstractPostproc
  */
 
 /**
- * ZIP archive extraction class - The all-in-one approach
+ * JPA archive extraction class
  */
-class AKUnarchiverZIP extends AKAbstractUnarchiver
+class AKUnarchiverJPA extends AKAbstractUnarchiver
 {
 	private $archiveHeaderData = array();
 
+	protected function readArchiveHeader()
+	{
+		debugMsg('Preparing to read archive header');
+		// Initialize header data array
+		$this->archiveHeaderData = new stdClass();
+
+		// Open the first part
+		debugMsg('Opening the first part');
+		$this->nextFile();
+
+		// Fail for unreadable files
+		if( $this->fp === false ) {
+			debugMsg('Could not open the first part');
+			return false;
+		}
+
+		// Read the signature
+		$sig = fread( $this->fp, 3 );
+
+		if ($sig != 'JPA')
+		{
+			// Not a JPA file
+			debugMsg('Invalid archive signature');
+			$this->setError( AKText::_('ERR_NOT_A_JPA_FILE') );
+			return false;
+		}
+
+		// Read and parse header length
+		$header_length_array = unpack( 'v', fread( $this->fp, 2 ) );
+		$header_length = $header_length_array[1];
+
+		// Read and parse the known portion of header data (14 bytes)
+		$bin_data = fread($this->fp, 14);
+		$header_data = unpack('Cmajor/Cminor/Vcount/Vuncsize/Vcsize', $bin_data);
+
+		// Load any remaining header data (forward compatibility)
+		$rest_length = $header_length - 19;
+		if( $rest_length > 0 )
+			$junk = fread($this->fp, $rest_length);
+		else
+			$junk = '';
+
+		// Temporary array with all the data we read
+		$temp = array(
+			'signature' => 			$sig,
+			'length' => 			$header_length,
+			'major' => 				$header_data['major'],
+			'minor' => 				$header_data['minor'],
+			'filecount' => 			$header_data['count'],
+			'uncompressedsize' => 	$header_data['uncsize'],
+			'compressedsize' => 	$header_data['csize'],
+			'unknowndata' => 		$junk
+		);
+		// Array-to-object conversion
+		foreach($temp as $key => $value)
+		{
+			$this->archiveHeaderData->{$key} = $value;
+		}
+
+		debugMsg('Header data:');
+		debugMsg('Length              : '.$header_length);
+		debugMsg('Major               : '.$header_data['major']);
+		debugMsg('Minor               : '.$header_data['minor']);
+		debugMsg('File count          : '.$header_data['count']);
+		debugMsg('Uncompressed size   : '.$header_data['uncsize']);
+		debugMsg('Compressed size	  : '.$header_data['csize']);
+
+		$this->currentPartOffset = @ftell($this->fp);
+
+		$this->dataReadLength = 0;
+
+		return true;
+	}
+
+	/**
+	 * Concrete classes must use this method to read the file header
+	 * @return bool True if reading the file was successful, false if an error occured or we reached end of archive
+	 */
+	protected function readFileHeader()
+	{
+		// If the current part is over, proceed to the next part please
+		if( $this->isEOF(true) ) {
+			debugMsg('Archive part EOF; moving to next file');
+			$this->nextFile();
+		}
+
+		debugMsg('Reading file signature');
+		// Get and decode Entity Description Block
+		$signature = fread($this->fp, 3);
+
+		$this->fileHeader = new stdClass();
+		$this->fileHeader->timestamp = 0;
+
+		// Check signature
+		if( $signature != 'JPF' )
+		{
+			if($this->isEOF(true))
+			{
+				// This file is finished; make sure it's the last one
+				$this->nextFile();
+				if(!$this->isEOF(false))
+				{
+					debugMsg('Invalid file signature before end of archive encountered');
+					$this->setError(AKText::sprintf('INVALID_FILE_HEADER', $this->currentPartNumber, $this->currentPartOffset));
+					return false;
+				}
+				// We're just finished
+				return false;
+			}
+			else
+			{
+				$screwed = true;
+				if(AKFactory::get('kickstart.setup.ignoreerrors', false)) {
+					debugMsg('Invalid file block signature; launching heuristic file block signature scanner');
+					$screwed = !$this->heuristicFileHeaderLocator();
+					if(!$screwed) {
+						$signature = 'JPF';
+					} else {
+						debugMsg('Heuristics failed. Brace yourself for the imminent crash.');
+					}
+				}
+				if($screwed) {
+					debugMsg('Invalid file block signature');
+					// This is not a file block! The archive is corrupt.
+					$this->setError(AKText::sprintf('INVALID_FILE_HEADER', $this->currentPartNumber, $this->currentPartOffset));
+					return false;
+				}
+			}
+		}
+		// This a JPA Entity Block. Process the header.
+
+		$isBannedFile = false;
+
+		// Read length of EDB and of the Entity Path Data
+		$length_array = unpack('vblocksize/vpathsize', fread($this->fp, 4));
+		// Read the path data
+		if($length_array['pathsize'] > 0) {
+			$file = fread( $this->fp, $length_array['pathsize'] );
+		} else {
+			$file = '';
+		}
+
+		// Handle file renaming
+		$isRenamed = false;
+		if(is_array($this->renameFiles) && (count($this->renameFiles) > 0) )
+		{
+			if(array_key_exists($file, $this->renameFiles))
+			{
+				$file = $this->renameFiles[$file];
+				$isRenamed = true;
+			}
+		}
+
+		// Handle directory renaming
+		$isDirRenamed = false;
+		if(is_array($this->renameDirs) && (count($this->renameDirs) > 0)) {
+			if(array_key_exists(dirname($file), $this->renameDirs)) {
+				$file = rtrim($this->renameDirs[dirname($file)],'/').'/'.basename($file);
+				$isRenamed = true;
+				$isDirRenamed = true;
+			}
+		}
+
+		// Read and parse the known data portion
+		$bin_data = fread( $this->fp, 14 );
+		$header_data = unpack('Ctype/Ccompression/Vcompsize/Vuncompsize/Vperms', $bin_data);
+		// Read any unknown data
+		$restBytes = $length_array['blocksize'] - (21 + $length_array['pathsize']);
+		if( $restBytes > 0 )
+		{
+			// Start reading the extra fields
+			while($restBytes >= 4)
+			{
+				$extra_header_data = fread($this->fp, 4);
+				$extra_header = unpack('vsignature/vlength', $extra_header_data);
+				$restBytes -= 4;
+				$extra_header['length'] -= 4;
+				switch($extra_header['signature'])
+				{
+					case 256:
+						// File modified timestamp
+						if($extra_header['length'] > 0)
+						{
+							$bindata = fread($this->fp, $extra_header['length']);
+							$restBytes -= $extra_header['length'];
+							$timestamps = unpack('Vmodified', substr($bindata,0,4));
+							$filectime = $timestamps['modified'];
+							$this->fileHeader->timestamp = $filectime;
+						}
+						break;
+
+					default:
+						// Unknown field
+						if($extra_header['length']>0) {
+							$junk = fread($this->fp, $extra_header['length']);
+							$restBytes -= $extra_header['length'];
+						}
+						break;
+				}
+			}
+			if($restBytes > 0) $junk = fread($this->fp, $restBytes);
+		}
+
+		$compressionType = $header_data['compression'];
+
+		// Populate the return array
+		$this->fileHeader->file = $file;
+		$this->fileHeader->compressed = $header_data['compsize'];
+		$this->fileHeader->uncompressed = $header_data['uncompsize'];
+		switch($header_data['type'])
+		{
+			case 0:
+				$this->fileHeader->type = 'dir';
+				break;
+
+			case 1:
+				$this->fileHeader->type = 'file';
+				break;
+
+			case 2:
+				$this->fileHeader->type = 'link';
+				break;
+		}
+		switch( $compressionType )
+		{
+			case 0:
+				$this->fileHeader->compression = 'none';
+				break;
+			case 1:
+				$this->fileHeader->compression = 'gzip';
+				break;
+			case 2:
+				$this->fileHeader->compression = 'bzip2';
+				break;
+		}
+		$this->fileHeader->permissions = $header_data['perms'];
+
+		// Find hard-coded banned files
+		if( (basename($this->fileHeader->file) == ".") || (basename($this->fileHeader->file) == "..") )
+		{
+			$isBannedFile = true;
+		}
+
+		// Also try to find banned files passed in class configuration
+		if((count($this->skipFiles) > 0) && (!$isRenamed) )
+		{
+			if(in_array($this->fileHeader->file, $this->skipFiles))
+			{
+				$isBannedFile = true;
+			}
+		}
+
+		// If we have a banned file, let's skip it
+		if($isBannedFile)
+		{
+			debugMsg('Skipping file '.$this->fileHeader->file);
+			// Advance the file pointer, skipping exactly the size of the compressed data
+			$seekleft = $this->fileHeader->compressed;
+			while($seekleft > 0)
+			{
+				// Ensure that we can seek past archive part boundaries
+				$curSize = @filesize($this->archiveList[$this->currentPartNumber]);
+				$curPos = @ftell($this->fp);
+				$canSeek = $curSize - $curPos;
+				if($canSeek > $seekleft) $canSeek = $seekleft;
+				@fseek( $this->fp, $canSeek, SEEK_CUR );
+				$seekleft -= $canSeek;
+				if($seekleft) $this->nextFile();
+			}
+
+			$this->currentPartOffset = @ftell($this->fp);
+			$this->runState = AK_STATE_DONE;
+			return true;
+		}
+
+		// Last chance to prepend a path to the filename
+		if(!empty($this->addPath) && !$isDirRenamed)
+		{
+			$this->fileHeader->file = $this->addPath.$this->fileHeader->file;
+		}
+
+		// Get the translated path name
+		$restorePerms = AKFactory::get('kickstart.setup.restoreperms', false);
+		if($this->fileHeader->type == 'file')
+		{
+			// Regular file; ask the postproc engine to process its filename
+			if($restorePerms)
+			{
+				$this->fileHeader->realFile = $this->postProcEngine->processFilename( $this->fileHeader->file, $this->fileHeader->permissions );
+			}
+			else
+			{
+				$this->fileHeader->realFile = $this->postProcEngine->processFilename( $this->fileHeader->file );
+			}
+		}
+		elseif($this->fileHeader->type == 'dir')
+		{
+			$dir = $this->fileHeader->file;
+
+			// Directory; just create it
+			if($restorePerms)
+			{
+				$this->postProcEngine->createDirRecursive( $this->fileHeader->file, $this->fileHeader->permissions );
+			}
+			else
+			{
+				$this->postProcEngine->createDirRecursive( $this->fileHeader->file, 0755 );
+			}
+			$this->postProcEngine->processFilename(null);
+		}
+		else
+		{
+			// Symlink; do not post-process
+			$this->postProcEngine->processFilename(null);
+		}
+
+		$this->createDirectory();
+
+		// Header is read
+		$this->runState = AK_STATE_HEADER;
+
+		$this->dataReadLength = 0;
+
+		return true;
+	}
+
+	/**
+	 * Concrete classes must use this method to process file data. It must set $runState to AK_STATE_DATAREAD when
+	 * it's finished processing the file data.
+	 * @return bool True if processing the file data was successful, false if an error occured
+	 */
+	protected function processFileData()
+	{
+		switch( $this->fileHeader->type )
+		{
+			case 'dir':
+				return $this->processTypeDir();
+				break;
+
+			case 'link':
+				return $this->processTypeLink();
+				break;
+
+			case 'file':
+				switch($this->fileHeader->compression)
+				{
+					case 'none':
+						return $this->processTypeFileUncompressed();
+						break;
+
+					case 'gzip':
+					case 'bzip2':
+						return $this->processTypeFileCompressedSimple();
+						break;
+
+				}
+				break;
+
+			default:
+				debugMsg('Unknown file type '.$this->fileHeader->type);
+				break;
+		}
+	}
+
+	private function processTypeFileUncompressed()
+	{
+		// Uncompressed files are being processed in small chunks, to avoid timeouts
+		if( ($this->dataReadLength == 0) && !AKFactory::get('kickstart.setup.dryrun','0') )
+		{
+			// Before processing file data, ensure permissions are adequate
+			$this->setCorrectPermissions( $this->fileHeader->file );
+		}
+
+		// Open the output file
+		if( !AKFactory::get('kickstart.setup.dryrun','0') )
+		{
+			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($this->fileHeader->file);
+			if ($this->dataReadLength == 0) {
+				$outfp = @fopen( $this->fileHeader->realFile, 'wb' );
+			} else {
+				$outfp = @fopen( $this->fileHeader->realFile, 'ab' );
+			}
+
+			// Can we write to the file?
+			if( ($outfp === false) && (!$ignore) ) {
+				// An error occured
+				debugMsg('Could not write to output file');
+				$this->setError( AKText::sprintf('COULDNT_WRITE_FILE', $this->fileHeader->realFile) );
+				return false;
+			}
+		}
+
+		// Does the file have any data, at all?
+		if( $this->fileHeader->compressed == 0 )
+		{
+			// No file data!
+			if( !AKFactory::get('kickstart.setup.dryrun','0') && is_resource($outfp) ) @fclose($outfp);
+			$this->runState = AK_STATE_DATAREAD;
+			return true;
+		}
+
+		// Reference to the global timer
+		$timer = AKFactory::getTimer();
+
+		$toReadBytes = 0;
+		$leftBytes = $this->fileHeader->compressed - $this->dataReadLength;
+
+		// Loop while there's data to read and enough time to do it
+		while( ($leftBytes > 0) && ($timer->getTimeLeft() > 0) )
+		{
+			$toReadBytes = ($leftBytes > $this->chunkSize) ? $this->chunkSize : $leftBytes;
+			$data = $this->fread( $this->fp, $toReadBytes );
+			$reallyReadBytes = akstringlen($data);
+			$leftBytes -= $reallyReadBytes;
+			$this->dataReadLength += $reallyReadBytes;
+			if($reallyReadBytes < $toReadBytes)
+			{
+				// We read less than requested! Why? Did we hit local EOF?
+				if( $this->isEOF(true) && !$this->isEOF(false) )
+				{
+					// Yeap. Let's go to the next file
+					$this->nextFile();
+				}
+				else
+				{
+					// Nope. The archive is corrupt
+					debugMsg('Not enough data in file. The archive is truncated or corrupt.');
+					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+					return false;
+				}
+			}
+			if( !AKFactory::get('kickstart.setup.dryrun','0') )
+				if(is_resource($outfp)) @fwrite( $outfp, $data );
+		}
+
+		// Close the file pointer
+		if( !AKFactory::get('kickstart.setup.dryrun','0') )
+			if(is_resource($outfp)) @fclose($outfp);
+
+		// Was this a pre-timeout bail out?
+		if( $leftBytes > 0 )
+		{
+			$this->runState = AK_STATE_DATA;
+		}
+		else
+		{
+			// Oh! We just finished!
+			$this->runState = AK_STATE_DATAREAD;
+			$this->dataReadLength = 0;
+		}
+
+		return true;
+	}
+
+	private function processTypeFileCompressedSimple()
+	{
+		if( !AKFactory::get('kickstart.setup.dryrun','0') )
+		{
+			// Before processing file data, ensure permissions are adequate
+			$this->setCorrectPermissions( $this->fileHeader->file );
+
+			// Open the output file
+			$outfp = @fopen( $this->fileHeader->realFile, 'wb' );
+
+			// Can we write to the file?
+			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($this->fileHeader->file);
+			if( ($outfp === false) && (!$ignore) ) {
+				// An error occured
+				debugMsg('Could not write to output file');
+				$this->setError( AKText::sprintf('COULDNT_WRITE_FILE', $this->fileHeader->realFile) );
+				return false;
+			}
+		}
+
+		// Does the file have any data, at all?
+		if( $this->fileHeader->compressed == 0 )
+		{
+			// No file data!
+			if( !AKFactory::get('kickstart.setup.dryrun','0') )
+				if(is_resource($outfp)) @fclose($outfp);
+			$this->runState = AK_STATE_DATAREAD;
+			return true;
+		}
+
+		// Simple compressed files are processed as a whole; we can't do chunk processing
+		$zipData = $this->fread( $this->fp, $this->fileHeader->compressed );
+		while( akstringlen($zipData) < $this->fileHeader->compressed )
+		{
+			// End of local file before reading all data, but have more archive parts?
+			if($this->isEOF(true) && !$this->isEOF(false))
+			{
+				// Yeap. Read from the next file
+				$this->nextFile();
+				$bytes_left = $this->fileHeader->compressed - akstringlen($zipData);
+				$zipData .= $this->fread( $this->fp, $bytes_left );
+			}
+			else
+			{
+				debugMsg('End of local file before reading all data with no more parts left. The archive is corrupt or truncated.');
+				$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+				return false;
+			}
+		}
+
+		if($this->fileHeader->compression == 'gzip')
+		{
+			$unzipData = gzinflate( $zipData );
+		}
+		elseif($this->fileHeader->compression == 'bzip2')
+		{
+			$unzipData = bzdecompress( $zipData );
+		}
+		unset($zipData);
+
+		// Write to the file.
+		if( !AKFactory::get('kickstart.setup.dryrun','0') && is_resource($outfp) )
+		{
+			@fwrite( $outfp, $unzipData, $this->fileHeader->uncompressed );
+			@fclose( $outfp );
+		}
+		unset($unzipData);
+
+		$this->runState = AK_STATE_DATAREAD;
+		return true;
+	}
+
+	/**
+	 * Process the file data of a link entry
+	 * @return bool
+	 */
+	private function processTypeLink()
+	{
+		$readBytes = 0;
+		$toReadBytes = 0;
+		$leftBytes = $this->fileHeader->compressed;
+		$data = '';
+
+		while( $leftBytes > 0)
+		{
+			$toReadBytes = ($leftBytes > $this->chunkSize) ? $this->chunkSize : $leftBytes;
+			$mydata = $this->fread( $this->fp, $toReadBytes );
+			$reallyReadBytes = akstringlen($mydata);
+			$data .= $mydata;
+			$leftBytes -= $reallyReadBytes;
+			if($reallyReadBytes < $toReadBytes)
+			{
+				// We read less than requested! Why? Did we hit local EOF?
+				if( $this->isEOF(true) && !$this->isEOF(false) )
+				{
+					// Yeap. Let's go to the next file
+					$this->nextFile();
+				}
+				else
+				{
+					debugMsg('End of local file before reading all data with no more parts left. The archive is corrupt or truncated.');
+					// Nope. The archive is corrupt
+					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+					return false;
+				}
+			}
+		}
+
+		// Try to remove an existing file or directory by the same name
+		if(file_exists($this->fileHeader->realFile)) { @unlink($this->fileHeader->realFile); @rmdir($this->fileHeader->realFile); }
+		// Remove any trailing slash
+		if(substr($this->fileHeader->realFile, -1) == '/') $this->fileHeader->realFile = substr($this->fileHeader->realFile, 0, -1);
+		// Create the symlink - only possible within PHP context. There's no support built in the FTP protocol, so no postproc use is possible here :(
+		if( !AKFactory::get('kickstart.setup.dryrun','0') )
+			@symlink($data, $this->fileHeader->realFile);
+
+		$this->runState = AK_STATE_DATAREAD;
+
+		return true; // No matter if the link was created!
+	}
+
+	/**
+	 * Process the file data of a directory entry
+	 * @return bool
+	 */
+	private function processTypeDir()
+	{
+		// Directory entries in the JPA do not have file data, therefore we're done processing the entry
+		$this->runState = AK_STATE_DATAREAD;
+		return true;
+	}
+
+	/**
+	 * Creates the directory this file points to
+	 */
+	protected function createDirectory()
+	{
+		if( AKFactory::get('kickstart.setup.dryrun','0') ) return true;
+
+		// Do we need to create a directory?
+		if(empty($this->fileHeader->realFile)) $this->fileHeader->realFile = $this->fileHeader->file;
+		$lastSlash = strrpos($this->fileHeader->realFile, '/');
+		$dirName = substr( $this->fileHeader->realFile, 0, $lastSlash);
+		$perms = $this->flagRestorePermissions ? $retArray['permissions'] : 0755;
+		$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($dirName);
+		if( ($this->postProcEngine->createDirRecursive($dirName, $perms) == false) && (!$ignore) ) {
+			$this->setError( AKText::sprintf('COULDNT_CREATE_DIR', $dirName) );
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+	protected function heuristicFileHeaderLocator()
+	{
+		$ret = false;
+		$fullEOF = false;
+
+		while(!$ret && !$fullEOF) {
+			$this->currentPartOffset = @ftell($this->fp);
+			if($this->isEOF(true)) {
+				$this->nextFile();
+			}
+
+			if($this->isEOF(false)) {
+				$fullEOF = true;
+				continue;
+			}
+
+			// Read 512Kb
+			$chunk = fread($this->fp, 524288);
+			$size_read = mb_strlen($string,'8bit');
+			//$pos = strpos($chunk, 'JPF');
+			$pos = mb_strpos($chunk, 'JPF', 0, '8bit');
+			if($pos !== false) {
+				// We found it!
+				$this->currentPartOffset += $pos + 3;
+				@fseek($this->fp, $this->currentPartOffset, SEEK_SET);
+				$ret = true;
+			} else {
+				// Not yet found :(
+				$this->currentPartOffset = @ftell($this->fp);
+			}
+		}
+
+		return $ret;
+	}
+}
+
+/**
+ * Akeeba Restore
+ * A JSON-powered JPA, JPS and ZIP archive extraction library
+ *
+ * @copyright   2010-2013 Nicholas K. Dionysopoulos / Akeeba Ltd.
+ * @license     GNU GPL v2 or - at your option - any later version
+ * @package     akeebabackup
+ * @subpackage  kickstart
+ */
+
+/**
+ * ZIP archive extraction class
+ *
+ * Since the file data portion of ZIP and JPA are similarly structured (it's empty for dirs,
+ * linked node name for symlinks, dumped binary data for no compressions and dumped gzipped
+ * binary data for gzip compression) we just have to subclass AKUnarchiverJPA and change the
+ * header reading bits. Reusable code ;)
+ */
+class AKUnarchiverZIP extends AKUnarchiverJPA
+{
 	var $expectDataDescriptor = false;
 
 	protected function readArchiveHeader()
@@ -3068,6 +3734,310 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 		return true;
 	}
 
+}
+
+/**
+ * Akeeba Restore
+ * A JSON-powered JPA, JPS and ZIP archive extraction library
+ *
+ * @copyright   2010-2013 Nicholas K. Dionysopoulos / Akeeba Ltd.
+ * @license     GNU GPL v2 or - at your option - any later version
+ * @package     akeebabackup
+ * @subpackage  kickstart
+ */
+
+/**
+ * JPS archive extraction class
+ */
+class AKUnarchiverJPS extends AKUnarchiverJPA
+{
+	private $archiveHeaderData = array();
+
+	private $password = '';
+
+	public function __construct()
+	{
+		parent::__construct();
+
+		$this->password = AKFactory::get('kickstart.jps.password','');
+	}
+
+	protected function readArchiveHeader()
+	{
+		// Initialize header data array
+		$this->archiveHeaderData = new stdClass();
+
+		// Open the first part
+		$this->nextFile();
+
+		// Fail for unreadable files
+		if( $this->fp === false ) return false;
+
+		// Read the signature
+		$sig = fread( $this->fp, 3 );
+
+		if ($sig != 'JPS')
+		{
+			// Not a JPA file
+			$this->setError( AKText::_('ERR_NOT_A_JPS_FILE') );
+			return false;
+		}
+
+		// Read and parse the known portion of header data (5 bytes)
+		$bin_data = fread($this->fp, 5);
+		$header_data = unpack('Cmajor/Cminor/cspanned/vextra', $bin_data);
+
+		// Load any remaining header data (forward compatibility)
+		$rest_length = $header_data['extra'];
+		if( $rest_length > 0 )
+			$junk = fread($this->fp, $rest_length);
+		else
+			$junk = '';
+
+		// Temporary array with all the data we read
+		$temp = array(
+			'signature' => 			$sig,
+			'major' => 				$header_data['major'],
+			'minor' => 				$header_data['minor'],
+			'spanned' => 			$header_data['spanned']
+		);
+		// Array-to-object conversion
+		foreach($temp as $key => $value)
+		{
+			$this->archiveHeaderData->{$key} = $value;
+		}
+
+		$this->currentPartOffset = @ftell($this->fp);
+
+		$this->dataReadLength = 0;
+
+		return true;
+	}
+
+	/**
+	 * Concrete classes must use this method to read the file header
+	 * @return bool True if reading the file was successful, false if an error occured or we reached end of archive
+	 */
+	protected function readFileHeader()
+	{
+		// If the current part is over, proceed to the next part please
+		if( $this->isEOF(true) ) {
+			$this->nextFile();
+		}
+
+		// Get and decode Entity Description Block
+		$signature = fread($this->fp, 3);
+
+		// Check for end-of-archive siganture
+		if($signature == 'JPE')
+		{
+			$this->setState('postrun');
+			return true;
+		}
+
+		$this->fileHeader = new stdClass();
+		$this->fileHeader->timestamp = 0;
+
+		// Check signature
+		if( $signature != 'JPF' )
+		{
+			if($this->isEOF(true))
+			{
+				// This file is finished; make sure it's the last one
+				$this->nextFile();
+				if(!$this->isEOF(false))
+				{
+					$this->setError(AKText::sprintf('INVALID_FILE_HEADER', $this->currentPartNumber, $this->currentPartOffset));
+					return false;
+				}
+				// We're just finished
+				return false;
+			}
+			else
+			{
+				fseek($this->fp, -6, SEEK_CUR);
+				$signature = fread($this->fp, 3);
+				if($signature == 'JPE')
+				{
+					return false;
+				}
+
+				$this->setError(AKText::sprintf('INVALID_FILE_HEADER', $this->currentPartNumber, $this->currentPartOffset));
+				return false;
+			}
+		}
+		// This a JPA Entity Block. Process the header.
+
+		$isBannedFile = false;
+
+		// Read and decrypt the header
+		$edbhData = fread($this->fp, 4);
+		$edbh = unpack('vencsize/vdecsize', $edbhData);
+		$bin_data = fread($this->fp, $edbh['encsize']);
+
+		// Decrypt and truncate
+		$bin_data = AKEncryptionAES::AESDecryptCBC($bin_data, $this->password, 128);
+		$bin_data = substr($bin_data,0,$edbh['decsize']);
+
+		// Read length of EDB and of the Entity Path Data
+		$length_array = unpack('vpathsize', substr($bin_data,0,2) );
+		// Read the path data
+		$file = substr($bin_data,2,$length_array['pathsize']);
+
+		// Handle file renaming
+		$isRenamed = false;
+		if(is_array($this->renameFiles) && (count($this->renameFiles) > 0) )
+		{
+			if(array_key_exists($file, $this->renameFiles))
+			{
+				$file = $this->renameFiles[$file];
+				$isRenamed = true;
+			}
+		}
+
+		// Handle directory renaming
+		$isDirRenamed = false;
+		if(is_array($this->renameDirs) && (count($this->renameDirs) > 0)) {
+			if(array_key_exists(dirname($file), $this->renameDirs)) {
+				$file = rtrim($this->renameDirs[dirname($file)],'/').'/'.basename($file);
+				$isRenamed = true;
+				$isDirRenamed = true;
+			}
+		}
+
+		// Read and parse the known data portion
+		$bin_data = substr($bin_data, 2 + $length_array['pathsize']);
+		$header_data = unpack('Ctype/Ccompression/Vuncompsize/Vperms/Vfilectime', $bin_data);
+
+		$this->fileHeader->timestamp = $header_data['filectime'];
+		$compressionType = $header_data['compression'];
+
+		// Populate the return array
+		$this->fileHeader->file = $file;
+		$this->fileHeader->uncompressed = $header_data['uncompsize'];
+		switch($header_data['type'])
+		{
+			case 0:
+				$this->fileHeader->type = 'dir';
+				break;
+
+			case 1:
+				$this->fileHeader->type = 'file';
+				break;
+
+			case 2:
+				$this->fileHeader->type = 'link';
+				break;
+		}
+		switch( $compressionType )
+		{
+			case 0:
+				$this->fileHeader->compression = 'none';
+				break;
+			case 1:
+				$this->fileHeader->compression = 'gzip';
+				break;
+			case 2:
+				$this->fileHeader->compression = 'bzip2';
+				break;
+		}
+		$this->fileHeader->permissions = $header_data['perms'];
+
+		// Find hard-coded banned files
+		if( (basename($this->fileHeader->file) == ".") || (basename($this->fileHeader->file) == "..") )
+		{
+			$isBannedFile = true;
+		}
+
+		// Also try to find banned files passed in class configuration
+		if((count($this->skipFiles) > 0) && (!$isRenamed) )
+		{
+			if(in_array($this->fileHeader->file, $this->skipFiles))
+			{
+				$isBannedFile = true;
+			}
+		}
+
+		// If we have a banned file, let's skip it
+		if($isBannedFile)
+		{
+			$done = false;
+			while(!$done)
+			{
+				// Read the Data Chunk Block header
+				$binMiniHead = fread($this->fp, 8);
+				if( in_array( substr($binMiniHead,0,3), array('JPF','JPE') ) )
+				{
+					// Not a Data Chunk Block header, I am done skipping the file
+					@fseek($this->fp,-8,SEEK_CUR); // Roll back the file pointer
+					$done = true; // Mark as done
+					continue; // Exit loop
+				}
+				else
+				{
+					// Skip forward by the amount of compressed data
+					$miniHead = unpack('Vencsize/Vdecsize');
+					@fseek($this->fp, $miniHead['encsize'], SEEK_CUR);
+				}
+			}
+
+			$this->currentPartOffset = @ftell($this->fp);
+			$this->runState = AK_STATE_DONE;
+			return true;
+		}
+
+		// Last chance to prepend a path to the filename
+		if(!empty($this->addPath) && !$isDirRenamed)
+		{
+			$this->fileHeader->file = $this->addPath.$this->fileHeader->file;
+		}
+
+		// Get the translated path name
+		$restorePerms = AKFactory::get('kickstart.setup.restoreperms', false);
+		if($this->fileHeader->type == 'file')
+		{
+			// Regular file; ask the postproc engine to process its filename
+			if($restorePerms)
+			{
+				$this->fileHeader->realFile = $this->postProcEngine->processFilename( $this->fileHeader->file, $this->fileHeader->permissions );
+			}
+			else
+			{
+				$this->fileHeader->realFile = $this->postProcEngine->processFilename( $this->fileHeader->file );
+			}
+		}
+		elseif($this->fileHeader->type == 'dir')
+		{
+			$dir = $this->fileHeader->file;
+			$this->fileHeader->realFile = $dir;
+
+			// Directory; just create it
+			if($restorePerms)
+			{
+				$this->postProcEngine->createDirRecursive( $this->fileHeader->file, $this->fileHeader->permissions );
+			}
+			else
+			{
+				$this->postProcEngine->createDirRecursive( $this->fileHeader->file, 0755 );
+			}
+			$this->postProcEngine->processFilename(null);
+		}
+		else
+		{
+			// Symlink; do not post-process
+			$this->postProcEngine->processFilename(null);
+		}
+
+		$this->createDirectory();
+
+		// Header is read
+		$this->runState = AK_STATE_HEADER;
+
+		$this->dataReadLength = 0;
+
+		return true;
+	}
+
 	/**
 	 * Concrete classes must use this method to process file data. It must set $runState to AK_STATE_DATAREAD when
 	 * it's finished processing the file data.
@@ -3099,10 +4069,6 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 
 				}
 				break;
-
-			default:
-				debugMsg('Unknown file type '.$this->fileHeader->type);
-				break;
 		}
 	}
 
@@ -3118,7 +4084,7 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 		// Open the output file
 		if( !AKFactory::get('kickstart.setup.dryrun','0') )
 		{
-			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false);
+			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($this->fileHeader->file);
 			if ($this->dataReadLength == 0) {
 				$outfp = @fopen( $this->fileHeader->realFile, 'wb' );
 			} else {
@@ -3126,37 +4092,103 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 			}
 
 			// Can we write to the file?
-			if(($outfp === false) && (!$ignore) && (!$this->isIgnoredDirectory($this->fileHeader->file))) {
+			if( ($outfp === false) && (!$ignore) ) {
 				// An error occured
-				debugMsg('Could not write to output file');
 				$this->setError( AKText::sprintf('COULDNT_WRITE_FILE', $this->fileHeader->realFile) );
 				return false;
 			}
 		}
 
 		// Does the file have any data, at all?
-		if( $this->fileHeader->compressed == 0 )
+		if( $this->fileHeader->uncompressed == 0 )
 		{
 			// No file data!
 			if( !AKFactory::get('kickstart.setup.dryrun','0') && is_resource($outfp) ) @fclose($outfp);
 			$this->runState = AK_STATE_DATAREAD;
 			return true;
 		}
+		else
+		{
+			$this->setError('An uncompressed file was detected; this is not supported by this archive extraction utility');
+			return false;
+		}
 
-		// Reference to the global timer
+		return true;
+	}
+
+	private function processTypeFileCompressedSimple()
+	{
 		$timer = AKFactory::getTimer();
 
-		$toReadBytes = 0;
-		$leftBytes = $this->fileHeader->compressed - $this->dataReadLength;
+		// Files are being processed in small chunks, to avoid timeouts
+		if( ($this->dataReadLength == 0) && !AKFactory::get('kickstart.setup.dryrun','0') )
+		{
+			// Before processing file data, ensure permissions are adequate
+			$this->setCorrectPermissions( $this->fileHeader->file );
+		}
 
-		// Loop while there's data to read and enough time to do it
+		// Open the output file
+		if( !AKFactory::get('kickstart.setup.dryrun','0') )
+		{
+			// Open the output file
+			$outfp = @fopen( $this->fileHeader->realFile, 'wb' );
+
+			// Can we write to the file?
+			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($this->fileHeader->file);
+			if( ($outfp === false) && (!$ignore) ) {
+				// An error occured
+				$this->setError( AKText::sprintf('COULDNT_WRITE_FILE', $this->fileHeader->realFile) );
+				return false;
+			}
+		}
+
+		// Does the file have any data, at all?
+		if( $this->fileHeader->uncompressed == 0 )
+		{
+			// No file data!
+			if( !AKFactory::get('kickstart.setup.dryrun','0') )
+				if(is_resource($outfp)) @fclose($outfp);
+			$this->runState = AK_STATE_DATAREAD;
+			return true;
+		}
+
+		$leftBytes = $this->fileHeader->uncompressed - $this->dataReadLength;
+
+		// Loop while there's data to write and enough time to do it
 		while( ($leftBytes > 0) && ($timer->getTimeLeft() > 0) )
 		{
-			$toReadBytes = ($leftBytes > $this->chunkSize) ? $this->chunkSize : $leftBytes;
+			// Read the mini header
+			$binMiniHeader = fread($this->fp, 8);
+			$reallyReadBytes = akstringlen($binMiniHeader);
+			if($reallyReadBytes < 8)
+			{
+				// We read less than requested! Why? Did we hit local EOF?
+				if( $this->isEOF(true) && !$this->isEOF(false) )
+				{
+					// Yeap. Let's go to the next file
+					$this->nextFile();
+					// Retry reading the header
+					$binMiniHeader = fread($this->fp, 8);
+					$reallyReadBytes = akstringlen($binMiniHeader);
+					// Still not enough data? If so, the archive is corrupt or missing parts.
+					if($reallyReadBytes < 8) {
+						$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+						return false;
+					}
+				}
+				else
+				{
+					// Nope. The archive is corrupt
+					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+					return false;
+				}
+			}
+
+			// Read the encrypted data
+			$miniHeader = unpack('Vencsize/Vdecsize', $binMiniHeader);
+			$toReadBytes = $miniHeader['encsize'];
 			$data = $this->fread( $this->fp, $toReadBytes );
 			$reallyReadBytes = akstringlen($data);
-			$leftBytes -= $reallyReadBytes;
-			$this->dataReadLength += $reallyReadBytes;
 			if($reallyReadBytes < $toReadBytes)
 			{
 				// We read less than requested! Why? Did we hit local EOF?
@@ -3164,17 +4196,52 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 				{
 					// Yeap. Let's go to the next file
 					$this->nextFile();
+					// Read the rest of the data
+					$toReadBytes -= $reallyReadBytes;
+					$restData = $this->fread( $this->fp, $toReadBytes );
+					$reallyReadBytes = akstringlen($restData);
+					if($reallyReadBytes < $toReadBytes) {
+						$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+						return false;
+					}
+					if(akstringlen($data) == 0) {
+						$data = $restData;
+					} else {
+						$data .= $restData;
+					}
 				}
 				else
 				{
 					// Nope. The archive is corrupt
-					debugMsg('Not enough data in file. The archive is truncated or corrupt.');
 					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
 					return false;
 				}
 			}
+
+			// Decrypt the data
+			$data = AKEncryptionAES::AESDecryptCBC($data, $this->password, 128);
+
+			// Is the length of the decrypted data less than expected?
+			$data_length = akstringlen($data);
+			if($data_length < $miniHeader['decsize']) {
+				$this->setError(AKText::_('ERR_INVALID_JPS_PASSWORD'));
+				return false;
+			}
+
+			// Trim the data
+			$data = substr($data,0,$miniHeader['decsize']);
+
+			// Decompress
+			$data = gzinflate($data);
+			$unc_len = akstringlen($data);
+
+			// Write the decrypted data
 			if( !AKFactory::get('kickstart.setup.dryrun','0') )
-				if(is_resource($outfp)) @fwrite( $outfp, $data );
+				if(is_resource($outfp)) @fwrite( $outfp, $data, akstringlen($data) );
+
+			// Update the read length
+			$this->dataReadLength += $unc_len;
+			$leftBytes = $this->fileHeader->uncompressed - $this->dataReadLength;
 		}
 
 		// Close the file pointer
@@ -3196,121 +4263,101 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 		return true;
 	}
 
-	private function processTypeFileCompressedSimple()
-	{
-		if( !AKFactory::get('kickstart.setup.dryrun','0') )
-		{
-			// Before processing file data, ensure permissions are adequate
-			$this->setCorrectPermissions( $this->fileHeader->file );
-
-			// Open the output file
-			$outfp = @fopen( $this->fileHeader->realFile, 'wb' );
-
-			// Can we write to the file?
-			$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false);
-			if (($outfp === false) && (!$ignore)  && (!$this->isIgnoredDirectory($this->fileHeader->file))) {
-				// An error occured
-				debugMsg('Could not write to output file');
-				$this->setError( AKText::sprintf('COULDNT_WRITE_FILE', $this->fileHeader->realFile) );
-				return false;
-			}
-		}
-
-		// Does the file have any data, at all?
-		if( $this->fileHeader->compressed == 0 )
-		{
-			// No file data!
-			if( !AKFactory::get('kickstart.setup.dryrun','0') )
-				if(is_resource($outfp)) @fclose($outfp);
-			$this->runState = AK_STATE_DATAREAD;
-			return true;
-		}
-
-		// Simple compressed files are processed as a whole; we can't do chunk processing
-		$zipData = $this->fread( $this->fp, $this->fileHeader->compressed );
-		while( akstringlen($zipData) < $this->fileHeader->compressed )
-		{
-			// End of local file before reading all data, but have more archive parts?
-			if($this->isEOF(true) && !$this->isEOF(false))
-			{
-				// Yeap. Read from the next file
-				$this->nextFile();
-				$bytes_left = $this->fileHeader->compressed - akstringlen($zipData);
-				$zipData .= $this->fread( $this->fp, $bytes_left );
-			}
-			else
-			{
-				debugMsg('End of local file before reading all data with no more parts left. The archive is corrupt or truncated.');
-				$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
-				return false;
-			}
-		}
-
-		if($this->fileHeader->compression == 'gzip')
-		{
-			$unzipData = gzinflate( $zipData );
-		}
-		elseif($this->fileHeader->compression == 'bzip2')
-		{
-			$unzipData = bzdecompress( $zipData );
-		}
-		unset($zipData);
-
-		// Write to the file.
-		if( !AKFactory::get('kickstart.setup.dryrun','0') && is_resource($outfp) )
-		{
-			@fwrite( $outfp, $unzipData, $this->fileHeader->uncompressed );
-			@fclose( $outfp );
-		}
-		unset($unzipData);
-
-		$this->runState = AK_STATE_DATAREAD;
-		return true;
-	}
-
 	/**
 	 * Process the file data of a link entry
 	 * @return bool
 	 */
 	private function processTypeLink()
 	{
-		$readBytes = 0;
-		$toReadBytes = 0;
-		$leftBytes = $this->fileHeader->compressed;
-		$data = '';
 
-		while( $leftBytes > 0)
+		// Does the file have any data, at all?
+		if( $this->fileHeader->uncompressed == 0 )
 		{
-			$toReadBytes = ($leftBytes > $this->chunkSize) ? $this->chunkSize : $leftBytes;
-			$mydata = $this->fread( $this->fp, $toReadBytes );
-			$reallyReadBytes = akstringlen($mydata);
-			$data .= $mydata;
-			$leftBytes -= $reallyReadBytes;
-			if($reallyReadBytes < $toReadBytes)
+			// No file data!
+			$this->runState = AK_STATE_DATAREAD;
+			return true;
+		}
+
+		// Read the mini header
+		$binMiniHeader = fread($this->fp, 8);
+		$reallyReadBytes = akstringlen($binMiniHeader);
+		if($reallyReadBytes < 8)
+		{
+			// We read less than requested! Why? Did we hit local EOF?
+			if( $this->isEOF(true) && !$this->isEOF(false) )
 			{
-				// We read less than requested! Why? Did we hit local EOF?
-				if( $this->isEOF(true) && !$this->isEOF(false) )
-				{
-					// Yeap. Let's go to the next file
-					$this->nextFile();
-				}
-				else
-				{
-					debugMsg('End of local file before reading all data with no more parts left. The archive is corrupt or truncated.');
-					// Nope. The archive is corrupt
+				// Yeap. Let's go to the next file
+				$this->nextFile();
+				// Retry reading the header
+				$binMiniHeader = fread($this->fp, 8);
+				$reallyReadBytes = akstringlen($binMiniHeader);
+				// Still not enough data? If so, the archive is corrupt or missing parts.
+				if($reallyReadBytes < 8) {
 					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
 					return false;
 				}
 			}
+			else
+			{
+				// Nope. The archive is corrupt
+				$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+				return false;
+			}
 		}
 
+		// Read the encrypted data
+		$miniHeader = unpack('Vencsize/Vdecsize', $binMiniHeader);
+		$toReadBytes = $miniHeader['encsize'];
+		$data = $this->fread( $this->fp, $toReadBytes );
+		$reallyReadBytes = akstringlen($data);
+		if($reallyReadBytes < $toReadBytes)
+		{
+			// We read less than requested! Why? Did we hit local EOF?
+			if( $this->isEOF(true) && !$this->isEOF(false) )
+			{
+				// Yeap. Let's go to the next file
+				$this->nextFile();
+				// Read the rest of the data
+				$toReadBytes -= $reallyReadBytes;
+				$restData = $this->fread( $this->fp, $toReadBytes );
+				$reallyReadBytes = akstringlen($data);
+				if($reallyReadBytes < $toReadBytes) {
+					$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+					return false;
+				}
+				$data .= $restData;
+			}
+			else
+			{
+				// Nope. The archive is corrupt
+				$this->setError( AKText::_('ERR_CORRUPT_ARCHIVE') );
+				return false;
+			}
+		}
+
+		// Decrypt the data
+		$data = AKEncryptionAES::AESDecryptCBC($data, $this->password, 128);
+
+		// Is the length of the decrypted data less than expected?
+		$data_length = akstringlen($data);
+		if($data_length < $miniHeader['decsize']) {
+			$this->setError(AKText::_('ERR_INVALID_JPS_PASSWORD'));
+			return false;
+		}
+
+		// Trim the data
+		$data = substr($data,0,$miniHeader['decsize']);
+
 		// Try to remove an existing file or directory by the same name
-		if(file_exists($this->fileHeader->realFile)) { @unlink($this->fileHeader->realFile); @rmdir($this->fileHeader->realFile); }
+		if(file_exists($this->fileHeader->file)) { @unlink($this->fileHeader->file); @rmdir($this->fileHeader->file); }
 		// Remove any trailing slash
-		if(substr($this->fileHeader->realFile, -1) == '/') $this->fileHeader->realFile = substr($this->fileHeader->realFile, 0, -1);
+		if(substr($this->fileHeader->file, -1) == '/') $this->fileHeader->file = substr($this->fileHeader->file, 0, -1);
 		// Create the symlink - only possible within PHP context. There's no support built in the FTP protocol, so no postproc use is possible here :(
+
 		if( !AKFactory::get('kickstart.setup.dryrun','0') )
-			@symlink($data, $this->fileHeader->realFile);
+		{
+			@symlink($data, $this->fileHeader->file);
+		}
 
 		$this->runState = AK_STATE_DATAREAD;
 
@@ -3336,12 +4383,11 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 		if( AKFactory::get('kickstart.setup.dryrun','0') ) return true;
 
 		// Do we need to create a directory?
-		if(empty($this->fileHeader->realFile)) $this->fileHeader->realFile = $this->fileHeader->file;
 		$lastSlash = strrpos($this->fileHeader->realFile, '/');
 		$dirName = substr( $this->fileHeader->realFile, 0, $lastSlash);
 		$perms = $this->flagRestorePermissions ? $retArray['permissions'] : 0755;
-		$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false);
-		if (($this->postProcEngine->createDirRecursive($dirName, $perms) == false) && (!$ignore) && (!$this->isIgnoredDirectory($dirname))) {
+		$ignore = AKFactory::get('kickstart.setup.ignoreerrors', false) || $this->isIgnoredDirectory($dirName);
+		if( ($this->postProcEngine->createDirRecursive($dirName, $perms) == false) && (!$ignore) ) {
 			$this->setError( AKText::sprintf('COULDNT_CREATE_DIR', $dirName) );
 			return false;
 		}
@@ -3349,42 +4395,6 @@ class AKUnarchiverZIP extends AKAbstractUnarchiver
 		{
 			return true;
 		}
-	}
-
-	protected function heuristicFileHeaderLocator()
-	{
-		$ret = false;
-		$fullEOF = false;
-
-		while(!$ret && !$fullEOF) {
-			$this->currentPartOffset = @ftell($this->fp);
-			if($this->isEOF(true)) {
-				die("PAPARIA");
-				$this->nextFile();
-			}
-
-			if($this->isEOF(false)) {
-				$fullEOF = true;
-				continue;
-			}
-
-			// Read 512Kb
-			$chunk = fread($this->fp, 524288);
-			$size_read = mb_strlen($string,'8bit');
-			//$pos = strpos($chunk, 'JPF');
-			$pos = mb_strpos($chunk, 'JPF', 0, '8bit');
-			if($pos !== false) {
-				// We found it!
-				$this->currentPartOffset += $pos + 3;
-				@fseek($this->fp, $this->currentPartOffset, SEEK_SET);
-				$ret = true;
-			} else {
-				// Not yet found :(
-				$this->currentPartOffset = @ftell($this->fp);
-			}
-		}
-
-		return $ret;
 	}
 }
 
@@ -3564,6 +4574,90 @@ class AKCoreTimer extends AKAbstractObject
 	public function resetTime()
 	{
 		$this->start_time = $this->microtime_float();
+	}
+}
+
+/**
+ * Akeeba Restore
+ * A JSON-powered JPA, JPS and ZIP archive extraction library
+ *
+ * @copyright   2010-2013 Nicholas K. Dionysopoulos / Akeeba Ltd.
+ * @license     GNU GPL v2 or - at your option - any later version
+ * @package     akeebabackup
+ * @subpackage  kickstart
+ */
+
+/**
+ * A filesystem scanner which uses opendir()
+ */
+class AKUtilsLister extends AKAbstractObject
+{
+	public function &getFiles($folder, $pattern = '*')
+	{
+		// Initialize variables
+		$arr = array();
+		$false = false;
+
+		if(!is_dir($folder)) return $false;
+
+		$handle = @opendir($folder);
+		// If directory is not accessible, just return FALSE
+		if ($handle === FALSE) {
+			$this->setWarning( 'Unreadable directory '.$folder);
+			return $false;
+		}
+
+		while (($file = @readdir($handle)) !== false)
+		{
+			if( !fnmatch($pattern, $file) ) continue;
+
+			if (($file != '.') && ($file != '..'))
+			{
+				$ds = ($folder == '') || ($folder == '/') || (@substr($folder, -1) == '/') || (@substr($folder, -1) == DIRECTORY_SEPARATOR) ? '' : DIRECTORY_SEPARATOR;
+				$dir = $folder . $ds . $file;
+				$isDir = is_dir($dir);
+				if (!$isDir) {
+					$arr[] = $dir;
+				}
+			}
+		}
+		@closedir($handle);
+
+		return $arr;
+	}
+
+	public function &getFolders($folder, $pattern = '*')
+	{
+		// Initialize variables
+		$arr = array();
+		$false = false;
+
+		if(!is_dir($folder)) return $false;
+
+		$handle = @opendir($folder);
+		// If directory is not accessible, just return FALSE
+		if ($handle === FALSE) {
+			$this->setWarning( 'Unreadable directory '.$folder);
+			return $false;
+		}
+
+		while (($file = @readdir($handle)) !== false)
+		{
+			if( !fnmatch($pattern, $file) ) continue;
+
+			if (($file != '.') && ($file != '..'))
+			{
+				$ds = ($folder == '') || ($folder == '/') || (@substr($folder, -1) == '/') || (@substr($folder, -1) == DIRECTORY_SEPARATOR) ? '' : DIRECTORY_SEPARATOR;
+				$dir = $folder . $ds . $file;
+				$isDir = is_dir($dir);
+				if ($isDir) {
+					$arr[] = $dir;
+				}
+			}
+		}
+		@closedir($handle);
+
+		return $arr;
 	}
 }
 


### PR DESCRIPTION
# Overview

**Note**: See Joomla! Issue Tracker item [32785](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32785) Please enter your test results there, not in this Pull Request on GitHub, prefixing your message with `@test`. Thank you.
## Technical analysis
### BUG 1

Updating Joomla! is impossible on servers which have a reserved, unwriteable, system folder called `logs`. All Plesk-based servers and certain hosts put a directory called `logs` inside the public web root. They use it to store Apache log files. Since this directory is owned by a system user and has strict permissions (0700, 0750 or 0755) it is not writeable by PHP.

Joomla!'s update packages have a folder called `logs` with a sole `index.html` file in it. When the update archive extraction reaches that file the update hangs and the user is left with a partially updated, bricked site. As the users cannot make this directory writeable by any means, they end up with a site that is impossible to update.

This Pull Request modifies the archive extractor (`administrator/components/com_joomlaupdate/restore.php`) to ignore unwriteable files in the `logs` directory, allowing the update process to continue.
### BUG 2

Moreover, logging was added recently to com_joomlaupdate. However, if the log directory is not set in Global Configuration or if it's set to an unwriteable directory the failure to write a log file results in an error message and inability to update Joomla!. This is just plain wrong, as logging is an _optional_ feature and its failure MUST NOT block the update of the CMS. This PR wraps the JLog::add lines in com_joomlaupdate with a try/catch statement to effectively ignore any logging errors and allow the site to be updated.
# Reproducing the bug and testing the PR
## Reproducing the bug
- Install a new Joomla! site based on the latest master branch
- Go to Components, Joomla! Update and click on Options
- Set the Update Server to Custom URL
- Set the Custom URL to http://akeebatest.s3.amazonaws.com/fakejupdate/list.xml
- Click on Save & Close. A new version 3.2.2 is detected. DO NOT TRY TO UPDATE JUST YET.
- Make your site's `logs` directory unwriteable. IMPORTANT: Changing the permissions IS NOT enough! com_joomlaupdate will try to fix the permissions if it can. You are advised to change the directory's ownership to root (Linux, Mac OS X) or Administrator (Windows). Then give it 0700 permissions (Linux, Mac OS X) or remove everyone's access except Administrator (Windows)
- Go back to your site and try to update to version 3.2.2.
- You get an error message that the log could not be opened. BUG 2 CONFIRMED. 
- Create a new top-level directory on your site called log-ok and make sure it's writeable by PHP (e.g. give it 0777 permissions – yes, 0777 is the number of the beast but this is just a test site which we'll delete afterwards)
- Go to Global Configuration and set the log directory from ...../logs to ...../log-ok (the dots represent the existing pathname already displayed)
- Go back to Components, Joomla! Update and start the update
- The package downloads and starts extracting.
- The update stops somewhere between 3% and 4% with an error saying that ...../logs/index.html could not be opened for writing. BUG 1 CONFIRMED.
## Testing the PR (true positive testing)

Let's make sure the PR fixes this issue.
- On the site you have already created delete tmp/joomla.zip
- Go to Global Configuration and set the log directory from ...../logok to ...../logs (the dots represent the existing pathname already displayed)
- Go back to Components, Joomla! Update and start the update
- The package downloads and starts extracting. FIX FOR BUG 2 CONFIRMED.
- The update completes. FIX FOR BUG 1 CONFIRMED.

Note: you will get a warning similar to the one [in this picture](https://www.dropbox.com/s/y0dzm1e24dvephf/Screenshot%202013-11-22%2015.27.30.png). This is expected, as my fake update package lacks a few files.

Also note that the Joomla! version is still 3.2.1. Did I mention enough times already that my update package is fake? :)
## Cross-testing the PR (false positive testing)

Let's make sure that making a different directory unwriteable still leads to an error. This is desirable, as it indicates ownership/permissions issues on the site.
- On the site you have already created delete tmp/joomla.zip if it still exists
- Make your site's `cli` directory unwriteable. IMPORTANT: Changing the permissions IS NOT enough! com_joomlaupdate will try to fix the permissions if it can. You are advised to change the directory's ownership to root (Linux, Mac OS X) or Administrator (Windows). Then give it 0700 permissions (Linux, Mac OS X) or remove everyone's access except Administrator (Windows)
- Go back to Components, Joomla! Update and start the update
- The package downloads and starts extracting. It throws an error halfway through about not being able to write a file in the cli directory. FALSE POSITIVE AVOIDANCE TEST SUCCESSFUL.
# Project management information
## Backwards compatibility

Backwards compatibility is not affected.
## Information to developers

None is required. This PR only modifies code used internally by Joomla!. Furthermore, the public API of the code is immutable after the application of this PR
## Severity of this bug

Medium-High as it makes it impossible to update Joomla! on several popular hosts.
