### PR TITLE
Improvement to result display in smart search

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -15,6 +15,9 @@ $mime = !empty($this->result->mime) ? 'mime-' . $this->result->mime : null;
 // Get the base url.
 $base = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
 
+// Calculate number of characters to display around the result
+$length = $this->params->get('description_length', 255) - strlen($this->query->input);
+
 // Get the route with highlighting information.
 if (!empty($this->query->highlight) && empty($this->result->mime) && $this->params->get('highlight_terms', 1) && JPluginHelper::isEnabled('system', 'highlight'))
 {
@@ -28,7 +31,8 @@ if (!empty($this->query->highlight) && empty($this->result->mime) && $this->para
 	<h4 class="result-title <?php echo $mime; ?>"><a href="<?php echo JRoute::_($route); ?>"><?php echo $this->result->title; ?></a></h4>
 	<?php if ($this->params->get('show_description', 1)) : ?>
 	<p class="result-text<?php echo $this->pageclass_sfx; ?>">
-		<?php echo JHtml::_('string.truncate', $this->result->description, $this->params->get('description_length', 255)); ?>
+		<?php preg_match('/(?:.){0,' . $length . '}' . $this->query->input . '(?:.){0,' . $length . '}/s', $this->result->description, $description); ?>
+		<?php echo $description[0]; ?>
 	</p>
 	<?php endif; ?>
 	<?php if ($this->params->get('show_url', 1)) : ?>


### PR DESCRIPTION
Results are truncated to a number of characters from the begining, so unless your query falls there, you won't see it in the results view, which may confuse the user who did the search.

This improves the truncation so that characters around the search query are shown. If it was the last word in the article, then chosen amount of characters before it will be shown (or after if it was at the begining), otherwise it aims for the search query to be in the middle of excerpt for optimal understanding.

Maybe such function would be useful to add to JHtml.string?
