### PR TITLE
[#33623] Improved the cache-key for JController Legacy

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -847,10 +847,13 @@ class JControllerLegacy extends JObject
 
 		if (empty($prefix))
 		{
-			$prefix = $this->getName() . 'View';
+			$prefix = $this->getName() . 'view';
 		}
 
 		$layout = isset($config['layout']) ? $config['layout'] : '';
+		
+		$prefix = strtolower($prefix);
+		
 
 		if (empty($views[$name][$type][$prefix][$layout]))
 		{

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -850,7 +850,7 @@ class JControllerLegacy extends JObject
 			$prefix = $this->getName() . 'View';
 		}
 
-		$layout = $config['layout'];
+		$layout = isset($config['layout']) ? $config['layout'] : '';
 
 		if (empty($views[$name][$type][$prefix][$layout]))
 		{

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -850,11 +850,13 @@ class JControllerLegacy extends JObject
 			$prefix = $this->getName() . 'View';
 		}
 
-		if (empty($views[$name]))
+		$layout = $config['layout'];
+
+		if (empty($views[$name][$type][$prefix][$layout]))
 		{
 			if ($view = $this->createView($name, $prefix, $type, $config))
 			{
-				$views[$name] = & $view;
+				$views[$name][$type][$prefix][$layout] = & $view;
 			}
 			else
 			{
@@ -862,7 +864,7 @@ class JControllerLegacy extends JObject
 			}
 		}
 
-		return $views[$name];
+		return $views[$name][$type][$prefix][$layout];
 	}
 
 	/**


### PR DESCRIPTION
JController’s getView key was way too liberal.  when getView had already been used for a view, eg comContent, everything else was ignored and the previous cache entry was being returned.

The revision now uses correct relevant parameters for each view.
