### PR TITLE
Use Portable PHP Passwords (PHPass) for password hashes.

### DIFF
--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -76,6 +76,9 @@ if (version_compare(PHP_VERSION, '5.4.0', '<'))
 define('JPATH_ISWIN', IS_WIN);
 define('JPATH_ISMAC', IS_MAC);
 
+// Register the PasswordHash lib
+JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
+
 // Register classes where the names have been changed to fit the autoloader rules
 // @deprecated  4.0
 JLoader::register('JSimpleCrypt', JPATH_PLATFORM . '/legacy/simplecrypt/simplecrypt.php');

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -306,10 +306,10 @@ abstract class JUserHelper
 	 */
 	public static function hashPassword($password)
 	{
-		// Use crypt-sha256, default 5000 rounds, with a 128-bit salt.
-		$salt = '$5$' . static::genRandomPassword(16);
+		// Use PHPass's portable hashes with a cost of 10.
+		$phpass = new PasswordHash(10, true);
 
-		return crypt($password, $salt);
+		return $phpass->HashPassword($password);
 	}
 
 	/**
@@ -330,13 +330,13 @@ abstract class JUserHelper
 		$rehash = false;
 		$match = false;
 
-		// If we are using the secure passwords from 3.2.1, crypt-sha256
-		if (strpos($hash, '$5$') === 0)
+		// If we are using phpass
+		if (strpos($hash, '$P$') === 0)
 		{
-			// Pass the entire hash to the crypt function
-			$testcrypt = crypt($password, $hash);
+			// Use PHPass's portable hashes with a cost of 10.
+			$phpass = new PasswordHash(10, true);
 
-			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
+			$match = $phpass->CheckPassword($password, $hash);
 
 			$rehash = false;
 		}

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -376,7 +376,7 @@ abstract class JUserHelper
 			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
 		}
 
-		// If we have a match, rehash to ensure we are using crypt-sha256
+		// If we have a match and rehash = true, rehash the password with the current algorithm.
 		if ((int) $user_id > 0 && $match && $rehash)
 		{
 			$user = new JUser($user_id);

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -306,9 +306,10 @@ abstract class JUserHelper
 	 */
 	public static function hashPassword($password)
 	{
-		$salt = static::genRandomPassword(32);
-		$crypted = md5($password . $salt);
-		return $crypted . ':' . $salt;
+		// Use crypt-sha256, default 5000 rounds, with a 128-bit salt.
+		$salt = '$5$' . static::genRandomPassword(16);
+
+		return crypt($password, $salt);
 	}
 
 	/**
@@ -329,7 +330,17 @@ abstract class JUserHelper
 		$rehash = false;
 		$match = false;
 
-		if ($hash[0] == '$')
+		// If we are using the secure passwords from 3.2.1, crypt-sha256
+		if (strpos($hash, '$5$') === 0)
+		{
+			// Pass the entire hash to the crypt function
+			$testcrypt = crypt($password, $hash);
+
+			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
+
+			$rehash = false;
+		}
+		elseif ($hash[0] == '$')
 		{
 			// JCrypt::hasStrongPasswordSupport() includes a fallback for us in the worst case
 			JCrypt::hasStrongPasswordSupport();
@@ -347,10 +358,7 @@ abstract class JUserHelper
 			$salt      = @$parts[1];
 			$testcrypt = static::getCryptedPassword($password, $salt, 'sha256', true);
 
-			if ($hash == $testcrypt)
-			{
-				$match = true;
-			}
+			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
 
 			$rehash = true;
 		}
@@ -361,19 +369,14 @@ abstract class JUserHelper
 			$crypt = $parts[0];
 			$salt  = @$parts[1];
 
-			if (!$salt)
-			{
-				$rehash = true;
-			}
+			$rehash = true;
 
 			$testcrypt = md5($password . $salt) . ($salt ? ':' . $salt : '');
 
-			if ($hash == $testcrypt)
-			{
-				$match = true;
-			}
+			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
 		}
 
+		// If we have a match, rehash to ensure we are using crypt-sha256
 		if ((int) $user_id > 0 && $match && $rehash)
 		{
 			$user = new JUser($user_id);
@@ -536,18 +539,18 @@ abstract class JUserHelper
 				}
 				break;
 
-				case 'sha256':
-					if ($seed)
-					{
-						return preg_replace('|^{sha256}|i', '', $seed);
-					}
-					else
-					{
-						return static::genRandomPassword(16);
-					}
-					break;
+			case 'sha256':
+				if ($seed)
+				{
+					return preg_replace('|^{sha256}|i', '', $seed);
+				}
+				else
+				{
+					return static::genRandomPassword(16);
+				}
+				break;
 
-				case 'crypt-md5':
+			case 'crypt-md5':
 				if ($seed)
 				{
 					return substr(preg_replace('|^{crypt}|i', '', $seed), 0, 12);

--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -1,0 +1,253 @@
+<?php
+#
+# Portable PHP password hashing framework.
+#
+# Version 0.3 / genuine.
+#
+# Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
+# the public domain.  Revised in subsequent years, still public domain.
+#
+# There's absolutely no warranty.
+#
+# The homepage URL for this framework is:
+#
+#	http://www.openwall.com/phpass/
+#
+# Please be sure to update the Version line if you edit this file in any way.
+# It is suggested that you leave the main version number intact, but indicate
+# your project name (after the slash) and add your own revision information.
+#
+# Please do not change the "private" password hashing method implemented in
+# here, thereby making your hashes incompatible.  However, if you must, please
+# change the hash type identifier (the "$P$") to something different.
+#
+# Obviously, since this code is in the public domain, the above are not
+# requirements (there can be none), but merely suggestions.
+#
+class PasswordHash {
+	var $itoa64;
+	var $iteration_count_log2;
+	var $portable_hashes;
+	var $random_state;
+
+	function PasswordHash($iteration_count_log2, $portable_hashes)
+	{
+		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+		if ($iteration_count_log2 < 4 || $iteration_count_log2 > 31)
+			$iteration_count_log2 = 8;
+		$this->iteration_count_log2 = $iteration_count_log2;
+
+		$this->portable_hashes = $portable_hashes;
+
+		$this->random_state = microtime();
+		if (function_exists('getmypid'))
+			$this->random_state .= getmypid();
+	}
+
+	function get_random_bytes($count)
+	{
+		$output = '';
+		if (is_readable('/dev/urandom') &&
+		    ($fh = @fopen('/dev/urandom', 'rb'))) {
+			$output = fread($fh, $count);
+			fclose($fh);
+		}
+
+		if (strlen($output) < $count) {
+			$output = '';
+			for ($i = 0; $i < $count; $i += 16) {
+				$this->random_state =
+				    md5(microtime() . $this->random_state);
+				$output .=
+				    pack('H*', md5($this->random_state));
+			}
+			$output = substr($output, 0, $count);
+		}
+
+		return $output;
+	}
+
+	function encode64($input, $count)
+	{
+		$output = '';
+		$i = 0;
+		do {
+			$value = ord($input[$i++]);
+			$output .= $this->itoa64[$value & 0x3f];
+			if ($i < $count)
+				$value |= ord($input[$i]) << 8;
+			$output .= $this->itoa64[($value >> 6) & 0x3f];
+			if ($i++ >= $count)
+				break;
+			if ($i < $count)
+				$value |= ord($input[$i]) << 16;
+			$output .= $this->itoa64[($value >> 12) & 0x3f];
+			if ($i++ >= $count)
+				break;
+			$output .= $this->itoa64[($value >> 18) & 0x3f];
+		} while ($i < $count);
+
+		return $output;
+	}
+
+	function gensalt_private($input)
+	{
+		$output = '$P$';
+		$output .= $this->itoa64[min($this->iteration_count_log2 +
+			((PHP_VERSION >= '5') ? 5 : 3), 30)];
+		$output .= $this->encode64($input, 6);
+
+		return $output;
+	}
+
+	function crypt_private($password, $setting)
+	{
+		$output = '*0';
+		if (substr($setting, 0, 2) == $output)
+			$output = '*1';
+
+		$id = substr($setting, 0, 3);
+		# We use "$P$", phpBB3 uses "$H$" for the same thing
+		if ($id != '$P$' && $id != '$H$')
+			return $output;
+
+		$count_log2 = strpos($this->itoa64, $setting[3]);
+		if ($count_log2 < 7 || $count_log2 > 30)
+			return $output;
+
+		$count = 1 << $count_log2;
+
+		$salt = substr($setting, 4, 8);
+		if (strlen($salt) != 8)
+			return $output;
+
+		# We're kind of forced to use MD5 here since it's the only
+		# cryptographic primitive available in all versions of PHP
+		# currently in use.  To implement our own low-level crypto
+		# in PHP would result in much worse performance and
+		# consequently in lower iteration counts and hashes that are
+		# quicker to crack (by non-PHP code).
+		if (PHP_VERSION >= '5') {
+			$hash = md5($salt . $password, TRUE);
+			do {
+				$hash = md5($hash . $password, TRUE);
+			} while (--$count);
+		} else {
+			$hash = pack('H*', md5($salt . $password));
+			do {
+				$hash = pack('H*', md5($hash . $password));
+			} while (--$count);
+		}
+
+		$output = substr($setting, 0, 12);
+		$output .= $this->encode64($hash, 16);
+
+		return $output;
+	}
+
+	function gensalt_extended($input)
+	{
+		$count_log2 = min($this->iteration_count_log2 + 8, 24);
+		# This should be odd to not reveal weak DES keys, and the
+		# maximum valid value is (2**24 - 1) which is odd anyway.
+		$count = (1 << $count_log2) - 1;
+
+		$output = '_';
+		$output .= $this->itoa64[$count & 0x3f];
+		$output .= $this->itoa64[($count >> 6) & 0x3f];
+		$output .= $this->itoa64[($count >> 12) & 0x3f];
+		$output .= $this->itoa64[($count >> 18) & 0x3f];
+
+		$output .= $this->encode64($input, 3);
+
+		return $output;
+	}
+
+	function gensalt_blowfish($input)
+	{
+		# This one needs to use a different order of characters and a
+		# different encoding scheme from the one in encode64() above.
+		# We care because the last character in our encoded string will
+		# only represent 2 bits.  While two known implementations of
+		# bcrypt will happily accept and correct a salt string which
+		# has the 4 unused bits set to non-zero, we do not want to take
+		# chances and we also do not want to waste an additional byte
+		# of entropy.
+		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+		$output = '$2a$';
+		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
+		$output .= '$';
+
+		$i = 0;
+		do {
+			$c1 = ord($input[$i++]);
+			$output .= $itoa64[$c1 >> 2];
+			$c1 = ($c1 & 0x03) << 4;
+			if ($i >= 16) {
+				$output .= $itoa64[$c1];
+				break;
+			}
+
+			$c2 = ord($input[$i++]);
+			$c1 |= $c2 >> 4;
+			$output .= $itoa64[$c1];
+			$c1 = ($c2 & 0x0f) << 2;
+
+			$c2 = ord($input[$i++]);
+			$c1 |= $c2 >> 6;
+			$output .= $itoa64[$c1];
+			$output .= $itoa64[$c2 & 0x3f];
+		} while (1);
+
+		return $output;
+	}
+
+	function HashPassword($password)
+	{
+		$random = '';
+
+		if (CRYPT_BLOWFISH == 1 && !$this->portable_hashes) {
+			$random = $this->get_random_bytes(16);
+			$hash =
+			    crypt($password, $this->gensalt_blowfish($random));
+			if (strlen($hash) == 60)
+				return $hash;
+		}
+
+		if (CRYPT_EXT_DES == 1 && !$this->portable_hashes) {
+			if (strlen($random) < 3)
+				$random = $this->get_random_bytes(3);
+			$hash =
+			    crypt($password, $this->gensalt_extended($random));
+			if (strlen($hash) == 20)
+				return $hash;
+		}
+
+		if (strlen($random) < 6)
+			$random = $this->get_random_bytes(6);
+		$hash =
+		    $this->crypt_private($password,
+		    $this->gensalt_private($random));
+		if (strlen($hash) == 34)
+			return $hash;
+
+		# Returning '*' on error is safe here, but would _not_ be safe
+		# in a crypt(3)-like function used _both_ for generating new
+		# hashes and for validating passwords against existing hashes.
+		return '*';
+	}
+
+	function CheckPassword($password, $stored_hash)
+	{
+		$hash = $this->crypt_private($password, $stored_hash);
+		if ($hash[0] == '*')
+			$hash = crypt($password, $stored_hash);
+
+		return $hash == $stored_hash;
+	}
+}
+
+?>

--- a/libraries/phpass/index.html
+++ b/libraries/phpass/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>


### PR DESCRIPTION
First of all, thank you to all involved in the discussions on pull requset #2555, everyone's input was very valueable and needed to help push this decision to help keep our users websites secure. Thank you very much to @hackwar for sticking with it through thick and thin, and getting a working implementation that I could now make that much more secure via this PR.

From @ircmaxell's comments on #2555 (and on Twitter today), it was decided that something more could be done that would be much more secure, and would still retain backward-compatibility with PHP versions < 5.3.7. I did a bit of research following Anthony's suggestions, and came up with the code here to implement [PHPass](http://www.openwall.com/phpass/)

As you can see, not much has changed. What this PR does is help move all passwords up to an algorithm that is much more secure than salted-md5 in a backwards compatible way. It should be entirely transparent to our users.

What we need now, in order to get this out for a timely release before the holidays, is LOTS of testing. If you are able to run multiple PHP environments, please test in all of them available.

In order to test, create a fresh Joomla installation. Then, apply this patch and log out. Once your logged out, check your database `#__users` table, you should see your 3.2 password in there prefixed with `$2y$` if you're running 5.3.7+ or `{SHA256}` if you're running a lower version. Then log back into the site (you should have no issues logging in, if you do, the test failed, and leave a -1 with details about your PHP environment). The entry in the database table should be changed, and it will now be prefixed with `$P$` which indicates that you password is now hashed using `phpass`. If you got this far, and don't have access to any other PHP environments to do extended testing in, I want to personally say thanks for taking the time, it is appreciated. Please leave a comment with a +1 that contains the PHP version you tested.

If you do have other environments available, can you do some extended testing? Awesome. The extended testing would consist of moving your Joomla installation to a new PHP environment, and making sure you are able to log in there as well without issue. One of the major issues that we encountered with implementing the BCrypt feature in 3.2 was when we went from a PHP version greater than 5.3.6 to something below. It would be _great_ if you could test that scenario and leave a comment detailing what environments you were able to test in.

If you do run into any issues while testing, including not being able to log in, or your password not being re-hashed to be prefixed with `$P$`, please leave a comment below with a -1, and detail the environment you were in that failed.

Thanks all!

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32930
