### PR TITLE
[#32842] fix tests

### DIFF
--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -754,8 +754,8 @@ class JViewLegacy extends JObject
 		// Loop through the path directories
 		foreach ($path as $dir)
 		{
-			// No surrounding spaces allowed!
-			$dir = trim($dir);
+			// Clean up the path
+			$dir = JPath::clean($dir);
 
 			// Add trailing separators as needed
 			if (substr($dir, -1) != DIRECTORY_SEPARATOR)

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1302,22 +1302,26 @@ class JDatabaseQueryTest extends TestCase
 			'Tests chaining.'
 		);
 
-		$this->assertThat(
+		$this->assertEquals(
+			'SET foo = 1',
 			trim(TestReflection::getValue($this->_instance, 'set')),
-			$this->identicalTo('SET foo = 1'),
 			'Tests set with a string.'
 		);
 
 		$this->_instance->set('bar = 2');
-		$this->assertEquals("SET foo = 1" . PHP_EOL . "\t, bar = 2", trim(TestReflection::getValue($this->_instance, 'set')), 'Tests appending with set().');
+		$this->assertEquals(
+			"SET foo = 1\n\t, bar = 2",
+			trim(TestReflection::getValue($this->_instance, 'set')),
+			'Tests appending with set().'
+		);
 
 		// Clear the set.
 		TestReflection::setValue($this->_instance, 'set', null);
 		$this->_instance->set(array('foo = 1', 'bar = 2'));
 
-		$this->assertThat(
+		$this->assertEquals(
+			"SET foo = 1\n\t, bar = 2",
 			trim(TestReflection::getValue($this->_instance, 'set')),
-			$this->identicalTo("SET foo = 1" . PHP_EOL . "\t, bar = 2"),
 			'Tests set with an array.'
 		);
 
@@ -1325,9 +1329,9 @@ class JDatabaseQueryTest extends TestCase
 		TestReflection::setValue($this->_instance, 'set', null);
 		$this->_instance->set(array('foo = 1', 'bar = 2'), ';');
 
-		$this->assertThat(
+		$this->assertEquals(
+			"SET foo = 1\n\t; bar = 2",
 			trim(TestReflection::getValue($this->_instance, 'set')),
-			$this->identicalTo("SET foo = 1" . PHP_EOL . "\t; bar = 2"),
 			'Tests set with an array and glue.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1693,7 +1693,7 @@ class JDatabaseQueryTest extends TestCase
 			(string) $this->_instance,
 			$this->equalTo(
 				PHP_EOL . "SELECT name" . PHP_EOL .
-				"FROM foo" . PHP_EOL . 
+				"FROM foo" . PHP_EOL .
 				"WHERE a=1" . PHP_EOL .
 				"UNION (" . PHP_EOL .
 				"SELECT name" . PHP_EOL .

--- a/tests/unit/suites/libraries/joomla/document/opensearch/JDocumentOpensearchTest.php
+++ b/tests/unit/suites/libraries/joomla/document/opensearch/JDocumentOpensearchTest.php
@@ -84,9 +84,9 @@ class JDocumentOpensearchTest extends TestCase
 			'<Url type="application/rss+xml" rel="suggestions" template="http://www.example.com?format=feed"/>' .
 			'</OpenSearchDescription>' . PHP_EOL;
 
-		$this->assertThat(
+		$this->assertXmlStringEqualsXmlString(
 			$this->object->render(),
-			$this->equalTo($expected)
+			$expected
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
@@ -126,7 +126,7 @@ class JGithubGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . PHP_EOL)
+					'gittest' => array('content' => 'GistContent' . "\n")
 				),
 				'public' => true,
 				'description' => 'This is a gist'

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
@@ -123,7 +123,7 @@ class JGithubPackageGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . PHP_EOL)
+					'gittest' => array('content' => 'GistContent' . "\n")
 				),
 				'public' => true,
 				'description' => 'This is a gist'

--- a/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
+++ b/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
@@ -252,7 +252,7 @@ class JModelLegacyTest extends TestCase
 	{
 		$paths = JModelLegacy::addIncludePath(__DIR__ . '/stubs');
 
-		$this->assertContains(__DIR__ . '/stubs', $paths);
+		$this->assertContains(__DIR__ . DIRECTORY_SEPARATOR . 'stubs', $paths);
 
 		$this->fixture = JModelLegacy::getInstance('Foobar', 'StubModel');
 		$this->assertTrue($this->fixture instanceof StubModelFoobar);


### PR DESCRIPTION
Same as #2616 but for staging

There are several tests which fail on windows due to cross platform issues (line endings and directory separators). 
Here's the tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32842&start=0

In case of line endings, where appropriate, I've changed the test to use `\n` instead of `PHP_EOL`. 
In case of directory separators, `JPath::clean()` will have already changed everything to `DIRECTORY_SEPARATOR` by the time the test runs so, I've changed the test to also use that instead of `/`. 
In a case where we are just testing an xml string, I've changed the test itself to `assertXmlStringEqualsXmlString` so that line ending issues are not even considered at all. 

There are still some tests failing in `JViewLegacyTest` but, in my opinion, these are actually problems with `JViewLegacy` and not the test. Basically, it should be calling `JPath::clean()` on directory strings but it isn't. So I will include those fixes in a different PR.  
