### PR TITLE
[#33324] fix JSessionStorageMemcache and JSessionStorageMemcached

### DIFF
--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -19,6 +19,14 @@ defined('JPATH_PLATFORM') or die;
 class JSessionStorageMemcache extends JSessionStorage
 {
 	/**
+	 * The registered servers stack.
+	 *
+	 * @var    array
+	 * @since  12.2
+	 */
+	private $_servers;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -36,6 +36,7 @@ class JSessionStorageMemcache extends JSessionStorage
 		$config = JFactory::getConfig();
 
 		// This will be an array of loveliness
+		// This might help: {@link http://www.php.net/manual/en/memcached.sessions.php#112439}
 		// @todo: multiple servers
 		$this->_servers = array(
 			array(
@@ -56,7 +57,7 @@ class JSessionStorageMemcache extends JSessionStorage
 	 */
 	public function register()
 	{
-
+		// This might help: {@link http://www.php.net/manual/en/memcached.sessions.php#112439}
 		// @todo: evaluate servers count first
 		$server = current($this->_servers);
 		

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -33,8 +33,6 @@ class JSessionStorageMemcache extends JSessionStorage
 			throw new RuntimeException('Memcache Extension is not available', 404);
 		}
 
-		parent::__construct($options);
-
 		$config = JFactory::getConfig();
 
 		// This will be an array of loveliness
@@ -45,6 +43,8 @@ class JSessionStorageMemcache extends JSessionStorage
 				'port' => $config->get('memcache_server_port', 11211)
 			)
 		);
+
+		parent::__construct($options);
 	}
 
 	/**
@@ -56,7 +56,11 @@ class JSessionStorageMemcache extends JSessionStorage
 	 */
 	public function register()
 	{
-		ini_set('session.save_path', $this->_servers['host'] . ':' . $this->_servers['port']);
+
+		// @todo: evaluate servers count first
+		$server = current($this->_servers);
+		
+		ini_set('session.save_path', $server['host'] . ':' . $server['port']);
 		ini_set('session.save_handler', 'memcache');
 	}
 

--- a/libraries/joomla/session/storage/memcached.php
+++ b/libraries/joomla/session/storage/memcached.php
@@ -19,6 +19,14 @@ defined('JPATH_PLATFORM') or die;
 class JSessionStorageMemcached extends JSessionStorage
 {
 	/**
+	 * The registered servers stack.
+	 *
+	 * @var    array
+	 * @since  12.2
+	 */
+	private $_servers;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.
@@ -33,11 +41,10 @@ class JSessionStorageMemcached extends JSessionStorage
 			throw new RuntimeException('Memcached Extension is not available', 404);
 		}
 
-		parent::__construct($options);
-
 		$config = JFactory::getConfig();
 
 		// This will be an array of loveliness
+		// This might help: {@link http://www.php.net/manual/en/memcached.sessions.php#112439}
 		// @todo: multiple servers
 		$this->_servers = array(
 			array(
@@ -45,6 +52,8 @@ class JSessionStorageMemcached extends JSessionStorage
 				'port' => $config->get('memcache_server_port', 11211)
 			)
 		);
+
+		parent::__construct($options);
 	}
 
 	/**
@@ -56,7 +65,11 @@ class JSessionStorageMemcached extends JSessionStorage
 	 */
 	public function register()
 	{
-		ini_set('session.save_path', $this->_servers['host'] . ':' . $this->_servers['port']);
+		// This might help: {@link http://www.php.net/manual/en/memcached.sessions.php#112439}
+		// @todo: evaluate servers count first
+		$server = current($this->_servers);
+		
+		ini_set('session.save_path', $server['host'] . ':' . $server['port']);
 		ini_set('session.save_handler', 'memcached');
 	}
 


### PR DESCRIPTION
Fixing issue described in [bug #33324](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33324), related to session storage classes JSessionStorageMemcache and JSessionStorageMemcached (libraries/joomla/session/storage/memcache(d).php)

There are presently three problems within this class.
1. Within the constructor an object variable is referenced that hasn't been initialised thus causing en error to be thrown trying to reference an uninitialised variable. So, $_servers is now a private object variable.
2. Within the constructor the parent class' constructor is called before the object variable $_servers was actually initialised.
3. The parent class' constructor's job is to call

```
$this->register($options)
```

This method is overridden by this class. Within the method the object variable $_servers is referenced for session.save_path population. Without the patch the call for $_servers ends up with no data. With the patch applied, the call receives the populated object variable containing all registered servers.
1. As it is obviously intended to register more than one server the variable $_servers is an array of arrays. Thus, in register it must be evaluated how many servers are registered and which one to select. I guess this will involve priority flags at some day. Currently there is only one server registered. So we have to reference this entry first before we can read its host:port for assignment. With this patch applied, this session handler is properly loaded and working.
