### PR TITLE
[#33306] Don't allow autocomplete on two-factor authentication field

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -58,7 +58,7 @@ JHtml::_('formbehavior.chosen');
 							<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 						</label>
 					</span>
-					<input name="secretkey" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+					<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<i class="icon-help"></i>
 					</span>

--- a/administrator/templates/hathor/html/mod_login/default.php
+++ b/administrator/templates/hathor/html/mod_login/default.php
@@ -25,7 +25,7 @@ JHtml::_('behavior.keepalive');
 					<label for="mod-login-secretkey">
 						<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 					</label>
-					<input name="secretkey" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" size="15"/>
+					<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" size="15"/>
 				</div>
 			</div>
 		<?php endif; ?>
@@ -33,7 +33,7 @@ JHtml::_('behavior.keepalive');
 			<label id="mod-login-language-lbl" for="lang"><?php echo JText::_('MOD_LOGIN_LANGUAGE'); ?></label>
 			<?php echo $langs; ?>
 		<?php endif; ?>
-		
+
 		<div class="clr"></div>
 
 		<div class="button-holder">

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -67,14 +67,14 @@ JHtml::_('bootstrap.tooltip');
 								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
+						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
 				</div>
 				<?php else: ?>
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
-					<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
+					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY') ?>" />
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>

--- a/templates/beez3/html/mod_login/default.php
+++ b/templates/beez3/html/mod_login/default.php
@@ -53,11 +53,11 @@ JHtml::_('behavior.keepalive');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend input-append">
 						<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
 					</div>
 				<?php else: ?>
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
-					<input id="modlgn-secretkey" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
 				<?php endif; ?>
 			</div>
 		</div>


### PR DESCRIPTION
The field where the key for two factor authentication should be a unique value each time it is used, so autocomplete shouldn't be enabled for this input.
