### PR TITLE
[#32855] Stop message: 'end() expects parameter 1 to be array, null given'

### DIFF
--- a/libraries/legacy/exception/exception.php
+++ b/libraries/legacy/exception/exception.php
@@ -99,6 +99,12 @@ class JException extends Exception
 	protected $backtrace = null;
 
 	/**
+	 * @var    array  An array of error messages or Exception objects.
+	 * @since  11.1
+	 */
+	protected $_errors = array();
+
+	/**
 	 * Constructor
 	 * - used to set up the error with all needed error details.
 	 *


### PR DESCRIPTION
``` PHP
PHP Warning: end() expects parameter 1 to be array, null given in ../libraries/legacy/exception/exception.php on line 280
```

Every time I need send email globally I get this message.

Tracker: #32855

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32855&start=0
