### PR TITLE
[#33348] fix JModelAdmin::publish()

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -933,7 +933,7 @@ abstract class JModelAdmin extends JModelForm
 				}
 
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
-				if ($table->checked_out && ((int) $table->checked_out !== (int) $user->id))
+				if (property_exists($table, 'checked_out') && ((int) $table->checked_out !== (int) $user->id))
 				{
 					JLog::add(JText::sprintf('COM_KEY2SWAP_ERROR_ROW_IS_CHECKED_OUT_BY', $pks[$i]), JLog::WARNING, 'jerror');
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -932,9 +932,8 @@ abstract class JModelAdmin extends JModelForm
 					return false;
 				}
 
-				// If the table is checked out by another user, drop it and report to the user
-				// trying to change its state.
-				if ($table->checked_out AND ((int) $table->checked_out !== (int) $user->id))
+				// If the table is checked out by another user, drop it and report to the user trying to change its state.
+				if ($table->checked_out && ((int) $table->checked_out !== (int) $user->id))
 				{
 					JLog::add(JText::sprintf('COM_KEY2SWAP_ERROR_ROW_IS_CHECKED_OUT_BY', $pks[$i]), JLog::WARNING, 'jerror');
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -926,7 +926,20 @@ abstract class JModelAdmin extends JModelForm
 				{
 					// Prune items that you can't change.
 					unset($pks[$i]);
+					
 					JLog::add(JText::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+
+				// If the table is checked out by another user, drop it and report to the user
+				// trying to change its state.
+				if ($table->checked_out AND ((int) $table->checked_out !== (int) $user->id))
+				{
+					JLog::add(JText::sprintf('COM_KEY2SWAP_ERROR_ROW_IS_CHECKED_OUT_BY', $pks[$i]), JLog::WARNING, 'jerror');
+
+					// Prune items that you can't change.
+					unset($pks[$i]);
 
 					return false;
 				}

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -933,7 +933,7 @@ abstract class JModelAdmin extends JModelForm
 				}
 
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
-				if (property_exists($table, 'checked_out') && ((int) $table->checked_out !== (int) $user->id))
+				if (property_exists($table, 'checked_out') && $table->checked_out && ($table->checked_out != $user->id))
 				{
 					JLog::add(JText::sprintf('COM_KEY2SWAP_ERROR_ROW_IS_CHECKED_OUT_BY', $pks[$i]), JLog::WARNING, 'jerror');
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -935,7 +935,7 @@ abstract class JModelAdmin extends JModelForm
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
 				if (property_exists($table, 'checked_out') && $table->checked_out && ($table->checked_out != $user->id))
 				{
-					JLog::add(JText::sprintf('COM_KEY2SWAP_ERROR_ROW_IS_CHECKED_OUT_BY', $pks[$i]), JLog::WARNING, 'jerror');
+					JLog::add(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), JLog::WARNING, 'jerror');
 
 					// Prune items that you can't change.
 					unset($pks[$i]);


### PR DESCRIPTION
Fixing issue described in [bug #33348](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33348), related to JModelAdmin (libraries/legacy/model/admin.php)

When trying to publish an item, the related table might be(en) checked out by another user. Thus, publishing will fail silently, since the table is going to try to check in only if is not checked out at all or if the user trying to check it in equals the one having checked it out. If they mismatch nothing is stated to the user trying to change its state, which is no good. So i added a check for this circumstance.
