### PR TITLE
RSS Feed with Unicode Alias fails to validate [#33478]

### DIFF
--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -37,7 +37,6 @@ class JDocumentRendererRSS extends JDocumentRenderer
      *
      * @since   11.1
      */
-	 
 
     public function encode($url)
     {

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -37,6 +37,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
      *
      * @since   11.1
      */
+	 
 
     public function encode($url)
     {

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -27,6 +27,31 @@ class JDocumentRendererRSS extends JDocumentRenderer
 	 */
 	protected $_mime = "application/rss+xml";
 
+
+    /**
+     * Convert links in a url from non-ascii to ascii and also handles spaces
+     *
+     * @param   string  $url  The url to be encoded
+     *
+     * @return  string  $url  The encoded url
+     *
+     * @since   11.1
+     */
+
+    public function encode($url)
+    {
+        $https = strpos($url, 'https://')===0;
+        $url = str_replace(['http://','https://'],'',$url);
+        $urlArr = split("/", $url);
+        foreach($urlArr as $key=>$urlPiece)
+        {
+            $urlArr[$key] = rawurlencode($urlPiece);
+        }
+        $url = $https?'https://':'http://';
+        $url .= join('/',$urlArr);
+        return $url ;
+    }
+
 	/**
 	 * Render the feed.
 	 *
@@ -73,17 +98,17 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		$feed .= "	<channel>\n";
 		$feed .= "		<title>" . $feed_title . "</title>\n";
 		$feed .= "		<description><![CDATA[" . $data->description . "]]></description>\n";
-		$feed .= "		<link>" . str_replace(' ', '%20', $url . $data->link) . "</link>\n";
-		$feed .= "		<lastBuildDate>" . htmlspecialchars($now->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
+		$feed .= "		<link>" . $this->encode($url . $data->link) . "</link>\n";
+        $feed .= "		<lastBuildDate>" . htmlspecialchars($now->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
 		$feed .= "		<generator>" . $data->getGenerator() . "</generator>\n";
-		$feed .= '		<atom:link rel="self" type="application/rss+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
+        $feed .= '		<atom:link rel="self" type="application/rss+xml" href="' . $this->encode($url . $syndicationURL) . "\"/>\n";
 
 		if ($data->image != null)
 		{
 			$feed .= "		<image>\n";
 			$feed .= "			<url>" . $data->image->url . "</url>\n";
 			$feed .= "			<title>" . htmlspecialchars($data->image->title, ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= "			<link>" . str_replace(' ', '%20', $data->image->link) . "</link>\n";
+            $feed .= "			<link>" . $this->encode( $data->image->link) . "</link>\n";
 			if ($data->image->width != "")
 			{
 				$feed .= "			<width>" . $data->image->width . "</width>\n";
@@ -160,15 +185,15 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		{
 			if ((strpos($data->items[$i]->link, 'http://') === false) && (strpos($data->items[$i]->link, 'https://') === false))
 			{
-				$data->items[$i]->link = str_replace(' ', '%20', $url . $data->items[$i]->link);
+                $data->items[$i]->link = $this->encode($url . $data->items[$i]->link);
 			}
 			$feed .= "		<item>\n";
 			$feed .= "			<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= "			<link>" . str_replace(' ', '%20', $data->items[$i]->link) . "</link>\n";
+            $feed .= "			<link>" . $this->encode($data->items[$i]->link) . "</link>\n";
 
 			if (empty($data->items[$i]->guid) === true)
 			{
-				$feed .= "			<guid isPermaLink=\"true\">" . str_replace(' ', '%20', $data->items[$i]->link) . "</guid>\n";
+                $feed .= "			<guid isPermaLink=\"true\">" . $this->encode($data->items[$i]->link) . "</guid>\n";
 			}
 			else
 			{
@@ -248,4 +273,5 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		return $text;
 	}
+
 }


### PR DESCRIPTION
Tracker code : # 33478

Joomla RSS feed contains invalid UTF-8 characters in URL, these fail validation and prevent certain libraries from using the feeds.
Assuming you have a category ID 173 which contains an article with an unicode alias, with an url like:
http://example.com/index.php?option=com_content&view=category&id=173&format=feed&type=rss&lang=en
http://validator.w3.org/feed will return the following errors:
This feed does not validate.
line 25, column 101: link must be a full and valid URL: http://example.com/company/news/1185-soso-ibérica-opens-new-fishing-garden
line 26, column 120: guid must be a full URL, unless isPermaLink attribute is false: http://example.com/company/news/1185-soso-ibérica-opens-new-fishing-garden

How to reproduce the problem and/or test the patch::
Setup a Joomla 3.2.3 with unicode aliases enabled in the global configuration; Create an article with a unicode character in the alias e.g. 'à' Run the rss feed through http://validator.w3.org/feed It will fail to validate both <link> (link) and <guid> (guid)
