### PR TITLE
Filter images in JFormFieldImageList

### DIFF
--- a/libraries/joomla/form/fields/imagelist.php
+++ b/libraries/joomla/form/fields/imagelist.php
@@ -27,24 +27,31 @@ class JFormFieldImageList extends JFormFieldFileList
 	 * @since  11.1
 	 */
 	protected $type = 'ImageList';
-
+	
+	
 	/**
-	 * Method to get the list of images field options.
+	 * Method to attach a JForm object to the field.
 	 * Use the filter attribute to specify allowable file extensions.
 	 *
-	 * @return  array  The field option objects.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
 	 *
-	 * @since   11.1
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   3.2
 	 */
-	protected function getOptions()
+	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		// Define the image file type filter.
 		$filter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
 
 		// Set the form field element attribute for file type filter.
 		$this->element->addAttribute('filter', $filter);
-
-		// Get the field options.
-		return parent::getOptions();
+		
+		return parent::setup($element, $value, $group);
 	}
 }

--- a/libraries/joomla/form/fields/imagelist.php
+++ b/libraries/joomla/form/fields/imagelist.php
@@ -27,31 +27,21 @@ class JFormFieldImageList extends JFormFieldFileList
 	 * @since  11.1
 	 */
 	protected $type = 'ImageList';
-	
-	
+
 	/**
-	 * Method to attach a JForm object to the field.
+	 * Method to get the list of images field options.
 	 * Use the filter attribute to specify allowable file extensions.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed             $value    The form field value to validate.
-	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
-	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                      full field name would end up being "bar[foo]".
+	 * @return  array  The field option objects.
 	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @see     JFormField::setup()
-	 * @since   3.2
+	 * @since   11.1
 	 */
-	public function setup(SimpleXMLElement $element, $value, $group = null)
+	protected function getOptions()
 	{
 		// Define the image file type filter.
-		$filter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
+		$this->filter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
 
-		// Set the form field element attribute for file type filter.
-		$element->addAttribute('filter', $filter);
-		
-		return parent::setup($element, $value, $group);
+		// Get the field options.
+		return parent::getOptions();
 	}
 }

--- a/libraries/joomla/form/fields/imagelist.php
+++ b/libraries/joomla/form/fields/imagelist.php
@@ -50,7 +50,7 @@ class JFormFieldImageList extends JFormFieldFileList
 		$filter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
 
 		// Set the form field element attribute for file type filter.
-		$this->element->addAttribute('filter', $filter);
+		$element->addAttribute('filter', $filter);
 		
 		return parent::setup($element, $value, $group);
 	}


### PR DESCRIPTION
Filter attribute has to be set before field is setup. Otherwise filter would not be used and there are all files from folder in a drop-down

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33183
