### PR TITLE
[#33062] Fix broken purge cache button in joomla update complete view

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
@@ -10,11 +10,16 @@
 defined('_JEXEC') or die;
 ?>
 
-<fieldset>
-	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING') ?>
-	</legend>
-	<p>
-		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE', JVERSION); ?>
-	</p>
-</fieldset>
+<form action="index.php" method="post" id="adminForm">
+	<fieldset>
+		<legend>
+			<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING') ?>
+		</legend>
+		<p>
+			<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE', JVERSION); ?>
+		</p>
+	</fieldset>
+	<?php echo JHtml::_('form.token'); ?>
+	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="option" value="com_joomlaupdate" />
+</form>


### PR DESCRIPTION
Fix broken purge cache button in joomla update complete view 

Issue tracker:

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33062&start=0
