### PR TITLE
Deprecate the use of an expression in JDocumentHtml::countModules()

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -493,6 +493,18 @@ class JDocumentHTML extends JDocument
 	{
 		$operators = '(\+|\-|\*|\/|==|\!=|\<\>|\<|\>|\<=|\>=|and|or|xor)';
 		$words = preg_split('# ' . $operators . ' #', $condition, null, PREG_SPLIT_DELIM_CAPTURE);
+
+		if (count($words) === 1)
+		{
+			$name = strtolower($words[0]);
+			$result = ((isset(parent::$_buffer['modules'][$name])) && (parent::$_buffer['modules'][$name] === false))
+				? 0 : count(JModuleHelper::getModules($name));
+
+			return $result;
+		}
+
+		JLog::add('Using an expression in JDocumentHtml::countModules() is deprecated.', JLog::WARNING, 'deprecated');
+
 		for ($i = 0, $n = count($words); $i < $n; $i += 2)
 		{
 			// Odd parts (modules)


### PR DESCRIPTION
This code never made it from the last platform update to the cms.
By deprecating the expressions on modules, we can remove the eval($str) in 4.0. (or maybe even faster???) This is good for HHVM http://hhvm.com
