### PR TITLE
Calendar should use jQuery

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -986,7 +986,7 @@ abstract class JHtml
 				$document = JFactory::getDocument();
 				$document
 					->addScriptDeclaration(
-					'window.addEvent(\'domready\', function() {Calendar.setup({
+					'jQuery(document).ready(function($) {Calendar.setup({
 				// Id of the input field
 				inputField: "' . $id . '",
 				// Format of the input field


### PR DESCRIPTION
Calendar is initializing after domready in Mootools, but Mootools is no longer loaded with calendar. 
This is why we should initialize calendar after domready but in jQuery.
Calendar is always loading Bootstrap Tooltips and it would load jQuery.
Calendar is not loading Mootools in any place so it can not depend on Mootools.
Also you will get error when you will try to load calendar on page where you have not loaded Mootools.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33066
