### PR TITLE
Wrong menu item id is assigned to article links when language filter enabled.  

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -197,7 +197,7 @@ abstract class ContactHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -196,13 +196,14 @@ abstract class ContactHelperRoute
 			}
 		}
 
+		// Check if the active menuitem matches the requested language
 		$active = $menus->getActive();
-		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		if ($active && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}
 
-		// if not found, return language specific home link
+		// If not found, return language specific home link
 		$default = $menus->getDefault($language);
 		return !empty($default->id) ? $default->id : null;
 	}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -210,7 +210,7 @@ abstract class ContentHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && $active->component == 'com_content' && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && $active->component == 'com_content' && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -209,13 +209,14 @@ abstract class ContentHelperRoute
 			}
 		}
 
+		// Check if the active menuitem matches the requested language
 		$active = $menus->getActive();
-		if ($active && $active->component == 'com_content' && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		if ($active && $active->component == 'com_content' && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}
 
-		// if not found, return language specific home link
+		// If not found, return language specific home link
 		$default = $menus->getDefault($language);
 		return !empty($default->id) ? $default->id : null;
 	}

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -200,13 +200,14 @@ abstract class NewsfeedsHelperRoute
 			}
 		}
 
+		// Check if the active menuitem matches the requested language
 		$active = $menus->getActive();
-		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		if ($active && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}
 
-		// if not found, return language specific home link
+		// If not found, return language specific home link
 		$default = $menus->getDefault($language);
 		return !empty($default->id) ? $default->id : null;
 	}

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -201,7 +201,7 @@ abstract class NewsfeedsHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -227,13 +227,14 @@ abstract class WeblinksHelperRoute
 			}
 		}
 
+		// Check if the active menuitem matches the requested language
 		$active = $menus->getActive();
-		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		if ($active && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}
 
-		// if not found, return language specific home link
+		// If not found, return language specific home link
 		$default = $menus->getDefault($language);
 		return !empty($default->id) ? $default->id : null;
 	}

--- a/components/com_weblinks/helpers/route.php
+++ b/components/com_weblinks/helpers/route.php
@@ -228,7 +228,7 @@ abstract class WeblinksHelperRoute
 		}
 
 		$active = $menus->getActive();
-		if ($active && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && (in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
 		{
 			return $active->id;
 		}


### PR DESCRIPTION
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33132

This should return the currently active menu item if its language matches the one needed for the link. Of course only after the search for a specific menu item for the category or article didn't find anything.
