### PR TITLE
Changed post-installation warning message

### DIFF
--- a/installation/language/en-AU/en-AU.ini
+++ b/installation/language/en-AU/en-AU.ini
@@ -125,7 +125,7 @@ INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic n
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
+INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE 'joomla/installation' FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -125,7 +125,7 @@ INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic n
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
+INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE 'joomla/installation' FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -125,7 +125,7 @@ INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic n
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
+INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE 'joomla/installation' FOLDER.<br />You will not be able to proceed beyond this point until the installation directory has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 


### PR DESCRIPTION
The message, 'PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION
 FOLDER.'was changed to  'PLEASE REMEMBER TO COMPLETELY REMOVE THE
'joomla/installation' FOLDER.'
Tracker ID: #33336
