### PR TITLE
[#32989] html.php - with escape in tooltipText(), entire result should be escaped.

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -892,10 +892,13 @@ abstract class JHtml
 	 */
 	public static function tooltipText($title = '', $content = '', $translate = 1, $escape = 1)
 	{
+		//initialise return value.
 		$result = '';
+
 		// don't process empty strings
 		if ($content != '' || $title != '')
 		{
+			
 			// Split title into title and content if the title contains '::' (old Mootools format).
 			if ($content == '' && !(strpos($title, '::') === false))
 			{
@@ -914,11 +917,13 @@ abstract class JHtml
 			{
 				$result = $content;
 			}
+			
 			// Use only the title, if title and text are the same.
 			elseif ($title == $content)
 			{
 				$result = '<strong>' . $title . '</strong>';
 			}
+			
 			// Use a formatted string combining the title and content.
 			elseif ($content != '')
 			{
@@ -927,6 +932,7 @@ abstract class JHtml
 			else {
 				$result = $title;
 			}
+			
 			// escape everything, if required.
 			if ($escape) {
 				$result = htmlspecialchars($result);

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -297,7 +297,6 @@ abstract class JHtml
 	 */
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
-		
 		// If http is present in filename
 		if (strpos($file, 'http') === 0)
 		{
@@ -305,7 +304,6 @@ abstract class JHtml
 		}
 		else
 		{
-			
 			// Extract extension and strip the file
 			$strip = JFile::stripExt($file);
 			$ext   = JFile::getExt($file);
@@ -334,7 +332,6 @@ abstract class JHtml
 			// If relative search in template directory or media directory
 			if ($relative)
 			{
-				
 				// Get the template
 				$template = JFactory::getApplication()->getTemplate();
 
@@ -371,7 +368,6 @@ abstract class JHtml
 					 */
 					foreach ($files as $file)
 					{
-						
 						// If the file is in the template folder
 						$path = JPATH_THEMES . "/$template/$folder/$file";
 
@@ -385,18 +381,15 @@ abstract class JHtml
 						}
 						else
 						{
-							
 							// If the file contains any /: it can be in an media extension subfolder
 							if (strpos($file, '/'))
 							{
-								
 								// Divide the file extracting the extension as the first part before /
 								list($extension, $file) = explode('/', $file, 2);
 
 								// If the file yet contains any /: it can be a plugin
 								if (strpos($file, '/'))
 								{
-									
 									// Divide the file extracting the element as the first part before /
 									list($element, $file) = explode('/', $file, 2);
 
@@ -450,7 +443,6 @@ abstract class JHtml
 								}
 								else
 								{
-									
 									// Try to deals in the extension media folder
 									$path = JPATH_ROOT . "/media/$extension/$folder/$file";
 
@@ -488,7 +480,7 @@ abstract class JHtml
 									}
 								}
 							}
-							
+
 							// Try to deal with system files in the media folder
 							else
 							{
@@ -507,7 +499,7 @@ abstract class JHtml
 					}
 				}
 			}
-			
+
 			// If not relative and http is not present in filename
 			else
 			{
@@ -654,7 +646,7 @@ abstract class JHtml
 				return $includes;
 			}
 		}
-		
+
 		// If inclusion is required
 		else
 		{
@@ -684,7 +676,6 @@ abstract class JHtml
 	 */
 	public static function script($file, $framework = false, $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true)
 	{
-		
 		// Include MooTools framework
 		if ($framework)
 		{
@@ -709,7 +700,7 @@ abstract class JHtml
 				return $includes;
 			}
 		}
-		
+
 		// If inclusion is required
 		else
 		{
@@ -761,7 +752,6 @@ abstract class JHtml
 	 */
 	public static function date($input = 'now', $format = null, $tz = true, $gregorian = false)
 	{
-		
 		// Get some system objects.
 		$config = JFactory::getConfig();
 		$user = JFactory::getUser();
@@ -769,35 +759,32 @@ abstract class JHtml
 		// UTC date converted to user time zone.
 		if ($tz === true)
 		{
-			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the user configuration.
 			$date->setTimeZone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
 		}
-		
+
 		// UTC date converted to server time zone.
 		elseif ($tz === false)
 		{
-			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the server configuration.
 			$date->setTimeZone(new DateTimeZone($config->get('offset')));
 		}
-		
+
 		// No date conversion.
 		elseif ($tz === null)
 		{
 			$date = JFactory::getDate($input);
 		}
-		
+
 		// UTC date converted to given time zone.
 		else
 		{
-			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
@@ -810,7 +797,7 @@ abstract class JHtml
 		{
 			$format = JText::_('DATE_FORMAT_LC1');
 		}
-		
+
 		// $format is an existing language key
 		elseif (JFactory::getLanguage()->hasKey($format))
 		{
@@ -882,7 +869,6 @@ abstract class JHtml
 
 		if ($class == 'hasTip')
 		{
-			
 			// Still using MooTools tooltips!
 			$tooltip = htmlspecialchars($tooltip, ENT_COMPAT, 'UTF-8');
 
@@ -914,14 +900,12 @@ abstract class JHtml
 	 */
 	public static function tooltipText($title = '', $content = '', $translate = 1, $escape = 1)
 	{
-		
 		// Initialise return value.
 		$result = '';
 
 		// Don't process empty strings
 		if ($content != '' || $title != '')
 		{
-			
 			// Split title into title and content if the title contains '::' (old Mootools format).
 			if ($content == '' && !(strpos($title, '::') === false))
 			{
@@ -940,13 +924,13 @@ abstract class JHtml
 			{
 				$result = $content;
 			}
-			
+
 			// Use only the title, if title and text are the same.
 			elseif ($title == $content)
 			{
 				$result = '<strong>' . $title . '</strong>';
 			}
-			
+
 			// Use a formatted string combining the title and content.
 			elseif ($content != '')
 			{
@@ -956,13 +940,14 @@ abstract class JHtml
 			{
 				$result = $title;
 			}
-			
+
 			// Escape everything, if required.
 			if ($escape)
 			{
 				$result = htmlspecialchars($result);
 			}
 		}
+
 		return $result;
 	}
 
@@ -1062,7 +1047,6 @@ abstract class JHtml
 	 */
 	public static function addIncludePath($path = '')
 	{
-		
 		// Force path to array
 		settype($path, 'array');
 
@@ -1093,7 +1077,6 @@ abstract class JHtml
 
 		foreach ($array as $k => $v)
 		{
-			
 			// Don't encode either of these types
 			if (is_null($v) || is_resource($v))
 			{
@@ -1115,13 +1098,11 @@ abstract class JHtml
 			{
 				if (strpos($v, '\\') === 0)
 				{
-					
 					// Items such as functions and JSON objects are prefixed with \, strip the prefix and don't encode them
 					$elements[] = $key . ': ' . substr($v, 1);
 				}
 				else
 				{
-					
 					// The safest way to insert a string
 					$elements[] = $key . ': ' . json_encode((string) $v);
 				}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -297,6 +297,7 @@ abstract class JHtml
 	 */
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
+		
 		// If http is present in filename
 		if (strpos($file, 'http') === 0)
 		{
@@ -304,6 +305,7 @@ abstract class JHtml
 		}
 		else
 		{
+			
 			// Extract extension and strip the file
 			$strip = JFile::stripExt($file);
 			$ext   = JFile::getExt($file);
@@ -332,6 +334,7 @@ abstract class JHtml
 			// If relative search in template directory or media directory
 			if ($relative)
 			{
+				
 				// Get the template
 				$template = JFactory::getApplication()->getTemplate();
 
@@ -368,6 +371,7 @@ abstract class JHtml
 					 */
 					foreach ($files as $file)
 					{
+						
 						// If the file is in the template folder
 						$path = JPATH_THEMES . "/$template/$folder/$file";
 
@@ -381,15 +385,18 @@ abstract class JHtml
 						}
 						else
 						{
+							
 							// If the file contains any /: it can be in an media extension subfolder
 							if (strpos($file, '/'))
 							{
+								
 								// Divide the file extracting the extension as the first part before /
 								list($extension, $file) = explode('/', $file, 2);
 
 								// If the file yet contains any /: it can be a plugin
 								if (strpos($file, '/'))
 								{
+									
 									// Divide the file extracting the element as the first part before /
 									list($element, $file) = explode('/', $file, 2);
 
@@ -443,6 +450,7 @@ abstract class JHtml
 								}
 								else
 								{
+									
 									// Try to deals in the extension media folder
 									$path = JPATH_ROOT . "/media/$extension/$folder/$file";
 
@@ -480,6 +488,7 @@ abstract class JHtml
 									}
 								}
 							}
+							
 							// Try to deal with system files in the media folder
 							else
 							{
@@ -498,6 +507,7 @@ abstract class JHtml
 					}
 				}
 			}
+			
 			// If not relative and http is not present in filename
 			else
 			{
@@ -644,6 +654,7 @@ abstract class JHtml
 				return $includes;
 			}
 		}
+		
 		// If inclusion is required
 		else
 		{
@@ -673,6 +684,7 @@ abstract class JHtml
 	 */
 	public static function script($file, $framework = false, $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true)
 	{
+		
 		// Include MooTools framework
 		if ($framework)
 		{
@@ -697,6 +709,7 @@ abstract class JHtml
 				return $includes;
 			}
 		}
+		
 		// If inclusion is required
 		else
 		{
@@ -748,6 +761,7 @@ abstract class JHtml
 	 */
 	public static function date($input = 'now', $format = null, $tz = true, $gregorian = false)
 	{
+		
 		// Get some system objects.
 		$config = JFactory::getConfig();
 		$user = JFactory::getUser();
@@ -755,29 +769,35 @@ abstract class JHtml
 		// UTC date converted to user time zone.
 		if ($tz === true)
 		{
+			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the user configuration.
 			$date->setTimeZone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
 		}
+		
 		// UTC date converted to server time zone.
 		elseif ($tz === false)
 		{
+			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the server configuration.
 			$date->setTimeZone(new DateTimeZone($config->get('offset')));
 		}
+		
 		// No date conversion.
 		elseif ($tz === null)
 		{
 			$date = JFactory::getDate($input);
 		}
+		
 		// UTC date converted to given time zone.
 		else
 		{
+			
 			// Get a date object based on UTC.
 			$date = JFactory::getDate($input, 'UTC');
 
@@ -790,6 +810,7 @@ abstract class JHtml
 		{
 			$format = JText::_('DATE_FORMAT_LC1');
 		}
+		
 		// $format is an existing language key
 		elseif (JFactory::getLanguage()->hasKey($format))
 		{
@@ -861,6 +882,7 @@ abstract class JHtml
 
 		if ($class == 'hasTip')
 		{
+			
 			// Still using MooTools tooltips!
 			$tooltip = htmlspecialchars($tooltip, ENT_COMPAT, 'UTF-8');
 
@@ -892,10 +914,11 @@ abstract class JHtml
 	 */
 	public static function tooltipText($title = '', $content = '', $translate = 1, $escape = 1)
 	{
-		//initialise return value.
+		
+		// Initialise return value.
 		$result = '';
 
-		// don't process empty strings
+		// Don't process empty strings
 		if ($content != '' || $title != '')
 		{
 			
@@ -929,12 +952,14 @@ abstract class JHtml
 			{
 				$result = '<strong>' . $title . '</strong><br />' . $content;
 			}
-			else {
+			else
+			{
 				$result = $title;
 			}
 			
-			// escape everything, if required.
-			if ($escape) {
+			// Escape everything, if required.
+			if ($escape)
+			{
 				$result = htmlspecialchars($result);
 			}
 		}
@@ -1037,6 +1062,7 @@ abstract class JHtml
 	 */
 	public static function addIncludePath($path = '')
 	{
+		
 		// Force path to array
 		settype($path, 'array');
 
@@ -1067,6 +1093,7 @@ abstract class JHtml
 
 		foreach ($array as $k => $v)
 		{
+			
 			// Don't encode either of these types
 			if (is_null($v) || is_resource($v))
 			{
@@ -1088,11 +1115,13 @@ abstract class JHtml
 			{
 				if (strpos($v, '\\') === 0)
 				{
+					
 					// Items such as functions and JSON objects are prefixed with \, strip the prefix and don't encode them
 					$elements[] = $key . ': ' . substr($v, 1);
 				}
 				else
 				{
+					
 					// The safest way to insert a string
 					$elements[] = $key . ': ' . json_encode((string) $v);
 				}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -889,55 +889,51 @@ abstract class JHtml
 	 * @return  string  The tooltip string
 	 *
 	 * @since   3.1.2
+	 * modified 2014-03-03. MrBenGriffin (Tracker ID 32989)
 	 */
 	public static function tooltipText($title = '', $content = '', $translate = 1, $escape = 1)
 	{
-		// Return empty in no title or content is given.
-		if ($title == '' && $content == '')
+		$result = '';
+		// don't process empty strings
+		if ($content != '' || $title != '')
 		{
-			return '';
-		}
+			// Split title into title and content if the title contains '::' (old Mootools format).
+			if ($content == '' && !(strpos($title, '::') === false))
+			{
+				list($title, $content) = explode('::', $title, 2);
+			}
 
-		// Split title into title and content if the title contains '::' (old Mootools format).
-		if ($content == '' && !(strpos($title, '::') === false))
-		{
-			list($title, $content) = explode('::', $title, 2);
-		}
+			// Pass texts through the JText if required.
+			if ($translate)
+			{
+				$title = JText::_($title);
+				$content = JText::_($content);
+			}
 
-		// Pass texts through the JText.
-		if ($translate)
-		{
-			$title = JText::_($title);
-			$content = JText::_($content);
+			// Use only the content if no title is given.
+			if ($title == '')
+			{
+				$result = $content;
+			}
+			// Use only the title, if title and text are the same.
+			elseif ($title == $content)
+			{
+				$result = '<strong>' . $title . '</strong>';
+			}
+			// Use a formatted string combining the title and content.
+			elseif ($content != '')
+			{
+				$result = '<strong>' . $title . '</strong><br />' . $content;
+			}
+			else {
+				$result = $title;
+			}
+			// escape everything, if required.
+			if ($escape) {
+				$result = htmlspecialchars($result);
+			}
 		}
-
-		// Escape the texts.
-		if ($escape)
-		{
-			$title = str_replace('"', '&quot;', $title);
-			$content = str_replace('"', '&quot;', $content);
-		}
-
-		// Return only the content if no title is given.
-		if ($title == '')
-		{
-			return $content;
-		}
-
-		// Return only the title if title and text are the same.
-		if ($title == $content)
-		{
-			return '<strong>' . $title . '</strong>';
-		}
-
-		// Return the formated sting combining the title and  content.
-		if ($content != '')
-		{
-			return '<strong>' . $title . '</strong><br />' . $content;
-		}
-
-		// Return only the title.
-		return $title;
+		return $result;
 	}
 
 	/**

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -889,7 +889,6 @@ abstract class JHtml
 	 * @return  string  The tooltip string
 	 *
 	 * @since   3.1.2
-	 * modified 2014-03-03. MrBenGriffin (Tracker ID 32989)
 	 */
 	public static function tooltipText($title = '', $content = '', $translate = 1, $escape = 1)
 	{

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1447,7 +1447,7 @@ class JHtmlTest extends TestCase
 		$this->assertThat(
 			JHtml::tooltip('Content', array('title' => 'Title')),
 			$this->equalTo(
-				'<span class="hasTooltip" title="<strong>Title</strong><br />Content"><img src="' .
+				'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
 				JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>'
 			),
 			'Tooltip with title and content failed'
@@ -1455,28 +1455,29 @@ class JHtmlTest extends TestCase
 
 		$this->assertThat(
 			JHtml::tooltip('Content', array('title' => 'Title', 'text' => 'Text')),
-			$this->equalTo('<span class="hasTooltip" title="<strong>Title</strong><br />Content">Text</span>'),
+			$this->equalTo('<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content">Text</span>'),
 			'Tooltip with title and content and text failed'
 		);
 
 		$this->assertThat(
 			JHtml::tooltip('Content', array('title' => 'Title', 'text' => 'Text', 'href' => 'http://www.monsite.com')),
-			$this->equalTo('<span class="hasTooltip" title="<strong>Title</strong><br />Content"><a href="http://www.monsite.com">Text</a></span>'),
+			$this->equalTo('<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>'),
 			'Tooltip with title and content and text and href failed'
 		);
 
 		$this->assertThat(
 			JHtml::tooltip('Content', array('title' => 'Title', 'alt' => 'MyAlt')),
 			$this->equalTo(
-				'<span class="hasTooltip" title="<strong>Title</strong><br />Content"><img src="' .
+				'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
 				JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>'
 			),
 			'Tooltip with title and content and alt failed'
 		);
+		
 		$this->assertThat(
 			JHtml::tooltip('Content', array('title' => 'Title', 'class' => 'hasTooltip2')),
 			$this->equalTo(
-				'<span class="hasTooltip2" title="<strong>Title</strong><br />Content"><img src="' .
+				'<span class="hasTooltip2" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
 				JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>'
 			),
 			'Tooltip with title and content and class failed'

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1397,9 +1397,9 @@ class JHtmlTest extends TestCase
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title'),
 			$this->equalTo(
-				'<span class="hasTooltip" title="<strong>Title</strong><br />Content"><img src="' .
-				JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>'
-			),
+				'<span class="hasTooltip" title="' .
+				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
+				'"><img src="/media/system/images/tooltip.png" alt="Tooltip" /></span>'			),
 			'Tooltip with title and content failed'
 		);
 
@@ -1673,7 +1673,7 @@ class JHtmlTest extends TestCase
 	{
 		$this->assertThat(
 			JHtml::tooltipText('Title::Content'),
-			$this->equalTo('<strong>Title</strong><br />Content'),
+			$this->equalTo('&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content'),
 			'A string with "::" should be converted'
 		);
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1411,7 +1411,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title', null, 'Text', 'http://www.monsite.com'),
-			$this->equalTo('<span class="hasTooltip" title="<strong>Title</strong><br />Content"><a href="http://www.monsite.com">Text</a></span>'),
+			$this->equalTo('<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>'),
 			'Tooltip with title and content and text and href failed'
 		);
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1405,7 +1405,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title', null, 'Text'),
-			$this->equalTo('<span class="hasTooltip" title="<strong>Title</strong><br />Content">Text</span>'),
+			$this->equalTo('<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content">Text</span>'),
 			'Tooltip with title and content and text failed'
 		);
 
@@ -1685,7 +1685,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertThat(
 			JHtml::tooltipText('Title', 'Content'),
-			$this->equalTo('<strong>Title</strong><br />Content'),
+			$this->equalTo('&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content'),
 			'A title and content should be combined'
 		);
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1418,7 +1418,9 @@ class JHtmlTest extends TestCase
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title', 'tooltip.png', null, null, 'MyAlt'),
 			$this->equalTo(
-				'<span class="hasTooltip" title="<strong>Title</strong><br />Content"><img src="' .
+				'<span class="hasTooltip" title="' .
+				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
+				'"><img src="' .
 				JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>'
 			),
 			'Tooltip with title and content and alt failed'
@@ -1427,7 +1429,9 @@ class JHtmlTest extends TestCase
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title', 'tooltip.png', null, null, 'MyAlt', 'hasTooltip2'),
 			$this->equalTo(
-				'<span class="hasTooltip2" title="<strong>Title</strong><br />Content"><img src="' . JUri::base(true) .
+				'<span class="hasTooltip2" title="'.
+				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
+				'"><img src="' . JUri::base(true) .
 				'/media/system/images/tooltip.png" alt="MyAlt" /></span>'
 			),
 			'Tooltip with title and content and alt and class failed'

--- a/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
@@ -204,8 +204,9 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
-		$equals = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" ' .
-			'title="<strong>Title</strong><br />The title.">Title<span class="star">&#160;*</span></label>';
+		$equals = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" title="' .
+			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;The title.' .
+			'">Title<span class="star">&#160;*</span></label>';
 
 		$this->assertThat(
 			$field->getLabel(),

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1169,8 +1169,9 @@ class JFormTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$expected = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" ' .
-				'title="<strong>Title</strong><br />The title.">Title<span class="star">&#160;*</span></label>';
+		$expected = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" title="' .
+			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;The title.' .
+			'">Title<span class="star">&#160;*</span></label>';
 
 		$this->assertThat(
 			$form->getLabel('title'),

--- a/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldTest_DataSet
 				'name' => 'myName',
 				'value' => 'The text field.',
 				'title' => 'My Title',
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip" title="<strong>My Title</strong><br />The description.">My Title</label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title</label>',
 				'unexisting' => null,
 			),
 			'<field name="myName" type="text" id="myId" label="My Title" description="The description."  value="Text Field" />',
@@ -111,7 +111,7 @@ class JHtmlFieldTest_DataSet
 		'RequiredLabel' => array(
 			array(
 				'required' => true,
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip required" title="<strong>My Title</strong><br />The description.">My Title<span class="star">&#160;*</span></label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip required" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title<span class="star">&#160;*</span></label>',
 			),
 			'<field name="myName" type="text" id="myId" required="true" label="My Title" description="The description." />',
 			'',

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
@@ -119,8 +119,8 @@ class JFormFieldSpacerTest extends TestCase
 		);
 
 		$equals = '<span class="spacer"><span class="before"></span><span>' .
-			'<label id="spacer-lbl" class="hasTooltip" title="<strong>spacer</strong>">spacer</label></span>' .
-			'<span class="after"></span></span>';
+			'<label id="spacer-lbl" class="hasTooltip" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label>' .
+			'</span><span class="after"></span></span>';
 
 		$this->assertEquals(
 			$equals,


### PR DESCRIPTION
Tracker 32989. If we are escaping tooltips for attributes, we need to escape the entire markup.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32989&start=0
