### PR TITLE
[#33423] Fixing onContentPrepareForm for multilang sites

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -394,10 +394,6 @@ class CategoriesModelCategory extends JModelAdmin
 		if ($assoc)
 		{
 			$languages = JLanguageHelper::getLanguages('lang_code');
-
-			// Force to array (perhaps move to $this->loadFormData())
-			$data = (array) $data;
-
 			$addform = new SimpleXMLElement('<form />');
 			$fields = $addform->addChild('fields');
 			$fields->addAttribute('name', 'associations');
@@ -407,7 +403,7 @@ class CategoriesModelCategory extends JModelAdmin
 			$add = false;
 			foreach ($languages as $tag => $language)
 			{
-				if (empty($data['language']) || $tag != $data['language'])
+				if (empty($data->language) || $tag != $data->language)
 				{
 					$add = true;
 					$field = $fieldset->addChild('field');

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -651,10 +651,6 @@ class ContactModelContact extends JModelAdmin
 		if ($assoc)
 		{
 			$languages = JLanguageHelper::getLanguages('lang_code');
-
-			// force to array (perhaps move to $this->loadFormData())
-			$data = (array) $data;
-
 			$addform = new SimpleXMLElement('<form />');
 			$fields = $addform->addChild('fields');
 			$fields->addAttribute('name', 'associations');
@@ -664,7 +660,7 @@ class ContactModelContact extends JModelAdmin
 			$add = false;
 			foreach ($languages as $tag => $language)
 			{
-				if (empty($data['language']) || $tag != $data['language'])
+				if (empty($data->language) || $tag != $data->language)
 				{
 					$add = true;
 					$field = $fieldset->addChild('field');

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -655,10 +655,6 @@ class ContentModelArticle extends JModelAdmin
 		if ($assoc)
 		{
 			$languages = JLanguageHelper::getLanguages('lang_code');
-
-			// force to array (perhaps move to $this->loadFormData())
-			$data = (array) $data;
-
 			$addform = new SimpleXMLElement('<form />');
 			$fields = $addform->addChild('fields');
 			$fields->addAttribute('name', 'associations');
@@ -668,7 +664,7 @@ class ContentModelArticle extends JModelAdmin
 			$add = false;
 			foreach ($languages as $tag => $language)
 			{
-				if (empty($data['language']) || $tag != $data['language'])
+				if (empty($data->language) || $tag != $data->language)
 				{
 					$add = true;
 					$field = $fieldset->addChild('field');

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -499,10 +499,6 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 		if ($assoc)
 		{
 			$languages = JLanguageHelper::getLanguages('lang_code');
-
-			// force to array (perhaps move to $this->loadFormData())
-			$data = (array) $data;
-
 			$addform = new SimpleXMLElement('<form />');
 			$fields = $addform->addChild('fields');
 			$fields->addAttribute('name', 'associations');
@@ -512,7 +508,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 			$add = false;
 			foreach ($languages as $tag => $language)
 			{
-				if (empty($data['language']) || $tag != $data['language'])
+				if (empty($data->language) || $tag != $data->language)
 				{
 					$add = true;
 					$field = $fieldset->addChild('field');

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -95,7 +95,7 @@ class PlgSystemLanguagecode extends JPlugin
 	 * Prepare form.
 	 *
 	 * @param   JForm  $form  The form to be altered.
-	 * @param   mixed $data  The associated data for the form.
+	 * @param   mixed  $data  The associated data for the form.
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -95,7 +95,7 @@ class PlgSystemLanguagecode extends JPlugin
 	 * Prepare form.
 	 *
 	 * @param   JForm  $form  The form to be altered.
-	 * @param   Object $data  The associated data for the form.
+	 * @param   mixed $data  The associated data for the form.
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -95,7 +95,7 @@ class PlgSystemLanguagecode extends JPlugin
 	 * Prepare form.
 	 *
 	 * @param   JForm  $form  The form to be altered.
-	 * @param   array  $data  The associated data for the form.
+	 * @param   Object $data  The associated data for the form.
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -196,7 +196,7 @@ class PlgUserProfile extends JPlugin
 	 * adds additional fields to the user editing form
 	 *
 	 * @param   JForm  $form  The form to be altered.
-	 * @param   array  $data  The associated data for the form.
+	 * @param   mixed  $data  The associated data for the form.
 	 *
 	 * @return  boolean
 	 *


### PR DESCRIPTION
When LanguageFilter plugin is enabled, the data object containing the form data (specified at http://docs.joomla.org/Plugin/Events/Content#onContentPrepareForm) gets converted to an array containing the data for some components, which results in inability to manipulate it as it isn't passed by reference.

This PR removes conversion to array and restores passing the data as an object, which seems to be the correct way.

To test, just make sure that multilingual assotiations/content still works fine when you are editing Content/Categories/Contacts/Newsfeeds

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33423&start=0
