### PR TITLE
Patch removing type hinting

### DIFF
--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -89,8 +89,13 @@ class ContenthistoryHelper
 	 *
 	 * @since   3.2
 	 */
-	public static function getFormValues($object, JTableContenttype $typesTable)
+	public static function getFormValues($object, $typesTable)
 	{
+		if (!(get_class($typesTable) == 'JTableContenttype'  || is_subclass_of($typesTable, 'JTableContenttype')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$labels = array();
 		$values = array();
 		$expandedObjectArray = static::createObjectArray($object);
@@ -145,8 +150,13 @@ class ContenthistoryHelper
 	 *
 	 * @since   3.2
 	 */
-	public static function getFormFile(JTableContenttype $typesTable)
+	public static function getFormFile($typesTable)
 	{
+		if (!(get_class($typesTable) == 'JTableContenttype'  || is_subclass_of($typesTable, 'JTableContenttype')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$result = false;
 		jimport('joomla.filesystem.file');
 		jimport('joomla.filesystem.folder');
@@ -321,8 +331,13 @@ class ContenthistoryHelper
 	 *
 	 * @since   3.2
 	 */
-	public static function prepareData(JTableContenthistory $table)
+	public static function prepareData($table)
 	{
+		if (!(get_class($table) == 'JTableContenttype'  || is_subclass_of($table, 'JTableContenttype')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$object = static::decodeFields($table->version_data);
 		$typesTable = JTable::getInstance('Contenttype');
 		$typesTable->load(array('type_id' => $table->ucm_type_id));

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -190,8 +190,13 @@ class JHelperContent
 	 *
 	 * @since   3.1
 	 */
-	public function getRowData(JTable $table)
+	public function getRowData($table)
 	{
+		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$data = new JHelper;
 
 		return $data->getRowData($table);

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -192,7 +192,7 @@ class JHelperContent
 	 */
 	public function getRowData($table)
 	{
-		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
 		{
 			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
 		}

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -80,8 +80,13 @@ class JHelper
 	 *
 	 * @since   3.2
 	 */
-	public function getRowData(JTable $table)
+	public function getRowData($table)
 	{
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$fields = $table->getFields();
 		$data = array();
 
@@ -104,8 +109,13 @@ class JHelper
 	 *
 	 * @since   3.2
 	 */
-	public function getDataObject(JTable $table)
+	public function getDataObject($table)
 	{
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$fields = $table->getFields();
 		$dataObject = new stdClass;
 

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -344,7 +344,7 @@ class JHelperTags extends JHelper
 	 */
 	public function deleteTagData($table, $contentItemId)
 	{
-		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
 		{
 			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
 		}

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -342,8 +342,13 @@ class JHelperTags extends JHelper
 	 *
 	 * @since   3.1
 	 */
-	public function deleteTagData(JTable $table, $contentItemId)
+	public function deleteTagData($table, $contentItemId)
 	{
+		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$result = $this->unTagItem($contentItemId, $table);
 
 		/**

--- a/libraries/cms/ucm/content.php
+++ b/libraries/cms/ucm/content.php
@@ -43,8 +43,13 @@ class JUcmContent extends JUcmBase
 	 *
 	 * @since   3.1
 	 */
-	public function __construct(JTable $table = null, $alias = null, JUcmType $type = null)
+	public function __construct($table = null, $alias = null, JUcmType $type = null)
 	{
+		if (!(is_null($table) || get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		// Setup dependencies.
 		$input = JFactory::getApplication()->input;
 		$this->alias = isset($alias) ? $alias : $input->get('option') . '.' . $input->get('view');

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -34,8 +34,13 @@ abstract class JTableObserver implements JObserverInterface
 	 *
 	 * @since   3.1.2
 	 */
-	public function __construct(JTable $table)
+	public function __construct($table)
 	{
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$table->attachObserver($this);
 		$this->table = $table;
 	}

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -388,8 +388,13 @@ abstract class JTable extends JObject implements JObservableInterface
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId(JTable $table = null, $id = null)
+	protected function _getAssetParentId($table = null, $id = null)
 	{
+		if (!(is_null($table) || get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		// For simple cases, parent to the asset root.
 		$assets = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
 		$rootId = $assets->getRootId();

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -70,8 +70,13 @@ class JTableCategory extends JTableNested
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId(JTable $table = null, $id = null)
+	protected function _getAssetParentId($table = null, $id = null)
 	{
+		if (!(is_null($table) || get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$assetId = null;
 
 		// This is a category under a category.

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -80,8 +80,13 @@ class JTableContent extends JTable
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId(JTable $table = null, $id = null)
+	protected function _getAssetParentId($table = null, $id = null)
 	{
+		if (!(is_null($table) || get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$assetId = null;
 
 		// This is a article under a category.

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -72,7 +72,7 @@ class JTableModule extends JTable
 	 */
 	protected function _getAssetParentId($table = null, $id = null)
 	{
-		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		if (!(get_class($table) == 'JTable'  || is_subclass_of($table, 'JTable')))
 		{
 			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
 		}

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -70,8 +70,13 @@ class JTableModule extends JTable
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId(JTable $table = null, $id = null)
+	protected function _getAssetParentId($table = null, $id = null)
 	{
+		if (!(get_class($typesTable) == 'JTable'  || is_subclass_of($typesTable, 'JTable')))
+		{
+			throw new Exception(JText::_('JERROR_WRONG_CLASS_TYPE'));
+		}
+
 		$assetId = null;
 
 		// This is a module that needs to parent with the extension.


### PR DESCRIPTION
The reason for doing this is that it breaks FOF tag implementation, while this only affects a couple of files I removed it for JTable\* classes in the whole repository so that we don't use Type Hinting for JTable*. Type hinting may be a good idea but it doesn't work in the real world with developing extensions for Joomla!

The main problem is that FOF uses the JHelperTags(), this is based on JHelper and here the function getRowData has a type Hint of JTable but in this case we have a FOFTable. The type hint makes the JHelperTags() useless for other extensions that are not using JTable directly. 
