### PR TITLE
[#33432] Mod Menu as "sidenav" - for Joomla! 2.5

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -55,7 +55,7 @@ class modMenuHelper
 					if (($start && $start > $item->level)
 						|| ($end && $item->level > $end)
 						|| (!$showAll && $item->level > 1 && !in_array($item->parent_id, $path))
-						|| ($start > 1 && !in_array($item->tree[$start-2], $path))
+						|| ($start > 1 && !in_array($item->tree[$start-2], $path) && $item->tree[$start-2] != $active->id)
 					) {
 						unset($items[$i]);
 						continue;


### PR DESCRIPTION
Changed condition in mod_menu/helper.php to allow show menu items from lover levels of active menu item.

This allow use module mod_menu as "side-navigation" because you can now see menu items under active parent menu item.

Tracker: [#33432] http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33432&start=650
