### PR TITLE
[#32937] Get media from module folder

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -467,6 +467,18 @@ abstract class JHtml
 										break;
 									}
 
+									// Try to deal with media files in the module folder
+									$path = JPATH_ROOT . "/modules/$extension/media/$folder/$file";
+
+									if (file_exists($path))
+									{
+										$md5 = dirname($path) . '/MD5SUM';
+										$includes[] = JUri::root(true) . "/modules/$extension/media/$folder/$file" .
+											(file_exists($md5) ? ('?' . file_get_contents($md5)) : '');
+
+										break;
+									}
+
 									// Try to deal with system files in the media folder
 									$path = JPATH_ROOT . "/media/system/$folder/$file";
 


### PR DESCRIPTION
I really love build extension in originally extension folder. Like language where if the language exists in extension folder, joomla by default load the file. I believe this feature can happen for media folder too.

Pull Request: #32937

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32937&start=0
