### PR TITLE
Wrong JText causes double string use 3.2

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -376,7 +376,7 @@ class UsersModelRegistration extends JModelForm
 		// Store the data.
 		if (!$user->save())
 		{
-			$this->setError(JText::sprintf('COM_USERS_REGISTRATION_SAVE_FAILED', $user->getError()));
+			$this->setError($user->getError());
 			return false;
 		}
 


### PR DESCRIPTION
When registering a new user in FE and username contains a space we get a double display of the "Registration failed:" string in the warning:
Registration failed: Registration failed: Please enter a valid username. No spaces, at least 2 characters and must not contain the following characters: < > \ " ' % ; ( ) &
