### PR TITLE
Fixing broken routing due to missing language parameter.

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -43,7 +43,7 @@ class JHtmlIcon
 		$uri	= JURI::getInstance();
 		$base	= $uri->toString(array('scheme', 'host', 'port'));
 		$template = JFactory::getApplication()->getTemplate();
-		$link	= $base.JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid) , false);
+		$link	= $base.JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language) , false);
 		$url	= 'index.php?option=com_mailto&tmpl=component&template='.$template.'&link='.MailToHelper::addLink($link);
 
 		$status = 'width=400,height=350,menubar=yes,resizable=yes';
@@ -131,7 +131,7 @@ class JHtmlIcon
 
 	static function print_popup($article, $params, $attribs = array())
 	{
-		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid);
+		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language);
 		$url .= '&tmpl=component&print=1&layout=default&page='.@ $request->limitstart;
 
 		$status = 'status=no,toolbar=no,scrollbars=yes,titlebar=no,menubar=no,resizable=yes,width=640,height=480,directories=no,location=no';

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -135,24 +135,25 @@ abstract class ContentHelperRoute
 	{
 		$app		= JFactory::getApplication();
 		$menus		= $app->getMenu('site');
+		$language	= isset($needles['language']) ? $needles['language'] : '*';
 
 		// Prepare the reverse lookup array.
-		if (self::$lookup === null)
+		if (!isset(self::$lookup[$language]))
 		{
-			self::$lookup = array();
+			self::$lookup[$language] = array();
 
 			$component	= JComponentHelper::getComponent('com_content');
 			$items		= $menus->getItems('component_id', $component->id);
 			foreach ($items as $item)
 			{
-				if (isset($item->query) && isset($item->query['view']))
+				if (isset($item->query) && isset($item->query['view']) && $item->language == $language) 
 				{
 					$view = $item->query['view'];
-					if (!isset(self::$lookup[$view])) {
-						self::$lookup[$view] = array();
+					if (!isset(self::$lookup[$language][$view])) {
+						self::$lookup[$language][$view] = array();
 					}
 					if (isset($item->query['id'])) {
-						self::$lookup[$view][$item->query['id']] = $item->id;
+						self::$lookup[$language][$view][$item->query['id']] = $item->id;
 					}
 				}
 			}
@@ -162,12 +163,12 @@ abstract class ContentHelperRoute
 		{
 			foreach ($needles as $view => $ids)
 			{
-				if (isset(self::$lookup[$view]))
+				if (isset(self::$lookup[$language][$view]))
 				{
 					foreach($ids as $id)
 					{
-						if (isset(self::$lookup[$view][(int)$id])) {
-							return self::$lookup[$view][(int)$id];
+						if (isset(self::$lookup[$language][$view][(int)$id])) {
+							return self::$lookup[$language][$view][(int)$id];
 						}
 					}
 				}
@@ -175,6 +176,10 @@ abstract class ContentHelperRoute
 		}
 		else
 		{
+			if ($language != '*') {
+				$needles['language'] = '*';
+				return self::_findItem($needles);
+			}
 			$active = $menus->getActive();
 			if ($active && $active->component == 'com_content') {
 				return $active->id;

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -157,7 +157,7 @@ class ContentModelArticles extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.title_alias, a.introtext, ' .
+				'a.id, a.title, a.alias, a.title_alias, a.introtext, a.language, ' .
 				'a.checked_out, a.checked_out_time, ' .
 				'a.catid, a.created, a.created_by, a.created_by_alias, ' .
 				// use created if modified is 0

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -19,7 +19,7 @@ $params = &$this->params;
 
 		<h2>
 		<?php if ($params->get('link_titles')): ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
 				<?php echo $this->escape($item->title); ?></a>
 		<?php else: ?>
 				<?php echo $this->escape($item->title); ?>

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -50,7 +50,7 @@ class ContentViewArticle extends JViewLegacy
 		$item->parent_slug	= $item->category_alias ? ($item->parent_id.':'.$item->parent_alias) : $item->parent_id;
 
 		// TODO: Change based on shownoauth
-		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language));
 
 		// Merge article params. If this is single-article view, menu params override article params
 		// Otherwise, article params override menu item params

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -25,7 +25,7 @@ JHtml::_('behavior.framework');
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -138,13 +138,13 @@ JHtml::_('behavior.framework');
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JURI($link1);
 		$link->setVar('return', base64_encode(urlencode($returnURL)));
 	endif;

--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
 	foreach ($this->link_items as &$item) :
 ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -102,7 +102,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 
 					<td class="list-title">
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid)); ?>">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?></a>
 
 						<?php if ($article->params->get('access-edit')) : ?>
@@ -155,7 +155,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 							$active		= $menu->getActive();
 							$itemId		= $active->id;
 							$link = JRoute::_('index.php?option=com_users&view=login&Itemid='.$itemId);
-							$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug));
+							$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language));
 							$fullURL = new JURI($link);
 							$fullURL->setVar('return', base64_encode(urlencode($returnURL)));
 						?>

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -40,7 +40,7 @@ class ContentViewCategory extends JViewLegacy
 			$row->slug = $row->alias ? ($row->id . ':' . $row->alias) : $row->id;
 
 			// Url link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
 
 			// Get row fulltext
 			$db = JFactory::getDBO();

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -21,7 +21,7 @@ $canEdit	= $this->item->params->get('access-edit');
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -138,13 +138,13 @@ $canEdit	= $this->item->params->get('access-edit');
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JURI($link1);
 		$link->setVar('return', base64_encode(urlencode($returnURL)));
 	endif;

--- a/components/com_content/views/featured/tmpl/default_links.php
+++ b/components/com_content/views/featured/tmpl/default_links.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <ol>
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -40,7 +40,7 @@ class ContentViewFeatured extends JViewLegacy
 			$row->slug = $row->alias ? ($row->id . ':' . $row->alias) : $row->id;
 
 			// Url link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
 
 			// Get row fulltext
 			$db = JFactory::getDBO();

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -196,7 +196,7 @@ abstract class modArticlesCategoryHelper
 
 			if ($access || in_array($item->access, $authorised)) {
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language));
 			}
 			 else {
 				// Angie Fixed Routing

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -98,7 +98,7 @@ abstract class modArticlesLatestHelper
 
 			if ($access || in_array($item->access, $authorised)) {
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language));
 			} else {
 				$item->link = JRoute::_('index.php?option=com_users&view=login');
 			}

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -34,7 +34,7 @@ abstract class modArticlesNewsHelper
 
 		$model->setState('list.select', 'a.fulltext, a.id, a.title, a.alias, a.title_alias, a.introtext, a.state, a.catid, a.created, a.created_by, a.created_by_alias,' .
 			' a.modified, a.modified_by, a.publish_up, a.publish_down, a.images, a.urls, a.attribs, a.metadata, a.metakey, a.metadesc, a.access,' .
-			' a.hits, a.featured' );
+			' a.hits, a.featured, a.language' );
 
 		// Access filter
 		$access = !JComponentHelper::getParams('com_content')->get('show_noauth');
@@ -67,7 +67,7 @@ abstract class modArticlesNewsHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 				$item->linkText = JText::_('MOD_ARTICLES_NEWS_READMORE');
 			}
 			else {

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -53,7 +53,7 @@ abstract class modArticlesPopularHelper
 
 			if ($access || in_array($item->access, $authorised)) {
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language));
 			} else {
 				$item->link = JRoute::_('index.php?option=com_users&view=login');
 			}

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -68,6 +68,7 @@ abstract class modRelatedItemsHelper
 					$query->select('a.title');
 					$query->select('DATE_FORMAT(a.created, "%Y-%m-%d") as created');
 					$query->select('a.catid');
+					$query->select('a.language');
 					$query->select('cc.access AS cat_access');
 					$query->select('cc.published AS cat_state');
 
@@ -115,7 +116,7 @@ abstract class modRelatedItemsHelper
 						{
 							if ($row->cat_state == 1)
 							{
-								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catslug));
+								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catslug, $row->language));
 								$related[] = $row;
 							}
 						}

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -235,7 +235,7 @@ class plgContentPagebreak extends JPlugin
 		$row->toc .= '<ul>
 		<li>
 
-			<a href="'. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid).'&showall=&limitstart=') .'" class="'.$class.'">'
+			<a href="'. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language).'&showall=&limitstart=') .'" class="'.$class.'">'
 			. $heading .
 			'</a>
 
@@ -245,7 +245,7 @@ class plgContentPagebreak extends JPlugin
 		$i = 2;
 
 		foreach ($matches as $bot) {
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid).'&showall=&limitstart='. ($i-1));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language).'&showall=&limitstart='. ($i-1));
 
 
 			if (@$bot[0]) {
@@ -275,7 +275,7 @@ class plgContentPagebreak extends JPlugin
 		}
 
 		if ($this->params->get('showall')) {
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid).'&showall=1&limitstart=');
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language).'&showall=1&limitstart=');
 			$class = ($showall == 1) ? 'toclink active' : 'toclink';
 			$row->toc .= '
 			<li>
@@ -304,7 +304,7 @@ class plgContentPagebreak extends JPlugin
 		if ($page < $n-1) {
 			$page_next = $page + 1;
 
-			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid).'&showall=&limitstart='. ($page_next));
+			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language).'&showall=&limitstart='. ($page_next));
 			// Next >>
 			$next = '<a href="'. $link_next .'">' . JText::_('JNEXT') . $pnSpace . JText::_('JGLOBAL_GT') . JText::_('JGLOBAL_GT') .'</a>';
 		} else {
@@ -314,7 +314,7 @@ class plgContentPagebreak extends JPlugin
 		if ($page > 0) {
 			$page_prev = $page - 1 == 0 ? '' : $page - 1;
 
-			$link_prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid).'&showall=&limitstart='. ($page_prev));
+			$link_prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language).'&showall=&limitstart='. ($page_prev));
 			// << Prev
 			$prev = '<a href="'. $link_prev .'">'. JText::_('JGLOBAL_LT') . JText::_('JGLOBAL_LT') . $pnSpace . JText::_('JPREV') .'</a>';
 		} else {

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -116,7 +116,7 @@ class plgContentPagenavigation extends JPlugin
 	        $case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
 	        $case_when1 .= ' ELSE ';
 	        $case_when1 .= $c_id.' END as catslug';
-      		$query->select('a.id,'.$case_when.','.$case_when1);
+      		$query->select('a.id, a.language,'.$case_when.','.$case_when1);
 			$query->from('#__content AS a');
 			$query->leftJoin('#__categories AS cc ON cc.id = a.catid');
 			$query->where('a.catid = '. (int)$row->catid .' AND a.state = '. (int)$row->state
@@ -160,13 +160,13 @@ class plgContentPagenavigation extends JPlugin
 			}
 
 			if ($row->prev) {
-				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catslug));
+				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catslug, $row->prev->language));
 			} else {
 				$row->prev = '';
 			}
 
 			if ($row->next) {
-				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catslug));
+				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catslug, $row->next->language));
 			} else {
 				$row->next = '';
 			}

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -270,7 +270,7 @@ class plgFinderContent extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug);
+		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		// Get the menu title if it exists.

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -150,7 +150,7 @@ class plgSearchContent extends JPlugin
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id.' END as catslug';
 
-			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created');
+			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language');
 			$query->select($query->concatenate(array('a.introtext', 'a.fulltext')).' AS text');
 			$query->select('c.title AS section, '.$case_when.','.$case_when1.', '.'\'2\' AS browsernav');
 
@@ -177,7 +177,7 @@ class plgSearchContent extends JPlugin
 			{
 				foreach($list as $key => $item)
 				{
-					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug);
+					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language);
 				}
 			}
 			$rows[] = $list;

--- a/templates/beez5/html/com_content/archive/default_items.php
+++ b/templates/beez5/html/com_content/archive/default_items.php
@@ -25,7 +25,7 @@ $params = &$this->params;
 
 		<h2>
 		<?php if ($params->get('link_titles')): ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 				<?php echo $this->escape($item->title); ?></a>
 		<?php else: ?>
 				<?php echo $this->escape($item->title); ?>

--- a/templates/beez5/html/com_content/category/blog_item.php
+++ b/templates/beez5/html/com_content/category/blog_item.php
@@ -29,7 +29,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -142,13 +142,13 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JURI($link1);
 		$link->setVar('return', base64_encode(urlencode($returnURL)));
 	endif;

--- a/templates/beez5/html/com_content/category/blog_links.php
+++ b/templates/beez5/html/com_content/category/blog_links.php
@@ -30,7 +30,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 	foreach ($this->link_items as &$item) :
 ?>
 		 <li>
-		  		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+		  		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 		</li>
 <?php endforeach; ?>

--- a/templates/beez5/html/com_content/category/default_articles.php
+++ b/templates/beez5/html/com_content/category/default_articles.php
@@ -103,7 +103,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 
 					<td class="list-title">
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid)); ?>">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?></a>
 					</td>
 
@@ -148,7 +148,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						$active		= $menu->getActive();
 						$itemId		= $active->id;
 						$link = JRoute::_('index.php?option=com_users&view=login&Itemid='.$itemId);
-						$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug));
+						$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language));
 						$fullURL = new JURI($link);
 						$fullURL->setVar('return', base64_encode(urlencode($returnURL)));
 					?>

--- a/templates/beez5/html/com_content/featured/default_item.php
+++ b/templates/beez5/html/com_content/featured/default_item.php
@@ -30,7 +30,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -148,13 +148,13 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JURI($link1);
 		$link->setVar('return', base64_encode(urlencode($returnURL)));
 	endif;

--- a/templates/beez5/html/com_content/featured/default_links.php
+++ b/templates/beez5/html/com_content/featured/default_links.php
@@ -23,7 +23,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <ol class="links">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>


### PR DESCRIPTION
When a URL to an article is supposed to be generated for another language than the current one, this fails due to Joomla not using the language parameter for ContentHelperRoute::getArticleRoute() right now. This normally rarely happens, since you can only see articles for your current language or for the 'all' language, but when using smart search, you get results for all languages. Due to this bug, the links to non-'all'-language articles are however wrong. This fixes this.

This fix was made possible and is sponsored by Pulsar Informatique: https://www.pulsar-agency.com/

Thanks for that.