### PR TITLE
[#31493] fix JForm::setFieldAttribute()

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -983,13 +983,14 @@ class JForm
 	 * @param   string  $attribute  The name of the attribute for which to set a value.
 	 * @param   mixed   $value      The value to set for the attribute.
 	 * @param   string  $group      The optional dot-separated form group path on which to find the field.
+	 * @param   boolean $replace    True to replace whole existing field attributes or false to append the new.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function setFieldAttribute($name, $attribute, $value, $group = null)
+	public function setFieldAttribute($name, $attribute, $value, $group = null, $replace = true)
 	{
 		// Make sure there is a valid JForm XML document.
 		if (!($this->xml instanceof SimpleXMLElement))
@@ -1009,7 +1010,29 @@ class JForm
 		// Otherwise set the attribute and return true.
 		else
 		{
-			$element[$attribute] = $value;
+			// If the attribute to be set must not merged with existing ones, simply set it.
+			if ($replace)
+			{
+				$element[$attribute] = $value;
+			}
+			// Otherwise merge it.
+			else
+			{
+				// Explode current attributes into array.
+				$attributes = explode(' ', (string) $element[$attribute]);
+
+				// Explode passed in values into array.
+				$value = explode(' ', trim($value));
+
+				// Merge both.
+				$attributes = array_unique(array_filter(array_merge($attributes, $value)));
+
+				// Sort for better readability.
+				sort($attributes);
+
+				// Set merged attributes back.
+				$element[$attribute] = trim(implode(' ', $attributes));
+			}
 
 			// Synchronize any paths found in the load.
 			$this->syncPaths();


### PR DESCRIPTION
Fixing issue described in [bug #31493](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31493), related to JForm (libraries/joomla/form/form.php)

Presently JForm::setFieldAttributes sets passed attribute values without taking care for existing ones which may lead to loss. To prevent this and add new attribute values preserving existing ones one had to call:

```
$form->setFieldAttribute(
   'fieldname',
   'attribute',
   $form->getFieldAttribute('fieldname', 'attribute', '', 'group') . ' newAttr1 newAttr2 newAttr3 ...',
   'group'
);
```

This is not very comfortable and might lead to very long statements. Also, it does not take care for value duplication. The PR adds an additional function parameter as flag for merging or replacing (default) along with an extended processing statement. Adding attribute value statements will then look like:

```
$form->setFieldAttribute(
   'fieldname',
   'attribute',
   'newAttr1 newAttr2 newAttr3 ...',   // a space separeted attributes list
   'group',
   false   // flag indicating whether to merge or replace
);
```

When the last paramter is passed and set to 'false' the form first reads all values of the related form fields attribute, dumps them into an array, merges the passed attribute values and finally filters for duplicates. This way all attribute values are set without having dupes.
