### PR TITLE
[#33441] fix FinderModelSearch::populateState() missing input filters

### DIFF
--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1164,20 +1164,18 @@ class FinderModelSearch extends JModelList
 		
 		// Allow customise the sort ordering. (currently this is 'hard' defined via menu item parameter)
 		$ordering = $app->getUserStateFromRequest("{$this->context}.ordercol", 'filter_order', $ordering);
-		$ordering = $filter->clean($ordering, 'CMD');
-		$ordering = strtolower("l.{$ordering}");
+		$ordering = JString::strtolower($filter->clean($ordering, 'CMD'));
 		// If this information is missing in the user's session, add it.
 		if (!JArrayHelper::getValue($this->filter_fields, $ordering, null))
 		{
 			$app->setUserState("{$this->context}.ordercol", $ordering);
 		}
 		// Replace the model's state.
-		$this->setState('list.ordering', $ordering);
+		$this->setState('list.ordering', "l.{$ordering}");
 		
 		// Allow customise the sort ordering direction. (currently this is 'hard' defined via menu item parameter)
 		$direction = $app->getUserStateFromRequest("{$this->context}.orderdir", 'filter_order_Dir', $direction);
-		$direction = $filter->clean($direction, 'WORD');
-		$direction = strtolower($direction);
+		$direction = JString::strtolower($filter->clean($direction, 'WORD'));
 		// If this information is missing in the user's session, add it.
 		if (!JArrayHelper::getValue($this->filter_fields, $direction, null))
 		{

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1126,8 +1126,14 @@ class FinderModelSearch extends JModelList
 		$this->setState('list.start', $input->get('limitstart', 0, 'uint'));
 		$this->setState('list.limit', $input->get('limit', $app->getCfg('list_limit', 20), 'uint'));
 
-		// Load the sort ordering.
-		$order = $params->get('sort_order', 'relevance');
+		/* Load the sort ordering.
+		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
+		 * More flexibility was way more user friendly. So we allow the user to pass a custom value
+		 * from the pool of fields that are indexed like the 'title' field.
+		 * Also, we allow this parameter to be passed in either case (lower/upper).
+		 */
+		$order = $input->getWord('order', $params->get('sort_order', 'relevance'));
+		$order = JString::strtolower($order);
 		switch ($order)
 		{
 			case 'date':
@@ -1142,13 +1148,23 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.ordering', 'm.weight');
 				break;
 
+			// custom field that is indexed and might be required for ordering
+			case 'title':
+				$this->setState('list.ordering', 'l.title');
+				break;
+
 			default:
 				$this->setState('list.ordering', 'l.link_id');
 				break;
 		}
 
-		// Load the sort direction.
-		$dirn = $params->get('sort_direction', 'desc');
+		/* Load the sort direction.
+		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
+		 * More flexibility was way more user friendly. So we allow to be inverted.
+		 * Also, we allow this parameter to be passed in either case (lower/upper).
+		 */
+		$dirn = $input->getWord('dir', $params->get('sort_direction', 'desc'));
+		$dirn = JString::strtolower($dirn);
 		switch ($dirn)
 		{
 			case 'asc':
@@ -1160,29 +1176,6 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.direction', 'DESC');
 				break;
 		}
-		
-		
-		// Allow customise the sort ordering. (currently this is 'hard' defined via menu item parameter)
-		$ordering = $app->getUserStateFromRequest("{$this->context}.ordercol", 'filter_order', $ordering);
-		$ordering = JString::strtolower($filter->clean($ordering, 'CMD'));
-		// If this information is missing in the user's session, add it.
-		if (!JArrayHelper::getValue($this->filter_fields, $ordering, null))
-		{
-			$app->setUserState("{$this->context}.ordercol", $ordering);
-		}
-		// Replace the model's state.
-		$this->setState('list.ordering', ($ordering ? "l.{$ordering}" : $ordering));
-		
-		// Allow customise the sort ordering direction. (currently this is 'hard' defined via menu item parameter)
-		$direction = $app->getUserStateFromRequest("{$this->context}.orderdir", 'filter_order_Dir', $direction);
-		$direction = JString::strtolower($filter->clean($direction, 'WORD'));
-		// If this information is missing in the user's session, add it.
-		if (!JArrayHelper::getValue($this->filter_fields, $direction, null))
-		{
-			$app->setUserState("{$this->context}.orderdir", $direction);
-		}
-		// Replace the model's state.
-		$this->setState('list.direction', $direction);
 
 		// Set the match limit.
 		$this->setState('match.limit', 1000);

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1163,7 +1163,7 @@ class FinderModelSearch extends JModelList
 		 * More flexibility was way more user friendly. So we allow to be inverted.
 		 * Also, we allow this parameter to be passed in either case (lower/upper).
 		 */
-		$dirn = $input->getWord('filter_order_DIR', $params->get('sort_direction', 'desc'));
+		$dirn = $input->getWord('filter_order_Dir', $params->get('sort_direction', 'desc'));
 		$dirn = JString::strtolower($dirn);
 		switch ($dirn)
 		{

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1126,8 +1126,8 @@ class FinderModelSearch extends JModelList
 		$this->setState('list.start', $input->get('limitstart', 0, 'uint'));
 		$this->setState('list.limit', $input->get('limit', $app->getCfg('list_limit', 20), 'uint'));
 
-		// Load the sort ordering allowing the user to pass in a field name to order by or fall back to component parameter.
-		$order = $input->getWord('order', $params->get('sort_order', 'relevance'));
+		// Load the sort ordering.
+		$order = $params->get('sort_order', 'relevance');
 		switch ($order)
 		{
 			case 'date':
@@ -1142,17 +1142,13 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.ordering', 'm.weight');
 				break;
 
-			case 'title':
-				$this->setState('list.ordering', 'l.title');
-				break;
-
 			default:
 				$this->setState('list.ordering', 'l.link_id');
 				break;
 		}
 
-		// Load the sort direction allowing the user to pass in a direction or fall back to component parameter.
-		$dirn = $input->getWord('dir', $params->get('sort_direction', 'desc'));
+		// Load the sort direction.
+		$dirn = $params->get('sort_direction', 'desc');
 		switch ($dirn)
 		{
 			case 'asc':
@@ -1164,6 +1160,31 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.direction', 'DESC');
 				break;
 		}
+		
+		
+		// Allow customise the sort ordering. (currently this is 'hard' defined via menu item parameter)
+		$ordering = $app->getUserStateFromRequest("{$this->context}.ordercol", 'filter_order', $ordering);
+		$ordering = $filter->clean($ordering, 'CMD');
+		$ordering = strtolower("l.{$ordering}");
+		// If this information is missing in the user's session, add it.
+		if (!JArrayHelper::getValue($this->filter_fields, $ordering, null))
+		{
+			$app->setUserState("{$this->context}.ordercol", $ordering);
+		}
+		// Replace the model's state.
+		$this->setState('list.ordering', $ordering);
+		
+		// Allow customise the sort ordering direction. (currently this is 'hard' defined via menu item parameter)
+		$direction = $app->getUserStateFromRequest("{$this->context}.orderdir", 'filter_order_Dir', $direction);
+		$direction = $filter->clean($direction, 'WORD');
+		$direction = strtolower($direction);
+		// If this information is missing in the user's session, add it.
+		if (!JArrayHelper::getValue($this->filter_fields, $direction, null))
+		{
+			$app->setUserState("{$this->context}.orderdir", $direction);
+		}
+		// Replace the model's state.
+		$this->setState('list.direction', $direction);
 
 		// Set the match limit.
 		$this->setState('match.limit', 1000);

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1126,8 +1126,8 @@ class FinderModelSearch extends JModelList
 		$this->setState('list.start', $input->get('limitstart', 0, 'uint'));
 		$this->setState('list.limit', $input->get('limit', $app->getCfg('list_limit', 20), 'uint'));
 
-		// Load the sort ordering.
-		$order = $params->get('sort_order', 'relevance');
+		// Load the sort ordering allowing the user to pass in a field name to order by or fall back to component parameter.
+		$order = $input->getWord('order', $params->get('sort_order', 'relevance'));
 		switch ($order)
 		{
 			case 'date':
@@ -1142,13 +1142,17 @@ class FinderModelSearch extends JModelList
 				$this->setState('list.ordering', 'm.weight');
 				break;
 
+			case 'title':
+				$this->setState('list.ordering', 'l.title');
+				break;
+
 			default:
 				$this->setState('list.ordering', 'l.link_id');
 				break;
 		}
 
-		// Load the sort direction.
-		$dirn = $params->get('sort_direction', 'desc');
+		// Load the sort direction allowing the user to pass in a direction or fall back to component parameter.
+		$dirn = $input->getWord('dir', $params->get('sort_direction', 'desc'));
 		switch ($dirn)
 		{
 			case 'asc':

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1171,7 +1171,7 @@ class FinderModelSearch extends JModelList
 			$app->setUserState("{$this->context}.ordercol", $ordering);
 		}
 		// Replace the model's state.
-		$this->setState('list.ordering', "l.{$ordering}");
+		$this->setState('list.ordering', ($ordering ? "l.{$ordering}" : $ordering));
 		
 		// Allow customise the sort ordering direction. (currently this is 'hard' defined via menu item parameter)
 		$direction = $app->getUserStateFromRequest("{$this->context}.orderdir", 'filter_order_Dir', $direction);

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1132,7 +1132,7 @@ class FinderModelSearch extends JModelList
 		 * from the pool of fields that are indexed like the 'title' field.
 		 * Also, we allow this parameter to be passed in either case (lower/upper).
 		 */
-		$order = $input->getWord('order', $params->get('sort_order', 'relevance'));
+		$order = $input->getWord('filter_order', $params->get('sort_order', 'relevance'));
 		$order = JString::strtolower($order);
 		switch ($order)
 		{
@@ -1163,7 +1163,7 @@ class FinderModelSearch extends JModelList
 		 * More flexibility was way more user friendly. So we allow to be inverted.
 		 * Also, we allow this parameter to be passed in either case (lower/upper).
 		 */
-		$dirn = $input->getWord('dir', $params->get('sort_direction', 'desc'));
+		$dirn = $input->getWord('filter_order_DIR', $params->get('sort_direction', 'desc'));
 		$dirn = JString::strtolower($dirn);
 		switch ($dirn)
 		{


### PR DESCRIPTION
Fixing issue described in [bug #33441](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33441), related to missing input filter parameters in FinderModelSearch::populateState (components/com_finder/models/search.php)
