### PR TITLE
[#33570] Make definition for install password fields for the admin user consistent with admin

### DIFF
--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -27,13 +27,17 @@
 		<field name="admin_password" type="password" id="admin_password" class="inputbox"
 			label="INSTL_ADMIN_PASSWORD_LABEL"
 			required="true"
+			filter="raw"
+			autocomplete="off"
 		/>
 
 		<field name="admin_password2" type="password" id="admin_password2" class="inputbox"
 			label="INSTL_ADMIN_PASSWORD2_LABEL"
 			required="true"
+			filter="raw"
 			validate="equals"
 			field="admin_password"
+			autocomplete="off"
 		/>
 
 		<field name="site_metadesc" type="textarea" id="site_metadesc" class="text_area"


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33570 for issue
