### PR TITLE
Check if $module is an object in JModuleHelper::renderModule()

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -140,6 +140,11 @@ abstract class JModuleHelper
 	{
 		static $chrome;
 
+		if (!is_object($module))
+		{
+			return;
+		}
+
 		if (defined('JDEBUG'))
 		{
 			JProfiler::getInstance('Application')->mark('beforeRenderModule ' . $module->module . ' (' . $module->title . ')');

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -140,8 +140,15 @@ abstract class JModuleHelper
 	{
 		static $chrome;
 
-		if (!is_object($module))
+		// Check that $module is a valid module object
+		if (!is_object($module) || !isset($module->module) || !isset($module->params))
 		{
+			if (defined('JDEBUG') && JDEBUG)
+			{
+				JLog::addLogger(array('text_file' => 'jmodulehelper.log.php'), JLog::ALL, array('modulehelper'));
+				JLog::add('JModuleHelper::renderModule($module) expects a module object', JLog::DEBUG, 'modulehelper');
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Fixing the PHP warning

> Creating default object from empty value in /.../libraries/cms/module/helper.php on line 164

if `JModuleHelper::renderModule()` is called without a proper module object.
