### PR TITLE
Porting to 2.5.x loading en-gb language first

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -54,10 +54,8 @@ class CategoriesHelper
 					$lang = JFactory::getLanguage();
 					// loading language file from the administrator/language directory then
 					// loading language file from the administrator/components/*extension*/language directory
-						$lang->load($component, JPATH_BASE, null, false, false)
-					||	$lang->load($component, JPath::clean(JPATH_ADMINISTRATOR.'/components/'.$component), null, false, false)
-					||	$lang->load($component, JPATH_BASE, $lang->getDefault(), false, false)
-					||	$lang->load($component, JPath::clean(JPATH_ADMINISTRATOR.'/components/'.$component), $lang->getDefault(), false, false);
+						$lang->load($component, JPATH_BASE, null, false, true)
+						|| $lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component), null, false, true);
  					call_user_func(array($cName, 'addSubmenu'), 'categories'.(isset($section)?'.'.$section:''));
 				}
 			}

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -315,10 +315,8 @@ class CategoriesModelCategory extends JModelAdmin
 
 		if (file_exists($path))
 		{
-			$lang->load($component, JPATH_BASE, null, false, false);
-			$lang->load($component, JPATH_BASE, $lang->getDefault(), false, false);
-			$lang->load($component, JPATH_BASE . '/components/' . $component, null, false, false);
-			$lang->load($component, JPATH_BASE . '/components/' . $component, $lang->getDefault(), false, false);
+			$lang->load($component, JPATH_BASE, null, false, true);
+			$lang->load($component, JPATH_BASE . '/components/' . $component, null, false, true);
 
 			if (!$form->loadFile($path, false))
 			{
@@ -337,7 +335,8 @@ class CategoriesModelCategory extends JModelAdmin
 
 			if (class_exists($cName) && is_callable(array($cName, 'onPrepareForm')))
 			{
-				$lang->load($component, JPATH_BASE, null, false, false) || $lang->load($component, JPATH_BASE . '/components/' . $component, null, false, false) || $lang->load($component, JPATH_BASE, $lang->getDefault(), false, false) || $lang->load($component, JPATH_BASE . '/components/' . $component, $lang->getDefault(), false, false);
+					$lang->load($component, JPATH_BASE, null, false, true)
+				||	$lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component), null, false, true);
 				call_user_func_array(array($cName, 'onPrepareForm'), array(&$form));
 
 				// Check for an error.

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -79,10 +79,8 @@ class CategoriesViewCategories extends JViewLegacy
 
 		// Need to load the menu language file as mod_menu hasn't been loaded yet.
 		$lang = JFactory::getLanguage();
-			$lang->load($component, JPATH_BASE, null, false, false)
-		||	$lang->load($component, JPATH_ADMINISTRATOR.'/components/'.$component, null, false, false)
-		||	$lang->load($component, JPATH_BASE, $lang->getDefault(), false, false)
-		||	$lang->load($component, JPATH_ADMINISTRATOR.'/components/'.$component, $lang->getDefault(), false, false);
+			$lang->load($component, JPATH_BASE, null, false, true)
+		||	$lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
 
  		// Load the category helper.
 		require_once JPATH_COMPONENT.'/helpers/categories.php';

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -67,10 +67,8 @@ class CategoriesViewCategory extends JViewLegacy
 
 		// Need to load the menu language file as mod_menu hasn't been loaded yet.
 		$lang = JFactory::getLanguage();
-			$lang->load($component, JPATH_BASE, null, false, false)
-		||	$lang->load($component, JPATH_ADMINISTRATOR.'/components/'.$component, null, false, false)
-		||	$lang->load($component, JPATH_BASE, $lang->getDefault(), false, false)
-		||	$lang->load($component, JPATH_ADMINISTRATOR.'/components/'.$component, $lang->getDefault(), false, false);
+			$lang->load($component, JPATH_BASE, null, false, true)
+		||	$lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
 
 		// Load the category helper.
 		require_once JPATH_COMPONENT.'/helpers/categories.php';

--- a/administrator/components/com_config/models/component.php
+++ b/administrator/components/com_config/models/component.php
@@ -105,10 +105,8 @@ class ConfigModelComponent extends JModelForm
 
 		// Load common and local language files.
 		$lang = JFactory::getLanguage();
-			$lang->load($option, JPATH_BASE, null, false, false)
-		||	$lang->load($option, JPATH_BASE . "/components/$option", null, false, false)
-		||	$lang->load($option, JPATH_BASE, $lang->getDefault(), false, false)
-		||	$lang->load($option, JPATH_BASE . "/components/$option", $lang->getDefault(), false, false);
+			$lang->load($option, JPATH_BASE, null, false, true)
+		||	$lang->load($option, JPATH_BASE . "/components/$option", null, false, true);
 
 		$result = JComponentHelper::getComponent($option);
 

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -118,49 +118,38 @@ class InstallerModel extends JModelList
 				case 'component':
 					$extension = $item->element;
 					$source = JPATH_ADMINISTRATOR . '/components/' . $extension;
-						$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, false)
-					||	$lang->load("$extension.sys", $source, null, false, false)
-					||	$lang->load("$extension.sys", JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-					||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
+					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
 				case 'file':
 					$extension = 'files_' . $item->element;
-						$lang->load("$extension.sys", JPATH_SITE, null, false, false)
-					||	$lang->load("$extension.sys", JPATH_SITE, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
 				break;
 				case 'library':
 					$extension = 'lib_' . $item->element;
-						$lang->load("$extension.sys", JPATH_SITE, null, false, false)
-					||	$lang->load("$extension.sys", JPATH_SITE, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
 				break;
 				case 'module':
 					$extension = $item->element;
 					$source = $path . '/modules/' . $extension;
-						$lang->load("$extension.sys", $path, null, false, false)
-					||	$lang->load("$extension.sys", $source, null, false, false)
-					||	$lang->load("$extension.sys", $path, $lang->getDefault(), false, false)
-					||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", $path, null, false, true)
+					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
 				case 'package':
 					$extension = $item->element;
-						$lang->load("$extension.sys", JPATH_SITE, null, false, false)
-					||	$lang->load("$extension.sys", JPATH_SITE, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
 				break;
 				case 'plugin':
 					$extension = 'plg_' . $item->folder . '_' . $item->element;
 					$source = JPATH_PLUGINS . '/' . $item->folder . '/' . $item->element;
-						$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, false)
-					||	$lang->load("$extension.sys", $source, null, false, false)
-					||	$lang->load("$extension.sys", JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-					||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
+					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
 				case 'template':
 					$extension = 'tpl_' . $item->element;
 					$source = $path . '/templates/' . $item->element;
-						$lang->load("$extension.sys", $path, null, false, false)
-					||	$lang->load("$extension.sys", $source, null, false, false)
-					||	$lang->load("$extension.sys", $path, $lang->getDefault(), false, false)
-					||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+						$lang->load("$extension.sys", $path, null, false, true)
+					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
 			}
 			if (!in_array($item->type, array('language', 'template', 'library'))) {

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -671,10 +671,8 @@ class MenusModelItem extends JModelAdmin
 				if (isset($args['option'])) {
 					// Load the language file for the component.
 					$lang = JFactory::getLanguage();
-					$lang->load($args['option'], JPATH_ADMINISTRATOR, null, false, false)
-					||	$lang->load($args['option'], JPATH_ADMINISTRATOR.'/components/'.$args['option'], null, false, false)
-					||	$lang->load($args['option'], JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-					||	$lang->load($args['option'], JPATH_ADMINISTRATOR.'/components/'.$args['option'], $lang->getDefault(), false, false);
+						$lang->load($args['option'], JPATH_ADMINISTRATOR, null, false, true)
+					||	$lang->load($args['option'], JPATH_ADMINISTRATOR . '/components/' . $args['option'], null, false, true);
 
 					// Determine the component id.
 					$component = JComponentHelper::getComponent($args['option']);
@@ -956,7 +954,7 @@ class MenusModelItem extends JModelAdmin
 
 			// Attempt to load the xml file.
 
-			if ($xmlFile && !$xml = simplexml_load_file($xmlFile)) 
+			if ($xmlFile && !$xml = simplexml_load_file($xmlFile))
 			{
 
 				throw new Exception(JText::_('JERROR_LOADFILE_FAILED'));

--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -73,10 +73,8 @@ class MenusModelMenutypes extends JModelLegacy
 						$this->rlu[MenusHelper::getLinkKey($option->request)] = $option->get('title');
 
 						if (isset($option->request['option'])) {
-								$lang->load($option->request['option'].'.sys', JPATH_ADMINISTRATOR, null, false, false)
-							||	$lang->load($option->request['option'].'.sys', JPATH_ADMINISTRATOR.'/components/'.$option->request['option'], null, false, false)
-							||	$lang->load($option->request['option'].'.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-							||	$lang->load($option->request['option'].'.sys', JPATH_ADMINISTRATOR.'/components/'.$option->request['option'], $lang->getDefault(), false, false);
+								$lang->load($option->request['option'] . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+							||	$lang->load($option->request['option'] . '.sys', JPATH_ADMINISTRATOR. '/components/'.$option->request['option'], null, false, true);
 						}
 					}
 				}
@@ -297,10 +295,8 @@ class MenusModelMenutypes extends JModelLegacy
 		{
 			if (JFolder::exists($folder . '/html/' . $component . '/' . $view)) {
 				$template = JFile::getName($folder);
-					$lang->load('tpl_'.$template.'.sys', JPATH_SITE, null, false, false)
-				||	$lang->load('tpl_'.$template.'.sys', JPATH_SITE.'/templates/'.$template, null, false, false)
-				||	$lang->load('tpl_'.$template.'.sys', JPATH_SITE, $lang->getDefault(), false, false)
-				||	$lang->load('tpl_'.$template.'.sys', JPATH_SITE.'/templates/'.$template, $lang->getDefault(), false, false);
+					$lang->load('tpl_' . $template . '.sys', JPATH_SITE, null, false, true)
+				||	$lang->load('tpl_' . $template . '.sys', JPATH_SITE . '/templates/' . $template, null, false, true);
 
 				$templateLayouts = JFolder::files($folder . '/html/' . $component . '/' . $view, '.xml$', false, true);
 

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -64,10 +64,8 @@ class MenusViewItems extends JViewLegacy
 				case 'component':
 				default:
 					// load language
-						$lang->load($item->componentname.'.sys', JPATH_ADMINISTRATOR, null, false, false)
-					||	$lang->load($item->componentname.'.sys', JPATH_ADMINISTRATOR.'/components/'.$item->componentname, null, false, false)
-					||	$lang->load($item->componentname.'.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-					||	$lang->load($item->componentname.'.sys', JPATH_ADMINISTRATOR.'/components/'.$item->componentname, $lang->getDefault(), false, false);
+						$lang->load($item->componentname . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+					||	$lang->load($item->componentname . '.sys', JPATH_ADMINISTRATOR . '/components/' . $item->componentname, null, false, true);
 
 					if (!empty($item->componentname)) {
 						$value	= JText::_($item->componentname);
@@ -91,10 +89,8 @@ class MenusViewItems extends JViewLegacy
 											$temp = explode(':', $vars['layout']);
 											$file = JPATH_SITE.'/templates/'.$temp[0].'/html/'.$item->componentname.'/'.$vars['view'].'/'.$temp[1].'.xml';
 											// Load template language file
-											$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, null, false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], null, false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE, $lang->getDefault(), false, false)
-											||	$lang->load('tpl_'.$temp[0].'.sys', JPATH_SITE.'/templates/'.$temp[0], $lang->getDefault(), false, false);
+												$lang->load('tpl_' . $temp[0] . '.sys', JPATH_SITE, null, false, true)
+											||	$lang->load('tpl_' . $temp[0] . '.sys', JPATH_SITE . '/templates/' . $temp[0], null, false, true);
 
 										}
 										else

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -163,10 +163,8 @@ abstract class ModulesHelper
 			$extension = $module->value;
 			$path = $clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 			$source = $path . "/modules/$extension";
-				$lang->load("$extension.sys", $path, null, false, false)
-			||	$lang->load("$extension.sys", $source, null, false, false)
-			||	$lang->load("$extension.sys", $path, $lang->getDefault(), false, false)
-			||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+				$lang->load("$extension.sys", $path, null, false, true)
+			||	$lang->load("$extension.sys", $source, null, false, true);
 			$modules[$i]->text = JText::_($module->text);
 		}
 		JArrayHelper::sortObjects($modules, 'text', 1, true, $lang->getLocale());

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -808,10 +808,8 @@ class ModulesModelModule extends JModelAdmin
 		$formFile	= JPath::clean($client->path.'/modules/'.$module.'/'.$module.'.xml');
 
 		// Load the core and/or local language file(s).
-			$lang->load($module, $client->path, null, false, false)
-		||	$lang->load($module, $client->path.'/modules/'.$module, null, false, false)
-		||	$lang->load($module, $client->path, $lang->getDefault(), false, false)
-		||	$lang->load($module, $client->path.'/modules/'.$module, $lang->getDefault(), false, false);
+			$lang->load($module, $client->path, null, false, true)
+		||	$lang->load($module, $client->path . '/modules/' . $module, null, false, true);
 
 		if (file_exists($formFile))
 		{

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -177,10 +177,8 @@ class ModulesModelModules extends JModelList
 		foreach($items as $item) {
 			$extension = $item->module;
 			$source = constant('JPATH_' . strtoupper($client)) . "/modules/$extension";
-				$lang->load("$extension.sys", constant('JPATH_' . strtoupper($client)), null, false, false)
-			||	$lang->load("$extension.sys", $source, null, false, false)
-			||	$lang->load("$extension.sys", constant('JPATH_' . strtoupper($client)), $lang->getDefault(), false, false)
-			||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+				$lang->load("$extension.sys", constant('JPATH_' . strtoupper($client)), null, false, true)
+			||	$lang->load("$extension.sys", $source, null, false, true);
 			$item->name = JText::_($item->name);
 			if (is_null($item->pages)) {
 				$item->pages = JText::_('JNONE');

--- a/administrator/components/com_modules/models/positions.php
+++ b/administrator/components/com_modules/models/positions.php
@@ -132,11 +132,9 @@ class ModulesModelPositions extends JModelList
 					$xml = simplexml_load_file($path);
 					if (isset($xml->positions[0]))
 					{
-						$lang->load('tpl_'.$template->element.'.sys', $client->path, null, false, false)
-					||	$lang->load('tpl_'.$template->element.'.sys', $client->path.'/templates/'.$template->element, null, false, false)
-					||	$lang->load('tpl_'.$template->element.'.sys', $client->path, $lang->getDefault(), false, false)
-					||	$lang->load('tpl_'.$template->element.'.sys', $client->path.'/templates/'.$template->element, $lang->getDefault(), false, false);
-						foreach ($xml->positions[0] as $position)
+						$lang->load('tpl_'.$template->element.'.sys', $client->path, null, false, true)
+					||	$lang->load('tpl_'.$template->element.'.sys', $client->path.'/templates/'.$template->element, null, false, true);
+					foreach ($xml->positions[0] as $position)
 						{
 							$value = (string)$position['value'];
 							$label = (string)$position;

--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -129,10 +129,8 @@ class ModulesModelSelect extends JModelList
 
 					// 1.5 Format; Core files or language packs then
 			// 1.6 3PD Extension Support
-				$lang->load($item->module.'.sys', $client->path, null, false, false)
-			||	$lang->load($item->module.'.sys', $client->path.'/modules/'.$item->module, null, false, false)
-			||	$lang->load($item->module.'.sys', $client->path, $lang->getDefault(), false, false)
-			||	$lang->load($item->module.'.sys', $client->path.'/modules/'.$item->module, $lang->getDefault(), false, false);
+				$lang->load($item->module . '.sys', $client->path, null, false, true)
+			||	$lang->load($item->module . '.sys', $client->path . '/modules/' . $item->module, null, false, true);
 			$item->name	= JText::_($item->name);
 
 			if (isset($item->xml) && $text = trim($item->xml->description)) {

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -217,10 +217,8 @@ class PluginsModelPlugin extends JModelAdmin
 
 		foreach ($elements as $elementa)
 		{
-				$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_ADMINISTRATOR, null, false, false)
-			||	$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_PLUGINS.'/'.$folder.'/'.$elementa, null, false, false)
-			||	$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-			||	$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_PLUGINS.'/'.$folder.'/'.$elementa, $lang->getDefault(), false, false);
+				$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_ADMINISTRATOR, null, false, true)
+			||	$lang->load('plg_'.$folder.'_'.$elementa.'.sys', JPATH_PLUGINS.'/'.$folder.'/'.$elementa, null, false, true);
 		}
 
 		if (empty($folder) || empty($element)) {
@@ -239,10 +237,8 @@ class PluginsModelPlugin extends JModelAdmin
 		}
 
 		// Load the core and/or local language file(s).
-			$lang->load('plg_'.$folder.'_'.$element, JPATH_ADMINISTRATOR, null, false, false)
-		||	$lang->load('plg_'.$folder.'_'.$element, JPATH_PLUGINS.'/'.$folder.'/'.$element, null, false, false)
-		||	$lang->load('plg_'.$folder.'_'.$element, JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-		||	$lang->load('plg_'.$folder.'_'.$element, JPATH_PLUGINS.'/'.$folder.'/'.$element, $lang->getDefault(), false, false);
+			$lang->load('plg_'.$folder.'_'.$element, JPATH_ADMINISTRATOR, null, false, true)
+			|| $lang->load('plg_'.$folder.'_'.$element, JPATH_PLUGINS.'/'.$folder.'/'.$element, null, false, true);
 
 
 		if (file_exists($formFile)) {

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -168,10 +168,8 @@ class PluginsModelPlugins extends JModelList
 		foreach($items as &$item) {
 			$source = JPATH_PLUGINS . '/' . $item->folder . '/' . $item->element;
 			$extension = 'plg_' . $item->folder . '_' . $item->element;
-				$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, false)
-			||	$lang->load($extension . '.sys', $source, null, false, false)
-			||	$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-			||	$lang->load($extension . '.sys', $source, $lang->getDefault(), false, false);
+				$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+			||	$lang->load($extension . '.sys', $source, null, false, true);
 			$item->name = JText::_($item->name);
 		}
 	}

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -325,10 +325,8 @@ class TemplatesModelStyle extends JModelAdmin
 		$formFile	= JPath::clean($client->path.'/templates/'.$template.'/templateDetails.xml');
 
 		// Load the core and/or local language file(s).
-			$lang->load('tpl_'.$template, $client->path, null, false, false)
-		||	$lang->load('tpl_'.$template, $client->path.'/templates/'.$template, null, false, false)
-		||	$lang->load('tpl_'.$template, $client->path, $lang->getDefault(), false, false)
-		||	$lang->load('tpl_'.$template, $client->path.'/templates/'.$template, $lang->getDefault(), false, false);
+			$lang->load('tpl_'.$template, $client->path, null, false, true)
+		||	$lang->load('tpl_'.$template, $client->path.'/templates/'.$template, null, false, true);
 
 		if (file_exists($formFile)) {
 			// Get the template form.

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -56,10 +56,8 @@ class TemplatesModelTemplate extends JModelLegacy
 			$lang	= JFactory::getLanguage();
 
 			// Load the core and/or local language file(s).
-			$lang->load('tpl_'.$template->element, $client->path, null, false, false)
-				||	$lang->load('tpl_'.$template->element, $client->path.'/templates/'.$template->element, null, false, false)
-				||	$lang->load('tpl_'.$template->element, $client->path, $lang->getDefault(), false, false)
-				||	$lang->load('tpl_'.$template->element, $client->path.'/templates/'.$template->element, $lang->getDefault(), false, false);
+				$lang->load('tpl_' . $template->element, $client->path, null, false, true)
+			||	$lang->load('tpl_' . $template->element, $client->path . '/templates/' . $template->element, null, false, true);
 
 			// Check if the template path exists.
 

--- a/administrator/components/com_users/helpers/debug.php
+++ b/administrator/components/com_users/helpers/debug.php
@@ -45,10 +45,8 @@ class UsersHelperDebug
 				// Load language
 				$extension 	= $item->value;
 				$source 	= JPATH_ADMINISTRATOR . '/components/' . $extension;
-				$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, false)
-				||	$lang->load("$extension.sys", $source, null, false, false)
-				||	$lang->load("$extension.sys", JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				||	$lang->load("$extension.sys", $source, $lang->getDefault(), false, false);
+					$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
+				||	$lang->load("$extension.sys", $source, null, false, true);
 
 				// Translate component name
 				$item->text = JText::_($item->text);
@@ -118,10 +116,8 @@ class UsersHelperDebug
 				$extension 	= 'com_config';
 				$source 	= JPATH_ADMINISTRATOR . '/components/' . $extension;
 
-					$lang->load($extension, JPATH_ADMINISTRATOR, null, false, false)
-				||	$lang->load($extension, $source, null, false, false)
-				||	$lang->load($extension, JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				||	$lang->load($extension, $source, $lang->getDefault(), false, false);
+					$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
+				||	$lang->load("$extension.sys", $source, null, false, true);
 			}
 		}
 

--- a/administrator/includes/application.php
+++ b/administrator/includes/application.php
@@ -82,7 +82,7 @@ class JAdministrator extends JApplication
 
 		// Load Library language
 		$lang = JFactory::getLanguage();
-		$lang->load('lib_joomla', JPATH_ADMINISTRATOR);
+		$lang->load('lib_joomla', JPATH_ADMINISTRATOR, null, false, true);
 	}
 
 	/**

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -101,10 +101,8 @@ abstract class ModMenuHelper
 					if (!empty($component->element)) {
 						// Load the core file then
 						// Load extension-local file.
-						$lang->load($component->element.'.sys', JPATH_BASE, null, false, false)
-					||	$lang->load($component->element.'.sys', JPATH_ADMINISTRATOR.'/components/'.$component->element, null, false, false)
-					||	$lang->load($component->element.'.sys', JPATH_BASE, $lang->getDefault(), false, false)
-					||	$lang->load($component->element.'.sys', JPATH_ADMINISTRATOR.'/components/'.$component->element, $lang->getDefault(), false, false);
+						$lang->load($component->element . '.sys', JPATH_BASE, null, false, true)
+					||	$lang->load($component->element . '.sys', JPATH_ADMINISTRATOR . '/components/' . $component->element, null, false, true);
 					}
 					$component->text = $lang->hasKey($component->title) ? JText::_($component->title) : $component->alias;
 				}

--- a/components/com_media/media.php
+++ b/components/com_media/media.php
@@ -28,9 +28,9 @@ define('COM_MEDIA_BASE',	JPATH_ROOT.'/'.$params->get('image_path', 'images'));
 define('COM_MEDIA_BASEURL', JURI::root().'/'.$params->get('image_path', 'images'));
 
 $lang = JFactory::getLanguage();
-	$lang->load('com_media', JPATH_ADMINISTRATOR, null, false, false)
-	||	$lang->load('com_media', JPATH_SITE, null, false, false)
-	||	$lang->load('com_media', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false);
+
+	$lang->load('com_media', JPATH_ADMINISTRATOR, null, false, true)
+||	$lang->load('com_media', JPATH_SITE, null, false, true);
 
 // Load the admin HTML view
 require_once JPATH_COMPONENT_ADMINISTRATOR.'/helpers/media.php';

--- a/components/com_users/helpers/html/users.php
+++ b/components/com_users/helpers/html/users.php
@@ -164,10 +164,8 @@ abstract class JHtmlUsers
 			$title = $db->loadResult();
 			if ($title)
 			{
-					$lang->load("plg_editors_$value.sys", JPATH_ADMINISTRATOR, null, false, false)
-				||	$lang->load("plg_editors_$value.sys", JPATH_PLUGINS . '/editors/' . $value, null, false, false)
-				||	$lang->load("plg_editors_$value.sys", JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				||	$lang->load("plg_editors_$value.sys", JPATH_PLUGINS . '/editors/' . $value, $lang->getDefault(), false, false);
+					$lang->load("plg_editors_$value.sys", JPATH_ADMINISTRATOR, null, false, true)
+				||	$lang->load("plg_editors_$value.sys", JPATH_PLUGINS . '/editors/' . $value, null, false, true);
 				$lang->load($title.'.sys');
 				return JText::_($title);
 			}

--- a/includes/application.php
+++ b/includes/application.php
@@ -119,11 +119,8 @@ final class JSite extends JApplication
 		$lang = JFactory::getLanguage();
 
 		// Try the lib_joomla file in the current language (without allowing the loading of the file in the default language)
-		$lang->load('lib_joomla', JPATH_SITE, null, false, false)
-		|| $lang->load('lib_joomla', JPATH_ADMINISTRATOR, null, false, false)
-		// Fallback to the lib_joomla file in the default language
-		|| $lang->load('lib_joomla', JPATH_SITE, null, true)
-		|| $lang->load('lib_joomla', JPATH_ADMINISTRATOR, null, true);
+		$lang->load('lib_joomla', JPATH_SITE, null, false, true)
+			|| $lang->load('lib_joomla', JPATH_ADMINISTRATOR, null, false, true);
 	}
 
 	/**

--- a/libraries/cms/form/field/templatestyle.php
+++ b/libraries/cms/form/field/templatestyle.php
@@ -80,10 +80,8 @@ class JFormFieldTemplateStyle extends JFormFieldGroupedList
 			foreach ($styles as $style)
 			{
 				$template = $style->template;
-				$lang->load('tpl_' . $template . '.sys', $client->path, null, false, false)
-					|| $lang->load('tpl_' . $template . '.sys', $client->path . '/templates/' . $template, null, false, false)
-					|| $lang->load('tpl_' . $template . '.sys', $client->path, $lang->getDefault(), false, false)
-					|| $lang->load('tpl_' . $template . '.sys', $client->path . '/templates/' . $template, $lang->getDefault(), false, false);
+					$lang->load('tpl_' . $template . '.sys', $client->path, null, false, true)
+				||	$lang->load('tpl_' . $template . '.sys', $client->path . '/templates/' . $template, null, false, true);
 				$name = JText::_($style->name);
 
 				// Initialize the group if necessary.

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -293,10 +293,8 @@ class JComponentHelper
 		// Load template language files.
 		$template = $app->getTemplate(true)->template;
 		$lang = JFactory::getLanguage();
-		$lang->load('tpl_' . $template, JPATH_BASE, null, false, false)
-			|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template", null, false, false)
-			|| $lang->load('tpl_' . $template, JPATH_BASE, $lang->getDefault(), false, false)
-			|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template", $lang->getDefault(), false, false);
+			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
+		||	$lang->load('tpl_' . $template, JPATH_THEMES . "/$template", null, false, true);
 
 		if (empty($option))
 		{
@@ -340,9 +338,8 @@ class JComponentHelper
 		$task = JRequest::getString('task');
 
 		// Load common and local language files.
-		$lang->load($option, JPATH_BASE, null, false, false) || $lang->load($option, JPATH_COMPONENT, null, false, false)
-			|| $lang->load($option, JPATH_BASE, $lang->getDefault(), false, false)
-			|| $lang->load($option, JPATH_COMPONENT, $lang->getDefault(), false, false);
+			$lang->load($option, JPATH_BASE, null, false, true)
+		||	$lang->load($option, JPATH_COMPONENT, null, false, true);
 
 		// Handle template preview outlining.
 		$contents = null;

--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -606,10 +606,8 @@ class JView extends JObject
 
 		// Load the language file for the template
 		$lang = JFactory::getLanguage();
-		$lang->load('tpl_' . $template, JPATH_BASE, null, false, false)
-			|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template", null, false, false)
-			|| $lang->load('tpl_' . $template, JPATH_BASE, $lang->getDefault(), false, false)
-			|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template", $lang->getDefault(), false, false);
+			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
+		||	$lang->load('tpl_' . $template, JPATH_THEMES . "/$template", null, false, true);
 
 		// Change the template folder if alternative layout is in different template
 		if (isset($layoutTemplate) && $layoutTemplate != '_' && $layoutTemplate != $template)

--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -165,10 +165,8 @@ abstract class JModuleHelper
 		{
 			$lang = JFactory::getLanguage();
 			// 1.5 or Core then 1.6 3PD
-			$lang->load($module->module, JPATH_BASE, null, false, false) ||
-				$lang->load($module->module, dirname($path), null, false, false) ||
-				$lang->load($module->module, JPATH_BASE, $lang->getDefault(), false, false) ||
-				$lang->load($module->module, dirname($path), $lang->getDefault(), false, false);
+				$lang->load($module->module, JPATH_BASE, null, false, true)
+			||	$lang->load($module->module, dirname($path), null, false, true);
 
 			$content = '';
 			ob_start();

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -575,12 +575,9 @@ class JDocumentHTML extends JDocument
 
 		// Load the language file for the template
 		$lang = JFactory::getLanguage();
-		// 1.5 or core then 1.6
 
-		$lang->load('tpl_' . $template, JPATH_BASE, null, false, false)
-			|| $lang->load('tpl_' . $template, $directory . '/' . $template, null, false, false)
-			|| $lang->load('tpl_' . $template, JPATH_BASE, $lang->getDefault(), false, false)
-			|| $lang->load('tpl_' . $template, $directory . '/' . $template, $lang->getDefault(), false, false);
+			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
+		||	$lang->load('tpl_' . $template, $directory . '/' . $template, null, false, true);
 
 		// Assign the variables
 		$this->template = $template;

--- a/libraries/joomla/form/fields/componentlayout.php
+++ b/libraries/joomla/form/fields/componentlayout.php
@@ -84,10 +84,8 @@ class JFormFieldComponentLayout extends JFormField
 
 			// Load language file
 			$lang = JFactory::getLanguage();
-			$lang->load($extn . '.sys', JPATH_ADMINISTRATOR, null, false, false)
-				|| $lang->load($extn . '.sys', JPATH_ADMINISTRATOR . '/components/' . $extn, null, false, false)
-				|| $lang->load($extn . '.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				|| $lang->load($extn . '.sys', JPATH_ADMINISTRATOR . '/components/' . $extn, $lang->getDefault(), false, false);
+				$lang->load($extn . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+			||	$lang->load($extn . '.sys', JPATH_ADMINISTRATOR . '/components/' . $extn, null, false, true);
 
 			// Get the database object and a new query object.
 			$db = JFactory::getDBO();
@@ -179,12 +177,8 @@ class JFormFieldComponentLayout extends JFormField
 				foreach ($templates as $template)
 				{
 					// Load language file
-					$lang->load('tpl_' . $template->element . '.sys', $client->path, null, false, false)
-						|| $lang->load('tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, null, false, false)
-						|| $lang->load('tpl_' . $template->element . '.sys', $client->path, $lang->getDefault(), false, false)
-						|| $lang->load(
-						'tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, $lang->getDefault(), false, false
-					);
+						$lang->load('tpl_' . $template->element . '.sys', $client->path, null, false, true)
+					||	$lang->load('tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, null, false, true);
 
 					$template_path = JPath::clean($client->path . '/templates/' . $template->element . '/html/' . $extn . '/' . $view);
 

--- a/libraries/joomla/form/fields/editors.php
+++ b/libraries/joomla/form/fields/editors.php
@@ -59,10 +59,8 @@ class JFormFieldEditors extends JFormFieldList
 		$lang = JFactory::getLanguage();
 		foreach ($options as $i => $option)
 		{
-			$lang->load('plg_editors_' . $option->value, JPATH_ADMINISTRATOR, null, false, false)
-				|| $lang->load('plg_editors_' . $option->value, JPATH_PLUGINS . '/editors/' . $option->value, null, false, false)
-				|| $lang->load('plg_editors_' . $option->value, JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				|| $lang->load('plg_editors_' . $option->value, JPATH_PLUGINS . '/editors/' . $option->value, $lang->getDefault(), false, false);
+				$lang->load('plg_editors_' . $option->value, JPATH_ADMINISTRATOR, null, false, true)
+			||	$lang->load('plg_editors_' . $option->value, JPATH_PLUGINS . '/editors/' . $option->value, null, false, true);
 			$options[$i]->text = JText::_($option->text);
 		}
 

--- a/libraries/joomla/form/fields/modulelayout.php
+++ b/libraries/joomla/form/fields/modulelayout.php
@@ -77,10 +77,8 @@ class JFormFieldModuleLayout extends JFormField
 
 			// Load language file
 			$lang = JFactory::getLanguage();
-			$lang->load($module . '.sys', $client->path, null, false, false)
-				|| $lang->load($module . '.sys', $client->path . '/modules/' . $module, null, false, false)
-				|| $lang->load($module . '.sys', $client->path, $lang->getDefault(), false, false)
-				|| $lang->load($module . '.sys', $client->path . '/modules/' . $module, $lang->getDefault(), false, false);
+				$lang->load($module . '.sys', $client->path, null, false, true)
+			||	$lang->load($module . '.sys', $client->path . '/modules/' . $module, null, false, true);
 
 			// Get the database object and a new query object.
 			$db = JFactory::getDBO();
@@ -147,13 +145,8 @@ class JFormFieldModuleLayout extends JFormField
 				foreach ($templates as $template)
 				{
 					// Load language file
-					$lang->load('tpl_' . $template->element . '.sys', $client->path, null, false, false)
-						|| $lang->load('tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, null, false, false)
-						|| $lang->load('tpl_' . $template->element . '.sys', $client->path, $lang->getDefault(), false, false)
-						|| $lang->load(
-						'tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, $lang->getDefault(),
-						false, false
-					);
+						$lang->load('tpl_' . $template->element . '.sys', $client->path, null, false, true)
+					||	$lang->load('tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element, null, false, true);
 
 					$template_path = JPath::clean($client->path . '/templates/' . $template->element . '/html/' . $module);
 

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -59,10 +59,8 @@ class JFormFieldPlugins extends JFormFieldList
 			{
 				$source = JPATH_PLUGINS . '/' . $folder . '/' . $item->value;
 				$extension = 'plg_' . $folder . '_' . $item->value;
-					$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, false)
-				||	$lang->load($extension . '.sys', $source, null, false, false)
-				||	$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false)
-				||	$lang->load($extension . '.sys', $source, $lang->getDefault(), false, false);
+					$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+				||	$lang->load($extension . '.sys', $source, null, false, true);
 				$options[$i]->text = JText::_($item->text);
 			}
 

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -145,9 +145,8 @@ class JInstallerComponent extends JAdapterInstance
 				$source = "$path/$folder";
 			}
 		}
-		$lang->load($extension . '.sys', $source, null, false, false) || $lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, false)
-			|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-			|| $lang->load($extension . '.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false);
+			$lang->load($extension . '.sys', $source, null, false, true)
+		||	$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, true);
 	}
 
 	/**
@@ -1455,10 +1454,10 @@ class JInstallerComponent extends JAdapterInstance
 				$query->where('type = '.$db->quote('component'));
 				$query->where('parent_id = 1');
 				$query->where('home = 0');
-				
+
 				$db->setQuery($query);
 				$menu_id = $db->loadResult();
-				
+
 				if(!$menu_id) {
 					// Oops! Could not get the menu ID. Go back and rollback changes.
 					JError::raiseWarning(1, $table->getError());
@@ -1468,10 +1467,10 @@ class JInstallerComponent extends JAdapterInstance
 					$query = $db->getQuery(true);
 					$query->delete('#__menu');
 					$query->where('id = '.(int)$menu_id);
-					
+
 					$db->setQuery($query);
 					$db->query();
-					
+
 					// Retry creating the menu item
 					if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store()) {
 						// Install failed, rollback changes

--- a/libraries/joomla/installer/adapters/file.php
+++ b/libraries/joomla/installer/adapters/file.php
@@ -38,10 +38,8 @@ class JInstallerFile extends JAdapterInstance
 		$extension = 'files_' . str_replace('files_', '', strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd')));
 		$lang = JFactory::getLanguage();
 		$source = $path;
-		$lang->load($extension . '.sys', $source, null, false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, null, false, false)
-			|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, $lang->getDefault(), false, false);
+			$lang->load($extension . '.sys', $source, null, false, true)
+		||	$lang->load($extension . '.sys', JPATH_SITE, null, false, true);
 	}
 
 	/**

--- a/libraries/joomla/installer/adapters/library.php
+++ b/libraries/joomla/installer/adapters/library.php
@@ -42,10 +42,8 @@ class JInstallerLibrary extends JAdapterInstance
 		$name = strtolower((string) $this->manifest->libraryname);
 		$lang = JFactory::getLanguage();
 		$source = $path ? $path : JPATH_PLATFORM . "/$name";
-		$lang->load($extension . '.sys', $source, null, false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, null, false, false)
-			|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, $lang->getDefault(), false, false);
+			$lang->load($extension . '.sys', $source, null, false, true)
+		||	$lang->load($extension . '.sys', JPATH_SITE, null, false, true);
 	}
 
 	/**

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -113,10 +113,8 @@ class JInstallerModule extends JAdapterInstance
 				}
 
 				$client = (string) $this->manifest->attributes()->client;
-				$lang->load($extension . '.sys', $source, null, false, false)
-					|| $lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), null, false, false)
-					|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-					|| $lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), $lang->getDefault(), false, false);
+					$lang->load($extension . '.sys', $source, null, false, true)
+				||	$lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), null, false, true);
 			}
 		}
 	}

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -45,10 +45,8 @@ class JInstallerPackage extends JAdapterInstance
 		$extension = 'pkg_' . strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->packagename, 'cmd'));
 		$lang = JFactory::getLanguage();
 		$source = $path;
-		$lang->load($extension . '.sys', $source, null, false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, null, false, false)
-			|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-			|| $lang->load($extension . '.sys', JPATH_SITE, $lang->getDefault(), false, false);
+			$lang->load($extension . '.sys', $source, null, false, true)
+		||	$lang->load($extension . '.sys', JPATH_SITE, null, false, true);
 	}
 
 	/**

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -109,10 +109,8 @@ class JInstallerPlugin extends JAdapterInstance
 				{
 					$source = "$path/$folder";
 				}
-				$lang->load($extension . '.sys', $source, null, false, false)
-					|| $lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, false)
-					|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-					|| $lang->load($extension . '.sys', JPATH_ADMINISTRATOR, $lang->getDefault(), false, false);
+					$lang->load($extension . '.sys', $source, null, false, true)
+				||	$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, true);
 			}
 		}
 	}

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -63,10 +63,8 @@ class JInstallerTemplate extends JAdapterInstance
 		$extension = "tpl_$name";
 		$lang = JFactory::getLanguage();
 		$source = $path ? $path : ($this->parent->extension->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/templates/' . $name;
-		$lang->load($extension . '.sys', $source, null, false, false)
-			|| $lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), null, false, false)
-			|| $lang->load($extension . '.sys', $source, $lang->getDefault(), false, false)
-			|| $lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), $lang->getDefault(), false, false);
+			$lang->load($extension . '.sys', $source, null, false, true)
+		||	$lang->load($extension . '.sys', constant('JPATH_' . strtoupper($client)), null, false, true);
 	}
 
 	/**

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -721,7 +721,7 @@ class JLanguage extends JObject
 	{
 		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
 		// with $default set to true
-		if (!JDEBUG && ($lang != $this->default) && $default)
+		if (!JFactory::getConfig()->get('debug_lang') && ($lang != $this->default) && $default)
 		{
 			$this->load($extension, $basePath, $this->default, false, true);
 		}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -719,6 +719,13 @@ class JLanguage extends JObject
 	 */
 	public function load($extension = 'joomla', $basePath = JPATH_BASE, $lang = null, $reload = false, $default = true)
 	{
+		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
+		// with $default set to true
+		if (!JDEBUG && ($lang != $this->default) && $default)
+		{
+			$this->load($extension, $basePath, $this->default, false, true);
+		}
+
 		if (!$lang)
 		{
 			$lang = $this->lang;

--- a/libraries/joomla/plugin/plugin.php
+++ b/libraries/joomla/plugin/plugin.php
@@ -101,9 +101,7 @@ abstract class JPlugin extends JEvent
 		}
 
 		$lang = JFactory::getLanguage();
-		return $lang->load(strtolower($extension), $basePath, null, false, false)
-			|| $lang->load(strtolower($extension), JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, false)
-			|| $lang->load(strtolower($extension), $basePath, $lang->getDefault(), false, false)
-			|| $lang->load(strtolower($extension), JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, $lang->getDefault(), false, false);
+		return $lang->load(strtolower($extension), $basePath, null, false, true)
+			|| $lang->load(strtolower($extension), JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
 	}
 }


### PR DESCRIPTION
This port the same PR that was merged into 3.2.x
It lets load en-GB language files before other language packs to cope for missing strings.
To test, delete some strings from any non en-GB language file and display the results, in admin or site.
Instead of the constant, one will get the English (en-GB) value when debug is off.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33354&start=0
