### PR TITLE
cURL support for reCAPTCHA plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -19,6 +19,10 @@ PLG_RECAPTCHA_THEME_BLACKGLASS="BlackGlass"
 PLG_RECAPTCHA_THEME_CLEAN="Clean"
 PLG_RECAPTCHA_LANG_LABEL="Language"
 PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
+PLG_RECAPTCHA_METHOD_FSOCK="FileSocket"
+PLG_RECAPTCHA_METHOD_CURL="Curl"
+PLG_RECAPTCHA_METHOD="Connection Method"
+PLG_RECAPTCHA_METHOD_DESC="How to connect to reCAPTCHA. If your server does not support FileSockets, or you get an error, try switching to cURL"
 
 ; Error messages
 PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="ReCaptcha plugin needs a private key to be set in its parameters. Please contact a site administrator."

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -20,7 +20,7 @@ PLG_RECAPTCHA_THEME_CLEAN="Clean"
 PLG_RECAPTCHA_LANG_LABEL="Language"
 PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
 PLG_RECAPTCHA_METHOD_FSOCK="FileSocket"
-PLG_RECAPTCHA_METHOD_CURL="Curl"
+PLG_RECAPTCHA_METHOD_CURL="cURL"
 PLG_RECAPTCHA_METHOD="Connection Method"
 PLG_RECAPTCHA_METHOD_DESC="How to connect to reCAPTCHA. If your server does not support FileSockets, or you get an error, try switching to cURL"
 

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -53,6 +53,17 @@
 			<option
 				value="red">PLG_RECAPTCHA_THEME_RED</option>
 			</field>
+		<field
+			name="method"
+			type="list"
+			default="fsock"
+			label="PLG_RECAPTCHA_METHOD"
+			description="PLG_RECAPTCHA_METHOD_DESC"
+			required="true"
+			>
+			<option value="fsock">PLG_RECAPTCHA_METHOD_FSOCK</option>
+			<option value="curl">PLG_RECAPTCHA_METHOD_CURL</option>
+		</field>
 		</fieldset>
 	</fields>
 	</config>


### PR DESCRIPTION
If your server doesn't support filesockets, reCAPTCHA doesn't work. 
This pull request adds cURL as a method of connection

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32867&start=0
