### PR TITLE
*[fix][#33478]Validating unicode url Feeds (RSS and Atom)

### DIFF
--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -117,7 +117,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			if ($data->items[$i]->link = JFilterOutput::stringURLSafe($data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -74,6 +74,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 
 		$feed = "<feed xmlns=\"http://www.w3.org/2005/Atom\" ";
+
 		if ($data->language != "")
 		{
 			$feed .= " xml:lang=\"" . $data->language . "\"";
@@ -81,6 +82,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		$feed .= ">\n";
 		$feed .= "	<title type=\"text\">" . $feed_title . "</title>\n";
 		$feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->description, ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
+
 		if (empty($data->category) === false)
 		{
 			if (is_array($data->category))
@@ -98,6 +100,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		$feed .= "	<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . "\"/>\n";
 		$feed .= "	<id>" . str_replace(' ', '%20', $data->getBase()) . "</id>\n";
 		$feed .= "	<updated>" . htmlspecialchars($now->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
+
 		if ($data->editor != "")
 		{
 			$feed .= "	<author>\n";
@@ -113,7 +116,16 @@ class JDocumentRendererAtom extends JDocumentRenderer
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
-			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+
+			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			{
+				$itemlink = $data->items[$i]->link;
+			}
+			else
+			{
+				$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+			}
+
 			$feed .= "	<entry>\n";
 			$feed .= "		<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
 			$feed .= '		<link rel="alternate" type="text/html" href="' . $url . $itemlink . "\"/>\n";
@@ -122,10 +134,12 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			{
 				$data->items[$i]->date = $now->toUnix();
 			}
+
 			$itemDate = JFactory::getDate($data->items[$i]->date);
 			$itemDate->setTimeZone($tz);
 			$feed .= "		<published>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</published>\n";
 			$feed .= "		<updated>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
+
 			if (empty($data->items[$i]->guid) === true)
 			{
 				$feed .= "		<id>" . str_replace(' ', '%20', $url . $itemlink) . "</id>\n";
@@ -145,11 +159,13 @@ class JDocumentRendererAtom extends JDocumentRenderer
 				}
 				$feed .= "		</author>\n";
 			}
+
 			if ($data->items[$i]->description != "")
 			{
 				$feed .= "		<summary type=\"html\">" . htmlspecialchars($data->items[$i]->description, ENT_COMPAT, 'UTF-8') . "</summary>\n";
 				$feed .= "		<content type=\"html\">" . htmlspecialchars($data->items[$i]->description, ENT_COMPAT, 'UTF-8') . "</content>\n";
 			}
+
 			if (empty($data->items[$i]->category) === false)
 			{
 				if (is_array($data->items[$i]->category))
@@ -164,6 +180,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 					$feed .= "		<category term=\"" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "\" />\n";
 				}
 			}
+
 			if ($data->items[$i]->enclosure != null)
 			{
 				$feed .= "		<link rel=\"enclosure\" href=\"" . $data->items[$i]->enclosure->url . "\" type=\""
@@ -171,6 +188,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			}
 			$feed .= "	</entry>\n";
 		}
+
 		$feed .= "</feed>\n";
 		return $feed;
 	}

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -117,7 +117,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if ($data->items[$i]->link = JFilterOutput::stringURLSafe($data->items[$i]->link))
+			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -153,6 +153,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			{
 				$feed .= "		<author>\n";
 				$feed .= "			<name>" . htmlspecialchars($data->items[$i]->author, ENT_COMPAT, 'UTF-8') . "</name>\n";
+
 				if ($data->items[$i]->authorEmail != "")
 				{
 					$feed .= "			<email>" . htmlspecialchars($data->items[$i]->authorEmail, ENT_COMPAT, 'UTF-8') . "</email>\n";

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -117,7 +117,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			if (!preg_match('/[\x80-\xFF]/', $data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -113,9 +113,10 @@ class JDocumentRendererAtom extends JDocumentRenderer
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
+			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
 			$feed .= "	<entry>\n";
 			$feed .= "		<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= '		<link rel="alternate" type="text/html" href="' . $url . $data->items[$i]->link . "\"/>\n";
+			$feed .= '		<link rel="alternate" type="text/html" href="' . $url . $itemlink . "\"/>\n";
 
 			if ($data->items[$i]->date == "")
 			{
@@ -127,7 +128,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			$feed .= "		<updated>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
 			if (empty($data->items[$i]->guid) === true)
 			{
-				$feed .= "		<id>" . str_replace(' ', '%20', $url . $data->items[$i]->link) . "</id>\n";
+				$feed .= "		<id>" . str_replace(' ', '%20', $url . $itemlink) . "</id>\n";
 			}
 			else
 			{

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -160,17 +160,18 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+
 			if ((strpos($itemlink, 'http://') === false) && (strpos($itemlink, 'https://') === false))
 			{
-				$itemlink = str_replace(' ', '%20', $itemlink);
+				$itemlink = str_replace(' ', '%20', $url . $itemlink);
 			}
 			$feed .= "		<item>\n";
 			$feed .= "			<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= "			<link>" . str_replace(' ', '%20', $url . $itemlink ) . "</link>\n";
+			$feed .= "			<link>" . str_replace(' ', '%20', $itemlink ) . "</link>\n";
 
 			if (empty($data->items[$i]->guid) === true)
 			{
-				$feed .= "			<guid isPermaLink=\"true\">" . str_replace(' ', '%20', $url . $itemlink) . "</guid>\n";
+				$feed .= "			<guid isPermaLink=\"true\">" . str_replace(' ', '%20', $itemlink) . "</guid>\n";
 			}
 			else
 			{

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -69,7 +69,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 
-		if (mb_check_encoding($data->link, 'ASCII'))
+		if ($data->link = JFilterOutput::stringURLSafe($data->link))
 		{
 			$datalink = $data->link;
 		}
@@ -182,7 +182,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			if ($data->items[$i]->link = JFilterOutput::stringURLSafe($data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -69,7 +69,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 
-		if (mb_check_encoding($data->link, 'ASCII'))
+		if (!preg_match('/[\x80-\xFF]/', $data->link))
 		{
 			$datalink = $data->link;
 		}
@@ -182,7 +182,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			if (!preg_match('/[\x80-\xFF]/', $data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -68,12 +68,13 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		}
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
+		$datalink = implode("/", array_map("rawurlencode", explode("/", $data->link)));
 
 		$feed = "<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">\n";
 		$feed .= "	<channel>\n";
 		$feed .= "		<title>" . $feed_title . "</title>\n";
 		$feed .= "		<description><![CDATA[" . $data->description . "]]></description>\n";
-		$feed .= "		<link>" . str_replace(' ', '%20', $url . $data->link) . "</link>\n";
+		$feed .= "		<link>" . str_replace(' ', '%20', $url . $datalink) . "</link>\n";
 		$feed .= "		<lastBuildDate>" . htmlspecialchars($now->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
 		$feed .= "		<generator>" . $data->getGenerator() . "</generator>\n";
 		$feed .= '		<atom:link rel="self" type="application/rss+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
@@ -158,17 +159,18 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
-			if ((strpos($data->items[$i]->link, 'http://') === false) && (strpos($data->items[$i]->link, 'https://') === false))
+			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+			if ((strpos($itemlink, 'http://') === false) && (strpos($itemlink, 'https://') === false))
 			{
-				$data->items[$i]->link = str_replace(' ', '%20', $url . $data->items[$i]->link);
+				$itemlink = str_replace(' ', '%20', $itemlink);
 			}
 			$feed .= "		<item>\n";
 			$feed .= "			<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= "			<link>" . str_replace(' ', '%20', $data->items[$i]->link) . "</link>\n";
+			$feed .= "			<link>" . str_replace(' ', '%20', $url . $itemlink ) . "</link>\n";
 
 			if (empty($data->items[$i]->guid) === true)
 			{
-				$feed .= "			<guid isPermaLink=\"true\">" . str_replace(' ', '%20', $data->items[$i]->link) . "</guid>\n";
+				$feed .= "			<guid isPermaLink=\"true\">" . str_replace(' ', '%20', $url . $itemlink) . "</guid>\n";
 			}
 			else
 			{

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -184,11 +184,11 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
 			{
-			$itemlink = $data->items[$i]->link;
+				$itemlink = $data->items[$i]->link;
 			}
 			else
 			{
-			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+				$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
 			}
 
 			if ((strpos($itemlink, 'http://') === false) && (strpos($itemlink, 'https://') === false))

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -69,7 +69,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 
-		if ($data->link = JFilterOutput::stringURLSafe($data->link))
+		if (mb_check_encoding($data->link, 'ASCII'))
 		{
 			$datalink = $data->link;
 		}
@@ -182,7 +182,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
 
-			if ($data->items[$i]->link = JFilterOutput::stringURLSafe($data->items[$i]->link))
+			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
 			{
 				$itemlink = $data->items[$i]->link;
 			}

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -68,7 +68,15 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		}
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
-		$datalink = implode("/", array_map("rawurlencode", explode("/", $data->link)));
+
+		if (mb_check_encoding($data->link, 'ASCII'))
+		{
+			$datalink = $data->link;
+		}
+		else
+		{
+			$datalink = implode("/", array_map("rawurlencode", explode("/", $data->link)));
+		}
 
 		$feed = "<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">\n";
 		$feed .= "	<channel>\n";
@@ -85,43 +93,52 @@ class JDocumentRendererRSS extends JDocumentRenderer
 			$feed .= "			<url>" . $data->image->url . "</url>\n";
 			$feed .= "			<title>" . htmlspecialchars($data->image->title, ENT_COMPAT, 'UTF-8') . "</title>\n";
 			$feed .= "			<link>" . str_replace(' ', '%20', $data->image->link) . "</link>\n";
+
 			if ($data->image->width != "")
 			{
 				$feed .= "			<width>" . $data->image->width . "</width>\n";
 			}
+
 			if ($data->image->height != "")
 			{
 				$feed .= "			<height>" . $data->image->height . "</height>\n";
 			}
+
 			if ($data->image->description != "")
 			{
 				$feed .= "			<description><![CDATA[" . $data->image->description . "]]></description>\n";
 			}
 			$feed .= "		</image>\n";
 		}
+
 		if ($data->language != "")
 		{
 			$feed .= "		<language>" . $data->language . "</language>\n";
 		}
+
 		if ($data->copyright != "")
 		{
 			$feed .= "		<copyright>" . htmlspecialchars($data->copyright, ENT_COMPAT, 'UTF-8') . "</copyright>\n";
 		}
+
 		if ($data->editorEmail != "")
 		{
 			$feed .= "		<managingEditor>" . htmlspecialchars($data->editorEmail, ENT_COMPAT, 'UTF-8') . ' ('
 				. htmlspecialchars($data->editor, ENT_COMPAT, 'UTF-8') . ")</managingEditor>\n";
 		}
+
 		if ($data->webmaster != "")
 		{
 			$feed .= "		<webMaster>" . htmlspecialchars($data->webmaster, ENT_COMPAT, 'UTF-8') . "</webMaster>\n";
 		}
+
 		if ($data->pubDate != "")
 		{
 			$pubDate = JFactory::getDate($data->pubDate);
 			$pubDate->setTimeZone($tz);
 			$feed .= "		<pubDate>" . htmlspecialchars($pubDate->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</pubDate>\n";
 		}
+
 		if (empty($data->category) === false)
 		{
 			if (is_array($data->category))
@@ -136,22 +153,27 @@ class JDocumentRendererRSS extends JDocumentRenderer
 				$feed .= "		<category>" . htmlspecialchars($data->category, ENT_COMPAT, 'UTF-8') . "</category>\n";
 			}
 		}
+
 		if ($data->docs != "")
 		{
 			$feed .= "		<docs>" . htmlspecialchars($data->docs, ENT_COMPAT, 'UTF-8') . "</docs>\n";
 		}
+
 		if ($data->ttl != "")
 		{
 			$feed .= "		<ttl>" . htmlspecialchars($data->ttl, ENT_COMPAT, 'UTF-8') . "</ttl>\n";
 		}
+
 		if ($data->rating != "")
 		{
 			$feed .= "		<rating>" . htmlspecialchars($data->rating, ENT_COMPAT, 'UTF-8') . "</rating>\n";
 		}
+
 		if ($data->skipHours != "")
 		{
 			$feed .= "		<skipHours>" . htmlspecialchars($data->skipHours, ENT_COMPAT, 'UTF-8') . "</skipHours>\n";
 		}
+
 		if ($data->skipDays != "")
 		{
 			$feed .= "		<skipDays>" . htmlspecialchars($data->skipDays, ENT_COMPAT, 'UTF-8') . "</skipDays>\n";
@@ -159,7 +181,15 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
+
+			if (mb_check_encoding($data->items[$i]->link, 'ASCII'))
+			{
+			$itemlink = $data->items[$i]->link;
+			}
+			else
+			{
 			$itemlink = implode("/", array_map("rawurlencode", explode("/", $data->items[$i]->link)));
+			}
 
 			if ((strpos($itemlink, 'http://') === false) && (strpos($itemlink, 'https://') === false))
 			{
@@ -207,16 +237,19 @@ class JDocumentRendererRSS extends JDocumentRenderer
 					$feed .= "			<category>" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "</category>\n";
 				}
 			}
+
 			if ($data->items[$i]->comments != "")
 			{
 				$feed .= "			<comments>" . htmlspecialchars($data->items[$i]->comments, ENT_COMPAT, 'UTF-8') . "</comments>\n";
 			}
+
 			if ($data->items[$i]->date != "")
 			{
 				$itemDate = JFactory::getDate($data->items[$i]->date);
 				$itemDate->setTimeZone($tz);
 				$feed .= "			<pubDate>" . htmlspecialchars($itemDate->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</pubDate>\n";
 			}
+
 			if ($data->items[$i]->enclosure != null)
 			{
 				$feed .= "			<enclosure url=\"";


### PR DESCRIPTION
Tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33478&start=0

To test feed validation, enable Unicode Aliases in Global Configuration, create a menu item linking to a content category. Aliases should contain non-ASCII characters for both the menu and articles. Using simple accented letters will be enough.

Display the feed obtained and check the source (unicode characters should display percentencoded), try Validating.

This PR is a first shot at it.
