### PR TITLE
Update JHtmlTest.php

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1397,8 +1397,9 @@ class JHtmlTest extends TestCase
 		$this->assertThat(
 			JHtml::tooltip('Content', 'Title'),
 			$this->equalTo(
-				'<span class="hasTooltip" title="<strong>Title</strong><br />Content"><img src="' .
-				JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>'
+				'<span class="hasTooltip" title="' .
+				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
+				'"><img src="/media/system/images/tooltip.png" alt="Tooltip" /></span>'
 			),
 			'Tooltip with title and content failed'
 		);
@@ -1673,7 +1674,7 @@ class JHtmlTest extends TestCase
 	{
 		$this->assertThat(
 			JHtml::tooltipText('Title::Content'),
-			$this->equalTo('<strong>Title</strong><br />Content'),
+			$this->equalTo('&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content'),
 			'A string with "::" should be converted'
 		);
 


### PR DESCRIPTION
Tooltips must be fully escaped, characters such as <> are disallowed in attributes. See JT 32989 / GH 3224
