### PR TITLE
 [#33332] Invalid language keys for registration password and confirm

### DIFF
--- a/components/com_users/models/forms/profile.xml
+++ b/components/com_users/models/forms/profile.xml
@@ -26,26 +26,26 @@
 			validate="username"
 		/>
 
-		<field name="password2" type="password"
-			autocomplete="off"
-			class="validate-password"
-			description="COM_USERS_DESIRED_PASSWORD"
-			field="password1"
-			filter="raw"
-			label="COM_USERS_PROFILE_PASSWORD1_LABEL"
-			message="COM_USERS_PROFILE_PASSWORD1_MESSAGE"
-			size="30"
-			validate="equals"
-		/>
-
 		<field name="password1" type="password"
 			autocomplete="off"
 			class="validate-password"
-			description="COM_USERS_PROFILE_PASSWORD2_DESC"
+			description="COM_USERS_DESIRED_PASSWORD"
 			filter="raw"
-			label="COM_USERS_PROFILE_PASSWORD2_LABEL"
+			label="COM_USERS_PROFILE_PASSWORD1_LABEL"
 			size="30"
 			validate="password"
+		/>
+
+		<field name="password2" type="password"
+			autocomplete="off"
+			class="validate-password"
+			description="COM_USERS_PROFILE_PASSWORD2_DESC"
+			field="password1"
+			filter="raw"
+			label="COM_USERS_PROFILE_PASSWORD2_LABEL"
+			message="COM_USERS_PROFILE_PASSWORD1_MESSAGE"
+			size="30"
+			validate="equals"
 		/>
 
 		<field name="email1" type="email"

--- a/components/com_users/models/forms/registration.xml
+++ b/components/com_users/models/forms/registration.xml
@@ -27,27 +27,28 @@
 			validate="username"
 		/>
 
-		<field name="password2" type="password"
+		<field name="password1" type="password"
 			autocomplete="off"
 			class="validate-password"
 			description="COM_USERS_DESIRED_PASSWORD"
 			field="password1"
 			filter="raw"
 			label="COM_USERS_PROFILE_PASSWORD1_LABEL"
-			message="COM_USERS_PROFILE_PASSWORD1_MESSAGE"
 			size="30"
-			validate="equals"
+			validate="password"
 			required="true"
 		/>
 
-		<field name="password1" type="password"
+		<field name="password2" type="password"
 			autocomplete="off"
 			class="validate-password"
 			description="COM_USERS_PROFILE_PASSWORD2_DESC"
+			field="password1"
 			filter="raw"
 			label="COM_USERS_PROFILE_PASSWORD2_LABEL"
+			message="COM_USERS_PROFILE_PASSWORD1_MESSAGE"
 			size="30"
-			validate="password"
+			validate="equals"
 			required="true"
 		/>
 


### PR DESCRIPTION
Password fields are messed: password1 should be main password and password2 should be confirm password.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33332&start=0
