### PR TITLE
Password Security: PHPass for Joomla! 2.5

### DIFF
--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -163,9 +163,7 @@ class UsersModelReset extends JModelForm
 		}
 
 		// Generate the new password hash.
-		$salt		= JUserHelper::genRandomPassword(32);
-		$crypted	= JUserHelper::getCryptedPassword($data['password1'], $salt);
-		$password	= $crypted.':'.$salt;
+		$password = JUserHelper::hashPassword($data['password1']);
 
 		// Update the user object.
 		$user->password			= $password;

--- a/installation/models/configuration.php
+++ b/installation/models/configuration.php
@@ -215,9 +215,7 @@ class JInstallationModelConfiguration extends JModelLegacy
 		}
 
 		// Create random salt/password for the admin user
-		$salt = JUserHelper::genRandomPassword(32);
-		$crypt = JUserHelper::getCryptedPassword($options->admin_password, $salt);
-		$cryptpass = $crypt.':'.$salt;
+		$cryptpass = JUserHelper::hashPassword($options->admin_password);
 
 		// take the admin user id
 		JLoader::register('JInstallationModelDatabase', JPATH_INSTALLATION . '/models/database.php');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -78,6 +78,9 @@ if (isset($_SERVER['HTTP_HOST']))
 // Import the base object library.
 JLoader::import('joomla.base.object');
 
+// Register PHPass
+JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
+
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/methods.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/methods.php');

--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -235,4 +235,38 @@ class JCrypt
 
 		return substr($randomStr, 0, $length);
 	}
+
+	/**
+	 * A timing safe comparison method. This defeats hacking
+	 * attempts that use timing based attack vectors.
+	 *
+	 * @param   string  $known    A known string to check against.
+	 * @param   string  $unknown  An unknown string to check.
+	 *
+	 * @return  boolean  True if the two strings are exactly the same.
+	 *
+	 * @since   3.2
+	 */
+	public static function timingSafeCompare($known, $unknown)
+	{
+		// Prevent issues if string length is 0
+		$known .= chr(0);
+		$unknown .= chr(0);
+
+		$knownLength = strlen($known);
+		$unknownLength = strlen($unknown);
+
+		// Set the result to the difference between the lengths
+		$result = $knownLength - $unknownLength;
+
+		// Note that we ALWAYS iterate over the user-supplied length to prevent leaking length info.
+		for ($i = 0; $i < $unknownLength; $i++)
+		{
+			// Using % here is a trick to prevent notices. It's safe, since if the lengths are different, $result is already non-0
+			$result |= (ord($known[$i % $knownLength]) ^ ord($unknown[$i]));
+		}
+
+		// They are only identical strings if $result is exactly 0...
+		return $result === 0;
+	}
 }

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -304,6 +304,76 @@ abstract class JUserHelper
 	}
 
 	/**
+	 * Hashes a password using the current encryption.
+	 *
+	 * @param   string  $password  The plaintext password to encrypt.
+	 *
+	 * @return  string  The encrypted password.
+	 *
+	 * @since   3.2.1
+	 */
+	public static function hashPassword($password)
+	{
+		// Use PHPass's portable hashes with a cost of 10.
+		$phpass = new PasswordHash(10, true);
+
+		return $phpass->HashPassword($password);
+	}
+
+	/**
+	 * Formats a password using the current encryption. If the user ID is given
+	 * and the hash does not fit the current hashing algorithm, it automatically
+	 * updates the hash.
+	 *
+	 * @param   string   $password  The plaintext password to check.
+	 * @param   string   $hash      The hash to verify against.
+	 * @param   integer  $user_id   ID of the user if the password hash should be updated
+	 *
+	 * @return  boolean  True if the password and hash match, false otherwise
+	 *
+	 * @since   3.2.1
+	 */
+	public static function verifyPassword($password, $hash, $user_id = 0)
+	{
+		$rehash = false;
+		$match = false;
+
+		// If we are using phpass
+		if (strpos($hash, '$P$') === 0)
+		{
+			// Use PHPass's portable hashes with a cost of 10.
+			$phpass = new PasswordHash(10, true);
+
+			$match = $phpass->CheckPassword($password, $hash);
+
+			$rehash = false;
+		}
+		else
+		{
+			// Check the password
+			$parts = explode(':', $hash);
+			$crypt = $parts[0];
+			$salt  = @$parts[1];
+
+			$rehash = true;
+
+			$testcrypt = md5($password . $salt) . ($salt ? ':' . $salt : '');
+
+			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
+		}
+
+		// If we have a match and rehash = true, rehash the password with the current algorithm.
+		if ((int) $user_id > 0 && $match && $rehash)
+		{
+			$user = new JUser($user_id);
+			$user->password = self::hashPassword($password);
+			$user->save();
+		}
+
+		return $match;
+	}
+
+	/**
 	 * Formats a password using the current encryption.
 	 *
 	 * @param   string   $plaintext     The plaintext password to encrypt.
@@ -319,6 +389,8 @@ abstract class JUserHelper
 	 * @return  string  The encrypted password.
 	 *
 	 * @since   11.1
+	 *
+	 * @deprecated  4.0
 	 */
 	public static function getCryptedPassword($plaintext, $salt = '', $encryption = 'md5-hex', $show_encrypt = false)
 	{

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -719,6 +719,7 @@ class JUser extends JObject
 		$this->params = (string) $this->_params;
 		$table->bind($this->getProperties());
 
+
 		// Allow an exception to be thrown.
 		try
 		{
@@ -757,8 +758,15 @@ class JUser extends JObject
 			// Check if I am a Super Admin
 			$iAmSuperAdmin = $my->authorise('core.admin');
 
+			$iAmRehashingSuperadmin = false;
+
+			if (($my->id == 0 && !$isNew) && $this->id == $oldUser->id && $oldUser->authorise('core.admin') && $oldUser->password != $this->password)
+			{
+				$iAmRehashingSuperadmin = true;
+			}
+
 			// We are only worried about edits to this account if I am not a Super Admin.
-			if ($iAmSuperAdmin != true)
+			if ($iAmSuperAdmin != true && $iAmRehashingSuperadmin != true)
 			{
 				if ($isNew)
 				{

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -620,9 +620,7 @@ class JUser extends JObject
 
 			$this->password_clear = JArrayHelper::getValue($array, 'password', '', 'string');
 
-			$salt = JUserHelper::genRandomPassword(32);
-			$crypt = JUserHelper::getCryptedPassword($array['password'], $salt);
-			$array['password'] = $crypt . ':' . $salt;
+			$array['password'] = JUserHelper::hashPassword($array['password']);
 
 			// Set the registration timestamp
 
@@ -657,9 +655,7 @@ class JUser extends JObject
 
 				$this->password_clear = JArrayHelper::getValue($array, 'password', '', 'string');
 
-				$salt = JUserHelper::genRandomPassword(32);
-				$crypt = JUserHelper::getCryptedPassword($array['password'], $salt);
-				$array['password'] = $crypt . ':' . $salt;
+				$array['password'] = JUserHelper::hashPassword($array['password']);
 			}
 			else
 			{

--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -1,0 +1,253 @@
+<?php
+#
+# Portable PHP password hashing framework.
+#
+# Version 0.3 / genuine.
+#
+# Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
+# the public domain.  Revised in subsequent years, still public domain.
+#
+# There's absolutely no warranty.
+#
+# The homepage URL for this framework is:
+#
+#	http://www.openwall.com/phpass/
+#
+# Please be sure to update the Version line if you edit this file in any way.
+# It is suggested that you leave the main version number intact, but indicate
+# your project name (after the slash) and add your own revision information.
+#
+# Please do not change the "private" password hashing method implemented in
+# here, thereby making your hashes incompatible.  However, if you must, please
+# change the hash type identifier (the "$P$") to something different.
+#
+# Obviously, since this code is in the public domain, the above are not
+# requirements (there can be none), but merely suggestions.
+#
+class PasswordHash {
+	var $itoa64;
+	var $iteration_count_log2;
+	var $portable_hashes;
+	var $random_state;
+
+	function PasswordHash($iteration_count_log2, $portable_hashes)
+	{
+		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+		if ($iteration_count_log2 < 4 || $iteration_count_log2 > 31)
+			$iteration_count_log2 = 8;
+		$this->iteration_count_log2 = $iteration_count_log2;
+
+		$this->portable_hashes = $portable_hashes;
+
+		$this->random_state = microtime();
+		if (function_exists('getmypid'))
+			$this->random_state .= getmypid();
+	}
+
+	function get_random_bytes($count)
+	{
+		$output = '';
+		if (is_readable('/dev/urandom') &&
+		    ($fh = @fopen('/dev/urandom', 'rb'))) {
+			$output = fread($fh, $count);
+			fclose($fh);
+		}
+
+		if (strlen($output) < $count) {
+			$output = '';
+			for ($i = 0; $i < $count; $i += 16) {
+				$this->random_state =
+				    md5(microtime() . $this->random_state);
+				$output .=
+				    pack('H*', md5($this->random_state));
+			}
+			$output = substr($output, 0, $count);
+		}
+
+		return $output;
+	}
+
+	function encode64($input, $count)
+	{
+		$output = '';
+		$i = 0;
+		do {
+			$value = ord($input[$i++]);
+			$output .= $this->itoa64[$value & 0x3f];
+			if ($i < $count)
+				$value |= ord($input[$i]) << 8;
+			$output .= $this->itoa64[($value >> 6) & 0x3f];
+			if ($i++ >= $count)
+				break;
+			if ($i < $count)
+				$value |= ord($input[$i]) << 16;
+			$output .= $this->itoa64[($value >> 12) & 0x3f];
+			if ($i++ >= $count)
+				break;
+			$output .= $this->itoa64[($value >> 18) & 0x3f];
+		} while ($i < $count);
+
+		return $output;
+	}
+
+	function gensalt_private($input)
+	{
+		$output = '$P$';
+		$output .= $this->itoa64[min($this->iteration_count_log2 +
+			((PHP_VERSION >= '5') ? 5 : 3), 30)];
+		$output .= $this->encode64($input, 6);
+
+		return $output;
+	}
+
+	function crypt_private($password, $setting)
+	{
+		$output = '*0';
+		if (substr($setting, 0, 2) == $output)
+			$output = '*1';
+
+		$id = substr($setting, 0, 3);
+		# We use "$P$", phpBB3 uses "$H$" for the same thing
+		if ($id != '$P$' && $id != '$H$')
+			return $output;
+
+		$count_log2 = strpos($this->itoa64, $setting[3]);
+		if ($count_log2 < 7 || $count_log2 > 30)
+			return $output;
+
+		$count = 1 << $count_log2;
+
+		$salt = substr($setting, 4, 8);
+		if (strlen($salt) != 8)
+			return $output;
+
+		# We're kind of forced to use MD5 here since it's the only
+		# cryptographic primitive available in all versions of PHP
+		# currently in use.  To implement our own low-level crypto
+		# in PHP would result in much worse performance and
+		# consequently in lower iteration counts and hashes that are
+		# quicker to crack (by non-PHP code).
+		if (PHP_VERSION >= '5') {
+			$hash = md5($salt . $password, TRUE);
+			do {
+				$hash = md5($hash . $password, TRUE);
+			} while (--$count);
+		} else {
+			$hash = pack('H*', md5($salt . $password));
+			do {
+				$hash = pack('H*', md5($hash . $password));
+			} while (--$count);
+		}
+
+		$output = substr($setting, 0, 12);
+		$output .= $this->encode64($hash, 16);
+
+		return $output;
+	}
+
+	function gensalt_extended($input)
+	{
+		$count_log2 = min($this->iteration_count_log2 + 8, 24);
+		# This should be odd to not reveal weak DES keys, and the
+		# maximum valid value is (2**24 - 1) which is odd anyway.
+		$count = (1 << $count_log2) - 1;
+
+		$output = '_';
+		$output .= $this->itoa64[$count & 0x3f];
+		$output .= $this->itoa64[($count >> 6) & 0x3f];
+		$output .= $this->itoa64[($count >> 12) & 0x3f];
+		$output .= $this->itoa64[($count >> 18) & 0x3f];
+
+		$output .= $this->encode64($input, 3);
+
+		return $output;
+	}
+
+	function gensalt_blowfish($input)
+	{
+		# This one needs to use a different order of characters and a
+		# different encoding scheme from the one in encode64() above.
+		# We care because the last character in our encoded string will
+		# only represent 2 bits.  While two known implementations of
+		# bcrypt will happily accept and correct a salt string which
+		# has the 4 unused bits set to non-zero, we do not want to take
+		# chances and we also do not want to waste an additional byte
+		# of entropy.
+		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+		$output = '$2a$';
+		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
+		$output .= '$';
+
+		$i = 0;
+		do {
+			$c1 = ord($input[$i++]);
+			$output .= $itoa64[$c1 >> 2];
+			$c1 = ($c1 & 0x03) << 4;
+			if ($i >= 16) {
+				$output .= $itoa64[$c1];
+				break;
+			}
+
+			$c2 = ord($input[$i++]);
+			$c1 |= $c2 >> 4;
+			$output .= $itoa64[$c1];
+			$c1 = ($c2 & 0x0f) << 2;
+
+			$c2 = ord($input[$i++]);
+			$c1 |= $c2 >> 6;
+			$output .= $itoa64[$c1];
+			$output .= $itoa64[$c2 & 0x3f];
+		} while (1);
+
+		return $output;
+	}
+
+	function HashPassword($password)
+	{
+		$random = '';
+
+		if (CRYPT_BLOWFISH == 1 && !$this->portable_hashes) {
+			$random = $this->get_random_bytes(16);
+			$hash =
+			    crypt($password, $this->gensalt_blowfish($random));
+			if (strlen($hash) == 60)
+				return $hash;
+		}
+
+		if (CRYPT_EXT_DES == 1 && !$this->portable_hashes) {
+			if (strlen($random) < 3)
+				$random = $this->get_random_bytes(3);
+			$hash =
+			    crypt($password, $this->gensalt_extended($random));
+			if (strlen($hash) == 20)
+				return $hash;
+		}
+
+		if (strlen($random) < 6)
+			$random = $this->get_random_bytes(6);
+		$hash =
+		    $this->crypt_private($password,
+		    $this->gensalt_private($random));
+		if (strlen($hash) == 34)
+			return $hash;
+
+		# Returning '*' on error is safe here, but would _not_ be safe
+		# in a crypt(3)-like function used _both_ for generating new
+		# hashes and for validating passwords against existing hashes.
+		return '*';
+	}
+
+	function CheckPassword($password, $stored_hash)
+	{
+		$hash = $this->crypt_private($password, $stored_hash);
+		if ($hash[0] == '*')
+			$hash = crypt($password, $stored_hash);
+
+		return $hash == $stored_hash;
+	}
+}
+
+?>

--- a/libraries/phpass/index.html
+++ b/libraries/phpass/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -30,7 +30,8 @@ class plgAuthenticationJoomla extends JPlugin
 	{
 		$response->type = 'Joomla';
 		// Joomla does not like blank passwords
-		if (empty($credentials['password'])) {
+		if (empty($credentials['password']))
+		{
 			$response->status = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::_('JGLOBAL_AUTH_EMPTY_PASS_NOT_ALLOWED');
 			return false;
@@ -45,34 +46,40 @@ class plgAuthenticationJoomla extends JPlugin
 
 		$query->select('id, password');
 		$query->from('#__users');
-		$query->where('username=' . $db->Quote($credentials['username']));
+		$query->where('username=' . $db->quote($credentials['username']));
 
 		$db->setQuery($query);
 		$result = $db->loadObject();
 
-		if ($result) {
-			$parts	= explode(':', $result->password);
-			$crypt	= $parts[0];
-			$salt	= @$parts[1];
-			$testcrypt = JUserHelper::getCryptedPassword($credentials['password'], $salt);
+		if ($result)
+		{
+			$match = JUserHelper::verifyPassword($credentials['password'], $result->password, $result->id);
 
-			if ($crypt == $testcrypt) {
+			if ($match === true)
+			{
 				$user = JUser::getInstance($result->id); // Bring this in line with the rest of the system
 				$response->email = $user->email;
 				$response->fullname = $user->name;
-				if (JFactory::getApplication()->isAdmin()) {
+
+				if (JFactory::getApplication()->isAdmin())
+				{
 					$response->language = $user->getParam('admin_language');
 				}
-				else {
+				else
+				{
 					$response->language = $user->getParam('language');
 				}
 				$response->status = JAuthentication::STATUS_SUCCESS;
 				$response->error_message = '';
-			} else {
+			}
+			else
+			{
 				$response->status = JAuthentication::STATUS_FAILURE;
 				$response->error_message = JText::_('JGLOBAL_AUTH_INVALID_PASS');
 			}
-		} else {
+		}
+		else
+		{
 			$response->status = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::_('JGLOBAL_AUTH_NO_USER');
 		}


### PR DESCRIPTION
This PR backports the password security fix from 3.2.1 to 2.5.x.

What we need now is LOTS of testing. If you are able to run multiple PHP environments, please test in all of them available.

In order to test, create a fresh Joomla installation. Then, apply this patch and log out. Once your logged out, check your database #__users table, you should see your password in there with a `:` somewhere near the middle. Now, log back into the site (you should have no issues logging in, if you do, the test failed, and leave a -1 with details about your PHP environment). The entry in the database table should be changed, and it will now be prefixed with `$P$` which indicates that you password is now hashed using phpass. If you got this far, and don't have access to any other PHP environments to do extended testing in, I want to personally say thanks for taking the time, it is appreciated. Please leave a comment with a +1 that contains the PHP version you tested.

If you do have other environments available, can you do some extended testing? Awesome. The extended testing would consist of moving your Joomla installation to a new PHP environment, and making sure you are able to log in there as well without issue.

One other item to test is a fresh installation with the patch already applied. You can download a complete installation with the patch applied from here: https://github.com/dongilbert/joomla-cms/archive/25PasswordSecurity.zip Use it to do a fresh installation, and just check to make sure that the password for the user you created is prefixed with `$P$` in the database, and that you can log in just fine. If you can, leave a +1 on a successful test! Thanks!

If you do run into any issues while testing, including not being able to log in, or your password not being re-hashed to be prefixed with `$P$`, please leave a comment below with a -1, and detail the environment you were in that failed.
