### PR TITLE
[fix] Notice when ordering some tables in back-end managers

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1140,7 +1140,17 @@ abstract class JModelAdmin extends JModelForm
 		$tableClassName = get_class($table);
 		$contentType = new JUcmType;
 		$type = $contentType->getTypeByTable($tableClassName);
-		$typeAlias = $type->type_alias;
+
+		// Cope for tables which are not concerned by tags
+		if ($type)
+		{
+			$typeAlias = $type->type_alias;
+		}
+		else
+		{
+			$typeAlias ='';
+		}
+
 		$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 		$conditions = array();
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1168,7 +1168,7 @@ abstract class JModelAdmin extends JModelForm
 				if ($type)
 				{
 					$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
-					$this->createTagsHelper($tagsObserver, $type, $pk, $typeAlias, $table);
+					$this->createTagsHelper($tagsObserver, $type, $pk, $type->type_alias, $table);
 				}
 
 				if (!$table->store())

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -272,7 +272,7 @@ abstract class JModelAdmin extends JModelForm
 	 */
 	protected function batchAccess($value, $pks, $contexts)
 	{
-		if (!$this->batchSet)
+		if (empty($this->batchSet))
 		{
 			// Set some needed variables.
 			$this->user = JFactory::getUser();
@@ -290,7 +290,10 @@ abstract class JModelAdmin extends JModelForm
 				$this->table->load($pk);
 				$this->table->access = (int) $value;
 
-				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				if (!empty($this->type))
+				{
+					static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				}
 
 				if (!$this->table->store())
 				{
@@ -326,7 +329,7 @@ abstract class JModelAdmin extends JModelForm
 	 */
 	protected function batchCopy($value, $pks, $contexts)
 	{
-		if (!$this->batchSet)
+		if (empty($this->batchSet))
 		{
 			// Set some needed variables.
 			$this->user = JFactory::getUser();
@@ -390,7 +393,10 @@ abstract class JModelAdmin extends JModelForm
 				return false;
 			}
 
-			static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			if (!empty($this->type))
+			{
+				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			}
 
 			// Store the row.
 			if (!$this->table->store())
@@ -427,7 +433,7 @@ abstract class JModelAdmin extends JModelForm
 	 */
 	protected function batchLanguage($value, $pks, $contexts)
 	{
-		if (!$this->batchSet)
+		if (empty($this->batchSet))
 		{
 			// Set some needed variables.
 			$this->user = JFactory::getUser();
@@ -445,7 +451,10 @@ abstract class JModelAdmin extends JModelForm
 				$this->table->load($pk);
 				$this->table->language = $value;
 
-				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				if (!empty($this->type))
+				{
+					static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				}
 
 				if (!$this->table->store())
 				{
@@ -481,7 +490,7 @@ abstract class JModelAdmin extends JModelForm
 	 */
 	protected function batchMove($value, $pks, $contexts)
 	{
-		if (!$this->batchSet)
+		if (empty($this->batchSet))
 		{
 			// Set some needed variables.
 			$this->user = JFactory::getUser();
@@ -537,7 +546,10 @@ abstract class JModelAdmin extends JModelForm
 				return false;
 			}
 
-			static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			if (!empty($this->type))
+			{
+				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			}
 
 			// Store the row.
 			if (!$this->table->store())
@@ -1137,6 +1149,10 @@ abstract class JModelAdmin extends JModelForm
 	public function saveorder($pks = null, $order = null)
 	{
 		$table = $this->getTable();
+		$tableClassName = get_class($table);
+		$contentType = new JUcmType;
+		$type = $contentType->getTypeByTable($tableClassName);
+		$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 		$conditions = array();
 
 		if (empty($pks))
@@ -1160,14 +1176,8 @@ abstract class JModelAdmin extends JModelForm
 			{
 				$table->ordering = $order[$i];
 
-				// Try to get the content type
-				$tableClassName = get_class($table);
-				$contentType    = new JUcmType;
-				$type           = $contentType->getTypeByTable($tableClassName);
-
 				if ($type)
 				{
-					$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 					$this->createTagsHelper($tagsObserver, $type, $pk, $type->type_alias, $table);
 				}
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -292,7 +292,7 @@ abstract class JModelAdmin extends JModelForm
 
 				if (!empty($this->type))
 				{
-					static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+					$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 				}
 
 				if (!$this->table->store())
@@ -395,7 +395,7 @@ abstract class JModelAdmin extends JModelForm
 
 			if (!empty($this->type))
 			{
-				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 			}
 
 			// Store the row.
@@ -453,7 +453,7 @@ abstract class JModelAdmin extends JModelForm
 
 				if (!empty($this->type))
 				{
-					static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+					$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 				}
 
 				if (!$this->table->store())
@@ -548,7 +548,7 @@ abstract class JModelAdmin extends JModelForm
 
 			if (!empty($this->type))
 			{
-				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 			}
 
 			// Store the row.

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1137,14 +1137,6 @@ abstract class JModelAdmin extends JModelForm
 	public function saveorder($pks = null, $order = null)
 	{
 		$table = $this->getTable();
-		$tableClassName = get_class($table);
-		$contentType = new JUcmType;
-		$type = $contentType->getTypeByTable($tableClassName);
-
-		// Cope for tables which are not concerned by tags
-		$typeAlias = isset($type->type_alias) ? $type->type_alias : '';
-
-		$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 		$conditions = array();
 
 		if (empty($pks))
@@ -1168,7 +1160,16 @@ abstract class JModelAdmin extends JModelForm
 			{
 				$table->ordering = $order[$i];
 
-				$this->createTagsHelper($tagsObserver, $type, $pk, $typeAlias, $table);
+				// Try to get the content type
+				$tableClassName = get_class($table);
+				$contentType    = new JUcmType;
+				$type           = $contentType->getTypeByTable($tableClassName);
+
+				if ($type)
+				{
+					$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
+					$this->createTagsHelper($tagsObserver, $type, $pk, $typeAlias, $table);
+				}
 
 				if (!$table->store())
 				{

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1142,14 +1142,7 @@ abstract class JModelAdmin extends JModelForm
 		$type = $contentType->getTypeByTable($tableClassName);
 
 		// Cope for tables which are not concerned by tags
-		if ($type)
-		{
-			$typeAlias = $type->type_alias;
-		}
-		else
-		{
-			$typeAlias ='';
-		}
+		$typeAlias = isset($type->type_alias) ? $type->type_alias : '';
 
 		$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 		$conditions = array();


### PR DESCRIPTION
When ajax ordering Plugins, Modules, Content languages, we get a Notice in the php logs.
[03-Apr-2014 08:42:58 UTC] PHP Notice:  Trying to get property of non-object in ROOT/libraries/legacy/model/admin.php on line 1143

It does not prevent the ordering from working fine.

This looks like coming from the fact that these tables are not concerned by content_types and therefore can't have a value for $type->type_alias

Here is a patch
