### PR TITLE
Cache root ID for nested sets table

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1202,8 +1202,17 @@ class JTableNested extends JTable
 	 */
 	public function getRootId()
 	{
+		static $rootId = array();
+
 		// Get the root item.
 		$k = $this->_tbl_key;
+
+		// Check to see we haven't figured this out yet.
+		$cacheKey = $this->_tbl . '_' . $k;
+		if ($rootId[$cacheKey] != null)
+		{
+			return $rootId[$cacheKey];
+		}
 
 		// Test for a unique record with parent_id = 0
 		$query = $this->_db->getQuery(true)
@@ -1215,6 +1224,7 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
+			$rootId[$cacheKey] = $result[0];
 			return $result[0];
 		}
 
@@ -1228,6 +1238,7 @@ class JTableNested extends JTable
 
 		if (count($result) == 1)
 		{
+			$rootId[$cacheKey] = $result[0];
 			return $result[0];
 		}
 
@@ -1245,6 +1256,7 @@ class JTableNested extends JTable
 
 			if (count($result) == 1)
 			{
+				$rootId[$cacheKey] = $result[0];
 				return $result[0];
 			}
 		}


### PR DESCRIPTION
The root ID of a nested sets table is highly unlikely to change within a single page load of the site. When there are potentially multiple queries being executed to determine the root ID, this can become redundant work on a popular tree. To avoid this, once we have determined the root ID for a given table-key combination, the code will cache it internally and return that later reducing the number of times that redundant queries need to be executed.

JoomlaCode Issue Tracker: https://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33187&start=0
