### PR TITLE
Catch the potential DB errors when "#__postinstall_messages" is missing

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -56,7 +56,16 @@ class CpanelViewCpanel extends JViewLegacy
 		}
 
 		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel', array('input' => array('eid' => 700)));
-		$messages = $messages_model->getItemList();
+		// In case of an Upgrade, the #__postinstall_messages is not present and therefore throw an Exception
+		// Here we intercept any error to allow displaying a cPanel without any "post messages".
+		try
+		{
+		   $messages = $messages_model->getItemList();
+		}
+		catch( RuntimeException $e) {
+		   $messages = array();
+		}
+
 
 		$this->postinstall_message_count = count($messages);
 


### PR DESCRIPTION
When we proceed with a manual upgrade from Joomla 2.5.17 to J3.2.1 by an unzip of J3.2.1 full package over a current J2.5.17 installation, the #__postinstall_messages is not present and cause the impossibility to login due to the "cPanel" that always abort on DB Error.

The purpose of this fix is to intercept such kind of errors and let the cPanel displayed without any "Post Install Messages".
