### PR TITLE
Conversation starter for JTable::publish() revision

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1488,13 +1488,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *                            If not set the instance property value is used.
 	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published]
 	 * @param   integer  $userId  The user id of the user performing the operation.
+	 * @param	string   $column  The column of the table holding publishing state.
 	 *
 	 * @return  boolean  True on success; false if $pks is empty.
 	 *
 	 * @link    http://docs.joomla.org/JTable/publish
 	 * @since   11.1
 	 */
-	public function publish($pks = null, $state = 1, $userId = 0)
+	public function publish($pks = null, $state = 1, $userId = 0, $column = 'published')
 	{
 		$k = $this->_tbl_keys;
 
@@ -1538,7 +1539,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			// Update the publishing state for rows with the given primary keys.
 			$query = $this->_db->getQuery(true)
 				->update($this->_tbl)
-				->set('published = ' . (int) $state);
+				->set($column . ' = ' . (int) $state);
 
 			// Determine if there is checkin support for the table.
 			if (property_exists($this, 'checked_out') || property_exists($this, 'checked_out_time'))


### PR DESCRIPTION
Not sure how valuable this will turn out to be in the long run, but while I was tooling around the db I noticed that some components used "published" for the publishing state column, and some used "state". Since JTable::publish() is hard-coded for the "published" column, anything using 'state' has to "roll their own" publish method.

By adding a fourth parameter ($column) to JTable's publish method, which defaults to 'published', any of the existing components that rolled their own with 'state' (from appearances, 'state' seems to be the current thinking of what that column should be called) can turn their current publish method into a one-line shim with a call to parent::publish that adds the table column they're using on the end. This results in a savings of around 70 lines per method replaced, if they pulled the entire publish method in.

Change adds one comment line to the docblock, and simply replaces the hard-coded table name with the fourth parameter. Older code is unaffected, because the parameter is written to default to what it is currently hard-coded to be. This simply allows 'state' to be used in place of 'published' for any component that needs it.

Attached to this PR is the change at its very simplest to illustrate the point.

Alternatively, existing components using state could be brought into line with the hardcoded 'published' to achieve the same goal. It just seemed to me that 'state' makes for a more accurate column name and looks to be where we're headed so this makes it possible for everyone to start moving that way now.
