### PR TITLE
Fix category batch copy

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1406,6 +1406,23 @@ class JTableNested extends JTable
 	}
 
 	/**
+	 * Method to reset class properties to the defaults set in the class
+	 * definition. It will ignore the primary key as well as any private class
+	 * properties (except $_errors).
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2.1
+	 */
+	public function reset()
+	{
+		parent::reset();
+
+		// Reset the location properties.
+		$this->setLocation(0);
+	}
+
+	/**
 	 * Method to update order of table rows
 	 *
 	 * @param   array  $idArray    id numbers of rows to be reordered.

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -294,7 +294,7 @@ abstract class JModelAdmin extends JModelForm
 
 				if (!$this->table->store())
 				{
-					$this->setError($table->getError());
+					$this->setError($this->table->getError());
 
 					return false;
 				}


### PR DESCRIPTION
### Issue

Try batch copy a category if
- the category itself has subcategories
- you also change the language or access level with the same batch process

This will fail with a fatal error in case of batchAccess or a lengthy error message in case of batchLanguage. The categories will be copied (sometimes even multiple times), but the access levels and languages are not correctly changed.
### Bugtracking

The problem is that the table->reset() function didn't reset the `_location` and `_location_id` properties of the table. Thus subsequent stores tried to move the categories again, which failed due to wrong parent ids.
### Fix

This PR adds JTableNested->reset() which will reset the locations (`using $this->setLocation(0)`) after the parent reset function was executed.

Fixes https://github.com/joomla/joomla-cms/pull/2628
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32827
