### PR TITLE
Remove the usage of the "inputbox" class from backend

### DIFF
--- a/administrator/components/com_admin/models/forms/profile.xml
+++ b/administrator/components/com_admin/models/forms/profile.xml
@@ -2,7 +2,6 @@
 <form>
 	<fieldset name="user_details">
 		<field name="name" type="text"
-			class="inputbox"
 			description="COM_ADMIN_USER_FIELD_NAME_DESC"
 			label="COM_ADMIN_USER_HEADING_NAME"
 			required="true"
@@ -10,7 +9,6 @@
 		/>
 
 		<field name="username" type="text"
-			class="inputbox"
 			description="COM_ADMIN_USER_FIELD_USERNAME_DESC"
 			label="COM_ADMIN_USER_FIELD_USERNAME_LABEL"
 			required="true"
@@ -40,7 +38,6 @@
 		/>
 
 		<field name="email" type="email"
-			class="inputbox"
 			description="COM_ADMIN_USER_FIELD_EMAIL_DESC"
 			label="JGLOBAL_EMAIL"
 			required="true"

--- a/administrator/components/com_banners/config.xml
+++ b/administrator/components/com_banners/config.xml
@@ -10,7 +10,7 @@
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
 			description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
 			default="0"
-			class="inputbox">
+			>
 			<option
 				value="1">COM_BANNERS_FIELD_VALUE_1</option>
 			<option
@@ -92,7 +92,6 @@
 			name="rules"
 			type="rules"
 			label="JCONFIG_PERMISSIONS_LABEL"
-			class="inputbox"
 			filter="rules"
 			validate="rules"
 			component="com_banners"

--- a/administrator/components/com_banners/helpers/html/banner.php
+++ b/administrator/components/com_banners/helpers/html/banner.php
@@ -34,7 +34,7 @@ abstract class JHtmlBanner
 			'<label id="batch-client-lbl" for="batch-client" class="hasTooltip" title="' . JHtml::tooltipText('COM_BANNERS_BATCH_CLIENT_LABEL', 'COM_BANNERS_BATCH_CLIENT_LABEL_DESC') . '">',
 			JText::_('COM_BANNERS_BATCH_CLIENT_LABEL'),
 			'</label>',
-			'<select name="batch[client_id]" class="inputbox" id="batch-client-id">',
+			'<select name="batch[client_id]" id="batch-client-id">',
 			'<option value="">' . JText::_('COM_BANNERS_BATCH_CLIENT_NOCHANGE') . '</option>',
 			'<option value="0">' . JText::_('COM_BANNERS_NO_CLIENT') . '</option>',
 			JHtml::_('select.options', static::clientlist(), 'value', 'text'),

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -8,18 +8,18 @@
 			label="JGLOBAL_FIELD_ID_LABEL" description="JGLOBAL_FIELD_ID_DESC" />
 
 		<field name="name" type="text"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40" label="COM_BANNERS_FIELD_NAME_LABEL"
 			description="COM_BANNERS_FIELD_NAME_DESC" required="true" />
 
-		<field name="alias" type="text" class="inputbox"
+		<field name="alias" type="text"
 			size="40" label="JFIELD_ALIAS_LABEL"
 			description="COM_BANNERS_FIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER" />
 
 		<field name="catid" type="categoryedit" extension="com_banners"
 			label="JCATEGORY" description="COM_BANNERS_FIELD_CATEGORY_DESC"
-			class="inputbox" required="true"
+			required="true"
 			addfieldpath="/administrator/components/com_categories/models/fields" />
 
 		<field name="state" type="list"
@@ -33,11 +33,11 @@
 		</field>
 
 		<field name="ordering" type="ordering" label="JFIELD_ORDERING_LABEL"
-			class="inputbox" description="JFIELD_ORDERING_DESC"
+			description="JFIELD_ORDERING_DESC"
 			table="#__banners" />
 
 		<field name="language" type="contentlanguage" label="JFIELD_LANGUAGE_LABEL"
-			description="COM_BANNERS_FIELD_LANGUAGE_DESC" class="inputbox">
+			description="COM_BANNERS_FIELD_LANGUAGE_DESC">
 			<option value="*">JALL</option>
 		</field>
 
@@ -45,28 +45,28 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox span12" size="45"
+			class="span12" size="45"
 			labelclass="control-label"
 		/>
 
-		<field name="description" type="textarea" class="inputbox"
+		<field name="description" type="textarea"
 			rows="3" cols="30" label="JGLOBAL_DESCRIPTION"
 			description="COM_BANNERS_FIELD_DESCRIPTION_DESC" />
 
 		<field name="type" type="list"
 			label="COM_BANNERS_FIELD_TYPE_LABEL" description="COM_BANNERS_FIELD_TYPE_DESC"
-			default="0" class="inputbox">
+			default="0">
 			<option value="0">COM_BANNERS_FIELD_VALUE_IMAGE
 			</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_CUSTOM
 			</option>
 		</field>
 
-		<field name="custombannercode" type="textarea" class="inputbox"
+		<field name="custombannercode" type="textarea"
 			rows="3" cols="30" filter="raw"
 			label="COM_BANNERS_FIELD_CUSTOMCODE_LABEL" description="COM_BANNERS_FIELD_CUSTOMCODE_DESC" />
 
-		<field name="clickurl" type="url" class="inputbox" filter="url"
+		<field name="clickurl" type="url" filter="url"
 			label="COM_BANNERS_FIELD_CLICKURL_LABEL" description="COM_BANNERS_FIELD_CLICKURL_DESC" />
 	</fieldset>
 
@@ -75,7 +75,7 @@
 
 		<field name="created" type="calendar"
 			label="COM_BANNERS_FIELD_CREATED_LABEL" description="COM_BANNERS_FIELD_CREATED_DESC"
-			class="inputbox" size="22" format="%Y-%m-%d %H:%M:%S"
+			size="22" format="%Y-%m-%d %H:%M:%S"
 			filter="user_utc" />
 
 		<field name="created_by" type="user"
@@ -83,7 +83,7 @@
 
 		<field name="created_by_alias" type="text"
 			label="COM_BANNERS_FIELD_CREATED_BY_ALIAS_LABEL" description="COM_BANNERS_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 
 		<field name="modified" type="calendar" class="readonly"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL" description="COM_BANNERS_FIELD_MODIFIED_DESC"
@@ -101,12 +101,12 @@
 
 		<field name="publish_up" type="calendar"
 			label="COM_BANNERS_FIELD_PUBLISH_UP_LABEL" description="COM_BANNERS_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="publish_down" type="calendar"
 			label="COM_BANNERS_FIELD_PUBLISH_DOWN_LABEL" description="COM_BANNERS_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 	</fieldset>
 
@@ -137,7 +137,7 @@
 
 		<field name="purchase_type" type="list"
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL" description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
-			default="0" class="inputbox">
+			default="0">
 			<option value="-1">COM_BANNERS_FIELD_VALUE_USECLIENTDEFAULT
 			</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_1
@@ -173,7 +173,7 @@
 	<fieldset name="metadata"
 		label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 
-		<field name="metakey" type="textarea" class="inputbox"
+		<field name="metakey" type="textarea"
 			rows="3" cols="30" label="JFIELD_META_KEYWORDS_LABEL"
 			description="COM_BANNERS_FIELD_METAKEYWORDS_DESC" />
 
@@ -199,20 +199,20 @@
 				description="COM_BANNERS_FIELD_IMAGE_DESC" />
 
 			<field name="width" type="text"
-				class="inputbox input-mini validate-numeric" label="COM_BANNERS_FIELD_WIDTH_LABEL"
+				class="input-mini validate-numeric" label="COM_BANNERS_FIELD_WIDTH_LABEL"
 				description="COM_BANNERS_FIELD_WIDTH_DESC" />
 
 			<field name="height" type="text"
-				class="inputbox input-mini validate-numeric" label="COM_BANNERS_FIELD_HEIGHT_LABEL"
+				class="input-mini validate-numeric" label="COM_BANNERS_FIELD_HEIGHT_LABEL"
 				description="COM_BANNERS_FIELD_HEIGHT_DESC" />
 
-			<field name="alt" type="text" class="inputbox"
+			<field name="alt" type="text"
 				label="COM_BANNERS_FIELD_ALT_LABEL" description="COM_BANNERS_FIELD_ALT_DESC" />
 		</fieldset>
 	</fields>
 
 	<fieldset name="custom">
-		<field name="bannercode" type="textarea" class="inputbox"
+		<field name="bannercode" type="textarea"
 			rows="3" cols="30" filter="raw"
 			label="COM_BANNERS_FIELD_CUSTOMCODE_LABEL" description="COM_BANNERS_FIELD_CUSTOMCODE_DESC" />
 	</fieldset>

--- a/administrator/components/com_banners/models/forms/client.xml
+++ b/administrator/components/com_banners/models/forms/client.xml
@@ -8,16 +8,16 @@
 			label="JGLOBAL_FIELD_ID_LABEL" description="JGLOBAL_FIELD_ID_DESC" />
 
 		<field name="name" type="text"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40" label="COM_BANNERS_FIELD_NAME_LABEL"
 			description="COM_BANNERS_FIELD_CLIENT_NAME_DESC"
 			required="true" />
 
-		<field name="contact" type="text" class="inputbox"
+		<field name="contact" type="text"
 			size="40" label="COM_BANNERS_FIELD_CONTACT_LABEL"
 			description="COM_BANNERS_FIELD_CONTACT_DESC" required="true" />
 
-		<field name="email" type="email" class="inputbox"
+		<field name="email" type="email"
 			size="40" label="COM_BANNERS_FIELD_EMAIL_LABEL"
 			description="COM_BANNERS_FIELD_EMAIL_DESC" validate="email"
 			required="true" />
@@ -36,13 +36,13 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox" size="45"
+			size="45"
 			labelclass="control-label"
 		/>
 
 		<field name="purchase_type" type="list"
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL" description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
-			default="0" class="inputbox"
+			default="0"
 		>
 			<option value="-1">JGLOBAL_USE_GLOBAL
 			</option>
@@ -83,7 +83,7 @@
 		label="JGLOBAL_FIELDSET_METADATA_OPTIONS"
 	>
 
-		<field name="metakey" type="textarea" class="inputbox"
+		<field name="metakey" type="textarea"
 			rows="3" cols="30" label="JFIELD_META_KEYWORDS_LABEL"
 			description="COM_BANNERS_FIELD_CLIENT_METAKEYWORDS_DESC" />
 
@@ -106,7 +106,7 @@
 	<fieldset name="extra" label="COM_BANNERS_EXTRA">
 
 		<field name="extrainfo" type="textarea"
-			class="inputbox span12"
+			class="span12"
 			rows="5" cols="80" label="COM_BANNERS_FIELD_EXTRAINFO_LABEL"
 			description="COM_BANNERS_FIELD_EXTRAINFO_DESC" />
 

--- a/administrator/components/com_banners/models/forms/download.xml
+++ b/administrator/components/com_banners/models/forms/download.xml
@@ -12,7 +12,7 @@
 		</field>
 
 		<field name="basename" type="text"
-			class="inputbox" size="40"
+			size="40"
 			label="COM_BANNERS_FIELD_BASENAME_LABEL" description="COM_BANNERS_FIELD_BASENAME_DESC" />
 
 	</fieldset>

--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -82,7 +82,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_BANNERS_LIST_LIMIT"
 			description="COM_BANNERS_LIST_LIMIT_DESC"

--- a/administrator/components/com_banners/models/forms/filter_clients.xml
+++ b/administrator/components/com_banners/models/forms/filter_clients.xml
@@ -22,7 +22,6 @@
 			label="COM_BANNERS_FILTER_PURCHASETYPE_LABEL"
 			description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
 			default="0"
-			class="inputbox"
 			onchange="this.form.submit();"
 		>
 			<option value="">COM_BANNERS_SELECT_TYPE</option>
@@ -62,7 +61,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_BANNERS_LIST_LIMIT"
 			description="COM_BANNERS_LIST_LIMIT_DESC"

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -62,7 +62,7 @@
 		type="text"
 		label="JGLOBAL_TITLE"
 		description="JFIELD_TITLE_DESC"
-		class="inputbox input-xxlarge input-large-text"
+		class="input-xxlarge input-large-text"
 		size="40"
 		required="true"/>
 
@@ -72,7 +72,6 @@
 		label="JFIELD_ALIAS_LABEL"
 		description="JFIELD_ALIAS_DESC"
 		hint="JFIELD_ALIAS_PLACEHOLDER"
-		class="inputbox"
 		size="45"/>
 
 	<field
@@ -80,7 +79,7 @@
 		type="text"
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 		description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-		class="inputbox span12"
+		class="span12"
 		size="45" />
 
 	<field
@@ -88,7 +87,7 @@
 		type="text"
 		label="JFIELD_NOTE_LABEL"
 		description="JFIELD_NOTE_DESC"
-		class="inputbox span12"
+		class="span12"
 		size="40"/>
 
 	<field
@@ -96,7 +95,6 @@
 		type="editor"
 		label="JGLOBAL_DESCRIPTION"
 		description="COM_CATEGORIES_DESCRIPTION_DESC"
-		class="inputbox"
 		filter="JComponentHelper::filterText"
 		buttons="true"
 		hide="readmore,pagebreak"/>
@@ -194,7 +192,7 @@
 		type="tag"
 		label="JTAG"
 		description="JTAG_DESC"
-		class="inputbox span12"
+		class="span12"
 		multiple="true"
 		>
 	</field>
@@ -207,7 +205,6 @@
 		translate_label="false"
 		filter="rules"
 		validate="rules"
-		class="inputbox"
 		component="com_content"
 		section="category"/>
 

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -88,7 +88,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_CATEGORIES_LIST_LIMIT"
 			description="COM_CATEGORIES_LIST_LIMIT_DESC"

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch.php
@@ -50,7 +50,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 							<?php echo JText::_('COM_CATEGORIES_BATCH_CATEGORY_LABEL'); ?>
 						</label>
 						<div id="batch-choose-action" class="combo controls">
-							<select name="batch[category_id]" class="inputbox" id="batch-category-id">
+							<select name="batch[category_id]" id="batch-category-id">
 								<option value=""><?php echo JText::_('JSELECT') ?></option>
 								<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
 							</select>

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -759,7 +759,6 @@
 			label="FIELD_RULES_LABEL"
 			translate_label="false"
 			validate="rules"
-			class="inputbox"
 			filter="rules">
 			<action
 				name="core.login.site"
@@ -815,7 +814,6 @@
 			name="filters"
 			type="filters"
 			label="COM_CONFIG_TEXT_FILTERS"
-			class="inputbox"
 			filter="" />
 	</fieldset>
 

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -275,7 +275,6 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -283,19 +282,17 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
 			<field name="linkc_name" type="text"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL" description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox" size="30" />
+				size="30" />
 
 			<field name="linkd_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -303,7 +300,7 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox" size="30"
+				size="30"
 			/>
 
 		<field

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -15,7 +15,7 @@
 			type="text"
 			label="COM_CONTACT_FIELD_NAME_LABEL"
 			description="COM_CONTACT_FIELD_NAME_DESC"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40"
 			required="true"
 		 />
@@ -25,7 +25,6 @@
 			label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER"
-			class="inputbox"
 			size="45"
 		/>
 
@@ -33,7 +32,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox span12" size="45"
+			class="span12" size="45"
 			labelclass="control-label"
 		/>
 
@@ -68,7 +67,6 @@
 			extension="com_contact"
 			label="JCATEGORY"
 			description="JFIELD_CATEGORY_DESC"
-			class="inputbox"
 			required="true"
 		/>
 
@@ -76,14 +74,12 @@
 			type="accesslevel"
 			label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC"
-			class="inputbox"
 			size="1"
 		/>
 
 		<field name="misc" type="editor"
 			label="COM_CONTACT_FIELD_INFORMATION_MISC_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_MISC_DESC"
-			class="inputbox"
 			filter="JComponentHelper::filterText"
 			buttons="true"
 			hide="readmore,pagebreak"
@@ -94,10 +90,10 @@
 
 		<field name="created_by_alias" type="text"
 			label="COM_CONTACT_FIELD_CREATED_BY_ALIAS_LABEL" description="COM_CONTACT_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 
 		<field name="created" type="calendar" label="COM_CONTACT_FIELD_CREATED_LABEL"
-			description="COM_CONTACT_FIELD_CREATED_DESC" class="inputbox" size="22"
+			description="COM_CONTACT_FIELD_CREATED_DESC" size="22"
 			format="%Y-%m-%d %H:%M:%S" filter="user_utc" />
 
 		<field name="modified" type="calendar" class="readonly"
@@ -122,7 +118,6 @@
 
 		<field name="ordering"
 			type="ordering"
-			class="inputbox"
 			label="JFIELD_ORDERING_LABEL"
 			description="JFIELD_ORDERING_DESC"
             content_type="com_contact.contact"
@@ -130,13 +125,13 @@
 
 		<field name="publish_up" type="calendar"
 			label="COM_CONTACT_FIELD_PUBLISH_UP_LABEL" description="COM_CONTACT_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc"
 		/>
 
 		<field name="publish_down" type="calendar"
 			label="COM_CONTACT_FIELD_PUBLISH_DOWN_LABEL" description="COM_CONTACT_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc"
 		/>
 
@@ -144,7 +139,6 @@
 			type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL"
 			description="JFIELD_META_KEYWORDS_DESC"
-			class="inputbox"
 			rows="3"
 			cols="30"
 		 />
@@ -153,13 +147,12 @@
 			type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			description="JFIELD_META_DESCRIPTION_DESC"
-			class="inputbox"
 			rows="3"
 			cols="30"
 		/>
 
 		<field name="language" type="contentlanguage" label="JFIELD_LANGUAGE_LABEL"
-			description="COM_CONTACT_FIELD_LANGUAGE_DESC" class="inputbox"
+			description="COM_CONTACT_FIELD_LANGUAGE_DESC"
 		>
 			<option value="*">JALL</option>
 		</field>
@@ -179,7 +172,7 @@
 			type="tag"
 			label="JTAG"
 			description="JTAG_DESC"
-			class="inputbox span12"
+			class="span12"
 			multiple="true"
 		>
 		</field>
@@ -252,21 +245,18 @@
 		<field name="con_position" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_POSITION_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_POSITION_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="email_to" type="email"
 			label="JGLOBAL_EMAIL"
 			description="COM_CONTACT_FIELD_INFORMATION_EMAIL_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="address" type="textarea"
 			label="COM_CONTACT_FIELD_INFORMATION_ADDRESS_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_ADDRESS_DESC"
-			class="inputbox"
 			rows="3"
 			cols="30"
 		/>
@@ -274,28 +264,24 @@
 		<field name="suburb" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_SUBURB_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_SUBURB_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="state" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_STATE_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_STATE_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="postcode" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_POSTCODE_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_POSTCODE_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="country" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_COUNTRY_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_COUNTRY_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
@@ -303,21 +289,18 @@
 			label="COM_CONTACT_FIELD_INFORMATION_TELEPHONE_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_TELEPHONE_DESC"
 
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="mobile" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_MOBILE_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="fax" type="text"
 			label="COM_CONTACT_FIELD_INFORMATION_FAX_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_FAX_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
@@ -326,26 +309,23 @@
 			filter="url"
 			label="COM_CONTACT_FIELD_INFORMATION_WEBPAGE_LABEL"
 			description="COM_CONTACT_FIELD_INFORMATION_WEBPAGE_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="sortname1" type="text"
 			label="COM_CONTACT_FIELD_SORTNAME1_LABEL"
 			description="COM_CONTACT_FIELD_SORTNAME1_DESC"
-			class="inputbox"
 			size="30"
 		/>
 
 		<field name="sortname2" type="text"
 			label="COM_CONTACT_FIELD_SORTNAME2_LABEL"
 			description="COM_CONTACT_FIELD_SORTNAME2_DESC"
-			class="inputbox" size="30" />
+			size="30" />
 
 		<field name="sortname3" type="text"
 			label="COM_CONTACT_FIELD_SORTNAME3_LABEL"
 			description="COM_CONTACT_FIELD_SORTNAME3_DESC"
-			class="inputbox"
 			size="30"
 		/>
 	</fieldset>
@@ -584,28 +564,24 @@
 			<field name="linka_name" type="text"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
 			<field name="linka" type="url" filter="url"
 				label="COM_CONTACT_FIELD_LINKA_LABEL"
 				description="COM_CONTACT_FIELD_LINKA_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
 			<field name="linkb_name" type="text"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
 			<field name="linkb" type="url" filter="url"
 				label="COM_CONTACT_FIELD_LINKB_LABEL"
 				description="COM_CONTACT_FIELD_LINKB_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -613,7 +589,6 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -621,7 +596,6 @@
 				type="url" filter="url"
 				label="COM_CONTACT_FIELD_LINKC_LABEL"
 				description="COM_CONTACT_FIELD_LINKC_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -629,7 +603,6 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 				/>
 
@@ -637,7 +610,6 @@
 				type="url" filter="url"
 				label="COM_CONTACT_FIELD_LINKD_LABEL"
 				description="COM_CONTACT_FIELD_LINKD_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -645,7 +617,6 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				class="inputbox"
 				size="30"
 			/>
 
@@ -653,7 +624,6 @@
 				type="text"
 				label="COM_CONTACT_FIELD_LINKE_LABEL"
 				description="COM_CONTACT_FIELD_LINKE_DESC"
-				class="inputbox"
 				size="30"
 			/>
 			<field

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -372,7 +372,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
-			class="inputbox">
+			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
 				<option value="2">JBROWSERTARGET_POPUP</option>
@@ -385,7 +385,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
-			class="inputbox">
+			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
 				<option value="2">JBROWSERTARGET_POPUP</option>
@@ -398,7 +398,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
-			class="inputbox">
+			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
 				<option value="2">JBROWSERTARGET_POPUP</option>
@@ -887,7 +887,6 @@
 			name="rules"
 			type="rules"
 			label="JCONFIG_PERMISSIONS_LABEL"
-			class="inputbox"
 			validate="rules"
 			filter="rules"
 			component="com_content"

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -9,21 +9,21 @@
 
 		<field name="title" type="text" label="JGLOBAL_TITLE"
 			description="JFIELD_TITLE_DESC"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40"
 			required="true" />
 
 		<field name="alias" type="text" label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER"
-			class="inputbox" size="40" />
+			size="40" />
 
 		<field name="version_note" type="text" label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox span12"
+			class="span12"
 			size="45" />
 
-		<field name="articletext" type="editor" class="inputbox"
+		<field name="articletext" type="editor"
 			label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL" description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
 			filter="JComponentHelper::filterText" buttons="true" />
 
@@ -43,7 +43,7 @@
 
 		<field name="catid" type="categoryedit"
 			label="JCATEGORY" description="JFIELD_CATEGORY_DESC"
-			class="inputbox" required="true"
+			required="true"
 		>
 		</field>
 
@@ -51,7 +51,7 @@
 			type="tag"
 			label="JTAG"
 			description="JTAG_DESC"
-			class="inputbox span12"
+			class="span12"
 			multiple="true"
 		>
 		</field>
@@ -62,7 +62,7 @@
 			type="spacer" />
 
 		<field name="created" type="calendar" label="COM_CONTENT_FIELD_CREATED_LABEL"
-			description="COM_CONTENT_FIELD_CREATED_DESC" class="inputbox" size="22"
+			description="COM_CONTENT_FIELD_CREATED_DESC" size="22"
 			format="%Y-%m-%d %H:%M:%S" filter="user_utc" />
 
 		<field name="created_by" type="user"
@@ -70,7 +70,7 @@
 
 		<field name="created_by_alias" type="text"
 			label="COM_CONTENT_FIELD_CREATED_BY_ALIAS_LABEL" description="COM_CONTENT_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 
 		<field name="modified" type="calendar" class="readonly"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL" description="COM_CONTENT_FIELD_MODIFIED_DESC"
@@ -89,12 +89,12 @@
 
 		<field name="publish_up" type="calendar"
 			label="COM_CONTENT_FIELD_PUBLISH_UP_LABEL" description="COM_CONTENT_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="publish_down" type="calendar"
 			label="COM_CONTENT_FIELD_PUBLISH_DOWN_LABEL" description="COM_CONTENT_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="version" type="text" class="readonly"
@@ -102,16 +102,16 @@
 			readonly="true" filter="unset" />
 
 		<field name="ordering" type="text" label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC" class="inputbox" size="6"
+			description="JFIELD_ORDERING_DESC" size="6"
 			default="0" />
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="metadesc" type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL" description="JFIELD_META_DESCRIPTION_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="access" type="accesslevel" label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC" size="1" />
@@ -137,7 +137,7 @@
 		</field>
 
 		<field name="rules" type="rules" label="JFIELD_RULES_LABEL"
-			translate_label="false" class="inputbox" filter="rules"
+			translate_label="false" filter="rules"
 			component="com_content" section="article" validate="rules"
 		/>
 
@@ -397,7 +397,7 @@
 			<field name="alternative_readmore" type="inputbox"
 				label="JFIELD_READMORE_LABEL"
 				description="JFIELD_READMORE_DESC"
-				class="inputbox" size="25" />
+				size="25" />
 
 			<field name="article_layout" type="componentlayout"
 				label="JFIELD_ALT_LAYOUT_LABEL"
@@ -598,7 +598,7 @@
 			<field name="alternative_readmore" type="hidden"
 				label="JFIELD_READMORE_LABEL"
 				description="JFIELD_READMORE_DESC"
-				class="inputbox" size="25" />
+				size="25" />
 
 			<field name="article_layout" type="hidden"
 				label="JFIELD_ALT_LAYOUT_LABEL"
@@ -612,7 +612,7 @@
 	<field name="xreference" type="text"
 		label="JFIELD_KEY_REFERENCE_LABEL"
 		description="JFIELD_KEY_REFERENCE_DESC"
-		class="inputbox" size="20" />
+		size="20" />
 
 	<fields name="images" label="COM_CONTENT_FIELD_IMAGE_OPTIONS">
 		<field
@@ -634,13 +634,11 @@
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
 			description="COM_CONTENT_FIELD_IMAGE_ALT_DESC"
-			class="inputbox"
 			size="20"/>
 		<field name="image_intro_caption"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
 			description="COM_CONTENT_FIELD_IMAGE_CAPTION_DESC"
-			class="inputbox"
 			size="20"/>
 		<field
 			name="spacer1"
@@ -666,13 +664,11 @@
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
 			description="COM_CONTENT_FIELD_IMAGE_ALT_DESC"
-			class="inputbox"
 			size="20"/>
 		<field name="image_fulltext_caption"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
 			description="COM_CONTENT_FIELD_IMAGE_CAPTION_DESC"
-			class="inputbox"
 			size="20"/>
 	</fields>
 	<fields name="urls" label="COM_CONTENT_FIELD_URLS_OPTIONS">
@@ -687,7 +683,6 @@
 			type="text"
 			label="COM_CONTENT_FIELD_URLA_LINK_TEXT_LABEL"
 			description="COM_CONTENT_FIELD_URL_LINK_TEXT_DESC"
-			class="inputbox"
 			size="20"/>
 		<field
 			name="targeta"
@@ -696,7 +691,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default=""
 			filter="options"
-			class="inputbox">
+			>
 			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
@@ -719,7 +714,6 @@
 			type="text"
 			label="COM_CONTENT_FIELD_URLB_LINK_TEXT_LABEL"
 			description="COM_CONTENT_FIELD_URL_LINK_TEXT_DESC"
-			class="inputbox"
 			size="20"/>
 		<field
 			name="targetb"
@@ -728,7 +722,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default=""
 			filter="options"
-			class="inputbox">
+			>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -752,7 +746,6 @@
 			type="text"
 			label="COM_CONTENT_FIELD_URLC_LINK_TEXT_LABEL"
 			description="COM_CONTENT_FIELD_URL_LINK_TEXT_DESC"
-			class="inputbox"
 			size="20"/>
 		<field
 			name="targetc"
@@ -761,7 +754,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default=""
 			filter="options"
-			class="inputbox">
+			>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -797,7 +790,7 @@
 			<field name="xreference" type="text"
 				label="COM_CONTENT_FIELD_XREFERENCE_LABEL"
 				description="COM_CONTENT_FIELD_XREFERENCE_DESC"
-				class="inputbox" size="20" />
+				size="20" />
 
 		</fieldset>
 	</fields>

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -394,7 +394,7 @@
 				hr="true"
 			/>
 
-			<field name="alternative_readmore" type="inputbox"
+			<field name="alternative_readmore" type="text"
 				label="JFIELD_READMORE_LABEL"
 				description="JFIELD_READMORE_DESC"
 				size="25" />

--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -116,7 +116,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
 			description="COM_CONTENT_LIST_LIMIT_DESC"

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -114,7 +114,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
 			description="COM_CONTENT_LIST_LIMIT_DESC"

--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -247,7 +247,6 @@
 			name="rules"
 			type="rules"
 			label="JCONFIG_PERMISSIONS_LABEL"
-			class="inputbox"
 			filter="rules"
 			validate="rules"
 			component="com_finder"

--- a/administrator/components/com_finder/models/forms/filter.xml
+++ b/administrator/components/com_finder/models/forms/filter.xml
@@ -7,16 +7,16 @@
 
 		<field
 			name="title" type="text" id="title"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			label="JGLOBAL_TITLE" description="COM_FINDER_FILTER_TITLE_DESCRIPTION"
 			size="40" default="" required="true" />
 
 		<field name="alias" type="text" label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
-			hint="JFIELD_ALIAS_PLACEHOLDER" class="inputbox" size="45" />
+			hint="JFIELD_ALIAS_PLACEHOLDER" size="45" />
 
 		<field name="created" type="calendar" label="JGLOBAL_FIELD_CREATED_LABEL"
-			description="JGLOBAL_FIELD_CREATED_DESC" class="inputbox" size="22"
+			description="JGLOBAL_FIELD_CREATED_DESC" size="22"
 			format="%Y-%m-%d %H:%M:%S" filter="user_utc" />
 
 		<field name="modified" type="calendar" class="readonly"
@@ -28,7 +28,7 @@
 
 		<field name="created_by_alias" type="text"
 			label="COM_FINDER_FIELD_CREATED_BY_ALIAS_LABEL" description="COM_FINDER_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 		<field name="modified_by" type="user"
 		label="JGLOBAL_FIELD_MODIFIED_BY_LABEL"
 		class="readonly"
@@ -72,7 +72,7 @@
 				<option value="1">COM_FINDER_FILTER_WHEN_AFTER</option>
 			</field>
 
-			<field name="d1" type="calendar" class="inputbox"
+			<field name="d1" type="calendar"
 				label="COM_FINDER_FILTER_START_DATE_LABEL" description="COM_FINDER_FILTER_START_DATE_DESCRIPTION"
 				size="22" format="%Y-%m-%d" filter="user_utc" />
 
@@ -89,7 +89,7 @@
 				<option value="1">COM_FINDER_FILTER_WHEN_AFTER</option>
 			</field>
 
-			<field name="d2" type="calendar" class="inputbox"
+			<field name="d2" type="calendar"
 				label="COM_FINDER_FILTER_END_DATE_LABEL" description="COM_FINDER_FILTER_END_DATE_DESCRIPTION"
 				size="22" format="%Y-%m-%d" filter="user_utc" />
 		</fieldset>

--- a/administrator/components/com_languages/models/forms/language.xml
+++ b/administrator/components/com_languages/models/forms/language.xml
@@ -10,7 +10,6 @@
 		/>
 
 		<field name="lang_code" type="text"
-			class="inputbox"
 			description="COM_LANGUAGES_FIELD_LANG_TAG_DESC"
 			label="COM_LANGUAGES_FIELD_LANG_TAG_LABEL"
 			maxlength="7"
@@ -19,7 +18,6 @@
 		/>
 
 		<field name="title" type="text"
-			class="inputbox"
 			description="COM_LANGUAGES_FIELD_TITLE_DESC"
 			label="JGLOBAL_TITLE"
 			maxlength="50"
@@ -28,7 +26,6 @@
 		/>
 
 		<field name="title_native" type="text"
-			class="inputbox"
 			description="COM_LANGUAGES_FIELD_TITLE_NATIVE_DESC"
 			label="COM_LANGUAGES_FIELD_TITLE_NATIVE_LABEL"
 			maxlength="50"
@@ -37,7 +34,6 @@
 		/>
 
 		<field name="sef" type="text"
-			class="inputbox"
 			description="COM_LANGUAGES_FIELD_LANG_CODE_DESC"
 			label="COM_LANGUAGES_FIELD_LANG_CODE_LABEL"
 			maxlength="7"
@@ -46,7 +42,6 @@
 		/>
 
 		<field name="image" type="filelist"
-			class="inputbox"
 			description="COM_LANGUAGES_FIELD_IMAGE_DESC"
 			label="COM_LANGUAGES_FIELD_IMAGE_LABEL"
 			stripext="1"
@@ -59,7 +54,6 @@
 		/>
 
 		<field name="description" type="textarea"
-			class="inputbox"
 			cols="80"
 			description="COM_LANGUAGES_FIELD_DESCRIPTION_DESC"
 			label="JGLOBAL_DESCRIPTION"
@@ -67,7 +61,6 @@
 		/>
 
 		<field name="published" type="list"
-			class="inputbox"
 			default="1"
 			description="COM_LANGUAGES_FIELD_PUBLISHED_DESC"
 			label="JSTATUS"
@@ -79,7 +72,6 @@
 		</field>
 		
 		<field name="access" type="accesslevel"
-		class="inputbox"
 		size="1"
 		label="JFIELD_ACCESS_LABEL"
 		description="JFIELD_ACCESS_DESC"
@@ -87,7 +79,6 @@
 	</fieldset>
 	<fieldset name="metadata" label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 		<field name="metakey" type="textarea"
-			class="inputbox"
 			description="JFIELD_META_KEYWORDS_DESC"
 			label="JFIELD_META_KEYWORDS_LABEL"
 			rows="3"
@@ -95,7 +86,6 @@
 		/>
 
 		<field name="metadesc" type="textarea"
-			class="inputbox"
 			description="JFIELD_META_DESCRIPTION_DESC"
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"

--- a/administrator/components/com_languages/models/forms/override.xml
+++ b/administrator/components/com_languages/models/forms/override.xml
@@ -4,7 +4,6 @@
 		<field
 			name="key"
 			type="text"
-			class="inputbox"
 			label="COM_LANGUAGES_OVERRIDE_FIELD_KEY_LABEL"
 			description="COM_LANGUAGES_OVERRIDE_FIELD_KEY_DESC"
 			size="60"
@@ -14,7 +13,6 @@
 		<field
 			name="override"
 			type="textarea"
-			class="inputbox"
 			label="COM_LANGUAGES_OVERRIDE_FIELD_OVERRIDE_LABEL"
 			description="COM_LANGUAGES_OVERRIDE_FIELD_OVERRIDE_DESC"
 			cols="50"
@@ -24,7 +22,6 @@
 		<field
 			name="both"
 			type="checkbox"
-			class="inputbox"
 			label="COM_LANGUAGES_OVERRIDE_FIELD_BOTH_LABEL"
 			description="COM_LANGUAGES_OVERRIDE_FIELD_BOTH_DESC"
 			value="true"
@@ -33,7 +30,6 @@
 		<field
 			name="searchstring"
 			type="text"
-			class="inputbox"
 			label="COM_LANGUAGES_OVERRIDE_FIELD_SEARCHSTRING_LABEL"
 			description="COM_LANGUAGES_OVERRIDE_FIELD_SEARCHSTRING_DESC"
 			size="50" />

--- a/administrator/components/com_media/models/manager.php
+++ b/administrator/components/com_media/models/manager.php
@@ -96,7 +96,7 @@ class MediaModelManager extends JModelLegacy
 		$author = $input->get('author', 0, 'integer');
 
 		// Create the drop-down folder select list
-		$list = JHtml::_('select.genericlist', $options, 'folderlist', 'class="inputbox" size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, '.$asset.', '.$author.')" ', 'value', 'text', $base);
+		$list = JHtml::_('select.genericlist', $options, 'folderlist', 'size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, '.$asset.', '.$author.')" ', 'value', 'text', $base);
 
 		return $list;
 	}

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -37,10 +37,10 @@ $input = JFactory::getApplication()->input;
 					<legend><?php echo JText::_('COM_MEDIA_DESCFTPTITLE'); ?></legend>
 					<?php echo JText::_('COM_MEDIA_DESCFTP'); ?>
 					<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-					<input type="text" id="username" name="username" class="inputbox" size="70" value="" />
+					<input type="text" id="username" name="username" size="70" value="" />
 
 					<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-					<input type="password" id="password" name="password" class="inputbox" size="70" value="" />
+					<input type="password" id="password" name="password" size="70" value="" />
 				</fieldset>
 			</form>
 		<?php endif; ?>
@@ -69,8 +69,8 @@ $input = JFactory::getApplication()->input;
 		<div id="collapseFolder" class="collapse">
 			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index');?>" name="folderForm" id="folderForm" class="form-inline" method="post">
 					<div class="path">
-						<input class="inputbox" type="text" id="folderpath" readonly="readonly" />
-						<input class="inputbox" type="text" id="foldername" name="foldername"  />
+						<input type="text" id="folderpath" readonly="readonly" />
+						<input type="text" id="foldername" name="foldername"  />
 						<input class="update-folder" type="hidden" name="folderbase" id="folderbase" value="<?php echo $this->state->folder; ?>" />
 						<button type="submit" class="btn"><i class="icon-folder-open"></i> <?php echo JText::_('COM_MEDIA_CREATE_FOLDER'); ?></button>
 					</div>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -89,7 +89,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_MENUS_LIST_LIMIT"
 			description="COM_MENUS_LIST_LIMIT_DESC"

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -16,7 +16,7 @@
 			type="text"
 			label="COM_MENUS_ITEM_FIELD_TITLE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_TITLE_DESC"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40"
 			required="true"/>
 
@@ -26,7 +26,6 @@
 			label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER"
-			class="inputbox"
 			size="40"/>
 
 		<field name="aliastip"
@@ -38,7 +37,7 @@
 			type="text"
 			label="JFIELD_NOTE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_NOTE_DESC"
-			class="inputbox span12"
+			class="span12"
 			size="40"/>
 
 		<field
@@ -47,7 +46,6 @@
 			label="COM_MENUS_ITEM_FIELD_LINK_LABEL"
 			description="COM_MENUS_ITEM_FIELD_LINK_DESC"
 			readonly="true"
-			class="inputbox"
 			size="50"/>
 
 		<field
@@ -55,7 +53,6 @@
 			type="menu"
 			label="COM_MENUS_ITEM_FIELD_ASSIGNED_LABEL"
 			description="COM_MENUS_ITEM_FIELD_ASSIGNED_DESC"
-			class="inputbox"
 			required="true"
 			size="1" />
 
@@ -64,7 +61,7 @@
 			type="menutype"
 			label="COM_MENUS_ITEM_FIELD_TYPE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_TYPE_DESC"
-			class="inputbox input-medium"
+			class="input-medium"
 			required="true"
 			size="40" />
 
@@ -97,7 +94,6 @@
 			description="COM_MENUS_ITEM_FIELD_PARENT_DESC"
 			default="1"
 			filter="int"
-			class="inputbox"
 			size="1">
 			<option
 				value="1">COM_MENUS_ITEM_ROOT</option>
@@ -109,7 +105,6 @@
 			label="COM_MENUS_ITEM_FIELD_ORDERING_LABEL"
 			description="COM_MENUS_ITEM_FIELD_ORDERING_DESC"
 			filter="int"
-			class="inputbox"
 			size="1">
 		</field>
 
@@ -125,7 +120,7 @@
 			description="COM_MENUS_ITEM_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
-			class="inputbox">
+			>
 				<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>
 				<option value="1">COM_MENUS_FIELD_VALUE_NEW_WITH_NAV</option>
 				<option value="2">COM_MENUS_FIELD_VALUE_NEW_WITHOUT_NAV</option>
@@ -135,7 +130,6 @@
 			name="access"
 			type="accesslevel"
 			id="access"
-			class="inputbox"
 			label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC"
 			default="1"
@@ -148,7 +142,7 @@
 			label="COM_MENUS_ITEM_FIELD_TEMPLATE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_TEMPLATE_DESC"
 			filter="int"
-			class="inputbox">
+			>
 			<option value="0">JOPTION_USE_DEFAULT</option>
 		</field>
 
@@ -169,7 +163,7 @@
 			type="contentlanguage"
 			label="JFIELD_LANGUAGE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_LANGUAGE_DESC"
-			class="inputbox">
+			>
 			<option value="*">JALL</option>
 		</field>
 

--- a/administrator/components/com_menus/models/forms/menu.xml
+++ b/administrator/components/com_menus/models/forms/menu.xml
@@ -15,7 +15,6 @@
 			type="text"
 			label="COM_MENUS_MENU_MENUTYPE_LABEL"
 			description="COM_MENUS_MENU_MENUTYPE_DESC"
-			class="inputbox"
 			size="30"
 			maxlength="24"
 			required="true" />
@@ -26,7 +25,6 @@
 			type="text"
 			label="JGLOBAL_TITLE"
 			description="COM_MENUS_MENU_TITLE_DESC"
-			class="inputbox"
 			size="30"
 			maxlength="48"
 			required="true" />
@@ -37,7 +35,6 @@
 			type="text"
 			label="JGLOBAL_DESCRIPTION"
 			description="COM_MENUS_MENU_DESCRIPTION_DESC"
-			class="inputbox"
 			size="30"
 			maxlength="255" />
 

--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -41,7 +41,7 @@ $published = $this->state->get('filter.published');
 						<?php echo JText::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
 					</label>
 					<div class="controls">
-						<select name="batch[menu_id]" class="inputbox" id="batch-menu-id">
+						<select name="batch[menu_id]" id="batch-menu-id">
 							<option value=""><?php echo JText::_('JSELECT') ?></option>
 							<?php echo JHtml::_('select.options', JHtml::_('menu.menuitems', array('published' => $published))); ?>
 						</select>

--- a/administrator/components/com_messages/models/forms/config.xml
+++ b/administrator/components/com_messages/models/forms/config.xml
@@ -30,7 +30,6 @@
 		<field
 			name="auto_purge"
 			type="text"
-			class="inputbox"
 			size="6"
 			default="7"
 			label="COM_MESSAGES_FIELD_AUTO_PURGE_LABEL"

--- a/administrator/components/com_messages/models/forms/message.xml
+++ b/administrator/components/com_messages/models/forms/message.xml
@@ -19,7 +19,6 @@
 		<field
 			name="message"
 			type="editor"
-			class="inputbox"
 			label="COM_MESSAGES_FIELD_MESSAGE_LABEL"
 			description="COM_MESSAGES_FIELD_MESSAGE_DESC"
 			required="true"

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -39,7 +39,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-left">
-				<select name="filter_state" class="inputbox" onchange="this.form.submit()">
+				<select name="filter_state" onchange="this.form.submit()">
 					<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 					<?php echo JHtml::_('select.options', MessagesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
 				</select>

--- a/administrator/components/com_modules/models/forms/module.xml
+++ b/administrator/components/com_modules/models/forms/module.xml
@@ -11,7 +11,7 @@
 		<field name="title" type="text"
 			description="COM_MODULES_FIELD_TITLE_DESC"
 			label="JGLOBAL_TITLE"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40"
 			maxlength="100"
 			required="true"
@@ -22,7 +22,7 @@
 			label="COM_MODULES_FIELD_NOTE_LABEL"
 			maxlength="100"
 			size="40"
-			class="inputbox span12"
+			class="span12"
 		/>
 
 		<field name="module" type="hidden"
@@ -98,7 +98,6 @@
 
 		<field name="content" type="editor"
 			buttons="true"
-			class="inputbox"
 			description="COM_MODULES_FIELD_CONTENT_DESC"
 			filter="JComponentHelper::filterText"
 			label="COM_MODULES_FIELD_CONTENT_LABEL"
@@ -123,7 +122,6 @@
 		<field name="rules" type="rules"
 			label="JFIELD_RULES_LABEL"
 			translate_label="false"
-			class="inputbox"
 			filter="rules"
 			component="com_modules"
 			section="module"

--- a/administrator/components/com_modules/views/positions/tmpl/modal.php
+++ b/administrator/components/com_modules/views/positions/tmpl/modal.php
@@ -37,17 +37,17 @@ $type      = $this->state->get('filter.type');
 		</div>
 
 		<div class="right">
-			<select name="filter_state" class="inputbox" onchange="this.form.submit()">
+			<select name="filter_state" onchange="this.form.submit()">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.templateStates'), 'value', 'text', $state, true);?>
 			</select>
 
-			<select name="filter_type" class="inputbox" onchange="this.form.submit()">
+			<select name="filter_type" onchange="this.form.submit()">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_TYPE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.types'), 'value', 'text', $type, true);?>
 			</select>
 
-			<select name="filter_template" class="inputbox" onchange="this.form.submit()">
+			<select name="filter_template" onchange="this.form.submit()">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TEMPLATE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.templates', $clientId), 'value', 'text', $template, true);?>
 			</select>

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -76,7 +76,6 @@
 			id="feed_character_count"
 			name="feed_character_count"
 			type="text"
-			class="inputbox"
 			size="6"
 			default="0"
 			label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -7,13 +7,13 @@
 
 		<field name="name" type="text" label="JGLOBAL_TITLE"
 			description="JFIELD_TITLE_DESC"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40"
 			required="true" />
 
 		<field name="alias" type="text" label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
-			hint="JFIELD_ALIAS_PLACEHOLDER" class="inputbox"
+			hint="JFIELD_ALIAS_PLACEHOLDER"
 			size="45" />
 
 		<field name="published" type="list"
@@ -32,12 +32,12 @@
 
 		<field name="catid" type="categoryedit" extension="com_newsfeeds"
 			label="JCATEGORY" description="COM_NEWSFEEDS_FIELD_CATEGORY_DESC"
-			class="inputbox" required="true"
+			required="true"
 		>
 		</field>
 
 		<field name="language" type="contentlanguage" label="JFIELD_LANGUAGE_LABEL"
-			description="COM_NEWSFEEDS_FIELD_LANGUAGE_DESC" class="inputbox"
+			description="COM_NEWSFEEDS_FIELD_LANGUAGE_DESC"
 		>
 			<option value="*">JALL</option>
 		</field>
@@ -46,7 +46,7 @@
 			type="tag"
 			label="JTAG"
 			description="JTAG_DESC"
-			class="inputbox span12"
+			class="span12"
 			multiple="true"
 		>
 		</field>
@@ -55,36 +55,35 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox span12" size="45"
+			class="span12" size="45"
 			labelclass="control-label"
 		/>
 
 		<field name="description" type="editor" buttons="true" hide="pagebreak,readmore"
-			class="inputbox"
 			filter="JComponentHelper::filterText"
 			label="JGLOBAL_DESCRIPTION" description="COM_NEWSFEEDS_FIELD_DESCRIPTION_DESC" />
 
 		<field name="link" type="url" filter="url"
-			class="inputbox span12"
+			class="span12"
 			size="60" label="COM_NEWSFEEDS_FIELD_LINK_LABEL"
 			description="COM_NEWSFEEDS_FIELD_LINK_DESC" required="true" />
 
-		<field name="numarticles" type="Text" class="inputbox"
+		<field name="numarticles" type="Text"
 			default="5" size="2" label="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_LABEL"
 			description="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_DESC"
 			required="true" />
 
-		<field name="cache_time" type="Text" class="inputbox"
+		<field name="cache_time" type="Text"
 			default="3600" size="4" label="COM_NEWSFEEDS_FIELD_CACHETIME_LABEL"
 			description="JGLOBAL_FIELD_FIELD_CACHETIME_DESC"
 			required="true" />
 
-		<field name="ordering" type="ordering" class="inputbox" content_type="com_newsfeeds.newsfeed"
+		<field name="ordering" type="ordering" content_type="com_newsfeeds.newsfeed"
 			label="JFIELD_ORDERING_LABEL" description="JFIELD_ORDERING_DESC" />
 
 		<field name="created" type="calendar"
 			label="JGLOBAL_FIELD_CREATED_LABEL" description="JGLOBAL_FIELD_CREATED_DESC"
-			class="inputbox" size="22" format="%Y-%m-%d %H:%M:%S"
+			size="22" format="%Y-%m-%d %H:%M:%S"
 			filter="user_utc" />
 
 		<field name="created_by" type="user"
@@ -92,7 +91,7 @@
 
 		<field name="created_by_alias" type="text"
 			label="JGLOBAL_FIELD_Created_by_alias_Label" description="JGLOBAL_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 
 		<field name="modified" type="calendar" class="readonly"
 			label="JGLOBAL_FIELD_Modified_Label" description="COM_NEWSFEEDS_FIELD_MODIFIED_DESC"
@@ -105,40 +104,40 @@
 			label="COM_NEWSFEEDS_FIELD_VERSION_LABEL" size="6" description="COM_NEWSFEEDS_FIELD_VERSION_DESC"
 			readonly="true" filter="unset" />
 
-		<field name="checked_out" type="Text" class="inputbox"
+		<field name="checked_out" type="Text"
 			size="6" label="JGLOBAL_FIELD_CHECKEDOUT_LABEL"
 			description="JGLOBAL_FIELD_CHECKEDOUT_DESC" readonly="true"
 			filter="unset" />
 
-		<field name="checked_out_time" type="Text" class="inputbox"
+		<field name="checked_out_time" type="Text"
 			size="6" label="JGLOBAL_FIELD_CHECKEDOUT_TIME_LABEL"
 			description="JGLOBAL_FIELD_CHECKEDOUT_TIME_DESC"
 			readonly="true" filter="unset" />
 
 		<field name="publish_up" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_UP_LABEL" description="JGLOBAL_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="publish_down" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_DOWN_LABEL" description="JGLOBAL_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="access" type="accesslevel" label="JFIELD_ACCESS_LABEL"
-			description="JFIELD_ACCESS_DESC" class="inputbox" size="1" />
+			description="JFIELD_ACCESS_DESC" size="1" />
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="metadesc" type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL" description="JFIELD_META_DESCRIPTION_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="xreference" type="text"
 			label="JFIELD_XREFERENCE_LABEL" description="JFIELD_XREFERENCE_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 	<fields name="images">
 		<fieldset name="images" label="JGLOBAL_FIELDSET_IMAGE_OPTIONS">
 			<field
@@ -160,13 +159,11 @@
 				type="text"
 				label="COM_NEWSFEEDS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_IMAGE_ALT_DESC"
-				class="inputbox"
 				size="20" />
 			<field name="image_first_caption"
 				type="text"
 				label="COM_NEWSFEEDS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_NEWSFEEDS_FIELD_IMAGE_CAPTION_DESC"
-				class="inputbox"
 				size="20" />
 			<field
 				name="spacer1"
@@ -192,30 +189,28 @@
 				type="text"
 				label="COM_NEWSFEEDS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_IMAGE_ALT_DESC"
-				class="inputbox"
 				size="20" />
 			<field name="image_second_caption"
 				type="text"
 				label="COM_NEWSFEEDS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_NEWSFEEDS_FIELD_IMAGE_CAPTION_DESC"
-				class="inputbox"
 				size="20" />
 		</fieldset>
 	</fields>
 	</fieldset>
 
 	<fieldset name="jbasic" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
-		<field name="numarticles" type="Text" class="inputbox"
+		<field name="numarticles" type="Text"
 			default="5" size="2" label="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_LABEL"
 			description="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_DESC"
 			required="true" />
 
-		<field name="cache_time" type="Text" class="inputbox"
+		<field name="cache_time" type="Text"
 			default="3600" size="4" label="COM_NEWSFEEDS_FIELD_CACHETIME_LABEL"
 			description="JGLOBAL_FIELD_FIELD_CACHETIME_DESC"
 			required="true" />
 
-		<field name="rtl" type="list" class="inputbox"
+		<field name="rtl" type="list"
 			default="0" label="COM_NEWSFEEDS_FIELD_RTL_LABEL"
 			description="COM_NEWSFEEDS_FIELD_RTL_DESC"
 		>

--- a/administrator/components/com_plugins/models/forms/plugin.xml
+++ b/administrator/components/com_plugins/models/forms/plugin.xml
@@ -35,13 +35,11 @@
 			type="accesslevel"
 			label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC"
-			class="inputbox"
 			size="1" />
 
 		<field
 			name="ordering"
 			type="Pluginordering"
-			class="inputbox"
 			label="JFIELD_ORDERING_LABEL"
 			description="JFIELD_ORDERING_DESC" />
 

--- a/administrator/components/com_postinstall/config.xml
+++ b/administrator/components/com_postinstall/config.xml
@@ -10,7 +10,6 @@
 			name="rules"
 			type="rules"
 			label="JCONFIG_PERMISSIONS_LABEL"
-			class="inputbox"
 			filter="rules"
 			component="com_postinstall"
 			section="component" />

--- a/administrator/components/com_redirect/models/forms/link.xml
+++ b/administrator/components/com_redirect/models/forms/link.xml
@@ -14,7 +14,6 @@
 		<field
 			name="old_url"
 			type="text"
-			class="inputbox"
 			label="COM_REDIRECT_FIELD_OLD_URL_LABEL"
 			description="COM_REDIRECT_FIELD_OLD_URL_DESC"
 			size="50"
@@ -23,7 +22,6 @@
 		<field
 			name="new_url"
 			type="text"
-			class="inputbox"
 			label="COM_REDIRECT_FIELD_NEW_URL_LABEL"
 			description="COM_REDIRECT_FIELD_NEW_URL_DESC"
 			size="50"
@@ -32,7 +30,6 @@
 		<field
 			name="comment"
 			type="text"
-			class="inputbox"
 			label="COM_REDIRECT_FIELD_COMMENT_LABEL"
 			description="COM_REDIRECT_FIELD_COMMENT_DESC"
 			size="40" />
@@ -42,7 +39,6 @@
 			type="list"
 			label="JSTATUS"
 			description="JFIELD_PUBLISHED_DESC"
-			class="inputbox"
 			size="1"
 			required="true"
 			default="1">
@@ -64,7 +60,6 @@
 			name="referer"
 			type="text"
 			id="referer"
-			class="inputbox"
 			label="COM_REDIRECT_FIELD_REFERRER_LABEL"
 			size="50"
 			readonly="true" />

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -71,7 +71,7 @@
 	<field
 		name="title"
 		type="text"
-		class="inputbox input-xxlarge input-large-text"
+		class="input-xxlarge input-large-text"
 		label="JGLOBAL_TITLE"
 		description="JFIELD_TITLE_DESC"
 		size="40"
@@ -81,7 +81,7 @@
 	<field
 		name="note"
 		type="text"
-		class="inputbox span12"
+		class="span12"
 		label="JFIELD_NOTE_LABEL"
 		description="JFIELD_NOTE_DESC"
 		size="40"
@@ -90,7 +90,6 @@
 	<field
 		name="description"
 		type="editor"
-		class="inputbox"
 		label="JGLOBAL_DESCRIPTION"
 		description="COM_TAGS_DESCRIPTION_DESC"
 		filter="JComponentHelper::filterText"
@@ -153,7 +152,6 @@
 	<field
 		name="alias"
 		type="text"
-		class="inputbox"
 		label="JFIELD_ALIAS_LABEL"
 		description="JFIELD_ALIAS_DESC"
 		hint="JFIELD_ALIAS_PLACEHOLDER"
@@ -170,7 +168,6 @@
 	<field
 		name="created_by_alias"
 		type="text"
-		class="inputbox"
 		labelclass="control-label"
 		label="JGLOBAL_FIELD_CREATED_BY_ALIAS_LABEL"
 		description="JGLOBAL_FIELD_CREATED_BY_ALIAS_DESC"
@@ -217,7 +214,7 @@
 		type="text" 
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 		description="JGLOBAL_FIELD_VERSION_NOTE_DESC" 
-		class="inputbox span12" size="45" 
+		class="span12" size="45" 
 		labelclass="control-label"
 	/>
 
@@ -241,7 +238,6 @@
 			<field
 				name="tag_link_class"
 				type="text"
-				class="inputbox"
 				labelclass="control-label"
 				label="COM_TAGS_FIELD_TAG_LINK_CLASS"
 				description="COM_TAGS_FIELD_TAG_LINK_CLASS_DESC"
@@ -276,7 +272,6 @@
 			<field
 				name="image_intro_alt"
 				type="text"
-				class="inputbox"
 				labelclass="control-label"
 				label="COM_TAGS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_TAGS_FIELD_IMAGE_ALT_DESC"
@@ -286,7 +281,6 @@
 			<field
 				name="image_intro_caption"
 				type="text"
-				class="inputbox"
 				labelclass="control-label"
 				label="COM_TAGS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_TAGS_FIELD_IMAGE_CAPTION_DESC"
@@ -323,7 +317,6 @@
 			<field
 				name="image_fulltext_alt"
 				type="text"
-				class="inputbox"
 				labelclass="control-label"
 				label="COM_TAGS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_TAGS_FIELD_IMAGE_ALT_DESC"
@@ -333,7 +326,6 @@
 			<field
 				name="image_fulltext_caption"
 				type="text"
-				class="inputbox"
 				labelclass="control-label"
 				label="COM_TAGS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_TAGS_FIELD_IMAGE_CAPTION_DESC"

--- a/administrator/components/com_templates/models/forms/style.xml
+++ b/administrator/components/com_templates/models/forms/style.xml
@@ -32,7 +32,7 @@
 		<field
 			name="title"
 			type="text"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="50"
 			label="COM_TEMPLATES_FIELD_TITLE_LABEL"
 			description="COM_TEMPLATES_FIELD_TITLE_DESC"

--- a/administrator/components/com_templates/models/forms/style_site.xml
+++ b/administrator/components/com_templates/models/forms/style_site.xml
@@ -6,7 +6,6 @@
 			type="contentlanguage"
 			label="COM_TEMPLATES_FIELD_HOME_LABEL"
 			description="COM_TEMPLATES_FIELD_HOME_SITE_DESC"
-			class="inputbox"
 			default="0">
 			<option value="0">JNO</option>
 			<option value="1">JALL</option>

--- a/administrator/components/com_users/models/forms/filter_users.xml
+++ b/administrator/components/com_users/models/forms/filter_users.xml
@@ -75,7 +75,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="inputbox input-mini"
+			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
 			description="COM_CONTENT_LIST_LIMIT_DESC"

--- a/administrator/components/com_users/models/forms/group.xml
+++ b/administrator/components/com_users/models/forms/group.xml
@@ -8,14 +8,13 @@
 		/>
 
 		<field name="title" type="text"
-			class="inputbox" required="true"
+			required="true"
 			description="COM_USERS_GROUP_FIELD_TITLE_DESC"
 			label="COM_USERS_GROUP_FIELD_TITLE_LABEL"
 			size="40"
 		/>
 
 		<field name="parent_id" type="groupparent"
-			class="inputbox"
 			description="COM_USERS_GROUP_FIELD_PARENT_DESC"
 			label="COM_USERS_GROUP_FIELD_PARENT_LABEL"
 			required="true"

--- a/administrator/components/com_users/models/forms/level.xml
+++ b/administrator/components/com_users/models/forms/level.xml
@@ -8,7 +8,7 @@
 		/>
 
 		<field name="title" type="text"
-			class="inputbox" required="true"
+			required="true"
 			description="COM_USERS_LEVEL_FIELD_TITLE_DESC"
 			label="COM_USERS_LEVEL_FIELD_TITLE_LABEL"
 			size="50"

--- a/administrator/components/com_users/models/forms/mail.xml
+++ b/administrator/components/com_users/models/forms/mail.xml
@@ -37,7 +37,7 @@
 		/>
 
 		<field name="subject" type="text"
-			class="inputbox span8"
+			class="span8"
 			description="COM_USERS_MAIL_FIELD_SUBJECT_DESC"
 			label="COM_USERS_MAIL_FIELD_SUBJECT_LABEL"
 			maxlength="150"
@@ -45,7 +45,7 @@
 		/>
 
 		<field name="message" type="textarea"
-			class="inputbox span11"
+			class="span11"
 			cols="70"
 			description="COM_USERS_MAIL_FIELD_MESSAGE_DESC"
 			label="COM_USERS_MAIL_FIELD_MESSAGE_LABEL"

--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -23,7 +23,6 @@
 		<field
 			name="catid"
 			type="category"
-			class="inputbox"
 			extension="com_users"
 			label="COM_USERS_FIELD_CATEGORY_ID_LABEL"
 			description="JFIELD_CATEGORY_DESC" >
@@ -32,7 +31,6 @@
 		<field
 			name="subject"
 			type="text"
-			class="inputbox"
 			size="80"
 			label="COM_USERS_FIELD_SUBJECT_LABEL"
 			description="COM_USERS_FIELD_SUBJECT_DESC"
@@ -41,7 +39,6 @@
 		<field
 			name="body"
 			type="editor"
-			class="inputbox"
 			rows="10"
 			cols="80"
 			filter="safehtml"
@@ -54,7 +51,6 @@
 			type="list"
 			label="JSTATUS"
 			description="COM_USERS_FIELD_STATE_DESC"
-			class="inputbox"
 			size="1"
 			default="1">
 			<option
@@ -70,7 +66,6 @@
 		<field
 			name="review_time"
 			type="calendar"
-			class="inputbox"
 			label="COM_USERS_FIELD_REVIEW_TIME_LABEL"
 			description="COM_USERS_FIELD_REVIEW_TIME_DESC"
 			default="0000-00-00"
@@ -119,12 +114,12 @@
 			
 		<field name="publish_up" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_UP_LABEL" description="JGLOBAL_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="publish_down" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_DOWN_LABEL" description="JGLOBAL_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />	
 			
 		<field 
@@ -132,7 +127,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox" size="45"
+			size="45"
 			labelclass="control-label"
 			/>	
 	

--- a/administrator/components/com_users/models/forms/user.xml
+++ b/administrator/components/com_users/models/forms/user.xml
@@ -2,7 +2,6 @@
 <form>
 	<fieldset name="user_details">
 		<field name="name" type="text"
-			class="inputbox"
 			description="COM_USERS_USER_FIELD_NAME_DESC"
 			label="COM_USERS_USER_FIELD_NAME_LABEL"
 			required="true"
@@ -10,7 +9,6 @@
 		/>
 
 		<field name="username" type="text"
-			class="inputbox"
 			description="COM_USERS_USER_FIELD_USERNAME_DESC"
 			label="COM_USERS_USER_FIELD_USERNAME_LABEL"
 			required="true"
@@ -19,7 +17,7 @@
 
 		<field name="password" type="password"
 			autocomplete="off"
-			class="inputbox validate-password"
+			class="validate-password"
 			description="COM_USERS_USER_FIELD_PASSWORD_DESC"
 			filter="raw"
 			validate="password"
@@ -29,7 +27,7 @@
 
 		<field name="password2" type="password"
 			autocomplete="off"
-			class="inputbox validate-password"
+			class="validate-password"
 			description="COM_USERS_USER_FIELD_PASSWORD2_DESC"
 			filter="raw"
 			label="COM_USERS_USER_FIELD_PASSWORD2_LABEL"
@@ -39,7 +37,6 @@
 		/>
 
 		<field name="email" type="email"
-			class="inputbox"
 			description="COM_USERS_USER_FIELD_EMAIL_DESC"
 			label="JGLOBAL_EMAIL"
 			required="true"

--- a/administrator/components/com_users/views/users/tmpl/default_batch.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch.php
@@ -31,7 +31,7 @@ JHtml::_('formbehavior.chosen', 'select');
 			</div>
 			<div id="batch-choose-action" class="combo controls">
 				<div class="control-group">
-					<select name="batch[group_id]" class="inputbox" id="batch-group-id">
+					<select name="batch[group_id]" id="batch-group-id">
 						<option value=""><?php echo JText::_('JSELECT') ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
 					</select>

--- a/administrator/components/com_weblinks/models/forms/weblink.xml
+++ b/administrator/components/com_weblinks/models/forms/weblink.xml
@@ -8,30 +8,28 @@
 			description="JGLOBAL_FIELD_ID_DESC"/>
 
 		<field name="title" type="text"
-			class="inputbox input-xxlarge input-large-text"
+			class="input-xxlarge input-large-text"
 			size="40" label="JGLOBAL_TITLE"
 			description="COM_WEBLINKS_FIELD_TITLE_DESC" required="true" />
 
-		<field name="alias" type="text" class="inputbox"
+		<field name="alias" type="text"
 			size="40" label="JFIELD_ALIAS_LABEL"
 			description="COM_WEBLINKS_FIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER" />
 
 		<field name="catid" type="categoryedit" extension="com_weblinks"
 			label="JCATEGORY" description="COM_WEBLINKS_FIELD_CATEGORY_DESC"
-			class="inputbox"
 		>
 		</field>
 
 
 		<field name="url" type="url"
-			class="inputbox span12"
+			class="span12"
 			filter="url"
 			size="40" label="COM_WEBLINKS_FIELD_URL_LABEL"
 			description="COM_WEBLINKS_FIELD_URL_DESC" required="true" />
 
 		<field name="description" type="editor" buttons="true" hide="pagebreak,readmore"
-			class="inputbox"
 			filter="JComponentHelper::filterText"
 			label="JGLOBAL_DESCRIPTION" description="COM_WEBLINKS_FIELD_DESCRIPTION_DESC" />
 
@@ -64,21 +62,21 @@
 				value="-2">JTRASHED</option>
 		</field>
 
-		<field name="ordering" type="ordering" class="inputbox"
+		<field name="ordering" type="ordering"
 			label="JFIELD_ORDERING_LABEL"
 			description="JFIELD_ORDERING_DESC"
 			content_type="com_weblinks.weblink"
         />
 
 		<field name="access" type="accesslevel" label="JFIELD_ACCESS_LABEL"
-			description="JFIELD_ACCESS_DESC" class="inputbox" size="1" />
+			description="JFIELD_ACCESS_DESC" size="1" />
 
 		<field
 			name="language"
 			type="contentlanguage"
 			label="JFIELD_LANGUAGE_LABEL"
 			description="COM_WEBLINKS_FIELD_LANGUAGE_DESC"
-			class="inputbox">
+			>
 			<option value="*">JALL</option>
 		</field>
 
@@ -86,7 +84,6 @@
 			type="tag"
 			label="JTAG"
 			description="JTAG_DESC"
-			class="inputbox"
 			multiple="true"
 		>
 		</field>
@@ -95,13 +92,13 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
-			class="inputbox" size="45"
+			size="45"
 			labelclass="control-label"
 		/>
 
 		<field name="created" type="calendar"
 			label="JGLOBAL_FIELD_CREATED_LABEL" description="JGLOBAL_FIELD_CREATED_DESC"
-			class="inputbox" size="22" format="%Y-%m-%d %H:%M:%S"
+			size="22" format="%Y-%m-%d %H:%M:%S"
 			filter="user_utc" />
 
 		<field name="created_by" type="user"
@@ -109,7 +106,7 @@
 
 		<field name="created_by_alias" type="text"
 			label="JGLOBAL_FIELD_CREATED_BY_ALIAS_LABEL" description="JGLOBAL_FIELD_CREATED_BY_ALIAS_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 
 		<field name="modified" type="calendar" class="readonly"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL" description="COM_WEBLINKS_FIELD_MODIFIED_DESC"
@@ -128,12 +125,12 @@
 
 		<field name="publish_up" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_UP_LABEL" description="JGLOBAL_FIELD_PUBLISH_UP_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="publish_down" type="calendar"
 			label="JGLOBAL_FIELD_PUBLISH_DOWN_LABEL" description="JGLOBAL_FIELD_PUBLISH_DOWN_DESC"
-			class="inputbox" format="%Y-%m-%d %H:%M:%S" size="22"
+			format="%Y-%m-%d %H:%M:%S" size="22"
 			filter="user_utc" />
 
 		<field name="version" type="text" class="readonly"
@@ -143,15 +140,15 @@
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="metadesc" type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL" description="JFIELD_META_DESCRIPTION_DESC"
-			class="inputbox" rows="3" cols="30" />
+			rows="3" cols="30" />
 
 		<field name="xreference" type="text"
 			label="JFIELD_XREFERENCE_LABEL" description="JFIELD_XREFERENCE_DESC"
-			class="inputbox" size="20" />
+			size="20" />
 	</fieldset>
 
 	<fields name="params" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
@@ -167,11 +164,11 @@
 			</field>
 
 			<field name="width" type="text"
-				class="inputbox validate-numeric" label="COM_WEBLINKS_FIELD_WIDTH_LABEL"
+				class="validate-numeric" label="COM_WEBLINKS_FIELD_WIDTH_LABEL"
 				description="COM_WEBLINKS_FIELD_WIDTH_DESC" />
 
 			<field name="height" type="text"
-				class="inputbox validate-numeric" label="COM_WEBLINKS_FIELD_HEIGHT_LABEL"
+				class="validate-numeric" label="COM_WEBLINKS_FIELD_HEIGHT_LABEL"
 				description="COM_WEBLINKS_FIELD_HEIGHT_DESC" />
 
 			<field name="count_clicks" type="list"
@@ -206,13 +203,11 @@
 				type="text"
 				label="COM_WEBLINKS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_WEBLINKS_FIELD_IMAGE_ALT_DESC"
-				class="inputbox"
 				size="20" />
 			<field name="image_first_caption"
 				type="text"
 				label="COM_WEBLINKS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_WEBLINKS_FIELD_IMAGE_CAPTION_DESC"
-				class="inputbox"
 				size="20" />
 
 			<field name="spacer1"
@@ -238,13 +233,11 @@
 				type="text"
 				label="COM_WEBLINKS_FIELD_IMAGE_ALT_LABEL"
 				description="COM_WEBLINKS_FIELD_IMAGE_ALT_DESC"
-				class="inputbox"
 				size="20" />
 			<field name="image_second_caption"
 				type="text"
 				label="COM_WEBLINKS_FIELD_IMAGE_CAPTION_LABEL"
 				description="COM_WEBLINKS_FIELD_IMAGE_CAPTION_DESC"
-				class="inputbox"
 				size="20" />
 		</fieldset>
 	</fields>

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -51,7 +51,7 @@
 					label="JCATEGORY"
 					description="MOD_LATEST_FIELD_CATEGORY_DESC"
 					default=""
-					class="inputbox">
+					>
 					<option
 						value="">JOPTION_ANY_CATEGORY</option>
 				</field>

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -34,7 +34,7 @@ abstract class ModLoginHelper
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 
-		return JHtml::_('select.genericlist', $languages, 'lang', ' class="inputbox advancedSelect"', 'value', 'text', null);
+		return JHtml::_('select.genericlist', $languages, 'lang', ' class="advancedSelect"', 'value', 'text', null);
 	}
 
 	/**

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -62,7 +62,6 @@
 					name="forum_url"
 					type="url"
 					filter="url"
-					class="inputbox"
 					size="30"
 					default=""
 					label="MOD_MENU_FIELD_FORUMURL_LABEL"

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -40,7 +40,7 @@
 					label="JCATEGORY"
 					description="MOD_POPULAR_FIELD_CATEGORY_DESC"
 					default=""
-					class="inputbox">
+					>
 					<option
 						value="">JOPTION_ANY_CATEGORY</option>
 				</field>

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -1360,11 +1360,6 @@ p.tab-description {
 	margin-left: 0;
 	margin-top: 5px;
 }
-#login-page form .inputbox {
-	width: 190px;
-	margin-left: 5px;
-	margin-bottom: 15px;
-}
 #login-page input,
 #login-page select {
 	float: right;

--- a/administrator/templates/hathor/css/template_rtl.css
+++ b/administrator/templates/hathor/css/template_rtl.css
@@ -262,9 +262,6 @@ p.tab-description {
 /**
  * Login Settings
  */
-#login-page form .inputbox {
-	margin-right: 5px;
-}
 #login-page input, #login-page select {
 	float: left;
 }

--- a/administrator/templates/hathor/html/com_admin/help/default.php
+++ b/administrator/templates/hathor/html/com_admin/help/default.php
@@ -16,7 +16,7 @@ jimport('joomla.language.help');
 	<fieldset class="adminform">
 		<legend><?php echo JText::_('COM_ADMIN_SEARCH'); ?></legend>
 		<input class="textarea" type="hidden" name="option" value="com_admin" />
-		<input type="text" name="helpsearch" size="40"  value="<?php echo $this->escape($this->help_search);?>" class="inputbox" />
+		<input type="text" name="helpsearch" size="40"  value="<?php echo $this->escape($this->help_search);?>" />
 		<input type="submit" value="<?php echo JText::_('COM_ADMIN_GO'); ?>" class="button" />
 		<input type="button" value="<?php echo JText::_('COM_ADMIN_CLEAR_RESULTS'); ?>" class="button" onclick="f=document.adminForm;f.helpsearch.value='';f.submit()" />
 	</fieldset>

--- a/administrator/templates/hathor/html/com_banners/banners/default.php
+++ b/administrator/templates/hathor/html/com_banners/banners/default.php
@@ -43,7 +43,7 @@ $saveOrder = $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>
@@ -51,7 +51,7 @@ $saveOrder = $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('COM_BANNERS_SELECT_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<option value=""><?php echo JText::_('COM_BANNERS_SELECT_CLIENT');?></option>
 				<?php echo JHtml::_('select.options', BannersHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
 			</select>
@@ -59,7 +59,7 @@ $saveOrder = $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_banners'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -67,7 +67,7 @@ $saveOrder = $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_banners/clients/default.php
+++ b/administrator/templates/hathor/html/com_banners/clients/default.php
@@ -41,7 +41,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>

--- a/administrator/templates/hathor/html/com_banners/tracks/default.php
+++ b/administrator/templates/hathor/html/com_banners/tracks/default.php
@@ -42,7 +42,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
             <label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('COM_BANNERS_SELECT_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<option value=""><?php echo JText::_('COM_BANNERS_SELECT_CLIENT');?></option>
 				<?php echo JHtml::_('select.options', BannersHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
 			</select>
@@ -51,7 +51,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
 			<?php $category = $this->state->get('filter.category_id');?>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_banners'), 'value', 'text', $category);?>
 			</select>
@@ -59,7 +59,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_type">
 				<?php echo JText::_('BANNERS_SELECT_TYPE'); ?>
 			</label>
-			<select name="filter_type" class="inputbox" id="filter_type">
+			<select name="filter_type" id="filter_type">
 				<?php echo JHtml::_('select.options', array(JHtml::_('select.option', '0', JText::_('COM_BANNERS_SELECT_TYPE')), JHtml::_('select.option', 1, JText::_('COM_BANNERS_IMPRESSION')), JHtml::_('select.option', 2, JText::_('COM_BANNERS_CLICK'))), 'value', 'text', $this->state->get('filter.type'));?>
 			</select>
 

--- a/administrator/templates/hathor/html/com_cache/cache/default.php
+++ b/administrator/templates/hathor/html/com_cache/cache/default.php
@@ -28,7 +28,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('COM_CACHE_SELECT_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<?php echo JHtml::_('select.options', CacheHelper::getClientOptions(), 'value', 'text', $this->state->get('clientId'));?>
 			</select>
 

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -45,31 +45,31 @@ $assoc		= JLanguageAssociations::isEnabled();
 
 				<div class="filter-select">
 					<label class="selectlabel" for="filter_level"><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></label>
-					<select name="filter_level" class="inputbox" id="filter_level">
+					<select name="filter_level" id="filter_level">
 						<option value=""><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></option>
 						<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level')); ?>
 					</select>
 
 					<label class="selectlabel" for="filter_published"><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></label>
-					<select name="filter_published" class="inputbox" id="filter_published">
+					<select name="filter_published" id="filter_published">
 						<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 					</select>
 
 					<label class="selectlabel" for="filter_access"><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></label>
-					<select name="filter_access" class="inputbox" id="filter_access">
+					<select name="filter_access" id="filter_access">
 						<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 					</select>
 
 					<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-					<select name="filter_language" class="inputbox" id="filter_language">
+					<select name="filter_language" id="filter_language">
 						<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 					</select>
 
 					<label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
-					<select name="filter_tag" class="inputbox" id="filter_tag">
+					<select name="filter_tag" id="filter_tag">
 						<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
 					</select>

--- a/administrator/templates/hathor/html/com_categories/categories/default_batch.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default_batch.php
@@ -41,7 +41,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 				</label>
 
 				<div id="batch-choose-action" class="combo controls">
-					<select name="batch[category_id]" class="inputbox" id="batch-category-id">
+					<select name="batch[category_id]" id="batch-category-id">
 						<option value=""><?php echo JText::_('JSELECT') ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
 					</select>

--- a/administrator/templates/hathor/html/com_contact/contacts/default.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/default.php
@@ -46,7 +46,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
@@ -54,7 +54,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_contact'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -62,7 +62,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -70,7 +70,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>
@@ -78,7 +78,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_tag">
 				<?php echo JText::_('JOPTION_SELECT_TAG'); ?>
 			</label>
-			<select name="filter_tag" class="inputbox" id="filter_tag">
+			<select name="filter_tag" id="filter_tag">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_contact/contacts/modal.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/modal.php
@@ -32,7 +32,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
@@ -48,7 +48,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_contact'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -58,7 +58,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
 			<?php else : ?>
 				<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-				<select name="filter_language" class="inputbox" id="filter_language">
+				<select name="filter_language" id="filter_language">
 					<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 					<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 				</select>

--- a/administrator/templates/hathor/html/com_content/articles/default.php
+++ b/administrator/templates/hathor/html/com_content/articles/default.php
@@ -43,43 +43,43 @@ $n			= count($this->items);
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_published"><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id"><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content'), 'value', 'text', $this->state->get('filter.category_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_level"><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></label>
-			<select name="filter_level" class="inputbox" id="filter_level">
+			<select name="filter_level" id="filter_level">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></option>
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access"><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_author_id"><?php echo JText::_('JOPTION_SELECT_AUTHOR'); ?></label>
-			<select name="filter_author_id" class="inputbox"  id="filter_author_id">
+			<select name="filter_author_id"  id="filter_author_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_AUTHOR'); ?></option>
 				<?php echo JHtml::_('select.options', $this->authors, 'value', 'text', $this->state->get('filter.author_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
-			<select name="filter_tag" class="inputbox" id="filter_tag">
+			<select name="filter_tag" id="filter_tag">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
 			</select>

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -41,19 +41,19 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_access"><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_published"><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id"><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -62,7 +62,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
 			<?php else : ?>
 			<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_content/featured/default.php
+++ b/administrator/templates/hathor/html/com_content/featured/default.php
@@ -41,31 +41,31 @@ $n			= count($this->items);
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_published"><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id"><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content'), 'value', 'text', $this->state->get('filter.category_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_level"><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></label>
-			<select name="filter_level" class="inputbox" id="filter_level">
+			<select name="filter_level" id="filter_level">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_MAX_LEVELS'); ?></option>
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access"><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>

--- a/administrator/templates/hathor/html/com_finder/filters/default.php
+++ b/administrator/templates/hathor/html/com_finder/filters/default.php
@@ -55,7 +55,7 @@ Joomla.submitbutton = function(pressbutton)
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_state"><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE'); ?></label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('finder.statelist'), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_finder/index/default.php
+++ b/administrator/templates/hathor/html/com_finder/index/default.php
@@ -69,13 +69,13 @@ Joomla.submitbutton = function(pressbutton)
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_type"><?php echo JText::_('COM_FINDER_INDEX_TYPE_FILTER'); ?></label>
-			<select name="filter_type" class="inputbox" id="filter_type">
+			<select name="filter_type" id="filter_type">
 				<option value=""><?php echo JText::_('COM_FINDER_INDEX_TYPE_FILTER'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('finder.typeslist'), 'value', 'text', $this->state->get('filter.type'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_state"><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE'); ?></label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('finder.statelist'), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_finder/maps/default.php
+++ b/administrator/templates/hathor/html/com_finder/maps/default.php
@@ -55,12 +55,12 @@ Joomla.submitbutton = function(pressbutton)
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_branch"><?php echo JText::sprintf('COM_FINDER_FILTER_BY', JText::_('COM_FINDER_MAPS')); ?></label>
-			<select name="filter_branch" class="inputbox" id="filter_branch">
+			<select name="filter_branch" id="filter_branch">
 				<?php echo JHtml::_('select.options', JHtml::_('finder.mapslist'), 'value', 'text', $this->state->get('filter.branch'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_state"><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE'); ?></label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('COM_FINDER_INDEX_FILTER_BY_STATE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('finder.statelist'), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_installer/default/default_ftp.php
+++ b/administrator/templates/hathor/html/com_installer/default/default_ftp.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 
 	<ul class="adminformlist">
 		<li><label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-		<input type="text" id="username" name="username" class="inputbox" value="" /></li>
+		<input type="text" id="username" name="username" value="" /></li>
 
 		<li><label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
 		<input type="password" id="password" name="password" class="input_box" value="" /></li>

--- a/administrator/templates/hathor/html/com_installer/manage/default_filter.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default_filter.php
@@ -23,14 +23,14 @@ defined('_JEXEC') or die;
 			<label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<?php echo JHtml::_('select.options', array('0' => JText::_('JSITE'), '1' => JText::_('JADMINISTRATOR')), 'value', 'text', $this->state->get('filter.client_id'), true);?>
 			</select>
 
             <label class="selectlabel" for="filter_status">
 				<?php echo JText::_('COM_INSTALLER_VALUE_STATE_SELECT'); ?>
 			</label>
-			<select name="filter_status" class="inputbox" id="filter_status">
+			<select name="filter_status" id="filter_status">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.status'), true);?>
 			</select>
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
             <label class="selectlabel" for="filter_type">
 				<?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'); ?>
 			</label>
-			<select name="filter_type" class="inputbox" id="filter_type">
+			<select name="filter_type" id="filter_type">
 				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT');?></option>
 				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true);?>
 			</select>
@@ -46,7 +46,7 @@ defined('_JEXEC') or die;
 			<label class="selectlabel" for="filter_group">
 				<?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'); ?>
 			</label>
-			<select name="filter_group" class="inputbox" id="filter_group">
+			<select name="filter_group" id="filter_group">
 				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT');?></option>
 				<?php echo JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.group'), true);?>
 			</select>

--- a/administrator/templates/hathor/html/com_languages/installed/default_ftp.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default_ftp.php
@@ -20,10 +20,10 @@ defined('_JEXEC') or die;
 
 		<div>
 			<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-			<input type="text" id="username" name="username" class="inputbox" value="" />
+			<input type="text" id="username" name="username" value="" />
 		</div>
 		<div>
 			<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-			<input type="password" id="password" name="password" class="inputbox" value="" />
+			<input type="password" id="password" name="password" value="" />
 		</div>
 	</fieldset>

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -45,7 +45,7 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('languages.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>

--- a/administrator/templates/hathor/html/com_languages/overrides/default.php
+++ b/administrator/templates/hathor/html/com_languages/overrides/default.php
@@ -32,7 +32,7 @@ $listDirn		= $this->escape($this->state->get('list.direction')); ?>
 			<button type="button" onclick="document.id('filter_search').value='';this.form.submit();"><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 		</div>
 		<div class="filter-select fltrt">
-			<select name="filter_language_client" class="inputbox" onchange="this.form.submit()">
+			<select name="filter_language_client" onchange="this.form.submit()">
 				<?php echo JHtml::_('select.options', $this->languages, null, 'text', $this->state->get('filter.language_client')); ?>
 			</select>
 		</div>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -47,14 +47,14 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="menutype">
 				<?php echo JText::_('TPL_HATHOR_COM_MENUS_MENU'); ?>
 			</label>
-			<select name="menutype" class="inputbox" id="menutype">
+			<select name="menutype" id="menutype">
 				<?php echo JHtml::_('select.options', JHtml::_('menu.menus'), 'value', 'text', $this->state->get('filter.menutype'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_level">
 				<?php echo JText::_('COM_MENUS_OPTION_SELECT_LEVEL'); ?>
 			</label>
-			<select name="filter_level" class="inputbox" id="filter_level">
+			<select name="filter_level" id="filter_level">
 				<option value=""><?php echo JText::_('COM_MENUS_OPTION_SELECT_LEVEL');?></option>
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level'));?>
 			</select>
@@ -62,7 +62,7 @@ $assoc		= JLanguageAssociations::isEnabled();
             <label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
@@ -70,7 +70,7 @@ $assoc		= JLanguageAssociations::isEnabled();
             <label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -78,7 +78,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_messages/messages/default.php
+++ b/administrator/templates/hathor/html/com_messages/messages/default.php
@@ -40,7 +40,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', MessagesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -44,14 +44,14 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
 			</select>
 
             <label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', ModulesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>
@@ -59,7 +59,7 @@ $saveOrder	= $listOrder == 'ordering';
             <label class="selectlabel" for="filter_position">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION'); ?>
 			</label>
-			<select name="filter_position" class="inputbox" id="filter_position">
+			<select name="filter_position" id="filter_position">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION');?></option>
 				<?php echo JHtml::_('select.options', ModulesHelper::getPositions($this->state->get('filter.client_id')), 'value', 'text', $this->state->get('filter.position'));?>
 			</select>
@@ -67,7 +67,7 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_module">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE'); ?>
 			</label>
-			<select name="filter_module" class="inputbox" id="filter_module">
+			<select name="filter_module" id="filter_module">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE');?></option>
 				<?php echo JHtml::_('select.options', ModulesHelper::getModules($this->state->get('filter.client_id')), 'value', 'text', $this->state->get('filter.module'));?>
 			</select>
@@ -75,7 +75,7 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -83,7 +83,7 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_modules/positions/modal.php
+++ b/administrator/templates/hathor/html/com_modules/positions/modal.php
@@ -39,7 +39,7 @@ $type      = $this->state->get('filter.type');
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.templateStates'), 'value', 'text', $state, true);?>
 			</select>
@@ -47,7 +47,7 @@ $type      = $this->state->get('filter.type');
 			<label class="selectlabel" for="filter_type">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_TYPE'); ?>
 			</label>
-			<select name="filter_type" class="inputbox" id="filter_type">
+			<select name="filter_type" id="filter_type">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_TYPE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.types'), 'value', 'text', $type, true);?>
 			</select>
@@ -55,7 +55,7 @@ $type      = $this->state->get('filter.type');
 			<label class="selectlabel" for="filter_template">
 				<?php echo JText::_('JOPTION_SELECT_TEMPLATE'); ?>
 			</label>
-			<select name="filter_template" class="inputbox" id="filter_template">
+			<select name="filter_template" id="filter_template">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TEMPLATE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('modules.templates', $clientId), 'value', 'text', $template, true);?>
 			</select>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -47,7 +47,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>
@@ -55,7 +55,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_newsfeeds'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -63,7 +63,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -71,7 +71,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>
@@ -79,7 +79,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			<label class="selectlabel" for="filter_tag">
 				<?php echo JText::_('JOPTION_SELECT_TAG'); ?>
 			</label>
-			<select name="filter_tag" class="inputbox" id="filter_tag">
+			<select name="filter_tag" id="filter_tag">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/modal.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/modal.php
@@ -32,7 +32,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>
@@ -48,7 +48,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_newsfeeds'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -58,7 +58,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
 			<?php else : ?>
 				<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-				<select name="filter_language" class="inputbox" id="filter_language">
+				<select name="filter_language" id="filter_language">
 					<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 					<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 				</select>

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -42,7 +42,7 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', PluginsHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>
@@ -50,14 +50,14 @@ $saveOrder	= $listOrder == 'ordering';
 			<label class="selectlabel" for="filter_folder">
 				<?php echo JText::_('COM_PLUGINS_OPTION_FOLDER'); ?>
 			</label>
-			<select name="filter_folder" class="inputbox" id="filter_folder">
+			<select name="filter_folder" id="filter_folder">
 				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER');?></option>
 				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder'));?>
 			</select>
             <label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_redirect/links/default.php
+++ b/administrator/templates/hathor/html/com_redirect/links/default.php
@@ -41,7 +41,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_published">
+			<select name="filter_state" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', RedirectHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>

--- a/administrator/templates/hathor/html/com_tags/tags/default.php
+++ b/administrator/templates/hathor/html/com_tags/tags/default.php
@@ -42,25 +42,25 @@ $n			= count($this->items);
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_published"><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access"><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_author_id"><?php echo JText::_('JOPTION_SELECT_AUTHOR'); ?></label>
-			<select name="filter_author_id" class="inputbox"  id="filter_author_id">
+			<select name="filter_author_id" id="filter_author_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_AUTHOR'); ?></option>
 				<?php echo JHtml::_('select.options', $this->authors, 'value', 'text', $this->state->get('filter.author_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language"><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>

--- a/administrator/templates/hathor/html/com_templates/styles/default.php
+++ b/administrator/templates/hathor/html/com_templates/styles/default.php
@@ -39,13 +39,13 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 		<div class="filter-select">
 			<label class="selectlabel" for="filter_template"><?php echo JText::_('COM_TEMPLATES_FILTER_TEMPLATE'); ?></label>
-			<select name="filter_template" class="inputbox" id="filter_template">
+			<select name="filter_template" id="filter_template">
 				<option value="0"><?php echo JText::_('COM_TEMPLATES_FILTER_TEMPLATE'); ?></option>
 				<?php echo JHtml::_('select.options', TemplatesHelper::getTemplateOptions($this->state->get('filter.client_id')), 'value', 'text', $this->state->get('filter.template'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_client_id"><?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?></label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<option value="*"><?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?></option>
 				<?php echo JHtml::_('select.options', TemplatesHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_templates/template/default.php
+++ b/administrator/templates/hathor/html/com_templates/template/default.php
@@ -443,7 +443,7 @@ if($this->type == 'image')
 				  method="post" name="adminForm" id="adminForm">
 				<fieldset class="panelform">
 					<label id="new_name" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL')?></label>
-					<input class="inputbox" type="text" id="new_name" name="new_name"  />
+					<input type="text" id="new_name" name="new_name"  />
 					<button type="submit"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_COPY'); ?></button>
 				</fieldset>
 				<?php echo JHtml::_('form.token'); ?>
@@ -454,7 +454,7 @@ if($this->type == 'image')
 					  method="post" name="adminForm" id="adminForm">
 					<fieldset class="panelform">
 						<label id="new_name" class="hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>"><?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?></label>
-						<input class="inputbox" type="text" name="new_name"  />
+						<input type="text" name="new_name"  />
 						<button type="submit"><?php echo JText::_('COM_TEMPLATES_BUTTON_RENAME'); ?></button>
 					</fieldset>
 					<?php echo JHtml::_('form.token'); ?>

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -42,7 +42,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<label class="selectlabel" for="filter_client_id">
 				<?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" class="inputbox" id="filter_client_id">
+			<select name="filter_client_id" id="filter_client_id">
 				<option value="*"><?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?></option>
 				<?php echo JHtml::_('select.options', TemplatesHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_users/debuggroup/default.php
+++ b/administrator/templates/hathor/html/com_users/debuggroup/default.php
@@ -38,7 +38,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 		<div class="filter-select fltrt">
 			<label class="selectlabel" for="filter_component"><?php echo JText::_('COM_USERS_OPTION_SELECT_COMPONENT'); ?></label>
-			<select name="filter_component" class="inputbox" id="filter_component">
+			<select name="filter_component" id="filter_component">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_COMPONENT');?></option>
 				<?php if (!empty($this->components))
 				{
@@ -47,13 +47,13 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</select>
 
 			<label class="selectlabel" for="filter_level_start"><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_START'); ?></label>
-			<select name="filter_level_start" class="inputbox" id="filter_level_start">
+			<select name="filter_level_start" id="filter_level_start">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_START');?></option>
 				<?php echo JHtml::_('select.options', $this->levels, 'value', 'text', $this->state->get('filter.level_start'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_level_end"><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_END'); ?></label>
-			<select name="filter_level_end" class="inputbox" id="filter_level_end">
+			<select name="filter_level_end" id="filter_level_end">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_END');?></option>
 				<?php echo JHtml::_('select.options', $this->levels, 'value', 'text', $this->state->get('filter.level_end'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_users/debuguser/default.php
+++ b/administrator/templates/hathor/html/com_users/debuguser/default.php
@@ -38,7 +38,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 		<div class="filter-select fltrt">
 			<label class="selectlabel" for="filter_component"><?php echo JText::_('COM_USERS_OPTION_SELECT_COMPONENT'); ?></label>
-			<select name="filter_component" class="inputbox" id="filter_component">
+			<select name="filter_component" id="filter_component">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_COMPONENT');?></option>
 				<?php if (!empty($this->components))
 				{
@@ -47,13 +47,13 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</select>
 
 			<label class="selectlabel" for="filter_level_start"><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_START'); ?></label>
-			<select name="filter_level_start" class="inputbox" id="filter_level_start">
+			<select name="filter_level_start" id="filter_level_start">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_START');?></option>
 				<?php echo JHtml::_('select.options', $this->levels, 'value', 'text', $this->state->get('filter.level_start'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_level_end"><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_END'); ?></label>
-			<select name="filter_level_end" class="inputbox" id="filter_level_end">
+			<select name="filter_level_end" id="filter_level_end">
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_SELECT_LEVEL_END');?></option>
 				<?php echo JHtml::_('select.options', $this->levels, 'value', 'text', $this->state->get('filter.level_end'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_users/notes/default.php
+++ b/administrator/templates/hathor/html/com_users/notes/default.php
@@ -38,7 +38,7 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id" >
+			<select name="filter_category_id" id="filter_category_id" >
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php
 				echo JHtml::_(
@@ -50,7 +50,7 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php
 				echo JHtml::_(

--- a/administrator/templates/hathor/html/com_users/users/default.php
+++ b/administrator/templates/hathor/html/com_users/users/default.php
@@ -45,7 +45,7 @@ $loggeduser = JFactory::getUser();
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('COM_USERS_FILTER_LABEL'); ?>
 			</label>
-			<select name="filter_state" class="inputbox" id="filter_state">
+			<select name="filter_state" id="filter_state">
 				<option value="*"><?php echo JText::_('COM_USERS_FILTER_STATE');?></option>
 				<?php echo JHtml::_('select.options', UsersHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>
@@ -53,7 +53,7 @@ $loggeduser = JFactory::getUser();
 			<label class="selectlabel" for="filter_active">
 				<?php echo JText::_('COM_USERS_FILTER_ACTIVE'); ?>
 			</label>
-			<select name="filter_active" class="inputbox" id="filter_active">
+			<select name="filter_active" id="filter_active">
 				<option value="*"><?php echo JText::_('COM_USERS_FILTER_ACTIVE');?></option>
 				<?php echo JHtml::_('select.options', UsersHelper::getActiveOptions(), 'value', 'text', $this->state->get('filter.active'));?>
 			</select>
@@ -61,7 +61,7 @@ $loggeduser = JFactory::getUser();
 			<label class="selectlabel" for="filter_group_id">
 				<?php echo JText::_('COM_USERS_FILTER_USERGROUP'); ?>
 			</label>
-			<select name="filter_group_id" class="inputbox" id="filter_group_id">
+			<select name="filter_group_id" id="filter_group_id">
 				<option value=""><?php echo JText::_('COM_USERS_FILTER_USERGROUP');?></option>
 				<?php echo JHtml::_('select.options', UsersHelper::getGroups(), 'value', 'text', $this->state->get('filter.group_id'));?>
 			</select>
@@ -69,7 +69,7 @@ $loggeduser = JFactory::getUser();
 			<label class="selectlabel" for="filter_range">
 				<?php echo JText::_('COM_USERS_FILTER_FILTER_DATE'); ?>
 			</label>
-			<select name="filter_range" class="inputbox"  id="filter_range" >
+			<select name="filter_range" id="filter_range" >
 				<option value=""><?php echo JText::_('COM_USERS_OPTION_FILTER_DATE');?></option>
 				<?php echo JHtml::_('select.options', Usershelper::getRangeOptions(), 'value', 'text', $this->state->get('filter.range'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -44,7 +44,7 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" class="inputbox" id="filter_published">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
 			</select>
@@ -52,7 +52,7 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
-			<select name="filter_category_id" class="inputbox" id="filter_category_id">
+			<select name="filter_category_id" id="filter_category_id">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
@@ -60,7 +60,7 @@ $saveOrder	= $listOrder == 'a.ordering';
             <label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" class="inputbox" id="filter_access">
+			<select name="filter_access" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -68,7 +68,7 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" class="inputbox" id="filter_language">
+			<select name="filter_language" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>
@@ -76,7 +76,7 @@ $saveOrder	= $listOrder == 'a.ordering';
 			<label class="selectlabel" for="filter_tag">
 				<?php echo JText::_('JOPTION_SELECT_TAG'); ?>
 			</label>
-			<select name="filter_tag" class="inputbox" id="filter_tag">
+			<select name="filter_tag" id="filter_tag">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag'));?>
 			</select>

--- a/administrator/templates/hathor/html/mod_login/default.php
+++ b/administrator/templates/hathor/html/mod_login/default.php
@@ -15,10 +15,10 @@ JHtml::_('behavior.keepalive');
 	<fieldset class="loginform">
 
 		<label id="mod-login-username-lbl" for="mod-login-username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-		<input name="username" id="mod-login-username" type="text" class="inputbox" size="15" />
+		<input name="username" id="mod-login-username" type="text" size="15" />
 
 		<label id="mod-login-password-lbl" for="mod-login-password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-		<input name="passwd" id="mod-login-password" type="password" class="inputbox" size="15" />
+		<input name="passwd" id="mod-login-password" type="password" size="15" />
 		<?php if (count($twofactormethods) > 1): ?>
 			<div class="control-group">
 				<div class="controls">

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -678,12 +678,6 @@ p.tab-description {
 /**
  * Login Settings
  */
-#login-page form .inputbox {
-	width: 190px;
-	margin-left: 5px;
-	margin-bottom: 15px;
-}
-
 #login-page input, #login-page select {
 	float: right;
 	clear: none;


### PR DESCRIPTION
Currently, we use the CSS class `inputbox` in 391 places in the backend, however it is only a single CSS rule dealing with it. And this one can be removed without any issues.

This PR removes the class from the backend, but leaves frontend (and libraries) untouched.

The one CSS rule which deals with that class is found in Hathor and targets the login page. For LTR languages, there is no change at all when we remove the rule. For RTL languages it even looks better :smile: 

There are two goals with this PR. First it removes unused and inconsistent output and second it will make it easier to deal with "chosen" as we can use a default class for `select` elements.

I targeted this PR against 3.3 because there is a theoretical chance of breaking 3rd party administrator templates if they exists and work with this class.
