### PR TITLE
[#33224] Determine published state for category permissions

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -125,8 +125,14 @@ class ContentModelCategory extends JModelList
 				// Create a new query object.
 		$db		= $this->getDbo();
 		$query	= $db->getQuery(true);
+		
+		$asset = 'com_content';
+		if ($pk)
+		{
+			$asset .= '.category.' . $pk;
+		}
 
-		if ((!$user->authorise('core.edit.state', 'com_content')) &&  (!$user->authorise('core.edit', 'com_content'))){
+		if ((!$user->authorise('core.edit.state', $asset)) &&  (!$user->authorise('core.edit', $asset))){
 			// limit to published for people who can't edit or edit.state.
 			$this->setState('filter.published', 1);
 			// Filter by start and end dates.


### PR DESCRIPTION
The published filter should be determined by the asset of the category instaed of the global component permissions.
Tracker item can be found here
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33224
