### PR TITLE
Missing metadata.xml causes item_type ending up untranslated

### DIFF
--- a/components/com_content/views/categories/metadata.xml
+++ b/components/com_content/views/categories/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<view
+		title="Categories">
+		<message><![CDATA[TYPECATEGLAYDESC]]></message>
+	</view>
+</metadata>


### PR DESCRIPTION
see trackeritem http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33157
