### PR TITLE
[#32568] JoomlaUpdate fails if remember me plugin is enabled.

### DIFF
--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -38,6 +38,12 @@ class PlgSystemRemember extends JPlugin
 	 */
 	public function onAfterInitialise()
 	{
+		// Get the application if not done by JPlugin. This may happen during upgrades from Joomla 2.5.
+		if (!$this->app)
+		{
+			$this->app = JFactory::getApplication();
+		}
+
 		// No remember me for admin.
 		if ($this->app->isAdmin())
 		{


### PR DESCRIPTION
### Issue

There are some reports that the remember me plugin causes the Joomla Updater to hang on the last step. That is due to a fatal error produced:

```
Fatal error: Call to a member function isAdmin() on a non-object in /.../plugins/system/remember/remember.php on line 42
```

The problem is that this only happens on some enviroments and on others it works fine.
It may be related to the order in which the files are replaced with the new ones during the update.

While JPlugin in 3.2 does populate `$this->app` automatically, this wasn't the case in earlier versions. I think that this is the problem we see here since we are in an undefined state regarding the Joomla version.
### Solution

This PR adds a check if `$this->app` is populated and if not it will get the Application.
### Testing Instructions

Of course make sure nothing breaks and the remember me still works as expected. Nothing should change here.
If you can reproduce the issue with the Joomla Updater, try with a patched zip and see if it works.
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32568
