### PR TITLE
Update contactcreator.php

### DIFF
--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -64,14 +64,14 @@ class PlgUserContactCreator extends JPlugin
 		JTable::addIncludePath(JPATH_ADMINISTRATOR.'/components/com_contact/tables');
 		$contact = JTable::getInstance('contact', 'ContactTable');
 
-		//See if a contact with same alias as that of present user name exists
+		// See if a contact with same alias as that of present user name exists
 		$db = JFactory::getDbo();
-		$db->setQuery('SELECT id FROM #__contact_details WHERE alias = "'. $user['name'].'"');
+		$db->setQuery('SELECT id FROM #__contact_details WHERE alias = "' . $user['name'] . '"');
 		$id2 = $db->loadResult();
-		if($id2)
+		if ($id2)
 		{	
-			//if same alias exists,append current date,time to alias
-			$contact->alias=$user['name'].JHtml::date($input = 'now', 'm/d/Y h:i:s a', false);
+			// if same alias exists,append current date,time to alias
+			$contact->alias=$user['name'] . JHtml::date($input = 'now', 'm/d/Y h:i:s a', false);
 		}
 		
 		if (!$contact)

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -68,9 +68,10 @@ class PlgUserContactCreator extends JPlugin
 		$db = JFactory::getDbo();
 		$db->setQuery('SELECT id FROM #__contact_details WHERE alias = "' . $user['name'] . '"');
 		$id2 = $db->loadResult();
-		if ($id2)
+	 
+	 	if ($id2)
 		{	
-			// if same alias exists,append current date,time to alias
+			// If same alias exists,append current date,time to alias
 			$contact->alias=$user['name'] . JHtml::date($input = 'now', 'm/d/Y h:i:s a', false);
 		}
 		

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -64,6 +64,16 @@ class PlgUserContactCreator extends JPlugin
 		JTable::addIncludePath(JPATH_ADMINISTRATOR.'/components/com_contact/tables');
 		$contact = JTable::getInstance('contact', 'ContactTable');
 
+		//See if a contact with same alias as that of present user name exists
+		$db = JFactory::getDbo();
+		$db->setQuery('SELECT id FROM #__contact_details WHERE alias = "'. $user['name'].'"');
+		$id2 = $db->loadResult();
+		if($id2)
+		{	
+			//if same alias exists,append current date,time to alias
+			$contact->alias=$user['name'].JHtml::date($input = 'now', 'm/d/Y h:i:s a', false);
+		}
+		
 		if (!$contact)
 		{
 			return false;


### PR DESCRIPTION
 Testing for same alias is not done by Contact Creator Plugin.Due to this, 2 contacts with same alias can be created(which is not desirable). So,the extra code ,line numbers 66 to 76, appends the current time stamp to alias if the same alias is already present.
Before Patch: ![before patch_2 contacts with same alias](https://f.cloud.github.com/assets/6712989/2192738/e4eddc9c-986d-11e3-8236-c6d0c7817606.png)
After Patch : ![after patch](https://f.cloud.github.com/assets/6712989/2192736/e4932432-986d-11e3-81a8-9b41c4e3fc63.png)

  The bug is reported at http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33291
