### PR TITLE
[#32994] Adding new JHtml function behavior.core to load core.js

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -61,9 +61,35 @@ abstract class JHtmlBehavior
 		}
 
 		JHtml::_('script', 'system/mootools-' . $type . '.js', false, true, false, false, $debug);
+
+		// Keep loading core.js for BC reasons
+ 		static::core();
+ 
+		static::$loaded[__METHOD__][$type] = true;
+
+		return;
+	}
+
+	/**
+	 * Method to load core.js into the document head.
+	 * 
+	 * Core.js defines the 'Joomla' namespace and contains functions which are used across extensions
+	 *
+	 * @return  void
+	 *
+	 * @since   3.3
+	 */
+	public static function core()
+	{
+		// Only load once
+		if (isset(static::$loaded[__METHOD__]))
+		{
+			return;
+		}
+
 		JHtml::_('jquery.framework');
 		JHtml::_('script', 'system/core.js', false, true);
-		static::$loaded[__METHOD__][$type] = true;
+		static::$loaded[__METHOD__] = true;
 
 		return;
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -79,12 +79,12 @@ class JHtmlBehaviorTest extends TestCase
 	public function getFrameworkData()
 	{
 		$data = array(
-			array(array('JHtmlBehavior::framework' => array('core' => true))),
-			array(array('JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true),
-			array(array('JHtmlBehavior::framework' => array('core' => true)), false, false),
-			array(array('JHtmlBehavior::framework' => array('core' => true)), false, true),
-			array(array('JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, false),
-			array(array('JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, true)
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true))),
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true),
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true)), false, false),
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true)), false, true),
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, false),
+			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, true)
 		);
 
 		return $data;

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -204,7 +204,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::formvalidation();
 		$this->assertEquals(
-			array('JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::formvalidation' => true),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::formvalidation' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -235,7 +235,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::switcher();
 		$this->assertEquals(
-			array('JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::switcher' => true),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::switcher' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -266,7 +266,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::combobox();
 		$this->assertEquals(
-			array('JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::combobox' => true),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::combobox' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -283,6 +283,7 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip', array()))) => true
@@ -291,6 +292,7 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array()))) => true
@@ -300,6 +302,7 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array('showDelay' => 1000)))) => true
@@ -361,6 +364,7 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal', array()))) => true
@@ -369,6 +373,7 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal2', array()))) => true
@@ -378,6 +383,7 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal2', array('size' => 1000)))) => true
@@ -439,12 +445,14 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true),
 					'JHtmlBehavior::multiselect' => array('adminForm' => true),
 				)
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true),
 					'JHtmlBehavior::multiselect' => array('adminForm2' => true),
 				),
@@ -502,6 +510,7 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::framework' => array('core' => true),
 					'JHtmlBehavior::tree' => array('myid' => true)
 				),
@@ -668,7 +677,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::noframes();
 		$this->assertEquals(
-			array('JHtmlBehavior::noframes' => true, 'JHtmlBehavior::framework' => array('core' => true)),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::noframes' => true, 'JHtmlBehavior::framework' => array('core' => true)),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}


### PR DESCRIPTION
### Issue

Currently, when we want to load `core.js` (kind of our own Joomla JavaScript "library") we use the same function as when we want to load the MooTools JavaScript library. That is `JHtml::_('behavior.framework')`.
So far this wasn't a problem since core.js needed MooTools anyway.
Since now core.js is rewritten to jQuery, that JHtml method also has to load the jQuery framework.
### Proposed Solution

This PR will introduce a new function `JHtml::_('behavior.core')` which is supposed to only load core.js. Since core.js depends on jQuery, it will also load jQuery. If we ever decide to rewrite core.js so it doesn't use jQuery anymore, this method could be changed easy to not loading jQuery anymore.
### Testing Instructions

This only introduces the new method. To test, you need to manually change the call `JHtml::_('behavior.framework')` to `JHtml::_('behavior.core')` where possible and see that mootools is now longer loaded but core.js still is.
**A good place to test would be the com_content category view with the table layout.
Change this line https://github.com/joomla/joomla-cms/blob/3.3-dev/components/com_content/views/category/tmpl/default_articles.php#L14 to `JHtml::_('behavior.core')`**.
Currently it will load mootools together with core.js.
If you comment the line out, neither will be loaded and the sorting function (clicking on table headers) will be broken.
Changing it to behavior.core will load core.js without mootools and the sorting will work (again).
When testing make sure you disable modules. They may load mootools as well (login for example does).
### Future work

This will also be needed work for future PRs to change the current calls and remove the (hopefully 
now) unneeded loading of Mootools.
My goal is to introduce this method now so it can be used as a base for future PRs.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32994
#### Remark

This is basically the same as PR #3047, but now against 3.3 and taking into account that core.js is rewritten now.
