### PR TITLE
[#32614] drop column support for PostgreSQL in Extension manager => Database

### DIFF
--- a/libraries/cms/schema/changeitem/postgresql.php
+++ b/libraries/cms/schema/changeitem/postgresql.php
@@ -73,6 +73,16 @@ class JSchemaChangeitemPostgresql extends JSchemaChangeitem
 				$this->queryType = 'ADD_COLUMN';
 				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]));
 			}
+			elseif ($alterCommand === 'DROP COLUMN')
+			{
+				$result = 'SELECT column_name FROM information_schema.columns WHERE table_name='
+				. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5]);
+			
+
+				$this->queryType = 'DROP_COLUMN';
+				$this->checkQueryExpected = 0;
+				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]));
+			}
 			elseif ($alterCommand === 'ALTER COLUMN')
 			{
 				if (strtoupper($wordArray[6]) == 'TYPE')


### PR DESCRIPTION
[#32614] 3.2.0 introduces drop column as schema updates for PostgreSQL. But there is no support for it, untill now!

tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32614&start=0
