### PR TITLE
Breadcrumb link wrong for the last item

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -212,7 +212,7 @@ class ContentViewArticle extends JViewLegacy
 			{
 				$title = $this->item->title;
 			}
-			$path = array(array('title' => $this->item->title, 'link' => ''));
+			$path = array(array('title' => $this->item->title, 'link' => ContentHelperRoute::getArticleRoute($this->item->id . ':' . $this->item->alias, $this->item->catid)));
 			$category = JCategories::getInstance('Content')->get($this->item->catid);
 
 			while ($category && ($menu->query['option'] != 'com_content' || $menu->query['view'] == 'article' || $id != $category->id) && $category->id > 1)


### PR DESCRIPTION
If you view an article to which there is no direct menu, and make all breadcrumb items as links, the last item will link to the homepage, instead of the current article
