### PR TITLE
change show_page_heading default

### DIFF
--- a/components/com_content/views/archive/tmpl/default.php
+++ b/components/com_content/views/archive/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.caption');
 ?>
 <div class="archive<?php echo $this->pageclass_sfx;?>">
-<?php if ($this->params->get('show_page_heading', 1)) : ?>
+<?php if ($this->params->get('show_page_heading', 0)) : ?>
 <div class="page-header">
 <h1>
 	<?php echo $this->escape($this->params->get('page_heading')); ?>

--- a/components/com_content/views/archive/tmpl/default.php
+++ b/components/com_content/views/archive/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.caption');
 ?>
 <div class="archive<?php echo $this->pageclass_sfx;?>">
-<?php if ($this->params->get('show_page_heading', 0)) : ?>
+<?php if ($this->params->get('show_page_heading')) : ?>
 <div class="page-header">
 <h1>
 	<?php echo $this->escape($this->params->get('page_heading')); ?>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -24,7 +24,7 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 
 ?>
 <div class="item-page<?php echo $this->pageclass_sfx?>">
-	<?php if ($this->params->get('show_page_heading', 0)) : ?>
+	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -24,7 +24,7 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 
 ?>
 <div class="item-page<?php echo $this->pageclass_sfx?>">
-	<?php if ($this->params->get('show_page_heading', 1)) : ?>
+	<?php if ($this->params->get('show_page_heading', 0)) : ?>
 	<div class="page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
 ?>
 <div class="blog<?php echo $this->pageclass_sfx; ?>">
-	<?php if ($this->params->get('show_page_heading', 0)) : ?>
+	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 		</div>

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
 ?>
 <div class="blog<?php echo $this->pageclass_sfx; ?>">
-	<?php if ($this->params->get('show_page_heading', 1)) : ?>
+	<?php if ($this->params->get('show_page_heading', 0)) : ?>
 		<div class="page-header">
 			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 		</div>

--- a/components/com_search/views/search/tmpl/default.php
+++ b/components/com_search/views/search/tmpl/default.php
@@ -12,7 +12,7 @@ JHtml::_('formbehavior.chosen', 'select');
 ?>
 
 <div class="search<?php echo $this->pageclass_sfx; ?>">
-<?php if ($this->params->get('show_page_heading', 1)) : ?>
+<?php if ($this->params->get('show_page_heading', 0)) : ?>
 <h1 class="page-title">
 	<?php if ($this->escape($this->params->get('page_heading'))) :?>
 		<?php echo $this->escape($this->params->get('page_heading')); ?>

--- a/components/com_search/views/search/tmpl/default.php
+++ b/components/com_search/views/search/tmpl/default.php
@@ -12,7 +12,7 @@ JHtml::_('formbehavior.chosen', 'select');
 ?>
 
 <div class="search<?php echo $this->pageclass_sfx; ?>">
-<?php if ($this->params->get('show_page_heading', 0)) : ?>
+<?php if ($this->params->get('show_page_heading')) : ?>
 <h1 class="page-title">
 	<?php if ($this->escape($this->params->get('page_heading'))) :?>
 		<?php echo $this->escape($this->params->get('page_heading')); ?>


### PR DESCRIPTION
The param show_page_heading still defaults to 1 in some views of com_content and in com_search which is not the desired default behavior.

This was supposedly changed in 2.5 (see Tracker #28682) , but it's back again.  Providing this for the sake of code consistency across components.
