### PR TITLE
[#33578] Remove ACL checks for specific menu item (J 3.x)

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -46,51 +46,6 @@ class MenusModelItem extends JModelAdmin
 	protected $helpLocal = false;
 
 	/**
-	 * Method to test whether a record can be deleted.
-	 *
-	 * @param   object    A record object.
-	 *
-	 * @return  boolean  True if allowed to delete the record. Defaults to the permission set in the component.
-	 * @since   1.6
-	 */
-	protected function canDelete($record)
-	{
-		if (!empty($record->id))
-		{
-			if ($record->published != -2)
-			{
-				return;
-			}
-			$user = JFactory::getUser();
-
-			return $user->authorise('core.delete', 'com_menus.item.' . (int) $record->id);
-		}
-	}
-
-	/**
-	 * Method to test whether a record can have its state edited.
-	 *
-	 * @param   object    A record object.
-	 *
-	 * @return  boolean  True if allowed to change the state of the record. Defaults to the permission set in the component.
-	 * @since   1.6
-	 */
-	protected function canEditState($record)
-	{
-		$user = JFactory::getUser();
-
-		if (!empty($record->id))
-		{
-			return $user->authorise('core.edit.state', 'com_menus.item.' . (int) $record->id);
-		}
-		// Default to component settings if menu item not known.
-		else
-		{
-			return parent::canEditState($record);
-		}
-	}
-
-	/**
 	 * Method to perform batch operations on an item or a set of items.
 	 *
 	 * @param   array  $commands  An array of commands to perform.


### PR DESCRIPTION
Current ACL checks are causing unexpected results as ACL is only available for com_menus in general. So no need to check for ACL settings for com_menus.item.XX, only com_menus available.

Example of wrong behaviour right now: someone with edit state allowed for com_menus is not able to change the state by clicking on the publish/unpublish icon. This patch will fix this.

JoomlaCode: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33578
## Test instructions:
- create a new user group
- allow "Admin Login" for this group in the global configuration permissions
- Go to the Menu Manager, click on the options button and allow "Access Administration Interface" and "Edit State" action for the group
- Add the new group to Access Level "special"
- create test user, assign to created group
- login with test user
- try to publish/unpublish a menu item. Result: "Edit state not permitted".
- apply patch
- try to publish/unpublish a menu item. Result: "1 menu item successfully unpublished/published"
