### PR TITLE
Trims whitespace from file so that install sql doesn't fail on some servers

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -287,7 +287,7 @@ class JInstaller extends JAdapter
 	 */
 	public function setPath($name, $value)
 	{
-		$this->paths[$name] = trim($value);
+		$this->paths[$name] = $value;
 	}
 
 	/**

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -287,7 +287,7 @@ class JInstaller extends JAdapter
 	 */
 	public function setPath($name, $value)
 	{
-		$this->paths[$name] = $value;
+		$this->paths[$name] = trim($value);
 	}
 
 	/**
@@ -909,7 +909,7 @@ class JInstaller extends JAdapter
 
 			if ($fCharset == 'utf8' && $fDriver == $dbDriver)
 			{
-				$sqlfile = $this->getPath('extension_root') . '/' . $file;
+				$sqlfile = $this->getPath('extension_root') . '/' . trim($file);
 
 				// Check that sql files exists before reading. Otherwise raise error for rollback
 				if (!file_exists($sqlfile))


### PR DESCRIPTION
Tracker item http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33154

The installation of extensions, with manifest file formatted as follows, will fail due to the white space in the file name. This PR trims that white space to resolve the failure.

```
<install>
    <sql>
        <file driver="mysql"
              charset="utf8">sql/install.mysql.utf8.sql
        </file>
    </sql>
</install>
```
