### PR TITLE
Removing doubled description tab in template styles

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -86,7 +86,7 @@ $canDo = TemplatesHelper::getActions();
 
 		<?php
 		$this->fieldsets = array();
-		$this->ignore_fieldsets = array('basic');
+		$this->ignore_fieldsets = array('basic', 'description');
 		echo JLayoutHelper::render('joomla.edit.params', $this);
 		?>
 


### PR DESCRIPTION
Same as https://github.com/joomla/joomla-cms/pull/2481, but for template styles.

To test you can create a fieldset named "description" in the templateDetails.xml and add a field to it. The tab will show up twice.
Apply patch and it will show up only once.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32957
