### PR TITLE
Implementing caching for getRootId() to save queries

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -97,6 +97,14 @@ class JTableNested extends JTable
 	 * @since  11.1
 	 */
 	protected $_debug = 0;
+	
+	/**
+	 * Cache for the root ID
+	 * 
+	 * @var    integer
+	 * @since  14.1
+	 */
+	protected static $root_id = 0;
 
 	/**
 	 * Sets the debug level on or off
@@ -1202,10 +1210,9 @@ class JTableNested extends JTable
 	 */
 	public function getRootId()
 	{
-		static $root_id = 0;
-		if ($root_id !== 0)
+		if ((int) self::$root_id > 0)
 		{
-			return $root_id;
+			return self::$root_id;
 		}
 
 		// Get the root item.
@@ -1221,8 +1228,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			$root_id = $result[0];
-			return $root_id;
+			self::$root_id = $result[0];
+			return self::$root_id;
 		}
 
 		// Test for a unique record with lft = 0
@@ -1235,8 +1242,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			$root_id = $result[0];
-			return $root_id;
+			self::$root_id = $result[0];
+			return self::$root_id;
 		}
 
 		$fields = $this->getFields();
@@ -1253,14 +1260,14 @@ class JTableNested extends JTable
 
 			if (count($result) == 1)
 			{
-				$root_id = $result[0];
-				return $root_id;
+				self::$root_id = $result[0];
+				return self::$root_id;
 			}
 		}
 
 		$e = new UnexpectedValueException(sprintf('%s::getRootId', get_class($this)));
 		$this->setError($e);
-		$root_id = false;
+		self::$root_id = false;
 
 		return false;
 	}

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -102,7 +102,7 @@ class JTableNested extends JTable
 	 * Cache for the root ID
 	 * 
 	 * @var    integer
-	 * @since  14.1
+	 * @since  3.3
 	 */
 	protected static $root_id = 0;
 

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1202,6 +1202,12 @@ class JTableNested extends JTable
 	 */
 	public function getRootId()
 	{
+		static $root_id = 0;
+		if ($root_id !== 0)
+		{
+			return $root_id;
+		}
+
 		// Get the root item.
 		$k = $this->_tbl_key;
 
@@ -1215,7 +1221,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			return $result[0];
+			$root_id = $result[0];
+			return $root_id;
 		}
 
 		// Test for a unique record with lft = 0
@@ -1228,7 +1235,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			return $result[0];
+			$root_id = $result[0];
+			return $root_id;
 		}
 
 		$fields = $this->getFields();
@@ -1245,12 +1253,14 @@ class JTableNested extends JTable
 
 			if (count($result) == 1)
 			{
-				return $result[0];
+				$root_id = $result[0];
+				return $root_id;
 			}
 		}
 
 		$e = new UnexpectedValueException(sprintf('%s::getRootId', get_class($this)));
 		$this->setError($e);
+		$root_id = false;
 
 		return false;
 	}

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -97,6 +97,14 @@ class JTableNested extends JTable
 	 * @since  11.1
 	 */
 	protected $_debug = 0;
+	
+	/**
+	 * Cache for the root ID
+	 * 
+	 * @var    integer
+	 * @since  14.1
+	 */
+	protected static $root_id = 0;
 
 	/**
 	 * Sets the debug level on or off
@@ -1202,10 +1210,9 @@ class JTableNested extends JTable
 	 */
 	public function getRootId()
 	{
-		static $root_id = 0;
-		if ($root_id !== 0)
+		if (self::$root_id !== 0)
 		{
-			return $root_id;
+			return self::$root_id;
 		}
 
 		// Get the root item.
@@ -1221,8 +1228,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			$root_id = $result[0];
-			return $root_id;
+			self::$root_id = $result[0];
+			return self::$root_id;
 		}
 
 		// Test for a unique record with lft = 0
@@ -1235,8 +1242,8 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
-			$root_id = $result[0];
-			return $root_id;
+			self::$root_id = $result[0];
+			return self::$root_id;
 		}
 
 		$fields = $this->getFields();
@@ -1253,14 +1260,14 @@ class JTableNested extends JTable
 
 			if (count($result) == 1)
 			{
-				$root_id = $result[0];
-				return $root_id;
+				self::$root_id = $result[0];
+				return self::$root_id;
 			}
 		}
 
 		$e = new UnexpectedValueException(sprintf('%s::getRootId', get_class($this)));
 		$this->setError($e);
-		$root_id = false;
+		self::$root_id = false;
 
 		return false;
 	}

--- a/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
@@ -130,14 +130,17 @@ class JTableNestedTest extends TestCaseDatabase
 
 		// Change the id of the root node.
 		self::$driver->setQuery('UPDATE #__categories SET parent_id = 99 WHERE id = 1')->execute();
+		$this->class->resetRootId();
 		$this->assertEquals(1, $this->class->getRootId(), 'Checks for lft = 0 case.');
 
 		// Change the lft of the root node.
 		self::$driver->setQuery('UPDATE #__categories SET lft = 99, alias = ' . self::$driver->q('root') . ' WHERE id = 1')->execute();
+		$this->class->resetRootId();
 		$this->assertEquals(1, $this->class->getRootId(), 'Checks for alias = root case.');
 
 		// Change the alias of the root node.
 		self::$driver->setQuery('UPDATE #__categories SET alias = ' . self::$driver->q('foo') . ' WHERE id = 1')->execute();
+		$this->class->resetRootId();
 		$this->assertFalse($this->class->getRootId(), 'Checks for failure.');
 	}
 
@@ -480,6 +483,7 @@ class JTableNestedTest extends TestCaseDatabase
 		// Reset the root node.
 		self::$driver->setQuery('UPDATE #__categories SET parent_id = 99, lft = 99, rgt = 99 WHERE id = 1')
 			->execute();
+		$this->class->resetRootId();
 
 		TestReflection::setValue($this->class, '_cache', array());
 		$this->assertFalse($this->class->rebuild(), 'Checks failure where no root node is found.');

--- a/tests/unit/suites/libraries/joomla/table/stubs/nested.php
+++ b/tests/unit/suites/libraries/joomla/table/stubs/nested.php
@@ -39,4 +39,14 @@ class NestedTable extends JTableNested
 	{
 		self::$unlocked = true;
 	}
+	
+	/**
+	 * Method to reset the root_id
+	 *
+	 * @return void
+	 */
+	public static function resetRootId()
+	{
+		self::$root_id = 0;
+	}
 }


### PR DESCRIPTION
The method getRootId() is executed numerous times per page load, for example when editing an article around 20 times. At the same time, that method always returns the same value. By adding a static variable as cache, we save us all those duplicate queries and they are only run once per table.
