### PR TITLE
[#32786] Stop canonical message in home page using featured view of com_content

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -207,6 +207,16 @@ function ContentBuildRoute(&$query)
 		}
 	}
 
+	if ($view == 'featured')
+	{
+		if (!$menuItemGiven)
+		{
+			$segments[] = $view;
+		}
+
+		unset($query['view']);
+	}
+
 	// if the layout is specified and it is the same as the layout in the menu item, we
 	// unset it so it doesn't go into the query string.
 	if (isset($query['layout']))


### PR DESCRIPTION
If I have in the home page the featured view of com_content, I get a SEO message:

![untitled-1](https://f.cloud.github.com/assets/441774/1606406/8a960f4e-5439-11e3-892c-560a5bc032e4.jpg)

The plugin is SEO Doctor for Firefox.

Tracker: #32786

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32786&start=0
