### PR TITLE
Remove unnecessary reset() function call in JHtmlSelect::radiolist().

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -733,7 +733,6 @@ abstract class JHtmlSelect
 	public static function radiolist($data, $name, $attribs = null, $optKey = 'value', $optText = 'text', $selected = null, $idtag = false,
 		$translate = false)
 	{
-		reset($data);
 
 		if (is_array($attribs))
 		{


### PR DESCRIPTION
Internal array pointer has not been used in JHtmlSelect::radiolist(). Therefore, the reset() call should be removed.

This PR also fixes HHVM compatibility.
