### PR TITLE
Fixing remember me function

### DIFF
--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -169,22 +169,7 @@ class PlgSystemRemember extends JPlugin
 				// We have a user with one cookie with a valid series and a corresponding record in the database.
 				if ($countResults === 1)
 				{
-					if (substr($results[0]->token, 0, 4) === '$2y$')
-					{
-						if (JCrypt::hasStrongPasswordSupport())
-						{
-							$match = password_verify($privateKey, $results[0]->token);
-						}
-					}
-					else
-					{
-						if (JCrypt::timingSafeCompare($results[0]->token, $privateKey))
-						{
-							$match = true;
-						}
-					}
-
-					if (empty($match))
+					if (!JCrypt::timingSafeCompare($results[0]->token, $privateKey))
 					{
 						JUserHelper::invalidateCookie($results[0]->user_id, $uastring);
 						JLog::add(JText::sprintf('PLG_SYSTEM_REMEMBER_ERROR_LOG_LOGIN_FAILED', $user->username), JLog::WARNING, 'security');

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -387,7 +387,7 @@ class PlgUserJoomla extends JPlugin
 
 		$query = $this->db->getQuery(true);
 
-		if (empty($user->cookieLogin) || $options['response'] != 'Cookie')
+		if (empty($options['user']->cookieLogin) || $options['responseType'] != 'Cookie')
 		{
 			// For users doing login from Joomla or other systems
 			$query->insert($this->db->quoteName('#__user_keys'));
@@ -441,7 +441,6 @@ class PlgUserJoomla extends JPlugin
 		$query
 			->delete('#__user_keys')
 			->where($this->db->quoteName('uastring') . ' = ' . $this->db->quote($cookieName))
-			->where($this->db->quoteName('series') . ' = ' . $this->db->quote(base64_encode($series)))
 			->where($this->db->quoteName('user_id') . ' = ' . $this->db->quote($options['username']));
 
 		$this->db->setQuery($query)->execute();

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -375,7 +375,7 @@ class PlgUserJoomla extends JPlugin
 			$this->db->setQuery($query)->execute();
 		}
 
-		$cookieValue = $privateKey . '.' . $series . '.' . $cookieName;
+		$cookieValue = $cryptedKey . '.' . $series . '.' . $cookieName;
 
 		// Destroy the old cookie.
 		$this->app->input->cookie->set($cookieName, false, time() - 42000, $this->app->get('cookie_path'), $this->app->get('cookie_domain'));
@@ -387,7 +387,7 @@ class PlgUserJoomla extends JPlugin
 
 		$query = $this->db->getQuery(true);
 
-		if (empty($user->cookieLogin) || $options['response'] != 'Coookie')
+		if (empty($user->cookieLogin) || $options['response'] != 'Cookie')
 		{
 			// For users doing login from Joomla or other systems
 			$query->insert($this->db->quoteName('#__user_keys'));


### PR DESCRIPTION
### Problem

Because the change to `JCrypt::hasStrongPasswordSupport()` to fix its bugs we currently have a non-working remember-me function
### Solution

In the remember system plugin:
- I removed the reference to this function and always use `JCrypt::timingSafeCompare()` to compare the `$privateKey`  from the cookie to the database stored `$token`. 

In the joomla user plugin:
- Fixed a typo from 'Coookie' to 'Cookie' (thanks to Leo Lammerink who pointed that out in the JBS google group)
- Storing the encrypted `$cryptedKey` instead of `$privateKey` into the cookie. Here I am a bit unsure how that was supposed to work prior. It probably was broken before?
### Question for security experts

The privateKey (which is just a random string) is encrypted using `JUserHelper::getCryptedPassword()` resulting in the cryptedKey which is now stored both in database and cookie. As far as I understand the system (which is based on http://jaspan.com/improved_persistent_login_cookie_best_practice), the whole encryption isn't needed here and serves no purpose. It's a non-guessable one-time token.
But I may be wrong.
