### PR TITLE
[#33517] Removes hardcoded non-breaking space after span element in tags layout

### DIFF
--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -22,7 +22,7 @@ JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/
 					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . '-' . $tag->alias)) ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
-				</span>&nbsp;
+				</span>
 			<?php endif; ?>
 		<?php endforeach; ?>
 	</div>


### PR DESCRIPTION
/layouts/joomla/content/tags.php line 25 contains a hardcoded space after the closing span element that is unnecessary and could potentially be problematic in certain implementations. Spacing should be handled by CSS instead.

Joomla tracker item at http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33517&tracker_id=33517
