### PR TITLE
Update error.php

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -213,7 +213,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 			<h1 class="page-title"><?php echo JText::_('ERROR'); ?></h1>
 		</div>
 	</header>
-	<?php if ((!$statusFixed) && ($this->countModules('status'))) : ?>
+	<?php if ((!$statusFixed) && ($this->getInstance()->countModules('status'))) : ?>
 		<!-- Begin Status Module -->
 		<div id="status" class="navbar status-top hidden-phone">
 			<div class="btn-toolbar">


### PR DESCRIPTION
<?php if ((!$statusFixed) && ($this->countModules('status'))) : ?>
needs to be changed by
<?php if ((!$statusFixed) && ($this->getInstance()->countModules('status'))) :?>

$this is, at that point, instantiated to JDocumentError which has not countModules method throwing an error.
