### PR TITLE
Correct strict standards error and initialize $app

### DIFF
--- a/components/com_contact/views/contact/view.vcf.php
+++ b/components/com_contact/views/contact/view.vcf.php
@@ -19,8 +19,11 @@ class ContactViewContact extends JViewLegacy
 
 	protected $item;
 
-	public function display()
+	public function display($tpl = null)
 	{
+		// Initialise application
+		$app = JFactory::getApplication();
+		
 		// Get model data.
 		$item = $this->get('Item');
 


### PR DESCRIPTION
display() method not compatible with JViewLegacy
$app object never initialized, causing fatal error
Tracker #33278
