### PR TITLE
[#25616] Delete URL-Parameter limitstart, if its value is 0

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -590,9 +590,9 @@ class JRouterSite extends JRouter
 
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
-			if ($limitstart = $uri->getVar('limitstart'))
+			if (!is_null($limitstart = $uri->getVar('limitstart')))
 			{
-				$uri->setVar('start', (int) $limitstart);
+				if($limitstart>0) $uri->setVar('start', (int) $limitstart);
 				$uri->delVar('limitstart');
 			}
 		}

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -590,11 +590,12 @@ class JRouterSite extends JRouter
 
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
-			if (!is_null($limitstart = $uri->getVar('limitstart')))
+			$limitstart = (int) $uri->getVar('limitstart');
+			if ($limistart > 0)
 			{
-				if($limitstart>0) $uri->setVar('start', (int) $limitstart);
-				$uri->delVar('limitstart');
+				$uri->setVar('start', $limitstart);
 			}
+			$uri->delVar('limitstart');
 		}
 
 		$uri->setPath($route);


### PR DESCRIPTION
Cosmetic change for consistence and avoidance of duplicate URLs.
See also this Bug report: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25616&start=0
Before change $limitstart was deleted if present, except if it was 0 (zero), because 0 evaluates to false.
