### PR TITLE
[#33407] Alter code that deals with PHP 5.3.1-5.3.9 support

### DIFF
--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -165,13 +165,13 @@ class JAdapter extends JObject
 	{
 		$files = new DirectoryIterator($this->_basepath . '/' . $this->_adapterfolder);
 
+		/* @type  $file  DirectoryIterator */
 		foreach ($files as $file)
 		{
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-			if (!$file->isFile() || substr($fileName, strrpos($fileName, '.') + 1) != 'php')
+			if (!$file->isFile() || $file->getExtension() != 'php')
 			{
 				continue;
 			}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -96,15 +96,13 @@ class JCache
 		// Get an iterator and loop trough the driver classes.
 		$iterator = new DirectoryIterator(__DIR__ . '/storage');
 
+		/* @type  $file  DirectoryIterator */
 		foreach ($iterator as $file)
 		{
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-			if (!$file->isFile()
-				|| substr($fileName, strrpos($fileName, '.') + 1) != 'php'
-				|| $fileName == 'helper.php')
+			if (!$file->isFile() || $file->getExtension() != 'php' || $fileName == 'helper.php')
 			{
 				continue;
 			}
@@ -606,17 +604,17 @@ class JCache
 						// We have to serialize the content of the arrays because the may contain other arrays which is a notice in PHP 5.4 and newer
 						$nowvalue 		= array_map('serialize', $headnow[$now]);
 						$beforevalue 	= array_map('serialize', $options['headerbefore'][$now]);
-						
+
 						$newvalue = array_diff_assoc($nowvalue, $beforevalue);
 						$newvalue = array_map('unserialize', $newvalue);
-						
+
 						// Special treatment for script and style declarations.
 						if (($now == 'script' || $now == 'style') && is_array($newvalue) && is_array($options['headerbefore'][$now]))
 						{
 							foreach ($newvalue as $type => $currentScriptStr)
 							{
 								if (isset($options['headerbefore'][$now][strtolower($type)]))
-								{ 
+								{
 									$oldScriptStr = $options['headerbefore'][$now][strtolower($type)];
 									if ($oldScriptStr != $currentScriptStr)
 									{

--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -128,12 +128,8 @@ class JCrypt
 		$length = (int) $length;
 		$sslStr = '';
 
-		/*
-		 * If a secure randomness generator exists and we don't
-		 * have a buggy PHP version use it.
-		 */
-		if (function_exists('openssl_random_pseudo_bytes')
-			&& (version_compare(PHP_VERSION, '5.3.4') >= 0 || IS_WIN))
+		// If a secure randomness generator exists use it.
+		if (function_exists('openssl_random_pseudo_bytes'))
 		{
 			$sslStr = openssl_random_pseudo_bytes($length, $strong);
 
@@ -297,39 +293,24 @@ class JCrypt
 	 * Tests for the availability of updated crypt().
 	 * Based on a method by Anthony Ferrera
 	 *
-	 * @return  boolean  True if updated crypt() is available.
+	 * @return  boolean  Always returns true since 3.3
 	 *
 	 * @note    To be removed when PHP 5.3.7 or higher is the minimum supported version.
 	 * @see     https://github.com/ircmaxell/password_compat/blob/master/version-test.php
 	 * @since   3.2
+	 * @deprecated  4.0
 	 */
 	public static function hasStrongPasswordSupport()
 	{
-		static $pass = null;
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated without replacement.', JLog::WARNING, 'deprecated');
 
-		if (is_null($pass))
+		if (!defined('PASSWORD_DEFAULT'))
 		{
-			// Check to see whether crypt() is supported.
-			if (version_compare(PHP_VERSION, '5.3.7', '>=') === true)
-			{
-				// We have safe PHP version.
-				$pass = true;
-			}
-			else
-			{
-				// We need to test if we have patched PHP version.
-				jimport('compat.password.lib.version_test');
-				$test = new version_test;
-				$pass = $test->version_test();
-			}
-
-			if ($pass && !defined('PASSWORD_DEFAULT'))
-			{
-				// Always make sure that the password hashing API has been defined.
-				include_once JPATH_ROOT . '/libraries/compat/password/lib/password.php';
-			}
+			// Always make sure that the password hashing API has been defined.
+			include_once JPATH_ROOT . '/libraries/compat/password/lib/password.php';
 		}
 
-		return $pass;
+		return true;
 	}
 }

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -204,13 +204,13 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		// Get an iterator and loop trough the driver classes.
 		$iterator = new DirectoryIterator(__DIR__ . '/driver');
 
+		/* @type  $file  DirectoryIterator */
 		foreach ($iterator as $file)
 		{
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-			if (!$file->isFile() || substr($fileName, strrpos($fileName, '.') + 1) != 'php')
+			if (!$file->isFile() || $file->getExtension() != 'php')
 			{
 				continue;
 			}

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -266,13 +266,11 @@ class JFilesystemHelper
 		{
 			$files = new DirectoryIterator(__DIR__ . '/streams');
 
+			/* @type  $file  DirectoryIterator */
 			foreach ($files as $file)
 			{
-				$filename = $file->getFilename();
-
 				// Only load for php files.
-				// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-				if (!$file->isFile() || substr($filename, strrpos($filename, '.') + 1) != 'php')
+				if (!$file->isFile() || $file->getExtension() !== 'php')
 				{
 					continue;
 				}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -688,14 +688,7 @@ class JFilterInput
 		if (!is_array($ttr))
 		{
 			// Entity decode
-			if (version_compare(PHP_VERSION, '5.3.4', '>='))
-			{
-				$trans_tbl = get_html_translation_table(HTML_ENTITIES, ENT_COMPAT, 'ISO-8859-1');
-			}
-			else
-			{
-				$trans_tbl = get_html_translation_table(HTML_ENTITIES, ENT_COMPAT);
-			}
+			$trans_tbl = get_html_translation_table(HTML_ENTITIES, ENT_COMPAT, 'ISO-8859-1');
 
 			foreach ($trans_tbl as $k => $v)
 			{

--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -98,13 +98,13 @@ class JHttpFactory
 		$names = array();
 		$iterator = new DirectoryIterator(__DIR__ . '/transport');
 
+		/* @type  $file  DirectoryIterator */
 		foreach ($iterator as $file)
 		{
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-			if ($file->isFile() && substr($fileName, strrpos($fileName, '.') + 1) == 'php')
+			if ($file->isFile() && $file->getExtension() == 'php')
 			{
 				$names[] = substr($fileName, 0, strrpos($fileName, '.'));
 			}

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -386,13 +386,13 @@ class JSession implements IteratorAggregate
 		// Get an iterator and loop trough the driver classes.
 		$iterator = new DirectoryIterator(__DIR__ . '/storage');
 
+		/* @type  $file  DirectoryIterator */
 		foreach ($iterator as $file)
 		{
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-			if (!$file->isFile() || substr($fileName, strrpos($fileName, '.') + 1) != 'php')
+			if (!$file->isFile() || $file->getExtension() != 'php')
 			{
 				continue;
 			}

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -84,13 +84,13 @@ abstract class JLoader
 				$iterator = new DirectoryIterator($parentPath);
 			}
 
+			/* @type  $file  DirectoryIterator */
 			foreach ($iterator as $file)
 			{
 				$fileName = $file->getFilename();
 
 				// Only load for php files.
-				// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
-				if ($file->isFile() && substr($fileName, strrpos($fileName, '.') + 1) == 'php')
+				if ($file->isFile() && $file->getExtension() == 'php')
 				{
 					// Get the class name and full path for each file.
 					$class = strtolower($classPrefix . preg_replace('#\.php$#', '', $fileName));


### PR DESCRIPTION
With the raise in support for 3.3 from PHP 5.3.1 to 5.3.10, there are places in the code base we can remove workarounds or checks dealing with PHP 5.3.1 to 5.3.9 support.  This PR does that.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33407
