### PR TITLE
Version Note field is shown based on com_content settings for all extensions

### DIFF
--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -12,7 +12,14 @@ defined('_JEXEC') or die;
 $app = JFactory::getApplication();
 $form = $displayData->getForm();
 $input = $app->input;
-$saveHistory = JComponentHelper::getParams($input->getCmd('extension', 'com_content'))->get('save_history', 0);
+$component = $input->getCmd('option', 'com_content');
+if ($component == 'com_categories')
+{
+	$extension	= $input->getCmd('extension', 'com_content');
+	$parts		= explode('.', $extension);
+	$component	= $parts[0];
+}
+$saveHistory = JComponentHelper::getParams($component)->get('save_history', 0);
 
 $fields = $displayData->get('fields') ?: array(
 	array('category', 'catid'),


### PR DESCRIPTION
### Issue

The "Version Note" field for the content versioning is shown in each extension regardless of the component settings.
### Bug description

This is due to a bug in the joomla.edit.global JLayout file which checks the component parameters based on the `extension` instead of the `option`.
### Proposed Fix

The PR will fix this by first checking for the option, and if this is 'com_categories' it will look up the extension instead and take only the first part of it (because the second may be a section, like "com_content.other").
### Testing
1. Enable Version History in com_content
2. Diable Version History in com_contact
3. Edit a contact and see that the "Version Note" field still shows.
4. Disable Version History in com_content
5. "Version Note" is no longer shown
6. Enable Version History in com_contact
7. "Version Note" still doesn't show.
8. Apply patch and make sure everything works now as expected (including categories).
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32889
