### PR TITLE
Fix tests

### DIFF
--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1340,7 +1340,7 @@ class JDatabaseQueryTest extends TestCase
 		);
 
 		$this->_instance->set('bar = 2');
-		$this->assertEquals("SET foo = 1" . PHP_EOL . "\t, bar = 2", trim(TestReflection::getValue($this->_instance, 'set')), 'Tests appending with set().');
+		$this->assertEquals("SET foo = 1\n\t, bar = 2", trim(TestReflection::getValue($this->_instance, 'set')), 'Tests appending with set().');
 
 		// Clear the set.
 		TestReflection::setValue($this->_instance, 'set', null);
@@ -1348,7 +1348,7 @@ class JDatabaseQueryTest extends TestCase
 
 		$this->assertThat(
 			trim(TestReflection::getValue($this->_instance, 'set')),
-			$this->identicalTo("SET foo = 1" . PHP_EOL . "\t, bar = 2"),
+			$this->identicalTo("SET foo = 1\n\t, bar = 2"),
 			'Tests set with an array.'
 		);
 
@@ -1358,7 +1358,7 @@ class JDatabaseQueryTest extends TestCase
 
 		$this->assertThat(
 			trim(TestReflection::getValue($this->_instance, 'set')),
-			$this->identicalTo("SET foo = 1" . PHP_EOL . "\t; bar = 2"),
+			$this->identicalTo("SET foo = 1\n\t; bar = 2"),
 			'Tests set with an array and glue.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/document/opensearch/JDocumentOpensearchTest.php
+++ b/tests/unit/suites/libraries/joomla/document/opensearch/JDocumentOpensearchTest.php
@@ -84,9 +84,9 @@ class JDocumentOpensearchTest extends TestCase
 			'<Url type="application/rss+xml" rel="suggestions" template="http://www.example.com?format=feed"/>' .
 			'</OpenSearchDescription>' . PHP_EOL;
 
-		$this->assertThat(
+		$this->assertXmlStringEqualsXmlString(
 			$this->object->render(),
-			$this->equalTo($expected)
+			$expected
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
@@ -123,7 +123,7 @@ class JGithubGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . PHP_EOL)
+					'gittest' => array('content' => 'GistContent' . "\n")
 				),
 				'public' => true,
 				'description' => 'This is a gist'

--- a/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
+++ b/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
@@ -252,7 +252,7 @@ class JModelLegacyTest extends TestCase
 	{
 		$paths = JModelLegacy::addIncludePath(__DIR__ . '/stubs');
 
-		$this->assertContains(__DIR__ . '/stubs', $paths);
+		$this->assertContains(__DIR__ . DIRECTORY_SEPARATOR . 'stubs', $paths);
 
 		$this->fixture = JModelLegacy::getInstance('Foobar', 'StubModel');
 		$this->assertTrue($this->fixture instanceof StubModelFoobar);


### PR DESCRIPTION
There are several tests which fail on windows due to cross platform issues (line endings and directory separators). 
Here's the tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32842&start=0

In case of line endings, where appropriate, I've changed the test to use `\n` instead of `PHP_EOL`. 
In case of directory separators, `JPath::clean()` will have already changed everything to `DIRECTORY_SEPARATOR` by the time the test runs so, I've changed the test to also use that instead of `/`. 
In a case where we are just testing an xml string, I've changed the test itself to `assertXmlStringEqualsXmlString` so that line ending issues are not even considered at all. 

There are still some tests failing in `JViewLegacyTest` but, in my opinion, these are actually problems with `JViewLegacy` and not the test. Basically, it should be calling `JPath::clean()` on directory strings but it isn't. So I will include those fixes in a different PR.  
