### PR TITLE
[#33595] Incorrect string truncate in com_tags 'tag' view 'default' layout

### DIFF
--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -79,7 +79,7 @@ $n = count($this->items);
 			<?php if ($this->params->get('tag_list_show_item_description', 1)) : ?>
 				<?php echo $item->event->beforeDisplayContent; ?>
 				<span class="tag-body">
-					<?php echo JHtml::_('string.truncate', $item->core_body, $this->params->get('tag_list_item_maximum_characters')); ?>
+					<?php echo JHtml::_('string.truncateComplex', $item->core_body, $this->params->get('tag_list_item_maximum_characters')); ?>
 				</span>
 				<?php echo $item->event->afterDisplayContent; ?>
 			<?php endif; ?>

--- a/libraries/cms/html/string.php
+++ b/libraries/cms/html/string.php
@@ -90,6 +90,14 @@ abstract class JHtmlString
 
 			if ($allowHtml)
 			{
+				// If string truncated inside tag: "... <script"
+				$lt = JString::strrpos($tmp, '<');
+				$gt = JString::strrpos($tmp, '>');
+				if (($gt === false && $lt !== false) || ($lt > $gt))
+				{
+					$tmp .= '>';
+				}
+
 				// Put all opened tags into an array
 				preg_match_all("#<([a-z][a-z0-9]*)\b.*?(?!/)>#i", $tmp, $result);
 				$openedTags = $result[1];


### PR DESCRIPTION
Incorrect string truncate in com_tags 'tag' view 'default' layout. Depending on the length of the html tags, the article body can be reduced to one word, if not be empty at all. There must be used 'string.truncateComplex' instead of 'string.truncate'

<h4>Tracker:</h4>

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33595&start=25
