### PR TITLE
Fix for (sub)menu with start level > 2 and actual == root

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -34,6 +34,8 @@ class ModMenuHelper
 
 		// Get active menu item
 		$base = self::getBase($params);
+		
+		
 		$user = JFactory::getUser();
 		$levels = $user->getAuthorisedViewLevels();
 		asort($levels);
@@ -45,6 +47,9 @@ class ModMenuHelper
 			$end     = (int) $params->get('endLevel');
 			$showAll = $params->get('showAllChildren');
 			$items   = $menu->getItems('menutype', $params->get('menutype'));
+			
+			$path = $base->tree;
+			$base_id = $base->tree[ max(0, $base->level - $start - 1) ];
 
 			$lastitem = 0;
 
@@ -54,8 +59,8 @@ class ModMenuHelper
 				{
 					if (($start && $start > $item->level)
 						|| ($end && $item->level > $end)
-						|| (!$showAll && $item->level > 1 && !in_array($item->parent_id, $path))
-						|| ($start > 1 && !in_array($base->id, $item->tree)))
+						// || (!$showAll && $item->level > 1 && !in_array($item->parent_id, $path))
+						|| ($start > 1 && !in_array($base_id, $item->tree)))
 					{
 						unset($items[$i]);
 						continue;

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -41,7 +41,6 @@ class ModMenuHelper
 		$cache = JFactory::getCache('mod_menu', '');
 		if (!($items = $cache->get($key)))
 		{
-			$path    = $base->tree;
 			$start   = (int) $params->get('startLevel');
 			$end     = (int) $params->get('endLevel');
 			$showAll = $params->get('showAllChildren');
@@ -56,7 +55,7 @@ class ModMenuHelper
 					if (($start && $start > $item->level)
 						|| ($end && $item->level > $end)
 						|| (!$showAll && $item->level > 1 && !in_array($item->parent_id, $path))
-						|| ($start > 1 && !in_array($item->tree[$start - 2], $path)))
+						|| ($start > 1 && !in_array($base->id, $item->tree)))
 					{
 						unset($items[$i]);
 						continue;


### PR DESCRIPTION
If I've understood the code well `$item->tree` contains all the item's parents, plus itself.
My use of case: I want to display all child of the active menu with depth's level 4 (legacy code, don't ask me why so deep...)
In my case, `$path` is the active menu's tree and is a root menu, so $path contains only itself.
I think this condition check `!in_array($item->tree[$start - 2], $path)` isn't correct, because if the level I want for my submenu is greater than 2 (4) and the current active menu is its root, it will still unset the item, because `$item->tree[$start - 2]` (direct son of the root) will not be in `$path`!

I think this patch is a more correct version and I've already tested it and seems to work well, but I don't know if can cause other bugs with other use cases.
