### PR TITLE
*Adapt language to user language for mail message

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -81,19 +81,6 @@ class PlgUserJoomla extends JPlugin
 	{
 		$mail_to_user = $this->params->get('mail_to_user', 1);
 
-		// Look for a user default language
-		$instance = $this->_getUser($user);
-		$user_langsite_code = $instance->getParam('language');
-
-		if (empty($user_langsite_code))
-		{
-			$user_lang_code = $instance->getParam('admin_language');
-		}
-		else
-		{
-			$user_lang_code = $user_langsite_code;
-		}
-
 		if ($isnew)
 		{
 			// TODO: Suck in the frontend registration emails here as well. Job for a rainy day.
@@ -101,16 +88,16 @@ class PlgUserJoomla extends JPlugin
 			{
 				if ($mail_to_user)
 				{
-					if (empty($user_lang_code))
-					{
-						$lang = JFactory::getLanguage();
-					}
-					else
-					{
-						// Send the mail using the default language defined for the user
-						JFactory::getLanguage()->setLanguage($user_lang_code);
-						$lang = JFactory::getLanguage();
-					}
+					/**
+					 * Look for user language. Priority:
+					 * 	1. User frontend language
+					 * 	2. User backend language
+					 * 	3. Default backend language
+					 */
+					$userParams = new JRegistry($user['params']);
+					$userLocale = $userParams->get('language', $userParams->get('admin_language'));
+
+					$lang = $userLocale ? JLanguage::getInstance($userLocale) : JFactory::getLanguage();
 
 					$lang->load('plg_user_joomla', JPATH_ADMINISTRATOR);
 
@@ -312,7 +299,7 @@ class PlgUserJoomla extends JPlugin
 		{
 			if (!$instance->save())
 			{
-				JLog::add('Error in autoregistration for user ' .  $user['username'] . '.', JLog::WARNING, 'error');
+				JLog::add('Error in autoregistration for user ' . $user['username'] . '.', JLog::WARNING, 'error');
 			}
 		}
 		else
@@ -329,7 +316,7 @@ class PlgUserJoomla extends JPlugin
 	 * We set a new cookie either for a user with no cookies or one
 	 * where the user used a cookie to authenticate.
 	 *
-	 * @param   array  options  Array holding options
+	 * @param   array  $options  Array holding options
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -383,6 +370,7 @@ class PlgUserJoomla extends JPlugin
 				$unique = true;
 			}
 		}
+
 		while ($unique === false);
 
 		// If a user logs in with non cookie login and remember me checked we will

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -88,6 +88,9 @@ class PlgUserJoomla extends JPlugin
 			{
 				if ($mail_to_user)
 				{
+					$lang = JFactory::getLanguage();
+					$defaultLocale = $lang->getTag();
+
 					/**
 					 * Look for user language. Priority:
 					 * 	1. User frontend language
@@ -95,9 +98,11 @@ class PlgUserJoomla extends JPlugin
 					 * 	3. Default backend language
 					 */
 					$userParams = new JRegistry($user['params']);
-					$userLocale = $userParams->get('language', $userParams->get('admin_language'));
 
-					$lang = $userLocale ? JLanguage::getInstance($userLocale) : JFactory::getLanguage();
+					if ($userLocale = $userParams->get('language', $userParams->get('admin_language')))
+					{
+						$lang->setLanguage($userLocale);
+					}
 
 					$lang->load('plg_user_joomla', JPATH_ADMINISTRATOR);
 
@@ -129,6 +134,12 @@ class PlgUserJoomla extends JPlugin
 						->addRecipient($user['email'])
 						->setSubject($emailSubject)
 						->setBody($emailBody);
+
+					// Set language back to default
+					if ($userLocale)
+					{
+						$lang->setLanguage($defaultLocale);
+					}
 
 					if (!$mail->Send())
 					{

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -95,11 +95,11 @@ class PlgUserJoomla extends JPlugin
 					 * Look for user language. Priority:
 					 * 	1. User frontend language
 					 * 	2. User backend language
-					 * 	3. Default backend language
 					 */
 					$userParams = new JRegistry($user['params']);
+					$userLocale = $userParams->get('language', $userParams->get('admin_language', $defaultLocale));
 
-					if ($userLocale = $userParams->get('language', $userParams->get('admin_language')))
+					if ($userLocale != $defaultLocale)
 					{
 						$lang->setLanguage($userLocale);
 					}
@@ -135,8 +135,8 @@ class PlgUserJoomla extends JPlugin
 						->setSubject($emailSubject)
 						->setBody($emailBody);
 
-					// Set language back to default
-					if ($userLocale)
+					// Set application language back to default if we changed it
+					if ($userLocale != $defaultLocale)
 					{
 						$lang->setLanguage($defaultLocale);
 					}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -81,6 +81,19 @@ class PlgUserJoomla extends JPlugin
 	{
 		$mail_to_user = $this->params->get('mail_to_user', 1);
 
+		// Look for a user default language
+		$instance = $this->_getUser($user);
+		$user_langsite_code = $instance->getParam('language');
+
+		if (empty($user_langsite_code))
+		{
+			$user_lang_code = $instance->getParam('admin_language');
+		}
+		else
+		{
+			$user_lang_code = $user_langsite_code;
+		}
+
 		if ($isnew)
 		{
 			// TODO: Suck in the frontend registration emails here as well. Job for a rainy day.
@@ -88,8 +101,17 @@ class PlgUserJoomla extends JPlugin
 			{
 				if ($mail_to_user)
 				{
-					// Load user_joomla plugin language (not done automatically).
-					$lang = JFactory::getLanguage();
+					if (empty($user_lang_code))
+					{
+						$lang = JFactory::getLanguage();
+					}
+					else
+					{
+						// Send the mail using the default language defined for the user
+						JFactory::getLanguage()->setLanguage($user_lang_code);
+						$lang = JFactory::getLanguage();
+					}
+
 					$lang->load('plg_user_joomla', JPATH_ADMINISTRATOR);
 
 					// Compute the mail subject.


### PR DESCRIPTION
When creating a user in back-end and plg_user_joomla is set to send mail to user, the language used for the message sent by mail was the language used by the administrator creating the user and not the new user site language if that one was defined.
This patch will make it possible to use the language defined for the user instead. It will first try to use the user default site language and, if not set, then the new user default admin language. If no language is set it will use the administrator language used when creating the user as before the patch.

See http://forum.joomla.org/viewtopic.php?f=617&t=808993

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33221&start=0
