### PR TITLE
[PR] Let php handle the default session storage

### DIFF
--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -28,6 +28,6 @@ class JSessionStorageNone extends JSessionStorage
 	 */
 	public function register()
 	{
-		ini_set('session.save_handler', 'files');
+		// Let php handle the session storage
 	}
 }


### PR DESCRIPTION
In https://github.com/joomla/joomla-cms/blob/master/libraries/joomla/session/storage/none.php
Class JSessionStorageNone forces using session.save_handler = files

I think the choice for the default handler should be left to php.

For instance Redis is not supported in the CMS at this time but if it might be configured in php.ini to be used as default for various reasons.
Please see https://groups.google.com/forum/#!topic/joomla-dev-general/stbltpP5QX4 for an example.

It seems that used to be the way to handle the default php session handler in the platform until 12.2 and this commit changed it:
https://github.com/joomla/joomla-platform/commit/a47f429c50852bf2a7a36e457639b6c414ded16e

This also blocks installing Joomla on read-only filesystems (eg. Google AppEngine) since the 'file' handler does not work on it and 'user' handler is the default and ONLY choice.

Freamwork doesn't force the handler either so should the cms.

The nice tracker item: http://issues.joomla.org/tracker/joomla-cms/2695
The ugly tracker item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33005&start=0
