### PR TITLE
[#33667] Remove unneeded constant

### DIFF
--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -63,7 +63,7 @@ final class JVersion
 	 */
 	public function isCompatible($minimum)
 	{
-		return version_compare(JVERSION, $minimum, 'ge');
+		return version_compare($this->getShortVersion(), $minimum, 'ge');
 	}
 
 	/**


### PR DESCRIPTION
As JVersion is just defined as getShortVersion() from the JVersion class it makes sense to just use that function. It means therefore that JVersion doesn't require cms.php to run as well which may be useful in some CLI apps
See #3521 and tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33667&start=0
