### PR TITLE
Update TagManager0001Test.php

### DIFF
--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -114,7 +114,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->tagManagerPage->addTag($tagName);
 		$message = $this->tagManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Tag successfully saved') >= 0, 'Tag save should return success');
-		$this->assertEquals(2, $this->tagManagerPage->getRowNumber($tagName), 'Test Tag should be in row 2');
+		$this->assertGreaterThanOrEqual(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be present');
 		$this->tagManagerPage->trashAndDelete($tagName);
 		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test Tag should not be present');
 	}

--- a/tests/system/webdriver/tests/components/TagManager0001Test.php
+++ b/tests/system/webdriver/tests/components/TagManager0001Test.php
@@ -114,7 +114,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->tagManagerPage->addTag($tagName);
 		$message = $this->tagManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Tag successfully saved') >= 0, 'Tag save should return success');
-		$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test Tag should be in row 2');
+		$this->assertEquals(2, $this->tagManagerPage->getRowNumber($tagName), 'Test Tag should be in row 2');
 		$this->tagManagerPage->trashAndDelete($tagName);
 		$this->assertFalse($this->tagManagerPage->getRowNumber($tagName), 'Test Tag should not be present');
 	}
@@ -134,7 +134,7 @@ class TagManager0001Test extends JoomlaWebdriverTestCase
 		$this->tagManagerPage->addTag($tagName, $caption, $alt, $float);
 		$message = $this->tagManagerPage->getAlertMessage();
 		$this->assertTrue(strpos($message, 'Tags successfully saved') >= 0, 'Tag save should return success');
-		$this->assertEquals(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be in row 1');
+		$this->assertGreaterThanOrEqual(1, $this->tagManagerPage->getRowNumber($tagName), 'Test test tag should be present');
 		$values = $this->tagManagerPage->getFieldValues('TagEditPage', $tagName, array('Title', 'Caption'));
 		$this->assertEquals(array($tagName, $caption), $values, 'Actual name, caption should match expected');
 		$this->tagManagerPage->trashAndDelete($tagName);


### PR DESCRIPTION
on line 117 the command was checking whether the tag was in row two but instead of that it was checking that if it was present in row 1.
on line 137 it was checking whether tag that was added its row number should be one but that's not necessary as if there exited some tags already then its row number would be accordingly as it should be but not 1. so now I am just checking here that its row number is greater or equal to 1.
