### PR TITLE
[#33335] var childrennumitems in JCategoryNode is never set

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -102,11 +102,14 @@ JHtml::_('behavior.caption');
 	<?php endif; ?>
 
 	<?php if (!empty($this->children[$this->category->id]) && $this->maxLevel != 0) : ?>
+		<?php if ($this->params->get('show_empty_categories', 1) || $this->category->childrennumitems > 0) : ?>
 		<div class="cat-children">
-			<?php if ($this->params->get('show_category_heading_title_text', 1) == 1) : ?>
+			<?php if ($this->params->get('show_category_heading_title_text', 1)) : ?>
 				<h3> <?php echo JTEXT::_('JGLOBAL_SUBCATEGORIES'); ?> </h3>
 			<?php endif; ?>
-			<?php echo $this->loadTemplate('children'); ?> </div>
+			<?php echo $this->loadTemplate('children'); ?> 
+		</div>
+		<?php endif; ?>
 	<?php endif; ?>
 	<?php if (($this->params->def('show_pagination', 1) == 1 || ($this->params->get('show_pagination') == 2)) && ($this->pagination->get('pages.total') > 1)) : ?>
 		<div class="pagination">

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -52,13 +52,16 @@ $tagsData  = $displayData->get('category')->tags->itemTags;
 		<?php echo $displayData->loadTemplate($displayData->subtemplatename); ?>
 
 		<?php if ($displayData->get('children') && $displayData->maxLevel != 0) : ?>
+			<?php if ($params->get('show_empty_categories', 1) || $displayData->get('category')->childrennumitems > 0) : ?>
 			<div class="cat-children">
-				<h3>
-					<?php echo JTEXT::_('JGLOBAL_SUBCATEGORIES'); ?>
-				</h3>
-
+				<?php if ($params->get('show_category_heading_title_text', 1)) : ?>
+					<h3>
+						<?php echo JTEXT::_('JGLOBAL_SUBCATEGORIES'); ?>
+					</h3>
+				<?php endif; ?>
 				<?php echo $displayData->loadTemplate('children'); ?>
 			</div>
+			<?php endif; ?>
 		<?php endif; ?>
 	</div>
 </div>

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -361,6 +361,8 @@ class JCategories
 		{
 			$this->_nodes[$id] = null;
 		}
+		
+		$this->_nodes[$id]->childrennumitems = $this->_nodes[$id]->getNumItems(true) - $this->_nodes[$id]->getNumItems(false);
 	}
 }
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -362,7 +362,10 @@ class JCategories
 			$this->_nodes[$id] = null;
 		}
 		
-		$this->_nodes[$id]->childrennumitems = $this->_nodes[$id]->getNumItems(true) - $this->_nodes[$id]->getNumItems(false);
+		if (isset($this->_options['countItems']))
+		{
+			$this->_nodes[$id]->childrennumitems = $this->_nodes[$id]->getNumItems(true) - $this->_nodes[$id]->getNumItems(false);
+		}
 	}
 }
 


### PR DESCRIPTION
When the option 'countItems' is passed to the JCategories load function, the var 'numitems' is created for JCategoryNode; however, 'childrennumitems' is never set.

The patch sets the value of 'childrennumitems' at the end of the load function, after all the nodes have been created.

Having this value available is helpful in cases such as Tracker #33002 -- where the "Subcategories" text is displayed even if user chooses to hide empty subcategories and none of the subcategories have items.

Patch also includes suggested changes to the content category layout file and to com_content blog category view to help with testing.
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33335
