### PR TITLE
Add method to enable/disable the observers calls

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -211,6 +211,20 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
+	 * Enable/Disable calling of observers (this is useful when calling parent:: function
+	 *
+	 * @param   boolean  $enabled  Enable (true) or Disable (false) the observer events
+	 *
+	 * @return  boolean  Returns old state
+	 *
+	 * @since   3.3.0
+	 */
+	public function doCallObservers($enabled)
+	{
+		return $this->_observers->doCallObservers($enabled);
+	}
+
+	/**
 	 * Get the columns from database table.
 	 *
 	 * @return  mixed  An array of the field names, or false if an error occurs.


### PR DESCRIPTION
Suppose that we have to insert some rows to category table. So we do this:

```
// Getting the category table
$category = JTable::getInstance('Category', 'JTable', array('dbo' => $this->_db));

// Bind data to save category
if (!$category->bind($row)) {
    throw new Exception($category->getError());
}

// Insert the category
if (!$category->store()) {
    throw new Exception($category->getError());
}
```

But this way to insert a new category returns the error: 'Application Instantiation Error' produced by the observers calls attached by default. Maybe this is an issue for the observers, i dont know why honesty, but i can solve the problem commenting this line:

https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/observer/updater.php#L104

The problem is that there is no way to disable the observable calls, so this patch add the method to disable the observable calls if the developers not need it.
