### PR TITLE
Fixing JHtmlContentLanguage::existing()

### DIFF
--- a/libraries/cms/html/contentlanguage.php
+++ b/libraries/cms/html/contentlanguage.php
@@ -54,13 +54,16 @@ abstract class JHtmlContentLanguage
 			// Set the query and load the options.
 			$db->setQuery($query);
 			static::$items = $db->loadObjectList();
-
-			if ($all)
-			{
-				array_unshift(static::$items, new JObject(array('value' => '*', 'text' => $translate ? JText::alt('JALL', 'language') : 'JALL_LANGUAGE')));
-			}
 		}
 
-		return static::$items;
+		if ($all)
+		{
+			$all_option = array(new JObject(array('value' => '*', 'text' => $translate ? JText::alt('JALL', 'language') : 'JALL_LANGUAGE')));
+			return array_merge($all_option, static::$items);
+		}
+		else
+		{
+			return static::$items;
+		}
 	}
 }


### PR DESCRIPTION
JHtmlContentLanguage::existing() uses a cached `static::$items` to return the list of installed languages. However this doesn't take into account the option for the `$all` and `translate` arguments of the function.
The first call determines what will be returned and subsequent calls always return the same, ignoring the passed arguments.

You can test this in com_content where the language batch function does miss the `All` option because the Search Tools are calling the function prior to the language batch.
This PR will solve that and restore the expected behavior.

See tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32846
Previous PR for reference: https://github.com/joomla/joomla-cms/pull/2621
