### PR TITLE
[#33284] type cast $plugin to string

### DIFF
--- a/libraries/cms/form/rule/captcha.php
+++ b/libraries/cms/form/rule/captcha.php
@@ -45,7 +45,7 @@ class JFormRuleCaptcha extends JFormRule
 		}
 		else
 		{
-			$captcha = JCaptcha::getInstance($plugin, array('namespace' => (string) $namespace));
+			$captcha = JCaptcha::getInstance((string) $plugin, array('namespace' => (string) $namespace));
 		}
 
 		// Test the value.


### PR DESCRIPTION
$plugin in JFormRuleCaptcha::getInstance() is a SimpleXMLElement and needs to be cast as string to avoid Error.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33284
