### PR TITLE
Use query builder in JUpdater->findUpdates()

### DIFF
--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -75,7 +75,7 @@ class JUpdater extends JAdapter
 
 		$retval	= false;
 
-		$query->select('DISTINCT a.update_site_id, a.type, a.location, a.last_check_timestamp, extra_query')
+		$query->select('DISTINCT a.update_site_id, a.type, a.location, a.last_check_timestamp, a.extra_query')
 			->from('#__update_sites AS a')
 			->where('a.enabled = 1');
 

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -70,10 +70,10 @@ class JUpdater extends JAdapter
 	 */
 	public function findUpdates($eid = 0, $cacheTimeout = 0)
 	{
-		$db	= $this->getDBO();
-		$query	= $db->getQuery(true);
+		$db     = $this->getDBO();
+		$query  = $db->getQuery(true);
 
-		$retval	= false;
+		$retval = false;
 
 		$query->select('DISTINCT a.update_site_id, a.type, a.location, a.last_check_timestamp, a.extra_query')
 			->from('#__update_sites AS a')
@@ -82,13 +82,14 @@ class JUpdater extends JAdapter
 		if ($eid)
 		{
 			$query->join('INNER', '#__update_sites_extensions AS b ON a.update_site_id = b.update_site_id');
-			if (is_int($eid))
-			{
-				$query->where('b.extension_id = ' . $eid);
-			}
-			elseif (is_array($eid))
+
+			if (is_array($eid))
 			{
 				$query->where('b.extension_id IN (' . implode(',', $eid) . ')');
+			}
+			elseif ((int) $eid)
+			{
+				$query->where('b.extension_id = ' . $eid);
 			}
 		}
 


### PR DESCRIPTION
### Testing instructions

Make sure that Joomla updates and extensions updates are found after the patch is applied.
### Proposed Changes
- Change the `$query` to use the querybuilder.
- Use an inner join instead of a subselect
- Do a proper filter if `$eid` is passed as a single integer. Currently it is expected as an array of integers and will do no filtering at all if a single integer is passed instead of an array. Instead it will search for updates in all sites, slowing down the process. We pass a single integer in some places, like in the Joomla Update component. Thus this should be a bit faster with this patch.
