### PR TITLE
Fixing broken URL creation when categories are trashed or unpublished

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -66,7 +66,7 @@ abstract class ContactHelperRoute
 			$category = JCategories::getInstance('Contact')->get($id);
 		}
 
-		if($id < 1)
+		if ($id < 1 || !($category instanceof JCategoryNode))
 		{
 			$link = '';
 		}
@@ -83,7 +83,7 @@ abstract class ContactHelperRoute
 
 			if ($item = self::_findItem($needles))
 			{
-				$link = 'index.php?Itemid='.$item;
+				$link .= '&Itemid='.$item;
 			}
 		}
 

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -68,7 +68,7 @@ abstract class NewsfeedsHelperRoute
 			$category = JCategories::getInstance('Newsfeeds')->get($id);
 		}
 
-		if($id < 1)
+		if ($id < 1 || !($category instanceof JCategoryNode))
 		{
 			$link = '';
 		}

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -87,6 +87,7 @@ abstract class WeblinksHelperRoute
 		}
 
 		if ($id < 1 || !($category instanceof JCategoryNode))
+		{
 			$link = '';
 		}
 		else {

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -86,7 +86,7 @@ abstract class WeblinksHelperRoute
 			$category = JCategories::getInstance('Weblinks')->get($id);
 		}
 
-		if ($id < 1) {
+		if ($id < 1 || !($category instanceof JCategoryNode))
 			$link = '';
 		}
 		else {


### PR DESCRIPTION
When a category is not published or when it is trashed, the URLs are not created and instead a fatal error is thrown. This is an issue with indexing in smart search.

And with the words of Cato the Elder: Ceterum censeo Joomlacode esse delendam (I believe that Joomlacode has to be destroyed. ;-) )
