### PR TITLE
Update file.php

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -185,6 +185,10 @@ class JFile
 
 		foreach ($files as $file)
 		{
+			if(!is_file($file))
+			{
+				continue;
+			}
 			$file = JPath::clean($file);
 
 			// Try making the file writable first. If it's read-only, it can't be deleted

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -185,10 +185,11 @@ class JFile
 
 		foreach ($files as $file)
 		{
-			if(!is_file($file))
+			if (!is_file($file))
 			{
 				continue;
 			}
+			
 			$file = JPath::clean($file);
 
 			// Try making the file writable first. If it's read-only, it can't be deleted

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -185,12 +185,12 @@ class JFile
 
 		foreach ($files as $file)
 		{
+			$file = JPath::clean($file);
+			
 			if (!is_file($file))
 			{
 				continue;
 			}
-			
-			$file = JPath::clean($file);
 
 			// Try making the file writable first. If it's read-only, it can't be deleted
 			// on Windows, even if the parent folder is writable


### PR DESCRIPTION
Prevents security issue where $file can be an empty string or directory path. If that happens the deletion fails but the directory is left writeable with 0777 permissions. If $file is empty then this is interpreted by chmod as the current director, so root folder of Joomla site is left writeable.
