### PR TITLE
Hardcoded Microdata for com_contact

### DIFF
--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -13,7 +13,7 @@ $cparams = JComponentHelper::getParams('com_media');
 
 jimport('joomla.html.html.bootstrap');
 ?>
-<div class="contact<?php echo $this->pageclass_sfx?>">
+<div class="contact<?php echo $this->pageclass_sfx?>" itemscope itemtype="http://schema.org/Person">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>
@@ -25,7 +25,7 @@ jimport('joomla.html.html.bootstrap');
 				<?php if ($this->item->published == 0) : ?>
 					<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 				<?php endif; ?>
-				<span class="contact-name"><?php echo $this->contact->name; ?></span>
+				<span class="contact-name" itemprop="name"><?php echo $this->contact->name; ?></span>
 			</h2>
 		</div>
 	<?php endif;  ?>
@@ -73,13 +73,13 @@ jimport('joomla.html.html.bootstrap');
 
 	<?php if ($this->contact->image && $this->params->get('show_image')) : ?>
 		<div class="thumbnail pull-right">
-			<?php echo JHtml::_('image', $this->contact->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('align' => 'middle')); ?>
+			<?php echo JHtml::_('image', $this->contact->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('align' => 'middle', 'itemprop' => 'image')); ?>
 		</div>
 	<?php endif; ?>
 
 	<?php if ($this->contact->con_position && $this->params->get('show_position')) : ?>
 		<dl class="contact-position dl-horizontal">
-			<dd>
+			<dd itemprop="jobTitle">
 				<?php echo $this->contact->con_position; ?>
 			</dd>
 		</dl>

--- a/components/com_contact/views/contact/tmpl/default_address.php
+++ b/components/com_contact/views/contact/tmpl/default_address.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  * jicon-text, jicon-none, jicon-icon
  */
 ?>
-<dl class="contact-address dl-horizontal">
+<dl class="contact-address dl-horizontal" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
 	<?php if (($this->params->get('address_check') > 0) &&
 		($this->contact->address || $this->contact->suburb  || $this->contact->state || $this->contact->country || $this->contact->postcode)) : ?>
 		<?php if ($this->params->get('address_check') > 0) : ?>
@@ -27,7 +27,7 @@ defined('_JEXEC') or die;
 
 		<?php if ($this->contact->address && $this->params->get('show_street_address')) : ?>
 			<dd>
-				<span class="contact-street">
+				<span class="contact-street" itemprop="streetAddress">
 					<?php echo $this->contact->address .'<br/>'; ?>
 				</span>
 			</dd>
@@ -35,28 +35,28 @@ defined('_JEXEC') or die;
 
 		<?php if ($this->contact->suburb && $this->params->get('show_suburb')) : ?>
 			<dd>
-				<span class="contact-suburb">
+				<span class="contact-suburb" itemprop="addressLocality">
 					<?php echo $this->contact->suburb .'<br/>'; ?>
 				</span>
 			</dd>
 		<?php endif; ?>
 		<?php if ($this->contact->state && $this->params->get('show_state')) : ?>
 			<dd>
-				<span class="contact-state">
+				<span class="contact-state" itemprop="addressRegion">
 					<?php echo $this->contact->state . '<br/>'; ?>
 				</span>
 			</dd>
 		<?php endif; ?>
 		<?php if ($this->contact->postcode && $this->params->get('show_postcode')) : ?>
 			<dd>
-				<span class="contact-postcode">
+				<span class="contact-postcode" itemprop="postalCode">
 					<?php echo $this->contact->postcode .'<br/>'; ?>
 				</span>
 			</dd>
 		<?php endif; ?>
 		<?php if ($this->contact->country && $this->params->get('show_country')) : ?>
 		<dd>
-			<span class="contact-country">
+			<span class="contact-country" itemprop="addressCountry">
 				<?php echo $this->contact->country .'<br/>'; ?>
 			</span>
 		</dd>
@@ -65,7 +65,7 @@ defined('_JEXEC') or die;
 
 <?php if ($this->contact->email_to && $this->params->get('show_email')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
+		<span class="<?php echo $this->params->get('marker_class'); ?>" itemprop="email">
 			<?php echo nl2br($this->params->get('marker_email')); ?>
 		</span>
 	</dt>
@@ -83,19 +83,19 @@ defined('_JEXEC') or die;
 		</span>
 	</dt>
 	<dd>
-		<span class="contact-telephone">
+		<span class="contact-telephone" itemprop="telephone">
 			<?php echo nl2br($this->contact->telephone); ?>
 		</span>
 	</dd>
 <?php endif; ?>
 <?php if ($this->contact->fax && $this->params->get('show_fax')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
+		<span class="<?php echo $this->params->get('marker_class'); ?>">
 			<?php echo $this->params->get('marker_fax'); ?>
 		</span>
 	</dt>
 	<dd>
-		<span class="contact-fax">
+		<span class="contact-fax" itemprop="faxNumber">
 		<?php echo nl2br($this->contact->fax); ?>
 		</span>
 	</dd>
@@ -107,7 +107,7 @@ defined('_JEXEC') or die;
 		</span>
 	</dt>
 	<dd>
-		<span class="contact-mobile">
+		<span class="contact-mobile" itemprop="telephone">
 			<?php echo nl2br($this->contact->mobile); ?>
 		</span>
 	</dd>
@@ -119,7 +119,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" itemprop="url">
 			<?php echo JStringPunycode::urlToUTF8($this->contact->webpage); ?></a>
 		</span>
 	</dd>

--- a/components/com_contact/views/contact/tmpl/default_links.php
+++ b/components/com_contact/views/contact/tmpl/default_links.php
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
 			$label = ($label) ? $label : $link;
 			?>
 			<li>
-				<a href="<?php echo $link; ?>">
+				<a href="<?php echo $link; ?>" itemprop="url">
 					<?php echo $label; ?>
 				</a>
 			</li>

--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -140,19 +140,19 @@ $params = &$this->item->params;
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_suburb_headings')) : ?>
-						<td class="item-suburb" itemscope itemtype="http://schema.org/PostalAddress">
+						<td class="item-suburb" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
 							<span itemprop="addressLocality"><?php echo $item->suburb; ?></span>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_state_headings')) : ?>
-						<td class="item-state" itemscope itemtype="http://schema.org/PostalAddress">
+						<td class="item-state" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
 							<span itemprop="addressRegion"><?php echo $item->state; ?></span>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_country_headings')) : ?>
-						<td class="item-state" itemscope itemtype="http://schema.org/PostalAddress">
+						<td class="item-state" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
 							<span itemprop="addressCountry"><?php echo $item->country; ?></span>
 						</td>
 					<?php endif; ?>

--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -95,7 +95,7 @@ $params = &$this->item->params;
 
 		<tbody>
 			<?php foreach ($this->items as $i => $item) : ?>
-				<tr class="<?php echo ($i % 2) ? "odd" : "even"; ?>">
+				<tr class="<?php echo ($i % 2) ? "odd" : "even"; ?>" itemscope itemtype="http://schema.org/Person">
 					<td class="item-num">
 						<?php echo $i; ?>
 					</td>
@@ -104,56 +104,57 @@ $params = &$this->item->params;
 						<?php if ($this->items[$i]->published == 0) : ?>
 							<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 						<?php endif; ?>
-						<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
-							<?php echo $item->name; ?></a>
+						<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>" itemprop="url">
+							<span itemprop="name"><?php echo $item->name; ?></span>
+						</a>
 					</td>
 
 					<?php if ($this->params->get('show_position_headings')) : ?>
-						<td class="item-position">
+						<td class="item-position" itemprop="jobTitle">
 							<?php echo $item->con_position; ?>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_email_headings')) : ?>
-						<td class="item-email">
+						<td class="item-email" itemprop="email">
 							<?php echo $item->email_to; ?>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_telephone_headings')) : ?>
-						<td class="item-phone">
+						<td class="item-phone" itemprop="telephone">
 							<?php echo $item->telephone; ?>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_mobile_headings')) : ?>
-						<td class="item-phone">
+						<td class="item-phone" itemprop="telephone">
 							<?php echo $item->mobile; ?>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_fax_headings')) : ?>
-					<td class="item-phone">
-						<?php echo $item->fax; ?>
-					</td>
+						<td class="item-phone" itemprop="faxNumber">
+							<?php echo $item->fax; ?>
+						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_suburb_headings')) : ?>
-					<td class="item-suburb">
-						<?php echo $item->suburb; ?>
-					</td>
+						<td class="item-suburb" itemprop="addressLocality">
+							<?php echo $item->suburb; ?>
+						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_state_headings')) : ?>
-					<td class="item-state">
-						<?php echo $item->state; ?>
-					</td>
+						<td class="item-state" itemprop="addressRegion">
+							<?php echo $item->state; ?>
+						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_country_headings')) : ?>
-					<td class="item-state">
-						<?php echo $item->country; ?>
-					</td>
+						<td class="item-state" itemprop="addressCountry">
+							<?php echo $item->country; ?>
+						</td>
 					<?php endif; ?>
 				</tr>
 			<?php endforeach; ?>

--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -140,20 +140,20 @@ $params = &$this->item->params;
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_suburb_headings')) : ?>
-						<td class="item-suburb" itemprop="addressLocality">
-							<?php echo $item->suburb; ?>
+						<td class="item-suburb" itemscope itemtype="http://schema.org/PostalAddress">
+							<span itemprop="addressLocality"><?php echo $item->suburb; ?></span>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_state_headings')) : ?>
-						<td class="item-state" itemprop="addressRegion">
-							<?php echo $item->state; ?>
+						<td class="item-state" itemscope itemtype="http://schema.org/PostalAddress">
+							<span itemprop="addressRegion"><?php echo $item->state; ?></span>
 						</td>
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_country_headings')) : ?>
-						<td class="item-state" itemprop="addressCountry">
-							<?php echo $item->country; ?>
+						<td class="item-state" itemscope itemtype="http://schema.org/PostalAddress">
+							<span itemprop="addressCountry"><?php echo $item->country; ?></span>
 						</td>
 					<?php endif; ?>
 				</tr>


### PR DESCRIPTION
This PR introduces Microdata tags to com_content in a hardcoded way.
This is based on some feedback that we don't need more parameters.

The PR is based on PR #3252, but unlike this one it doesn't use the Microdata library and instead just hardcodes the tags into the layouts.
#### Advantage
- Easy to understand
- Easy to change for endusers and designers who like to override a layout
#### Disadvantages
- You can't enable/disable Microdata tags globally or per contact. You can of course use layout overrides and alternate layouts to achieve the same. It's also to note that there isn't really a reason to turn the Microdata off.
- You can't select a different Microdata type for a contact using a parameter. It's hardcoded to be "Person". You can of course use layout overrides and alternate layouts here as well to achieve the same, but you need to make sure yourself that the properties are valid for the selected type.
#### Testing

Test the different views of com_contact and check the microdata output using the Google richsnippet test tool: http://www.google.com/webmasters/tools/richsnippets
