### PR TITLE
[#33067] JText::script is not loading Joomla core.js

### DIFF
--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -219,6 +219,8 @@ class JDocumentRendererHead extends JDocumentRenderer
 		// Generate script language declarations.
 		if (count(JText::script()))
 		{
+			JHtml::_('script', 'system/core.js', false, true);
+			
 			$buffer .= $tab . '<script type="text/javascript">' . $lnEnd;
 			$buffer .= $tab . $tab . '(function() {' . $lnEnd;
 			$buffer .= $tab . $tab . $tab . 'var strings = ' . json_encode(JText::script()) . ';' . $lnEnd;

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -219,18 +219,9 @@ class JDocumentRendererHead extends JDocumentRenderer
 		// Generate script language declarations.
 		if (count(JText::script()))
 		{
-			JHtml::_('script', 'system/core.js', false, true);
-			
 			$buffer .= $tab . '<script type="text/javascript">' . $lnEnd;
 			$buffer .= $tab . $tab . '(function() {' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . 'var strings = ' . json_encode(JText::script()) . ';' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . 'if (typeof Joomla == \'undefined\') {' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . $tab . 'Joomla = {};' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . $tab . 'Joomla.JText = strings;' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . '}' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . 'else {' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . $tab . 'Joomla.JText.load(strings);' . $lnEnd;
-			$buffer .= $tab . $tab . $tab . '}' . $lnEnd;
+			$buffer .= $tab . $tab . $tab . 'Joomla.JText.load(' . json_encode(JText::script()) . ');' . $lnEnd;
 			$buffer .= $tab . $tab . '})();' . $lnEnd;
 			$buffer .= $tab . '</script>' . $lnEnd;
 		}

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -355,8 +355,6 @@ class JText
 		{
 			// Normalize the key and translate the string.
 			self::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
-			
-			JHtml::_('script', 'system/core.js', false, true);
 		}
 
 		return self::$strings;

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -355,6 +355,17 @@ class JText
 		{
 			// Normalize the key and translate the string.
 			self::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
+			
+			// Load core.js dependence
+			
+			// Remove as soon as core.js is rewritten to jQuery
+			// https://github.com/joomla/joomla-cms/pull/2687
+			// https://github.com/joomla/joomla-cms/pull/3047
+			JHtml::_('behavior.framework');
+			JHtml::_('script', 'system/core.js', false, true);
+			
+			/* Uncomment as soon as core.js is rewritten to jQuery
+			JHtml::_('behavior.core'); */
 		}
 
 		return self::$strings;

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -355,6 +355,8 @@ class JText
 		{
 			// Normalize the key and translate the string.
 			self::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
+			
+			JHtml::_('script', 'system/core.js', false, true);
 		}
 
 		return self::$strings;

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -357,15 +357,7 @@ class JText
 			self::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 			
 			// Load core.js dependence
-			
-			// Remove as soon as core.js is rewritten to jQuery
-			// https://github.com/joomla/joomla-cms/pull/2687
-			// https://github.com/joomla/joomla-cms/pull/3047
-			JHtml::_('behavior.framework');
-			JHtml::_('script', 'system/core.js', false, true);
-			
-			/* Uncomment as soon as core.js is rewritten to jQuery
-			JHtml::_('behavior.core'); */
+			JHtml::_('behavior.core');
 		}
 
 		return self::$strings;


### PR DESCRIPTION
JText::script should always load system JavaScript file: core.js which has declaration of function: Joomla.JText._ which should be used in JavaScript files for translating strings. If Mootools is not loaded or some other resource which is loading core.js then you will get an error trying to use: Joomla.JText._

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33067
