### PR TITLE
[#33325] Value doesn't evaluated as default

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -241,14 +241,6 @@ abstract class JFormField
 	protected $value;
 
 	/**
-	 * The default value of the form field.
-	 *
-	 * @var    mixed
-	 * @since  11.1
-	 */
-	protected $default;
-
-	/**
 	 * The size of the form field.
 	 *
 	 * @var    integer
@@ -426,7 +418,6 @@ abstract class JFormField
 			case 'validate':
 			case 'pattern':
 			case 'group':
-			case 'default':
 				$this->$name = (string) $value;
 				break;
 
@@ -547,12 +538,10 @@ abstract class JFormField
 
 		$attributes = array(
 			'multiple', 'name', 'id', 'hint', 'class', 'description', 'labelclass', 'onchange',
-			'onclick', 'validate', 'pattern', 'default', 'required',
+			'onclick', 'validate', 'pattern', 'required',
 			'disabled', 'readonly', 'autofocus', 'hidden', 'autocomplete', 'spellcheck',
 			'translateHint', 'translateLabel','translate_label', 'translateDescription',
 			'translate_description' ,'size');
-
-		$this->default = isset($element['value']) ? (string) $element['value'] : $this->default;
 
 		// Set the field default value.
 		$this->value = $value;

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -39,6 +39,14 @@ class JFormFieldCheckbox extends JFormField
 	protected $checked = false;
 
 	/**
+	 * The value of the field if checked.
+	 *
+	 * @var    string
+	 * @since  3.2
+	 */
+	protected $checkedValue = '1';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to the the value.
@@ -52,6 +60,7 @@ class JFormFieldCheckbox extends JFormField
 		switch ($name)
 		{
 			case 'checked':
+			case 'checkedValue':
 				return $this->$name;
 		}
 
@@ -75,6 +84,11 @@ class JFormFieldCheckbox extends JFormField
 			case 'checked':
 				$value = (string) $value;
 				$this->$name = ($value == 'true' || $value == $name || $value == '1');
+				break;
+
+			case 'checkedValue':
+				$value = (string) $value;
+				$this->$name = $value;
 				break;
 
 			default:
@@ -106,6 +120,9 @@ class JFormFieldCheckbox extends JFormField
 			$this->checked = ($checked == 'true' || $checked == 'checked' || $checked == '1');
 
 			empty($this->value) || $this->checked ? null : $this->checked = true;
+
+			$value = (string) $this->element['value'];
+			$this->checkedValue = !empty($value) ? $value : '1';
 		}
 
 		return $return;
@@ -124,7 +141,6 @@ class JFormFieldCheckbox extends JFormField
 		// Initialize some field attributes.
 		$class     = !empty($this->class) ? ' class="' . $this->class . '"' : '';
 		$disabled  = $this->disabled ? ' disabled' : '';
-		$value     = !empty($this->default) ? $this->default : '1';
 		$required  = $this->required ? ' required aria-required="true"' : '';
 		$autofocus = $this->autofocus ? ' autofocus' : '';
 		$checked   = $this->checked || !empty($this->value) ? ' checked' : '';
@@ -138,7 +154,7 @@ class JFormFieldCheckbox extends JFormField
 		JHtml::_('script', 'system/html5fallback.js', false, true);
 
 		return '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $onchange
+			. htmlspecialchars($this->checkedValue, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $onchange
 			. $required . $autofocus . ' />';
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxTest.php
@@ -90,7 +90,7 @@ class JFormFieldCheckboxTest extends TestCase
 	{
 		$field = new JFormFieldCheckbox;
 		$element = simplexml_load_string(
-			'<field name="myName" type="checkbox" checked="true" />');
+			'<field name="myName" type="checkbox" checked="true" value="red" />');
 
 		$this->assertThat(
 			$field->setup($element, ''),
@@ -101,6 +101,12 @@ class JFormFieldCheckboxTest extends TestCase
 		$this->assertThat(
 			$field->checked,
 			$this->isTrue(),
+			'Line:' . __LINE__ . ' The property should be computed from the XML.'
+		);
+
+		$this->assertEquals(
+			'red',
+			$field->checkedValue,
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldCheckbox-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldCheckbox-helper-dataset.php
@@ -29,20 +29,29 @@ class JHtmlFieldCheckboxTest_DataSet
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',
-				'default' => 'red',
-				'value' => 'red',
+				'checkedValue' => 'red',
 			),
-			'<input type="checkbox" name="myTestName" id="myTestId" value="red" checked />',
+			'<input type="checkbox" name="myTestName" id="myTestId" value="red" />',
 		),
 
-		'NoValueChecked' => array(
+		// Default gets evaluated as value.
+		'NoValueCheckedUsingDefault' => array(
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',
-				'default' => 'red',
+				'value' => 'red',
+				'checkedValue' => '1',
+			),
+			'<input type="checkbox" name="myTestName" id="myTestId" value="1" checked />',
+		),
+
+		'NoValueCheckedUsingChecked' => array(
+			array(
+				'id' => 'myTestId',
+				'name' => 'myTestName',
 				'checked' => true,
 			),
-			'<input type="checkbox" name="myTestName" id="myTestId" value="red" checked />',
+			'<input type="checkbox" name="myTestName" id="myTestId" value="1" checked />',
 		),
 
 		'Disabled' => array(


### PR DESCRIPTION
if value attribute is present in the xml of a field it should be evaluated as its default value.
Check issue https://github.com/joomla/joomla-cms/issues/3158

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33325&start=0
