### PR TITLE
Fix for JDatabaseQuery->union method.  See #32995.

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -364,6 +364,11 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->where;
 				}
 
+				if ($this->union)
+				{
+					$query .= (string) $this->union;
+				}
+
 				if ($this->group)
 				{
 					$query .= (string) $this->group;
@@ -378,15 +383,6 @@ abstract class JDatabaseQuery
 				{
 					$query .= (string) $this->order;
 				}
-
-				break;
-
-			case 'union':
-				$query .= (string) $this->union;
-				break;
-
-			case 'unionAll':
-				$query .= (string) $this->unionAll;
 				break;
 
 			case 'delete':
@@ -1524,10 +1520,14 @@ abstract class JDatabaseQuery
 	 * Add a query to UNION with the current query.
 	 * Multiple unions each require separate statements and create an array of unions.
 	 *
-	 * Usage:
+	 * Usage (the $query base query MUST be a select query):
 	 * $query->union('SELECT name FROM  #__foo')
-	 * $query->union('SELECT name FROM  #__foo','distinct')
+	 * $query->union('SELECT name FROM  #__foo', true)
 	 * $query->union(array('SELECT name FROM  #__foo','SELECT name FROM  #__bar'))
+	 * $query->union($query2)->union($query3)
+	 * $query->union(array($query2, $query3))
+	 *
+	 * @link http://dev.mysql.com/doc/refman/5.0/en/union.html
 	 *
 	 * @param   mixed    $query     The JDatabaseQuery object or string to union.
 	 * @param   boolean  $distinct  True to only return distinct rows from the union.
@@ -1539,13 +1539,6 @@ abstract class JDatabaseQuery
 	 */
 	public function union($query, $distinct = false, $glue = '')
 	{
-		// Clear any ORDER BY clause in UNION query
-		// See http://dev.mysql.com/doc/refman/5.0/en/union.html
-		if (!is_null($this->order))
-		{
-			$this->clear('order');
-		}
-
 		// Set up the DISTINCT flag, the name with parentheses, and the glue.
 		if ($distinct)
 		{
@@ -1562,7 +1555,7 @@ abstract class JDatabaseQuery
 		// Get the JDatabaseQueryElement if it does not exist
 		if (is_null($this->union))
 		{
-				$this->union = new JDatabaseQueryElement($name, $query, "$glue");
+			$this->union = new JDatabaseQueryElement($name, $query, "$glue");
 		}
 		// Otherwise append the second UNION.
 		else
@@ -1574,10 +1567,12 @@ abstract class JDatabaseQuery
 	}
 
 	/**
-	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union with the Distinct clause.
+	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to union with the DISTINCT keyword.
 	 *
 	 * Usage:
 	 * $query->unionDistinct('SELECT name FROM  #__foo')
+	 *
+	 * @see     union
 	 *
 	 * @param   mixed   $query  The JDatabaseQuery object or string to union.
 	 * @param   string  $glue   The glue by which to join the conditions.
@@ -1808,12 +1803,13 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->union('SELECT name FROM  #__foo')
-	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 * $query->union(array('SELECT name FROM  #__foo','SELECT name FROM  #__bar'))
 	 *
+	 * @see     union
+	 *
 	 * @param   mixed    $query     The JDatabaseQuery object or string to union.
-	 * @param   boolean  $distinct  True to only return distinct rows from the union.
-	 * @param   string   $glue      The glue by which to join the conditions.
+	 * @param   boolean  $distinct  Not used - ignored.
+	 * @param   string   $glue      Not used - ignored.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1821,8 +1817,8 @@ abstract class JDatabaseQuery
 	 */
 	public function unionAll($query, $distinct = false, $glue = '')
 	{
-			$glue = ')' . PHP_EOL . 'UNION ALL (';
-			$name = 'UNION ALL ()';
+		$glue = ')' . PHP_EOL . 'UNION ALL (';
+		$name = 'UNION ALL ()';
 
 		// Get the JDatabaseQueryElement if it does not exist
 		if (is_null($this->unionAll))
@@ -1839,3 +1835,4 @@ abstract class JDatabaseQuery
 		return $this;
 	}
 }
+

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -3,7 +3,7 @@
  * @package     Joomla.UnitTest
  * @subpackage  Database
  *
- * @copyright   Copyright (C) 2005 - 2013 Open Source Matters. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -323,37 +323,6 @@ class JDatabaseQueryTest extends TestCase
 		);
 	}
 
-	/**
-	 * Tests the union element of __toString.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function test__toStringUnion()
-	{
-		$this->markTestIncomplete('This test does not work!');
-		$this->_instance->select('*')
-			->union('SELECT id FROM a');
-
-		$this->assertEquals("UNION (SELECT id FROM a)", trim($this->_instance));
-	}
-
-	/**
-	 * Tests the unionAll element of __toString.
-	 *
-	 * @return  void
-	 *
-	 * @since   13.1
-	 */
-	public function test__toStringUnionAll()
-	{
-		$this->markTestIncomplete('This test does not work!');
-		$this->_instance->select('*')
-		->unionAll('SELECT id FROM a');
-
-		$this->assertEquals("UNION ALL (SELECT id FROM a)", trim($this->_instance));
-	}
 	/**
 	 * Tests the JDatabaseQuery::call method.
 	 *

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1725,7 +1725,83 @@ class JDatabaseQueryTest extends TestCase
 				"UNION (" . PHP_EOL .
 				"SELECT name" . PHP_EOL .
 				"FROM bar" . PHP_EOL .
-				"WHERE b=2)" . PHP_EOL
+				"WHERE b=2)"
+			)
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method when passed two query objects chained.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.??
+	 */
+	public function testUnionObjectsChained()
+	{
+		$this->_instance->select('name')->from('foo')->where('a=1');
+
+		$q2 = new JDatabaseQueryInspector($this->dbo);
+		$q2->select('name')->from('bar')->where('b=2');
+
+		$q3 = new JDatabaseQueryInspector($this->dbo);
+		$q3->select('name')->from('baz')->where('c=3');
+
+		TestReflection::setValue($this->_instance, 'union', null);
+		$this->_instance->union($q2)->union($q3);
+
+		$this->assertThat(
+			(string) $this->_instance,
+			$this->equalTo(
+				PHP_EOL . "SELECT name" . PHP_EOL .
+				"FROM foo" . PHP_EOL .
+				"WHERE a=1" . PHP_EOL .
+				"UNION (" . PHP_EOL .
+				"SELECT name" . PHP_EOL .
+				"FROM bar" . PHP_EOL .
+				"WHERE b=2)" . PHP_EOL .
+				"UNION (" . PHP_EOL .
+				"SELECT name" . PHP_EOL .
+				"FROM baz" . PHP_EOL .
+				"WHERE c=3)"
+			)
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method when passed two query objects in an array.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.??
+	 */
+	public function testUnionObjectsArray()
+	{
+		$this->_instance->select('name')->from('foo')->where('a=1');
+
+		$q2 = new JDatabaseQueryInspector($this->dbo);
+		$q2->select('name')->from('bar')->where('b=2');
+
+		$q3 = new JDatabaseQueryInspector($this->dbo);
+		$q3->select('name')->from('baz')->where('c=3');
+
+		TestReflection::setValue($this->_instance, 'union', null);
+		$this->_instance->union(array($q2, $q3));
+
+		$this->assertThat(
+			(string) $this->_instance,
+			$this->equalTo(
+				PHP_EOL . "SELECT name" . PHP_EOL .
+				"FROM foo" . PHP_EOL .
+				"WHERE a=1" . PHP_EOL .
+				"UNION (" . PHP_EOL .
+				"SELECT name" . PHP_EOL .
+				"FROM bar" . PHP_EOL .
+				"WHERE b=2)" . PHP_EOL .
+				"UNION (" . PHP_EOL .
+				"SELECT name" . PHP_EOL .
+				"FROM baz" . PHP_EOL .
+				"WHERE c=3)"
 			)
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1553,26 +1553,6 @@ class JDatabaseQueryTest extends TestCase
 	 *
 	 * @since   12.1
 	 */
-	public function testUnionClear()
-	{
-		TestReflection::setValue($this->_instance, 'union', null);
-		TestReflection::setValue($this->_instance, 'order', null);
-		$this->_instance->order('bar');
-		$this->_instance->union('SELECT name FROM foo');
-		$this->assertThat(
-			TestReflection::getValue($this->_instance, 'order'),
-			$this->equalTo(null),
-			'Tests that ORDER BY is cleared with union.'
-		);
-	}
-
-	/**
-	 * Tests the JDatabaseQuery::union method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
 	public function testUnionUnion()
 	{
 		TestReflection::setValue($this->_instance, 'union', null);
@@ -1716,6 +1696,37 @@ class JDatabaseQueryTest extends TestCase
 			$teststring,
 			$this->equalTo(PHP_EOL . "UNION DISTINCT (SELECT name FROM foo)" . PHP_EOL . "UNION DISTINCT (SELECT name FROM bar)"),
 			'Tests rendered query with two unions distinct.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method when passed a query object instead of a string.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.??
+	 */
+	public function testUnionObject()
+	{
+		$this->_instance->select('name')->from('foo')->where('a=1');
+
+		$q2 = new JDatabaseQueryInspector($this->dbo);
+		$q2->select('name')->from('bar')->where('b=2');
+
+		TestReflection::setValue($this->_instance, 'union', null);
+		$this->_instance->union($q2);
+
+		$this->assertThat(
+			(string) $this->_instance,
+			$this->equalTo(
+				PHP_EOL . "SELECT name" . PHP_EOL .
+				"FROM foo" . PHP_EOL . 
+				"WHERE a=1" . PHP_EOL .
+				"UNION (" . PHP_EOL .
+				"SELECT name" . PHP_EOL .
+				"FROM bar" . PHP_EOL .
+				"WHERE b=2)" . PHP_EOL
+			)
 		);
 	}
 


### PR DESCRIPTION
Also minor corrections and improvements to docblocks for union methods.

Union method currently just doesn't work at all.  This fixes it.  See tracker #32995 and PR #1629.  If accepted this fix also needs to go into Joomla 2.5 and Framework 1.x.
