### PR TITLE
Avoid aborting Joomla on any DB errors that forbid executing the Database / Fix

### DIFF
--- a/libraries/cms/schema/changeitem.php
+++ b/libraries/cms/schema/changeitem.php
@@ -197,7 +197,14 @@ abstract class JSchemaChangeitem
 		if ($this->checkQuery)
 		{
 			$this->db->setQuery($this->checkQuery);
-			$rows = $this->db->loadObject();
+			try
+			{
+				$rows = $this->db->loadObject();
+			}
+			catch( RuntimeException $e)
+			{
+				$rows = false;
+			}
 
 			if ($rows !== false)
 			{


### PR DESCRIPTION
In case of a manual upgrade from Joomla 2.5.17 to J3.2.1, it happens that some tables or columns are not present in the DB before that the DB / Fix is applied and therefore may cause DB Errors.

To allow using the Database / Fix functionality, it is important that this intercept all kind of DB errors.

This is why we added a try/cath on the loadObject that allow have access to the Extension Manager / Database / Fix action.
