### PR TITLE
[fix] Ignore System tests config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # Test Related Files #
 /phpunit.xml
 /tests/system/webdriver/tests/logs/
+/tests/system/servers/configdef.php
 
 # phpDocumentor Logs #
 phpdoc-*
@@ -25,3 +26,4 @@ phpdoc-*
 administrator/components/com_patchtester/
 administrator/templates/hathor/html/com_patchtester
 components/com_patchtester/
+


### PR DESCRIPTION
/tests/system/servers/configdef.php contains config data for testing. It should be ignored by the repo because is different in every machine

Note that the file doesn't exist in the repo, but is like configuration.php, you create it for running Joomla. So is better to ignore it, this will allow to do the testing in the same repo folder.
