### PR TITLE
Use alternative CURL when allow_url_open is OFF

### DIFF
--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -49,13 +49,13 @@ class JFeedFactory
 				// This is an error
 				throw new RuntimeException('Unable to open the feed.');
 			}
-			// Otherwise, 
+			// Otherwise,
 			else
 			{
 				// Retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
 				$connector = JHttpFactory::getHttp();
 				$feed = $connector->get($uri);
-				
+
 				// Set the value to the XMLReader parser
 				if (!$reader->xml($feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 				{

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -43,31 +43,21 @@ class JFeedFactory
 		// Open the URI within the stream reader.
 		if (!$reader->open($uri, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 		{
-			// IF allow_url_fopen is enabled or CURL is not available
-			if( ini_get('allow_url_fopen') || !function_exists( "curl_init" ) )
+			// IF allow_url_fopen is enabled
+			if( ini_get('allow_url_fopen'))
 			{
 				// This is an error
 				throw new RuntimeException('Unable to open the feed.');
 			}
-			// Otherwise, retry with usage of CURL
+			// Otherwise, 
 			else
 			{
-				// Resuce with CURL
-				$ch = curl_init();
-				$timeout = 5;
-				curl_setopt ($ch, CURLOPT_URL, $uri);
-				curl_setopt ($ch, CURLOPT_RETURNTRANSFER, 1);
-				curl_setopt ($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-				$file_contents = curl_exec($ch);
-				$error  = curl_error( $ch);
-				curl_close($ch);
+				// retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
+				$connector = JHttpFactory::getHttp();
+				$feed = $connector->get($uri);
 				
-				if( !empty( $error ))
-				{
-					throw new RuntimeException('Unable to open the feed with CURL.');
-				}
 				// Set the value to the XMLReader parser
-				if ( !$reader->xml( $file_contents, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
+				if ( !$reader->xml( $feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 				{
 					throw new RuntimeException('Unable to parse the feed.');
 				}

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -43,8 +43,8 @@ class JFeedFactory
 		// Open the URI within the stream reader.
 		if (!$reader->open($uri, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 		{
-			// IF allow_url_fopen is enabled
-			if( ini_get('allow_url_fopen'))
+			// If allow_url_fopen is enabled
+			if (ini_get('allow_url_fopen'))
 			{
 				// This is an error
 				throw new RuntimeException('Unable to open the feed.');
@@ -52,12 +52,12 @@ class JFeedFactory
 			// Otherwise, 
 			else
 			{
-				// retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
+				// Retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
 				$connector = JHttpFactory::getHttp();
 				$feed = $connector->get($uri);
 				
 				// Set the value to the XMLReader parser
-				if ( !$reader->xml( $feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
+				if (!$reader->xml($feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 				{
 					throw new RuntimeException('Unable to parse the feed.');
 				}

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -43,7 +43,35 @@ class JFeedFactory
 		// Open the URI within the stream reader.
 		if (!$reader->open($uri, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 		{
-			throw new RuntimeException('Unable to open the feed.');
+			// IF allow_url_fopen is enabled or CURL is not available
+			if( ini_get('allow_url_fopen') || !function_exists( "curl_init" ) )
+			{
+				// This is an error
+				throw new RuntimeException('Unable to open the feed.');
+			}
+			// Otherwise, retry with usage of CURL
+			else
+			{
+				// Resuce with CURL
+				$ch = curl_init();
+				$timeout = 5;
+				curl_setopt ($ch, CURLOPT_URL, $uri);
+				curl_setopt ($ch, CURLOPT_RETURNTRANSFER, 1);
+				curl_setopt ($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+				$file_contents = curl_exec($ch);
+				$error  = curl_error( $ch);
+				curl_close($ch);
+				
+				if( !empty( $error ))
+				{
+					throw new RuntimeException('Unable to open the feed with CURL.');
+				}
+				// Set the value to the XMLReader parser
+				if ( !$reader->xml( $file_contents, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
+				{
+					throw new RuntimeException('Unable to parse the feed.');
+				}
+			}
 		}
 
 		try


### PR DESCRIPTION
We propose to add an alternative method to get the feed when the allow_url_open is OFF.
When the allow_url_open is OFF, the XMLReader::open always fails because the URL can not be connected.

So we propose to get the Feed with the alternative CURL when it is present.
