### PR TITLE
[#33662] Microdata in single article view causes invalid HTML

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -197,9 +197,9 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<section itemprop="articleBody">
+	<div itemprop="articleBody">
 		<?php echo $this->item->text; ?>
-	</section>
+	</div>
 
 	<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 		<div class="article-info muted">

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -197,9 +197,9 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<span itemprop="articleBody">
+	<section itemprop="articleBody">
 		<?php echo $this->item->text; ?>
-	</span>
+	</section>
 
 	<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 		<div class="article-info muted">


### PR DESCRIPTION
### Issue

With #3358 I implemented hardcoded Microdata into the layouts. However I used a `<span>` to assign the `articleBody` item property. Since spans aren't allowed to contain block elements, this causes now a validation error when checking with the W3C validator.
See Issue #3508 and Tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33662
### Solution

Using `<div>` instead of the `<span>` like suggested by @betweenbrain in the original PR solves the issue.
### Testing

Validate the single article view with Joomla 3.3 RC and verify the error. Apply this PR and check again. It should verify and the template should not change in any way.
