### PR TITLE
Using the "joomla.content.icons" JLayout for article and feature view

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -64,23 +64,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	</div>
 	<?php endif; ?>
 	<?php if (!$this->print) : ?>
-		<?php if ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon')) : ?>
-		<div class="btn-group pull-right">
-			<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span> <span class="caret"></span> </a>
-			<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
-			<ul class="dropdown-menu actions">
-				<?php if ($params->get('show_print_icon')) : ?>
-				<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
-				<?php endif; ?>
-				<?php if ($params->get('show_email_icon')) : ?>
-				<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
-				<?php endif; ?>
-				<?php if ($canEdit) : ?>
-				<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
-				<?php endif; ?>
-			</ul>
-		</div>
-		<?php endif; ?>
+		<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
 	<?php else : ?>
 		<?php if ($useDefList) : ?>
 			<div id="pop-print" class="btn hidden-print">

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -44,21 +44,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 	<span class="label label-warning"><?php echo JText::_('JEXPIRED'); ?></span>
 <?php endif; ?>
 
-<?php if ($params->get('show_print_icon') || $params->get('show_email_icon') || $canEdit) : ?>
-	<div class="btn-group pull-right"> <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" role="button"> <span class="icon-cog"></span> <span class="caret"></span> </a>
-		<ul class="dropdown-menu">
-		<?php if ($params->get('show_print_icon')) : ?>
-			<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
-		<?php endif; ?>
-		<?php if ($params->get('show_email_icon')) : ?>
-			<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
-		<?php endif; ?>
-		<?php if ($canEdit) : ?>
-			<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
-		<?php endif; ?>
-		</ul>
-	</div>
-<?php endif; ?>
+<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
 
 <?php // Todo Not that elegant would be nice to group the params ?>
 <?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')


### PR DESCRIPTION
## Issue

Currently we use this layout already in the com_content category view. It's a nice way to replace the current "actions" dropdown menu (that one with "print", "email" and "edit" icons) within a template without overriding the whole page output.
## Testing
1. Make sure the dropdown menu looks the same before and after patch
2. Test if you can override the dropdown menu using a template override (copy the layout from /layouts/joomla/content/icons.php to /templates/your_template/html/layouts/joomla/content/icons.php and adjust)
