### PR TITLE
[#33551] Users not able to select root category as parent

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -158,7 +158,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				// To take save or create in a category you need to have create rights for that category
 				// unless the item is already in that category.
 				// Unset the option if the user isn't authorised for it. In this field assets are always categories.
-				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
+				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true && $option->level != 0)
 				{
 					unset($options[$i]);
 				}


### PR DESCRIPTION
At the moment there is a bug with creating a new category in certain ACL setups. This prevents users to select "No parent" for new categories, so they can only assign it as child to one of the existing ones.

This pull request fix this issue. 

JoomlaCode: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33551
## Test instructions:
- create a new user group, with Public as parent
- allow "Admin Login" for this group in the global configuration permissions
- Go to the article manager, click on the options and set the following actions to allowed for the new group "Access Administration Interface" and "Create"
- add the new group to Access Level "Special"
- Create test user, assign to created group
- login with test user
- create new category, notice not possible to select "No parent" as parent
- apply patch
- create new category, and notice that you are now able to select "No parent" as parent
## Screenshots before & after patch

Before:
![screen shot 2014-04-01 at 22 59 49](https://cloud.githubusercontent.com/assets/522834/2584612/9def7410-b9e0-11e3-8ce0-de51b424e751.png)
After:
![screen shot 2014-04-01 at 22 45 25](https://cloud.githubusercontent.com/assets/522834/2584617/a6f8e424-b9e0-11e3-9b83-9c1e71cc057d.png)
