### PR TITLE
Update intro_image.php - add link to images

### DIFF
--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -13,9 +13,12 @@ $params  = $displayData->params;
 <?php $images = json_decode($displayData->images); ?>
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/> </div>
+	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
+	        <a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>">
+	            <img <?php if ($images->image_intro_caption):
+	                    echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+	                endif; ?>
+	                src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
+	        </a>
+    	</div>
 <?php endif; ?>


### PR DESCRIPTION
Reference: https://groups.google.com/forum/#!topic/joomla-dev-cms/2l8Xy0MaAfo
Standard behaviour in blogs is that images are linked to blog item full text page. Currently only the title can be linked to the full text. The proposed change adds a link to blog image.
Disadvantage: there is no parameter to switch the link off. So if a user does not want the images linked, the layout needs to be overridden. Currently users who DO want the link need to override.
I believe the majority of users will want the images linked, so unlike now, in the future only a minority will need to create an override.
Ideal would be an additional parameter next to the setting for linked titles.
