### PR TITLE
[#33314] fix $originalOrders undefined var

### DIFF
--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -69,6 +69,39 @@ class CategoriesControllerCategories extends JControllerAdmin
 	}
 
 	/**
+	 * Save the manual order inputs from the categories list page.
+	 *
+	 * @return      void
+	 *
+	 * @since       1.6
+	 * @see         JControllerAdmin::saveorder()
+	 * @deprecated  4.0
+	 */
+	public function saveorder()
+	{
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+
+		JLog::add('CategoriesControllerCategories::saveorder() is deprecated. Function will be removed in 4.0', JLog::WARNING, 'deprecated');
+		
+		// Get the arrays from the Request
+		$order = $this->input->post->get('order', null, 'array');
+		$originalOrder = explode(',', $this->input->getString('original_order_values'));
+
+		// Make sure something has changed
+		if (!($order === $originalOrder))
+		{
+			parent::saveorder();
+		}
+		else
+		{
+			// Nothing to reorder
+			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+
+			return true;
+		}
+	}
+
+	/**
 	 * Deletes and returns correctly.
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -69,35 +69,6 @@ class CategoriesControllerCategories extends JControllerAdmin
 	}
 
 	/**
-	 * Save the manual order inputs from the categories list page.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.6
-	 */
-	public function saveorder()
-	{
-		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
-
-		// Get the arrays from the Request
-		$order = $this->input->post->get('order', null, 'array');
-		$originalOrder = explode(',', $this->input->getString('original_order_values'));
-
-		// Make sure something has changed
-		if (!($order === $originalOrder))
-		{
-			parent::saveorder();
-		}
-		else
-		{
-			// Nothing to reorder
-			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
-
-			return true;
-		}
-	}
-
-	/**
 	 * Deletes and returns correctly.
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -24,7 +24,6 @@ $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 $ordering 	= ($listOrder == 'a.lft');
 $saveOrder 	= ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$originalOrders = array();
 
 if ($saveOrder)
 {
@@ -215,7 +214,6 @@ $sortFields = $this->getSortFields();
 		<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="original_order_values" value="<?php echo implode($originalOrders, ','); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -61,27 +61,6 @@ class MenusControllerItems extends JControllerAdmin
 		}
 	}
 
-	public function saveorder()
-	{
-		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
-
-		// Get the arrays from the Request
-		$order = $this->input->post->get('order', null, 'array');
-		$originalOrder = explode(',', $this->input->getString('original_order_values'));
-
-		// Make sure something has changed
-		if (!($order === $originalOrder))
-		{
-			parent::saveorder();
-		}
-		else
-		{
-			// Nothing to reorder
-			$this->setRedirect(JRoute::_('index.php?option='.$this->option.'&view='.$this->view_list, false));
-			return true;
-		}
-	}
-
 	/**
 	 * Method to set the home property for a list of items
 	 *

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -62,6 +62,37 @@ class MenusControllerItems extends JControllerAdmin
 	}
 
 	/**
+	 * Save the manual order inputs from the menu items list view
+	 * 
+	 * @return      void
+	 * 
+	 * @see         JControllerAdmin::saveorder()
+	 * @deprecated  4.0
+	 */
+	public function saveorder()
+	{
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+
+		JLog::add('MenusControllerItems::saveorder() is deprecated. Function will be removed in 4.0', JLog::WARNING, 'deprecated');
+		
+		// Get the arrays from the Request
+		$order = $this->input->post->get('order', null, 'array');
+		$originalOrder = explode(',', $this->input->getString('original_order_values'));
+
+		// Make sure something has changed
+		if (!($order === $originalOrder))
+		{
+			parent::saveorder();
+		}
+		else
+		{
+			// Nothing to reorder
+			$this->setRedirect(JRoute::_('index.php?option='.$this->option.'&view='.$this->view_list, false));
+			return true;
+		}
+	}
+
+	/**
 	 * Method to set the home property for a list of items
 	 *
 	 * @since   1.6

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -24,7 +24,6 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 $ordering 	= ($listOrder == 'a.lft');
 $canOrder	= $user->authorise('core.edit.state',	'com_menus');
 $saveOrder 	= ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$originalOrders = array();
 
 if ($saveOrder)
 {
@@ -249,7 +248,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="original_order_values" value="<?php echo implode($originalOrders, ','); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -30,7 +30,6 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'categoryList', 'adminForm', strtolower($listDirn), $saveOrderingUrl, false, true);
 }
 $sortFields = $this->getSortFields();
-$originalOrders = array();
 ?>
 <script type="text/javascript">
 	Joomla.orderTable = function() {
@@ -232,7 +231,6 @@ $originalOrders = array();
 		<input type="hidden" name="boxchecked" value="0" />
 		<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
 		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
-		<input type="hidden" name="original_order_values" value="<?php echo implode($originalOrders, ','); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -30,6 +30,7 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'categoryList', 'adminForm', strtolower($listDirn), $saveOrderingUrl, false, true);
 }
 $sortFields = $this->getSortFields();
+$originalOrders = array();
 ?>
 <script type="text/javascript">
 	Joomla.orderTable = function() {
@@ -125,7 +126,6 @@ $sortFields = $this->getSortFields();
 				</tfoot>
 				<tbody>
 				<?php
-				$originalOrders = array();
 				foreach ($this->items as $i => $item) :
 					$orderkey   = array_search($item->id, $this->ordering[$item->parent_id]);
 					$canCreate  = $user->authorise('core.create',     'com_tags');

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -116,7 +116,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 				</thead>
 
 				<tbody>
-					<?php $originalOrders = array(); ?>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<?php
 						$orderkey = array_search($item->id, $this->ordering[$item->parent_id]);
@@ -159,7 +158,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 									<?php endif; ?>
 									<?php $disabled = $saveOrder ? '' : 'disabled="disabled"'; ?>
 									<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
-									<?php $originalOrders[] = $orderkey + 1; ?>
 								<?php else : ?>
 									<?php echo $orderkey + 1; ?>
 								<?php endif; ?>
@@ -201,7 +199,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<input type="hidden" name="boxchecked" value="0" />
 			<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
 			<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
-			<input type="hidden" name="original_order_values" value="<?php echo implode($originalOrders, ','); ?>" />
 			<?php echo JHtml::_('form.token'); ?>
 		</div>
 	</form>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -134,7 +134,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 
 		<tbody>
 		<?php
-		$originalOrders = array();
 		foreach ($this->items as $i => $item) :
 			$orderkey   = array_search($item->id, $this->ordering[$item->parent_id]);
 			$canCreate  = $user->authorise('core.create',     'com_menus');
@@ -180,7 +179,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
 						<input type="text" name="order[]" value="<?php echo $orderkey + 1;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
-						<?php $originalOrders[] = $orderkey + 1; ?>
 					<?php else : ?>
 						<?php echo $orderkey + 1;?>
 					<?php endif; ?>
@@ -244,7 +242,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 	<input type="hidden" name="boxchecked" value="0" />
 	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
 	<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
-	<input type="hidden" name="original_order_values" value="<?php echo implode($originalOrders, ','); ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>


### PR DESCRIPTION
As reported in Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33314

$originalOrders var is only set if Tags exist -- moved $originalOrders = array() to earlier in code where other fields are initialized.
