### PR TITLE
Fix wrong results returned by isEnabled

### DIFF
--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -123,9 +123,14 @@ class JLanguageAssociations
 			// If already tested, don't test again.
 			if (!$tested)
 			{
-				$params = new JRegistry(JPluginHelper::getPlugin('system', 'languagefilter')->params);
+				$plugin = JPluginHelper::getPlugin('system', 'languagefilter');
 
-				$enabled  = (boolean) $params->get('item_associations', true);
+				if (!empty($plugin))
+				{
+					$params = new JRegistry($plugin->params);
+					$enabled  = (boolean) $params->get('item_associations', true);
+				}
+
 				$tested = true;
 			}
 		}


### PR DESCRIPTION
When language filter plugin is disabled and language filter is enabled in code using JFactory::getApplication()->setLanguageFilter(true) calling JLanguageAssociations->isEnabled causes notices and fatal errors and returns wrong result if item associations are in fact disabled.

What happens is that JPluginHelper::getPlugin returns empty array when certain plugin is disabled and since there is no params to be passed to JRegistry and $enabled gets default value.
