### PR TITLE
[#29015] [bugfix] Allow "model" in model class name.

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -386,12 +386,15 @@ abstract class JModelLegacy extends JObject
 	{
 		if (empty($this->name))
 		{
-			$r = null;
-			if (!preg_match('/Model(.*)/i', get_class($this), $r))
+			$classname = get_class($this);
+			$modelpos = strpos($classname, 'Model');
+
+			if ($modelpos === false)
 			{
 				throw new Exception(JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
 			}
-			$this->name = strtolower($r[1]);
+
+			$this->name = strtolower(substr($classname, $modelpos + 5));
 		}
 
 		return $this->name;

--- a/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
+++ b/tests/unit/suites/libraries/joomla/model/JModelLegacyTest.php
@@ -192,17 +192,12 @@ class JModelLegacyTest extends TestCase
 	/**
 	 * Tests the getName method.
 	 *
-	 * @expectedException      Exception
-	 * @expectedExceptionCode  500
-	 *
 	 * @since   12.3
 	 *
 	 * @return  void
 	 */
 	public function testGetName()
 	{
-		$this->markTestSkipped('CMS has not yet received Platform updates to implement this test');
-
 		// Test default fixture
 		$this->assertEquals('lead', $this->fixture->getName());
 		$this->assertEquals('com_test', TestReflection::getValue($this->fixture, 'option'));
@@ -221,6 +216,7 @@ class JModelLegacyTest extends TestCase
 		$this->assertFalse(JModelLegacy::getInstance('Does', 'NotExist'));
 
 		// Test creating class that does exist, but does not contain 'Model' (uppercase)
+		$this->setExpectedException('Exception', 'JLIB_APPLICATION_ERROR_MODEL_GET_NAME', 500);
 		$this->fixture = JModelLegacy::getInstance('NomodelInName');
 		$this->fixture->getName();
 	}


### PR DESCRIPTION
This PR implements the same methodology in `JModelLegacy::getName` as `JViewLegacy::getName`. Fixes tracker [#29015](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29015)

This fixes an error where you wouldn't be able to have a model named `CarpenterModelRemodel` or `RemodelModelModels`.

The methodology to determine the name has been in use in `JViewLegacy::getName` for the past year without issue.
