### PR TITLE
Removing a leftover </span> from mod_breadcrumbs

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -17,7 +17,7 @@ JHtml::_('bootstrap.tooltip');
 	<?php
 	if ($params->get('showHere', 1))
 	{
-		echo '<li class="active">' . JText::_('MOD_BREADCRUMBS_HERE') . '&#160;</span></li>';
+		echo '<li class="active">' . JText::_('MOD_BREADCRUMBS_HERE') . '&#160;</li>';
 	}
 	else
 	{


### PR DESCRIPTION
An orphaned `</span>` has been found and returned to the storage for future use.

This </span> wasn't properly removed with https://github.com/joomla/joomla-cms/commit/7edbcf3b137c05c4f3dd27fe2c7ad9c7aa676d49

The span will only show if the "Show 'You are here'" option is enabled.
