### PR TITLE
[CODE STYLE] Corrected: Concat operator must be followed by one space

### DIFF
--- a/components/com_newsfeeds/newsfeeds.php
+++ b/components/com_newsfeeds/newsfeeds.php
@@ -9,9 +9,9 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_COMPONENT.'/helpers/route.php';
+require_once JPATH_COMPONENT . '/helpers/route.php';
 JTable::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/tables');
 
-$controller	= JControllerLegacy::getInstance('Newsfeeds');
+$controller = JControllerLegacy::getInstance('Newsfeeds');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();


### PR DESCRIPTION
- Corrected: Concat operator must be preceeded by one space
