### PR TITLE
Fix for : storing user if user is blocked and no user groups is attached...

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -314,12 +314,13 @@ class JTableUser extends JTable
 		$this->groups = $groups;
 		unset($groups);
 
+ 		$query = $this->_db->getQuery(true)
+ 
 		// Store the group data if the user data was saved.
 		if (is_array($this->groups) && count($this->groups))
 		{
 			// Delete the old user group maps.
-			$query = $this->_db->getQuery(true)
-				->delete($this->_db->quoteName('#__user_usergroup_map'))
+			$query = $query->delete($this->_db->quoteName('#__user_usergroup_map'))
 				->where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id);
 			$this->_db->setQuery($query);
 			$this->_db->execute();


### PR DESCRIPTION
... with object.

$user->block == 1
and $user->groups == array()

Then at line number 346, $query variable is used without being initialized. It was initialized at line number 321, which will not be executed in my case.
