### PR TITLE
Fix "Install from URL" and "Install from WEB" - be more flexible [#33316]

### DIFF
--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -60,8 +60,25 @@ abstract class JInstallerHelper
 
 		if (isset($response->headers['Content-Disposition']))
 		{
+			// Expected format:
+			// Content-Disposition: attachment; filename="fname.ext"
 			$contentfilename = explode("\"", $response->headers['Content-Disposition']);
-			$target = $contentfilename[1];
+
+			if (isset($contentfilename[1]))
+			{
+				$target = $contentfilename[1];
+			}
+			else
+			{
+				// Expected format:
+				// Content-Disposition: attachment; filename=fname.ext
+				$contentfilename = explode('filename=', $response->headers['Content-Disposition']);
+
+				if (isset($contentfilename[1]))
+				{
+					$target = trim($contentfilename[1], '"');
+				}
+			}
 		}
 
 		// Set the target path if not given


### PR DESCRIPTION
Currently the "Install from URL" and "Install from WEB" tasks fail in some special cases.
#### Test:

Try the "Install from URL" task with the following URL:
https://github.com/jtester/TestExtension/archive/1.0.zip

**Expected**: Installation successful
**Actual**: Unable to find install package
#### Test2:

Download the package first and install via "Upload"

**Expected**: Installation successful
**Actual**: Installation successful

Apply the patch

The "Install from URL" task should work now.

Ref: Old bug tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33316
