### PR TITLE
Ensure param for showing page header works in beeze

### DIFF
--- a/templates/beez3/html/com_content/category/blog.php
+++ b/templates/beez3/html/com_content/category/blog.php
@@ -21,20 +21,16 @@ $cparams = JComponentHelper::getParams('com_media');
 // It will be a separate class if the user starts it with a space
 ?>
 <section class="blog<?php echo $this->pageclass_sfx;?>">
-<?php if ($this->params->get('show_page_heading') != 0 or $this->params->get('show_category_title')) : ?>
+<?php if ($this->params->get('show_page_heading') != 0) : ?>
 <h1>
-	<?php
-	if ($this->params->get('show_page_heading') != 0)
-	{
-		echo $this->escape($this->params->get('page_heading'));
-	}
-	
-	if ($this->params->get('show_category_title'))
-	{
-		echo '<span class="subheading-category">'.JHtml::_('content.prepare', $this->category->title, '', 'com_content.category.title').'</span>';
-	}
-	?>
+	<?php echo $this->escape($this->params->get('page_heading')); ?>
 </h1>
+<?php endif; ?>
+
+<?php if ($this->params->get('show_category_title')) : ?>
+<h2>
+	<?php echo '<span class="subheading-category">'.JHtml::_('content.prepare', $this->category->title, '', 'com_content.category.title').'</span>'; ?>
+</h2>
 <?php endif; ?>
 
 <?php if ($this->params->get('show_description', 1) || $this->params->def('show_description_image', 1)) : ?>

--- a/templates/beez3/html/com_content/category/blog.php
+++ b/templates/beez3/html/com_content/category/blog.php
@@ -28,8 +28,8 @@ $cparams = JComponentHelper::getParams('com_media');
 <?php endif; ?>
 
 <?php if ($this->params->get('show_category_title')) : ?>
-<h2>
-	<?php echo '<span class="subheading-category">'.JHtml::_('content.prepare', $this->category->title, '', 'com_content.category.title').'</span>'; ?>
+<h2 class="subheading-category">
+	<?php echo JHtml::_('content.prepare', $this->category->title, '', 'com_content.category.title'); ?>
 </h2>
 <?php endif; ?>
 

--- a/templates/beez3/html/com_content/category/blog.php
+++ b/templates/beez3/html/com_content/category/blog.php
@@ -23,8 +23,13 @@ $cparams = JComponentHelper::getParams('com_media');
 <section class="blog<?php echo $this->pageclass_sfx;?>">
 <?php if ($this->params->get('show_page_heading') != 0 or $this->params->get('show_category_title')) : ?>
 <h1>
-	<?php echo $this->escape($this->params->get('page_heading')); ?>
-	<?php if ($this->params->get('show_category_title'))
+	<?php
+	if ($this->params->get('show_page_heading') != 0)
+	{
+		echo $this->escape($this->params->get('page_heading'));
+	}
+	
+	if ($this->params->get('show_category_title'))
 	{
 		echo '<span class="subheading-category">'.JHtml::_('content.prepare', $this->category->title, '', 'com_content.category.title').'</span>';
 	}


### PR DESCRIPTION
In beez3 hiding the page heading whilst still showing the category title will end up with the page heading still showing - all in the same h1 tag. This fixes that.
### Testing

Turn off page heading param and on category title. Observe both still appear

Apply Patch

Only category title appears (in a h2 tag now). Verify turning on page heading param makes the page heading reappear (in a h1 tag).
