### PR TITLE
PostgreSQL - query fix in mod_articles_archive

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -31,7 +31,8 @@ class ModArchiveHelper
 			->select($query->year($db->quoteName('created')) . ' AS created_year')
 			->from('#__content')
 			->where('state = 2 AND checked_out = 0')
-			->group('created_year DESC, created_month DESC');
+			->group('created_year, created_month, created, id, title')
+			->order('created_year DESC, created_month DESC');
 
 		// Filter by language
 		if (JFactory::getApplication()->getLanguageFilter())


### PR DESCRIPTION
#### Steps to reproduce the issue

Activate the module mod_articles_archive (Archived Articles)
#### Expected result

No errors
#### Actual result

Syntax error. PostgreSQL does not accept GROUP BY followed by DESC, like MySQL DOES
#### System information (as much as possible)

PostgreSQL 9.3
#### Additional comments
