### PR TITLE
$app->registeredurlparams is not defined

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -692,6 +692,8 @@ class JCache
 	{
 		$app = JFactory::getApplication();
 
+		$registeredurlparams = new stdClass;
+
 		// Get url parameters set by plugins
 		if (!empty($app->registeredurlparams))
 		{


### PR DESCRIPTION
Moving the rest of the function inside the if loop makes sure $app->registeredurlparams is only referred to if actually exists.

This was causing memory leak on 3.2.1 Joomla install over PHP 5.5, performance has increased after the fix.

This is a replacement for #2706 with a better fix, since there was no response from @FriendlyHacker in 2 months. Thank you for your work.
