### PR TITLE
[#33454] JMicrodata: small bug fix, reset params after the display() method

### DIFF
--- a/libraries/joomla/microdata/microdata.php
+++ b/libraries/joomla/microdata/microdata.php
@@ -130,6 +130,23 @@ class JMicrodata
 	}
 
 	/**
+	 * Reset all params
+	 *
+	 * @return void
+	 * 
+	 * @since   3.2
+	 */
+	protected function resetParams()
+	{
+		$this->content          = null;
+		$this->machineContent	= null;
+		$this->property         = null;
+		$this->fallbackProperty = null;
+		$this->fallbackType     = null;
+		$this->fallback         = false;
+	}
+
+	/**
 	 * Enable or Disable Microdata semantics output
 	 *
 	 * @param   boolean  $flag  Enable or disable microdata output
@@ -355,6 +372,9 @@ class JMicrodata
 		// Control if the Microdata output is enabled, otherwise return the content or empty string
 		if (!$this->enabled)
 		{
+			// Reset params
+			$this->resetParams();
+
 			return ($emptyOutput) ? '' : $html;
 		}
 
@@ -552,11 +572,7 @@ class JMicrodata
 		}
 
 		// Reset params
-		$this->content          = null;
-		$this->property         = null;
-		$this->fallbackProperty = null;
-		$this->fallbackType     = null;
-		$this->fallback         = false;
+		$this->resetParams();
 
 		return $html;
 	}
@@ -757,7 +773,7 @@ class JMicrodata
 	}
 
 	/**
-	 * Return the microdata in a <meta> tag with the machine content inside.
+	 * Return the microdata in a <meta> tag with content for machines.
 	 *
 	 * @param   string   $content   The machine content to display
 	 * @param   string   $property  The Property
@@ -797,7 +813,7 @@ class JMicrodata
 	}
 
 	/**
-	 * Return the microdata in an <span> tag.
+	 * Return the microdata in a <span> tag.
 	 *
 	 * @param   string   $content   The human value
 	 * @param   string   $property  Optional, the human value to display

--- a/tests/unit/suites/libraries/joomla/microdata/JMicrodataTest.php
+++ b/tests/unit/suites/libraries/joomla/microdata/JMicrodataTest.php
@@ -240,6 +240,12 @@ class JMicrodataTest extends PHPUnit_Framework_TestCase
 			->display('meta', true);
 
 		$this->assertEquals($responce, '');
+
+		// Test if the params are reseted after display(), if the library is disabled
+		$this->assertNull($this->handler->getFallbackProperty());
+		$this->assertNull($this->handler->getFallbackType());
+		$this->assertNull($this->handler->getProperty());
+		$this->assertNull($this->handler->getContent());
 	}
 
 	/**


### PR DESCRIPTION
Patch for a small bug.

Problem:
Not all params are reseted after the display() method.
For example:

``` php
$microdata = new JMicrodata('Article');
$html = $microdata->enable(false)->property('name')->content('TITLE ARTICLE ')->display()
    . $microdata->property('aggregateRating')->display();
```

It returns

``` html
TITLE ARTICLE TITLE ARTICLE
```

but the output should be

``` html
TITLE ARTICLE
```

The problem is that the `$content` param is not reseted when JMicrodata is disabled.

Bug Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33454&start=0
