### PR TITLE
PHP notice: Undefined variable: parts in ajax response

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -66,7 +66,7 @@ elseif ($input->get('module'))
 			$parts = explode('-', $module);
 		}
 
-		if ($parts)
+		if (isset($parts))
 		{
 			$class = 'mod';
 			foreach ($parts as $part)


### PR DESCRIPTION
After making following fixes
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32693&start=0
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32166&start=0
there is a PHP notice about undefined $parts variable which is clear when you will have a look at the code.

Enable maximal error reporting in global configuration. Make an ajax request to module which name does not have _ and - (also without prefix mod_). You will get PHP notice in JSON response which would break code.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33121
