### PR TITLE
Select list feature for comma-separated selected values

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -670,20 +670,11 @@ abstract class JHtmlSelect
 
 				$extra = ($id ? ' id="' . $id . '"' : '') . ($label ? ' label="' . $label . '"' : '') . ($attr ? ' ' . $attr : '') . $extra;
 
-				// Select multiple values comma separated
-				$comma_flag = false;
-
-				if (is_string($options['list.select']))
-				{
-					$comma_separated = explode(",", $options['list.select']);
-					$comma_flag = (count($comma_separated) > 1) ? true : false;
-				}
 
 				if (is_array($options['list.select']) || $comma_flag === true )
 				{
-
-					// Declare array if selected items are comma-separated
-					if ($comma_flag === true)
+					// Select multiple values comma separated
+					if (is_string($options['list.select']) && strpos($options['list.select'], ',') !== false)
 					{
 						$options['list.select'] = explode(",", $options['list.select']);
 					}

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -670,8 +670,7 @@ abstract class JHtmlSelect
 
 				$extra = ($id ? ' id="' . $id . '"' : '') . ($label ? ' label="' . $label . '"' : '') . ($attr ? ' ' . $attr : '') . $extra;
 
-
-				if (is_array($options['list.select']) || $comma_flag === true )
+				if (is_array($options['list.select']))
 				{
 					// Select multiple values comma separated
 					if (is_string($options['list.select']) && strpos($options['list.select'], ',') !== false)

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -670,8 +670,24 @@ abstract class JHtmlSelect
 
 				$extra = ($id ? ' id="' . $id . '"' : '') . ($label ? ' label="' . $label . '"' : '') . ($attr ? ' ' . $attr : '') . $extra;
 
-				if (is_array($options['list.select']))
+				// Select multiple values comma separated
+				$comma_flag = false;
+
+				if (is_string($options['list.select']))
 				{
+					$comma_separated = explode(",", $options['list.select']);
+					$comma_flag = (count($comma_separated) > 1) ? true : false;
+				}
+
+				if (is_array($options['list.select']) || $comma_flag === true )
+				{
+
+					// Declare array if selected items are comma-separated
+					if ($comma_flag === true)
+					{
+						$options['list.select'] = explode(",", $options['list.select']);
+					}
+
 					foreach ($options['list.select'] as $val)
 					{
 						$key2 = is_object($val) ? $val->$options['option.key'] : $val;


### PR DESCRIPTION
With this patch, we can save the multiple values from select inputs using comma-separated directly into the database.

When we save the multiple values into out database we can use this code into our save method on model:

```
// Comma-separated multiple values
$data['multiple_select'] = implode(",", $data['multiple_select']);
```
