### PR TITLE
[#32957] Removing doubled description tab in template styles

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -85,7 +85,7 @@ $user = JFactory::getUser();
 
 		<?php
 		$this->fieldsets = array();
-		$this->ignore_fieldsets = array('basic');
+		$this->ignore_fieldsets = array('basic', 'description');
 		echo JLayoutHelper::render('joomla.edit.params', $this);
 		?>
 


### PR DESCRIPTION
Same as PR #2685 but against staging and same as PR #2481, but for template styles.

To test you can create a fieldset named "description" in the templateDetails.xml and add a field to it. The tab will show up twice.
Apply patch and it will show up only once.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32957
#### Comment by JM on Original PR

> When one creates such a description fieldset:
> If the template xml description is long, we then get in the details Tab a link to "Show full description".
> Clicking on that link then loads the Description Tab which may contain fields unrelated to the `<description>` in the xml.
> Also, forgot to say that the long description is fully displayed in the Details tab.
