### PR TITLE
[#33434] Impossible to load user by username when not logged in

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -794,4 +794,3 @@ abstract class JFactory
 		return $retval;
 	}
 }
-

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -241,7 +241,7 @@ abstract class JFactory
 				$instance = JUser::getInstance();
 			}
 		}
-		elseif ($instance->id != $id)
+		elseif ($instance->id !== $id)
 		{
 			$instance = JUser::getInstance($id);
 		}

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -794,3 +794,4 @@ abstract class JFactory
 		return $retval;
 	}
 }
+


### PR DESCRIPTION
I wanted to load user by username, like in Example 2 at http://docs.joomla.org/JFactory/getUser.

But, due to a bug in JFactory::getUser() that is not possible.

If we pass a username, we reach this condition:

elseif ($instance->id != $id)
{
$instance = JUser::getInstance($id);
}

But $instance->id will be 0 if person viewing the site is not logged in, and because $id is string and loose comparison is used, string will evaluate to 0 as well, condition won't be satisfied, and empty user object will be returned.

The fix is simple, just making it a strict comparison instead of loose.

To test, make sure nothing broke on the user pages or anywhere where you load User object

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33434&start=0
