### PR TITLE
Adding `nochange` and `noposition` option to module batch processing

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 $clientId  = $this->state->get('filter.client_id');
 $published = $this->state->get('filter.published');
 $positions = JHtml::_('modules.positions', $clientId, $published);
+$positions['']['items'][] = ModulesHelper::createOption('nochange', JText::_('COM_MODULES_BATCH_POSITION_NOCHANGE'));
+$positions['']['items'][] = ModulesHelper::createOption('noposition', JText::_('COM_MODULES_BATCH_POSITION_NOPOSITION'));
 
 // Add custom position to options
 $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');


### PR DESCRIPTION
Currently, you can't batch copy a module if you don't select a position. That means you can copy a module with the position `none`. The help text also says 

> When copying and not changing position, it is nevertheless necessary to select 'Keep Original Position' in the dropdown

Although the `Keep original Position` doesn't exist.

This PR reimplements both options into the batch processing.
### Testing

Make especially sure you can batch copy a module
- which currently has the 'position' `none` by selecting the option `Keep original Position`
- which currently has any position by selecting the option `Keep original Position`
- to the 'position' `none` by selecting the option `No Module Position`

Of course also test if nothing from the existing functionality broke :smiley: 

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32844
