### PR TITLE
[#33961] Unknown property filling error log

### DIFF
--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -35,7 +35,6 @@ class TagsViewTag extends JViewLegacy
 		}
 
 		// Get some data from the model
-		$tag      = $this->get('Item');
 		$items    = $this->get('Items');
 		foreach ($items as $item)
 		{
@@ -58,13 +57,9 @@ class TagsViewTag extends JViewLegacy
 			$feeditem->link        = $link;
 			$feeditem->description = $description;
 			$feeditem->date        = $date;
+			$feeditem->category    = $title;
 			$feeditem->author      = $author;
 			
-			if (isset($tag[0]->title))
-			{
-				$feeditem->category = $tag[0]->title;
-			}
-
 			if ($feedEmail == 'site')
 			{
 				$item->authorEmail = $siteEmail;

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -58,8 +58,12 @@ class TagsViewTag extends JViewLegacy
 			$feeditem->link        = $link;
 			$feeditem->description = $description;
 			$feeditem->date        = $date;
-			$feeditem->category    = $tag->title;
 			$feeditem->author      = $author;
+			
+			if (isset($tag[0]->title))
+			{
+				$feeditem->category = $tag[0]->title;
+			}
 
 			if ($feedEmail == 'site')
 			{

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -35,6 +35,7 @@ class TagsViewTag extends JViewLegacy
 		}
 
 		// Get some data from the model
+		$tag      = $this->get('Item');
 		$items    = $this->get('Items');
 		foreach ($items as $item)
 		{
@@ -57,7 +58,7 @@ class TagsViewTag extends JViewLegacy
 			$feeditem->link        = $link;
 			$feeditem->description = $description;
 			$feeditem->date        = $date;
-			$feeditem->category    = $item->title;
+			$feeditem->category    = $tag->title;
 			$feeditem->author      = $author;
 
 			if ($feedEmail == 'site')


### PR DESCRIPTION
When search engines or users open feed page of a tag, error log is filled with

`PHP Notice:  Undefined property: stdClass::$title in /home/joomla3.2/public_html/components/com_tags/views/tag/view.feed.php on line 60`

It seems author wanted to get title of the tag, so I changed the code accordingly, as the title comes from UCM and it's already processed few lines above.

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33961&start=0
