### PR TITLE
also advance to end of array for object-based observers

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -202,7 +202,6 @@ class JDispatcher extends JObject
 			}
 
 			$this->_observers[] = $observer;
-			end($this->_observers);
 			$methods = array($observer['event']);
 		}
 		else
@@ -227,6 +226,7 @@ class JDispatcher extends JObject
 			$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
 		}
 
+		end($this->_observers);
 		$key = key($this->_observers);
 
 		foreach ($methods as $method)


### PR DESCRIPTION
This is a backport to the 2.5 branch, see the following:

https://github.com/joomla/joomla-cms/commit/791f5612ac7305f94789411f4c3fc459c91077a5
