### PR TITLE
[#33602] Tags in com_content - Distinction between article and category tags

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -1,272 +1,243 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-	<fieldset
-			name="articles"
-			label="JGLOBAL_ARTICLES"
-			description="COM_CONTENT_CONFIG_ARTICLE_SETTINGS_DESC">
-		<field
-				name="article_layout"
-				type="componentlayout"
-				label="JGLOBAL_FIELD_LAYOUT_LABEL"
-				description="JGLOBAL_FIELD_LAYOUT_DESC"
-				menuitems="true"
-				extension="com_content"
-				view="article"
+	<fieldset name="articles"
+	          label="JGLOBAL_ARTICLES"
+	          description="COM_CONTENT_CONFIG_ARTICLE_SETTINGS_DESC">
+		<field name="article_layout"
+		       type="componentlayout"
+		       label="JGLOBAL_FIELD_LAYOUT_LABEL"
+		       description="JGLOBAL_FIELD_LAYOUT_DESC"
+		       menuitems="true"
+		       extension="com_content"
+		       view="article"
 				/>
-		<field
-				name="show_title"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-				description="JGLOBAL_SHOW_TITLE_DESC">
+		<field name="show_title"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_TITLE_LABEL"
+		       description="JGLOBAL_SHOW_TITLE_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="link_titles"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-				description="JGLOBAL_LINKED_TITLES_DESC">
+		<field name="link_titles"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_LINKED_TITLES_LABEL"
+		       description="JGLOBAL_LINKED_TITLES_DESC">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="show_intro"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-				description="JGLOBAL_SHOW_INTRO_DESC">
+		<field name="show_intro"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_INTRO_LABEL"
+		       description="JGLOBAL_SHOW_INTRO_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="info_block_position"
-				type="list"
-				default="0"
-				label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-				description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+		<field name="info_block_position"
+		       type="list"
+		       default="0"
+		       label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+		       description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 			<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 		</field>
-		<field
-				name="show_category"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				default="1">
+		<field name="show_category"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_CATEGORY_LABEL"
+		       description="JGLOBAL_SHOW_CATEGORY_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="link_category"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				default="1">
+		<field name="link_category"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_LINK_CATEGORY_LABEL"
+		       description="JGLOBAL_LINK_CATEGORY_DESC"
+		       default="1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="show_parent_category"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				default="1">
+		<field name="show_parent_category"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+		       description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="link_parent_category"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				default="1">
+		<field name="link_parent_category"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+		       description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+		       default="1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="spacer1"
-				type="spacer"
-				hr="true"
+		<field name="spacer1"
+		       type="spacer"
+		       hr="true"
 				/>
-		<field
-				name="show_author"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				default="1">
+		<field name="show_author"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_AUTHOR_LABEL"
+		       description="JGLOBAL_SHOW_AUTHOR_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="link_author"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				default="0">
+		<field name="link_author"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_LINK_AUTHOR_LABEL"
+		       description="JGLOBAL_LINK_AUTHOR_DESC"
+		       default="0">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="show_create_date"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				default="1">
+		<field name="show_create_date"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+		       description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_modify_date"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				default="1">
+		<field name="show_modify_date"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+		       description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_publish_date"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				default="1">
+		<field name="show_publish_date"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+		       description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_item_navigation"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				default="1">
+		<field name="show_item_navigation"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+		       description="JGLOBAL_SHOW_NAVIGATION_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_vote"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_VOTE_LABEL"
-				description="JGLOBAL_SHOW_VOTE_DESC"
-				default="0">
+		<field name="show_vote"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_VOTE_LABEL"
+		       description="JGLOBAL_SHOW_VOTE_DESC"
+		       default="0">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_readmore"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				default="1">
+		<field name="show_readmore"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_READMORE_LABEL"
+		       description="JGLOBAL_SHOW_READMORE_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_readmore_title"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-				default="1">
+		<field name="show_readmore_title"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+		       description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="readmore_limit"
-				type="text"
-				label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
-				description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
-				default="100"
+		<field name="readmore_limit"
+		       type="text"
+		       label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
+		       description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
+		       default="100"
 				/>
-		<field
-				id="show_tags"
-				name="show_tags"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
-				description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
+		<field id="show_tags"
+		       name="show_tags"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+		       description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="spacer2"
-				type="spacer"
-				hr="true"
+		<field name="spacer2"
+		       type="spacer"
+		       hr="true"
 				/>
-		<field
-				name="show_icons"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				default="1">
+		<field name="show_icons"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_ICONS_LABEL"
+		       description="JGLOBAL_SHOW_ICONS_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_print_icon"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				default="1">
+		<field name="show_print_icon"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+		       description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_email_icon"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-				default="1">
+		<field name="show_email_icon"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
+		       description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_hits"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				default="1">
+		<field name="show_hits"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_HITS_LABEL"
+		       description="JGLOBAL_SHOW_HITS_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="show_noauth"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="0"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
+		<field name="show_noauth"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+		       description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="urls_position"
-				type="list"
-				default="0"
-				label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
-				description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
+		<field name="urls_position"
+		       type="list"
+		       default="0"
+		       label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
+		       description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 		</field>
@@ -274,133 +245,119 @@
 	<fieldset name="editinglayout"
 	          label="COM_CONTENT_EDITING_LAYOUT"
 	          description="COM_CONTENT_CONFIG_EDITOR_LAYOUT">
-		<field
-				name="show_publishing_options"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_LABEL"
-				description="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_DESC"
+		<field name="show_publishing_options"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_LABEL"
+		       description="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_DESC"
 				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="show_article_options"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="COM_CONTENT_SHOW_ARTICLE_OPTIONS_LABEL"
-				description="COM_CONTENT_SHOW_ARTICLE_OPTIONS_DESC"
+		<field name="show_article_options"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="COM_CONTENT_SHOW_ARTICLE_OPTIONS_LABEL"
+		       description="COM_CONTENT_SHOW_ARTICLE_OPTIONS_DESC"
 				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="save_history"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="0"
-				label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
-				description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
+		<field name="save_history"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
+		       description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
 				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="history_limit"
-				type="text"
-				filter="integer"
-				label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
-				description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
-				default="10"
+		<field name="history_limit"
+		       type="text"
+		       filter="integer"
+		       label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
+		       description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
+		       default="10"
 				/>
-		<field
-				name="show_urls_images_frontend"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="0"
-				label="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_LABEL"
-				description="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_DESC"
+		<field name="show_urls_images_frontend"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_LABEL"
+		       description="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_DESC"
 				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="show_urls_images_backend"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="0"
-				label="COM_CONTENT_SHOW_IMAGES_URLS_BACK_LABEL"
-				description="COM_CONTENT_SHOW_IMAGES_URLS_BACK_DESC"
+		<field name="show_urls_images_backend"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="COM_CONTENT_SHOW_IMAGES_URLS_BACK_LABEL"
+		       description="COM_CONTENT_SHOW_IMAGES_URLS_BACK_DESC"
 				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-				name="spacer3"
-				type="spacer"
-				hr="true"
+		<field name="spacer3"
+		       type="spacer"
+		       hr="true"
 				/>
-		<field
-				name="targeta"
-				type="list"
-				label="COM_CONTENT_URL_FIELD_A_BROWSERNAV_LABEL"
-				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-				default="Parent"
-				filter="int"
-				class="inputbox">
+		<field name="targeta"
+		       type="list"
+		       label="COM_CONTENT_URL_FIELD_A_BROWSERNAV_LABEL"
+		       description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+		       default="Parent"
+		       filter="int"
+		       class="inputbox">
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
 			<option value="2">JBROWSERTARGET_POPUP</option>
 			<option value="3">JBROWSERTARGET_MODAL</option>
 		</field>
-		<field
-				name="targetb"
-				type="list"
-				label="COM_CONTENT_URL_FIELD_B_BROWSERNAV_LABEL"
-				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-				default="Parent"
-				filter="int"
-				class="inputbox">
+		<field name="targetb"
+		       type="list"
+		       label="COM_CONTENT_URL_FIELD_B_BROWSERNAV_LABEL"
+		       description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+		       default="Parent"
+		       filter="int"
+		       class="inputbox">
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
 			<option value="2">JBROWSERTARGET_POPUP</option>
 			<option value="3">JBROWSERTARGET_MODAL</option>
 		</field>
-		<field
-				name="targetc"
-				type="list"
-				label="COM_CONTENT_URL_FIELD_C_BROWSERNAV_LABEL"
-				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-				default="Parent"
-				filter="int"
-				class="inputbox">
+		<field name="targetc"
+		       type="list"
+		       label="COM_CONTENT_URL_FIELD_C_BROWSERNAV_LABEL"
+		       description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+		       default="Parent"
+		       filter="int"
+		       class="inputbox">
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
 			<option value="2">JBROWSERTARGET_POPUP</option>
 			<option value="3">JBROWSERTARGET_MODAL</option>
 		</field>
-		<field
-				name="spacer4"
-				type="spacer"
-				hr="true"
+		<field name="spacer4"
+		       type="spacer"
+		       hr="true"
 				/>
-
-		<field
-				name="float_intro"
-				type="list"
-				label="COM_CONTENT_FLOAT_INTRO_LABEL"
-				description="COM_CONTENT_FLOAT_DESC">
+		<field name="float_intro"
+		       type="list"
+		       label="COM_CONTENT_FLOAT_INTRO_LABEL"
+		       description="COM_CONTENT_FLOAT_DESC">
 			<option value="right">COM_CONTENT_RIGHT</option>
 			<option value="left">COM_CONTENT_LEFT</option>
 			<option value="none">COM_CONTENT_NONE</option>
 		</field>
-		<field
-				name="float_fulltext"
-				type="list"
-				label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
-				description="COM_CONTENT_FLOAT_DESC">
+		<field name="float_fulltext"
+		       type="list"
+		       label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
+		       description="COM_CONTENT_FLOAT_DESC">
 			<option value="right">COM_CONTENT_RIGHT</option>
 			<option value="left">COM_CONTENT_LEFT</option>
 			<option value="none">COM_CONTENT_NONE</option>
@@ -410,22 +367,20 @@
 	          label="JCATEGORY"
 	          description="COM_CONTENT_CONFIG_CATEGORY_SETTINGS_DESC"
 			>
-		<field
-				name="category_layout"
-				type="componentlayout"
-				label="JGLOBAL_FIELD_LAYOUT_LABEL"
-				description="JGLOBAL_FIELD_LAYOUT_DESC"
-				menuitems="true"
-				extension="com_content"
-				view="category"
+		<field name="category_layout"
+		       type="componentlayout"
+		       label="JGLOBAL_FIELD_LAYOUT_LABEL"
+		       description="JGLOBAL_FIELD_LAYOUT_DESC"
+		       menuitems="true"
+		       extension="com_content"
+		       view="category"
 				/>
-		<field
-				name="show_category_heading_title_text"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
-				default="1">
+		<field name="show_category_heading_title_text"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+		       description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
+		       default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
@@ -644,7 +599,6 @@
 			<option value="5">J5</option>
 		</field>
 	</fieldset>
-
 	<fieldset name="list_default_parameters"
 	          label="JGLOBAL_LIST_LAYOUT_OPTIONS"
 	          description="COM_CONTENT_CONFIG_LIST_SETTINGS_DESC"
@@ -799,22 +753,20 @@
 	          label="JGLOBAL_INTEGRATION_LABEL"
 	          description="COM_CONTENT_CONFIG_INTEGRATION_SETTINGS_DESC"
 			>
-		<field
-				name="show_feed_link"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="1"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC">
+		<field name="show_feed_link"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+		       description="JGLOBAL_SHOW_FEED_LINK_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		<field
-				name="feed_summary"
-				type="list"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				default="0">
+		<field name="feed_summary"
+		       type="list"
+		       label="JGLOBAL_FEED_SUMMARY_LABEL"
+		       description="JGLOBAL_FEED_SUMMARY_DESC"
+		       default="0">
 			<option
 					value="0">JGLOBAL_INTRO_TEXT
 			</option>
@@ -822,30 +774,27 @@
 					value="1">JGLOBAL_FULL_TEXT
 			</option>
 		</field>
-		<field
-				name="feed_show_readmore"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				label="JGLOBAL_FEED_SHOW_READMORE_LABEL"
-				description="JGLOBAL_FEED_SHOW_READMORE_DESC"
-				default="0">
+		<field name="feed_show_readmore"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_FEED_SHOW_READMORE_LABEL"
+		       description="JGLOBAL_FEED_SHOW_READMORE_DESC"
+		       default="0">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
 	</fieldset>
-	<fieldset
-			name="permissions"
-			label="JCONFIG_PERMISSIONS_LABEL"
-			description="JCONFIG_PERMISSIONS_DESC"
+	<fieldset name="permissions"
+	          label="JCONFIG_PERMISSIONS_LABEL"
+	          description="JCONFIG_PERMISSIONS_DESC"
 			>
-		<field
-				name="rules"
-				type="rules"
-				label="JCONFIG_PERMISSIONS_LABEL"
-				class="inputbox"
-				validate="rules"
-				filter="rules"
-				component="com_content"
-				section="component"/>
+		<field name="rules"
+		       type="rules"
+		       label="JCONFIG_PERMISSIONS_LABEL"
+		       class="inputbox"
+		       validate="rules"
+		       filter="rules"
+		       component="com_content"
+		       section="component"/>
 	</fieldset>
 </config>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -1,495 +1,468 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<fieldset
-		name="articles"
-		label="JGLOBAL_ARTICLES"
-		description="COM_CONTENT_CONFIG_ARTICLE_SETTINGS_DESC">
-
+			name="articles"
+			label="JGLOBAL_ARTICLES"
+			description="COM_CONTENT_CONFIG_ARTICLE_SETTINGS_DESC">
 		<field
-			name="article_layout" type="componentlayout"
-			label="JGLOBAL_FIELD_LAYOUT_LABEL"
-			description="JGLOBAL_FIELD_LAYOUT_DESC"
-			menuitems="true"
-			extension="com_content"
-			view="article"
-		/>
-
+				name="article_layout"
+				type="componentlayout"
+				label="JGLOBAL_FIELD_LAYOUT_LABEL"
+				description="JGLOBAL_FIELD_LAYOUT_DESC"
+				menuitems="true"
+				extension="com_content"
+				view="article"
+				/>
 		<field
-			name="show_title"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_TITLE_LABEL"
-			description="JGLOBAL_SHOW_TITLE_DESC">
+				name="show_title"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="JGLOBAL_SHOW_TITLE_LABEL"
+				description="JGLOBAL_SHOW_TITLE_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="link_titles"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_LINKED_TITLES_LABEL"
-			description="JGLOBAL_LINKED_TITLES_DESC">
+				name="link_titles"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="JGLOBAL_LINKED_TITLES_LABEL"
+				description="JGLOBAL_LINKED_TITLES_DESC">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-
 		<field
-			name="show_intro"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_INTRO_LABEL"
-			description="JGLOBAL_SHOW_INTRO_DESC">
+				name="show_intro"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="JGLOBAL_SHOW_INTRO_LABEL"
+				description="JGLOBAL_SHOW_INTRO_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="info_block_position"
-			type="list"
-			default="0"
-			label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-			description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+				name="info_block_position"
+				type="list"
+				default="0"
+				label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+				description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 			<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 		</field>
-
 		<field
-			name="show_category"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_CATEGORY_LABEL"
-			description="JGLOBAL_SHOW_CATEGORY_DESC"
-			default="1">
+				name="show_category"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_CATEGORY_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="link_category"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_LINK_CATEGORY_LABEL"
-			description="JGLOBAL_LINK_CATEGORY_DESC"
-			default="1">
+				name="link_category"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_LINK_CATEGORY_LABEL"
+				description="JGLOBAL_LINK_CATEGORY_DESC"
+				default="1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-
 		<field
-			name="show_parent_category"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-			description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-			default="1">
+				name="show_parent_category"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="link_parent_category"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-			description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-			default="1">
+				name="link_parent_category"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+				default="1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-
 		<field
-			name="spacer1"
-			type="spacer"
-			hr="true"
-			/>
-
+				name="spacer1"
+				type="spacer"
+				hr="true"
+				/>
 		<field
-			name="show_author"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_AUTHOR_LABEL"
-			description="JGLOBAL_SHOW_AUTHOR_DESC"
-			default="1">
+				name="show_author"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_AUTHOR_LABEL"
+				description="JGLOBAL_SHOW_AUTHOR_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="link_author"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_LINK_AUTHOR_LABEL"
-			description="JGLOBAL_LINK_AUTHOR_DESC"
-			default="0">
+				name="link_author"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_LINK_AUTHOR_LABEL"
+				description="JGLOBAL_LINK_AUTHOR_DESC"
+				default="0">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-
 		<field
-			name="show_create_date"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-			description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-			default="1">
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_modify_date"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-			description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-			default="1">
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_publish_date"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-			description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-			default="1">
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_item_navigation"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-			description="JGLOBAL_SHOW_NAVIGATION_DESC"
-			default="1">
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_vote"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-			default="0">
+				name="show_create_date"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
 		<field
-			name="show_readmore"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_READMORE_LABEL"
-			description="JGLOBAL_SHOW_READMORE_DESC"
-			default="1">
+				name="show_modify_date"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="show_readmore_title"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-			description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-			default="1">
+				name="show_publish_date"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="readmore_limit"
-			type="text"
-			label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
-			description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
-			default="100"
-		/>
-
-		<field
-			id="show_tags"
-			name="show_tags"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
-			description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
+				name="show_item_navigation"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+				description="JGLOBAL_SHOW_NAVIGATION_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="spacer2"
-			type="spacer"
-			hr="true"
-			/>
-		<field
-			name="show_icons"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_ICONS_LABEL"
-			description="JGLOBAL_SHOW_ICONS_DESC"
-			default="1">
+				name="show_vote"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_VOTE_LABEL"
+				description="JGLOBAL_SHOW_VOTE_DESC"
+				default="0">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="show_print_icon"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-			description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-			default="1">
+				name="show_readmore"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_READMORE_LABEL"
+				description="JGLOBAL_SHOW_READMORE_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="show_email_icon"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-			description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-			default="1">
+				name="show_readmore_title"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+				default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="show_hits"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_HITS_LABEL"
-			description="JGLOBAL_SHOW_HITS_DESC"
-			default="1">
+				name="readmore_limit"
+				type="text"
+				label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
+				description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
+				default="100"
+				/>
+		<field
+				id="show_tags"
+				name="show_tags"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+				description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field
-			name="show_noauth"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-			description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
+				name="spacer2"
+				type="spacer"
+				hr="true"
+				/>
+		<field
+				name="show_icons"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_ICONS_LABEL"
+				description="JGLOBAL_SHOW_ICONS_DESC"
+				default="1">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field
+				name="show_print_icon"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+				default="1">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field
+				name="show_email_icon"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
+				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
+				default="1">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field
+				name="show_hits"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_HITS_LABEL"
+				description="JGLOBAL_SHOW_HITS_DESC"
+				default="1">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field
+				name="show_noauth"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="0"
+				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-			<field
-			name="urls_position"
-			type="list"
-			default="0"
-			label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
-			description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
+		<field
+				name="urls_position"
+				type="list"
+				default="0"
+				label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
+				description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 		</field>
 	</fieldset>
-	<fieldset name="editinglayout" label="COM_CONTENT_EDITING_LAYOUT"
-				description="COM_CONTENT_CONFIG_EDITOR_LAYOUT">
+	<fieldset name="editinglayout"
+	          label="COM_CONTENT_EDITING_LAYOUT"
+	          description="COM_CONTENT_CONFIG_EDITOR_LAYOUT">
 		<field
-			name="show_publishing_options"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_LABEL"
-			description="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_DESC"
-			>
+				name="show_publishing_options"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_LABEL"
+				description="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_DESC"
+				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
 		<field
-			name="show_article_options"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="COM_CONTENT_SHOW_ARTICLE_OPTIONS_LABEL"
-			description="COM_CONTENT_SHOW_ARTICLE_OPTIONS_DESC"
-			>
+				name="show_article_options"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="COM_CONTENT_SHOW_ARTICLE_OPTIONS_LABEL"
+				description="COM_CONTENT_SHOW_ARTICLE_OPTIONS_DESC"
+				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
 		<field
-			name="save_history"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
-			description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
-			>
+				name="save_history"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="0"
+				label="JGLOBAL_SAVE_HISTORY_OPTIONS_LABEL"
+				description="JGLOBAL_SAVE_HISTORY_OPTIONS_DESC"
+				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
 		<field
-			name="history_limit"
-			type="text"
-			filter="integer"
-			label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
-			description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
-			default="10"
-		/>
+				name="history_limit"
+				type="text"
+				filter="integer"
+				label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
+				description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
+				default="10"
+				/>
 		<field
-			name="show_urls_images_frontend"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_LABEL"
-			description="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_DESC"
-			>
+				name="show_urls_images_frontend"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="0"
+				label="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_LABEL"
+				description="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_DESC"
+				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
 		<field
-			name="show_urls_images_backend"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="COM_CONTENT_SHOW_IMAGES_URLS_BACK_LABEL"
-			description="COM_CONTENT_SHOW_IMAGES_URLS_BACK_DESC"
-			>
+				name="show_urls_images_backend"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="0"
+				label="COM_CONTENT_SHOW_IMAGES_URLS_BACK_LABEL"
+				description="COM_CONTENT_SHOW_IMAGES_URLS_BACK_DESC"
+				>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
 		<field
-			name="spacer3"
-			type="spacer"
-			hr="true"
-			/>
+				name="spacer3"
+				type="spacer"
+				hr="true"
+				/>
 		<field
-			name="targeta"
-			type="list"
-			label="COM_CONTENT_URL_FIELD_A_BROWSERNAV_LABEL"
-			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-			default="Parent"
-			filter="int"
-			class="inputbox">
-				<option value="0">JBROWSERTARGET_PARENT</option>
-				<option value="1">JBROWSERTARGET_NEW</option>
-				<option value="2">JBROWSERTARGET_POPUP</option>
-				<option value="3">JBROWSERTARGET_MODAL</option>
+				name="targeta"
+				type="list"
+				label="COM_CONTENT_URL_FIELD_A_BROWSERNAV_LABEL"
+				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+				default="Parent"
+				filter="int"
+				class="inputbox">
+			<option value="0">JBROWSERTARGET_PARENT</option>
+			<option value="1">JBROWSERTARGET_NEW</option>
+			<option value="2">JBROWSERTARGET_POPUP</option>
+			<option value="3">JBROWSERTARGET_MODAL</option>
 		</field>
 		<field
-			name="targetb"
-			type="list"
-			label="COM_CONTENT_URL_FIELD_B_BROWSERNAV_LABEL"
-			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-			default="Parent"
-			filter="int"
-			class="inputbox">
-				<option value="0">JBROWSERTARGET_PARENT</option>
-				<option value="1">JBROWSERTARGET_NEW</option>
-				<option value="2">JBROWSERTARGET_POPUP</option>
-				<option value="3">JBROWSERTARGET_MODAL</option>
+				name="targetb"
+				type="list"
+				label="COM_CONTENT_URL_FIELD_B_BROWSERNAV_LABEL"
+				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+				default="Parent"
+				filter="int"
+				class="inputbox">
+			<option value="0">JBROWSERTARGET_PARENT</option>
+			<option value="1">JBROWSERTARGET_NEW</option>
+			<option value="2">JBROWSERTARGET_POPUP</option>
+			<option value="3">JBROWSERTARGET_MODAL</option>
 		</field>
 		<field
-			name="targetc"
-			type="list"
-			label="COM_CONTENT_URL_FIELD_C_BROWSERNAV_LABEL"
-			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
-			default="Parent"
-			filter="int"
-			class="inputbox">
-				<option value="0">JBROWSERTARGET_PARENT</option>
-				<option value="1">JBROWSERTARGET_NEW</option>
-				<option value="2">JBROWSERTARGET_POPUP</option>
-				<option value="3">JBROWSERTARGET_MODAL</option>
-		</field>	
+				name="targetc"
+				type="list"
+				label="COM_CONTENT_URL_FIELD_C_BROWSERNAV_LABEL"
+				description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
+				default="Parent"
+				filter="int"
+				class="inputbox">
+			<option value="0">JBROWSERTARGET_PARENT</option>
+			<option value="1">JBROWSERTARGET_NEW</option>
+			<option value="2">JBROWSERTARGET_POPUP</option>
+			<option value="3">JBROWSERTARGET_MODAL</option>
+		</field>
 		<field
-			name="spacer4"
-			type="spacer"
-			hr="true"
-			/>
+				name="spacer4"
+				type="spacer"
+				hr="true"
+				/>
 
 		<field
-			name="float_intro"
-			type="list"
-			label="COM_CONTENT_FLOAT_INTRO_LABEL"
-			description="COM_CONTENT_FLOAT_DESC">
-				<option value="right">COM_CONTENT_RIGHT</option>
-				<option value="left">COM_CONTENT_LEFT</option>
-				<option value="none">COM_CONTENT_NONE</option>
+				name="float_intro"
+				type="list"
+				label="COM_CONTENT_FLOAT_INTRO_LABEL"
+				description="COM_CONTENT_FLOAT_DESC">
+			<option value="right">COM_CONTENT_RIGHT</option>
+			<option value="left">COM_CONTENT_LEFT</option>
+			<option value="none">COM_CONTENT_NONE</option>
 		</field>
 		<field
-			name="float_fulltext"
-			type="list"
-			label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
-			description="COM_CONTENT_FLOAT_DESC">
-				<option value="right">COM_CONTENT_RIGHT</option>
-				<option value="left">COM_CONTENT_LEFT</option>
-				<option value="none">COM_CONTENT_NONE</option>
+				name="float_fulltext"
+				type="list"
+				label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
+				description="COM_CONTENT_FLOAT_DESC">
+			<option value="right">COM_CONTENT_RIGHT</option>
+			<option value="left">COM_CONTENT_LEFT</option>
+			<option value="none">COM_CONTENT_NONE</option>
 		</field>
-
 	</fieldset>
-
 	<fieldset name="category"
-		label="JCATEGORY"
-		description="COM_CONTENT_CONFIG_CATEGORY_SETTINGS_DESC"
-		>
-
+	          label="JCATEGORY"
+	          description="COM_CONTENT_CONFIG_CATEGORY_SETTINGS_DESC"
+			>
 		<field
-			name="category_layout" type="componentlayout"
-			label="JGLOBAL_FIELD_LAYOUT_LABEL"
-			description="JGLOBAL_FIELD_LAYOUT_DESC"
-			menuitems="true"
-			extension="com_content"
-			view="category"
-		/>
-		<field 
-			name="show_category_heading_title_text"
-			type="radio"
-			class="btn-group btn-group-yesno"
- 			label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-			description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
-			default="1">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
+				name="category_layout"
+				type="componentlayout"
+				label="JGLOBAL_FIELD_LAYOUT_LABEL"
+				description="JGLOBAL_FIELD_LAYOUT_DESC"
+				menuitems="true"
+				extension="com_content"
+				view="category"
+				/>
+		<field
+				name="show_category_heading_title_text"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
+				default="1">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
 		<field name="show_category_title"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_CATEGORY_TITLE"
-			description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-			default="1"
-			>
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_CATEGORY_TITLE"
+		       description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
+		       default="1"
+				>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_description"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+		       description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_description_image"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-			description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+		       description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
-
-		<field name="maxLevel" type="list"
-			description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
-			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
-			default="-1"
-		>
+		<field name="maxLevel"
+		       type="list"
+		       description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
+		       label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
+		       default="-1"
+				>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
 			<option value="1">J1</option>
@@ -498,83 +471,77 @@
 			<option value="4">J4</option>
 			<option value="5">J5</option>
 		</field>
-
 		<field name="show_empty_categories"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-			description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-			default="0"
-		>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+		       description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+		       default="0"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_no_articles"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="COM_CONTENT_NO_ARTICLES_LABEL"
-			description="COM_CONTENT_NO_ARTICLES_DESC"
-			default="1"
-			>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="COM_CONTENT_NO_ARTICLES_LABEL"
+		       description="COM_CONTENT_NO_ARTICLES_DESC"
+		       default="1"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_subcat_desc"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-			default="1"
-		>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+		       description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+		       default="1"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_cat_num_articles"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-			description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-			default="1"
-			>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+		       description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+		       default="1"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
-		<field name="show_tags" type="radio"
-			label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
-			description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
-			class="btn-group btn-group-yesno"
-			default="1"
-		>
+		<field name="show_cat_tags"
+		       type="radio"
+		       label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+		       description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 	</fieldset>
-
 	<fieldset name="categories"
-		label="JCATEGORIES"
-		description="COM_CONTENT_CONFIG_CATEGORIES_SETTINGS_DESC"
-		>
-		<field name="show_base_description"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_LABEL"
-			description="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_DESC"
+	          label="JCATEGORIES"
+	          description="COM_CONTENT_CONFIG_CATEGORIES_SETTINGS_DESC"
 			>
+		<field name="show_base_description"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_LABEL"
+		       description="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_DESC"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
-		<field name="maxLevelcat" type="list"
-			default="-1"
-			description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
-			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
-		>
+		<field name="maxLevelcat"
+		       type="list"
+		       default="-1"
+		       description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
+		       label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
+				>
 			<option value="-1">JALL</option>
 			<option value="1">J1</option>
 			<option value="2">J2</option>
@@ -582,99 +549,92 @@
 			<option value="4">J4</option>
 			<option value="5">J5</option>
 		</field>
-
 		<field name="show_empty_categories_cat"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="0"
-			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-			description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-		>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="0"
+		       label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+		       description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_subcat_desc_cat"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-		>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+		       description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 		<field name="show_cat_num_articles_cat"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-			description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-		>
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+		       description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+				>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
 	</fieldset>
-
 	<fieldset name="blog_default_parameters"
-		label="COM_CONTENT_CONFIG_BLOG_SETTINGS_LABEL"
-		description="COM_CONTENT_CONFIG_BLOG_SETTINGS_DESC"
-		>
-
-		<field name="num_leading_articles"
-			type="text"
-			default="1"
-			label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-			description="JGLOBAL_NUM_LEADING_ARTICLES_DESC">
-		</field>
-
-		<field name="num_intro_articles"
-			type="text"
-			default="4"
-			label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-			description="JGLOBAL_NUM_INTRO_ARTICLES_DESC">
-		</field>
-
-		<field name="num_columns"
-			type="text"
-			default="2"
-			label="JGLOBAL_NUM_COLUMNS_LABEL"
-			description="JGLOBAL_NUM_COLUMNS_DESC">
-		</field>
-
-		<field name="num_links"
-			type="text"
-			default="4"
-			label="JGLOBAL_NUM_LINKS_LABEL"
-			description="JGLOBAL_NUM_LINKS_DESC">
-		</field>
-
-		<field name="multi_column_order"
-			type="list"
-			default="0"
-			label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-			description="JGLOBAL_MULTI_COLUMN_ORDER_DESC">
-			<option
-				value="0">JGLOBAL_DOWN</option>
-			<option
-				value="1">JGLOBAL_ACROSS</option>
-		</field>
-
-		<field name="spacer1"
-			type="spacer"
-			hr="true"
-			/>
-		<field name="subcategories" type="spacer" class="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-			/>
-
-		<field name="show_subcategory_content" type="list"
-				default="0"
-				description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
-				label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
+	          label="COM_CONTENT_CONFIG_BLOG_SETTINGS_LABEL"
+	          description="COM_CONTENT_CONFIG_BLOG_SETTINGS_DESC"
 			>
+		<field name="num_leading_articles"
+		       type="text"
+		       default="1"
+		       label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
+		       description="JGLOBAL_NUM_LEADING_ARTICLES_DESC">
+		</field>
+		<field name="num_intro_articles"
+		       type="text"
+		       default="4"
+		       label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
+		       description="JGLOBAL_NUM_INTRO_ARTICLES_DESC">
+		</field>
+		<field name="num_columns"
+		       type="text"
+		       default="2"
+		       label="JGLOBAL_NUM_COLUMNS_LABEL"
+		       description="JGLOBAL_NUM_COLUMNS_DESC">
+		</field>
+		<field name="num_links"
+		       type="text"
+		       default="4"
+		       label="JGLOBAL_NUM_LINKS_LABEL"
+		       description="JGLOBAL_NUM_LINKS_DESC">
+		</field>
+		<field name="multi_column_order"
+		       type="list"
+		       default="0"
+		       label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+		       description="JGLOBAL_MULTI_COLUMN_ORDER_DESC">
+			<option
+					value="0">JGLOBAL_DOWN
+			</option>
+			<option
+					value="1">JGLOBAL_ACROSS
+			</option>
+		</field>
+		<field name="spacer1"
+		       type="spacer"
+		       hr="true"
+				/>
+		<field name="subcategories"
+		       type="spacer"
+		       class="spacer"
+		       label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
+				/>
+		<field name="show_subcategory_content"
+		       type="list"
+		       default="0"
+		       description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
+		       label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
+				>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
 			<option value="1">J1</option>
@@ -686,211 +646,206 @@
 	</fieldset>
 
 	<fieldset name="list_default_parameters"
-		label="JGLOBAL_LIST_LAYOUT_OPTIONS"
-		description="COM_CONTENT_CONFIG_LIST_SETTINGS_DESC"
-		>
-
-		<field name="show_pagination_limit"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_DISPLAY_SELECT_LABEL"
-			description="JGLOBAL_DISPLAY_SELECT_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-		<field name="filter_field"
-			type="list"
-			default="hide"
-			label="JGLOBAL_FILTER_FIELD_LABEL"
-			description="JGLOBAL_FILTER_FIELD_DESC">
-				<option value="hide">JHIDE</option>
-				<option value="title">JGLOBAL_TITLE</option>
-				<option value="author">JAUTHOR</option>
-				<option value="hits">JGLOBAL_HITS</option>
-		</field>
-
-		<field name="show_headings"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_HEADINGS_LABEL"
-			description="JGLOBAL_SHOW_HEADINGS_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-		<field name="list_show_date"
-			type="list"
-			default="0"
-			label="JGLOBAL_SHOW_DATE_LABEL"
-			description="JGLOBAL_SHOW_DATE_DESC">
-				<option value="0">JHIDE</option>
-				<option value="created">JGLOBAL_CREATED</option>
-				<option value="modified">JGLOBAL_MODIFIED</option>
-				<option value="published">JPUBLISHED</option>
-		</field>
-
-		<field name="date_format"
-			type="text"
-			size="15"
-			label="JGLOBAL_DATE_FORMAT_LABEL"
-			description="JGLOBAL_DATE_FORMAT_DESC" />
-
-		<field name="list_show_hits"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_LIST_HITS_LABEL"
-			description="JGLOBAL_LIST_HITS_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-		<field name="list_show_author"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_LIST_AUTHOR_LABEL"
-			description="JGLOBAL_LIST_AUTHOR_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-	</fieldset>
-
-	<fieldset name="shared"
-		label="COM_CONTENT_SHARED_LABEL"
-		description="COM_CONTENT_SHARED_DESC"
-		>
-	<field name="orderby_pri"
-			type="list"
-			default="none"
-			label="JGLOBAL_CATEGORY_ORDER_LABEL"
-			description="JGLOBAL_CATEGORY_ORDER_DESC">
-			<option
-				value="none">JGLOBAL_NO_ORDER</option>
-			<option
-				value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-			<option
-				value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-			<option
-				value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
-		</field>
-
-		<field name="orderby_sec"
-			type="list"
-			default="rdate"
-			label="JGLOBAL_Article_Order_Label"
-			description="JGLOBAL_Article_Order_Desc">
-			<option
-				value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
-			<option
-				value="date">JGLOBAL_OLDEST_FIRST</option>
-			<option
-				value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-			<option
-				value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-			<option
-				value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
-			<option
-				value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
-			<option
-				value="hits">JGLOBAL_MOST_HITS</option>
-			<option
-				value="rhits">JGLOBAL_LEAST_HITS</option>
-			<option
-				value="order">JGLOBAL_ARTICLE_MANAGER_ORDER</option>
-		</field>
-
-		<field name="order_date" type="list"
-				default="published"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
+	          label="JGLOBAL_LIST_LAYOUT_OPTIONS"
+	          description="COM_CONTENT_CONFIG_LIST_SETTINGS_DESC"
 			>
-				<option value="created">JGLOBAL_CREATED</option>
-				<option value="modified">JGLOBAL_MODIFIED</option>
-				<option value="published">JPUBLISHED</option>
-			</field>
-
-		<field name="show_pagination"
-			type="list"
-			default="2"
-			label="JGLOBAL_Pagination_Label"
-			description="JGLOBAL_Pagination_Desc">
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-				<option value="2">JGLOBAL_AUTO</option>
-		</field>
-
-		<field name="show_pagination_results"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-			description="JGLOBAL_PAGINATION_RESULTS_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-	</fieldset>
-
-	<fieldset name="integration"
-		label="JGLOBAL_INTEGRATION_LABEL"
-		description="COM_CONTENT_CONFIG_INTEGRATION_SETTINGS_DESC"
-		>
-
-		<field
-			name="show_feed_link"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			default="1"
-			label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-			description="JGLOBAL_SHOW_FEED_LINK_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="feed_summary"
-			type="list"
-			label="JGLOBAL_FEED_SUMMARY_LABEL"
-			description="JGLOBAL_FEED_SUMMARY_DESC"
-			default="0">
-			<option
-				value="0">JGLOBAL_INTRO_TEXT</option>
-			<option
-				value="1">JGLOBAL_FULL_TEXT</option>
-		</field>
-
-		<field
-			name="feed_show_readmore"
-			type="radio"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_FEED_SHOW_READMORE_LABEL"
-			description="JGLOBAL_FEED_SHOW_READMORE_DESC"
-			default="0">
+		<field name="show_pagination_limit"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_DISPLAY_SELECT_LABEL"
+		       description="JGLOBAL_DISPLAY_SELECT_DESC">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
+		<field name="filter_field"
+		       type="list"
+		       default="hide"
+		       label="JGLOBAL_FILTER_FIELD_LABEL"
+		       description="JGLOBAL_FILTER_FIELD_DESC">
+			<option value="hide">JHIDE</option>
+			<option value="title">JGLOBAL_TITLE</option>
+			<option value="author">JAUTHOR</option>
+			<option value="hits">JGLOBAL_HITS</option>
+		</field>
+		<field name="show_headings"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_SHOW_HEADINGS_LABEL"
+		       description="JGLOBAL_SHOW_HEADINGS_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field name="list_show_date"
+		       type="list"
+		       default="0"
+		       label="JGLOBAL_SHOW_DATE_LABEL"
+		       description="JGLOBAL_SHOW_DATE_DESC">
+			<option value="0">JHIDE</option>
+			<option value="created">JGLOBAL_CREATED</option>
+			<option value="modified">JGLOBAL_MODIFIED</option>
+			<option value="published">JPUBLISHED</option>
+		</field>
+		<field name="date_format"
+		       type="text"
+		       size="15"
+		       label="JGLOBAL_DATE_FORMAT_LABEL"
+		       description="JGLOBAL_DATE_FORMAT_DESC"/>
+		<field name="list_show_hits"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_LIST_HITS_LABEL"
+		       description="JGLOBAL_LIST_HITS_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field name="list_show_author"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_LIST_AUTHOR_LABEL"
+		       description="JGLOBAL_LIST_AUTHOR_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
 	</fieldset>
-
-	<fieldset
-		name="permissions"
-		label="JCONFIG_PERMISSIONS_LABEL"
-		description="JCONFIG_PERMISSIONS_DESC"
-		>
-
+	<fieldset name="shared"
+	          label="COM_CONTENT_SHARED_LABEL"
+	          description="COM_CONTENT_SHARED_DESC"
+			>
+		<field name="orderby_pri"
+		       type="list"
+		       default="none"
+		       label="JGLOBAL_CATEGORY_ORDER_LABEL"
+		       description="JGLOBAL_CATEGORY_ORDER_DESC">
+			<option
+					value="none">JGLOBAL_NO_ORDER
+			</option>
+			<option
+					value="alpha">JGLOBAL_TITLE_ALPHABETICAL
+			</option>
+			<option
+					value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL
+			</option>
+			<option
+					value="order">JGLOBAL_CATEGORY_MANAGER_ORDER
+			</option>
+		</field>
+		<field name="orderby_sec"
+		       type="list"
+		       default="rdate"
+		       label="JGLOBAL_Article_Order_Label"
+		       description="JGLOBAL_Article_Order_Desc">
+			<option
+					value="rdate">JGLOBAL_MOST_RECENT_FIRST
+			</option>
+			<option
+					value="date">JGLOBAL_OLDEST_FIRST
+			</option>
+			<option
+					value="alpha">JGLOBAL_TITLE_ALPHABETICAL
+			</option>
+			<option
+					value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL
+			</option>
+			<option
+					value="author">JGLOBAL_AUTHOR_ALPHABETICAL
+			</option>
+			<option
+					value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL
+			</option>
+			<option
+					value="hits">JGLOBAL_MOST_HITS
+			</option>
+			<option
+					value="rhits">JGLOBAL_LEAST_HITS
+			</option>
+			<option
+					value="order">JGLOBAL_ARTICLE_MANAGER_ORDER
+			</option>
+		</field>
+		<field name="order_date"
+		       type="list"
+		       default="published"
+		       description="JGLOBAL_ORDERING_DATE_DESC"
+		       label="JGLOBAL_ORDERING_DATE_LABEL"
+				>
+			<option value="created">JGLOBAL_CREATED</option>
+			<option value="modified">JGLOBAL_MODIFIED</option>
+			<option value="published">JPUBLISHED</option>
+		</field>
+		<field name="show_pagination"
+		       type="list"
+		       default="2"
+		       label="JGLOBAL_Pagination_Label"
+		       description="JGLOBAL_Pagination_Desc">
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
+			<option value="2">JGLOBAL_AUTO</option>
+		</field>
+		<field name="show_pagination_results"
+		       type="radio"
+		       class="btn-group btn-group-yesno"
+		       default="1"
+		       label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+		       description="JGLOBAL_PAGINATION_RESULTS_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+	</fieldset>
+	<fieldset name="integration"
+	          label="JGLOBAL_INTEGRATION_LABEL"
+	          description="COM_CONTENT_CONFIG_INTEGRATION_SETTINGS_DESC"
+			>
 		<field
-			name="rules"
-			type="rules"
+				name="show_feed_link"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				default="1"
+				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+				description="JGLOBAL_SHOW_FEED_LINK_DESC">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		<field
+				name="feed_summary"
+				type="list"
+				label="JGLOBAL_FEED_SUMMARY_LABEL"
+				description="JGLOBAL_FEED_SUMMARY_DESC"
+				default="0">
+			<option
+					value="0">JGLOBAL_INTRO_TEXT
+			</option>
+			<option
+					value="1">JGLOBAL_FULL_TEXT
+			</option>
+		</field>
+		<field
+				name="feed_show_readmore"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="JGLOBAL_FEED_SHOW_READMORE_LABEL"
+				description="JGLOBAL_FEED_SHOW_READMORE_DESC"
+				default="0">
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+	</fieldset>
+	<fieldset
+			name="permissions"
 			label="JCONFIG_PERMISSIONS_LABEL"
-			class="inputbox"
-			validate="rules"
-			filter="rules"
-			component="com_content"
-			section="component" />
+			description="JCONFIG_PERMISSIONS_DESC"
+			>
+		<field
+				name="rules"
+				type="rules"
+				label="JCONFIG_PERMISSIONS_LABEL"
+				class="inputbox"
+				validate="rules"
+				filter="rules"
+				component="com_content"
+				section="component"/>
 	</fieldset>
 </config>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -12,73 +12,71 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 // Create shortcuts to some parameters.
-$params  = $this->item->params;
-$images  = json_decode($this->item->images);
-$urls    = json_decode($this->item->urls);
-$canEdit = $params->get('access-edit');
-$user    = JFactory::getUser();
-$info    = $params->get('info_block_position', 0);
-JHtml::_('behavior.caption');
-$useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
-	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author'));
+$params     = $this->item->params;
+$images     = json_decode($this->item->images);
+$urls       = json_decode($this->item->urls);
+$canEdit    = $params->get('access-edit');
+$user       = JFactory::getUser();
+$info       = $params->get('info_block_position', 0);
+$useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date') || $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author'));
 
+JHtml::_('behavior.caption');
 ?>
-<div class="item-page<?php echo $this->pageclass_sfx?>">
+<div class="item-page<?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading', 1)) : ?>
-	<div class="page-header">
-		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
-	</div>
-	<?php endif;
-if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && $this->item->paginationrelative)
-{
-	echo $this->item->pagination;
-}
-?>
+		<div class="page-header">
+			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
+		</div>
+	<?php endif; ?>
+	<?php if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && $this->item->paginationrelative) : ?>
+		<?php echo $this->item->pagination; ?>
+	<?php endif; ?>
 	<?php if (!$useDefList && $this->print) : ?>
 		<div id="pop-print" class="btn hidden-print">
 			<?php echo JHtml::_('icon.print_screen', $this->item, $params); ?>
 		</div>
-		<div class="clearfix"> </div>
+		<div class="clearfix"></div>
 	<?php endif; ?>
 	<?php if ($params->get('show_title') || $params->get('show_author')) : ?>
-	<div class="page-header">
-		<h2>
-			<?php if ($params->get('show_title')) : ?>
-				<?php if ($params->get('link_titles') && !empty($this->item->readmore_link)) : ?>
-					<a href="<?php echo $this->item->readmore_link; ?>"> <?php echo $this->escape($this->item->title); ?></a>
-				<?php else : ?>
-					<?php echo $this->escape($this->item->title); ?>
+		<div class="page-header">
+			<h2>
+				<?php if ($params->get('show_title')) : ?>
+					<?php if ($params->get('link_titles') && !empty($this->item->readmore_link)) : ?>
+						<a href="<?php echo $this->item->readmore_link; ?>"> <?php echo $this->escape($this->item->title); ?></a>
+					<?php else : ?>
+						<?php echo $this->escape($this->item->title); ?>
+					<?php endif; ?>
 				<?php endif; ?>
+			</h2>
+			<?php if ($this->item->state == 0) : ?>
+				<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 			<?php endif; ?>
-		</h2>
-		<?php if ($this->item->state == 0) : ?>
-			<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
-		<?php endif; ?>
-		<?php if (strtotime($this->item->publish_up) > strtotime(JFactory::getDate())) : ?>
-			<span class="label label-warning"><?php echo JText::_('JNOTPUBLISHEDYET'); ?></span>
-		<?php endif; ?>
-		<?php if ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00') : ?>
-			<span class="label label-warning"><?php echo JText::_('JEXPIRED'); ?></span>
-		<?php endif; ?>
-	</div>
+			<?php if (strtotime($this->item->publish_up) > strtotime(JFactory::getDate())) : ?>
+				<span class="label label-warning"><?php echo JText::_('JNOTPUBLISHEDYET'); ?></span>
+			<?php endif; ?>
+			<?php if ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00') : ?>
+				<span class="label label-warning"><?php echo JText::_('JEXPIRED'); ?></span>
+			<?php endif; ?>
+		</div>
 	<?php endif; ?>
 	<?php if (!$this->print) : ?>
 		<?php if ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon')) : ?>
-		<div class="btn-group pull-right">
-			<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span> <span class="caret"></span> </a>
-			<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
-			<ul class="dropdown-menu actions">
-				<?php if ($params->get('show_print_icon')) : ?>
-				<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
-				<?php endif; ?>
-				<?php if ($params->get('show_email_icon')) : ?>
-				<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
-				<?php endif; ?>
-				<?php if ($canEdit) : ?>
-				<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
-				<?php endif; ?>
-			</ul>
-		</div>
+			<div class="btn-group pull-right">
+				<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span>
+					<span class="caret"></span> </a>
+				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
+				<ul class="dropdown-menu actions">
+					<?php if ($params->get('show_print_icon')) : ?>
+						<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
+					<?php endif; ?>
+					<?php if ($params->get('show_email_icon')) : ?>
+						<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
+					<?php endif; ?>
+					<?php if ($canEdit) : ?>
+						<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
+					<?php endif; ?>
+				</ul>
+			</div>
 		<?php endif; ?>
 	<?php else : ?>
 		<?php if ($useDefList) : ?>
@@ -87,112 +85,11 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 			</div>
 		<?php endif; ?>
 	<?php endif; ?>
-
 	<?php if ($useDefList && ($info == 0 || $info == 2)) : ?>
 		<div class="article-info muted">
 			<dl class="article-info">
-			<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
-
-			<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
-				<dd class="createdby">
-					<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
-					<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
-						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
-					<?php else: ?>
-						<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
-					<?php endif; ?>
-				</dd>
-			<?php endif; ?>
-			<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
-				<dd class="parent-category-name">
-					<?php $title = $this->escape($this->item->parent_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
-					<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
-						<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
-					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
-					<?php endif; ?>
-				</dd>
-			<?php endif; ?>
-			<?php if ($params->get('show_category')) : ?>
-				<dd class="category-name">
-					<?php $title = $this->escape($this->item->category_title);
-					$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>';?>
-					<?php if ($params->get('link_category') && $this->item->catslug) : ?>
-						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
-					<?php else : ?>
-						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
-					<?php endif; ?>
-				</dd>
-			<?php endif; ?>
-
-			<?php if ($params->get('show_publish_date')) : ?>
-				<dd class="published">
-					<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
-				</dd>
-			<?php endif; ?>
-
-			<?php if ($info == 0) : ?>
-				<?php if ($params->get('show_modify_date')) : ?>
-					<dd class="modified">
-						<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
-					</dd>
-				<?php endif; ?>
-				<?php if ($params->get('show_create_date')) : ?>
-					<dd class="create">
-						<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
-					</dd>
-				<?php endif; ?>
-
-				<?php if ($params->get('show_hits')) : ?>
-					<dd class="hits">
-						<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
-					</dd>
-				<?php endif; ?>
-			<?php endif; ?>
-			</dl>
-		</div>
-	<?php endif; ?>
-
-	<?php if ($params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
-		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
-
-		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
-	<?php endif; ?>
-
-	<?php if (!$params->get('show_intro')) : echo $this->item->event->afterDisplayTitle; endif; ?>
-	<?php echo $this->item->event->beforeDisplayContent; ?>
-
-	<?php if (isset($urls) && ((!empty($urls->urls_position) && ($urls->urls_position == '0')) || ($params->get('urls_position') == '0' && empty($urls->urls_position)))
-		|| (empty($urls->urls_position) && (!$params->get('urls_position')))) : ?>
-	<?php echo $this->loadTemplate('links'); ?>
-	<?php endif; ?>
-	<?php if ($params->get('access-view')):?>
-	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
-	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_fulltext_caption):
-		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_fulltext_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/> </div>
-	<?php endif; ?>
-	<?php
-	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
-		echo $this->item->pagination;
-	endif;
-	?>
-	<?php if (isset ($this->item->toc)) :
-		echo $this->item->toc;
-	endif; ?>
-	<?php echo $this->item->text; ?>
-
-	<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
-		<div class="article-info muted">
-			<dl class="article-info">
-			<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
-
-			<?php if ($info == 1) : ?>
-				<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
+				<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
+				<?php if ($params->get('show_author') && !empty($this->item->author)) : ?>
 					<dd class="createdby">
 						<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
 						<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
@@ -204,9 +101,9 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 				<?php endif; ?>
 				<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 					<dd class="parent-category-name">
-						<?php	$title = $this->escape($this->item->parent_title);
-						$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>';?>
-						<?php if ($params->get('link_parent_category') && $this->item->parent_slug) : ?>
+						<?php $title = $this->escape($this->item->parent_title);
+						$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>'; ?>
+						<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
 							<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 						<?php else : ?>
 							<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
@@ -215,8 +112,8 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 				<?php endif; ?>
 				<?php if ($params->get('show_category')) : ?>
 					<dd class="category-name">
-						<?php 	$title = $this->escape($this->item->category_title);
-						$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>';?>
+						<?php $title = $this->escape($this->item->category_title); ?>
+						<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>'; ?>
 						<?php if ($params->get('link_category') && $this->item->catslug) : ?>
 							<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 						<?php else : ?>
@@ -226,72 +123,164 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 				<?php endif; ?>
 				<?php if ($params->get('show_publish_date')) : ?>
 					<dd class="published">
-						<span class="icon-calendar"></span>
-						<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+						<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 					</dd>
 				<?php endif; ?>
-			<?php endif; ?>
-
-			<?php if ($params->get('show_create_date')) : ?>
-				<dd class="create">
-					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
-				</dd>
-			<?php endif; ?>
-			<?php if ($params->get('show_modify_date')) : ?>
-				<dd class="modified">
-					<span class="icon-calendar"></span>
-					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
-				</dd>
-			<?php endif; ?>
-			<?php if ($params->get('show_hits')) : ?>
-				<dd class="hits">
-					<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
-				</dd>
-			<?php endif; ?>
+				<?php if ($info == 0) : ?>
+					<?php if ($params->get('show_modify_date')) : ?>
+						<dd class="modified">
+							<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						</dd>
+					<?php endif; ?>
+					<?php if ($params->get('show_create_date')) : ?>
+						<dd class="create">
+							<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+						</dd>
+					<?php endif; ?>
+					<?php if ($params->get('show_hits')) : ?>
+						<dd class="hits">
+							<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
+						</dd>
+					<?php endif; ?>
+				<?php endif; ?>
 			</dl>
 		</div>
 	<?php endif; ?>
-
-	<?php
-if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && !$this->item->paginationrelative):
-	echo $this->item->pagination;
-?>
+	<?php if ($info == 0 && $params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>
-	<?php if (isset($urls) && ((!empty($urls->urls_position) && ($urls->urls_position == '1')) || ($params->get('urls_position') == '1'))) : ?>
-	<?php echo $this->loadTemplate('links'); ?>
+	<?php if (!$params->get('show_intro')) : echo $this->item->event->afterDisplayTitle; endif; ?>
+	<?php echo $this->item->event->beforeDisplayContent; ?>
+	<?php if (isset($urls) && ((!empty($urls->urls_position) && ($urls->urls_position == '0')) || ($params->get('urls_position') == '0' && empty($urls->urls_position)))
+		|| (empty($urls->urls_position) && (!$params->get('urls_position')))
+	) : ?>
+		<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
-	<?php // Optional teaser intro text for guests ?>
+	<?php if ($params->get('access-view')): ?>
+		<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
+			<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
+			<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"><img
+					<?php if ($images->image_fulltext_caption) : ?>
+						<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
+					<?php endif; ?>
+					src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" />
+			</div>
+		<?php endif; ?>
+		<?php if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative) : ?>
+			<?php echo $this->item->pagination; ?>
+		<?php endif; ?>
+		<?php if (isset ($this->item->toc)) : ?>
+			<?php echo $this->item->toc; ?>
+		<?php endif; ?>
+		<?php echo $this->item->text; ?>
+		<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
+			<div class="article-info muted">
+				<dl class="article-info">
+					<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
+					<?php if ($info == 1) : ?>
+						<?php if ($params->get('show_author') && !empty($this->item->author)) : ?>
+							<dd class="createdby">
+								<?php $author = $this->item->created_by_alias ? $this->item->created_by_alias : $this->item->author; ?>
+								<?php if (!empty($this->item->contact_link) && $params->get('link_author') == true) : ?>
+									<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
+								<?php else: ?>
+									<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
+								<?php endif; ?>
+							</dd>
+						<?php endif; ?>
+						<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
+							<dd class="parent-category-name">
+								<?php    $title = $this->escape($this->item->parent_title);
+								$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>'; ?>
+								<?php if ($params->get('link_parent_category') && $this->item->parent_slug) : ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
+								<?php else : ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', $title); ?>
+								<?php endif; ?>
+							</dd>
+						<?php endif; ?>
+						<?php if ($params->get('show_category')) : ?>
+							<dd class="category-name">
+								<?php $title = $this->escape($this->item->category_title); ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)) . '">' . $title . '</a>'; ?>
+								<?php if ($params->get('link_category') && $this->item->catslug) : ?>
+									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
+								<?php else : ?>
+									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $title); ?>
+								<?php endif; ?>
+							</dd>
+						<?php endif; ?>
+						<?php if ($params->get('show_publish_date')) : ?>
+							<dd class="published">
+								<span class="icon-calendar"></span>
+								<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+							</dd>
+						<?php endif; ?>
+					<?php endif; ?>
+					<?php if ($params->get('show_create_date')) : ?>
+						<dd class="create">
+							<span class="icon-calendar"></span>
+							<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
+						</dd>
+					<?php endif; ?>
+					<?php if ($params->get('show_modify_date')) : ?>
+						<dd class="modified">
+							<span class="icon-calendar"></span>
+							<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+						</dd>
+					<?php endif; ?>
+					<?php if ($params->get('show_hits')) : ?>
+						<dd class="hits">
+							<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
+						</dd>
+					<?php endif; ?>
+				</dl>
+				<?php if ($params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+					<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+					<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
+				<?php endif; ?>
+			</div>
+		<?php endif; ?>
+		<?php if ($info != 0 && $params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+			<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+			<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
+		<?php endif; ?>
+		<?php if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && !$this->item->paginationrelative) : ?>
+			<?php echo $this->item->pagination; ?>
+		<?php endif; ?>
+		<?php if (isset($urls) && ((!empty($urls->urls_position) && ($urls->urls_position == '1')) || ($params->get('urls_position') == '1'))) : ?>
+			<?php echo $this->loadTemplate('links'); ?>
+		<?php endif; ?>
+		<?php // Optional teaser intro text for guests ?>
 	<?php elseif ($params->get('show_noauth') == true && $user->get('guest')) : ?>
-	<?php echo $this->item->introtext; ?>
-	<?php //Optional link to let them register to see the whole article. ?>
-	<?php if ($params->get('show_readmore') && $this->item->fulltext != null) :
-		$link1 = JRoute::_('index.php?option=com_users&view=login');
-		$link = new JUri($link1);?>
-	<p class="readmore">
-		<a href="<?php echo $link; ?>">
-		<?php $attribs = json_decode($this->item->attribs); ?>
-		<?php
-		if ($attribs->alternative_readmore == null) :
-			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		elseif ($readmore = $this->item->alternative_readmore) :
-			echo $readmore;
-			if ($params->get('show_readmore_title', 0) != 0) :
-				echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-			endif;
-		elseif ($params->get('show_readmore_title', 0) == 0) :
-			echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-		else :
-			echo JText::_('COM_CONTENT_READ_MORE');
-			echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-		endif; ?>
-		</a>
-	</p>
+		<?php echo $this->item->introtext; ?>
+		<?php //Optional link to let them register to see the whole article. ?>
+		<?php if ($params->get('show_readmore') && $this->item->fulltext != null) : ?>
+			<?php $link1 = JRoute::_('index.php?option=com_users&view=login'); ?>
+			<?php $link  = new JUri($link1); ?>
+			<p class="readmore">
+				<a href="<?php echo $link; ?>">
+					<?php $attribs = json_decode($this->item->attribs); ?>
+					<?php if ($attribs->alternative_readmore == null) : ?>
+						<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
+					<?php elseif ($readmore = $this->item->alternative_readmore) : ?>
+						<?php echo $readmore; ?>
+						<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+							<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+						<?php endif; ?>
+					<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
+						<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+					<?php else : ?>
+						<?php echo JText::_('COM_CONTENT_READ_MORE'); ?>
+						<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+					<?php endif; ?>
+				</a>
+			</p>
+		<?php endif; ?>
 	<?php endif; ?>
+	<?php if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && $this->item->paginationrelative) : ?>
+		<?php echo $this->item->pagination; ?>
 	<?php endif; ?>
-	<?php
-if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && $this->item->paginationrelative) :
-	echo $this->item->pagination;
-?>
-	<?php endif; ?>
-	<?php echo $this->item->event->afterDisplayContent; ?> </div>
+	<?php echo $this->item->event->afterDisplayContent; ?>
+</div>

--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -1,288 +1,253 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_content_article_view_default_title" option="com_content_article_view_default_option">
+	<layout title="com_content_article_view_default_title"
+	        option="com_content_article_view_default_option">
 		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_SINGLE_ARTICLE"
-		/>
+				key="JHELP_MENUS_MENU_ITEM_ARTICLE_SINGLE_ARTICLE"
+				/>
 		<message>
 			<![CDATA[com_content_article_view_default_desc]]>
 		</message>
 	</layout>
-
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
 		<fieldset name="request"
-			addfieldpath="/administrator/components/com_content/models/fields">
-
-			<field name="id" type="modal_article"
-				label="COM_CONTENT_FIELD_SELECT_ARTICLE_LABEL"
-				required="true"
-				edit="true"
-				clear="false"
-				description="COM_CONTENT_FIELD_SELECT_ARTICLE_DESC"
-			/>
+		          addfieldpath="/administrator/components/com_content/models/fields">
+			<field name="id"
+			       type="modal_article"
+			       label="COM_CONTENT_FIELD_SELECT_ARTICLE_LABEL"
+			       required="true"
+			       edit="true"
+			       clear="false"
+			       description="COM_CONTENT_FIELD_SELECT_ARTICLE_DESC"
+					/>
 		</fieldset>
 	</fields>
-
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">
-
 		<!-- Basic options. -->
 		<fieldset name="basic"
-			label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL">
-
-		<field
-			name="show_title"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_TITLE_LABEL"
-			description="JGLOBAL_SHOW_TITLE_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="link_titles"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_LINKED_TITLES_LABEL"
-			description="JGLOBAL_LINKED_TITLES_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-
-		<field 
-			name="show_intro" 
-			type="radio"
-			class="btn-group"
-			description="JGLOBAL_SHOW_INTRO_DESC"
-			label="JGLOBAL_SHOW_INTRO_LABEL">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="info_block_position"
-			type="radio"
-			class="btn-group"
-			label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-			description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
-			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
-			<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
-		</field>
-
-
-		<field
-			name="show_category"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_CATEGORY_LABEL"
-			description="JGLOBAL_SHOW_CATEGORY_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="link_category"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_LINK_CATEGORY_LABEL"
-			description="JGLOBAL_LINK_CATEGORY_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-
-		<field
-			name="show_parent_category"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-			description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="link_parent_category"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-			description="JGLOBAL_LINK_PARENT_CATEGORY_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-
-		<field
-			name="show_author"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_AUTHOR_LABEL"
-			description="JGLOBAL_SHOW_AUTHOR_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="link_author"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_LINK_AUTHOR_LABEL"
-			description="JGLOBAL_LINK_AUTHOR_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-
-		<field
-			name="show_create_date"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-			description="JGLOBAL_SHOW_CREATE_DATE_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_modify_date"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-			description="JGLOBAL_SHOW_MODIFY_DATE_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_publish_date"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-			description="JGLOBAL_SHOW_PUBLISH_DATE_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_item_navigation"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-			description="JGLOBAL_SHOW_NAVIGATION_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_vote"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field name="show_tags" 
-			type="radio"
-			class="btn-group"
-			label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
-			description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_icons"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_ICONS_LABEL"
-			description="JGLOBAL_SHOW_ICONS_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_print_icon"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-			description="JGLOBAL_SHOW_PRINT_ICON_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_email_icon"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-			description="JGLOBAL_SHOW_EMAIL_ICON_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_hits"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_HITS_LABEL"
-			description="JGLOBAL_SHOW_HITS_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_tags"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_TAGS_LABEL"
-			description="JGLOBAL_SHOW_TAGS_DESC">
-			<option	value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
-		<field
-			name="show_noauth"
-			type="radio"
-			class="btn-group"
-			label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-			description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-		<field
-			name="urls_position"
-			type="radio"
-			class="btn-group"
-		    	label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
-			description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
-			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
-		</field>
+		          label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL">
+			<field
+					name="show_title"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_TITLE_LABEL"
+					description="JGLOBAL_SHOW_TITLE_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="link_titles"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_LINKED_TITLES_LABEL"
+					description="JGLOBAL_LINKED_TITLES_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field
+					name="show_intro"
+					type="radio"
+					class="btn-group"
+					description="JGLOBAL_SHOW_INTRO_DESC"
+					label="JGLOBAL_SHOW_INTRO_LABEL">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="info_block_position"
+					type="radio"
+					class="btn-group"
+					label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+					description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
+				<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
+				<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
+			</field>
+			<field
+					name="show_category"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_CATEGORY_LABEL"
+					description="JGLOBAL_SHOW_CATEGORY_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="link_category"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_LINK_CATEGORY_LABEL"
+					description="JGLOBAL_LINK_CATEGORY_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field
+					name="show_parent_category"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+					description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="link_parent_category"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+					description="JGLOBAL_LINK_PARENT_CATEGORY_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field
+					name="show_author"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_AUTHOR_LABEL"
+					description="JGLOBAL_SHOW_AUTHOR_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="link_author"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_LINK_AUTHOR_LABEL"
+					description="JGLOBAL_LINK_AUTHOR_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field
+					name="show_create_date"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+					description="JGLOBAL_SHOW_CREATE_DATE_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_modify_date"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+					description="JGLOBAL_SHOW_MODIFY_DATE_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_publish_date"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+					description="JGLOBAL_SHOW_PUBLISH_DATE_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_item_navigation"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+					description="JGLOBAL_SHOW_NAVIGATION_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_vote"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_VOTE_LABEL"
+					description="JGLOBAL_SHOW_VOTE_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_icons"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_ICONS_LABEL"
+					description="JGLOBAL_SHOW_ICONS_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_print_icon"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+					description="JGLOBAL_SHOW_PRINT_ICON_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_email_icon"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
+					description="JGLOBAL_SHOW_EMAIL_ICON_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_hits"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_HITS_LABEL"
+					description="JGLOBAL_SHOW_HITS_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field name="show_tags"
+			       type="radio"
+			       class="btn-group"
+			       label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+			       description="COM_CONTENT_FIELD_SHOW_TAGS_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field
+					name="show_noauth"
+					type="radio"
+					class="btn-group"
+					label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+					description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field
+					name="urls_position"
+					type="radio"
+					class="btn-group"
+					label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
+					description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
+				<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
+			</field>
 		</fieldset>
 	</fields>
 </metadata>

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -19,7 +19,6 @@ JHtml::_('behavior.caption');
 			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 		</div>
 	<?php endif; ?>
-
 	<?php if ($this->params->get('show_category_title', 1) or $this->params->get('page_subheading')) : ?>
 		<h2> <?php echo $this->escape($this->params->get('page_subheading')); ?>
 			<?php if ($this->params->get('show_category_title')) : ?>
@@ -27,12 +26,10 @@ JHtml::_('behavior.caption');
 			<?php endif; ?>
 		</h2>
 	<?php endif; ?>
-
-	<?php if ($this->params->get('show_tags', 1) && !empty($this->category->tags->itemTags)) : ?>
+	<?php if ($this->params->get('show_cat_tags', 1) && !empty($this->category->tags->itemTags)) : ?>
 		<?php $this->category->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->category->tagLayout->render($this->category->tags->itemTags); ?>
 	<?php endif; ?>
-
 	<?php if ($this->params->get('show_description', 1) || $this->params->def('show_description_image', 1)) : ?>
 		<div class="category-desc clearfix">
 			<?php if ($this->params->get('show_description_image') && $this->category->getParams()->get('image')) : ?>
@@ -43,64 +40,52 @@ JHtml::_('behavior.caption');
 			<?php endif; ?>
 		</div>
 	<?php endif; ?>
-
 	<?php if (empty($this->lead_items) && empty($this->link_items) && empty($this->intro_items)) : ?>
 		<?php if ($this->params->get('show_no_articles', 1)) : ?>
 			<p><?php echo JText::_('COM_CONTENT_NO_ARTICLES'); ?></p>
 		<?php endif; ?>
 	<?php endif; ?>
-
 	<?php $leadingcount = 0; ?>
 	<?php if (!empty($this->lead_items)) : ?>
 		<div class="items-leading clearfix">
 			<?php foreach ($this->lead_items as &$item) : ?>
 				<div
 					class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>">
-					<?php
-					$this->item = & $item;
-					echo $this->loadTemplate('item');
-					?>
+					<?php $this->item = & $item; ?>
+					<?php echo $this->loadTemplate('item'); ?>
 				</div>
 				<?php $leadingcount++; ?>
 			<?php endforeach; ?>
 		</div><!-- end items-leading -->
 	<?php endif; ?>
-
-	<?php
-	$introcount = (count($this->intro_items));
-	$counter = 0;
-	?>
-
+	<?php $introcount = (count($this->intro_items)); ?>
+	<?php $counter = 0;	?>
 	<?php if (!empty($this->intro_items)) : ?>
 		<?php foreach ($this->intro_items as $key => &$item) : ?>
 			<?php $rowcount = ((int) $key % (int) $this->columns) + 1; ?>
 			<?php if ($rowcount == 1) : ?>
 				<?php $row = $counter / $this->columns; ?>
 				<div class="items-row cols-<?php echo (int) $this->columns; ?> <?php echo 'row-' . $row; ?> row-fluid clearfix">
-			<?php endif; ?>
-			<div class="span<?php echo round((12 / $this->columns)); ?>">
-				<div
-					class="item column-<?php echo $rowcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>">
-					<?php
-					$this->item = & $item;
-					echo $this->loadTemplate('item');
-					?>
-				</div>
-				<!-- end item -->
-				<?php $counter++; ?>
-			</div><!-- end span -->
-			<?php if (($rowcount == $this->columns) or ($counter == $introcount)) : ?>
+					<?php endif; ?>
+					<div class="span<?php echo round((12 / $this->columns)); ?>">
+						<div
+							class="item column-<?php echo $rowcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>">
+							<?php $this->item = & $item; ?>
+							<?php echo $this->loadTemplate('item'); ?>
+						</div>
+						<!-- end item -->
+						<?php $counter++; ?>
+					</div><!-- end span -->
+					<?php if (($rowcount == $this->columns) or ($counter == $introcount)) : ?>
 				</div><!-- end row -->
 			<?php endif; ?>
 		<?php endforeach; ?>
 	<?php endif; ?>
-
 	<?php if (!empty($this->link_items)) : ?>
 		<div class="items-more">
 			<?php echo $this->loadTemplate('links'); ?>
 		</div>
 	<?php endif; ?>
-
 	<?php if (!empty($this->children[$this->category->id]) && $this->maxLevel != 0) : ?>
 		<div class="cat-children">
 			<?php if ($this->params->get('show_category_heading_title_text', 1) == 1) : ?>

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -1,76 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="COM_CONTENT_CATEGORY_VIEW_BLOG_TITLE" option="COM_CONTENT_CATEGORY_VIEW_BLOG_OPTION">
+	<layout title="COM_CONTENT_CATEGORY_VIEW_BLOG_TITLE"
+	        option="COM_CONTENT_CATEGORY_VIEW_BLOG_OPTION">
 		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG"
-		/>
+				key="JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG"
+				/>
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_BLOG_DESC]]>
 		</message>
 	</layout>
-
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
 		<fieldset name="request"
-		 >
-
-			<field name="id" type="category"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
-				extension="com_content"
-				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
-				required="true"
-			/>
+				>
+			<field name="id"
+			       type="category"
+			       description="JGLOBAL_CHOOSE_CATEGORY_DESC"
+			       extension="com_content"
+			       label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+			       required="true"
+					/>
 		</fieldset>
 	</fields>
-
 	<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
-
+	<fields name="params">
+		<fieldset name="basic"
+		          label="JGLOBAL_CATEGORY_OPTIONS">
 			<field name="layout_type"
-				type="hidden"
-				default="blog"
-			/>
-		  	<field name="show_category_heading_title_text"
-				type="list"
- 				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-		</field>
-			<field name="show_category_title" type="list"
-				label="JGLOBAL_SHOW_CATEGORY_TITLE"
-				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-			>
+			       type="hidden"
+			       default="blog"
+					/>
+			<field name="show_category_heading_title_text"
+			       type="list"
+			       label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+			       description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_description" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-			>
+			<field name="show_category_title"
+			       type="list"
+			       label="JGLOBAL_SHOW_CATEGORY_TITLE"
+			       description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_description_image" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-			>
+			<field name="show_description"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="maxLevel" type="list"
-				description="JGLOBAL_MAXLEVEL_DESC"
-				label="JGLOBAL_MAXLEVEL_LABEL"
-			>
+			<field name="show_description_image"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="maxLevel"
+			       type="list"
+			       description="JGLOBAL_MAXLEVEL_DESC"
+			       label="JGLOBAL_MAXLEVEL_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="-1">JALL</option>
 				<option value="0">JNONE</option>
@@ -80,99 +80,109 @@
 				<option value="4">J4</option>
 				<option value="5">J5</option>
 			</field>
-
-			<field name="show_empty_categories" type="list"
-				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-				description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-			>
+			<field name="show_empty_categories"
+			       type="list"
+			       label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+			       description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_no_articles" type="list"
-				label="COM_CONTENT_NO_ARTICLES_LABEL"
-				description="COM_CONTENT_NO_ARTICLES_DESC"
-				>
+			<field name="show_no_articles"
+			       type="list"
+			       label="COM_CONTENT_NO_ARTICLES_LABEL"
+			       description="COM_CONTENT_NO_ARTICLES_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_subcat_desc" type="list"
-			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-			>
+			<field name="show_subcat_desc"
+			       type="list"
+			       label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+			       description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_cat_num_articles" type="list"
-				label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-				description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-			>
+			<field name="show_cat_num_articles"
+			       type="list"
+			       label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+			       description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="page_subheading" type="text"
-				description="JGLOBAL_SUBHEADING_DESC"
-				label="JGLOBAL_SUBHEADING_LABEL"
-				size="20"
-			/>
-
-</fieldset>
-
-<fieldset name="advanced" label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
-
-			<field name="bloglayout" type="spacer" class="text"
-					label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
-			/>
-
-
-			<field name="num_leading_articles" type="text"
-				description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
-				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-				size="3"
-			/>
-
-			<field name="num_intro_articles" type="text"
-				description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
-				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-				size="3"
-			/>
-
-			<field name="num_columns" type="text"
-				description="JGLOBAL_NUM_COLUMNS_DESC"
-				label="JGLOBAL_NUM_COLUMNS_LABEL"
-				size="3"
-			/>
-
-			<field name="num_links" type="text"
-				description="JGLOBAL_NUM_LINKS_DESC"
-				label="JGLOBAL_NUM_LINKS_LABEL"
-				size="3"
-			/>
-
-			<field name="multi_column_order" type="list"
-				description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
-				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-			>
+			<field name="show_cat_tags"
+			       type="list"
+			       label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+			       description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="page_subheading"
+			       type="text"
+			       description="JGLOBAL_SUBHEADING_DESC"
+			       label="JGLOBAL_SUBHEADING_LABEL"
+			       size="20"
+					/>
+		</fieldset>
+		<fieldset name="advanced"
+		          label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
+			<field name="bloglayout"
+			       type="spacer"
+			       class="text"
+			       label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
+					/>
+			<field name="num_leading_articles"
+			       type="text"
+			       description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
+			       label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
+			       size="3"
+					/>
+			<field name="num_intro_articles"
+			       type="text"
+			       description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
+			       label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
+			       size="3"
+					/>
+			<field name="num_columns"
+			       type="text"
+			       description="JGLOBAL_NUM_COLUMNS_DESC"
+			       label="JGLOBAL_NUM_COLUMNS_LABEL"
+			       size="3"
+					/>
+			<field name="num_links"
+			       type="text"
+			       description="JGLOBAL_NUM_LINKS_DESC"
+			       label="JGLOBAL_NUM_LINKS_LABEL"
+			       size="3"
+					/>
+			<field name="multi_column_order"
+			       type="list"
+			       description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
+			       label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JGLOBAL_DOWN</option>
 				<option value="1">JGLOBAL_ACROSS</option>
 			</field>
-			<field name="subcategories" type="spacer" class="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-			/>
+			<field name="subcategories"
+			       type="spacer"
+			       class="spacer"
+			       label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
+					/>
+			<field name="show_subcategory_content"
+			       type="list"
 
-		<field name="show_subcategory_content" type="list"
-
-				description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
-				label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
-			>
+			       description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
+			       label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNONE</option>
 				<option value="-1">JALL</option>
@@ -182,28 +192,27 @@
 				<option value="4">J4</option>
 				<option value="5">J5</option>
 			</field>
-
 			<field
-			name="spacer1"
-			type="spacer"
-			hr="true"
-			/>
-
-			<field name="orderby_pri" type="list"
-				description="JGLOBAL_CATEGORY_ORDER_DESC"
-				label="JGLOBAL_CATEGORY_ORDER_LABEL"
-			>
+					name="spacer1"
+					type="spacer"
+					hr="true"
+					/>
+			<field name="orderby_pri"
+			       type="list"
+			       description="JGLOBAL_CATEGORY_ORDER_DESC"
+			       label="JGLOBAL_CATEGORY_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="none">JGLOBAL_NO_ORDER</option>
 				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
 				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
 				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
 			</field>
-
-			<field name="orderby_sec" type="list"
-				description="JGLOBAL_ARTICLE_ORDER_DESC"
-				label="JGLOBAL_ARTICLE_ORDER_LABEL"
-			>
+			<field name="orderby_sec"
+			       type="list"
+			       description="JGLOBAL_ARTICLE_ORDER_DESC"
+			       label="JGLOBAL_ARTICLE_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
 				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
@@ -216,287 +225,292 @@
 				<option value="rhits">JGLOBAL_LEAST_HITS</option>
 				<option value="order">JGLOBAL_ORDERING</option>
 			</field>
-
-			<field name="order_date" type="list"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
-			>
+			<field name="order_date"
+			       type="list"
+			       description="JGLOBAL_ORDERING_DATE_DESC"
+			       label="JGLOBAL_ORDERING_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
 			</field>
-
-			<field name="show_pagination" type="list"
-				description="JGLOBAL_PAGINATION_DESC"
-				label="JGLOBAL_PAGINATION_LABEL"
-			>
+			<field name="show_pagination"
+			       type="list"
+			       description="JGLOBAL_PAGINATION_DESC"
+			       label="JGLOBAL_PAGINATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
-
-			<field name="show_pagination_results" type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
+			<field name="show_pagination_results"
+			       type="list"
+			       label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+			       description="JGLOBAL_PAGINATION_RESULTS_DESC">
 
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-</fieldset>
-
-<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field name="show_title" type="list"
-				description="JGLOBAL_SHOW_TITLE_DESC"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-			>
+		</fieldset>
+		<fieldset name="article"
+		          label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+			<field name="show_title"
+			       type="list"
+			       description="JGLOBAL_SHOW_TITLE_DESC"
+			       label="JGLOBAL_SHOW_TITLE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_titles" type="list"
-				description="JGLOBAL_LINKED_TITLES_DESC"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-			>
+			<field name="link_titles"
+			       type="list"
+			       description="JGLOBAL_LINKED_TITLES_DESC"
+			       label="JGLOBAL_LINKED_TITLES_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_intro" type="list"
-				description="JGLOBAL_SHOW_INTRO_DESC"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-			>
+			<field name="show_intro"
+			       type="list"
+			       description="JGLOBAL_SHOW_INTRO_DESC"
+			       label="JGLOBAL_SHOW_INTRO_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-				name="info_block_position"
-				type="list"
-				default=""
-				label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-				description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+					name="info_block_position"
+					type="list"
+					default=""
+					label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+					description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 				<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 				<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 			</field>
-
-			<field name="show_category" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-			>
+			<field name="show_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_category" type="list"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-			>
+			<field name="link_category"
+			       type="list"
+			       description="JGLOBAL_LINK_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_parent_category" type="list"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-			>
+			<field name="show_parent_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_parent_category" type="list"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-			>
+			<field name="link_parent_category"
+			       type="list"
+			       description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_author" type="list"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-			>
+			<field name="show_author"
+			       type="list"
+			       description="JGLOBAL_SHOW_AUTHOR_DESC"
+			       label="JGLOBAL_SHOW_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_author" type="list"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-			>
+			<field name="link_author"
+			       type="list"
+			       description="JGLOBAL_LINK_AUTHOR_DESC"
+			       label="JGLOBAL_LINK_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNo</option>
 				<option value="1">JYes</option>
 			</field>
-
-			<field name="show_create_date" type="list"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-			>
+			<field name="show_create_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+			       label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_modify_date" type="list"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-			>
+			<field name="show_modify_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+			       label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_publish_date" type="list"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-			>
+			<field name="show_publish_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+			       label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_item_navigation" type="list"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-			>
+			<field name="show_item_navigation"
+			       type="list"
+			       description="JGLOBAL_SHOW_NAVIGATION_DESC"
+			       label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-
 			<field
-			name="show_vote" type="list"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-			<option value="0">JHIDE</option>
-			<option	value="1">JSHOW</option>
-		</field>
-
+					name="show_vote"
+					type="list"
+					label="JGLOBAL_SHOW_VOTE_LABEL"
+					description="JGLOBAL_SHOW_VOTE_DESC"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
 			<field
-				name="show_readmore"
-				type="list"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-			>
+					name="show_readmore"
+					type="list"
+					description="JGLOBAL_SHOW_READMORE_DESC"
+					label="JGLOBAL_SHOW_READMORE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-				name="show_readmore_title"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-			>
+					name="show_readmore_title"
+					type="list"
+					label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+					description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_icons" type="list"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="show_print_icon" type="list"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-			>
+			<field name="show_icons"
+			       type="list"
+			       description="JGLOBAL_SHOW_ICONS_DESC"
+			       label="JGLOBAL_SHOW_ICONS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_email_icon" type="list"
-				description="JGLOBAL_Show_Email_Icon_Desc"
-				label="JGLOBAL_Show_Email_Icon_Label"
-			>
+			<field name="show_print_icon"
+			       type="list"
+			       description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+			       label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_hits" type="list"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-			>
+			<field name="show_email_icon"
+			       type="list"
+			       description="JGLOBAL_Show_Email_Icon_Desc"
+			       label="JGLOBAL_Show_Email_Icon_Label"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_noauth" type="list"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-			>
+			<field name="show_hits"
+			       type="list"
+			       description="JGLOBAL_SHOW_HITS_DESC"
+			       label="JGLOBAL_SHOW_HITS_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="show_tags"
+			       type="list"
+			       description="COM_CONTENT_FIELD_SHOW_TAGS_DESC"
+			       label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="show_noauth"
+			       type="list"
+			       description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
+			       label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-</fieldset>
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
-		>
-
-			<field name="show_feed_link" type="list"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-			>
+		</fieldset>
+		<fieldset name="integration"
+		          label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
+				>
+			<field name="show_feed_link"
+			       type="list"
+			       description="JGLOBAL_SHOW_FEED_LINK_DESC"
+			       label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="feed_summary" type="list"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-			>
+			<field name="feed_summary"
+			       type="list"
+			       description="JGLOBAL_FEED_SUMMARY_DESC"
+			       label="JGLOBAL_FEED_SUMMARY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JGLOBAL_INTRO_TEXT</option>
 				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
-</fields>
+	</fields>
 </metadata>

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -7,79 +7,71 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;?>
-<?php
-// Create a shortcut for params.
-$params = $this->item->params;
-JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
-$canEdit = $this->item->params->get('access-edit');
+defined('_JEXEC') or die;
+
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
 JHtml::_('behavior.framework');
+
+// Create a shortcut for params.
+$params     = $this->item->params;
+$canEdit    = $this->item->params->get('access-edit');
 ?>
 <?php if ($this->item->state == 0 || strtotime($this->item->publish_up) > strtotime(JFactory::getDate())
-	|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
+|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00')) : ?>
 	<div class="system-unpublished">
 <?php endif; ?>
-
 <?php echo JLayoutHelper::render('joomla.content.blog_style_default_item_title', $this->item); ?>
-
 <?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
-
+<?php if ($params->get('show_tags') && !empty($this->item->tags->itemTags)) : ?>
+	<?php echo JLayoutHelper::render('joomla.content.tags', $this->item->tags->itemTags); ?>
+<?php endif; ?>
 <?php // Todo Not that elegant would be nice to group the params ?>
 <?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
-	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') ); ?>
-
+|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author')); ?>
 <?php if ($useDefList) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'above')); ?>
 <?php endif; ?>
-
 <?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
-
-
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 <?php endif; ?>
 <?php echo $this->item->event->beforeDisplayContent; ?> <?php echo $this->item->introtext; ?>
-
 <?php if ($useDefList) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'below')); ?>
-<?php  endif; ?>
-
-<?php if ($params->get('show_readmore') && $this->item->readmore) :
-	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
-	else :
-		$menu = JFactory::getApplication()->getMenu();
-		$active = $menu->getActive();
-		$itemId = $active->id;
-		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
-		$link = new JUri($link1);
-		$link->setVar('return', base64_encode($returnURL));
-	endif; ?>
-
-	<p class="readmore"><a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
-
-	<?php if (!$params->get('access-view')) :
-		echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-	elseif ($readmore = $this->item->alternative_readmore) :
-		echo $readmore;
-		if ($params->get('show_readmore_title', 0) != 0) :
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-		endif;
-	elseif ($params->get('show_readmore_title', 0) == 0) :
-		echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-	else :
-		echo JText::_('COM_CONTENT_READ_MORE');
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-	endif; ?>
-
-	</a></p>
-
 <?php endif; ?>
-
+<?php if ($params->get('show_readmore') && $this->item->readmore) : ?>
+	<?php if ($params->get('access-view')) : ?>
+		<?php $link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
+	<?php else : ?>
+		<?php $menu      = JFactory::getApplication()->getMenu(); ?>
+		<?php $active    = $menu->getActive(); ?>
+		<?php $itemId    = $active->id; ?>
+		<?php $link1     = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId); ?>
+		<?php $returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
+		<?php $link      = new JUri($link1); ?>
+		<?php $link->setVar('return', base64_encode($returnURL)); ?>
+	<?php endif; ?>
+	<p class="readmore">
+		<a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
+			<?php if (!$params->get('access-view')) : ?>
+				<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
+			<?php elseif ($readmore = $this->item->alternative_readmore) : ?>
+				<?php echo $readmore; ?>
+				<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+					<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+				<?php endif; ?>
+			<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
+				<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+			<?php else : ?>
+				<?php echo JText::_('COM_CONTENT_READ_MORE'); ?>
+				<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+			<?php endif; ?>
+		</a>
+	</p>
+<?php endif; ?>
 <?php if ($this->item->state == 0 || strtotime($this->item->publish_up) > strtotime(JFactory::getDate())
-	|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
-</div>
+|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00')) : ?>
+	</div>
 <?php endif; ?>
-
 <?php echo $this->item->event->afterDisplayContent; ?>

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="COM_CONTENT_CATEGORY_VIEW_DEFAULT_TITLE" option="COM_CONTENT_CATEGORY_VIEW_DEFAULT_OPTION">
+	<layout title="COM_CONTENT_CATEGORY_VIEW_DEFAULT_TITLE"
+	        option="COM_CONTENT_CATEGORY_VIEW_DEFAULT_OPTION">
 		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_LIST"
-		/>
+				key="JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_LIST"
+				/>
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
-
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
 		<fieldset name="request"
-		>
-
-			<field name="id" type="category"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
-				extension="com_content"
-				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
-				required="true"
-			/>
+				>
+			<field name="id"
+			       type="category"
+			       description="JGLOBAL_CHOOSE_CATEGORY_DESC"
+			       extension="com_content"
+			       label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+			       required="true"
+					/>
 		</fieldset>
 	</fields>
-
 	<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
-
-			<field name="show_category_title" type="list"
-				label="JGLOBAL_SHOW_CATEGORY_TITLE"
-				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-			>
+	<fields name="params">
+		<fieldset name="basic"
+		          label="JGLOBAL_CATEGORY_OPTIONS">
+			<field name="show_category_title"
+			       type="list"
+			       label="JGLOBAL_SHOW_CATEGORY_TITLE"
+			       description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_description" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-			>
+			<field name="show_description"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_description_image" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-			>
+			<field name="show_description_image"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="maxLevel" type="list"
-				description="JGLOBAL_MAXLEVEL_DESC"
-				label="JGLOBAL_MAXLEVEL_LABEL"
-			>
+			<field name="maxLevel"
+			       type="list"
+			       description="JGLOBAL_MAXLEVEL_DESC"
+			       label="JGLOBAL_MAXLEVEL_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="-1">JALL</option>
 				<option value="0">JNONE</option>
@@ -67,154 +67,153 @@
 				<option value="4">J4</option>
 				<option value="5">J5</option>
 			</field>
-
-			<field name="show_empty_categories" type="list"
-				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-				description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-			>
+			<field name="show_empty_categories"
+			       type="list"
+			       label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+			       description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_no_articles" type="list"
-				label="COM_CONTENT_NO_ARTICLES_LABEL"
-				description="COM_CONTENT_NO_ARTICLES_DESC"
-				>
+			<field name="show_no_articles"
+			       type="list"
+			       label="COM_CONTENT_NO_ARTICLES_LABEL"
+			       description="COM_CONTENT_NO_ARTICLES_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
 			<field name="show_category_heading_title"
-					type="list"
- 					label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-					description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-			</field>
-			<field name="show_subcat_desc" type="list"
-			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-			>
+			       type="list"
+			       label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+			       description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_cat_num_articles" type="list"
-				label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-				description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-			>
+			<field name="show_subcat_desc"
+			       type="list"
+			       label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+			       description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_tags" type="list"
-				label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
-				description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
-			>
+			<field name="show_cat_num_articles"
+			       type="list"
+			       label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+			       description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="page_subheading" type="text"
-				description="JGLOBAL_SUBHEADING_DESC"
-				label="JGLOBAL_SUBHEADING_LABEL"
-				size="20"
-			/>
-
-</fieldset>
-
-<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
-
-			<field name="show_pagination_limit" type="list"
-				description="JGLOBAL_DISPLAY_SELECT_DESC"
-				label="JGLOBAL_DISPLAY_SELECT_LABEL"
-			>
+			<field name="show_cat_tags"
+			       type="list"
+			       label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+			       description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="filter_field" type="list"
-				description="JGLOBAL_FILTER_FIELD_DESC"
-				label="JGLOBAL_FILTER_FIELD_LABEL"
-			>
+			<field name="page_subheading"
+			       type="text"
+			       description="JGLOBAL_SUBHEADING_DESC"
+			       label="JGLOBAL_SUBHEADING_LABEL"
+			       size="20"
+					/>
+		</fieldset>
+		<fieldset name="advanced"
+		          label="JGLOBAL_LIST_LAYOUT_OPTIONS">
+			<field name="show_pagination_limit"
+			       type="list"
+			       description="JGLOBAL_DISPLAY_SELECT_DESC"
+			       label="JGLOBAL_DISPLAY_SELECT_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="filter_field"
+			       type="list"
+			       description="JGLOBAL_FILTER_FIELD_DESC"
+			       label="JGLOBAL_FILTER_FIELD_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="hide">JHIDE</option>
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
 			</field>
-
-			<field name="show_headings" type="list"
-				description="JGLOBAL_SHOW_HEADINGS_DESC"
-				label="JGLOBAL_SHOW_HEADINGS_LABEL"
-			>
+			<field name="show_headings"
+			       type="list"
+			       description="JGLOBAL_SHOW_HEADINGS_DESC"
+			       label="JGLOBAL_SHOW_HEADINGS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="list_show_date" type="list"
-				description="JGLOBAL_SHOW_DATE_DESC"
-				label="JGLOBAL_SHOW_DATE_LABEL"
-			>
+			<field name="list_show_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_DATE_DESC"
+			       label="JGLOBAL_SHOW_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
 			</field>
-
-			<field name="date_format" type="text"
-				description="JGLOBAL_DATE_FORMAT_DESC"
-				label="JGLOBAL_DATE_FORMAT_LABEL"
-				size="15"
-			/>
-
-			<field name="list_show_hits" type="list"
-				description="JGLOBAL_LIST_HITS_DESC"
-				label="JGLOBAL_LIST_HITS_LABEL"
-			>
+			<field name="date_format"
+			       type="text"
+			       description="JGLOBAL_DATE_FORMAT_DESC"
+			       label="JGLOBAL_DATE_FORMAT_LABEL"
+			       size="15"
+					/>
+			<field name="list_show_hits"
+			       type="list"
+			       description="JGLOBAL_LIST_HITS_DESC"
+			       label="JGLOBAL_LIST_HITS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="list_show_author" type="list"
-				description="JGLOBAL_LIST_AUTHOR_DESC"
-				label="JGLOBAL_LIST_AUTHOR_LABEL"
-			>
+			<field name="list_show_author"
+			       type="list"
+			       description="JGLOBAL_LIST_AUTHOR_DESC"
+			       label="JGLOBAL_LIST_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-			name="spacer1"
-			type="spacer"
-			hr="true"
-			/>
-
-			<field name="orderby_pri" type="list"
-				description="JGLOBAL_CATEGORY_ORDER_DESC"
-				label="JGLOBAL_CATEGORY_ORDER_LABEL"
-			>
+					name="spacer1"
+					type="spacer"
+					hr="true"
+					/>
+			<field name="orderby_pri"
+			       type="list"
+			       description="JGLOBAL_CATEGORY_ORDER_DESC"
+			       label="JGLOBAL_CATEGORY_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="none">JGLOBAL_NO_ORDER</option>
 				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
 				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
 				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
 			</field>
-
-			<field name="orderby_sec" type="list"
-				description="JGLOBAL_ARTICLE_ORDER_DESC"
-				label="JGLOBAL_ARTICLE_ORDER_LABEL"
-			>
+			<field name="orderby_sec"
+			       type="list"
+			       description="JGLOBAL_ARTICLE_ORDER_DESC"
+			       label="JGLOBAL_ARTICLE_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
 				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
@@ -227,39 +226,40 @@
 				<option value="rhits">JGLOBAL_LEAST_HITS</option>
 				<option value="order">JGLOBAL_ORDERING</option>
 			</field>
-
-			<field name="order_date" type="list"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
-			>
+			<field name="order_date"
+			       type="list"
+			       description="JGLOBAL_ORDERING_DATE_DESC"
+			       label="JGLOBAL_ORDERING_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
 			</field>
-
-			<field name="show_pagination" type="list"
-				description="JGLOBAL_PAGINATION_DESC"
-				label="JGLOBAL_PAGINATION_LABEL"
-			>
+			<field name="show_pagination"
+			       type="list"
+			       description="JGLOBAL_PAGINATION_DESC"
+			       label="JGLOBAL_PAGINATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
-
-			<field name="show_pagination_results" type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
+			<field name="show_pagination_results"
+			       type="list"
+			       label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+			       description="JGLOBAL_PAGINATION_RESULTS_DESC">
 
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
-		</field>
-		<field name="display_num" type="list"
-				default="10"
-				description="JGLOBAL_NUMBER_ITEMS_LIST_DESC"
-				label="JGLOBAL_NUMBER_ITEMS_LIST_LABEL">
+			</field>
+			<field name="display_num"
+			       type="list"
+			       default="10"
+			       description="JGLOBAL_NUMBER_ITEMS_LIST_DESC"
+			       label="JGLOBAL_NUMBER_ITEMS_LIST_LABEL">
 				<option value="5">J5</option>
 				<option value="10">J10</option>
 				<option value="15">J15</option>
@@ -269,224 +269,224 @@
 				<option value="50">J50</option>
 				<option value="100">J100</option>
 				<option value="0">JALL</option>
-		</field>
-
-</fieldset>
-
-<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field name="show_title" type="list"
-				description="JGLOBAL_SHOW_TITLE_DESC"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-			>
+			</field>
+		</fieldset>
+		<fieldset name="article"
+		          label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+			<field name="show_title"
+			       type="list"
+			       description="JGLOBAL_SHOW_TITLE_DESC"
+			       label="JGLOBAL_SHOW_TITLE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_titles" type="list"
-				description="JGLOBAL_LINKED_TITLES_DESC"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-			>
+			<field name="link_titles"
+			       type="list"
+			       description="JGLOBAL_LINKED_TITLES_DESC"
+			       label="JGLOBAL_LINKED_TITLES_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_intro" type="list"
-				description="JGLOBAL_SHOW_INTRO_DESC"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-			>
+			<field name="show_intro"
+			       type="list"
+			       description="JGLOBAL_SHOW_INTRO_DESC"
+			       label="JGLOBAL_SHOW_INTRO_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_category" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-			>
+			<field name="show_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_category" type="list"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-			>
+			<field name="link_category"
+			       type="list"
+			       description="JGLOBAL_LINK_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_parent_category" type="list"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-			>
+			<field name="show_parent_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_parent_category" type="list"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-			>
+			<field name="link_parent_category"
+			       type="list"
+			       description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_author" type="list"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-			>
+			<field name="show_author"
+			       type="list"
+			       description="JGLOBAL_SHOW_AUTHOR_DESC"
+			       label="JGLOBAL_SHOW_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_author" type="list"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-			>
+			<field name="link_author"
+			       type="list"
+			       description="JGLOBAL_LINK_AUTHOR_DESC"
+			       label="JGLOBAL_LINK_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNo</option>
 				<option value="1">JYes</option>
 			</field>
-
-			<field name="show_create_date" type="list"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-			>
+			<field name="show_create_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+			       label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_modify_date" type="list"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-			>
+			<field name="show_modify_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+			       label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_publish_date" type="list"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-			>
+			<field name="show_publish_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+			       label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_item_navigation" type="list"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-			>
+			<field name="show_item_navigation"
+			       type="list"
+			       description="JGLOBAL_SHOW_NAVIGATION_DESC"
+			       label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
 			<field
-			name="show_vote" type="list"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="0">JHIDE</option>
-			<option	value="1">JSHOW</option>
-		</field>
-
+					name="show_vote"
+					type="list"
+					label="JGLOBAL_SHOW_VOTE_LABEL"
+					description="JGLOBAL_SHOW_VOTE_DESC"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
 			<field
-				name="show_readmore"
-				type="list"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-			>
+					name="show_readmore"
+					type="list"
+					description="JGLOBAL_SHOW_READMORE_DESC"
+					label="JGLOBAL_SHOW_READMORE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-				name="show_readmore_title"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-			>
+					name="show_readmore_title"
+					type="list"
+					label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+					description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_icons" type="list"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-			>
+			<field name="show_icons"
+			       type="list"
+			       description="JGLOBAL_SHOW_ICONS_DESC"
+			       label="JGLOBAL_SHOW_ICONS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_print_icon" type="list"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-			>
+			<field name="show_print_icon"
+			       type="list"
+			       description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+			       label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_email_icon" type="list"
-				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-			>
+			<field name="show_email_icon"
+			       type="list"
+			       description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
+			       label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_hits" type="list"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-			>
+			<field name="show_hits"
+			       type="list"
+			       description="JGLOBAL_SHOW_HITS_DESC"
+			       label="JGLOBAL_SHOW_HITS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_noauth" type="list"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-			>
+			<field name="show_noauth"
+			       type="list"
+			       description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
+			       label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-</fieldset>
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
-		>
-
-			<field name="show_feed_link" type="list"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-			>
+		</fieldset>
+		<fieldset name="integration"
+		          label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
+				>
+			<field name="show_feed_link"
+			       type="list"
+			       description="JGLOBAL_SHOW_FEED_LINK_DESC"
+			       label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="feed_summary" type="list"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-			>
+			<field name="feed_summary"
+			       type="list"
+			       description="JGLOBAL_FEED_SUMMARY_DESC"
+			       label="JGLOBAL_FEED_SUMMARY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JGLOBAL_INTRO_TEXT</option>
 				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
-</fields>
+	</fields>
 </metadata>

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -193,10 +193,9 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="spacer1"
-					type="spacer"
-					hr="true"
+			<field name="spacer1"
+			       type="spacer"
+			       hr="true"
 					/>
 			<field name="orderby_pri"
 			       type="list"
@@ -250,7 +249,6 @@
 			       type="list"
 			       label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 			       description="JGLOBAL_PAGINATION_RESULTS_DESC">
-
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -390,31 +388,28 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_vote"
-					type="list"
-					label="JGLOBAL_SHOW_VOTE_LABEL"
-					description="JGLOBAL_SHOW_VOTE_DESC"
+			<field name="show_vote"
+			       type="list"
+			       label="JGLOBAL_SHOW_VOTE_LABEL"
+			       description="JGLOBAL_SHOW_VOTE_DESC"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_readmore"
-					type="list"
-					description="JGLOBAL_SHOW_READMORE_DESC"
-					label="JGLOBAL_SHOW_READMORE_LABEL"
+			<field name="show_readmore"
+			       type="list"
+			       description="JGLOBAL_SHOW_READMORE_DESC"
+			       label="JGLOBAL_SHOW_READMORE_LABEL"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_readmore_title"
-					type="list"
-					label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-					description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+			<field name="show_readmore_title"
+			       type="list"
+			       label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+			       description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -1,85 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="COM_CONTENT_FEATURED_VIEW_DEFAULT_TITLE" option="COM_CONTENT_FEATURED_VIEW_DEFAULT_OPTION">
+	<layout title="COM_CONTENT_FEATURED_VIEW_DEFAULT_TITLE"
+	        option="COM_CONTENT_FEATURED_VIEW_DEFAULT_OPTION">
 		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_FEATURED"
-		/>
+				key="JHELP_MENUS_MENU_ITEM_ARTICLE_FEATURED"
+				/>
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_FEATURED_DESC]]>
 		</message>
 	</layout>
-
-<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-<fieldset name="advanced" label="COM_MENUS_LAYOUT_FEATURED_OPTIONS">
+	<!-- Add fields to the parameters object for the layout. -->
+	<fields name="params">
+		<fieldset name="advanced"
+		          label="COM_MENUS_LAYOUT_FEATURED_OPTIONS">
 			<field
-			name="featured_categories"
-			type="category"
-			extension="com_content"
-			multiple="true"
-			size="10"
-			default=""
-			label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
-			description="COM_CONTENT_FEATURED_CATEGORIES_DESC" >
-			<option value="">JOPTION_ALL_CATEGORIES</option>
+					name="featured_categories"
+					type="category"
+					extension="com_content"
+					multiple="true"
+					size="10"
+					default=""
+					label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
+					description="COM_CONTENT_FEATURED_CATEGORIES_DESC">
+				<option value="">JOPTION_ALL_CATEGORIES</option>
 			</field>
-
 			<field name="layout_type"
-				type="hidden"
-				default="blog"
-			/>
-			<field name="bloglayout" type="spacer" class="text"
-					label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
-			/>
-
-			<field name="num_leading_articles" type="text"
-				description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
-				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-				size="3"
-			/>
-
-			<field name="num_intro_articles" type="text"
-				description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
-				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-				size="3"
-			/>
-
-			<field name="num_columns" type="text"
-				description="JGLOBAL_NUM_COLUMNS_DESC"
-				label="JGLOBAL_NUM_COLUMNS_LABEL"
-				size="3"
-			/>
-
-			<field name="num_links" type="text"
-				description="JGLOBAL_NUM_LINKS_DESC"
-				label="JGLOBAL_NUM_LINKS_LABEL"
-				size="3"
-			/>
-
-			<field name="multi_column_order" type="list"
-				description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
-				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-			>
+			       type="hidden"
+			       default="blog"
+					/>
+			<field name="bloglayout"
+			       type="spacer"
+			       class="text"
+			       label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
+					/>
+			<field name="num_leading_articles"
+			       type="text"
+			       description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
+			       label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
+			       size="3"
+					/>
+			<field name="num_intro_articles"
+			       type="text"
+			       description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
+			       label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
+			       size="3"
+					/>
+			<field name="num_columns"
+			       type="text"
+			       description="JGLOBAL_NUM_COLUMNS_DESC"
+			       label="JGLOBAL_NUM_COLUMNS_LABEL"
+			       size="3"
+					/>
+			<field name="num_links"
+			       type="text"
+			       description="JGLOBAL_NUM_LINKS_DESC"
+			       label="JGLOBAL_NUM_LINKS_LABEL"
+			       size="3"
+					/>
+			<field name="multi_column_order"
+			       type="list"
+			       description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
+			       label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JGLOBAL_Down</option>
 				<option value="1">JGLOBAL_Across</option>
 			</field>
-
-			<field name="orderby_pri" type="list"
-				description="JGLOBAL_CATEGORY_ORDER_DESC"
-				label="JGLOBAL_CATEGORY_ORDER_LABEL"
-			>
+			<field name="orderby_pri"
+			       type="list"
+			       description="JGLOBAL_CATEGORY_ORDER_DESC"
+			       label="JGLOBAL_CATEGORY_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="none">JGLOBAL_No_Order</option>
 				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
 				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
 				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
 			</field>
-
-			<field name="orderby_sec" type="list"
-				description="JGLOBAL_ARTICLE_ORDER_DESC"
-				label="JGLOBAL_ARTICLE_ORDER_LABEL"
-			>
+			<field name="orderby_sec"
+			       type="list"
+			       description="JGLOBAL_ARTICLE_ORDER_DESC"
+			       label="JGLOBAL_ARTICLE_ORDER_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
 				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
@@ -92,286 +94,292 @@
 				<option value="rhits">JGLOBAL_LEAST_HITS</option>
 				<option value="order">JGLOBAL_ORDERING</option>
 			</field>
-
-			<field name="order_date" type="list"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
-			>
+			<field name="order_date"
+			       type="list"
+			       description="JGLOBAL_ORDERING_DATE_DESC"
+			       label="JGLOBAL_ORDERING_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
 			</field>
-
-			<field name="show_pagination" type="list"
-				description="JGLOBAL_PAGINATION_DESC"
-				label="JGLOBAL_PAGINATION_LABEL"
-			>
+			<field name="show_pagination"
+			       type="list"
+			       description="JGLOBAL_PAGINATION_DESC"
+			       label="JGLOBAL_PAGINATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
-
-			<field name="show_pagination_results" type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
+			<field name="show_pagination_results"
+			       type="list"
+			       label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+			       description="JGLOBAL_PAGINATION_RESULTS_DESC">
 
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-
-</fieldset>
-
-<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field name="show_title" type="list"
-				description="JGLOBAL_SHOW_TITLE_DESC"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-			>
+		</fieldset>
+		<fieldset name="article"
+		          label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+			<field name="show_title"
+			       type="list"
+			       description="JGLOBAL_SHOW_TITLE_DESC"
+			       label="JGLOBAL_SHOW_TITLE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_titles" type="list"
-				description="JGLOBAL_LINKED_TITLES_DESC"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-			>
+			<field name="link_titles"
+			       type="list"
+			       description="JGLOBAL_LINKED_TITLES_DESC"
+			       label="JGLOBAL_LINKED_TITLES_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNo</option>
 				<option value="1">JYes</option>
 			</field>
-
-			<field name="show_intro" type="list"
-				description="JGLOBAL_SHOW_INTRO_DESC"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-			>
+			<field name="show_intro"
+			       type="list"
+			       description="JGLOBAL_SHOW_INTRO_DESC"
+			       label="JGLOBAL_SHOW_INTRO_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-				name="info_block_position"
-				type="list"
-				default=""
-				label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-				description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+					name="info_block_position"
+					type="list"
+					default=""
+					label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+					description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 				<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
 				<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 			</field>
-
-			<field name="show_category" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-			>
+			<field name="show_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_category" type="list"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-			>
+			<field name="link_category"
+			       type="list"
+			       description="JGLOBAL_LINK_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNo</option>
 				<option value="1">JYes</option>
 			</field>
-
-			<field name="show_parent_category" type="list"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-			>
+			<field name="show_parent_category"
+			       type="list"
+			       description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_parent_category" type="list"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-			>
+			<field name="link_parent_category"
+			       type="list"
+			       description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+			       label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-
-			<field name="show_author" type="list"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-			>
+			<field name="show_author"
+			       type="list"
+			       description="JGLOBAL_SHOW_AUTHOR_DESC"
+			       label="JGLOBAL_SHOW_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="link_author" type="list"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-			>
+			<field name="link_author"
+			       type="list"
+			       description="JGLOBAL_LINK_AUTHOR_DESC"
+			       label="JGLOBAL_LINK_AUTHOR_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNo</option>
 				<option value="1">JYes</option>
 			</field>
-
-			<field name="show_create_date" type="list"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-			>
+			<field name="show_create_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+			       label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_modify_date" type="list"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-			>
+			<field name="show_modify_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+			       label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_publish_date" type="list"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-			>
+			<field name="show_publish_date"
+			       type="list"
+			       description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+			       label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_item_navigation" type="list"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-			>
+			<field name="show_item_navigation"
+			       type="list"
+			       description="JGLOBAL_SHOW_NAVIGATION_DESC"
+			       label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-			name="show_vote" type="list"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-			<option value="0">JHIDE</option>
-			<option	value="1">JSHOW</option>
-		</field>
-
+					name="show_vote"
+					type="list"
+					label="JGLOBAL_SHOW_VOTE_LABEL"
+					description="JGLOBAL_SHOW_VOTE_DESC"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
 			<field
-				name="show_readmore"
-				type="list"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-			>
+					name="show_readmore"
+					type="list"
+					description="JGLOBAL_SHOW_READMORE_DESC"
+					label="JGLOBAL_SHOW_READMORE_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
 			<field
-				name="show_readmore_title"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-			>
+					name="show_readmore_title"
+					type="list"
+					label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+					description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_icons" type="list"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="show_print_icon" type="list"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-			>
+			<field name="show_icons"
+			       type="list"
+			       description="JGLOBAL_SHOW_ICONS_DESC"
+			       label="JGLOBAL_SHOW_ICONS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_email_icon" type="list"
-				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-			>
+			<field name="show_print_icon"
+			       type="list"
+			       description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+			       label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_hits" type="list"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-			>
+			<field name="show_email_icon"
+			       type="list"
+			       description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
+			       label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="show_noauth" type="list"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-			>
+			<field name="show_hits"
+			       type="list"
+			       description="JGLOBAL_SHOW_HITS_DESC"
+			       label="JGLOBAL_SHOW_HITS_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="show_tags"
+			       type="list"
+			       description="COM_CONTENT_FIELD_SHOW_TAGS_DESC"
+			       label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+					>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+			<field name="show_noauth"
+			       type="list"
+			       description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
+			       label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
-</fieldset>
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
-		>
-
-			<field name="show_feed_link" type="list"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-			>
+		</fieldset>
+		<fieldset name="integration"
+		          label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
+				>
+			<field name="show_feed_link"
+			       type="list"
+			       description="JGLOBAL_SHOW_FEED_LINK_DESC"
+			       label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
-			<field name="feed_summary" type="list"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-			>
+			<field name="feed_summary"
+			       type="list"
+			       description="JGLOBAL_FEED_SUMMARY_DESC"
+			       label="JGLOBAL_FEED_SUMMARY_LABEL"
+					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JGLOBAL_INTRO_TEXT</option>
 				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
-</fields>
+	</fields>
 </metadata>

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -13,15 +13,14 @@
 	<fields name="params">
 		<fieldset name="advanced"
 		          label="COM_MENUS_LAYOUT_FEATURED_OPTIONS">
-			<field
-					name="featured_categories"
-					type="category"
-					extension="com_content"
-					multiple="true"
-					size="10"
-					default=""
-					label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
-					description="COM_CONTENT_FEATURED_CATEGORIES_DESC">
+			<field name="featured_categories"
+			       type="category"
+			       extension="com_content"
+			       multiple="true"
+			       size="10"
+			       default=""
+			       label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
+			       description="COM_CONTENT_FEATURED_CATEGORIES_DESC">
 				<option value="">JOPTION_ALL_CATEGORIES</option>
 			</field>
 			<field name="layout_type"
@@ -156,12 +155,11 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="info_block_position"
-					type="list"
-					default=""
-					label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
-					description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
+			<field name="info_block_position"
+			       type="list"
+			       default=""
+			       label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
+			       description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
@@ -268,32 +266,29 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_vote"
-					type="list"
-					label="JGLOBAL_SHOW_VOTE_LABEL"
-					description="JGLOBAL_SHOW_VOTE_DESC"
+			<field name="show_vote"
+			       type="list"
+			       label="JGLOBAL_SHOW_VOTE_LABEL"
+			       description="JGLOBAL_SHOW_VOTE_DESC"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_readmore"
-					type="list"
-					description="JGLOBAL_SHOW_READMORE_DESC"
-					label="JGLOBAL_SHOW_READMORE_LABEL"
+			<field name="show_readmore"
+			       type="list"
+			       description="JGLOBAL_SHOW_READMORE_DESC"
+			       label="JGLOBAL_SHOW_READMORE_LABEL"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field
-					name="show_readmore_title"
-					type="list"
-					label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-					description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+			<field name="show_readmore_title"
+			       type="list"
+			       label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+			       description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
 					>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 // Create a shortcut for params.
-$params     = &$this->item->params;
+$params     = $this->item->params;
 $images     = json_decode($this->item->images);
 $canEdit    = $this->item->params->get('access-edit');
 $info       = $this->item->params->get('info_block_position', 0);
@@ -211,12 +211,12 @@ $info       = $this->item->params->get('info_block_position', 0);
 	<?php if ($params->get('access-view')) : ?>
 		<?php $link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
 	<?php else : ?>
-		<?php $menu = JFactory::getApplication()->getMenu(); ?>
-		<?php $active = $menu->getActive(); ?>
-		<?php $itemId = $active->id; ?>
-		<?php $link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId); ?>
-		<?php $returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
-		<?php $link = new JUri($link1); ?>
+		<?php $menu         = JFactory::getApplication()->getMenu(); ?>
+		<?php $active       = $menu->getActive(); ?>
+		<?php $itemId       = $active->id; ?>
+		<?php $link1        = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId); ?>
+		<?php $returnURL    = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
+		<?php $link         = new JUri($link1); ?>
 		<?php $link->setVar('return', base64_encode($returnURL)); ?>
 	<?php endif; ?>
 	<p class="readmore">

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -10,28 +10,27 @@
 defined('_JEXEC') or die;
 
 // Create a shortcut for params.
-$params = &$this->item->params;
-$images = json_decode($this->item->images);
-$canEdit = $this->item->params->get('access-edit');
-$info    = $this->item->params->get('info_block_position', 0);
-
+$params     = &$this->item->params;
+$images     = json_decode($this->item->images);
+$canEdit    = $this->item->params->get('access-edit');
+$info       = $this->item->params->get('info_block_position', 0);
 ?>
 
 <?php if ($this->item->state == 0 || strtotime($this->item->publish_up) > strtotime(JFactory::getDate())
-	|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
-	<div class="system-unpublished">
+|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
+<div class="system-unpublished">
 <?php endif; ?>
-
 <?php if ($params->get('show_title')) : ?>
 	<h2 class="item-title">
-	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>"> <?php echo $this->escape($this->item->title); ?></a>
-	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
-	<?php endif; ?>
+		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+				<?php echo $this->escape($this->item->title); ?>
+			</a>
+		<?php else : ?>
+			<?php echo $this->escape($this->item->title); ?>
+		<?php endif; ?>
 	</h2>
 <?php endif; ?>
-
 <?php if ($this->item->state == 0) : ?>
 	<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 <?php endif; ?>
@@ -41,33 +40,29 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php if ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00') : ?>
 	<span class="label label-warning"><?php echo JText::_('JEXPIRED'); ?></span>
 <?php endif; ?>
-
 <?php if ($params->get('show_print_icon') || $params->get('show_email_icon') || $canEdit) : ?>
 	<div class="btn-group pull-right"> <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" role="button"> <span class="icon-cog"></span> <span class="caret"></span> </a>
 		<ul class="dropdown-menu">
-		<?php if ($params->get('show_print_icon')) : ?>
-			<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
-		<?php endif; ?>
-		<?php if ($params->get('show_email_icon')) : ?>
-			<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
-		<?php endif; ?>
-		<?php if ($canEdit) : ?>
-			<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
-		<?php endif; ?>
+			<?php if ($params->get('show_print_icon')) : ?>
+				<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $this->item, $params); ?> </li>
+			<?php endif; ?>
+			<?php if ($params->get('show_email_icon')) : ?>
+				<li class="email-icon"> <?php echo JHtml::_('icon.email', $this->item, $params); ?> </li>
+			<?php endif; ?>
+			<?php if ($canEdit) : ?>
+				<li class="edit-icon"> <?php echo JHtml::_('icon.edit', $this->item, $params); ?> </li>
+			<?php endif; ?>
 		</ul>
 	</div>
 <?php endif; ?>
-
 <?php // Todo Not that elegant would be nice to group the params ?>
 <?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') ); ?>
-
 <?php if ($useDefList && ($info == 0 ||  $info == 2)) : ?>
 	<dl class="article-info  muted">
 		<dt class="article-info-term">
-		<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
+			<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
 		</dt>
-
 		<?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
 			<dd class="createdby">
 				<?php $author = $this->item->author; ?>
@@ -79,11 +74,10 @@ $info    = $this->item->params->get('info_block_position', 0);
 				<?php endif; ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 			<dd class="parent-category-name">
-				<?php $title = $this->escape($this->item->parent_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($this->item->parent_title); ?>
+				<?php $url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>'; ?>
 				<?php if ($params->get('link_parent_category') && !empty($this->item->parent_slug)) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 				<?php else : ?>
@@ -91,11 +85,10 @@ $info    = $this->item->params->get('info_block_position', 0);
 				<?php endif; ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_category')) : ?>
 			<dd class="category-name">
-				<?php $title = $this->escape($this->item->category_title);
-				$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
+				<?php $title = $this->escape($this->item->category_title); ?>
+				<?php $url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>'; ?>
 				<?php if ($params->get('link_category') && $this->item->catslug) : ?>
 					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 				<?php else : ?>
@@ -103,54 +96,51 @@ $info    = $this->item->params->get('info_block_position', 0);
 				<?php endif; ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_publish_date')) : ?>
 			<dd class="published">
 				<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($info == 0) : ?>
 			<?php if ($params->get('show_modify_date')) : ?>
 				<dd class="modified">
-				<span class="icon-calendar"></span>
-				<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+					<span class="icon-calendar"></span>
+					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 				</dd>
 			<?php endif; ?>
-
 			<?php if ($params->get('show_create_date')) : ?>
 				<dd class="create">
 					<span class="icon-calendar"></span>
 					<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
 				</dd>
 			<?php endif; ?>
-
 			<?php if ($params->get('show_hits')) : ?>
 				<dd class="hits">
 					<span class="icon-eye-open"></span>
 					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 				</dd>
 			<?php endif; ?>
-
+			<?php if ($this->params->get('show_tags', 1)) : ?>
+				<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+				<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
+			<?php endif; ?>
 		<?php endif; ?>
 	</dl>
 <?php endif; ?>
-
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
 	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/> </div>
+		<?php if ($images->image_intro_caption): ?>
+			<?php echo 'class="caption"'.' title="' .htmlspecialchars($images->image_intro_caption) .'"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
+	</div>
 <?php endif; ?>
-
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 <?php endif; ?>
 <?php echo $this->item->event->beforeDisplayContent; ?> <?php echo $this->item->introtext; ?>
-
-<?php if ($useDefList && ($info == 1 ||  $info == 2)) : ?>
+<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 	<dl class="article-info muted">
 		<dt class="article-info-term">
 			<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
@@ -167,11 +157,10 @@ $info    = $this->item->params->get('info_block_position', 0);
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
-
 			<?php if ($params->get('show_parent_category') && !empty($this->item->parent_slug)) : ?>
 				<dd class="parent-category-name">
-					<?php	$title = $this->escape($this->item->parent_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>';?>
+					<?php $title = $this->escape($this->item->parent_title); ?>
+					<?php $url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)).'">'.$title.'</a>'; ?>
 					<?php if ($params->get('link_parent_category') && $this->item->parent_slug) : ?>
 						<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 					<?php else : ?>
@@ -179,11 +168,10 @@ $info    = $this->item->params->get('info_block_position', 0);
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
-
 			<?php if ($params->get('show_category')) : ?>
 				<dd class="category-name">
-					<?php $title = $this->escape($this->item->category_title);
-					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
+					<?php $title = $this->escape($this->item->category_title); ?>
+					<?php $url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>'; ?>
 					<?php if ($params->get('link_category') && $this->item->catslug) : ?>
 						<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 					<?php else : ?>
@@ -191,77 +179,66 @@ $info    = $this->item->params->get('info_block_position', 0);
 					<?php endif; ?>
 				</dd>
 			<?php endif; ?>
-
 			<?php if ($params->get('show_publish_date')) : ?>
 				<dd class="published">
 					<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $this->item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 				</dd>
 			<?php endif; ?>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_create_date')) : ?>
 			<dd class="create">
 				<span class="icon-calendar"></span> <?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $this->item->created, JText::_('DATE_FORMAT_LC3'))); ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_modify_date')) : ?>
 			<dd class="modified">
 				<span class="icon-calendar"></span>
 				<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $this->item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 			</dd>
 		<?php endif; ?>
-
 		<?php if ($params->get('show_hits')) : ?>
 			<dd class="hits">
 				<span class="icon-eye-open"></span> <?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 			</dd>
 		<?php endif; ?>
 	</dl>
-
 	<?php if ($this->params->get('show_tags', 1)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>
-
 <?php endif; ?>
-
-<?php if ($params->get('show_readmore') && $this->item->readmore) :
-	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
-	else :
-		$menu = JFactory::getApplication()->getMenu();
-		$active = $menu->getActive();
-		$itemId = $active->id;
-		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
-		$link = new JUri($link1);
-		$link->setVar('return', base64_encode($returnURL));
-	endif; ?>
-
-	<p class="readmore"><a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
-
-	<?php if (!$params->get('access-view')) :
-		echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-	elseif ($readmore = $this->item->alternative_readmore) :
-		echo $readmore;
-		if ($params->get('show_readmore_title', 0) != 0) :
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-		endif;
-	elseif ($params->get('show_readmore_title', 0) == 0) :
-		echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-	else :
-		echo JText::_('COM_CONTENT_READ_MORE');
-		echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-	endif; ?>
-
-	</a></p>
-
+<?php if ($params->get('show_readmore') && $this->item->readmore) : ?>
+	<?php if ($params->get('access-view')) : ?>
+		<?php $link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
+	<?php else : ?>
+		<?php $menu = JFactory::getApplication()->getMenu(); ?>
+		<?php $active = $menu->getActive(); ?>
+		<?php $itemId = $active->id; ?>
+		<?php $link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId); ?>
+		<?php $returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>
+		<?php $link = new JUri($link1); ?>
+		<?php $link->setVar('return', base64_encode($returnURL)); ?>
+	<?php endif; ?>
+	<p class="readmore">
+		<a class="btn" href="<?php echo $link; ?>"> <span class="icon-chevron-right"></span>
+			<?php if (!$params->get('access-view')) : ?>
+				<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
+			<?php elseif ($readmore = $this->item->alternative_readmore) : ?>
+				<?php echo $readmore; ?>
+				<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+					<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+				<?php endif; ?>
+			<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
+				<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+			<?php else : ?>
+				<?php echo JText::_('COM_CONTENT_READ_MORE'); ?>
+				<?php echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit')); ?>
+			<?php endif; ?>
+		</a>
+	</p>
 <?php endif; ?>
-
 <?php if ($this->item->state == 0 || strtotime($this->item->publish_up) > strtotime(JFactory::getDate())
-	|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
-</div>
+|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>
+	</div>
 <?php endif; ?>
-
 <?php echo $this->item->event->afterDisplayContent; ?>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -11,52 +11,52 @@ defined('JPATH_BASE') or die;
 
 // Note that this layout opens a div with the page class suffix. If you do not use the category children
 // layout you need to close this div either by overriding this file or in your main layout.
-$params  = $displayData->params;
-$extension = $displayData->get('category')->extension;
-$canEdit = $params->get('access-edit');
-$className = substr($extension, 4);
+$params     = $displayData->params;
+$extension  = $displayData->get('category')->extension;
+$canEdit    = $params->get('access-edit');
+$className  = substr($extension, 4);
+
 // This will work for the core components but not necessarily for other components
 // that may have different pluralisation rules.
 if (substr($className, -1) == 's')
 {
 	$className = rtrim($className, 's');
 }
-$tagsData  = $displayData->get('category')->tags->itemTags;
+
+$tagsData = $displayData->get('category')->tags->itemTags;
 ?>
 <div>
-	<div class="<?php echo $className .'-category' . $displayData->pageclass_sfx;?>">
+	<div class="<?php echo $className . '-category' . $displayData->pageclass_sfx; ?>">
 		<?php if ($params->get('show_page_heading')) : ?>
 			<h1>
 				<?php echo $displayData->escape($params->get('page_heading')); ?>
 			</h1>
 		<?php endif; ?>
-		<?php if($params->get('show_category_title', 1)) : ?>
+		<?php if ($params->get('show_category_title', 1)) : ?>
 			<h2>
-				<?php echo JHtml::_('content.prepare', $displayData->get('category')->title, '', $extension.'.category.title'); ?>
+				<?php echo JHtml::_('content.prepare', $displayData->get('category')->title, '', $extension . '.category.title'); ?>
 			</h2>
 		<?php endif; ?>
-		<?php if ($params->get('show_tags', 1)) : ?>
+		<?php if ($params->get('show_cat_tags', 1)) : ?>
 			<?php echo JLayoutHelper::render('joomla.content.tags', $tagsData); ?>
 		<?php endif; ?>
 		<?php if ($params->get('show_description', 1) || $params->def('show_description_image', 1)) : ?>
 			<div class="category-desc">
 				<?php if ($params->get('show_description_image') && $displayData->get('category')->getParams()->get('image')) : ?>
-					<img src="<?php echo $displayData->get('category')->getParams()->get('image'); ?>"/>
+					<img src="<?php echo $displayData->get('category')->getParams()->get('image'); ?>" />
 				<?php endif; ?>
 				<?php if ($params->get('show_description') && $displayData->get('category')->description) : ?>
-					<?php echo JHtml::_('content.prepare', $displayData->get('category')->description, '', $extension .'.category'); ?>
+					<?php echo JHtml::_('content.prepare', $displayData->get('category')->description, '', $extension . '.category'); ?>
 				<?php endif; ?>
 				<div class="clr"></div>
 			</div>
 		<?php endif; ?>
 		<?php echo $displayData->loadTemplate($displayData->subtemplatename); ?>
-
 		<?php if ($displayData->get('children') && $displayData->maxLevel != 0) : ?>
 			<div class="cat-children">
 				<h3>
 					<?php echo JTEXT::_('JGLOBAL_SUBCATEGORIES'); ?>
 				</h3>
-
 				<?php echo $displayData->loadTemplate('children'); ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
Bugfix of the described problem here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33602&start=0

Most important thing is the introduction of the new attribute "show_cat_tags" to distinct between the tags for articles and categories. The output and control of the tags for the different layouts (featured, blog, article) was also improved.

How to test?

Create some articles and categories with tags. Also create menu entries for the described layout views. Now play around with the different setting possibilities -> Enable and disable the option "Show Tags" for articles and categories in
- menu entries
- global settings
- article

Plus in the pull request: many code styling improvements
