### PR TITLE
[#32645] JHtmlSelect class: If option's label ends with a hyphen, that hyphen is missing.

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -651,7 +651,7 @@ abstract class JHtmlSelect
 			else
 			{
 				// If no string after hyphen - take hyphen out
-				$splitText = preg_split('/ -[\s]*/', $text, 2, PREG_SPLIT_NO_EMPTY);
+				$splitText = preg_split('/ -[\s]*/', $text, 1, PREG_SPLIT_NO_EMPTY);
 				$text = isset($splitText[0]) ? $splitText[0] : '';
 
 				if (!empty($splitText[1]))


### PR DESCRIPTION
Joomla Code's tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32645
