### PR TITLE
Hardcoded Microdata for com_content

### DIFF
--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -112,7 +112,7 @@ $params = $this->params;
 						<dd>
 							<div class="hits">
 								<span class="icon-eye-open"></span> 
-								<meta content="UserPageVisits:<?php echo $item->hits; ?>" itemprop="interactionCount" />
+								<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $item->hits; ?>" />
 								<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 							</div>
 						</dd>

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -16,21 +16,23 @@ $params = $this->params;
 <div id="archive-items">
 	<?php foreach ($this->items as $i => $item) : ?>
 		<?php $info = $item->params->get('info_block_position', 0); ?>
-		<div class="row<?php echo $i % 2; ?>">
+		<div class="row<?php echo $i % 2; ?>" itemscope itemtype="http://schema.org/Article">
 			<div class="page-header">
-				<h2>
+				<h2 itemprop="name">
 					<?php if ($params->get('link_titles')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>"> <?php echo $this->escape($item->title); ?></a>
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>" itemprop="url">
+							<?php echo $this->escape($item->title); ?>
+						</a>
 					<?php else: ?>
 						<?php echo $this->escape($item->title); ?>
 					<?php endif; ?>
 				</h2>
 				<?php if ($params->get('show_author') && !empty($item->author )) : ?>
-					<div class="createdby">
-					<?php $author = $item->author; ?>
-					<?php $author = ($item->created_by_alias ? $item->created_by_alias : $author); ?>
+					<div class="createdby" itemscope itemtype="http://schema.org/Person">
+					<?php $author = ($item->created_by_alias) ? $item->created_by_alias : $item->author; ?>
+					<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 						<?php if (!empty($item->contact_link) && $params->get('link_author') == true) : ?>
-							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 						<?php else: ?>
 							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 						<?php endif; ?>
@@ -49,12 +51,12 @@ $params = $this->params;
 				<?php if ($params->get('show_parent_category') && !empty($item->parent_slug)) : ?>
 					<dd>
 						<div class="parent-category-name">
-							<?php	$title = $this->escape($item->parent_title);
-							$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)).'">' . $title . '</a>'; ?>
+							<?php $title = $this->escape($item->parent_title); ?>
 							<?php if ($params->get('link_parent_category') && !empty($item->parent_slug)) : ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 							<?php else : ?>
-								<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+								<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 							<?php endif; ?>
 						</div>
 					</dd>
@@ -62,12 +64,12 @@ $params = $this->params;
 				<?php if ($params->get('show_category')) : ?>
 					<dd>
 						<div class="category-name">
-							<?php $title = $this->escape($item->category_title);
-							$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)).'">' . $title . '</a>'; ?>
+							<?php $title = $this->escape($item->category_title); ?>
 							<?php if ($params->get('link_category') && $item->catslug) : ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 							<?php else : ?>
-								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 							<?php endif; ?>
 						</div>
 					</dd>
@@ -76,7 +78,10 @@ $params = $this->params;
 				<?php if ($params->get('show_publish_date')) : ?>
 					<dd>
 						<div class="published">
-							<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+							<span class="icon-calendar"></span>
+							<time datetime="<?php echo JHtmlDate($item->publish_up, 'c'); ?>" itemprop="datePublished">
+								<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+							</time>
 						</div>
 					</dd>
 				<?php endif; ?>
@@ -85,14 +90,20 @@ $params = $this->params;
 					<?php if ($params->get('show_modify_date')) : ?>
 						<dd>
 							<div class="modified">
-								<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+								<span class="icon-calendar"></span>
+								<time datetime="<?php echo JHtmlDate($item->modified, 'c'); ?>" itemprop="dateModified">
+									<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+								</time>
 							</div>
 						</dd>
 					<?php endif; ?>
 					<?php if ($params->get('show_create_date')) : ?>
 						<dd>
 							<div class="create">
-								<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+								<span class="icon-calendar"></span>
+								<time datetime="<?php echo JHtmlDate($item->created, 'c'); ?>" itemprop="dateCreated">
+									<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+								</time>
 							</div>
 						</dd>
 					<?php endif; ?>
@@ -100,7 +111,9 @@ $params = $this->params;
 					<?php if ($params->get('show_hits')) : ?>
 						<dd>
 							<div class="hits">
-								<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
+								<span class="icon-eye-open"></span> 
+								<meta content="UserPageVisits:<?php echo $item->hits; ?>" itemprop="interactionCount" />
+								<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 							</div>
 						</dd>
 					<?php endif; ?>
@@ -110,7 +123,7 @@ $params = $this->params;
 		<?php endif; ?>
 
 		<?php if ($params->get('show_intro')) :?>
-			<div class="intro"> <?php echo JHtml::_('string.truncateComplex', $item->introtext, $params->get('introtext_limit')); ?> </div>
+			<div class="intro" itemprop="articleBody"> <?php echo JHtml::_('string.truncateComplex', $item->introtext, $params->get('introtext_limit')); ?> </div>
 		<?php endif; ?>
 
 		<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
@@ -122,25 +135,25 @@ $params = $this->params;
 					<?php if ($params->get('show_parent_category') && !empty($item->parent_slug)) : ?>
 						<dd>
 							<div class="parent-category-name">
-								<?php	$title = $this->escape($item->parent_title);
-								$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '">' . $title . '</a>';?>
-							<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
-								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
-							<?php else : ?>
-								<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
-							<?php endif; ?>
+								<?php $title = $this->escape($item->parent_title); ?>
+								<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
+								<?php else : ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
+								<?php endif; ?>
 							</div>
 						</dd>
 					<?php endif; ?>
 					<?php if ($params->get('show_category')) : ?>
 						<dd>
 							<div class="category-name">
-								<?php 	$title = $this->escape($item->category_title);
-								$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '">' . $title . '</a>'; ?>
+								<?php $title = $this->escape($item->category_title); ?>
 								<?php if ($params->get('link_category') && $item->catslug) : ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 								<?php endif; ?>
 							</div>
 						</dd>
@@ -148,7 +161,10 @@ $params = $this->params;
 					<?php if ($params->get('show_publish_date')) : ?>
 						<dd>
 							<div class="published">
-								<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+								<span class="icon-calendar"></span>
+								<time datetime="<?php echo JHtmlDate($item->publish_up, 'c'); ?>" itemprop="datePublished">
+									<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+								</time>
 							</div>
 						</dd>
 					<?php endif; ?>
@@ -156,22 +172,30 @@ $params = $this->params;
 
 				<?php if ($params->get('show_create_date')) : ?>
 					<dd>
-						<div class="create"><span class="icon-calendar">
-							</span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						<div class="create">
+							<span class="icon-calendar"></span>
+							<time datetime="<?php echo JHtmlDate($item->created, 'c'); ?>" itemprop="dateCreated">
+								<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+							</time>
 						</div>
 					</dd>
 				<?php endif; ?>
 				<?php if ($params->get('show_modify_date')) : ?>
 					<dd>
-						<div class="modified"><span class="icon-calendar">
-							</span> <?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						<div class="modified">
+							<span class="icon-calendar"></span>
+							<time datetime="<?php echo JHtmlDate($item->modified, 'c'); ?>" itemprop="dateModified">
+								<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+							</time>
 						</div>
 					</dd>
 				<?php endif; ?>
 				<?php if ($params->get('show_hits')) : ?>
 					<dd>
 						<div class="hits">
-							<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
+							<span class="icon-eye-open"></span> 
+							<meta content="UserPageVisits:<?php echo $item->hits; ?>" itemprop="interactionCount" />
+							<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 						</div>
 					</dd>
 				<?php endif; ?>

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -28,7 +28,7 @@ $params = $this->params;
 					<?php endif; ?>
 				</h2>
 				<?php if ($params->get('show_author') && !empty($item->author )) : ?>
-					<div class="createdby" itemscope itemtype="http://schema.org/Person">
+					<div class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
 					<?php $author = ($item->created_by_alias) ? $item->created_by_alias : $item->author; ?>
 					<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 						<?php if (!empty($item->contact_link) && $params->get('link_author') == true) : ?>
@@ -79,7 +79,7 @@ $params = $this->params;
 					<dd>
 						<div class="published">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtmlDate($item->publish_up, 'c'); ?>" itemprop="datePublished">
+							<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
 								<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>
@@ -91,7 +91,7 @@ $params = $this->params;
 						<dd>
 							<div class="modified">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtmlDate($item->modified, 'c'); ?>" itemprop="dateModified">
+								<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
 									<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -101,7 +101,7 @@ $params = $this->params;
 						<dd>
 							<div class="create">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtmlDate($item->created, 'c'); ?>" itemprop="dateCreated">
+								<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
 									<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -162,7 +162,7 @@ $params = $this->params;
 						<dd>
 							<div class="published">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtmlDate($item->publish_up, 'c'); ?>" itemprop="datePublished">
+								<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
 									<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -174,7 +174,7 @@ $params = $this->params;
 					<dd>
 						<div class="create">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtmlDate($item->created, 'c'); ?>" itemprop="dateCreated">
+							<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
 								<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>
@@ -184,7 +184,7 @@ $params = $this->params;
 					<dd>
 						<div class="modified">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtmlDate($item->modified, 'c'); ?>" itemprop="dateModified">
+							<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
 								<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -23,7 +23,8 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author'));
 
 ?>
-<div class="item-page<?php echo $this->pageclass_sfx?>">
+<div class="item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="http://schema.org/Article">
+	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? JFactory::getConfig()->get('language') : $this->item->language; ?>" />
 	<?php if ($this->params->get('show_page_heading', 1)) : ?>
 	<div class="page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
@@ -42,10 +43,10 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<?php endif; ?>
 	<?php if ($params->get('show_title') || $params->get('show_author')) : ?>
 	<div class="page-header">
-		<h2>
+		<h2 itemprop="name">
 			<?php if ($params->get('show_title')) : ?>
 				<?php if ($params->get('link_titles') && !empty($this->item->readmore_link)) : ?>
-					<a href="<?php echo $this->item->readmore_link; ?>"> <?php echo $this->escape($this->item->title); ?></a>
+					<a href="<?php echo $this->item->readmore_link; ?>" itemprop="url"> <?php echo $this->escape($this->item->title); ?></a>
 				<?php else : ?>
 					<?php echo $this->escape($this->item->title); ?>
 				<?php endif; ?>
@@ -94,10 +95,11 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
 
 			<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
-				<dd class="createdby">
+				<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
 					<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
+					<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 					<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
-						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 					<?php else: ?>
 						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 					<?php endif; ?>
@@ -105,48 +107,59 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<?php endif; ?>
 			<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 				<dd class="parent-category-name">
-					<?php $title = $this->escape($this->item->parent_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+					<?php $title = $this->escape($this->item->parent_title); ?>
 					<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
+						<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 						<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+						<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
 			<?php if ($params->get('show_category')) : ?>
 				<dd class="category-name">
-					<?php $title = $this->escape($this->item->category_title);
-					$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>';?>
+					<?php $title = $this->escape($this->item->category_title); ?>
 					<?php if ($params->get('link_category') && $this->item->catslug) : ?>
+						<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($params->get('show_publish_date')) : ?>
 				<dd class="published">
-					<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+					<span class="icon-calendar"></span>
+					<time datetime="<?php echo JHtml::_('date', $this->item->publish_up, 'c'); ?>" itemprop="datePublished">
+						<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($info == 0) : ?>
 				<?php if ($params->get('show_modify_date')) : ?>
 					<dd class="modified">
-						<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						<span class="icon-calendar"></span>
+						<time datetime="<?php echo JHtml::_('date', $this->item->modified, 'c'); ?>" itemprop="dateModified">
+							<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						</time>
 					</dd>
 				<?php endif; ?>
 				<?php if ($params->get('show_create_date')) : ?>
 					<dd class="create">
-						<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+						<span class="icon-calendar"></span>
+						<time datetime="<?php echo JHtml::_('date', $this->item->created, 'c'); ?>" itemprop="dateCreated">
+							<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+						</time>
 					</dd>
 				<?php endif; ?>
 
 				<?php if ($params->get('show_hits')) : ?>
 					<dd class="hits">
-						<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
+						<span class="icon-eye-open"></span>
+						<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $this->item->hits; ?>" />
+						<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 					</dd>
 				<?php endif; ?>
 			<?php endif; ?>
@@ -174,7 +187,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<?php if ($images->image_fulltext_caption):
 		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_fulltext_caption) . '"';
 	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/> </div>
+	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
 	<?php endif; ?>
 	<?php
 	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
@@ -184,7 +197,9 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<?php echo $this->item->text; ?>
+	<span itemprop="articleBody">
+		<?php echo $this->item->text; ?>
+	</span>
 
 	<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 		<div class="article-info muted">
@@ -193,10 +208,11 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 
 			<?php if ($info == 1) : ?>
 				<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
-					<dd class="createdby">
+					<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
 						<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
+						<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 						<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
-							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 						<?php else: ?>
 							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 						<?php endif; ?>
@@ -204,30 +220,32 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 				<?php endif; ?>
 				<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 					<dd class="parent-category-name">
-						<?php	$title = $this->escape($this->item->parent_title);
-						$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>';?>
+						<?php $title = $this->escape($this->item->parent_title); ?>
 						<?php if ($params->get('link_parent_category') && $this->item->parent_slug) : ?>
+							<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 							<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 						<?php else : ?>
-							<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+							<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 						<?php endif; ?>
 					</dd>
 				<?php endif; ?>
 				<?php if ($params->get('show_category')) : ?>
 					<dd class="category-name">
-						<?php 	$title = $this->escape($this->item->category_title);
-						$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>';?>
+						<?php $title = $this->escape($this->item->category_title); ?>
 						<?php if ($params->get('link_category') && $this->item->catslug) : ?>
+							<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 							<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 						<?php else : ?>
-							<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+							<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 						<?php endif; ?>
 					</dd>
 				<?php endif; ?>
 				<?php if ($params->get('show_publish_date')) : ?>
 					<dd class="published">
 						<span class="icon-calendar"></span>
-						<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+						<time datetime="<?php echo JHtml::_('date', $this->item->publish_up, 'c'); ?>" itemprop="datePublished">
+							<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+						</time>
 					</dd>
 				<?php endif; ?>
 			<?php endif; ?>
@@ -235,18 +253,24 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			<?php if ($params->get('show_create_date')) : ?>
 				<dd class="create">
 					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					<time datetime="<?php echo JHtml::_('date', $this->item->created, 'c'); ?>" itemprop="dateCreated">
+						<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 			<?php if ($params->get('show_modify_date')) : ?>
 				<dd class="modified">
 					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+					<time datetime="<?php echo JHtml::_('date', $this->item->modified, 'c'); ?>" itemprop="dateModified">
+						<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 			<?php if ($params->get('show_hits')) : ?>
 				<dd class="hits">
-					<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
+					<span class="icon-eye-open"></span>
+					<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $this->item->hits; ?>" />
+					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 				</dd>
 			<?php endif; ?>
 			</dl>

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -13,7 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 JHtml::_('behavior.caption');
 ?>
-<div class="blog<?php echo $this->pageclass_sfx; ?>">
+<div class="blog<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="http://schema.org/Blog>
 	<?php if ($this->params->get('show_page_heading', 1)) : ?>
 		<div class="page-header">
 			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
@@ -54,8 +54,8 @@ JHtml::_('behavior.caption');
 	<?php if (!empty($this->lead_items)) : ?>
 		<div class="items-leading clearfix">
 			<?php foreach ($this->lead_items as &$item) : ?>
-				<div
-					class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>">
+				<div class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>"
+					itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
 					<?php
 					$this->item = & $item;
 					echo $this->loadTemplate('item');
@@ -79,8 +79,8 @@ JHtml::_('behavior.caption');
 				<div class="items-row cols-<?php echo (int) $this->columns; ?> <?php echo 'row-' . $row; ?> row-fluid clearfix">
 			<?php endif; ?>
 			<div class="span<?php echo round((12 / $this->columns)); ?>">
-				<div
-					class="item column-<?php echo $rowcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>">
+				<div class="item column-<?php echo $rowcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>"
+					itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
 					<?php
 					$this->item = & $item;
 					echo $this->loadTemplate('item');

--- a/components/com_content/views/featured/tmpl/default.php
+++ b/components/com_content/views/featured/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('behavior.caption');
 // If the page class is defined, add to class as suffix.
 // It will be a separate class if the user starts it with a space
 ?>
-<div class="blog-featured<?php echo $this->pageclass_sfx;?>">
+<div class="blog-featured<?php echo $this->pageclass_sfx;?>" itemscope itemtype="http://schema.org/Blog>
 <?php if ($this->params->get('show_page_heading') != 0) : ?>
 <div class="page-header">
 	<h1>
@@ -29,7 +29,8 @@ JHtml::_('behavior.caption');
 <?php if (!empty($this->lead_items)) : ?>
 <div class="items-leading clearfix">
 	<?php foreach ($this->lead_items as &$item) : ?>
-		<div class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> clearfix">
+		<div class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> clearfix" 
+			itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
 			<?php
 				$this->item = &$item;
 				echo $this->loadTemplate('item');
@@ -57,7 +58,8 @@ JHtml::_('behavior.caption');
 
 		<div class="items-row cols-<?php echo (int) $this->columns;?> <?php echo 'row-'.$row; ?> row-fluid">
 		<?php endif; ?>
-			<div class="item column-<?php echo $rowcount;?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> span<?php echo round((12 / $this->columns));?>">
+			<div class="item column-<?php echo $rowcount;?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> span<?php echo round((12 / $this->columns));?>"
+				itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
 			<?php
 					$this->item = &$item;
 					echo $this->loadTemplate('item');

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -23,9 +23,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php endif; ?>
 
 <?php if ($params->get('show_title')) : ?>
-	<h2 class="item-title">
+	<h2 class="item-title" itemprop="name">
 	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>"> <?php echo $this->escape($this->item->title); ?></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>" itemprop="url">
+			<?php echo $this->escape($this->item->title); ?>
+		</a>
 	<?php else : ?>
 		<?php echo $this->escape($this->item->title); ?>
 	<?php endif; ?>
@@ -69,11 +71,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 		</dt>
 
 		<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
-			<dd class="createdby">
-				<?php $author = $this->item->author; ?>
-				<?php $author = ($this->item->created_by_alias ? $this->item->created_by_alias : $author); ?>
+			<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
+				<?php $author = ($this->item->created_by_alias) ? $this->item->created_by_alias : $this->item->author; ?>
+				<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 				<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
-					<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+					<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 				<?php else: ?>
 					<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 				<?php endif; ?>
@@ -82,52 +84,60 @@ $info    = $this->item->params->get('info_block_position', 0);
 
 		<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 			<dd class="parent-category-name">
-				<?php $title = $this->escape($this->item->parent_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($this->item->parent_title); ?>
 				<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
+					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+					<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 				<?php endif; ?>
 			</dd>
 		<?php endif; ?>
 
 		<?php if ($params->get('show_category')) : ?>
 			<dd class="category-name">
-				<?php $title = $this->escape($this->item->category_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($this->item->category_title); ?>
 				<?php if ($params->get('link_category') && $this->item->catslug) : ?>
+					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 				<?php endif; ?>
 			</dd>
 		<?php endif; ?>
 
 		<?php if ($params->get('show_publish_date')) : ?>
 			<dd class="published">
-				<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+				<span class="icon-calendar"></span>
+				<time datetime="<?php echo JHtml::_('date', $this->item->publish_up, 'c'); ?>" itemprop="datePublished">
+					<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+				</time>
 			</dd>
 		<?php endif; ?>
 
 		<?php if ($info == 0) : ?>
 			<?php if ($params->get('show_modify_date')) : ?>
 				<dd class="modified">
-				<span class="icon-calendar"></span>
-				<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+					<span class="icon-calendar"></span>
+					<time datetime="<?php echo JHtml::_('date', $this->item->modified, 'c'); ?>" itemprop="dateModified">
+						<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($params->get('show_create_date')) : ?>
 				<dd class="create">
 					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					<time datetime="<?php echo JHtml::_('date', $this->item->created, 'c'); ?>" itemprop="dateCreated">
+						<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($params->get('show_hits')) : ?>
 				<dd class="hits">
 					<span class="icon-eye-open"></span>
+					<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $this->item->hits; ?>" />
 					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 				</dd>
 			<?php endif; ?>
@@ -157,11 +167,11 @@ $info    = $this->item->params->get('info_block_position', 0);
 		</dt>
 		<?php if ($info == 1) : ?>
 			<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
-				<dd class="createdby">
-					<?php $author = $this->item->author; ?>
-					<?php $author = ($this->item->created_by_alias ? $this->item->created_by_alias : $author); ?>
+				<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
+					<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
+					<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 					<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
-						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 					<?php else : ?>
 						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 					<?php endif; ?>
@@ -170,51 +180,61 @@ $info    = $this->item->params->get('info_block_position', 0);
 
 			<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 				<dd class="parent-category-name">
-					<?php	$title = $this->escape($this->item->parent_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+					<?php $title = $this->escape($this->item->parent_title); ?>
 					<?php if ($params->get('link_parent_category') && $this->item->parent_slug) : ?>
+						<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 						<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+						<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($params->get('show_category')) : ?>
 				<dd class="category-name">
-					<?php $title = $this->escape($this->item->category_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
+					<?php $title = $this->escape($this->item->category_title); ?>
 					<?php if ($params->get('link_category') && $this->item->catslug) : ?>
+						<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
 
 			<?php if ($params->get('show_publish_date')) : ?>
 				<dd class="published">
-					<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+					<span class="icon-calendar"></span>
+					<time datetime="<?php echo JHtml::_('date', $this->item->publish_up, 'c'); ?>" itemprop="datePublished">
+						<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 				</dd>
 			<?php endif; ?>
 		<?php endif; ?>
 
 		<?php if ($params->get('show_create_date')) : ?>
 			<dd class="create">
-				<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+				<span class="icon-calendar"></span>
+				<time datetime="<?php echo JHtml::_('date', $this->item->created, 'c'); ?>" itemprop="dateCreated">
+					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+				</time>
 			</dd>
 		<?php endif; ?>
 
 		<?php if ($params->get('show_modify_date')) : ?>
 			<dd class="modified">
 				<span class="icon-calendar"></span>
-				<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+				<time datetime="<?php echo JHtml::_('date', $this->item->modified, 'c'); ?>" itemprop="dateModified">
+					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+				</time>
 			</dd>
 		<?php endif; ?>
 
 		<?php if ($params->get('show_hits')) : ?>
 			<dd class="hits">
-				<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
+				<span class="icon-eye-open"></span>
+				<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $this->item->hits; ?>" />
+				<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 			</dd>
 		<?php endif; ?>
 	</dl>
@@ -239,7 +259,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>
 
-	<p class="readmore"><a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
+	<p class="readmore"><a class="btn" href="<?php echo $link; ?>" itemprop="url"> <span class="icon-chevron-right"></span>
 
 	<?php if (!$params->get('access-view')) :
 		echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');

--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -20,9 +20,9 @@ JHtml::_('behavior.framework');
 		<div class="page-header">
 
 			<?php if ($params->get('show_title')) : ?>
-				<h2>
+				<h2 itemprop="name">
 					<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>" itemprop="url">
 						<?php echo $this->escape($displayData->title); ?></a>
 					<?php else : ?>
 						<?php echo $this->escape($displayData->title); ?>

--- a/layouts/joomla/content/info_block/author.php
+++ b/layouts/joomla/content/info_block/author.php
@@ -10,11 +10,11 @@
 defined('JPATH_BASE') or die;
 
 ?>
-<dd class="createdby">
-	<?php $author = $displayData['item']->author; ?>
-	<?php $author = ($displayData['item']->created_by_alias ? $displayData['item']->created_by_alias : $author); ?>
+<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
+	<?php $author = ($displayData['item']->created_by_alias ? $displayData['item']->created_by_alias : $displayData['item']->author); ?>
+	<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 	<?php if (!empty($displayData['item']->contact_link ) && $displayData['params']->get('link_author') == true) : ?>
-		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author)); ?>
+		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author, array('itemprop' => 'url'))); ?>
 	<?php else :?>
 		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 	<?php endif; ?>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -11,11 +11,11 @@ defined('JPATH_BASE') or die;
 
 ?>
 			<dd class="category-name">
-				<?php $title = $this->escape($displayData['item']->category_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($displayData['item']->category_title); ?>
 				<?php if ($displayData['params']->get('link_category') && $displayData['item']->catslug) : ?>
+					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
 				<?php endif; ?>
 			</dd>

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -12,5 +12,7 @@ defined('JPATH_BASE') or die;
 ?>
 			<dd class="create">
 					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $displayData['item']->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					<time datetime="<?php echo JHtml::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
+						<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $displayData['item']->created, JText::_('DATE_FORMAT_LC3'))); ?>
+					</time>
 			</dd>

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -12,5 +12,6 @@ defined('JPATH_BASE') or die;
 ?>
 			<dd class="hits">
 					<span class="icon-eye-open"></span>
+					<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>" />
 					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
 			</dd>

--- a/layouts/joomla/content/info_block/modify_date.php
+++ b/layouts/joomla/content/info_block/modify_date.php
@@ -12,5 +12,7 @@ defined('JPATH_BASE') or die;
 ?>
 			<dd class="modified">
 				<span class="icon-calendar"></span>
-				<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $displayData['item']->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+				<time datetime="<?php echo JHtml::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
+					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $displayData['item']->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+				</time>
 			</dd>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -11,11 +11,11 @@ defined('JPATH_BASE') or die;
 
 ?>
 			<dd class="parent-category-name">
-				<?php $title = $this->escape($displayData['item']->parent_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($displayData['item']->parent_title); ?>
 				<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
+					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
 					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+					<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
 				<?php endif; ?>
 			</dd>

--- a/layouts/joomla/content/info_block/publish_date.php
+++ b/layouts/joomla/content/info_block/publish_date.php
@@ -10,5 +10,8 @@
 defined('JPATH_BASE') or die;
 ?>
 			<dd class="published">
-				<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $displayData['item']->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+				<span class="icon-calendar"></span>
+				<time datetime="<?php echo JHtml::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
+					<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $displayData['item']->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+				</time>
 			</dd>

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -15,7 +15,7 @@ $params  = $displayData->params;
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
 	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
 	<?php if ($images->image_intro_caption):
-		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
+		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
 	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/> </div>
+	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="thumbnailUrl"/> </div>
 <?php endif; ?>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -18,7 +18,7 @@ JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/
 			<?php if (in_array($tag->access, JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id')))) : ?>
 				<?php $tagParams = new JRegistry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
-				<span class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>">
+				<span class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">
 					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . '-' . $tag->alias)) ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -11,9 +11,9 @@ defined('_JEXEC') or die;
 ?>
 <ul class="latestnews<?php echo $moduleclass_sfx; ?>">
 <?php foreach ($list as $item) :  ?>
-	<li>
-		<a href="<?php echo $item->link; ?>">
-			<?php echo $item->title; ?></a>
+	<li itemscope itemtype="http://schema.org/Article">
+		<a href="<?php echo $item->link; ?>" itemprop="url">
+			<span itemprop="name"><?php echo $item->title; ?></span></a>
 	</li>
 <?php endforeach; ?>
 </ul>

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -69,8 +69,12 @@ class PlgContentVote extends JPlugin
 				$img .= $starImageOff;
 			}
 
-			$html .= '<div class="content_rating">';
-			$html .= '<p class="unseen element-invisible">' . JText::sprintf('PLG_VOTE_USER_RATING', $rating, '5') . '</p>';
+			$html .= '<div class="content_rating" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">';
+			$html .= '<p class="unseen element-invisible">'
+					. JText::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>')
+					. '<meta itemprop="ratingCount" content="' . (int) $row->rating_count . '" />'
+					. '<meta itemprop="worstRating" content="0" />'
+					. '</p>';
 			$html .= $img;
 			$html .= '</div>';
 


### PR DESCRIPTION
This PR introduces Microdata tags to com_content in a hardcoded way.
This is based on some feedback that we don't need more parameters.

The PR is based on PR #3252 and the newer PR #3330. But unlike those two it doesn't use the Microdata library and instead just hardcodes the tags into the layouts.
#### Advantage
- Easy to understand
- Easy to change for endusers and designers who like to override a layout
#### Disadvantages
- You can't enable/disable Microdata tags globally or per article. You can of course use layout overrides and alternate layouts to achieve the same. It's also to note that there isn't really a reason to turn the Microdata off.
- You can't select a different Microdata type for an article using a parameter. It's hardcoded to be "Article" for single articles and "Blog" & "BlogPosting" for the blog layout in the category and featured view. You can of course use layout overrides and alternate layouts here as well to achieve the same, but you need to make sure yourself that the properties are valid for the selected type.
#### Testing

Test the different views of com_content and check the microdata output using the Google richsnippet test tool: http://www.google.com/webmasters/tools/richsnippets
If the vote plugin is enabled, the search result should show the voting as well.
The latest articles module contains also some Microdata tags with this change.
