### PR TITLE
Removing `else` so the fallbacks indeed get used

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -132,12 +132,11 @@ abstract class ContactHelperRoute
 				}
 			}
 		}
-		else
+
+		$active = $menus->getActive();
+		if ($active)
 		{
-			$active = $menus->getActive();
-			if ($active) {
-				return $active->id;
-			}
+			return $active->id;
 		}
 
 		return null;

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -174,16 +174,17 @@ abstract class ContentHelperRoute
 				}
 			}
 		}
-		else
+
+		if ($language != '*')
 		{
-			if ($language != '*') {
-				$needles['language'] = '*';
-				return self::_findItem($needles);
-			}
-			$active = $menus->getActive();
-			if ($active && $active->component == 'com_content') {
-				return $active->id;
-			}
+			$needles['language'] = '*';
+			return self::_findItem($needles);
+		}
+
+		$active = $menus->getActive();
+		if ($active && $active->component == 'com_content')
+		{
+			return $active->id;
 		}
 
 		return null;

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -134,12 +134,11 @@ abstract class NewsfeedsHelperRoute
 				}
 			}
 		}
-		else
+
+		$active = $menus->getActive();
+		if ($active)
 		{
-			$active = $menus->getActive();
-			if ($active) {
-				return $active->id;
-			}
+			return $active->id;
 		}
 
 		return null;

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -138,24 +138,27 @@ abstract class WeblinksHelperRoute
 			}
 		}
 
-		if ($needles) {
+		if ($needles)
+		{
 			foreach ($needles as $view => $ids)
 			{
-				if (isset(self::$lookup[$view])) {
+				if (isset(self::$lookup[$view]))
+				{
 					foreach($ids as $id)
 					{
-						if (isset(self::$lookup[$view][(int)$id])) {
+						if (isset(self::$lookup[$view][(int)$id]))
+						{
 							return self::$lookup[$view][(int)$id];
 						}
 					}
 				}
 			}
 		}
-		else {
-			$active = $menus->getActive();
-			if ($active) {
-				return $active->id;
-			}
+
+		$active = $menus->getActive();
+		if ($active)
+		{
+			return $active->id;
 		}
 
 		return null;


### PR DESCRIPTION
### Issue

If the RouteHelper doesn't find a matching Itemid (menu item) for a given article, it will just return nothing.
It should however fall back to the currently active Itemid instead.
This bug basically is a regression from a previous PR https://github.com/joomla/joomla-cms/pull/1708. However since the PR itself is good and fixes a valid issue, I don't want to revert it.
### Proposed Fix

This PR only takes the fallback code out of the if-else clause in the `_findItem()` function. The `else` makes no sense anymore since we always have `$needles`. With this PR if nothing is found using the `$needles`, it will return the current active Itemid like it used to be.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33011
Also some discussion on https://groups.google.com/d/topic/joomlabugsquad/-UyLy58q95Y/discussion
