### PR TITLE
Make testSortObjects() compatible with HHVM

### DIFF
--- a/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
@@ -1597,7 +1597,11 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 			$output = JArrayHelper::sortObjects($input, $key, $direction, $casesensitive, $locale);
 		}
 
-		$this->assertEquals($expect, $output, $message);
+                $this->assertEquals(sizeof($expect), sizeof($output), $message);
+                for ($i = 0; $i < sizeof($expect); $i++) {
+                        echo $expect[$i]->$key;
+                        $this->assertEquals($expect[$i]->$key, $output[$i]->$key, $message);
+                }
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
@@ -1597,11 +1597,10 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 			$output = JArrayHelper::sortObjects($input, $key, $direction, $casesensitive, $locale);
 		}
 
-                $this->assertEquals(sizeof($expect), sizeof($output), $message);
-                for ($i = 0; $i < sizeof($expect); $i++) {
-                        echo $expect[$i]->$key;
-                        $this->assertEquals($expect[$i]->$key, $output[$i]->$key, $message);
-                }
+		$this->assertEquals(sizeof($expect), sizeof($output), $message);
+		for ($i = 0; $i < sizeof($expect); $i++) {
+			$this->assertEquals($expect[$i]->$key, $output[$i]->$key, $message);
+		}
 	}
 
 	/**


### PR DESCRIPTION
In Zend PHP, order in the result output of usort() function is undefined, if two items has the same key value. Therefore, this means that JArrayHelper::sortObjects can return two items with the same key in any order as it uses usort() in its implementation. However, testSortObjects() assumes that usort() is always consistent, which is not guaranteed and at least not in the case of HHVM.

This patch will make testSortObjects() works in both Zend and HHVM PHP implementations.
