### PR TITLE
[#33468] JFormFieldTextarea wrong property name in setter

### DIFF
--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -81,7 +81,7 @@ class JFormFieldTextarea extends JFormField
 		{
 			case 'rows':
 			case 'columns':
-				$this->name = (int) $value;
+				$this->$name = (int) $value;
 				break;
 
 			default:


### PR DESCRIPTION
Instead of setting the desired field the value (rows or columns) you set the value to the property name.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33468&start=0
