### PR TITLE
Bug tracker item #33234 - getRootId query called over and over again

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -141,10 +141,8 @@ class JAccess
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			// TODO: $rootId doesn't seem to be used!
 			$db = JFactory::getDbo();
 			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
-			$rootId = $assets->getRootId();
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.


### PR DESCRIPTION
when creating new article same query runs 50-60 times..

tracked down the problem to a line of code that is not being used anyhow so i deleted it.
now we need to test and see if there is no side effects for this action.
