### PR TITLE
[2.5.x] Fixing version comparison for database schema

### DIFF
--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -41,7 +41,7 @@ defined('_JEXEC') or die;
 							<li><?php echo JText::_('COM_INSTALLER_MSG_DATABASE_FILTER_ERROR'); ?>
 						<?php endif; ?>
 
-						<?php if (version_compare($this->schemaVersion, JVERSION) != 0) : ?>
+						<?php if ($this->schemaVersion != $this->changeset->getSchema()) : ?>
 							<li><?php echo JText::sprintf('COM_INSTALLER_MSG_DATABASE_SCHEMA_ERROR', $this->schemaVersion, JVERSION); ?></li>
 						<?php endif; ?>
 

--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -44,7 +44,7 @@ class InstallerViewDatabase extends InstallerViewDefault
 		$this->pagination = $this->get('Pagination');
 		$this->errorCount = count($this->errors);
 
-		if (version_compare($this->schemaVersion, JVERSION) != 0)
+		if ($this->schemaVersion != $this->changeset->getSchema())
 		{
 			$this->errorCount++;
 		}


### PR DESCRIPTION
#2147 tried to fix a broken version comparison that was there, but did it in a wrong way. The schema was compared against the Joomla version, although the two have actually very little in common.

$this->schemaVersion is the schema version stored in the database. $this->changeset->getSchema() is the latest available file in the respective folder of com_admin. Those 2 should be compared and not $this->schemaVersion with the Joomla version.

Since before #2147 it only compared the first 5 characters of the schemaVersion and the Joomla version, the check was always positive for all Joomla 2.5.1x versions and it only wanted to update for new Joomla 3.x.x versions, but didn't really react during development time. Introducing the version comparison showed that bug, but didn't really fix it. This PR should do that.

Mea culpa.
