### PR TITLE
# Multilingual: solving 404 when Remove URL Language Code is set to YES (Master)

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -280,7 +280,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// redirect if sef does not exists and language is not the default one
 					if (!isset(self::$sefs[$sef]) && $lang_code != self::$default_lang)
 					{
-						$sef = isset(self::$lang_codes[$lang_code]) ? self::$lang_codes[$lang_code]->sef : self::$default_sef;
+						$sef = isset(self::$lang_codes[$lang_code]) && empty($path) ? self::$lang_codes[$lang_code]->sef : self::$default_sef;
 						$uri->setPath($sef . '/' . $path);
 
 						if ($app->getCfg('sef_rewrite'))


### PR DESCRIPTION
This pull closes #2670 (it removes some not valid commits in the old pull)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&...

Test instructions:

Create a multilingual site with 3 content languages.
For example English, Spanish, French: en-GB, es-ES, fr-FR

Set default site language to English
Set default browser language to French

Set SEF on

Set the language filter plugin to

Language Selection for new Visitors. Browser Settings
Automatic language change YES
Menu Associations/Items Associations YES
Remove URL Language Code YES
Cookie Lifetime Year

Create for each content language at least 2 articles, one as featured, the other not.
In English article1 and article2

Each Content language should have 2 menu items.
One set to Home linking to Featured articles
The other as a single article menu item

So we Have for each Content language these menu items
Home (name equivalent for the other languages)
Article2 (name different for other languages)

Now Load Front End.

In English (Default site language + SEF + Remove URL Language Code set to YES) we will have these urls for these menu items:
mysite.com
mysite.com/article2

In French

mysite.com/fr/
mysite.com/fr/monarticle2

In Spanish
mysite.com/es/
mysite.com/es/articulo2

BEFORE PATCH:

Display French Front end page

Then open a new browser window and enter this url:
mysite.com/article2

You will get a 404

AFTER PATCH

You should get the correct page in English
