### PR TITLE
[imp]Missing limit box in smartsearch index page

### DIFF
--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -68,6 +68,10 @@ Joomla.submitbutton = function(pressbutton)
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
 				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
+			<div class="btn-group pull-right hidden-phone">
+				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>
+				<?php echo $this->pagination->getLimitBox(); ?>
+			</div>
 		</div>
 		<div class="clearfix"> </div>
 		<?php if (!$this->pluginState['plg_content_finder']->enabled) : ?>


### PR DESCRIPTION
administrator/index.php?option=com_finder&view=index
After patch:
![screen shot 2014-02-15 at 16 42 25](https://f.cloud.github.com/assets/869724/2178111/db490e68-9657-11e3-89fe-d9b89364c46c.png)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33282&start=0
