### PR TITLE
Update JHtmlField-helper-dataset.php

### DIFF
--- a/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldTest_DataSet
 				'name' => 'myName',
 				'value' => 'The text field.',
 				'title' => 'My Title',
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip" title="<strong>My Title</strong><br />The description.">My Title</label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title</label>',
 				'unexisting' => null,
 			),
 			'<field name="myName" type="text" id="myId" label="My Title" description="The description."  value="Text Field" />',
@@ -111,7 +111,7 @@ class JHtmlFieldTest_DataSet
 		'RequiredLabel' => array(
 			array(
 				'required' => true,
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip required" title="<strong>My Title</strong><br />The description.">My Title<span class="star">&#160;*</span></label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip required" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title<span class="star">&#160;*</span></label>',
 			),
 			'<field name="myName" type="text" id="myId" required="true" label="My Title" description="The description." />',
 			'',


### PR DESCRIPTION
Tooltips must be fully escaped, characters such as <> are disallowed in attributes. See JT 32989 / GH 3224
