### PR TITLE
[#32441] Fix divison by 0 issue in debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -747,7 +747,7 @@ class PlgSystemDebug extends JPlugin
 
 				// How heavy should the string length count: 0 - 1.
 				$ratio = 0.5;
-				$timeScore = $queryTime / (strlen($query) * $ratio) * 200;
+				$timeScore = $queryTime / ((strlen($query) + 1) * $ratio) * 200;
 
 				// Determine color of bargraph depending on query speed and presence of warnings in EXPLAIN.
 				if ($timeScore > 10)


### PR DESCRIPTION
If you send an empty DB query (thus strlen($query) = 0) you get a division by 0. With this little change, the string length is always at least 1. Since this is onyl to roughly guess if a query is good or bad, changing the result of this by +1 doesn't have a real impact. This will also mean, that these queries get a high value and show up as bad. And I think we can all agree that an empty query is simply a waste of perfectly good CPU cycles. ;-)

This is a replacement for PR #1539 by @elinw Thank you!

Tracker item is here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32441&start=0
