### PR TITLE
 [#33075] mod_breadcrumbs shows "You are here" as tooltip instead of text

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -17,7 +17,11 @@ JHtml::_('bootstrap.tooltip');
 	<?php
 	if ($params->get('showHere', 1))
 	{
-		echo '<li class="active"><span class="divider icon-location hasTooltip" title="' . JText::_('MOD_BREADCRUMBS_HERE') . '"></span></li>';
+		echo '<li class="active">' . JText::_('MOD_BREADCRUMBS_HERE') . '&#160;</span></li>';
+	}
+	else
+	{
+		echo '<li class="active"><span class="divider icon-location"></span></li>';
 	}
 
 	// Get rid of duplicated entries on trail including home page when using multilanguage


### PR DESCRIPTION
Tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33075&start=0
