### PR TITLE
Add preprocess() method to component router interface

### DIFF
--- a/components/com_banners/router.php
+++ b/components/com_banners/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_banners
  * @since       3.3
  */
-class BannersRouter implements JComponentRouter
+class BannersRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_banners component
+	 * Preprocess method for the com_banners component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class BannersRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_banners/router.php
+++ b/components/com_banners/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_banners
  * @since       3.3
  */
-class BannersRouter implements JComponentRouterInterface
+class BannersRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_banners component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_banners component
 	 *

--- a/components/com_banners/router.php
+++ b/components/com_banners/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class BannersRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_banners component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_banners component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_contact
  * @since       3.3
  */
-class ContactRouter implements JComponentRouter
+class ContactRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_contact component
+	 * Preprocess method for the com_contact component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class ContactRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_contact
  * @since       3.3
  */
-class ContactRouter implements JComponentRouterInterface
+class ContactRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_contact component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_contact component
 	 *

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class ContactRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_contact component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_contact component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_content
  * @since       3.3
  */
-class ContentRouter implements JComponentRouter
+class ContentRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_content component
+	 * Preprocess method for the com_content component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class ContentRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class ContentRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_content component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_content component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_content
  * @since       3.3
  */
-class ContentRouter implements JComponentRouterInterface
+class ContentRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_content component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_content component
 	 *

--- a/components/com_finder/router.php
+++ b/components/com_finder/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_finder
  * @since       3.3
  */
-class FinderRouter implements JComponentRouter
+class FinderRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_finder component
+	 * Preprocess method for the com_finder component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class FinderRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_finder/router.php
+++ b/components/com_finder/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_finder
  * @since       3.3
  */
-class FinderRouter implements JComponentRouterInterface
+class FinderRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_finder component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_finder component
 	 *

--- a/components/com_finder/router.php
+++ b/components/com_finder/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class FinderRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_finder component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_finder component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_newsfeeds
  * @since       3.3
  */
-class NewsfeedsRouter implements JComponentRouter
+class NewsfeedsRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_newsfeeds component
+	 * Preprocess method for the com_newsfeeds component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class NewsfeedsRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_newsfeeds
  * @since       3.3
  */
-class NewsfeedsRouter implements JComponentRouterInterface
+class NewsfeedsRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_newsfeeds component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_newsfeeds component
 	 *

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class NewsfeedsRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_newsfeeds component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_newsfeeds component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_search/router.php
+++ b/components/com_search/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_search
  * @since       3.3
  */
-class SearchRouter implements JComponentRouter
+class SearchRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_search component
+	 * Preprocess method for the com_search component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class SearchRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_search/router.php
+++ b/components/com_search/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_search
  * @since       3.3
  */
-class SearchRouter implements JComponentRouterInterface
+class SearchRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_search component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_search component
 	 *

--- a/components/com_search/router.php
+++ b/components/com_search/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class SearchRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_search component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_search component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_tags
  * @since       3.3
  */
-class TagsRouter implements JComponentRouterInterface
+class TagsRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_tags component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_tags component
 	 *

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class TagsRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_tags component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_tags component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_tags
  * @since       3.3
  */
-class TagsRouter implements JComponentRouter
+class TagsRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_tags component
+	 * Preprocess method for the com_tags component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class TagsRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -16,28 +16,16 @@ defined('_JEXEC') or die;
  * @subpackage  com_users
  * @since       3.2
  */
-class UsersRouter implements JComponentRouterInterface
+class UsersRouter extends JComponentRouterBase
 {
 	/**
-	 * Preprocess method for the com_users component
+	 * Build the route for the com_users component
 	 *
-	 * @param   array  $query  An associative array of URL arguments
+	 * @param   array  &$query  An array of URL arguments
 	 *
 	 * @return  array  The URL arguments to use to assemble the subsequent URL.
 	 *
 	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
-	/**
-	 * Function to build a Users URL route.
-	 *
-	 * @return  array  The array of query string values for which to build a route.
-	 * @return  array  The URL route with segments represented as an array.
-	 * @since    1.5
 	 */
 	public function build(&$query)
 	{
@@ -207,11 +195,13 @@ class UsersRouter implements JComponentRouterInterface
 	}
 
 	/**
-	 * Function to parse a Users URL route.
+	 * Parse the segments of a URL.
 	 *
-	 * @return  array  The URL route with segments represented as an array.
-	 * @return  array  The array of variables to set in the request.
-	 * @since    1.5
+	 * @param   array  &$segments  The segments of the URL to parse.
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 *
+	 * @since   3.3
 	 */
 	public function parse(&$segments)
 	{

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class UsersRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_users component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Function to build a Users URL route.
 	 *
 	 * @return  array  The array of query string values for which to build a route.

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_users
  * @since       3.2
  */
-class UsersRouter implements JComponentRouter
+class UsersRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_users component
+	 * Preprocess method for the com_users component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class UsersRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class WeblinksRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_weblinks component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_weblinks component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_weblinks
  * @since       3.3
  */
-class WeblinksRouter implements JComponentRouterInterface
+class WeblinksRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_weblinks component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_weblinks component
 	 *

--- a/components/com_weblinks/router.php
+++ b/components/com_weblinks/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_weblinks
  * @since       3.3
  */
-class WeblinksRouter implements JComponentRouter
+class WeblinksRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_weblinks component
+	 * Preprocess method for the com_weblinks component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class WeblinksRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_wrapper/router.php
+++ b/components/com_wrapper/router.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
  * @subpackage  com_wrapper
  * @since       3.3
  */
-class WrapperRouter implements JComponentRouter
+class WrapperRouter implements JComponentRouterInterface
 {
 	/**
-	 * Make method for the com_wrapper component
+	 * Preprocess method for the com_wrapper component
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -27,7 +27,7 @@ class WrapperRouter implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/components/com_wrapper/router.php
+++ b/components/com_wrapper/router.php
@@ -19,6 +19,20 @@ defined('_JEXEC') or die;
 class WrapperRouter implements JComponentRouter
 {
 	/**
+	 * Make method for the com_wrapper component
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_wrapper component
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/components/com_wrapper/router.php
+++ b/components/com_wrapper/router.php
@@ -16,22 +16,8 @@ defined('_JEXEC') or die;
  * @subpackage  com_wrapper
  * @since       3.3
  */
-class WrapperRouter implements JComponentRouterInterface
+class WrapperRouter extends JComponentRouterBase
 {
-	/**
-	 * Preprocess method for the com_wrapper component
-	 *
-	 * @param   array  $query  An associative array of URL arguments
-	 *
-	 * @return  array  The URL arguments to use to assemble the subsequent URL.
-	 *
-	 * @since   3.3
-	 */
-	public function preprocess($query)
-	{
-		return $query;
-	}
-
 	/**
 	 * Build the route for the com_wrapper component
 	 *

--- a/libraries/cms/component/router.php
+++ b/libraries/cms/component/router.php
@@ -19,7 +19,24 @@ defined('JPATH_PLATFORM') or die;
 interface JComponentRouter
 {
 	/**
+	 * Prepare-method for URLs
+	 * This method is meant to validate and complete the URL parameters.
+	 * For example it can add the Itemid or set a language parameter.
+	 * This method is executed on each URL, regardless of SEF mode switched 
+	 * on or not.
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query);
+
+	/**
 	 * Build method for URLs
+	 * This method is meant to transform the query parameters into a more human
+	 * readable form. It is only executed when SEF mode is switched on.
 	 *
 	 * @param   array  &$query  An array of URL arguments
 	 *
@@ -31,6 +48,8 @@ interface JComponentRouter
 
 	/**
 	 * Parse method for URLs
+	 * This method is meant to transform the human readable URL back into
+	 * query parameters. It is only executed when SEF mode is switched on.
 	 *
 	 * @param   array  &$segments  The segments of the URL to parse.
 	 *

--- a/libraries/cms/component/router/base.php
+++ b/libraries/cms/component/router/base.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Base component routing class
+ *
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ * @since       3.3
+ */
+abstract class JComponentRouterBase implements JComponentRouterInterface
+{
+	/**
+	 * Generic method to preprocess a URL
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function preprocess($query)
+	{
+		return $query;
+	}
+}

--- a/libraries/cms/component/router/interface.php
+++ b/libraries/cms/component/router/interface.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Component
  * @since       3.3
  */
-interface JComponentRouter
+interface JComponentRouterInterface
 {
 	/**
 	 * Prepare-method for URLs
@@ -31,7 +31,7 @@ interface JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query);
+	public function preprocess($query);
 
 	/**
 	 * Build method for URLs

--- a/libraries/cms/component/router/legacy.php
+++ b/libraries/cms/component/router/legacy.php
@@ -39,6 +39,20 @@ class JComponentRouterLegacy implements JComponentRouter
 	}
 
 	/**
+	 * Generic make function for missing or legacy component router
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.3
+	 */
+	public function make($query)
+	{
+		return $query;
+	}
+
+	/**
 	 * Generic build function for missing or legacy component router
 	 *
 	 * @param   array  &$query  An array of URL arguments

--- a/libraries/cms/component/router/legacy.php
+++ b/libraries/cms/component/router/legacy.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Component
  * @since       3.3
  */
-class JComponentRouterLegacy implements JComponentRouter
+class JComponentRouterLegacy implements JComponentRouterInterface
 {
 	/**
 	 * Name of the component
@@ -39,7 +39,7 @@ class JComponentRouterLegacy implements JComponentRouter
 	}
 
 	/**
-	 * Generic make function for missing or legacy component router
+	 * Generic preprocess function for missing or legacy component router
 	 *
 	 * @param   array  $query  An associative array of URL arguments
 	 *
@@ -47,7 +47,7 @@ class JComponentRouterLegacy implements JComponentRouter
 	 *
 	 * @since   3.3
 	 */
-	public function make($query)
+	public function preprocess($query)
 	{
 		return $query;
 	}

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -400,7 +400,7 @@ class JRouterSite extends JRouter
 
 		return $vars;
 	}
-	
+
 	/**
 	 * Function to build a raw route
 	 *
@@ -419,13 +419,13 @@ class JRouterSite extends JRouter
 		{
 			return;
 		}
-		
+
 		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
 
 		$crouter = $this->getComponentRouter($component);
 
 		$query = $crouter->preprocess($query);
-		
+
 		$uri->setQuery($query);
 	}
 
@@ -477,7 +477,7 @@ class JRouterSite extends JRouter
 		$crouter = $this->getComponentRouter($component);
 
 		$query = $crouter->preprocess($query);
-		
+
 		$parts = $crouter->build($query);
 
 		// Encode the route segments
@@ -717,7 +717,7 @@ class JRouterSite extends JRouter
 			{
 				$reflection = new ReflectionClass($name);
 
-				if (in_array('JComponentRouter', $reflection->getInterfaceNames()))
+				if (in_array('JComponentRouterInterface', $reflection->getInterfaceNames()))
 				{
 					$this->componentRouters[$component] = new $name();
 				}
@@ -746,7 +746,7 @@ class JRouterSite extends JRouter
 	{
 		$reflection = new ReflectionClass($router);
 
-		if (in_array('JComponentRouter', $reflection->getInterfaceNames()))
+		if (in_array('JComponentRouterInterface', $reflection->getInterfaceNames()))
 		{
 			$this->componentRouters[$component] = $router;
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -424,7 +424,7 @@ class JRouterSite extends JRouter
 
 		$crouter = $this->getComponentRouter($component);
 
-		$query = $crouter->make($query);
+		$query = $crouter->preprocess($query);
 		
 		$uri->setQuery($query);
 	}
@@ -476,7 +476,7 @@ class JRouterSite extends JRouter
 
 		$crouter = $this->getComponentRouter($component);
 
-		$query = $crouter->make($query);
+		$query = $crouter->preprocess($query);
 		
 		$parts = $crouter->build($query);
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -400,6 +400,34 @@ class JRouterSite extends JRouter
 
 		return $vars;
 	}
+	
+	/**
+	 * Function to build a raw route
+	 *
+	 * @param   JUri  &$uri  The internal URL
+	 *
+	 * @return  string  Raw Route
+	 *
+	 * @since   3.2
+	 */
+	protected function buildRawRoute(&$uri)
+	{
+		// Get the query data
+		$query = $uri->getQuery(true);
+
+		if (!isset($query['option']))
+		{
+			return;
+		}
+		
+		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
+
+		$crouter = $this->getComponentRouter($component);
+
+		$query = $crouter->make($query);
+		
+		$uri->setQuery($query);
+	}
 
 	/**
 	 * Function to build a sef route
@@ -448,6 +476,8 @@ class JRouterSite extends JRouter
 
 		$crouter = $this->getComponentRouter($component);
 
+		$query = $crouter->make($query);
+		
 		$parts = $crouter->build($query);
 
 		// Encode the route segments


### PR DESCRIPTION
This PR replaces #3244 at the request of @Hackwar with just the addition of the `preprocess()` method into the router interface.  I also took motivation from that PR and implemented an `abstract class JComponentRouterBase` which can later house the duplicated code that was trying to be handled in the old PR.
