### PR TITLE
Update JFormFieldSpacerTest.php

### DIFF
--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
@@ -119,8 +119,8 @@ class JFormFieldSpacerTest extends TestCase
 		);
 
 		$equals = '<span class="spacer"><span class="before"></span><span>' .
-			'<label id="spacer-lbl" class="hasTooltip" title="<strong>spacer</strong>">spacer</label></span>' .
-			'<span class="after"></span></span>';
+			'<label id="spacer-lbl" class="hasTooltip" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label>' .
+			'</span><span class="after"></span></span>';
 
 		$this->assertEquals(
 			$equals,


### PR DESCRIPTION
Tooltips must be fully escaped, characters such as <> are disallowed in attributes. See JT 32989 / GH 3224
