### PR TITLE
[#32396] set the X-UA-Compatible header to IE=edge

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -62,6 +62,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage()); ?></title>
 	<?php // If debug  mode
 		$debug = JFactory::getConfig()->get('debug_lang');

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -75,6 +75,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
 
 	<!-- Template color -->


### PR DESCRIPTION
Because of this: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32396&start=0
