### PR TITLE
[#33081] Get rid of including phpunit classes from pear

### DIFF
--- a/tests/unit/core/case/database.php
+++ b/tests/unit/core/case/database.php
@@ -6,10 +6,13 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once 'PHPUnit/Extensions/Database/TestCase.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/XmlDataSet.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/QueryDataSet.php';
-require_once 'PHPUnit/Extensions/Database/DataSet/MysqlXmlDataSet.php';
+if (!class_exists('PHPUnit_Extensions_Database_TestCase'))
+{
+	require_once 'PHPUnit/Extensions/Database/TestCase.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/XmlDataSet.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/QueryDataSet.php';
+	require_once 'PHPUnit/Extensions/Database/DataSet/MysqlXmlDataSet.php';
+}
 
 /**
  * Abstract test case class for database testing.


### PR DESCRIPTION
We use hard code including PHPUnit Database package now. But it will cause the error if we use phpunit.phar or other phpunit package without pear.

If we type `php phpunit.phar` in Joomla dir, return this error:

```
Warning: require_once(PHPUnit/Extensions/Database/TestCase.php): failed to open stream: No such file or directory in D:\www\repo\joomladev\tests\unit\core\case\database.php on line 9

Fatal error: require_once(): Failed opening required 'PHPUnit/Extensions/Database/TestCase.php' (include_path='.;C:\bin\pear\pear') in D:\www\repo\joomladev\tests\unit\core\case\database.php on line 9PHP Warning:  require_once(PHPUnit/Extensions/Database/TestCase.php): failed to open stream: No such file or directory in D:\www\repo\joomladev\tests\unit\core\case\database.php on line 9

PHP Fatal error:  require_once(): Failed opening required 'PHPUnit/Extensions/Database/TestCase.php' (include_path='.;C:\bin\pear\pear') in D:\www\repo\joomladev\tests\unit\core\case\database.php on line 9

Process finished with exit code 255
```

So I do this change to get rid of hard code including PHPUnit Database from pear that developers can use their own phpunit package to test Joomla.

JTracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33081&start=0
