### PR TITLE
Load the tabs save script only on the edit form

### DIFF
--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -8,7 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.tabstate');
 
 require_once JPATH_COMPONENT.'/helpers/route.php';
 require_once JPATH_COMPONENT.'/helpers/query.php';

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.calendar');
 JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.tabstate');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.modal', 'a.modal_jform_contenthistory');
 


### PR DESCRIPTION
This PR moves the call to save the state from the content.php bootstrap file to the form view where it belongs to. At the moment it is also useless to have it there because there is no apply function in the front where the state of the tabs needs to be save (check the comment below).
The tracker item http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32953 is already opened.

As stated in the tracker item http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31372 in the comment from  Jean-Marie Simonet
_Note: for now it is useless on frontend, but it may one day if we introduce Save (Apply) and correct checkin._
