### PR TITLE
fixed bug on caching and pathway workaround

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -649,7 +649,7 @@ class JCache
 		if ($app->isSite() && $loptions['nopathway'] != 1)
 		{
 			$pathway = $app->getPathWay();
-			$cached['pathway'] = isset($data['pathway']) ? $data['pathway'] : $pathway->getPathway();
+			$cached['pathway'] = is_array($data) && isset($data['pathway']) ? $data['pathway'] : $pathway->getPathway();
 		}
 
 		if ($loptions['nomodules'] != 1)


### PR DESCRIPTION
isset($data['pathway']) returns true even when $data is not an array...
This happens for PHP versions lower than 5.4.x
