### PR TITLE
Fixing Travis for JRegistryFormatXmlTest

### DIFF
--- a/tests/unit/suites/libraries/joomla/registry/format/JRegistryFormatXmlTest.php
+++ b/tests/unit/suites/libraries/joomla/registry/format/JRegistryFormatXmlTest.php
@@ -43,7 +43,7 @@ class JRegistryFormatXMLTest extends PHPUnit_Framework_TestCase
 			"<node name=\"foo\" type=\"string\">bar</node>" .
 			"<node name=\"quoted\" type=\"string\">\"stringwithquotes\"</node>" .
 			"<node name=\"booleantrue\" type=\"boolean\">1</node>" .
-			"<node name=\"booleanfalse\" type=\"boolean\"></node>" .
+			"<node name=\"booleanfalse\" type=\"boolean\"/>" .
 			"<node name=\"numericint\" type=\"integer\">42</node>" .
 			"<node name=\"numericfloat\" type=\"double\">3.1415</node>" .
 			"<node name=\"section\" type=\"object\">" .


### PR DESCRIPTION
The problem is that the empty `booleanfalse` returns as a autoclosed tag instead of explicitely returning a closing tag.
I couldn't track it down to a change in code, so it's maybe related to the testing enviroment itself. Maybe @mbabker knows more?

According to http://stackoverflow.com/questions/17400065/generate-xml-with-simplexmlelement-with-some-empty-filelds one can't change the behavior of `SimpleXMLElement`, thus just changing the expected result should fix it.
