### PR TITLE
[#33605] Update contactcreator.php

### DIFF
--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -89,6 +89,7 @@ class PlgUserContactCreator extends JPlugin
 			$contact->user_id  = $user_id;
 			$contact->email_to = $user['email'];
 			$contact->catid    = $categoryId;
+			$contact->access   = '1';
 			$contact->language = '*';
 			$contact->generateAlias();
 


### PR DESCRIPTION
Error in contacts created by plugin "Contact Creator" 
See the related tracker on 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33605

source: www.allaroundtheweb.it/segui-blog-allaroundtheweb/categoria/joomla/articolo/382/joomla-3-exception-with-message-contact-not-found-come-risolvere-questo-baco-fastidioso-how-to-resolve.html
