### PR TITLE
[#33076] Add JHelperPath class in cms libraries

### DIFF
--- a/libraries/cms/helper/path.php
+++ b/libraries/cms/helper/path.php
@@ -21,9 +21,8 @@ defined('_JEXEC') or die;
 class JHelperPath
 {
 	/**
-	 * The mapper to find extension type.
-	 *
-	 * @var  array
+	 * @var    array  The mapper to find extension type.
+	 * @since  3.3
 	 */
 	protected static $extMapper = array(
 		'com_' => 'components',
@@ -41,6 +40,8 @@ class JHelperPath
 	 * @param   boolean  $absolute  True to return whole path.
 	 *
 	 * @return  string  The found path.
+	 *
+	 * @since  3.3
 	 */
 	public static function get($element, $client = null, $absolute = true)
 	{
@@ -107,6 +108,8 @@ class JHelperPath
 	 * @param   boolean  $absolute  True to return whole path.
 	 *
 	 * @return  string  The found path.
+	 *
+	 * @since   3.3
 	 */
 	public static function getAdmin($element, $absolute = true)
 	{
@@ -120,6 +123,8 @@ class JHelperPath
 	 * @param   boolean  $absolute  True to return whole path.
 	 *
 	 * @return  string  The found path.
+	 *
+	 * @since   3.3
 	 */
 	public static function getSite($element, $absolute = true)
 	{
@@ -134,6 +139,8 @@ class JHelperPath
 	 * @return  array
 	 *
 	 * @throws  \InvalidArgumentException
+	 *
+	 * @since   3.3
 	 */
 	protected static function extractElement($element)
 	{
@@ -173,6 +180,8 @@ class JHelperPath
 	 * @param   string  $prefix  The extension prefix.
 	 *
 	 * @return  string|null  Extension type name.
+	 *
+	 * @since   3.3
 	 */
 	protected static function getExtName($prefix)
 	{

--- a/libraries/cms/helper/path.php
+++ b/libraries/cms/helper/path.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Helper
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Path Helper
+ *
+ * A static class help finding extension path.
+ *
+ * @package     Joomla.Libraries
+ * @subpackage  Helper
+ * @since       3.3
+ */
+class JHelperPath
+{
+	/**
+	 * The mapper to find extension type.
+	 *
+	 * @var  array
+	 */
+	protected static $extMapper = array(
+		'com_' => 'components',
+		'mod_' => 'modules',
+		'plg_' => 'plugins',
+		'lib_' => 'libraries',
+		'tpl_' => 'templates'
+	);
+
+	/**
+	 * Get the path of extension.
+	 *
+	 * @param   string   $element   The extension element name, example: com_content or plg_group_name
+	 * @param   string   $client    Site or administrator.
+	 * @param   boolean  $absolute  True to return whole path.
+	 *
+	 * @return  string  The found path.
+	 */
+	public static function get($element, $client = null, $absolute = true)
+	{
+		$element = strtolower($element);
+
+		list($extension, $name, $group) = static::extractElement($element);
+
+		$folder = $name;
+
+		// Assign name path.
+		switch ($extension)
+		{
+			case 'components':
+			case 'modules':
+				$folder = $element;
+				break;
+
+			case 'plugins':
+				$folder = $group . '/' . $name;
+				$client = 'site';
+				break;
+
+			case 'libraries':
+				$client = 'site';
+				break;
+
+			default:
+				$folder = $name;
+				break;
+		}
+
+		// Build path
+		$path = $extension . '/' . $folder;
+
+		if (!$absolute)
+		{
+			return $path;
+		}
+
+		// Add absolute path.
+		switch ($client)
+		{
+			case 'site':
+				$path = JPATH_SITE . '/' . $path;
+				break;
+
+			case 'admin':
+			case 'administrator':
+				$path = JPATH_ADMINISTRATOR . '/' . $path;
+				break;
+
+			default:
+				$path = JPATH_BASE . '/' . $path;
+				break;
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Get path of administrator.
+	 *
+	 * @param   string   $element   The extension element name, example: com_content or plg_group_name
+	 * @param   boolean  $absolute  True to return whole path.
+	 *
+	 * @return  string  The found path.
+	 */
+	public static function getAdmin($element, $absolute = true)
+	{
+		return static::get($element, 'administrator', $absolute);
+	}
+
+	/**
+	 * Get path of front-end.
+	 *
+	 * @param   string   $element   The extension element name, example: com_content or plg_group_name
+	 * @param   boolean  $absolute  True to return whole path.
+	 *
+	 * @return  string  The found path.
+	 */
+	public static function getSite($element, $absolute = true)
+	{
+		return static::get($element, 'site', $absolute);
+	}
+
+	/**
+	 * Extract element.
+	 *
+	 * @param   string  $element  he extension element name, example: com_content or plg_group_name
+	 *
+	 * @return  array
+	 *
+	 * @throws  \InvalidArgumentException
+	 */
+	protected static function extractElement($element)
+	{
+		$prefix = substr($element, 0, 4);
+
+		$ext = static::getExtName($prefix);
+
+		if (!$ext)
+		{
+			throw new \InvalidArgumentException(sprintf('Need extension prefix, "%s" given.', $element));
+		}
+
+		$group = '';
+		$name = substr($element, 4);
+
+		// Get group
+		if ($ext == 'plugins')
+		{
+			$name  = explode('_', $name);
+
+			$group = array_shift($name);
+
+			$name  = implode('_', $name);
+
+			if (!$name)
+			{
+				throw new \InvalidArgumentException(sprintf('Plugin name need group, eg: "plg_group_name", "%s" given.', $element));
+			}
+		}
+
+		return array($ext, $name, $group);
+	}
+
+	/**
+	 * Get extension type name.
+	 *
+	 * @param   string  $prefix  The extension prefix.
+	 *
+	 * @return  string|null  Extension type name.
+	 */
+	protected static function getExtName($prefix)
+	{
+		if (!empty(static::$extMapper[$prefix]))
+		{
+			return static::$extMapper[$prefix];
+		}
+
+		return null;
+	}
+}

--- a/tests/unit/suites/libraries/cms/helper/JHelperPathTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperPathTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * @package        Joomla.UnitTest
+ * @subpackage     Helper
+ * @copyright      Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license        GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JHelperPath.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Helper
+ * @since       3.3
+ */
+class JHelperPathTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * Path provider of component.
+	 *
+	 * @return array
+	 *
+	 * @since  3.3
+	 */
+	public function pathProviderComponent()
+	{
+		return array(
+			// Component in base client
+			array('com_content', null, true, JPATH_BASE . '/components/com_content'),
+
+			// Component in site client
+			array('com_content', 'site', true, JPATH_SITE . '/components/com_content'),
+
+			// Component in admin client
+			array('com_content', 'admin', true, JPATH_ADMINISTRATOR . '/components/com_content'),
+
+			// Component in administrator client
+			array('com_content', 'administrator', true, JPATH_ADMINISTRATOR . '/components/com_content'),
+
+			// Component in administrator client with relative path
+			array('com_content', 'administrator', false, 'components/com_content'),
+		);
+	}
+
+	/**
+	 * Path provider of module.
+	 *
+	 * @return array
+	 *
+	 * @since  3.3
+	 */
+	public function pathProviderModule()
+	{
+		return array(
+			// Module in base client
+			array('mod_latest_news', null, true, JPATH_BASE . '/modules/mod_latest_news'),
+
+			// Module in site client
+			array('mod_latest_news', 'site', true, JPATH_SITE . '/modules/mod_latest_news'),
+
+			// Module in admin client
+			array('mod_quickicon', 'admin', true, JPATH_ADMINISTRATOR . '/modules/mod_quickicon'),
+
+			// Module in administrator client
+			array('mod_quickicon', 'administrator', true, JPATH_ADMINISTRATOR . '/modules/mod_quickicon'),
+
+			// Module in administrator client with relative path
+			array('mod_quickicon', 'administrator', false, 'modules/mod_quickicon'),
+		);
+	}
+
+	/**
+	 * Path provider of plugin.
+	 *
+	 * @return array
+	 *
+	 * @since  3.3
+	 */
+	public function pathProviderPlugin()
+	{
+		return array(
+			// Plugin system in base client
+			array('plg_system_cache', null, true, JPATH_SITE . '/plugins/system/cache'),
+
+			// Plugin system in site client
+			array('plg_system_cache', 'site', true, JPATH_SITE . '/plugins/system/cache'),
+
+			// Plugin system in site client
+			array('plg_system_cache', 'admin', true, JPATH_SITE . '/plugins/system/cache'),
+
+			// Plugin system in site client
+			array('plg_system_cache', 'administrator', true, JPATH_SITE . '/plugins/system/cache'),
+
+			// Plugin system in site client with relative path
+			array('plg_system_cache', 'administrator', false, 'plugins/system/cache'),
+		);
+	}
+
+	/**
+	 * Path provider of library.
+	 *
+	 * @return array
+	 *
+	 * @since  3.3
+	 */
+	public function pathProviderLibrary()
+	{
+		return array(
+			// Library in base client
+			array('lib_fof', null, true, JPATH_SITE . '/libraries/fof'),
+
+			// Library in site client
+			array('lib_fof', 'site', true, JPATH_SITE . '/libraries/fof'),
+
+			// Library in site client
+			array('lib_fof', 'admin', true, JPATH_SITE . '/libraries/fof'),
+
+			// Library in site client
+			array('lib_fof', 'administrator', true, JPATH_SITE . '/libraries/fof'),
+
+			// Library in site client with relative path
+			array('lib_fof', 'administrator', false, 'libraries/fof'),
+		);
+	}
+
+	/**
+	 * Path provider of template.
+	 *
+	 * @return array
+	 *
+	 * @since  3.3
+	 */
+	public function pathProviderTemplate()
+	{
+		return array(
+			// Template in base client
+			array('tpl_protostar', null, true, JPATH_BASE . '/templates/protostar'),
+
+			// Template in site client
+			array('tpl_protostar', 'site', true, JPATH_SITE . '/templates/protostar'),
+
+			// Template in admin client
+			array('tpl_isis', 'admin', true, JPATH_ADMINISTRATOR . '/templates/isis'),
+
+			// Template in administrator client
+			array('tpl_isis', 'administrator', true, JPATH_ADMINISTRATOR . '/templates/isis'),
+
+			// Template in administrator client with relative path
+			array('tpl_isis', 'administrator', false, 'templates/isis'),
+		);
+	}
+
+	/**
+	 * Test get path of component
+	 *
+	 * @param   string  $element   Extension element name.
+	 * @param   string  $client    Client, 'site', 'admin' or 'administrator'.
+	 * @param   string  $absolute  True to get whole path.
+	 * @param   string  $result    The result to compare.
+	 *
+	 * @dataProvider  pathProviderComponent
+	 *
+	 * @return  void
+	 *
+	 * @since  3.3
+	 */
+	public function testGetComponent($element, $client, $absolute, $result)
+	{
+		$path = JHelperPath::get($element, $client, $absolute);
+		$this->assertEquals($path, $result);
+	}
+
+	/**
+	 * Test get path of module
+	 *
+	 * @param   string  $element   Extension element name.
+	 * @param   string  $client    Client, 'site', 'admin' or 'administrator'.
+	 * @param   string  $absolute  True to get whole path.
+	 * @param   string  $result    The result to compare.
+	 *
+	 * @dataProvider  pathProviderModule
+	 *
+	 * @return  void
+	 *
+	 * @since   3.3
+	 */
+	public function testGetModule($element, $client, $absolute, $result)
+	{
+		$path = JHelperPath::get($element, $client, $absolute);
+		$this->assertEquals($path, $result);
+	}
+
+	/**
+	 * Test get path of plugin
+	 *
+	 * @param   string  $element   Extension element name.
+	 * @param   string  $client    Client, 'site', 'admin' or 'administrator'.
+	 * @param   string  $absolute  True to get whole path.
+	 * @param   string  $result    The result to compare.
+	 *
+	 * @dataProvider  pathProviderPlugin
+	 *
+	 * @return  void
+	 *
+	 * @since   3.3
+	 */
+	public function testGetPlugin($element, $client, $absolute, $result)
+	{
+		$path = JHelperPath::get($element, $client, $absolute);
+		$this->assertEquals($path, $result);
+	}
+
+	/**
+	 * Test get path of library
+	 *
+	 * @param   string  $element   Extension element name.
+	 * @param   string  $client    Client, 'site', 'admin' or 'administrator'.
+	 * @param   string  $absolute  True to get whole path.
+	 * @param   string  $result    The result to compare.
+	 *
+	 * @dataProvider  pathProviderLibrary
+	 *
+	 * @return  void
+	 *
+	 * @since   3.3
+	 */
+	public function testGetLibrary($element, $client, $absolute, $result)
+	{
+		$path = JHelperPath::get($element, $client, $absolute);
+		$this->assertEquals($path, $result);
+	}
+
+	/**
+	 * Test get path of template
+	 *
+	 * @param   string  $element   Extension element name.
+	 * @param   string  $client    Client, 'site', 'admin' or 'administrator'.
+	 * @param   string  $absolute  True to get whole path.
+	 * @param   string  $result    The result to compare.
+	 *
+	 * @dataProvider  pathProviderTemplate
+	 *
+	 * @return  void
+	 *
+	 * @since   3.3
+	 */
+	public function testGetTemplate($element, $client, $absolute, $result)
+	{
+		$path = JHelperPath::get($element, $client, $absolute);
+		$this->assertEquals($path, $result);
+	}
+}


### PR DESCRIPTION
## Introduction

When we have to get a component path, we use `JPATH_COMPONENT` now. But this constant is dynamic, we can't get a component path in other component. And if we get Model of a component, we need add some path first:

``` php
JForm::addFormPath( COMPONENT_PATH . '/models/forms');
JForm::addFieldPath( COMPONENT_PATH . '/models/fields' );

$model->addTablePath(COMPONENT_PATH . '/tables');

$model->getForm();
$model->getTable();
```

Model cannot guess path they located.
## The new PathHelper

Now we can use `JHelperPath` to get extension path, for example:

``` php
JHelperPath::get('com_content'); // /var/www/joomla/components/com_content

JHelperPath::get('mod_latest_news', 'site'); // /var/www/joomla/modules/mod_latest_news

JHelperPath::get('plg_system_debug'); // /var/www/joomla/plugins/system/debug

JHelperPath::getAdmin('tpl_isis'); // /var/www/joomla/administrator/templates/isis

JHelperPath::getAdmin('com_content', true); // components/com_content (Relative path)
```

With this class, controller and model will be able to guess where they located:

``` php
// Set the default view search path
if (array_key_exists('table_path', $config))
{
    $this->addTablePath($config['table_path']);
}

// Guess component position
elseif (!empty($this->option))
{
    $this->addTablePath(JHelperPath::get($this->option) . '/tables');
    $this->addTablePath(JHelperPath::get($this->option) . '/table');
}

// Use constant
elseif (defined('JPATH_COMPONENT_ADMINISTRATOR'))
{
    $this->addTablePath(JPATH_COMPONENT_ADMINISTRATOR . '/tables');
    $this->addTablePath(JPATH_COMPONENT_ADMINISTRATOR . '/table');
}
```
