### PR TITLE
Extensions manager doesn't show correct long extension version.

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.2.2-2014-01-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.2.2-2014-01-18.sql
@@ -1,0 +1,2 @@
+/* Update updates version length */
+ALTER TABLE `#__updates` MODIFY `version` varchar(32) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.2.2-2014-01-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.2.2-2014-01-18.sql
@@ -1,0 +1,2 @@
+/* Update updates version length */
+ALTER TABLE "#__updates" ALTER COLUMN "version" TYPE varchar(32);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.2.2-2014-01-18.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.2.2-2014-01-18.sql
@@ -1,0 +1,2 @@
+/* Update updates version length */
+ALTER TABLE [#__updates] ALTER COLUMN [version] [nvarchar](32) '';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1755,7 +1755,7 @@ CREATE TABLE IF NOT EXISTS `#__updates` (
   `type` varchar(20) DEFAULT '',
   `folder` varchar(20) DEFAULT '',
   `client_id` tinyint(3) DEFAULT 0,
-  `version` varchar(10) DEFAULT '',
+  `version` varchar(32) DEFAULT '',
   `data` text NOT NULL,
   `detailsurl` text NOT NULL,
   `infourl` text NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1681,7 +1681,7 @@ CREATE TABLE "#__updates" (
   "type" varchar(20) DEFAULT '',
   "folder" varchar(20) DEFAULT '',
   "client_id" smallint DEFAULT 0,
-  "version" varchar(10) DEFAULT '',
+  "version" varchar(32) DEFAULT '',
   "data" text DEFAULT '' NOT NULL,
   "detailsurl" text NOT NULL,
   "infourl" text NOT NULL,

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2783,7 +2783,7 @@ CREATE TABLE [#__updates](
 	[type] [nvarchar](20) DEFAULT '',
 	[folder] [nvarchar](20) DEFAULT '',
 	[client_id] [smallint] DEFAULT 0,
-	[version] [nvarchar](10) DEFAULT '',
+	[version] [nvarchar](32) DEFAULT '',
 	[data] [nvarchar](max) NOT NULL DEFAULT '',
 	[detailsurl] [nvarchar](max) NOT NULL,
 	[infourl] [nvarchar](max) NOT NULL,


### PR DESCRIPTION
Issue tracker: [33166](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33166&start=0)

The problem is that the `version` column in the `#__updates` table is has type of varchar(10).

Let's say we have installed version `1.0.0-beta` and there's `1.0.0-beta.2` available. What happens when checking for new extension updates?

1) **Extesnion manager > Update** recognizes that there's new veresion
2) `JUpdater` stores information in `#__updates` table
3) **Extension Manager > Update** shows trucated version:

```
1.0.0-beta.2
1234567890|2
```

I suggest we change the limit to 32 characters to be safe ([semver.org](http://semver.org) doesn't recommend any particular size limit).

I've updated the Installation SQL files and Update SQL files, but would be grateful if somebody would revise the syntax for **postgresql** and **sqlazure**.

Workaround:
use `1.0.0-b.2`

This is a patch for staging branch
