### PR TITLE
fix tooltips appearing behind Batch modal window

### DIFF
--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -27,11 +27,11 @@ abstract class JHtmlBatch
 	 */
 	public static function access()
 	{
-		JHtml::_('bootstrap.tooltip');
+		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
 
 		// Create the batch selector to change an access level on a selection list.
 		return
-			'<label id="batch-access-lbl" for="batch-access" class="hasToolip"'
+			'<label id="batch-access-lbl" for="batch-access" class="modalTooltip"'
 			. 'title="' . JHtml::tooltipText('JLIB_HTML_BATCH_ACCESS_LABEL', 'JLIB_HTML_BATCH_ACCESS_LABEL_DESC') . '">'
 			. JText::_('JLIB_HTML_BATCH_ACCESS_LABEL')
 			. '</label>'
@@ -88,11 +88,11 @@ abstract class JHtmlBatch
 	 */
 	public static function language()
 	{
-		JHtml::_('bootstrap.tooltip');
+		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
 
 		// Create the batch selector to change the language on a selection list.
 		return
-			'<label id="batch-language-lbl" for="batch-language-id" class="hasToolip"'
+			'<label id="batch-language-lbl" for="batch-language-id" class="modalTooltip"'
 			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_LANGUAGE_LABEL', 'JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">'
 			. JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL')
 			. '</label>'
@@ -113,7 +113,7 @@ abstract class JHtmlBatch
 	 */
 	public static function user($noUser = true)
 	{
-		JHtml::_('bootstrap.tooltip');
+		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
 
 		$optionNo = '';
 
@@ -124,7 +124,7 @@ abstract class JHtmlBatch
 
 		// Create the batch selector to select a user on a selection list.
 		return
-			'<label id="batch-user-lbl" for="batch-user" class="hasTooltip"'
+			'<label id="batch-user-lbl" for="batch-user" class="modalTooltip"'
 			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_USER_LABEL', 'JLIB_HTML_BATCH_USER_LABEL_DESC') . '">'
 			. JText::_('JLIB_HTML_BATCH_USER_LABEL')
 			. '</label>'
@@ -144,11 +144,11 @@ abstract class JHtmlBatch
 	 */
 	public static function tag()
 	{
-		JHtml::_('bootstrap.tooltip');
+		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
 
 		// Create the batch selector to tag items on a selection list.
 		return
-			'<label id="batch-tag-lbl" for="batch-tag-id" class="hasTooltip"'
+			'<label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip"'
 			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC') . '">'
 			. JText::_('JLIB_HTML_BATCH_TAG_LABEL')
 			. '</label>'

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -31,7 +31,7 @@ abstract class JHtmlBatch
 
 		// Create the batch selector to change an access level on a selection list.
 		return
-			'<label id="batch-access-lbl" for="batch-access" class="modalTooltip"'
+			'<label id="batch-access-lbl" for="batch-access" class="modalTooltip" '
 			. 'title="' . JHtml::tooltipText('JLIB_HTML_BATCH_ACCESS_LABEL', 'JLIB_HTML_BATCH_ACCESS_LABEL_DESC') . '">'
 			. JText::_('JLIB_HTML_BATCH_ACCESS_LABEL')
 			. '</label>'


### PR DESCRIPTION
This was an outgrowth of PR #3141 where it was noted that when performing Batch actions in any component, the tooltips appear behind the modal window.  This is because bootstrap attaches .hasTooltip to "body".

This patch changes the CSS selector for each Batch widget to .modalTooltip and sets the container to .modal-body.

We have one successful test as mentioned in Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33303
