### PR TITLE
Fixed [#33098]

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -68,6 +68,10 @@ class JFormFieldCalendar extends JFormField
 		{
 			$attributes['onchange'] = (string) $this->element['onchange'];
 		}
+		if($this->element['value'])
+		{
+			$this->value = (string) $this->element['value'];
+		}
 
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Platform
  * @subpackage  HTML
  *
- * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -891,6 +891,7 @@ abstract class JHtml
 				);
 				$done[] = $id;
 			}
+	
 			return '<input type="text" title="' . (0 !== (int) $value ? self::_('date', $value, null, null) : '') . '" name="' . $name . '" id="' . $id
 				. '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
 				. self::_('image', 'system/calendar.png', JText::_('JLIB_HTML_CALENDAR'), array('class' => 'calendar', 'id' => $id . '_img'), true);
@@ -898,7 +899,7 @@ abstract class JHtml
 		else
 		{
 			return '<input type="text" title="' . (0 !== (int) $value ? self::_('date', $value, null, null) : '')
-				. '" value="' . (0 !== (int) $value ? self::_('date', $value, 'Y-m-d H:i:s', null) : '') . '" ' . $attribs
+				. '" value="' . (0 !== (int) $value ? self::_('date', $value, str_replace("%","",$format), null) : '') . '" ' . $attribs
 				. ' /><input type="hidden" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '" />';
 		}
 	}


### PR DESCRIPTION
ISSUE : JHtml::calendar ignores $format when readonly attrib set
DETAILS : replaced hard coded format on line #902
