### PR TITLE
Wrong parameter passed to "move" method.

### DIFF
--- a/administrator/components/com_users/models/levels.php
+++ b/administrator/components/com_users/models/levels.php
@@ -160,7 +160,7 @@ class UsersModelLevels extends JModelList
 
 		// Move the row.
 		// TODO: Where clause to restrict category.
-		$table->move($pk);
+		$table->move($direction);
 
 		return true;
 	}


### PR DESCRIPTION
`move` takes the direction as a parameter, not the primary key (`$pk`) value.
