### PR TITLE
[#30700] fix JModelForm::checkin()

### DIFF
--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -53,6 +53,12 @@ abstract class JModelForm extends JModelLegacy
 				$this->setError($table->getError());
 				return false;
 			}
+ 
+			// If there is no checked_out or checked_out_time field, just return true.
+			if (!property_exists($table, 'checked_out') || !property_exists($table, 'checked_out_time'))
+			{
+				return true;
+			}
 
 			// Check if this is the user having previously checked out the row.
 			if ($table->checked_out > 0 && $table->checked_out != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))


### PR DESCRIPTION
Fixing issue described in [bug #30700](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30700), related to notices for unset properties of the $table object in JModelForm (libraries/legacy/model/form.php)
