### PR TITLE
Stop config html.view.templates details cascading to future config html....

### DIFF
--- a/components/com_config/view/cms/html.php
+++ b/components/com_config/view/cms/html.php
@@ -154,6 +154,22 @@ abstract class ConfigViewCmsHtml extends JViewHtml
 			// clear it.
 			$this->_output = ob_get_contents();
 			ob_end_clean();
+		//clear the template name and description at this point as well if they are set,
+			
+			if(isset($this->name))
+			{
+				unset($this->name);
+			}
+
+			if(isset($this->description))
+			{
+				unset($this->description);
+			}
+
+			if(isset($this->fieldsname))
+			{
+				unset($this->fieldsname);
+			}
 
 			return $this->_output;
 		}


### PR DESCRIPTION
...view.templates

The ConfigViewCmsHtml is just overwritten for each Loadtemplate() call...any parameters NOT overwritten by a future template will perpetuate.  IE add a description into the site (site settings) configuration template.  It will be written to all subsequent templates.

This patch provides a quick fix that resets the name, fieldname and description after the output buffer is cleared and the template  _output is returned.
