### PR TITLE
[#33147] Category metadata params are not checked in JViewCategory

### DIFF
--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -238,20 +238,31 @@ class JViewCategory extends JViewLegacy
 		}
 
 		$this->document->setTitle($title);
-
-		$metadesc = (trim($this->params->get('menu-meta_description')) != '' ? trim($this->params->get('menu-meta_description')) : trim($this->category->metadesc));
+		
+		// If this is the active menu item, use the menu item metadata, else fall back to the category metadata
+		if ($this->menu && $this->menu->query['option'] == $this->category->extension && $this->menu->query['view'] == 'category' && $this->menu->query['id'] == $this->category->id)
+		{
+			$metadesc	= (trim($this->params->get('menu-meta_description')) != '' ? trim($this->params->get('menu-meta_description')) : trim($this->category->metadesc));
+			$metakey	= (trim($this->params->get('menu-meta_keywords')) != '' ? trim($this->params->get('menu-meta_keywords')) : trim($this->category->metakey));
+			$robots		= ($this->params->get('robots') ?: $this->category->params->get('robots'));
+		}
+		else 
+		{
+			$metadesc	= trim($this->category->metadesc);
+			$metakey	= trim($this->category->metakey);
+			$robots		= $this->category->params->get('robots');
+		}
+				
 		if ($metadesc)
 		{
 			$this->document->setDescription($metadesc);
 		}
 
-		$metakey = (trim($this->params->get('menu-meta_keywords')) != '' ? trim($this->params->get('menu-meta_keywords')) : trim($this->category->metakey));
 		if ($metakey)
 		{
 			$this->document->setMetadata('keywords', $metakey);
 		}
 
-		$robots = ($this->params->get('robots') ?: $this->category->params->get('robots'));
 		if ($robots)
 		{
 			$this->document->setMetadata('robots', $robots);

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -239,19 +239,19 @@ class JViewCategory extends JViewLegacy
 
 		$this->document->setTitle($title);
 
-		$metadesc = (trim($this->category->metadesc) != '' ? trim($this->category->metadesc) : trim($this->params->get('menu-meta_description')));
+		$metadesc = (trim($this->params->get('menu-meta_description')) != '' ? trim($this->params->get('menu-meta_description')) : trim($this->category->metadesc));
 		if ($metadesc)
 		{
 			$this->document->setDescription($metadesc);
 		}
 
-		$metakey = (trim($this->category->metakey) != '' ? trim($this->category->metakey) : trim($this->params->get('menu-meta_keywords')));
+		$metakey = (trim($this->params->get('menu-meta_keywords')) != '' ? trim($this->params->get('menu-meta_keywords')) : trim($this->category->metakey));
 		if ($metakey)
 		{
 			$this->document->setMetadata('keywords', $metakey);
 		}
 
-		$robots = ($this->category->params->get('robots') ?: $this->params->get('robots'));
+		$robots = ($this->params->get('robots') ?: $this->category->params->get('robots'));
 		if ($robots)
 		{
 			$this->document->setMetadata('robots', $robots);

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -141,6 +141,7 @@ class JViewCategory extends JViewLegacy
 		$cparams          = $category->getParams();
 		$category->params = clone($params);
 		$category->params->merge($cparams);
+		$category->params->merge($category->getMetadata());
 
 		$children = array($category->id => $children);
 
@@ -238,19 +239,22 @@ class JViewCategory extends JViewLegacy
 
 		$this->document->setTitle($title);
 
-		if ($this->params->get('menu-meta_description'))
+		$metadesc = (trim($this->category->metadesc) != '' ? trim($this->category->metadesc) : trim($this->params->get('menu-meta_description')));
+		if ($metadesc)
 		{
-			$this->document->setDescription($this->params->get('menu-meta_description'));
+			$this->document->setDescription($metadesc);
 		}
 
-		if ($this->params->get('menu-meta_keywords'))
+		$metakey = (trim($this->category->metakey) != '' ? trim($this->category->metakey) : trim($this->params->get('menu-meta_keywords')));
+		if ($metakey)
 		{
-			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
+			$this->document->setMetadata('keywords', $metakey);
 		}
 
-		if ($this->params->get('robots'))
+		$robots = ($this->category->params->get('robots') ?: $this->params->get('robots'));
+		if ($robots)
 		{
-			$this->document->setMetadata('robots', $this->params->get('robots'));
+			$this->document->setMetadata('robots', $robots);
 		}
 	}
 


### PR DESCRIPTION
Category metadesc, metakey and robots are stored in separate db fields and are not checked as part of $this->params in the prepareDocument() method.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33147
