### PR TITLE
Adding the "showon" feature to component settings

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -56,9 +56,19 @@ JHtml::_('formbehavior.chosen', 'select');
 							if (isset($fieldSet->description) && !empty($fieldSet->description)) :
 								echo '<p class="tab-description">'.JText::_($fieldSet->description).'</p>';
 							endif;
-							foreach ($this->form->getFieldset($name) as $field):
+							foreach ($this->form->getFieldset($name) as $field) :
+								$class	= '';
+								$rel	= '';
+								if ($showon = $field->getAttribute('showon')) :
+									JHtml::_('jquery.framework');
+									JHtml::_('script', 'jui/cms.js', false, true);
+									$id		= $this->form->getFormControl();
+									$showon	= explode(':', $showon, 2);
+									$class	= ' showon_' . implode(' showon_', explode(',', $showon[1]));
+									$rel	= ' rel="showon_' . $id . '['. $showon[0] . ']"';
+								endif;
 						?>
-							<div class="control-group">
+							<div class="control-group<?php echo $class; ?>"<?php echo $rel; ?>>
 						<?php if (!$field->hidden && $name != "permissions") : ?>
 								<div class="control-label">
 									<?php echo $field->label; ?>

--- a/media/jui/js/cms.js
+++ b/media/jui/js/cms.js
@@ -27,9 +27,9 @@ if (jQuery) {
 				$('[rel=\"showon_'+target+'\"]').each(function(){
 					var i = jQuery(this);
 					if (i.hasClass('showon_' + v))
-						i.show();
+						i.slideDown();
 					else
-						i.hide();
+						i.slideUp();
 				});
 			};
 		$('[rel^=\"showon_\"]').each(function(){


### PR DESCRIPTION
### Overview

In the Joomla Global Configuration we use an `showon` attribute to show/hide certain fields based on the state of a "parent" field. You can see this for example with the FTP settings where the settings itself only show when "Enable FTP" is set to "Yes".

This PR takes this feature to the component settings so it can be used by 3rd party extensions as well.

It also changes the animation slightly which was suggested in the original PR https://github.com/joomla/joomla-cms/pull/1240 by @beat and will make it slide up and down instead of an instannt toggle.
### Testing

You can add a `showon` attribute to any config field you want to hide. For example in `administrator/components/com_banners/config.xml` you add `showon="track_impressions:1"` to the "track_clicks" field. So it looks like this:

```
        <field
            name="track_clicks"
            type="radio"
            class="btn-group btn-group-yesno"
            default="0"
            showon="track_impressions:1"
            label="COM_BANNERS_FIELD_TRACKCLICK_LABEL"
            description="COM_BANNERS_FIELD_TRACKCLICK_DESC">
            <option value="1">JYES</option>
            <option value="0">JNO</option>
        </field>
```

This will only show the "Track Clicks" settings if the "Track Impressions" is set to "Yes" (which has the value `1`).

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33196
