### PR TITLE
Do not disable field attributes for a new category.

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -227,7 +227,9 @@ class CategoriesModelCategory extends JModelAdmin
 			$data['extension'] = $extension;
 		}
 		$user = JFactory::getUser();
-		if (!$user->authorise('core.edit.state', $extension . '.category.' . $jinput->get('id')))
+                // Do not disable attributes on a new category
+                $oldCat = $jinput->get('id', 0);
+                if ($oldCat != 0 && !$user->authorise('core.edit.state', $extension . '.category.' . $jinput->get('id')))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('ordering', 'disabled', 'true');


### PR DESCRIPTION
When Super User creates a new category, the default state for the status attribute is published. However, when a non super user with r/w access for com_content creates a new category, during creation, the field attributes are disabled. As a result, the user is unable to set the state field and the newly created category ends up with status unpublished. Next the user can modify the status by selecting the category for edit.

Also for the newly created category, authorisation is looked up based on the category id. However, for the new category, an id does not exist yet and hence the fields are disabled, for every user which is not Super User. 

This fix checks if id does exist and if not (new category), disabling is skipped. If a user is allowed to create a new category, the user should be able to define the relevant fields.
