### PR TITLE
Bind Variable Fix Within PDO Driver

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -697,11 +697,14 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 			$query->setLimit($limit, $offset);
 		}
 
-		$query = $this->replacePrefix((string) $query);
+		// Create a stringified version of the query (with prefixes replaced):
+		$sql = $this->replacePrefix((string) $query);
 
-		$this->prepared = $this->connection->prepare($query, $driverOptions);
+		// Use the stringified version in the prepare call:
+		$this->prepared = $this->connection->prepare($sql, $driverOptions);
 
-		// Store reference to the JDatabaseQuery instance:
+		// Store reference to the original JDatabaseQuery instance within the class.
+		// This is important since binding variables depends on it within execute():
 		parent::setQuery($query, $offset, $limit);
 
 		return $this;


### PR DESCRIPTION
This fix is to revert back to original behavior needed to allow bounded variables to be used within the PDO Driver (and specifically within the Oracle Driver that inherits from it).

Without the fix above, what happens is the instance of JDatabaseQuery stored in $query ends up getting replaced with a simple string on line 701 and that eventually gets stored in the parent::setQuery() call on line 708.

Later, when execute() is called, since the string is not an instance of JDatabaseQuery, the checks within execute that trigger the bounded variables to be set no longer function correctly and the variables end up being unbounded and results in a query error.

With the simple corrections above, the $query instance remains intact with a separate $sql variable being used instead to hold the "stringified" version of the query with the database prefix replacements and that gets used to prepare the query within the database connection.

This allows the parent::setQuery() call on line 708 to still store a reference to the JDatabaseQuery instance properly and for everything to work as expected for the bounded variables.

-Omar
