### PR TITLE
changing implementation of Canonical URL creation

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -24,10 +24,12 @@ class PlgSystemSef extends JPlugin
 	 *
 	 * @since   3.0
 	 */
-	public function onAfterRoute()
+	public function onContentBeforeDisplay($article, $params, $limitstart)
 	{
 		$app = JFactory::getApplication();
 		$doc = JFactory::getDocument();
+		$option = JRequest::getCmd('option'); 
+		$view = JRequest::getCmd('view');
 
 		if ($app->getName() != 'site' || $doc->getType() !== 'html')
 		{
@@ -47,6 +49,11 @@ class PlgSystemSef extends JPlugin
 		$parsed = $router->parse($uri);
 		$fakelink = 'index.php?' . http_build_query($parsed);
 		$link = $domain . JRoute::_($fakelink, false);
+
+		if($article == 'com_content.article' && ($option == "com_content" && $view == "article"))
+		{
+			$link = JRoute::_( ContentHelperRoute::getArticleRoute( (int)$params->id, $params->catslug),false,-1);
+		}
 
 		if ($uri !== $link)
 		{

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -28,8 +28,8 @@ class PlgSystemSef extends JPlugin
 	{
 		$app = JFactory::getApplication();
 		$doc = JFactory::getDocument();
-		$option = JRequest::getCmd('option'); 
-		$view = JRequest::getCmd('view');
+		$option = $app->input->getCmd('option', null);
+		$view = $app->input->getCmd('view', null);
 
 		if ($app->getName() != 'site' || $doc->getType() !== 'html')
 		{


### PR DESCRIPTION
- changing trigger from onAfterRoute to onContentBeforeDisplay (because I need content information for creation of Canonical URL)
- add if-then-else statement for creation of proper Canonical URL for com_content view=article

Reason for this pull request is to solve the wrong Canonical URL for an article. Problem is that Google will index all provided canonical weblinks. You will end up with duplicate content. 

examples with com_content and view = article
open an article in a category blog view and look at the created Canonical URL
- http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014
- \* canonical url = http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014

add parameters to the URL and take a look at the created Canonical URL
- http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014?utm_source=newsmail&utm_medium=email&utm_campaign=newsmail_2014_03 
- \* canonical url = http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014?utm_source=newsmail&utm_medium=email&utm_campaign=newsmail_2014_03
- \* expected canonical url = http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014

add an extra subcategory in the URL and take a look at the created Canonical URL
- http://www.byte.nl/nieuws/banaan/2553-byte-op-de-joomladagen-2014
- \* canonical url = http://www.byte.nl/nieuws?catid=0&id=2553
- \* expected canonical url = http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen-2014

remove a part of the URL and take a look at the created Canonical URL
- http://www.byte.nl/nieuws/2553-byte-op-de-joomladagen 
