### PR TITLE
Wrong config calls for cookie settings in languagefilter and logout plugin

### DIFF
--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -734,7 +734,7 @@ abstract class JUserHelper
 
 		// Destroy the cookie in the browser.
 		$app = JFactory::getApplication();
-		$app->input->cookie->set($cookieName, false, time() - 42000, $app->get('cookie_path'), $app->get('cookie_domain'), false, true);
+		$app->input->cookie->set($cookieName, false, time() - 42000, $app->get('cookie_path', '/'), $app->get('cookie_domain'), false, true);
 
 		return true;
 	}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -116,8 +116,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Create a cookie.
 					$conf = JFactory::getConfig();
-					$cookie_domain 	= $conf->get('config.cookie_domain', '');
-					$cookie_path 	= $conf->get('config.cookie_path', '/');
+					$cookie_domain 	= $conf->get('cookie_domain', '');
+					$cookie_path 	= $conf->get('cookie_path', '/');
 					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 					$app->input->cookie->set(JApplication::getHash('language'), $lang_code);
 
@@ -463,8 +463,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Create a cookie.
 					$conf = JFactory::getConfig();
-					$cookie_domain 	= $conf->get('config.cookie_domain', '');
-					$cookie_path 	= $conf->get('config.cookie_path', '/');
+					$cookie_domain 	= $conf->get('cookie_domain', '');
+					$cookie_path 	= $conf->get('cookie_path', '/');
 					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 				}
 			}
@@ -515,8 +515,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				// Create a cookie.
 				$conf = JFactory::getConfig();
-				$cookie_domain 	= $conf->get('config.cookie_domain', '');
-				$cookie_path 	= $conf->get('config.cookie_path', '/');
+				$cookie_domain 	= $conf->get('cookie_domain', '');
+				$cookie_path 	= $conf->get('cookie_path', '/');
 				setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 
 				// Change the language code.

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -45,8 +45,8 @@ class PlgSystemLogout extends JPlugin
 		{
 			// Destroy the cookie.
 			$conf = JFactory::getConfig();
-			$cookie_domain = $conf->get('config.cookie_domain', '');
-			$cookie_path   = $conf->get('config.cookie_path', '/');
+			$cookie_domain = $conf->get('cookie_domain', '');
+			$cookie_path   = $conf->get('cookie_path', '/');
 			setcookie($hash, false, time() - 86400, $cookie_path, $cookie_domain);
 
 			// Set the error handler for E_ALL to be the class handleError method.
@@ -71,8 +71,8 @@ class PlgSystemLogout extends JPlugin
 			// Create the cookie.
 			$hash = JApplication::getHash('PlgSystemLogout');
 			$conf = JFactory::getConfig();
-			$cookie_domain 	= $conf->get('config.cookie_domain', '');
-			$cookie_path 	= $conf->get('config.cookie_path', '/');
+			$cookie_domain 	= $conf->get('cookie_domain', '');
+			$cookie_path 	= $conf->get('cookie_path', '/');
 			setcookie($hash, true, time() + 86400, $cookie_path, $cookie_domain);
 		}
 


### PR DESCRIPTION
This PR fixes two issues related to cookie settings in global configuration
- The languagefilter and logout plugins were looking for the config parameters `config.cookie_domain` and `config.cookie_path`. The correct call is without the `config.` part.
- There were some places where the `cookie_path` parameter didn't fetch the correct default value `/`. Together with SEF turned on, this could result in cookies only being valid for a submenu of the page since the path was taken from the current URL instead from root.
