### PR TITLE
Add deprecating support for removed components getActions method

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -71,6 +71,28 @@ class CategoriesHelper
 		}
 	}
 
+	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @param   string   $extension   The extension.
+	 * @param   integer  $categoryId  The category ID.
+	 *
+	 * @return  JObject
+	 *
+	 * @since   1.6
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions($extension, $categoryId = 0)
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions($extension, 'category', $categoryId);
+
+		return $result;
+	}
+
 	public static function getAssociations($pk, $extension = 'com_content')
 	{
 		$associations = array();

--- a/administrator/components/com_finder/helpers/finder.php
+++ b/administrator/components/com_finder/helpers/finder.php
@@ -51,4 +51,23 @@ class FinderHelper
 			$vName == 'filters'
 		);
 	}
+
+	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject  A JObject containing the allowed actions.
+	 *
+	 * @since   2.5
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_finder');
+
+		return $result;
+	}
 }

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -115,4 +115,23 @@ class InstallerHelper
 
 		return $options;
 	}
+
+	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @since   1.6
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_installer');
+
+		return $result;
+	}
 }

--- a/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
+++ b/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_joomlaupdate
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Joomla! update helper.
+ *
+ * @package     Joomla.Administrator
+ * @subpackage  com_joomlaupdate
+ * @since       2.5.4
+ */
+class JoomlaupdateHelper
+{
+	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @since	2.5.4
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_joomlaupdate');
+
+		return $result;
+	}
+}

--- a/administrator/components/com_languages/helpers/languages.php
+++ b/administrator/components/com_languages/helpers/languages.php
@@ -51,6 +51,24 @@ class LanguagesHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_languages');
+
+		return $result;
+	}
+
+	/**
 	 * Method for parsing ini files
 	 *
 	 * @param   string  $filename Path and name of the ini file to parse

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -43,6 +43,27 @@ class MenusHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @param   integer  The menu ID.
+	 *
+	 * @return  JObject
+	 *
+	 * @since   1.6
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions($parentId = 0)
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_menus');
+
+		return $result;
+	}
+
+	/**
 	 * Gets a standard form of a link for lookups.
 	 *
 	 * @param   mixed    A link string or array of request variables.

--- a/administrator/components/com_messages/helpers/messages.php
+++ b/administrator/components/com_messages/helpers/messages.php
@@ -40,6 +40,24 @@ class MessagesHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_messages');
+
+		return $result;
+	}
+
+	/**
 	 * Get a list of filter options for the state of a module.
 	 *
 	 * @return  array  An array of JHtmlOption elements.

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -29,6 +29,33 @@ abstract class ModulesHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @param   integer  The module ID.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions($moduleId = 0)
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		if (empty($moduleId))
+		{
+			$result = JHelperContent::getActions('com_modules');
+		}
+		else
+		{
+			$result = JHelperContent::getActions('com_modules', 'module', $moduleId);
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Get a list of filter options for the state of a module.
 	 *
 	 * @return  array  An array of JHtmlOption elements.

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -31,6 +31,24 @@ class PluginsHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_plugins');
+
+		return $result;
+	}
+
+	/**
 	 * Returns an array of standard published state filter options.
 	 *
 	 * @return  string    The HTML code for the select tag

--- a/administrator/components/com_redirect/helpers/redirect.php
+++ b/administrator/components/com_redirect/helpers/redirect.php
@@ -31,6 +31,24 @@ class RedirectHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_redirect');
+
+		return $result;
+	}
+
+	/**
 	 * Returns an array of standard published state filter options.
 	 *
 	 * @return  string  	The HTML code for the select tag

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -29,6 +29,24 @@ class SearchHelper
 		// Not required.
 	}
 
+	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_search');
+
+		return $result;
+	}
+
 	public static function santiseSearchWord(&$searchword, $searchphrase)
 	{
 		$ignored = false;

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -40,6 +40,24 @@ class TemplatesHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_templates');
+
+		return $result;
+	}
+
+	/**
 	 * Get a list of filter options for the application clients.
 	 *
 	 * @return  array  An array of JHtmlOption elements.

--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -72,6 +72,24 @@ class UsersHelper
 	}
 
 	/**
+	 * Gets a list of the actions that can be performed.
+	 *
+	 * @return  JObject
+	 *
+	 * @deprecated  3.2  Use JHelperContent::getActions() instead
+	 */
+	public static function getActions()
+	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+
+		// Get list of actions
+		$result = JHelperContent::getActions('com_users');
+
+		return $result;
+	}
+
+	/**
 	 * Get a list of filter options for the blocked state of a user.
 	 *
 	 * @return  array  An array of JHtmlOption elements.


### PR DESCRIPTION
The fix for the Joomla getActions() method in this pull request https://github.com/joomla/joomla-cms/pull/2728 solved the issues, but is missing deprecating support for the removed getActions method in the component helpers (which are replaced by JHelperContent::getActions(). 

This is now causing issues in 3rd party extensions as reported over here for example: https://github.com/t3framework/t3/issues/249

This pull request re-adds the methods for the getActions checks in the core component helpers. The methods convert the requests to the new JHelperContent::getActions() method and logs the usage of depreciated code.

My apologizes for not adding the deprecating support in the initial pull request. 

Please test this pull request to confirm it is fixing the issues for 3rd party extensions.
