### PR TITLE
[#32739] Add .gm-style for Google Maps

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -56,7 +56,8 @@ img {
 	-ms-interpolation-mode: bicubic;
 }
 #map_canvas img,
-.google-maps img {
+.google-maps img,
+.gm-style img {
 	max-width: none;
 }
 button,

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -56,7 +56,8 @@ img {
 	-ms-interpolation-mode: bicubic;
 }
 #map_canvas img,
-.google-maps img {
+.google-maps img,
+.gm-style img {
 	max-width: none;
 }
 button,

--- a/media/jui/less/reset.less
+++ b/media/jui/less/reset.less
@@ -89,7 +89,8 @@ img {
 
 // Prevent max-width from affecting Google Maps
 #map_canvas img,
-.google-maps img {
+.google-maps img,
+.gm-style img {
   max-width: none;
 }
 

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -56,7 +56,8 @@ img {
 	-ms-interpolation-mode: bicubic;
 }
 #map_canvas img,
-.google-maps img {
+.google-maps img,
+.gm-style img {
 	max-width: none;
 }
 button,


### PR DESCRIPTION
The current version of the Google Maps API uses .gm-style instead of #map_canvas or .google-maps, so the corresponding CSS lines need to be adapted.

JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32739
