### PR TITLE
[#33665] The property "catslug" missing on view category.

### DIFF
--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -88,6 +88,7 @@ class ContentViewCategory extends JViewLegacy
 				$item->parent_slug = null;
 			}
 
+			$item->catslug = $item->category_alias ? ($item->catid.':'.$item->category_alias) : $item->catid;
 			$item->event = new stdClass();
 
 			$dispatcher = JDispatcher::getInstance();


### PR DESCRIPTION
This patch adds a property "catslug" to the objects of the articles on view "Category". This is a patch for Joomla! 2.5. 
This issue does not exist in Joomla! 3.

Joomla!Code Tracker Page:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33665
