### PR TITLE
[#33347] fix JTable::publish()

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1500,7 +1500,8 @@ abstract class JTable extends JObject implements JObservableInterface
 
 		// Check if the table has a state field at all using common titles.
 		$field = null;
-		if (! property_exists($this, 'published') && ! property_exists($this, 'state'))
+		
+		if (!property_exists($this, 'published') && !property_exists($this, 'state'))
 		{
 			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), 'Table has no state field.'));
 			$this->setError($e);

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1498,6 +1498,30 @@ abstract class JTable extends JObject implements JObservableInterface
 	{
 		$k = $this->_tbl_keys;
 
+		// Check if the table has a state field at all using common titles.
+		$field = null;
+		if (! property_exists($this, 'published') && ! property_exists($this, 'state'))
+		{
+			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), 'Table has no state field.'));
+			$this->setError($e);
+
+			return false;
+		}
+		// Calculate, which field most probably acts as the state field.
+		else
+		{
+			// If the most commonly used field exists, use this.
+			if (property_exists($this, 'published'))
+			{
+				$field = 'published';
+			}
+			// If not, but there is a 'state' field, use that.
+			elseif (property_exists($this, 'state'))
+			{
+				$field = 'state';
+			}
+		}
+
 		if (!is_null($pks))
 		{
 			foreach ($pks AS $key => $pk)
@@ -1538,7 +1562,8 @@ abstract class JTable extends JObject implements JObservableInterface
 			// Update the publishing state for rows with the given primary keys.
 			$query = $this->_db->getQuery(true)
 				->update($this->_tbl)
-				->set('published = ' . (int) $state);
+				// Don't hardcode the field name. Use our detected field.
+				->set("{$field} = " . (int) $state);
 
 			// Determine if there is checkin support for the table.
 			if (property_exists($this, 'checked_out') || property_exists($this, 'checked_out_time'))
@@ -1575,7 +1600,8 @@ abstract class JTable extends JObject implements JObservableInterface
 
 			if ($ours)
 			{
-				$this->published = $state;
+				// Don't hardcode the field name. Use our detected field.
+				$this->{$field} = $state;
 			}
 		}
 


### PR DESCRIPTION
Fixing issue described in [bug #33347](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33347), related to JTable (libraries/joomla/table/table.php)

The publish-function must take care for the field to use for its task. While today it is not only the 'published' field that holds a row's state, but also a field named 'state' (e.g. content-table), it must be taken care of which field to use. For that reason i added a first check for the field's general availability and a second check for the mentioned fields giving the most commonly use one - 'published' - priority. Also the query and value re-assignment were fixed to reference the field from the variable that holds the detected field name. This allows for more flexibility and less unchanged rows.
