### PR TITLE
loadmodule renders only first module of type

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -113,8 +113,9 @@ class plgContentLoadmodule extends JPlugin
 	// there is a title.
 	protected function _loadmod($module, $title, $style = 'none')
 	{
-		if (!isset(self::$mods[$module])) {
-			self::$mods[$module] = '';
+		$moduleinstance = $module . JStringNormalise::toCamelCase($title);
+		if (!isset(self::$mods[$moduleinstance])) {
+			self::$mods[$moduleinstance] = '';
 			$document	= JFactory::getDocument();
 			$renderer	= $document->loadRenderer('module');
 			$mod		= JModuleHelper::getModule($module, $title);
@@ -129,8 +130,7 @@ class plgContentLoadmodule extends JPlugin
 
 			echo $renderer->render($mod, $params);
 
-			self::$mods[$module] = ob_get_clean();
+			self::$mods[$moduleinstance] = ob_get_clean();
 		}
-		return self::$mods[$module];
-	}
-}
+		return self::$mods[$moduleinstance];
+	}}

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -133,4 +133,5 @@ class plgContentLoadmodule extends JPlugin
 			self::$mods[$moduleinstance] = ob_get_clean();
 		}
 		return self::$mods[$moduleinstance];
-	}}
+	}
+}


### PR DESCRIPTION
plgContentLoadmodule::_loadmod() caches content it creates using just the module type as the index.  If more than one module of the same type is included using {loadmodule}, whichever module renders first provides the content for all instances of that module type.

The fix uses a concatenation of the module type and title, providing a unique index.
