### PR TITLE
[#33552] [fix] Accessing undefined elements on Configuration > Text filters

### DIFF
--- a/administrator/components/com_config/model/field/filters.php
+++ b/administrator/components/com_config/model/field/filters.php
@@ -32,7 +32,7 @@ class JFormFieldFilters extends JFormField
 	 * TODO: Add access check.
 	 *
 	 * @return	string	The field input markup.
-	 * 
+	 *
 	 * @since	1.6
 	 */
 	protected function getInput()
@@ -73,7 +73,11 @@ class JFormFieldFilters extends JFormField
 			{
 				$this->value[$group->value] = array('filter_type' => 'BL', 'filter_tags' => '', 'filter_attributes' => '');
 			}
+
 			$group_filter = $this->value[$group->value];
+
+			$group_filter['filter_tags']       = !empty($group_filter['filter_tags']) ? $group_filter['filter_tags'] : '';
+			$group_filter['filter_attributes'] = !empty($group_filter['filter_attributes']) ? $group_filter['filter_attributes'] : '';
 
 			$html[] = '	<tr>';
 			$html[] = '		<th class="acl-groups left">';
@@ -96,6 +100,7 @@ class JFormFieldFilters extends JFormField
 			$html[] = '		</td>';
 			$html[] = '	</tr>';
 		}
+
 		$html[] = '	</tbody>';
 
 		// Close the table.
@@ -115,7 +120,7 @@ class JFormFieldFilters extends JFormField
 	 * A helper to get the list of user groups.
 	 *
 	 * @return	array
-	 * 
+	 *
 	 * @since	1.6
 	 */
 	protected function getUserGroups()


### PR DESCRIPTION
Issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33552

Global configuration shows some notices on text filters tab when error reporting is set to maximum.

See image:
http://joomlacode.org/gf/download/trackeritem/33552/158508/undefined-text-filters.png
