### PR TITLE
User selector is blank by default

### DIFF
--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -80,7 +80,7 @@ class JFormFieldUser extends JFormField
 		}
 		else
 		{
-			$table->username = JText::_('JLIB_FORM_SELECT_USER');
+			$table->name = JText::_('JLIB_FORM_SELECT_USER');
 		}
 
 		// Create a dummy text field with the user name.


### PR DESCRIPTION
User selector displays "Select a User" when you explicitly clear the selection by pressing the button "- No User -", but it is blank by default.

How to reproduce the problem: Go to User > User Notes and create a new note. The User ID field is blank. Click on the blue button in order to select an user. Once arrived on the users list click on "No User" button. The users list disappears, but this time the User ID field contains the text "Select a User".

Source file: libraries/cms/form/field/user.php
Since JText::_('JLIB_FORM_SELECT_USER') is not a valid username, it's clear that the original code wanted to assign JText::_('JLIB_FORM_SELECT_USER') to $table->name instead of $table->username.
