### PR TITLE
[#33295] Adding the "showon" & hiddenLabel feature to JForm

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -19,8 +19,8 @@ defined('_JEXEC') or die;
 
 ?>
 
-<div class="control-group">
-	<?php if (!isset($displayData['hiddenLabel']) || isset($displayData['hiddenLabel']) && $displayData['hiddenLabel'] == false) : ?>
+<div class="control-group <?php echo $displayData['options']['class']; ?>" <?php echo $displayData['options']['rel']; ?>>
+	<?php if (empty($displayData['options']['hiddenLabel'])) : ?>
 		<div class="control-label"><?php echo $displayData['label']; ?></div>
 	<?php endif; ?>
 	<div class="controls"><?php echo $displayData['input']; ?></div>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -12,9 +12,9 @@ defined('_JEXEC') or die;
 /**
  * Layout variables
  * ---------------------
- * 	$hiddenLabel     : (boolean) Do we have to show the label
- * 	$label           : (string) The html code for the label (not required if hiddenLabel is true)
- * 	$input           : (string)  The input field html code
+ * 	$options         : (array)  Optional parameters
+ * 	$label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
+ * 	$input           : (string) The input field html code
  */
 
 ?>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 ?>
 
 <?php
-if(!empty($displayData['options']['showonEnabled']))
+if (!empty($displayData['options']['showonEnabled']))
 {
 	JHtml::_('jquery.framework');
 	JHtml::_('script', 'jui/cms.js', false, true);

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -19,6 +19,14 @@ defined('_JEXEC') or die;
 
 ?>
 
+<?php
+if(!empty($displayData['options']['showonEnabled']))
+{
+	JHtml::_('jquery.framework');
+	JHtml::_('script', 'jui/cms.js', false, true);
+}
+?>
+
 <div class="control-group <?php echo $displayData['options']['class']; ?>" <?php echo $displayData['options']['rel']; ?>>
 	<?php if (empty($displayData['options']['hiddenLabel'])) : ?>
 		<div class="control-label"><?php echo $displayData['label']; ?></div>

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -900,18 +900,20 @@ abstract class JFormField
 			return $this->getInput();
 		}
 
-		if (empty($options['class']))
+		if (!isset($options['class']))
 		{
 			$options['class'] = '';
 		}
       
 		$options['rel'] = '';
 		
-		if (empty($options['hiddenLabel']) && $this->getAttribute('hiddenLabel')) {
+		if (empty($options['hiddenLabel']) && $this->getAttribute('hiddenLabel'))
+		{
 			$options['hiddenLabel'] = true;
 		}
       
-		if ($showon = $this->getAttribute('showon')) {
+		if ($showon = $this->getAttribute('showon'))
+		{
 			$showon   = explode(':', $showon, 2);
 			$options['class'] .= ' showon_' . implode(' showon_', explode(',', $showon[1]));
 			$id = $this->getName($showon[0]);

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -912,12 +912,11 @@ abstract class JFormField
 		}
       
 		if ($showon = $this->getAttribute('showon')) {
-			JHtml::_('jquery.framework');
-			JHtml::_('script', 'jui/cms.js', false, true);
 			$showon   = explode(':', $showon, 2);
 			$options['class'] .= ' showon_' . implode(' showon_', explode(',', $showon[1]));
 			$id = $this->getName($showon[0]);
 			$options['rel'] = ' rel="showon_' . $id . '"';
+			$options['showonEnabled'] = true;
 		}
 
 		return JLayoutHelper::render($this->renderLayout, array('input' => $this->getInput(), 'label' => $this->getLabel(), 'options' => $options));

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -900,8 +900,26 @@ abstract class JFormField
 			return $this->getInput();
 		}
 
-		$hiddenLabel = isset($options['hiddenLabel']) ? $options['hiddenLabel'] : false;
+		if (empty($options['class']))
+		{
+			$options['class'] = '';
+		}
+      
+		$options['rel'] = '';
+		
+		if (empty($options['hiddenLabel']) && $this->getAttribute('hiddenLabel')) {
+			$options['hiddenLabel'] = true;
+		}
+      
+		if ($showon = $this->getAttribute('showon')) {
+			JHtml::_('jquery.framework');
+			JHtml::_('script', 'jui/cms.js', false, true);
+			$showon   = explode(':', $showon, 2);
+			$options['class'] .= ' showon_' . implode(' showon_', explode(',', $showon[1]));
+			$id = $this->getName($showon[0]);
+			$options['rel'] = ' rel="showon_' . $id . '"';
+		}
 
-		return JLayoutHelper::render($this->renderLayout, array('input' => $this->getInput(), 'label' => $this->getLabel(), 'hiddenLabel' => $hiddenLabel));
+		return JLayoutHelper::render($this->renderLayout, array('input' => $this->getInput(), 'label' => $this->getLabel(), 'options' => $options));
 	}
 }


### PR DESCRIPTION
This is like PR #3127, just in sync with the latest changes, and it also adds support for hidden labels on xml level. Here is the copy of the test instructions/description from the previous PR:
### Overview

In the Joomla Global Configuration we use showon attribute to show/hide certain fields based on the state of a "parent" field. You can see this for example with the FTP settings where the settings itself only show when "Enable FTP" is set to "Yes". It's also available for Component settings.

This PR takes this feature to the JForm so it can be used in any xml file.
### Testing

You can add a showon attribute to any config field you want to hide. For example in 
 modules\mod_finder\mod_finder.xml you add to line 94
 showon="show_label:1". So it looks like this:

```
                <field
                    name="label_pos"
                    type="list"
                    default="left"
                    showon="show_label:1"
                    label="MOD_FINDER_FIELDSET_ADVANCED_LABEL_POS_LABEL"
                    description="MOD_FINDER_FIELDSET_ADVANCED_LABEL_POS_DESCRIPTION">
                    <option
                        value="right">JGLOBAL_RIGHT</option>
                    <option
                        value="left">JGLOBAL_LEFT</option>
                    <option
                        value="top">MOD_FINDER_CONFIG_OPTION_TOP</option>
                    <option
                        value="bottom">MOD_FINDER_CONFIG_OPTION_BOTTOM</option>
                </field>
```

This will only show the "Label position" setting only if the "Show Label" is set to "Yes" (which has the value 1).

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33295&start=0
