### PR TITLE
[#] Fix spinner not appearing while installing language

### DIFF
--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -16,9 +16,9 @@ $version = new JVersion;
 <script type="text/javascript">
     function installLanguages() {
         var $ = jQuery.noConflict();
-        $(install_languages_desc).hide();
-        $(wait_installing).show();
-        $(wait_installing_spinner).show();
+		$('#install_languages_desc').hide();
+		$('#wait_installing').show();
+		$('#wait_installing_spinner').show();
         Install.submitform();
     }
 </script>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -14,13 +14,13 @@ defined('_JEXEC') or die;
 $version = new JVersion;
 ?>
 <script type="text/javascript">
-    function installLanguages() {
-        var $ = jQuery.noConflict();
+	function installLanguages() {
+		var $ = jQuery.noConflict();
 		$('#install_languages_desc').hide();
 		$('#wait_installing').show();
 		$('#wait_installing_spinner').show();
-        Install.submitform();
-    }
+		Install.submitform();
+	}
 </script>
 
 <?php echo JHtml::_('installation.stepbarlanguages'); ?>


### PR DESCRIPTION
## Description

This old change make this javascript to stop working: https://github.com/joomla/joomla-cms/commit/08658c34cbc45db8e578277a468517a756e2846d because the ID selector (#) was removed.
## JoomlaCode Issue

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33106&start=0 
## Testing instructions
- Do all Joomla Install steps until the last sceen, and in the same installer go to "install languages"

![screen shot 2014-01-09 at 11 11 28](https://f.cloud.github.com/assets/1375475/1876681/5aa5a536-7916-11e3-873e-1ee2685168e5.png)
- Choose several languages from the list and click next

![screen shot 2014-01-09 at 11 13 29](https://f.cloud.github.com/assets/1375475/1876691/8622414c-7916-11e3-94b2-f05cff3efcc6.png)
- When you apply the patch you should be able to see a spinner with a text saying that the installation may take several seconds (without the patch this was not working):

![screen shot 2014-01-09 at 11 13 40](https://f.cloud.github.com/assets/1375475/1876706/b32c065a-7916-11e3-8273-0c568f70e284.png)
