### PR TITLE
Update warnings.php

### DIFF
--- a/administrator/components/com_installer/models/warnings.php
+++ b/administrator/components/com_installer/models/warnings.php
@@ -105,13 +105,13 @@ class InstallerModelWarnings extends JModelList
 		}
 
 		$memory_limit = $this->return_bytes(ini_get('memory_limit'));
-		if ($memory_limit < (8 * 1024 * 1024))
+		if ($memory_limit < (8 * 1024 * 1024) && $memory_limit != -1)
 		{
 			// 8MB
 			$messages[] = array('message' => JText::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYWARN'),
 					'description' => JText::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYDESC'));
 		}
-		elseif ($memory_limit < (16 * 1024 * 1024))
+		elseif ($memory_limit < (16 * 1024 * 1024) && $memory_limit != -1)
 		{
 			// 16MB
 			$messages[] = array('message' => JText::_('COM_INSTALLER_MSG_WARNINGS_MEDMEMORYWARN'),


### PR DESCRIPTION
Extension Manager should not display a warning about PHP memory limit if memory_limit is set to -1
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33230
