### PR TITLE
fixed com_content permission control bug in administration

### DIFF
--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -44,7 +44,7 @@ class ContentViewArticle extends JViewLegacy
 		$this->form		= $this->get('Form');
 		$this->item		= $this->get('Item');
 		$this->state	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions($this->state->get('filter.category_id'), 0, 'com_content');
+		$this->canDo	= JHelperContent::getActions($this->item->catid, 0, 'com_content');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))


### PR DESCRIPTION
Step to reproduce bug:
- create new group "Backend editors"
- create user "Pippo" and assign it to the new group 
- create category "Editor category"
- assign permission to access Administration and com_content component
- assign permission to create/edit article for category "Editor category"
- login as Pippo and go to the Content component
- filter articles by category "Editor category"
- create a new article and save&close
- edit the newly created article

At this point I expect the user to be able to edit and save the article. Instead save buttons are not present in the toolbar (only the cancel option is there).
This is due to the 'filter.category_id' state not being set. Instead we should check for the category the article belongs to (which we can get by catid article property).
