### PR TITLE
[#33394] Move JHtml Bootstrap Accordion functions into JLayouts

### DIFF
--- a/layouts/libraries/cms/html/bootstrap/addslide.php
+++ b/layouts/libraries/cms/html/bootstrap/addslide.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<div class="accordion-group<?php echo $displayData['class']; ?>">
+	<div class="accordion-heading">
+		<strong><a href="#<?php echo $displayData['id']; ?>" data-parent="#<?php echo $displayData['selector']; ?>" data-toggle="collapse" class="accordion-toggle">
+			<?php echo $text; ?>
+		</a></strong>
+	</div>
+	<div class="accordion-body collapse<?php echo $displayData['in']; ?>" id="<?php echo $displayData['id']; ?>">
+		<div class="accordion-inner">

--- a/layouts/libraries/cms/html/bootstrap/addslide.php
+++ b/layouts/libraries/cms/html/bootstrap/addslide.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 <div class="accordion-group<?php echo $displayData['class']; ?>">
 	<div class="accordion-heading">
 		<strong><a href="#<?php echo $displayData['id']; ?>" data-parent="#<?php echo $displayData['selector']; ?>" data-toggle="collapse" class="accordion-toggle">
-			<?php echo $text; ?>
+			<?php echo $displayData['text']; ?>
 		</a></strong>
 	</div>
 	<div class="accordion-body collapse<?php echo $displayData['in']; ?>" id="<?php echo $displayData['id']; ?>">

--- a/layouts/libraries/cms/html/bootstrap/endaccordion.php
+++ b/layouts/libraries/cms/html/bootstrap/endaccordion.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+?>
+
+</div>

--- a/layouts/libraries/cms/html/bootstrap/endaccordion.php
+++ b/layouts/libraries/cms/html/bootstrap/endaccordion.php
@@ -10,5 +10,4 @@
 defined('_JEXEC') or die;
 
 ?>
-
 </div>

--- a/layouts/libraries/cms/html/bootstrap/endslide.php
+++ b/layouts/libraries/cms/html/bootstrap/endslide.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+?>
+
+</div></div></div>

--- a/layouts/libraries/cms/html/bootstrap/endslide.php
+++ b/layouts/libraries/cms/html/bootstrap/endslide.php
@@ -10,5 +10,4 @@
 defined('_JEXEC') or die;
 
 ?>
-
 </div></div></div>

--- a/layouts/libraries/cms/html/bootstrap/startaccordion.php
+++ b/layouts/libraries/cms/html/bootstrap/startaccordion.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$selector = empty($displayData['selector']) ? '' : $displayData['selector'];
+
+?>
+
+<div id="<?php echo $selector; ?>" class="accordion">

--- a/layouts/libraries/cms/html/bootstrap/startaccordionscript.php
+++ b/layouts/libraries/cms/html/bootstrap/startaccordionscript.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$selector = empty($displayData['selector']) ? '' : $displayData['selector'];
+
+// Setup options object
+$opt['parent'] = isset($displayData['params']['parent']) ? (boolean) $displayData['params']['parent'] : false;
+$opt['toggle'] = isset($displayData['params']['toggle']) ? (boolean) $displayData['params']['toggle'] : true;
+$opt['active'] = isset($displayData['params']['active']) ? (string) $displayData['params']['active'] : '';
+
+$options = JHtml::getJSObject($opt);
+
+// Include Bootstrap JS Framework
+JHtml::_('bootstrap.framework');
+
+echo "(function($){
+		$('#$selector').collapse($options);
+	})(jQuery);"

--- a/layouts/libraries/cms/html/bootstrap/startaccordionscript.php
+++ b/layouts/libraries/cms/html/bootstrap/startaccordionscript.php
@@ -23,4 +23,4 @@ JHtml::_('bootstrap.framework');
 
 echo "(function($){
 		$('#$selector').collapse($options);
-	})(jQuery);"
+	})(jQuery);";

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -566,29 +566,18 @@ abstract class JHtmlBootstrap
 
 		if (!isset(static::$loaded[__METHOD__][$sig]))
 		{
-			// Include Bootstrap framework
-			static::framework();
-
-			// Setup options object
-			$opt['parent'] = isset($params['parent']) ? (boolean) $params['parent'] : false;
-			$opt['toggle'] = isset($params['toggle']) ? (boolean) $params['toggle'] : true;
-			$opt['active'] = isset($params['active']) ? (string) $params['active'] : '';
-
-			$options = JHtml::getJSObject($opt);
-
 			// Attach accordion to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
-					$('#$selector').collapse($options);
-				})(jQuery);"
-			);
+			JFactory::getDocument()
+				->addScriptDeclaration(JLayoutHelper::render('libraries.cms.html.bootstrap.startaccordionscript', array('selector' => $selector, 'params' => $params)));
 
 			// Set static array
 			static::$loaded[__METHOD__][$sig] = true;
 			static::$loaded[__METHOD__]['active'] = $opt['active'];
 		}
 
-		return '<div id="' . $selector . '" class="accordion">';
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endaccordion');
+
+		return $html;
 	}
 
 	/**
@@ -600,7 +589,9 @@ abstract class JHtmlBootstrap
 	 */
 	public static function endAccordion()
 	{
-		return '</div>';
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endaccordion');
+
+		return $html;
 	}
 
 	/**
@@ -619,15 +610,9 @@ abstract class JHtmlBootstrap
 	{
 		$in = (static::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
-
-		$html = '<div class="accordion-group' . $class . '">'
-			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">'
-			. $text
-			. '</a></strong>'
-			. '</div>'
-			. '<div class="accordion-body collapse' . $in . '" id="' . $id . '">'
-			. '<div class="accordion-inner">';
+		
+		$layout = new JLayoutFile('libraries.cms.html.bootstrap.addslide')
+		$html = $layout->render(array('selector' => $selector, 'text' => $text, 'id' => $id, 'class' => $class, 'in' => $in));
 
 		return $html;
 	}
@@ -641,7 +626,9 @@ abstract class JHtmlBootstrap
 	 */
 	public static function endSlide()
 	{
-		return '</div></div></div>';
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endslide');
+
+		return $html;
 	}
 
 	/**

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -572,10 +572,11 @@ abstract class JHtmlBootstrap
 
 			// Set static array
 			static::$loaded[__METHOD__][$sig] = true;
-			static::$loaded[__METHOD__]['active'] = $opt['active'];
+			$active = isset($params['active']) ? (string) $params['active'] : '';
+			static::$loaded[__METHOD__]['active'] = $active;
 		}
 
-		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.endaccordion');
+		$html = JLayoutHelper::render('libraries.cms.html.bootstrap.startaccordion');
 
 		return $html;
 	}
@@ -611,7 +612,7 @@ abstract class JHtmlBootstrap
 		$in = (static::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 		
-		$layout = new JLayoutFile('libraries.cms.html.bootstrap.addslide')
+		$layout = new JLayoutFile('libraries.cms.html.bootstrap.addslide');
 		$html = $layout->render(array('selector' => $selector, 'text' => $text, 'id' => $id, 'class' => $class, 'in' => $in));
 
 		return $html;


### PR DESCRIPTION
**How to reproduce the problem and/or test the patch::**

Test that any uses of JHtml functions all work as expected. The best example to test is going to the the frontend contact option (if you have the sliders option activated). There should be no change before and after the patch

Note the unit tests still pass :)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33394&start=0
