### PR TITLE
Cache loading router to prevent extra filesystem calls

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -443,13 +443,9 @@ class JRouterSite extends JRouter
 		$tmp       = '';
 		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
 
-		// Use the component routing handler if it exists
-		$path = JPATH_SITE . '/components/' . $component . '/router.php';
-
 		// Use the custom routing handler if it exists
-		if (file_exists($path) && !empty($query))
+		if (!empty($query) && $this->loadComponentRouter($component))
 		{
-			require_once $path;
 			$function = substr($component, 4) . 'BuildRoute';
 			$function = str_replace(array("-", "."), "", $function);
 			$parts    = $function($query);
@@ -524,6 +520,41 @@ class JRouterSite extends JRouter
 		// Set query again in the URI
 		$uri->setQuery($query);
 		$uri->setPath($route);
+	}
+
+	/**
+	 * Load the component router using a static path cache to prevent excessive file_exists.
+	 *
+	 * @param   $component  string  The component router to load.
+	 *
+	 * @return  boolean  If the router exists to load.
+	 *
+	 * @since   3.5
+	 */
+	protected function loadComponentRouter($component)
+	{
+		static $pathList = array();
+
+		if (isset($pathList[$component]))
+		{
+			return $pathList[$component];
+		}
+
+		// Use the component routing handler if it exists
+		$path = JPATH_SITE . '/components/' . $component . '/router.php';
+
+		// Use the custom routing handler if it exists
+		if (file_exists($path))
+		{
+			$pathList[$component] = true;
+			require_once($path);
+		}
+		else
+		{
+			$pathList[$component] = false;
+		}
+
+		return $pathList[$component];
 	}
 
 	/**


### PR DESCRIPTION
This change shifts the code to import the component specific router in a single function instead of inlining it with the rest of the SEF route generation code. This should also make this segment of code easier to unit test later.

The main reason for the change is to prevent redundant file_exists checks for the router when the router has already been loaded. This is problematic on slow disks and in situations where JFile::read is used (JFile::read triggers clearstatcache which wipes out PHP's cache; this is irrelevant to Joomla as the file would have already been loaded anyway).

This can help improve performance particularly on network shared Joomla instances (e.g. NFS filer).

JoomlaCode issue: https://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33186&start=0
