### PR TITLE
[#33028] [PR] Allow replacing xml form field's descendants

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -770,7 +770,7 @@ class JForm
 					{
 						$olddom = dom_import_simplexml($current);
 						$loadeddom = dom_import_simplexml($field);
-						$addeddom = $olddom->ownerDocument->importNode($loadeddom);
+						$addeddom = $olddom->ownerDocument->importNode($loadeddom, true);
 						$olddom->parentNode->replaceChild($addeddom, $olddom);
 						$loadeddom->parentNode->removeChild($loadeddom);
 					}

--- a/tests/unit/suites/libraries/joomla/form/JFormDataHelper.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormDataHelper.php
@@ -350,6 +350,22 @@ class JFormDataHelper
 	</fields>
 </form>';
 
+	public static $loadReplacementDocument = '<form>
+	<fields>
+		<fields
+			name="params">
+			<field
+				name="show_title"
+				type="radio"
+				default="2">
+				<option value="2">JDefault</option>
+				<option value="1">JYes</option>
+				<option value="0">JNo</option>
+			</field>
+		</fields>
+	</fields>
+</form>';
+
 	public static $loadFieldDocument = '<form>
 	<fields>
 		<field

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1439,7 +1439,7 @@ class JFormTest extends TestCase
 		$this->assertThat(
 			count($form->getXML()->xpath('/form/fields/fields[@name="params"]/field[@name="show_title"]/option')),
 			$this->equalTo(3),
-			'Line:' . __LINE__ . ' The show_abstract in the params group is supposed to have 3 descendant nodes.'
+			'Line:' . __LINE__ . ' The show_title in the params group is supposed to have 3 descendant nodes.'
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1412,6 +1412,35 @@ class JFormTest extends TestCase
 				'Line:' . __LINE__ . ' Replace should leave fields in the original order.'
 			);
 		}
+
+		return $form;
+	}
+
+	/**
+	 * Test the JForm::load method for descendent field elements
+	 *
+	 * This method can load an XML data object, or parse an XML string.
+	 *
+	 * @depends testLoad
+	 *
+	 * @return void
+	 */
+	// @var $form JForm
+	public function testLoad_ReplaceDescendent(JForm $form)
+	{
+		// Check the replacement data loads ok.
+		$this->assertThat(
+			$form->load(JFormDataHelper::$loadReplacementDocument),
+			$this->isTrue(),
+			'Line:' . __LINE__ . ' XML string should load successfully.'
+		);
+
+		// Check that replaced options are present
+		$this->assertThat(
+			count($form->getXML()->xpath('/form/fields/fields[@name="params"]/field[@name="show_title"]/option')),
+			$this->equalTo(3),
+			'Line:' . __LINE__ . ' The show_abstract in the params group is supposed to have 3 descendant nodes.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses the issue of replacing XML for fields definitions which contain descendants like <option> nodes for list field.

Lets consider a content plugin with the following implementation:

``` php
public function onContentPrepareForm($form, $data)
{
    // The name of the form we want to process
    $formName = 'com_config.application';

    // The xml definition of our additions/replacements
    $fileName = __DIR__.'/forms/'.$formName.'.xml';

    // Only process com_config application forms and only process it if the override file exists
    if ($form->getName() == $formName && is_file($fileName))
    {
        // Attempt to load the XML file as a simpleXml object
        $gaeXml = simplexml_load_file($fileName);

        // Replace XML nodes[aka Joomla Form fields] in this form with ones that have been defined in our replacement file
        $form->load($gaeXml);
    }
}
```

Basically, its intention is to add/replace elements from a form,
Joomla 'Global Configuration' form in this case
#### Extracted, original definition of a form field from com_config.application

``` xml
<field
  name="mailer"
  type="list"
  default="mail"
  label="COM_CONFIG_FIELD_MAIL_MAILER_LABEL"
  description="COM_CONFIG_FIELD_MAIL_MAILER_DESC"
  required="true"
  filter="word">
    <option value="mail">COM_CONFIG_FIELD_VALUE_PHP_MAIL</option>
    <option value="sendmail">COM_CONFIG_FIELD_VALUE_SENDMAIL</option>
    <option value="smtp">COM_CONFIG_FIELD_VALUE_SMTP</option>
</field>
```
#### Field definition we want to set instead and also the expected result

(added 'gae' option and changed 'default' attribute)

``` xml
<field
  name="mailer"
  type="list"
  default="gae"
  label="COM_CONFIG_FIELD_MAIL_MAILER_LABEL"
  description="COM_CONFIG_FIELD_MAIL_MAILER_DESC"
  required="true"
  filter="word">
    <option value="gae">COM_CONFIG_FIELD_VALUE_GAE_MAIL</option>
    <option value="mail">COM_CONFIG_FIELD_VALUE_PHP_MAIL</option>
    <option value="sendmail">COM_CONFIG_FIELD_VALUE_SENDMAIL</option>
    <option value="smtp">COM_CONFIG_FIELD_VALUE_SMTP</option>
</field>
```
#### Actual result is as follows (the descendants options are not copied over):

``` xml
<field
  name="mailer"
  type="list"
  default="gae"
  label="COM_CONFIG_FIELD_MAIL_MAILER_LABEL"
  description="COM_CONFIG_FIELD_MAIL_MAILER_DESC"
  required="true"
  filter="word">
</field>
```

I think, when replacing a form this way, all nodes should be copied.

The nice tracker url: http://issues.joomla.org/tracker/joomla-cms/2708
The ugly tracker url: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33028
