### PR TITLE
[#33446] Move readmore button to layouts

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -57,7 +57,7 @@ JHtml::_('behavior.framework');
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>
 
-  <?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
+	<?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
 
 <?php endif; ?>
 

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -57,23 +57,7 @@ JHtml::_('behavior.framework');
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>
 
-	<p class="readmore"><a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
-
-	<?php if (!$params->get('access-view')) :
-		echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-	elseif ($readmore = $this->item->alternative_readmore) :
-		echo $readmore;
-		if ($params->get('show_readmore_title', 0) != 0) :
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-		endif;
-	elseif ($params->get('show_readmore_title', 0) == 0) :
-		echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-	else :
-		echo JText::_('COM_CONTENT_READ_MORE');
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-	endif; ?>
-
-	</a></p>
+  <?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
 
 <?php endif; ?>
 

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -239,7 +239,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>
 
-  <?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
+	<?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
 
 <?php endif; ?>
 

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -239,23 +239,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>
 
-	<p class="readmore"><a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
-
-	<?php if (!$params->get('access-view')) :
-		echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-	elseif ($readmore = $this->item->alternative_readmore) :
-		echo $readmore;
-		if ($params->get('show_readmore_title', 0) != 0) :
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-		endif;
-	elseif ($params->get('show_readmore_title', 0) == 0) :
-		echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-	else :
-		echo JText::_('COM_CONTENT_READ_MORE');
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-	endif; ?>
-
-	</a></p>
+  <?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>
 
 <?php endif; ?>
 

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+$params = $displayData['params'];
+$item = $displayData['item'];
+?>
+
+<p class="readmore">
+  <a class="btn" href="<?php echo $displayData['link']; ?>">
+    <span class="icon-chevron-right"></span>
+    <?php if (!$params->get('access-view')) :
+      echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
+    elseif ($readmore = $item->alternative_readmore) :
+      echo $readmore;
+      if ($params->get('show_readmore_title', 0) != 0) :
+      echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
+      endif;
+    elseif ($params->get('show_readmore_title', 0) == 0) :
+      echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
+    else :
+      echo JText::_('COM_CONTENT_READ_MORE');
+      echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
+    endif; ?>
+  </a>
+</p>

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -12,20 +12,20 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-  <a class="btn" href="<?php echo $displayData['link']; ?>">
-    <span class="icon-chevron-right"></span>
-    <?php if (!$params->get('access-view')) :
-      echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-    elseif ($readmore = $item->alternative_readmore) :
-      echo $readmore;
-      if ($params->get('show_readmore_title', 0) != 0) :
-      echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
-      endif;
-    elseif ($params->get('show_readmore_title', 0) == 0) :
-      echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-    else :
-      echo JText::_('COM_CONTENT_READ_MORE');
-      echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
-    endif; ?>
-  </a>
+	<a class="btn" href="<?php echo $displayData['link']; ?>">
+		<span class="icon-chevron-right"></span>
+		<?php if (!$params->get('access-view')) :
+			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
+		elseif ($readmore = $item->alternative_readmore) :
+			echo $readmore;
+			if ($params->get('show_readmore_title', 0) != 0) :
+				echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
+			endif;
+		elseif ($params->get('show_readmore_title', 0) == 0) :
+			echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
+		else :
+			echo JText::_('COM_CONTENT_READ_MORE');
+			echo JHtml::_('string.truncate', ($item->title), $params->get('readmore_limit'));
+		endif; ?>
+	</a>
 </p>


### PR DESCRIPTION
This commit creates a layout for the readmore button and uses this layout in featured/default_item.php and category/blog_item.php.

JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33446
