### PR TITLE
No longer load MooTools with com_content

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -804,7 +804,7 @@ abstract class JHtmlBehavior
 		}
 		// Include jQuery
 		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/tabs-state.js', true, true);
+		JHtml::_('script', 'system/tabs-state.js', false, true);
 		self::$loaded[__METHOD__] = true;
 	}
 }

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -87,7 +87,7 @@ abstract class JHtmlBehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 
-		JHtml::_('script', 'system/caption.js', true, true);
+		JHtml::_('script', 'system/caption.js', false, true);
 
 		// Attach caption to document
 		JFactory::getDocument()->addScriptDeclaration(

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -804,6 +804,7 @@ abstract class JHtmlBehavior
 		}
 		// Include jQuery
 		JHtml::_('jquery.framework');
+
 		JHtml::_('script', 'system/tabs-state.js', false, true);
 		self::$loaded[__METHOD__] = true;
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -137,7 +137,7 @@ class JHtmlBehaviorTest extends TestCase
 	{
 		$data = array(
 			array(array('JHtmlBehavior::caption' => array('img.caption' => true))),
-			array(array('JHtmlBehavior::caption' => array('img.caption2' => true), 'img.caption2'),
+			array(array('JHtmlBehavior::caption' => array('img.caption2' => true)), 'img.caption2'),
 		);
 
 		return $data;

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -136,8 +136,8 @@ class JHtmlBehaviorTest extends TestCase
 	public function getCaptionData()
 	{
 		$data = array(
-			array(array('JHtmlBehavior::caption' => array('img.caption' => true), 'JHtmlBehavior::framework' => array('core' => true))),
-			array(array('JHtmlBehavior::caption' => array('img.caption2' => true), 'JHtmlBehavior::framework' => array('core' => true)), 'img.caption2'),
+			array(array('JHtmlBehavior::caption' => array('img.caption' => true))),
+			array(array('JHtmlBehavior::caption' => array('img.caption2' => true), 'img.caption2'),
 		);
 
 		return $data;


### PR DESCRIPTION
Since caption.js is refactored to JQuery we no longer need to load the MooTools framework here.

To test: See if mootools is loaded when caption.js is loaded. This is currently the case for featured, blog and article views where caption.js is always loaded. Make sure captions still work.
