### PR TITLE
[#33295] Adding the "showon" feature to JForm

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -896,4 +896,3 @@ abstract class JFormField
 			. '</div>';
 	}
 }
-hidden

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -875,9 +875,19 @@ abstract class JFormField
 		{
 			return $this->getInput();
 		}
+		
+		if ($showon = $this->getAttribute('showon'))
+		{
+			JHtml::_('jquery.framework');
+			JHtml::_('script', 'jui/cms.js', false, true);
+			$showon = explode(':', $showon, 2);
+			$class = ' showon_' . implode(' showon_', explode(',', $showon[1]));
+			$id = $this->getName($showon[0]);
+			$rel = ' rel="showon_' . $id . '"';
+		}
 
 		return
-			'<div class="control-group">'
+			'<div class="control-group' . $class . '"' . $rel . '>'
 			. '<div class="control-label">' . $this->getLabel() . '</div>'
 			. '<div class="controls">' . $this->getInput() . '</div>'
 			. '</div>';

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -896,3 +896,4 @@ abstract class JFormField
 			. '</div>';
 	}
 }
+hidden

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -876,9 +876,6 @@ abstract class JFormField
 			return $this->getInput();
 		}
 		
-		$class = '';
-		$rel = '';
-		
 		if ($showon = $this->getAttribute('showon'))
 		{
 			JHtml::_('jquery.framework');
@@ -896,4 +893,3 @@ abstract class JFormField
 			. '</div>';
 	}
 }
-hidden

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -876,6 +876,9 @@ abstract class JFormField
 			return $this->getInput();
 		}
 		
+		$class = '';
+		$rel = '';
+		
 		if ($showon = $this->getAttribute('showon'))
 		{
 			JHtml::_('jquery.framework');
@@ -893,3 +896,4 @@ abstract class JFormField
 			. '</div>';
 	}
 }
+hidden


### PR DESCRIPTION
### Overview

In the Joomla Global Configuration we use showon attribute to show/hide certain fields based on the state of a "parent" field. You can see this for example with the FTP settings where the settings itself only show when "Enable FTP" is set to "Yes". It's also available for Component settings.

This PR takes this feature to the JForm so it can be used in any xml file.
### Testing

You can add a showon attribute to any config field you want to hide. For example in 
 modules\mod_finder\mod_finder.xml you add to line 94
 showon="show_label:1". So it looks like this:

```
                <field
                    name="label_pos"
                    type="list"
                    default="left"
                    showon="show_label:1"
                    label="MOD_FINDER_FIELDSET_ADVANCED_LABEL_POS_LABEL"
                    description="MOD_FINDER_FIELDSET_ADVANCED_LABEL_POS_DESCRIPTION">
                    <option
                        value="right">JGLOBAL_RIGHT</option>
                    <option
                        value="left">JGLOBAL_LEFT</option>
                    <option
                        value="top">MOD_FINDER_CONFIG_OPTION_TOP</option>
                    <option
                        value="bottom">MOD_FINDER_CONFIG_OPTION_BOTTOM</option>
                </field>
```

This will only show the "Label position" setting only if the "Show Label" is set to "Yes" (which has the value 1).

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33295&start=0
