### PR TITLE
Control over the HEAD meta, styles, script

### DIFF
--- a/libraries/joomla/document/html/renderer/meta.php
+++ b/libraries/joomla/document/html/renderer/meta.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JDocument head renderer
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ * @since       11.1
+ */
+class JDocumentRendererMeta extends JDocumentRenderer
+{
+	/**
+	 * Renders the document head and returns the results as a string
+	 *
+	 * @param   string  $head     (unused)
+	 * @param   array   $params   Associative array of values
+	 * @param   string  $content  The script
+	 *
+	 * @return  string  The output of the script
+	 *
+	 * @since   11.1
+	 *
+	 * @note    Unused arguments are retained to preserve backward compatibility.
+	 */
+	public function render($meta, $params = array(), $content = null)
+	{
+		ob_start();
+		echo $this->fetchmeta($this->_doc);
+		$buffer = ob_get_contents();
+		ob_end_clean();
+
+		return $buffer;
+	}
+
+	/**
+	 * Generates the head HTML and return the results as a string
+	 *
+	 * @param   JDocument  $document  The document for which the head will be created
+	 *
+	 * @return  string  The head hTML
+	 *
+	 * @since   11.1
+	 */
+	public function fetchmeta($document)
+	{
+		// Convert the tagids to titles
+		if (isset($document->_metaTags['standard']['tags']))
+		{
+			$tagsHelper = new JHelperTags;
+			$document->_metaTags['standard']['tags'] = implode(', ', $tagsHelper->getTagNames($document->_metaTags['standard']['tags']));
+		}
+
+		// Trigger the onBeforeCompileHead event
+		$app = JFactory::getApplication();
+		$app->triggerEvent('onBeforeCompileHead');
+
+		// Get line endings
+		$lnEnd = $document->_getLineEnd();
+		$tab = $document->_getTab();
+		$tagEnd = ' />';
+		$buffer = '';
+
+		// Generate charset when using HTML5 (should happen first)
+		if ($document->isHtml5())
+		{
+			$buffer .= $tab . '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
+		}
+
+		// Generate base tag (need to happen early)
+		$base = $document->getBase();
+		if (!empty($base))
+		{
+			$buffer .= $tab . '<base href="' . $document->getBase() . '" />' . $lnEnd;
+		}
+
+		// Generate META tags (needs to happen as early as possible in the head)
+		foreach ($document->_metaTags as $type => $tag)
+		{
+			foreach ($tag as $name => $content)
+			{
+				if ($type == 'http-equiv' && !($document->isHtml5() && $name == 'content-type'))
+				{
+					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content) . '" />' . $lnEnd;
+				}
+				elseif ($type == 'standard' && !empty($content))
+				{
+					$buffer .= $tab . '<meta name="' . $name . '" content="' . htmlspecialchars($content) . '" />' . $lnEnd;
+				}
+			}
+		}
+
+		// Don't add empty descriptions
+		$documentDescription = $document->getDescription();
+		if ($documentDescription)
+		{
+			$buffer .= $tab . '<meta name="description" content="' . htmlspecialchars($documentDescription) . '" />' . $lnEnd;
+		}
+
+		// Don't add empty generators
+		$generator = $document->getGenerator();
+		if ($generator)
+		{
+			$buffer .= $tab . '<meta name="generator" content="' . htmlspecialchars($generator) . '" />' . $lnEnd;
+		}
+
+		$buffer .= $tab . '<title>' . htmlspecialchars($document->getTitle(), ENT_COMPAT, 'UTF-8') . '</title>' . $lnEnd;
+
+		// Generate link declarations
+		foreach ($document->_links as $link => $linkAtrr)
+		{
+			$buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
+			if ($temp = JArrayHelper::toString($linkAtrr['attribs']))
+			{
+				$buffer .= ' ' . $temp;
+			}
+			$buffer .= ' />' . $lnEnd;
+		}
+
+		return $buffer;
+	}
+}

--- a/libraries/joomla/document/html/renderer/scripts.php
+++ b/libraries/joomla/document/html/renderer/scripts.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JDocument head renderer
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ * @since       11.1
+ */
+class JDocumentRendererScripts extends JDocumentRenderer
+{
+	/**
+	 * Renders the document head and returns the results as a string
+	 *
+	 * @param   string  $head     (unused)
+	 * @param   array   $params   Associative array of values
+	 * @param   string  $content  The script
+	 *
+	 * @return  string  The output of the script
+	 *
+	 * @since   11.1
+	 *
+	 * @note    Unused arguments are retained to preserve backward compatibility.
+	 */
+	public function render($scripts, $params = array(), $content = null)
+	{
+		ob_start();
+		echo $this->fetchScripts($this->_doc);
+		$buffer = ob_get_contents();
+		ob_end_clean();
+
+		return $buffer;
+	}
+
+	/**
+	 * Generates the head HTML and return the results as a string
+	 *
+	 * @param   JDocument  $document  The document for which the head will be created
+	 *
+	 * @return  string  The head hTML
+	 *
+	 * @since   11.1
+	 */
+	public function fetchScripts($document)
+	{
+		// Trigger the onBeforeCompileHead event
+		$app = JFactory::getApplication();
+		$app->triggerEvent('onBeforeCompileHead');
+
+		// Get line endings
+		$lnEnd = $document->_getLineEnd();
+		$tab = $document->_getTab();
+		$tagEnd = ' />';
+		$buffer = '';
+
+
+		// Generate script file links
+		foreach ($document->_scripts as $strSrc => $strAttr)
+		{
+			$buffer .= $tab . '<script src="' . $strSrc . '"';
+			if (!is_null($strAttr['mime']))
+			{
+				$buffer .= ' type="' . $strAttr['mime'] . '"';
+			}
+			if ($strAttr['defer'])
+			{
+				$buffer .= ' defer="defer"';
+			}
+			if ($strAttr['async'])
+			{
+				$buffer .= ' async="async"';
+			}
+			$buffer .= '></script>' . $lnEnd;
+		}
+
+		// Generate script declarations
+		foreach ($document->_script as $type => $content)
+		{
+			$buffer .= $tab . '<script type="' . $type . '">' . $lnEnd;
+
+			// This is for full XHTML support.
+			if ($document->_mime != 'text/html')
+			{
+				$buffer .= $tab . $tab . '<![CDATA[' . $lnEnd;
+			}
+
+			$buffer .= $content . $lnEnd;
+
+			// See above note
+			if ($document->_mime != 'text/html')
+			{
+				$buffer .= $tab . $tab . ']]>' . $lnEnd;
+			}
+			$buffer .= $tab . '</script>' . $lnEnd;
+		}
+
+		// Generate script language declarations.
+		if (count(JText::script()))
+		{
+			$buffer .= $tab . '<script type="text/javascript">' . $lnEnd;
+			$buffer .= $tab . $tab . '(function() {' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . 'var strings = ' . json_encode(JText::script()) . ';' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . 'if (typeof Joomla == \'undefined\') {' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . $tab . 'Joomla = {};' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . $tab . 'Joomla.JText = strings;' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . '}' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . 'else {' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . $tab . 'Joomla.JText.load(strings);' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . '}' . $lnEnd;
+			$buffer .= $tab . $tab . '})();' . $lnEnd;
+			$buffer .= $tab . '</script>' . $lnEnd;
+		}
+
+		foreach ($document->_custom as $custom)
+		{
+			$buffer .= $tab . $custom . $lnEnd;
+		}
+
+		return $buffer;
+	}
+}

--- a/libraries/joomla/document/html/renderer/styles.php
+++ b/libraries/joomla/document/html/renderer/styles.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ *
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JDocument head renderer
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Document
+ * @since       11.1
+ */
+class JDocumentRendererStyles extends JDocumentRenderer
+{
+	/**
+	 * Renders the document head and returns the results as a string
+	 *
+	 * @param   string  $head     (unused)
+	 * @param   array   $params   Associative array of values
+	 * @param   string  $content  The script
+	 *
+	 * @return  string  The output of the script
+	 *
+	 * @since   11.1
+	 *
+	 * @note    Unused arguments are retained to preserve backward compatibility.
+	 */
+	public function render($styles, $params = array(), $content = null)
+	{
+		ob_start();
+		echo $this->fetchstyles($this->_doc);
+		$buffer = ob_get_contents();
+		ob_end_clean();
+
+		return $buffer;
+	}
+
+	/**
+	 * Generates the head HTML and return the results as a string
+	 *
+	 * @param   JDocument  $document  The document for which the head will be created
+	 *
+	 * @return  string  The head hTML
+	 *
+	 * @since   11.1
+	 */
+	public function fetchstyles($document)
+	{
+		// Trigger the onBeforeCompileHead event
+		$app = JFactory::getApplication();
+		$app->triggerEvent('onBeforeCompileHead');
+
+		// Get line endings
+		$lnEnd = $document->_getLineEnd();
+		$tab = $document->_getTab();
+		$tagEnd = ' />';
+		$buffer = '';
+
+		// Generate stylesheet links
+		foreach ($document->_styleSheets as $strSrc => $strAttr)
+		{
+			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '" type="' . $strAttr['mime'] . '"';
+			if (!is_null($strAttr['media']))
+			{
+				$buffer .= ' media="' . $strAttr['media'] . '" ';
+			}
+			if ($temp = JArrayHelper::toString($strAttr['attribs']))
+			{
+				$buffer .= ' ' . $temp;
+			}
+			$buffer .= $tagEnd . $lnEnd;
+		}
+
+		// Generate stylesheet declarations
+		foreach ($document->_style as $type => $content)
+		{
+			$buffer .= $tab . '<style type="' . $type . '">' . $lnEnd;
+
+			// This is for full XHTML support.
+			if ($document->_mime != 'text/html')
+			{
+				$buffer .= $tab . $tab . '<![CDATA[' . $lnEnd;
+			}
+
+			$buffer .= $content . $lnEnd;
+
+			// See above note
+			if ($document->_mime != 'text/html')
+			{
+				$buffer .= $tab . $tab . ']]>' . $lnEnd;
+			}
+			$buffer .= $tab . '</style>' . $lnEnd;
+		}
+		return $buffer;
+	}
+}


### PR DESCRIPTION
The 

```
<jdoc:include type="head" />
```

will still render the complete head. But using this:

```
<head>
<jdoc:include type="meta" />
<jdoc:include type="styles" />
```

you can echo the scripts at the bottom of the page
eg.:

```
<jdoc:include type="scripts" />
</body>
```
