### PR TITLE
[#33327] Missing target="_parent", external URL menu type

### DIFF
--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -30,7 +30,7 @@ $flink = JFilterOutput::ampReplace(htmlspecialchars($flink));
 switch ($item->browserNav) :
 	default:
 	case 0:
-?><a <?php echo $class; ?>href="<?php echo $flink; ?>" <?php echo $title; ?>><?php echo $linktype; ?></a><?php
+?><a <?php echo $class; ?>href="<?php echo $flink; ?>" target="_parent" <?php echo $title; ?>><?php echo $linktype; ?></a><?php
 		break;
 	case 1:
 		// _blank


### PR DESCRIPTION
When creating a menu item type 'External URL', with target window "parent", it is missing the target="_parent" to get link opens in parent frame.

Note: "_parent" needed in firefox when site in a pinned tab.

Issue Tracker 33327 : http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33327
