### PR TITLE
[#33337] fix 'show_tags' in content category layout

### DIFF
--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -111,6 +111,15 @@
 				<option value="1">JSHOW</option>
 			</field>
 
+			<field name="show_tags" type="list"
+				label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+				description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
 			<field name="page_subheading" type="text"
 				description="JGLOBAL_SUBHEADING_DESC"
 				label="JGLOBAL_SUBHEADING_LABEL"

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -35,7 +35,7 @@ $tagsData  = $displayData->get('category')->tags->itemTags;
 				<?php echo JHtml::_('content.prepare', $displayData->get('category')->title, '', $extension.'.category'); ?>
 			</h2>
 		<?php endif; ?>
-		<?php if ($displayData->get('show_tags', 1)) : ?>
+		<?php if ($params->get('show_tags', 1)) : ?>
 			<?php echo JLayoutHelper::render('joomla.content.tags', $tagsData); ?>
 		<?php endif; ?>
 		<?php if ($params->get('show_description', 1) || $params->def('show_description_image', 1)) : ?>


### PR DESCRIPTION
'show_tags' is incorrectly taken from $displayData instead of $params
It is forced to always be true since it doesn't exist in $displayData ($displayData->get('show_tags', 1)).

Can be tested by setting Content Category param for show_tags to Hide.  They are always displayed.
Also cannot override the component-level setting in the menu item as the field does not exist there.

Patch corrects the layout file and adds the show_tags field to content category xml file.
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33337
