### PR TITLE
[#33465] fix JModelAdmin::delete()

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -770,10 +770,19 @@ abstract class JModelAdmin extends JModelForm
 			}
 			else
 			{
-				$error = $table->getError() ? $table->getError() : JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED');
+				if ($table->getError())
+				{
+					$this->setError($table->getError());
+					return false;
+				}
 
-				$this->setError($error);
-				return false;
+				$key = $table->getKeyName();
+
+				if (empty($table->$key))
+				{
+					$this->setError(JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED'));
+					return false;
+				}
 			}
 		}
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -770,7 +770,9 @@ abstract class JModelAdmin extends JModelForm
 			}
 			else
 			{
-				$this->setError($table->getError());
+				$error = $table->getError() ? $table->getError() : JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED');
+
+				$this->setError($error);
 				return false;
 			}
 		}

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -735,13 +735,13 @@ abstract class JModelAdmin extends JModelForm
 
 					if (in_array(false, $result, true))
 					{
-						$this->setError($table->getError());
+						$this->setError($dispatcher->getError());
 						return false;
 					}
 
 					if (!$table->delete($pk))
 					{
-						$this->setError($table->getError());
+						$this->setError($dispatcher->getError());
 						return false;
 					}
 


### PR DESCRIPTION
Fixing issue described in [bug #33465](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33465), related to JModelAdmin::delete() not reporting something when deletion failed due to empty row data.
