### PR TITLE
[Code Style] Concat operator must be followed by one space

### DIFF
--- a/administrator/components/com_admin/views/help/tmpl/default.php
+++ b/administrator/components/com_admin/views/help/tmpl/default.php
@@ -35,7 +35,7 @@ JHtml::_('bootstrap.tooltip');
 					<li class="nav-header"><?php echo JText::_('COM_ADMIN_ALPHABETICAL_INDEX'); ?></li>
 					<?php foreach ($this->toc as $k => $v):?>
 						<li>
-						    <?php $url = JHelp::createUrl('JHELP_'.strtoupper($k)); ?>
+						    <?php $url = JHelp::createUrl('JHELP_' . strtoupper($k)); ?>
 							<?php echo JHtml::_('link', $url, $v, array('target' => 'helpFrame'));?>
 						</li>
 					<?php endforeach;?>


### PR DESCRIPTION
Fix missing spaces before and after concat operator at
/administrator/components/com_admin/views/help/tmpl/default.php

Line:   38
Column: 49
