### PR TITLE
[#33453] JHtmlBootstrap::addTab() double escapes quotes

### DIFF
--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -30,7 +30,7 @@ JHtml::_('formbehavior.chosen', 'select');
 	<fieldset>
 		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic')); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', empty($this->item->id) ? JText::_('COM_REDIRECT_NEW_LINK', true) : JText::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id, true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', empty($this->item->id) ? JText::_('COM_REDIRECT_NEW_LINK', true) : JText::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id, array('jsSafe' => true))); ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('old_url'); ?></div>
 					<div class="controls"><?php echo rawurldecode($this->form->getInput('old_url')); ?></div>

--- a/layouts/libraries/cms/html/bootstrap/addtabscript.php
+++ b/layouts/libraries/cms/html/bootstrap/addtabscript.php
@@ -18,7 +18,7 @@ $title = empty($displayData['title']) ? '' : $displayData['title'];
 echo "(function($){
 				$(document).ready(function() {
 					// Handler for .ready() called.
-					var tab = $('<li class=\"" . addslashes($active) . "\"><a href=\"#" . addslashes($id) . "\" data-toggle=\"tab\">" . addslashes($title) . "</a></li>');
-					$('#" . addslashes($selector) . "Tabs').append(tab);
+					var tab = $('<li class=\"" . $active . "\"><a href=\"#" . $id . "\" data-toggle=\"tab\">" . $title . "</a></li>');
+					$('#" . $selector . "Tabs').append(tab);
 				});
 			})(jQuery);";


### PR DESCRIPTION
### Issue

Tab titles generated using the JLayout `layouts/libraries/cms/html/bootstrap/addtabscript.php` will be escaped by that JLayout. But the title is already escaped using `JText::_('CONSTANT', true)` (The second argument `true` means `jsSafe`). Thus we end up double escaping the title.
### Test

Edit a language string which will end up in a tab title and add a single quote to it. For example:
`COM_NEWSFEEDS_EDIT_NEWSFEED="Edit News' Feed"`
This one will end up in the newsfeed edit form like this:
![newsfeed](https://f.cloud.github.com/assets/1018684/2384059/ff99665c-a906-11e3-9be3-76e522afb1f7.png)
Apply patch and the backslash will be gone.
### Background

This is a regression introduced with Joomla 3.2.3 due to this PR: #3203
The problem (which we didn't catch...) was that before it used `JText::sprintf('CONSTANT', true)`. But `JText::sprintf()` doesn't take a second argument, thus it didn't escape the string. Since that PR also changed the JText calls to `JText::_('CONSTANT', true)` (removing the sprintf part), the strings are now correctly escaped already.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33453
