### PR TITLE
[#3289] Wrong message for empty contact category list

### DIFF
--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -15,7 +15,7 @@ $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
 <?php if (empty($this->items)) : ?>
-	<p> <?php echo JText::_('COM_CONTACT_NO_CONTACS'); ?>	 </p>
+	<p> <?php echo JText::_('COM_CONTACT_NO_CONTACTS'); ?>	 </p>
 <?php else : ?>
 
 	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -15,7 +15,7 @@ $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
 <?php if (empty($this->items)) : ?>
-	<p> <?php echo JText::_('COM_CONTACT_NO_ARTICLES'); ?>	 </p>
+	<p> <?php echo JText::_('COM_CONTACT_NO_CONTACS'); ?>	 </p>
 <?php else : ?>
 
 	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">

--- a/templates/beez3/html/com_contact/category/default_items.php
+++ b/templates/beez3/html/com_contact/category/default_items.php
@@ -15,7 +15,7 @@ $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
 <?php if (empty($this->items)) : ?>
-	<p> <?php echo JText::_('COM_CONTACT_NO_ARTICLES'); ?> </p>
+	<p> <?php echo JText::_('COM_CONTACT_NO_CONTACTS'); ?> </p>
 <?php else : ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">


### PR DESCRIPTION
#### Steps to reproduce the issue

On clean j323 install with learning demo data create a menu item to contact category C
Pick the menu item in the frontend and see: No articles to display
#### Expected result

To see: There are no Contacts to display
text from COM_CONTACT_NO_CONTACTS instead of COM_CONTACT_NO_ARTICLES
#### Actual result

You get: No articles to display
#### System information (as much as possible)

Clean J323 install with learning demo data.
#### Additional comments

Replacing COM_CONTACT_NO_ARTICLES with COM_CONTACT_NO_CONTACTS makes COM_CONTACT_NO_ARTICLES unused, which normally should have it removed.
Considering that articles are also shown for contacts it might be intended to be used.
Separate issue I think, removing/using.
