### PR TITLE
[#31538] fix FinderController::display()

### DIFF
--- a/components/com_finder/controller.php
+++ b/components/com_finder/controller.php
@@ -43,8 +43,12 @@ class FinderController extends JControllerLegacy
 		$viewName = $input->get('view', 'search', 'word');
 		$input->set('view', $viewName);
 
-		// Don't cache view for search queries
-		if ($input->get('q') || $input->get('f') || $input->get('t'))
+		/* Don't cache view for search queries
+		 * The last condition must explicitly force the filter type 'array', 
+		 * because the default filter type is 'string', which makes JFilter::get() 
+		 * fail to check for 't' (is array) as its default filter type applied is 'cmd'.
+		 */
+		if ($input->get('q', null, 'string') || $input->get('f', null, 'int') || $input->get('t', null, 'array'))
 		{
 			$cachable = false;
 		}

--- a/components/com_finder/controller.php
+++ b/components/com_finder/controller.php
@@ -48,7 +48,7 @@ class FinderController extends JControllerLegacy
 		 * because the default filter type is 'string', which makes JFilter::get() 
 		 * fail to check for 't' (is array) as its default filter type applied is 'cmd'.
 		 */
-		if ($input->get('q', null, 'string') || $input->get('f', null, 'int') || $input->get('t', null, 'array'))
+		if ($input->getString('q', null) || $input->getInt('f', null) || $input->get('t', null, 'array'))
 		{
 			$cachable = false;
 		}


### PR DESCRIPTION
This error is caused by the com_finder's master controller's display method, which does not respect the type of the URL parameter 't' while it computes the 'cachable' variable. Basically it expects to find the URL parameters
`q // the keyword`,
`f // a pre-defined filter`,
`t // one or more selected taxonomies`. 

The latter most likely contains more than one value and is therefore be passed in as an array like `index.php?option=com_finder&view=search&q=Diner&f=&t[]=italian&t[]=pizza&t[]=distance&t[]=25`

Then in the controller's display method the query string is processed the following way:

`if ($input->get('q') || $input->get('f') || $input->get('t')) { ... }`

A check to JInput::get() reveals this method to sanitize the passed input by calling

`$this->filter->clean()`

falling back to the default filter `cmd` if no specific filter was passed in. Since the URL parameter `t` is an array the condition in com_finder's master controller must be more specific taking data types into account. The following proper condition fixes the issue:

`if ($input->get('q', null, 'string') || $input->get('f', null, 'int') || $input->get('t', null, 'array'))
{ ... }`

Associated tracker item: [#31538](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31538)
