### PR TITLE
[#33450] Don't load tags layouts unless there are tags

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -154,7 +154,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 		</div>
 	<?php endif; ?>
 
-	<?php if ($params->get('show_tags', 1) && !empty($this->item->tags)) : ?>
+	<?php if ($params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33450&start=0

The tags JLayout because some tags info is always set in `$this->item->tags` The solution is to check for the actual tags themselves rather than the full tags system.
## Testing
1. Test the tags layout is shown in the frontend by viewing an article without tags. Adding a `die;` at the top of the layout (https://github.com/joomla/joomla-cms/blob/staging/layouts/joomla/content/tags.php) should kill your page.
### APPLY PR
1. Check your article without tags. The page should load happily now because the JLayout isn't being loaded.
2. Check an article with tags and ensure the tags still show as expected in the frontend (don't forget to remove the die)
