### PR TITLE
Hathor hide all modules in icon position when more then 1 module is assigned in control panel

### DIFF
--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -159,13 +159,7 @@ else
 
 					<!-- Display the Quick Icon Shortcuts -->
 					<div class="cpanel-icons">
-						<?php if ($this->countModules('icon') > 1):?>
-							<?php echo JHtml::_('sliders.start', 'position-icon', array('useCookie' => 1));?>
-							<jdoc:include type="modules" name="icon" />
-							<?php echo JHtml::_('sliders.end');?>
-						<?php else:?>
-							<jdoc:include type="modules" name="icon" />
-						<?php endif;?>
+						<jdoc:include type="modules" name="icon" />
 					</div>
 
 					<!-- Display Admin Information Panels -->


### PR DESCRIPTION
How to reproduce the problem and/or test the patch::
add more then one module in "icon" position in hathor template

Joomla tracker :
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32792
