### PR TITLE
Create JHtml::_('behavior.core') to decouble core.js from mootools framework

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -61,14 +61,17 @@ abstract class JHtmlBehavior
 		}
 
 		JHtml::_('script', 'system/mootools-' . $type . '.js', false, true, false, false, $debug);
+
+		/* Uncomment as soon as core.js is rewritten to jQuery (Pull https://github.com/joomla/joomla-cms/pull/2687)
 		// Keep loading core.js for BC reasons
 		static::core();
+		*/
+
 		static::$loaded[__METHOD__][$type] = true;
 
 		return;
 	}
 
-// Note to myself: this has to wait for implementation till core.js is converted to jQuery
 	/**
 	 * Method to load core.js into the document head.
 	 * 
@@ -80,6 +83,10 @@ abstract class JHtmlBehavior
 	 */
 	public static function core()
 	{
+		// Only a proxy for now. Remove when core.js is rewritten to jQuery (Pull https://github.com/joomla/joomla-cms/pull/2687)
+		static::framework();
+
+		/* Uncomment as soon as core.js is rewritten to jQuery
 		// Only load once
 		if (isset(static::$loaded[__METHOD__]))
 		{
@@ -89,6 +96,7 @@ abstract class JHtmlBehavior
 		JHtml::_('jquery.framework');
 		JHtml::_('script', 'system/core.js', false, true);
 		static::$loaded[__METHOD__] = true;
+		*/
 
 		return;
 	}

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -61,8 +61,34 @@ abstract class JHtmlBehavior
 		}
 
 		JHtml::_('script', 'system/mootools-' . $type . '.js', false, true, false, false, $debug);
-		JHtml::_('script', 'system/core.js', false, true);
+		// Keep loading core.js for BC reasons
+		static::core();
 		static::$loaded[__METHOD__][$type] = true;
+
+		return;
+	}
+
+// Note to myself: this has to wait for implementation till core.js is converted to jQuery
+	/**
+	 * Method to load core.js into the document head.
+	 * 
+	 * Core.js defines the 'Joomla' namespace and contains functions which are used across extensions
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2.2
+	 */
+	public static function core()
+	{
+		// Only load once
+		if (isset(static::$loaded[__METHOD__]))
+		{
+			return;
+		}
+
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/core.js', false, true);
+		static::$loaded[__METHOD__] = true;
 
 		return;
 	}

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -62,7 +62,10 @@ abstract class JHtmlBehavior
 
 		JHtml::_('script', 'system/mootools-' . $type . '.js', false, true, false, false, $debug);
 
-		/* Uncomment as soon as core.js is rewritten to jQuery (Pull https://github.com/joomla/joomla-cms/pull/2687)
+		// Remove as soon as core.js is rewritten to jQuery (Pull https://github.com/joomla/joomla-cms/pull/2687)
+		JHtml::_('script', 'system/core.js', false, true);
+
+		/* Uncomment as soon as core.js is rewritten to jQuery
 		// Keep loading core.js for BC reasons
 		static::core();
 		*/


### PR DESCRIPTION
### Issue

Currently, when we want to load `core.js` (kind of our own Joomla JavaScript "library") we use the same function as when we want to load the MooTools JavaScript library. That is `JHtml::_('behavior.framework')`.
So far this wasn't a problem since core.js needed MooTools anyway.
Since we want to remove MooTools and there are quite a few PRs around which deals with that and also rewrites core.js to jQuery, we may end up loading MooTools only to get core.js. This is of course not good.
### Proposed Solution

This PR will introduce a new function `JHtml::_('behavior.core')` which is supposed to only load core.js.
Currently, this would still load MooTools since core.js depends on it. It's implemented as a simple proxy to behavior.framework for now.
As soon as core.js is rewritten to jQuery, the function can be changed to load jquery.framework and core.js instead.
I already wrote the code for that with comments what needs to be done.
### Goal

Introducing this new class already "ahead of time" would allow us to start rewriting our extensions to use this new class, so when core.js is changed, we don't need to change anything anymore.
After all core javascript functions are rewritten to jQuery, we can then deprecate behavior.framework and remove it with J4.0.
This also gives 3rd party developers a bit more time to do the transition.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32994
