### PR TITLE
fix editorType to read correct element

### DIFF
--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -211,7 +211,9 @@ class JFormFieldEditor extends JFormFieldTextarea
 
 			$buttons    = (string) $this->element['buttons'];
 			$hide       = (string) $this->element['hide'];
-			$editorType = (string) $this->element['editor'];
+			
+			// For backward compatibility, revert to editor if editorType is not provided
+			$editorType = ($this->element['editorType'] ? (string) $this->element['editorType'] : (string) $this->element['editor']);
 
 			if ($buttons == 'true' || $buttons == 'yes' || $buttons == '1')
 			{


### PR DESCRIPTION
In JFormFieldEditor, $editorType reads $element['editor'] instead of $element['editorType']

For BC, added a fallback to use 'editor' if 'editorType' is not provided as an attribute.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33257
