### PR TITLE
[#33359] [#33359] Added support for localized numeric format, 3rd attempt.

### DIFF
--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -174,7 +174,7 @@ JFactory::getDocument()->addScriptDeclaration("
 					<?php echo htmlspecialchars($item->editor); ?>
 				</td>
 				<td class="center">
-					<?php echo number_format((int) $item->character_count, 0, '.', ','); ?>
+					<?php echo number_format((int) $item->character_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')); ?>
 				</td>
 			</tr>
 			<?php $i++; ?>

--- a/administrator/components/com_finder/views/statistics/tmpl/default.php
+++ b/administrator/components/com_finder/views/statistics/tmpl/default.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 
 <div class="row-fluid">
 	<div class="span6">
-		<p class="tab-description"><?php echo JText::sprintf('COM_FINDER_STATISTICS_STATS_DESCRIPTION', number_format($this->data->term_count), number_format($this->data->link_count), number_format($this->data->taxonomy_node_count), number_format($this->data->taxonomy_branch_count)); ?></p>
+		<p class="tab-description"><?php echo JText::sprintf('COM_FINDER_STATISTICS_STATS_DESCRIPTION', number_format($this->data->term_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')), number_format($this->data->link_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_node_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_branch_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'))); ?></p>
 		<table class="table table-striped table-condensed">
 			<thead>
 				<tr>
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
 						?>
 					</td>
 					<td>
-						<span class="badge badge-info"><?php echo number_format($type->link_count);?></span>
+						<span class="badge badge-info"><?php echo number_format($type->link_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'));?></span>
 					</td>
 				</tr>
 				<?php endforeach; ?>
@@ -47,7 +47,7 @@ defined('_JEXEC') or die;
 						<strong><?php echo JText::_('COM_FINDER_STATISTICS_LINK_TYPE_TOTAL'); ?></strong>
 					</td>
 					<td>
-						<span class="badge badge-info"><?php echo number_format($this->data->link_count); ?></span>
+						<span class="badge badge-info"><?php echo number_format($this->data->link_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')); ?></span>
 					</td>
 				</tr>
 			</tbody>

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -915,6 +915,11 @@ THURSDAY="Thursday"
 FRI="Fri"
 FRIDAY="Friday"
 
+; Localized number format
+
+DECIMALS_SEPARATOR="."
+THOUSANDS_SEPARATOR=","
+
 ; Time Zones - this data has been removed as it is no longer used by Joomla 3.x
 
 ; Mailer Codes

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -300,6 +300,11 @@ THURSDAY="Thursday"
 FRI="Fri"
 FRIDAY="Friday"
 
+; Localized number format
+
+DECIMALS_SEPARATOR="."
+THOUSANDS_SEPARATOR=","
+
 ; Time Zones - this data has been removed as it is no longer used by Joomla 3.x
 
 PHPMAILER_PROVIDE_ADDRESS="You must provide at least one recipient email address."

--- a/libraries/joomla/cache/storage/helper.php
+++ b/libraries/joomla/cache/storage/helper.php
@@ -65,7 +65,7 @@ class JCacheStorageHelper
 	 */
 	public function updateSize($size)
 	{
-		$this->size = number_format($this->size + $size, 2, '.', '');
+		$this->size = number_format($this->size + $size, 2, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'));
 		$this->count++;
 	}
 }

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -641,7 +641,7 @@ class PlgSystemDebug extends JPlugin
 		$bytes = memory_get_usage();
 
 		return '<span class="label">' . JHtml::_('number.bytes', $bytes) . '</span>'
-			. ' (<span class="label">' . number_format($bytes) . ' ' . JText::_('PLG_DEBUG_BYTES') . '</span>)';
+			. ' (<span class="label">' . number_format($bytes, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')) . ' ' . JText::_('PLG_DEBUG_BYTES') . '</span>)';
 	}
 
 	/**


### PR DESCRIPTION
Formatting numeric values sometimes involves decimals separator and thousands separator.
A wide variety of formats exists in the world (see http://en.wikipedia.org/wiki/Thousands_separator#Digit_grouping), but currently Joomla only uses the North American format, where the decimals separator is a mark and the thousands separator is a comma (2,000.5 MB). For example, European format is the opposite (2.000,5 MB).
Currently the format is hardcoded into the code so that it can't be easily changed.

This contribute removes the constants "." and "," used along the Joomla code, and introduces the use of DECIMALS_SEPARATOR and THOUSANDS_SEPARATOR language strings, which will be localized by the language Teams.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33359&start=0
