### PR TITLE
Fix a failing unit test [#32813]

### DIFF
--- a/tests/unit/suites/libraries/joomla/registry/format/JRegistryFormatXmlTest.php
+++ b/tests/unit/suites/libraries/joomla/registry/format/JRegistryFormatXmlTest.php
@@ -39,11 +39,16 @@ class JRegistryFormatXMLTest extends PHPUnit_Framework_TestCase
 		$object->section->key = 'value';
 		$object->array = array('nestedarray' => array('test1' => 'value1'));
 
+		// Check for different PHP behavior of displaying boolean false in XML.
+		$checkFalse = '<check/>' == simplexml_load_string('<test/>')->addChild('check', false)->asXML()
+			? '/>'
+			: '></node>';
+
 		$string = "<?xml version=\"1.0\"?>\n<registry>" .
 			"<node name=\"foo\" type=\"string\">bar</node>" .
 			"<node name=\"quoted\" type=\"string\">\"stringwithquotes\"</node>" .
 			"<node name=\"booleantrue\" type=\"boolean\">1</node>" .
-			"<node name=\"booleanfalse\" type=\"boolean\"></node>" .
+			"<node name=\"booleanfalse\" type=\"boolean\"" . $checkFalse .
 			"<node name=\"numericint\" type=\"integer\">42</node>" .
 			"<node name=\"numericfloat\" type=\"double\">3.1415</node>" .
 			"<node name=\"section\" type=\"object\">" .


### PR DESCRIPTION
This should fix a unit test that is currently failing like:

```
1) JRegistryFormatXMLTest::testObjectToString
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?xml version="1.0"?>
-<registry><node name="foo" type="string">bar</node><node name="quoted" type="string">"stringwithquotes"</node><node name="booleantrue" type="boolean">1</node><node name="booleanfalse" type="boolean"></node><node name="numericint" type="integer">42</node><node name="numericfloat" type="double">3.1415</node><node name="section" type="object"><node name="key" type="string">value</node></node><node name="array" type="array"><node name="nestedarray" type="array"><node name="test1" type="string">value1</node></node></node></registry>
+<registry><node name="foo" type="string">bar</node><node name="quoted" type="string">"stringwithquotes"</node><node name="booleantrue" type="boolean">1</node><node name="booleanfalse" type="boolean"/><node name="numericint" type="integer">42</node><node name="numericfloat" type="double">3.1415</node><node name="section" type="object"><node name="key" type="string">value</node></node><node name="array" type="array"><node name="nestedarray" type="array"><node name="test1" type="string">value1</node></node></node></registry>
 '
```

Ref: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32813&start=0
