### PR TITLE
[#33539] Do not log in the user using cookie if a password reset is required

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -135,7 +135,8 @@ class PlgAuthenticationCookie extends JPlugin
 		$query = $this->db->getQuery(true)
 			->select($this->db->quoteName(array('id', 'username', 'password')))
 			->from($this->db->quoteName('#__users'))
-			->where($this->db->quoteName('username') . ' = ' . $this->db->quote($results[0]->user_id));
+			->where($this->db->quoteName('username') . ' = ' . $this->db->quote($results[0]->user_id))
+			->where($this->db->quoteName('requireReset') . ' = 0');
 		$result = $this->db->setQuery($query)->loadObject();
 
 		if ($result)


### PR DESCRIPTION
### Issue

The recently merged PR #3128 introduces the ability to require a password reset which forces the user to the profile page after he logged in. This works fine.
However if the user is logged in using the remember me cookie, it results in an interesting situation where the user has to edit the profile page, but isn't allowed because he is logged in using a cookie :smile: 
There is no way out as the user is stuck on the profile page which he is unable to leave and isn't allowed to save.
### Proposed Fix

This PR adds a check in the cookie authentication plugin which only logs the user in if `requireReset` isn't set.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33539
