### PR TITLE
Two factor authentication on front-end

### DIFF
--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -52,9 +52,7 @@ JHtml::_('behavior.keepalive');
 				<?php endif; ?>
 			<?php endforeach; ?>
 
-			<?php $tfa = JPluginHelper::getPlugin('twofactorauth'); ?>
-
-			<?php if (!is_null($tfa) && $tfa != array()): ?>
+			<?php if ($this->tfa): ?>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getField('secretkey')->label; ?>

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -53,6 +53,10 @@ class UsersViewLogin extends JViewLegacy
 		{
 			$this->setLayout($active->query['layout']);
 		}
+		
+		require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
+		$tfa = UsersHelper::getTwoFactorMethods();
+		$this->tfa = is_array($tfa) && count($tfa) > 1;
 
 		//Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));


### PR DESCRIPTION
When two factor authentication is enabled and in all plugins it is set to use it only in back-end then in front-end secret key field should be hidden in users component as in login module.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33153
