### PR TITLE
[#32807] add column support for extension manager->database for MSSQL

### DIFF
--- a/libraries/cms/schema/changeitem/sqlsrv.php
+++ b/libraries/cms/schema/changeitem/sqlsrv.php
@@ -46,7 +46,7 @@ class JSchemaChangeitemSqlsrv extends JSchemaChangeitem
 
 		// Fix up extra spaces around () and in general
 		$find = array('#((\s*)\(\s*([^)\s]+)\s*)(\))#', '#(\s)(\s*)#');
-		$replace = array('($3)', '$1');
+		$replace = array(' ($3) ', '$1');
 		$updateQuery = preg_replace($find, $replace, $this->updateQuery);
 		$wordArray = explode(' ', $updateQuery);
 
@@ -63,11 +63,11 @@ class JSchemaChangeitemSqlsrv extends JSchemaChangeitem
 		if ($command === 'ALTER TABLE')
 		{
 			$alterCommand = strtoupper($wordArray[3] . ' ' . $wordArray[4]);
-			if ($alterCommand == 'ADD')
+			if (strtoupper($wordArray[3]) == 'ADD' && strtoupper($wordArray[4]) != 'DEFAULT')
 			{
 				$result = 'SELECT * FROM INFORMATION_SCHEMA.Columns ' . $wordArray[2] . ' WHERE COLUMN_NAME = ' . $this->fixQuote($wordArray[5]);
-				$this->queryType = 'ADD';
-				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]));
+				$this->queryType = 'ADD_COLUMN';
+				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[4]));
 			}
 			elseif ($alterCommand == 'CREATE INDEX')
 			{

--- a/libraries/cms/schema/changeitem/sqlsrv.php
+++ b/libraries/cms/schema/changeitem/sqlsrv.php
@@ -65,7 +65,7 @@ class JSchemaChangeitemSqlsrv extends JSchemaChangeitem
 			$alterCommand = strtoupper($wordArray[3] . ' ' . $wordArray[4]);
 			if (strtoupper($wordArray[3]) == 'ADD' && strtoupper($wordArray[4]) != 'DEFAULT')
 			{
-				$result = 'SELECT * FROM INFORMATION_SCHEMA.Columns ' . $wordArray[2] . ' WHERE COLUMN_NAME = ' . $this->fixQuote($wordArray[5]);
+				$result = 'SELECT * FROM INFORMATION_SCHEMA.Columns ' . $wordArray[2] . ' WHERE COLUMN_NAME = ' . $this->fixQuote($wordArray[4]);
 				$this->queryType = 'ADD_COLUMN';
 				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[4]));
 			}


### PR DESCRIPTION
See tracker [#32807] http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32807&start=0

Unfortunately JC is not reliable. So, in the unlikely event someone wants to use Extension manager->Database on MSSQL this is what this PR is about:

Extension manager->Database has very limited use but for other platforms it detects whether structural updates are applied in your environment. One of those structural changes is the ALTER TABLE <table> ADD <column>. This PR fixes the BUGS with the MSSQL implementation of that.

So, currently no differences are detected related to the columns added by updates. After applying this PR these added columns are detected when missing. And added when Fix is used!

You might also be interested in its counterpart #2615
