### PR TITLE
PHP Fatal error when a DB error throw a RuntimeException exception

### DIFF
--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -800,7 +800,10 @@ abstract class JError
 			}
 
 			@ob_end_clean();
-			$document->setTitle(JText::_('Error') . ': ' . $error->get('code'));
+			// When there is a DB error, the $error can be a RuntimeException object and the get function does not exists.
+			// So test that the get function is present to avoid a PHP Fatail error that forbid reporting the error.
+			if ( method_exists( $error, 'get')) { $document->setTitle(JText::_('Error') . ': ' . $error->get('code')); }
+			else                                { $document->setTitle(JText::_('Error')); }
 			$data = $document->render(false, array('template' => $template, 'directory' => JPATH_THEMES, 'debug' => $config->get('debug')));
 
 			// Failsafe to get the error displayed.


### PR DESCRIPTION
It may happen that an error is resulting of a DB Error.
In this case the $error can be a "RuntimeException" object that does not contain the "get" function.

This fix allow verifying that the $error has a "get" method and avoid a PHP Fatal error that forbid to report the real DB error.
