### PR TITLE
Remove wrong HTML in calendar form field

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -207,10 +207,6 @@ class JFormFieldCalendar extends JFormField
 				break;
 		}
 
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
 		return JHtml::_('calendar', $this->value, $this->name, $this->id, $format, $attributes);
 	}
 }


### PR DESCRIPTION
Whatever these 2 lines are supposed to do, they have no business in the form field. If those are actually needed, they should be part of JHTML::calendar() and not here.

There is no HTML5 neither in the form field, nor in the JHtml::calendar() method.
