### PR TITLE
Remove PHP notice when languagecode plugin is published

### DIFF
--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -91,9 +91,6 @@ class PlgSystemLanguagecode extends JPlugin
 	 */
 	public function onContentPrepareForm($form, $data)
 	{
-		// Ensure that data is an object
-		$data = (object) $data;
-
 		// Check we have a form
 		if (!($form instanceof JForm))
 		{
@@ -101,18 +98,11 @@ class PlgSystemLanguagecode extends JPlugin
 			return false;
 		}
 
-		// Check we are manipulating a valid form.
-		$app = JFactory::getApplication();
-		if ($form->getName() != 'com_plugins.plugin'
-			|| isset($data->name) && $data->name != 'plg_system_languagecode'
-			|| empty($data) && !$app->getUserState('plg_system_language_code.edit')
-		)
+		// Check we are manipulating the languagecode plugin.
+		if ($form->getName() != 'com_plugins.plugin' || !$form->getField('languagecodeplugin', 'params'))
 		{
 			return true;
 		}
-
-		// Mark the plugin as being edited
-		$app->setUserState('plg_system_language_code.edit', $data->name == 'plg_system_languagecode');
 
 		// Get site languages
 		if ($languages = JLanguage::getKnownLanguages(JPATH_SITE))

--- a/plugins/system/languagecode/languagecode.xml
+++ b/plugins/system/languagecode/languagecode.xml
@@ -18,5 +18,10 @@
 		<language tag="en-GB">language/en-GB/en-GB.plg_system_languagecode.ini</language>
 		<language tag="en-GB">language/en-GB/en-GB.plg_system_languagecode.sys.ini</language>
 	</languages>
-	<config />
+	<config>
+		<fields name="params">
+			<field name="languagecodeplugin" type="hidden" 
+				default="true" />
+		</fields>
+	</config>
 </extension>


### PR DESCRIPTION
### Issue

When the languagecode plugin is enabled, you get a PHP notice about `$data->name` each time you save another plugin. This is because `$data` is `null` during the save process when it comes to the `onContentPrepareForm` event. Thus the check fails.
Also `empty($data)` always returns true because `$data` is converted to an object (empty() returns always true for objects)
### Proposed Solution

I've added a new hidden parameter `languagecodeplugin` to the plugin manifest.
During the `onContentPrepareForm` event, I now only check for the presence of this field in the form and only process further if the field is present.
This makes the checks simpler and removes the PHP notice
### Test Instructions
- Enable the languagecode plugin and make sure you can edit and save the language codes.
- Edit and save any other plugin
- Check PHP error logs to make sure no notices are generated anymore.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33001
