### PR TITLE
Proposed onAfterRenderModules event in modules rendering

### DIFF
--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -54,6 +54,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 			$buffer .= $moduleHtml;
 		}
 
+                JDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
 		return $buffer;
 	}
 }

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -54,7 +54,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 			$buffer .= $moduleHtml;
 		}
 
-                JDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
+                JEventDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
 		return $buffer;
 	}
 }

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -54,7 +54,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 			$buffer .= $moduleHtml;
 		}
 
-                JEventDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
+		JEventDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
 		return $buffer;
 	}
 }

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -55,6 +55,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 		}
 
 		JEventDispatcher::getInstance()->trigger('onAfterRenderModules', array(&$buffer, &$params));
+		
 		return $buffer;
 	}
 }


### PR DESCRIPTION
During development and usage of JotCache extension (#13155 on JED) was found that exclusion and dynamic restore of modules during page caching requires processing inside core modules.php code. The best way is to trigger event on the end of template position modules rendering and process all necessary operations in plugin.
Proposed patch is working in JotCache 4.1.0 for J3.2 using class overlay.
