### PR TITLE
Error in featured view article dropdown

### DIFF
--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -107,10 +107,10 @@ $saveOrder	= $listOrder == 'fp.ordering';
 								<?php
 								// Create dropdown items
 								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'newsfeeds');
+								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
 
 								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'newsfeeds');
+								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
 
 								// Render dropdown list
 								echo JHtml::_('actionsdropdown.render', $this->escape($item->title));


### PR DESCRIPTION
simple copy/paste error for the dropdown. set to newsfeeds instead of articles when choosing Trash or Archive
![screen shot 2014-02-13 at 09 24 31](https://f.cloud.github.com/assets/869724/2157894/696540ee-9488-11e3-99be-f68706e6eb4b.png)
Tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33266&start=0
