### PR TITLE
Missing labels on filter fields

### DIFF
--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -18,6 +18,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 	<?php foreach ($filters as $fieldName => $field) : ?>
 		<?php if ($fieldName != 'filter_search') : ?>
 			<div class="js-stools-field-filter">
+				<?php echo $field->label; ?>
 				<?php echo $field->input; ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
This code shown the labels associated to the filter fields in backend view.
I know that currently the "select" fields don't need a label because the first item inside the select is (improperly) used as label.
To test it go on "Content" > "Article Manager" and set the "Status" filter to "All", and the language filter to "All" too. Now, it is impossible to distinguish between the two filters. If you don't remember their position, you have to open them and see the options in order to remember what each filter regards.

But the major problem associated to the lack of the labels impacts the other kind of fields such as Radio button (yes/no) and calendars, which currently are unusable as filter fields without their labels.
For example, Components > Banners > Tracks currently can't use
JLayoutHelper::render("searchtools.default", ...) 
because the calendar fields without their labels wouldn't make sense.

Beware, showing the labels points out a problem in the Joomla standard backend components filter, which contain filter fields having values for properties like "labels" and "descriptions" which don't exist in the language files.
For example, after enabled the visualization of the labels as this patch does, go to Content > Article Manager.
Labels are displayed, but the IDs appear untranslated.
COM_CONTENT_FILTER_PUBLISHED, JOPTION_FILTER_CATEGORY, JOPTION_FILTER_LEVEL and many more.
In my opinion does not make much sense using nonexistent IDs in the xml descriptor. Empty strings would be better.
