### PR TITLE
[#32958] Show fieldset descriptions in modules, menus, plugins parameters

### DIFF
--- a/layouts/joomla/edit/fieldset.php
+++ b/layouts/joomla/edit/fieldset.php
@@ -25,11 +25,6 @@ $extraFields = $displayData->get('extra_fields') ? : array();
 
 if ($displayData->get('show_options', 1))
 {
-	if (isset($fieldSet->description) && trim($fieldSet->description))
-	{
-		echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
-	}
-
 	if (isset($extraFields[$name]))
 	{
 		foreach ($extraFields[$name] as $f)

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -67,6 +67,11 @@ if ($displayData->get('show_options', 1))
 
 		echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-' . $name, $label);
 
+		if (isset($fieldSet->description) && trim($fieldSet->description))
+		{
+			echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
+		}
+
 		$displayData->fieldset = $name;
 		echo JLayoutHelper::render('joomla.edit.fieldset', $displayData);
 


### PR DESCRIPTION
Same as PR #2686, but against staging.
### Issue

Fieldset descriptions don't show up. This is because the code is currently in the layout `joomla.edit.fieldset` but we don't have this description information there. It looks for a property of the (assumed) object `$fieldSet` while in fact `$fieldSet` is an array of fields.
This is the case everywhere except for the component parameters itself. So in modules, plugins, menus and templates parameters and maybe also other places.
### Solution

Moving the code to the `joomla.edit.params` layout where this information (the object) is present.
### Testing Instructions

Try to add a description to a fieldset. For example in modules/mod_articles_news/mod_articles_news.xml change 

```
<fieldset
    name="advanced">
```

to 

```
<fieldset
    name="advanced" description="test">
```

Currently, the description isn't shown, after the patch is applied it will show.
### Known Limitations

This patch only covers "custom" fieldsets. The basic ones (like `basic`, `description`, `request`) are threated differently in the code and thus need to be taken care seperately.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32958
