### PR TITLE
[#30929] fix JHtmlQuery::suggested()

### DIFF
--- a/components/com_finder/helpers/html/query.php
+++ b/components/com_finder/helpers/html/query.php
@@ -139,7 +139,7 @@ abstract class JHtmlQuery
 			{
 				if (isset($token->suggestion))
 				{
-					$suggested = str_replace($token->term, $token->suggestion, $suggested);
+					$suggested = str_ireplace($token->term, $token->suggestion, $suggested);
 				}
 			}
 
@@ -148,7 +148,7 @@ abstract class JHtmlQuery
 			{
 				if (isset($token->suggestion))
 				{
-					$suggested = str_replace($token->term, $token->suggestion, $suggested);
+					$suggested = str_ireplace($token->term, $token->suggestion, $suggested);
 				}
 			}
 


### PR DESCRIPTION
Fixing issue described in [bug #30929](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=30929), related a case sensitive alternative search terms creation (components/com_finder/helpers/html/query.php)
