### PR TITLE
[#33055] Update pagebreak.php;  If pagebreak added to article a Notice: Undefined property: stdClass::$toc in pagebreak.php is created  

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -259,7 +259,7 @@ class PlgContentPagebreak extends JPlugin
 		$showall = $input->getInt('showall', 0);
 
 		// TOC header.
-		$row->toc .= '<div class="pull-right article-index">';
+		$row->toc = '<div class="pull-right article-index">';
 
 		if ($this->params->get('article_index') == 1)
 		{


### PR DESCRIPTION
[#33055] makes no sense to keep the adding point; With > php5.5 it would create a notice, because the $row->toc doesn't exist at that specific time.
