### PR TITLE
 Menu Class Suffix

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Note. It is important to remove spaces between elements.
 ?>
 <?php // The menu class is deprecated. Use nav instead. ?>
-<ul class="nav menu<?php echo $class_sfx;?>"<?php
+<ul class="nav menu <?php echo $class_sfx;?>"<?php
 	$tag = '';
 
 	if ($params->get('tag_id') != null)


### PR DESCRIPTION
This has cause problems such as described here: http://forum.joomla.org/viewtopic.php?f=708&t=789859

Many people have mentioned putting a space before the class "nav-pills" this is the reason that this pull is needed.
