### PR TITLE
[#33472] *Correcting RTL css for Firefox

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8138,7 +8138,7 @@ a.grid_true {
 	float: right;
 }
 .input-append .add-on {
-	float: left;
+	float: none;
 }
 .input-prepend .add-on,
 .input-prepend .btn {

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -203,7 +203,7 @@
 	float: right;
 }
 .input-append .add-on {
-	float: left;
+	float: none;
 }
 .input-prepend .add-on,
 .input-prepend .btn {

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -197,7 +197,7 @@
 	float: right;
 }
 .input-append .add-on{
-	float: left;
+	float: none;
 }
 .input-prepend .add-on,
 .input-prepend .btn {


### PR DESCRIPTION
After merging https://github.com/joomla/joomla-cms/pull/461 we still have an error in RTL when using Firefox (no problem in Chrome or Safari).
To test, add this code in back-end view:
`
<?php JHtml::_('formbehavior.chosen', '.chosen'); ?> <div class="input-append input-prepend"> <span class="add-on">$</span> <select name="jform[metadata][robots]" id="jform_metadata_robots" style="display: none;" class="chosen"> <option selected="selected" value="">Use Global</option> <option value="index, follow">Index, Follow</option> <option value="noindex, follow">No index, follow</option> <option value="index, nofollow">Index, No follow</option> <option value="noindex, nofollow">No index, no follow</option> </select> <span class="add-on">.00</span> </div> 
`

Before patch:

![rtl](https://f.cloud.github.com/assets/869724/2427953/9ff50632-ac1e-11e3-82cc-78cf28b61317.png)

After patch we will get

![rtlafterpatch](https://f.cloud.github.com/assets/869724/2427962/415deef8-ac1f-11e3-96f1-e662b82664f9.png)

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33472&start=0
