### PR TITLE
Open class InstallationApplicationWeb for inheritance and parameters

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -16,17 +16,24 @@ defined('_JEXEC') or die;
  * @subpackage  Application
  * @since       3.1
  */
-final class InstallationApplicationWeb extends JApplicationCms
+class InstallationApplicationWeb extends JApplicationCms
 {
 	/**
 	 * Class constructor.
 	 *
+	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
+	 *                          input object.  If the argument is a JInput object that object will become
+	 *                          the application's input object, otherwise a default input object is created.
+	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
+	 *                          config object.  If the argument is a JRegistry object that object will become
+	 *                          the application's config object, otherwise a default config object is created.
+	 * 
 	 * @since   3.1
 	 */
-	public function __construct()
+	public function __construct(JInput $input = null, JRegistry $config = null)
 	{
 		// Run the parent constructor
-		parent::__construct();
+		parent::__construct($input, $config);
 
 		// Load and set the dispatcher
 		$this->loadDispatcher();


### PR DESCRIPTION
One case is creating a custom installer extending class InstallationApplicationWeb.

 The issue here is the the constructor by default is completely locked down.

It is impossible to instantialize the InstallationApplicationWeb class with customer parameters, for example to setup a custom session handler which is hardcoded later to use Joomla "none" handler using files.

I'd like to open the class by either removing the final keywork or allowing parameters in the constructor, or even both.

This would enable one to use different session handlers for installation like memcached on Google Apple Cloud since.

Tracker Item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemBrowse&tracker_id=8103
