### PR TITLE
[#33620] User selector goes wrong in user id validation

### DIFF
--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -76,7 +76,9 @@ class JFormFieldUser extends JFormField
 		// Handle the special case for "current".
 		elseif (strtoupper($this->value) == 'CURRENT')
 		{
-			$table->load(JFactory::getUser()->id);
+			// 'CURRENT' is not a reasonable value to be placed in the html
+			$this->value = JFactory::getUser()->id;
+			$table->load($this->value);
 		}
 		else
 		{
@@ -99,7 +101,7 @@ class JFormFieldUser extends JFormField
 		$html[] = '</div>';
 
 		// Create the real field, hidden, that stored the user id.
-		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . (int) $this->value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $this->value . '" />';
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
Under some circumstances the "User selector" implicitly assumes that "no selection" means "user id = 0", which is a valid value to be saved in the database.
This brings to paradoxes, for example you can inserts records with user id = 0 even when the "user id" is a required filed.
For example: Go to User > User Notes and create a new note. There is no user selected, but it is a required field, as shown by the asterisk. Fill out "Subject" and "Note", but leave empty the user. Press the "Save & Close" button. You have just created a user note which is not associated to any user.

This is caused by an useless type cast to int, which turns invalid values like an empty string to 0 which is a valid id.

Under different circumstances the id is handled correctly simply by avoiding the type cast to int. For example, repeat the steps above, but before saving the record, press the user selection button. Once in the users list clear the selection by pressing the button "- No User -". This time the record won't be saved and a the message "Field required: User ID" will be displayed.

Tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33620&start=0
