### PR TITLE
Add valid_elements option to TinyMCE plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -33,6 +33,8 @@ PLG_TINY_FIELD_DATEFORMAT_DESC="Format of inserted date. Only works in Extended 
 PLG_TINY_FIELD_DATEFORMAT_LABEL="Date Format"
 PLG_TINY_FIELD_DIRECTION_DESC="Choose default text direction"
 PLG_TINY_FIELD_DIRECTION_LABEL="Text Direction"
+PLG_TINY_FIELD_VALIDELEMENTS_DESC="Defines which elements will remain in the edited text when the editor saves (default is a mixture of the full HTML5 and HTML4 specification)."
+PLG_TINY_FIELD_VALIDELEMENTS_LABEL="Valid Elements"
 PLG_TINY_FIELD_ELEMENTS_DESC="Allows the addition of specific valid elements to the existing rule set."
 PLG_TINY_FIELD_ELEMENTS_LABEL="Extended Valid Elements"
 PLG_TINY_FIELD_ENCODING_DESC="Controls how HTML entities are encoded. Recommended setting is 'raw'. 'named' = used named entity encoding (for example, '&lt;'). 'numeric' = use numeric HTML encoding (for example, '%03c'). raw = Do not encode HTML entities. Note that searching content may not work properly if setting is not 'raw'."

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -174,8 +174,9 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		$invalid_elements	= $this->params->def('invalid_elements', 'script,applet,iframe');
+		$valid_elements     = $this->params->def('valid_elements', '');
 		$extended_elements	= $this->params->def('extended_elements', '');
-
+		
 		// theme_advanced_* settings
 		$toolbar			= $this->params->def('toolbar', 'top');
 		$toolbar_align		= $this->params->def('toolbar_align', 'left');
@@ -539,6 +540,7 @@ class PlgEditorTinymce extends JPlugin
 					inline_styles : true,
 					gecko_spellcheck : true,
 					entity_encoding : \"$entity_encoding\",
+					valid_elements : \"$valid_elements\",
 					extended_valid_elements : \"$elements\",
 					$forcenewline
 					invalid_elements : \"$invalid_elements\",
@@ -581,6 +583,7 @@ class PlgEditorTinymce extends JPlugin
 					inline_styles : true,
 					gecko_spellcheck : true,
 					entity_encoding : \"$entity_encoding\",
+					valid_elements : \"$valid_elements\",
 					extended_valid_elements : \"$elements\",
 					$forcenewline
 					invalid_elements : \"$invalid_elements\",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -134,7 +134,14 @@
 					label="PLG_TINY_FIELD_PROHIBITED_LABEL"
 					rows="2"
 				/>
-
+				
+				<field name="valid_elements" type="textarea"
+					cols="30"
+					description="PLG_TINY_FIELD_VALIDELEMENTS_DESC"
+					label="PLG_TINY_FIELD_VALIDELEMENTS_LABEL"
+					rows="2"
+				/>
+				
 				<field name="extended_elements" type="textarea"
 					cols="30"
 					description="PLG_TINY_FIELD_ELEMENTS_DESC"


### PR DESCRIPTION
Add valid_elements option to TinyMCE plugin (http://www.tinymce.com/wiki.php/configuration:valid_elements). This option allows users to change the default behavior (e.g.: set _[_] to include all elements and all attributes).
