### PR TITLE
[#32854] Use JLayout to render debug backtrace

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -251,6 +251,61 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo $this->error->getMessage();?>
 						</blockquote>
 						<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
+						<p>
+						<?php
+						$contents = null;
+						$backtrace = $this->error->getTrace();
+
+						if (is_array($backtrace))
+						{
+						$j = 1;
+						?>
+						<table cellpadding="0" cellspacing="0" class="Table table table-striped">
+							<thead>
+							<tr>
+								<th colspan="3" class="th"><strong>Call stack</strong></th>
+							</tr>
+							<tr>
+								<th class="th"><strong>#</strong></th>
+								<th class="th"><strong>Function</strong></th>
+								<th class="th"><strong>Location</strong></th>
+							</tr>
+							</thead>
+							<tbody>
+							<?php for ($i = count($backtrace) - 1; $i >= 0; $i--):?>
+								<tr>
+									<td class="TD"><?php echo $j;?></td>
+									<td class="TD">
+										<?php
+										if (isset($backtrace[$i]['class']))
+										{
+											echo $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()';
+										}
+										else
+										{
+											echo $backtrace[$i]['function'] . '()';
+										}
+										?>
+									</td>
+									<td class="TD">
+										<?php
+										if (isset($backtrace[$i]['file']))
+										{
+											echo $backtrace[$i]['file'] . ':' . $backtrace[$i]['line'];
+										}
+										else
+										{
+											echo '&#160';
+										}
+										?>
+									</td>
+								</tr>
+								<?php $j++;?>
+							<?php endfor;?>
+							</tbody>
+						</table>
+						<?php } ?>
+						</p>
 						<!-- End Content -->
 					</div>
 			</div>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -252,61 +252,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 						</blockquote>
 						<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
 						<?php if ($this->debug):?>
-						<p>
-						<?php
-						$contents = null;
-						$backtrace = $this->error->getTrace();
-
-						if (is_array($backtrace))
-						{
-						$j = 1;
-						?>
-						<table cellpadding="0" cellspacing="0" class="Table table table-striped">
-							<thead>
-							<tr>
-								<th colspan="3" class="th"><strong>Call stack</strong></th>
-							</tr>
-							<tr>
-								<th class="th"><strong>#</strong></th>
-								<th class="th"><strong>Function</strong></th>
-								<th class="th"><strong>Location</strong></th>
-							</tr>
-							</thead>
-							<tbody>
-							<?php for ($i = count($backtrace) - 1; $i >= 0; $i--):?>
-								<tr>
-									<td class="TD"><?php echo $j;?></td>
-									<td class="TD">
-										<?php
-										if (isset($backtrace[$i]['class']))
-										{
-											echo $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()';
-										}
-										else
-										{
-											echo $backtrace[$i]['function'] . '()';
-										}
-										?>
-									</td>
-									<td class="TD">
-										<?php
-										if (isset($backtrace[$i]['file']))
-										{
-											echo $backtrace[$i]['file'] . ':' . $backtrace[$i]['line'];
-										}
-										else
-										{
-											echo '&#160';
-										}
-										?>
-									</td>
-								</tr>
-								<?php $j++;?>
-							<?php endfor;?>
-							</tbody>
-						</table>
-						<?php } ?>
-						</p>
+							<?php echo $this->renderBacktrace(); ?>
 						<?php endif; ?>
 						<!-- End Content -->
 					</div>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -251,6 +251,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo $this->error->getMessage();?>
 						</blockquote>
 						<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
+						<?php if ($this->debug):?>
 						<p>
 						<?php
 						$contents = null;
@@ -306,6 +307,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 						</table>
 						<?php } ?>
 						</p>
+						<?php endif; ?>
 						<!-- End Content -->
 					</div>
 			</div>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1788,8 +1788,8 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 --
 
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
-(1, 'Joomla Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
+(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
 (3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0);
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1714,8 +1714,8 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 -- Dumping data for table #__update_sites
 --
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
-(1, 'Joomla Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
+(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
 (3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0);
 
 --

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2749,9 +2749,9 @@ CREATE TABLE [#__update_sites](
 SET IDENTITY_INSERT [#__update_sites] ON;
 
 INSERT INTO [#__update_sites] ([update_site_id], [name], [type], [location], [enabled], [last_check_timestamp])
-SELECT 1, 'Joomla Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0
+SELECT 1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0
 UNION ALL
-SELECT 2, 'Joomla Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0
+SELECT 2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0
 UNION ALL
 SELECT 3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0;
 

--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/** @var $displayData array */
+$class = isset($displayData['class']) ? $displayData['class'] : 'table table-striped table-bordered';
+$backtraceList = $displayData['backtrace'];
+?>
+<table cellpadding="0" cellspacing="0" class="Table <?php echo $class ?>">
+	<tr>
+		<td colspan="3" class="TD">
+			<strong>Call stack</strong>
+		</td>
+	</tr>
+
+	<tr>
+		<td class="TD">
+			<strong>#</strong>
+		</td>
+		<td class="TD">
+			<strong>Function</strong>
+		</td>
+		<td class="TD">
+			<strong>Location</strong>
+		</td>
+	</tr>
+
+	<?php foreach ($backtraceList as $k => $backtrace): ?>
+	<tr>
+		<td class="TD">
+			<?php echo $k + 1; ?>
+		</td>
+
+		<?php if (isset($backtrace['class'])): ?>
+		<td class="TD">
+			<?php echo $backtrace['class'] . $backtrace['type'] . $backtrace['function'] . '()'; ?>
+		</td>
+		<?php else: ?>
+		<td class="TD">
+			<?php echo $backtrace['function'] . '()'; ?>
+		</td>
+		<?php endif; ?>
+
+		<?php if (isset($backtrace['file'])): ?>
+		<td class="TD">
+			<?php echo $backtrace['file'] . ':' . $backtrace['line'] ?>
+		</td>
+		<?php else: ?>
+		<td class="TD">
+			&#160;
+		</td>
+		<?php endif; ?>
+	</tr>
+	<?php endforeach; ?>
+</table>

--- a/layouts/joomla/error/index.html
+++ b/layouts/joomla/error/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -151,46 +151,7 @@ class JDocumentError extends JDocument
 	{
 		$contents = null;
 		$backtrace = $this->_error->getTrace();
-		if (is_array($backtrace))
-		{
-			ob_start();
-			$j = 1;
-			echo '<table cellpadding="0" cellspacing="0" class="Table">';
-			echo '	<tr>';
-			echo '		<td colspan="3" class="TD"><strong>Call stack</strong></td>';
-			echo '	</tr>';
-			echo '	<tr>';
-			echo '		<td class="TD"><strong>#</strong></td>';
-			echo '		<td class="TD"><strong>Function</strong></td>';
-			echo '		<td class="TD"><strong>Location</strong></td>';
-			echo '	</tr>';
-			for ($i = count($backtrace) - 1; $i >= 0; $i--)
-			{
-				echo '	<tr>';
-				echo '		<td class="TD">' . $j . '</td>';
-				if (isset($backtrace[$i]['class']))
-				{
-					echo '	<td class="TD">' . $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()</td>';
-				}
-				else
-				{
-					echo '	<td class="TD">' . $backtrace[$i]['function'] . '()</td>';
-				}
-				if (isset($backtrace[$i]['file']))
-				{
-					echo '		<td class="TD">' . $backtrace[$i]['file'] . ':' . $backtrace[$i]['line'] . '</td>';
-				}
-				else
-				{
-					echo '		<td class="TD">&#160;</td>';
-				}
-				echo '	</tr>';
-				$j++;
-			}
-			echo '</table>';
-			$contents = ob_get_contents();
-			ob_end_clean();
-		}
-		return $contents;
+
+		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $backtrace));
 	}
 }

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1601,55 +1601,7 @@ class PlgSystemDebug extends JPlugin
 	{
 		$backtrace = $error->getTrace();
 
-		$html = array();
-
-		if (is_array($backtrace))
-		{
-			$j = 1;
-
-			$html[] = '<table cellpadding="0" cellspacing="0">';
-
-			$html[] = '<tr>';
-			$html[] = '<td colspan="3"><strong>Call stack</strong></td>';
-			$html[] = '</tr>';
-
-			$html[] = '<tr>';
-			$html[] = '<th>#</th>';
-			$html[] = '<th>Function</th>';
-			$html[] = '<th>Location</th>';
-			$html[] = '</tr>';
-
-			for ($i = count($backtrace) - 1; $i >= 0; $i--)
-			{
-				$link = '&#160;';
-
-				if (isset($backtrace[$i]['file']))
-				{
-					$link = $this->formatLink($backtrace[$i]['file'], $backtrace[$i]['line']);
-				}
-
-				$html[] = '<tr>';
-				$html[] = '<td>' . $j . '</td>';
-
-				if (isset($backtrace[$i]['class']))
-				{
-					$html[] = '<td>' . $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()</td>';
-				}
-				else
-				{
-					$html[] = '<td>' . $backtrace[$i]['function'] . '()</td>';
-				}
-
-				$html[] = '<td>' . $link . '</td>';
-
-				$html[] = '</tr>';
-				$j++;
-			}
-
-			$html[] = '</table>';
-		}
-
-		return implode('', $html);
+		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $backtrace));
 	}
 
 	/**


### PR DESCRIPTION
## Introduction

In current time, we use `setError()`, `getError()` and `JError::raiseError()` in component to send error message.

However, if we use `Exception` to throw error, the debug plugin will not render backtrace for developer. It only work when we use `JError::reiseError()`.

It's because we have this code: https://github.com/joomla/joomla-cms/blob/master/plugins/system/debug/debug.php#L213

``` php
if (JDEBUG)
        {
            if (JError::getErrors())
            {
                $html[] = $this->display('errors');
            }
```

To detect whether display errors or not. When we throw an exception, the `JError::getErrors()` will return null.
## The Modification

I added backtrace table in isis `error.php`, this code are consult from `JDocumentError::renderBacktrace()`, but I dont' use this method because it rendered a table without bootstrap table style.

So I wrote backtrace renderer in isis to support Bootstrap style. I dont't want to change `JDocumentError`, because it is a Platform class not CMS class.
## Screenshot

![p2013-12-01-3](https://f.cloud.github.com/assets/1639206/1650232/eb7e84cc-5a73-11e3-996e-81446b8b5845.jpg)

JTracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32854&start=0
