### PR TITLE
Query-fix in com_content article modal

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -94,20 +94,25 @@ class JFormFieldModal_Article extends JFormField
 			$link .= '&amp;forcedLanguage='.$this->element['language'];
 		}
 
-		$db	= JFactory::getDbo();
-		$db->setQuery(
-			'SELECT title' .
-			' FROM #__content' .
-			' WHERE id = '.(int) $this->value
-		);
+		$title = false;
 
-		try
+		if ((int)$this->value > 0)
 		{
-			$title = $db->loadResult();
-		}
-		catch (RuntimeException $e)
-		{
-			JError::raiseWarning(500, $e->getMessage());
+			$db	= JFactory::getDbo();
+			$db->setQuery(
+				'SELECT title' .
+				' FROM #__content' .
+				' WHERE id = '.(int) $this->value
+			);
+
+			try
+			{
+				$title = $db->loadResult();
+			}
+			catch (RuntimeException $e)
+			{
+				JError::raiseWarning(500, $e->getMessage());
+			}
 		}
 
 		if (empty($title))


### PR DESCRIPTION
This change prevents the query from being executed when the value is 0. There is never an article with ID 0 and especially when there are more than one modal select per page, you have several unnecessary queries.
