### PR TITLE
[#30790] fix JHtmlBehavior::noframes()

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -671,7 +671,7 @@ abstract class JHtmlBehavior
 		$document->addStyleDeclaration('html { display:none }');
 		$document->addScriptDeclaration($js);
 
-		JFactory::getApplication()->setHeader('X-Frames-Options', 'SAMEORIGIN');
+		JFactory::getApplication()->setHeader('X-Frame-Options', 'SAMEORIGIN');
 
 		static::$loaded[__METHOD__] = true;
 	}


### PR DESCRIPTION
Fixing issue described in [bug #30790](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=30790), related to header typo (libraries/cms/html/behavior.php)
Correct header name is X-Frame-Options not X-Frames-Options as stated in [the docs](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options)
