### PR TITLE
Update TagManager0001Test.php

### DIFF
--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -134,7 +134,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->tagManagerPage->addTag($tagName, $caption, $alt, $float);
 		$message = $this->tagManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Tags successfully saved') >= 0, 'Tag save should return success');
-		$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be in row 1');
+	//	$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be in row 1');
 		$values = $this->tagManagerPage->getFieldValues('TagEditPage', $tagName, array('Title', 'Caption'));
 		$this->assertEquals(array($tagName, $caption), $values, 'Actual name, caption should match expected');
 		$this->tagManagerPage->trashAndDelete($tagName);


### PR DESCRIPTION
I have commented the line 137 as its was responsible for a failure. It was checking that every time a tag was added its row number should be one but that's not necessary as if there exited some tags already then its row number would be accordingly as it should be but not 1.
Right Now i have commented it, it can also be removed.
