### PR TITLE
[#33412] Make JEventDispatcher compatible with HHVM

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -204,7 +204,6 @@ class JEventDispatcher extends JObject
 			}
 
 			$this->_observers[] = $observer;
-			end($this->_observers);
 			$methods = array($observer['event']);
 		}
 		else
@@ -229,6 +228,7 @@ class JEventDispatcher extends JObject
 			$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
 		}
 
+		end($this->_observers);
 		$key = key($this->_observers);
 
 		foreach ($methods as $method)


### PR DESCRIPTION
According to HHVM inconsistencies guildline, "Under Zend PHP, foreach by value will modify the array's internal cursor under certain circumstances. Under HipHop VM, foreach by value will never modify the array's internal cursor.

Moving end() from above key() function to below it also make the code easier to understand as the behavior of foreach with array cursor is complicated to understand.

JoomlaCode Tracker Item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33412&start=0
