### PR TITLE
Sort DESC column in administration table

### DIFF
--- a/media/jui/js/jquery.searchtools.js
+++ b/media/jui/js/jquery.searchtools.js
@@ -142,7 +142,7 @@
 
 				// Order to set
 				var newOrderCol = $(this).attr('data-order');
-				var newDirection = 'ASC';
+				var newDirection = $(this).attr('data-direction');
 				var newOrdering = newOrderCol + ' ' + newDirection;
 
 				// The data-order attrib is required


### PR DESCRIPTION
This fixes sorting column in descending order.
It still does not work if field list[fullordering] is not defined
