### PR TITLE
Catch the potential DB errors when "#__postinstall_messages" is missing

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -56,8 +56,17 @@ class CpanelViewCpanel extends JViewLegacy
 		}
 
 		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel', array('input' => array('eid' => 700)));
-		$messages = $messages_model->getItemList();
-
+		try
+		{
+			$messages = $messages_model->getItemList();
+		}
+		catch (RuntimeException $e)
+		{
+			$messages = array();
+			
+			// Still render the error message from the Exception object
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
 		$this->postinstall_message_count = count($messages);
 
 		parent::display($tpl);


### PR DESCRIPTION
Based on comment from bakual in PR 2822, I have move this PR from master to staging and also included the enhancement frm mbabker
https://github.com/joomla/joomla-cms/pull/2821
