### PR TITLE
Fix "Error displaying the error page: Application Instantiation Error" Error [#33251]

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -78,7 +78,7 @@ class JErrorPage
 		}
 		catch (Exception $e)
 		{
-			exit('Error displaying the error page: ' . $e->getMessage());
+			exit('Error displaying the error page: ' . $e->getMessage() . ': ' . $error->getMessage());
 		}
 	}
 }


### PR DESCRIPTION
This tries to "mask" a long standing bad behavior of the Joomla! CMS when a database connection can not be established.
The root cause are some bad designed exception handlers and wrong return values.
The effect is the following unhelpful message on a blank screen:

`Error displaying the error page: Application Instantiation Error`

The solution here is a very simple "fix" that only adds the **first** exception message to the final error output:

**Example:**

`Error displaying the error page: Application Instantiation Error: Could not connect to MySQL.`

So, at least one might have a clue what's going on :wink: 

**Test instructions:**
Change the database credentials in configuration.php to something invalid and reload the page.

Good ol' joomlacode tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33251
