### PR TITLE
[#33587] 'onContentPrepare' trigger not working in com_tags 'tag' view 'default' layout

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -104,7 +104,10 @@ class TagsViewTag extends JViewLegacy
 				$itemElement->event->afterDisplayContent = trim(implode("\n", $results));
 
 				// Write the results back into the body
-				if ( !empty($itemElement->core_body) ) $itemElement->core_body = $itemElement->text;
+				if (!empty($itemElement->core_body))
+				{
+					$itemElement->core_body = $itemElement->text;
+				}
 			}
 		}
 

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -103,6 +103,8 @@ class TagsViewTag extends JViewLegacy
 				$results = $dispatcher->trigger('onContentAfterDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
 				$itemElement->event->afterDisplayContent = trim(implode("\n", $results));
 
+				// Write the results back into the body
+				if ( !empty($itemElement->core_body) ) $itemElement->core_body = $itemElement->text;
 			}
 		}
 


### PR DESCRIPTION
Results of the 'onContentPrepare' event trigger was not returned to the item body

<h4>Testing Instructions</h4>

Add email address to the article body and go to the 'tag' view (with 'Item description' set to 'show') . Before PR is applied, address displayed as plain text. After PR is applied, address protected by javascript.

<h4>Tracker</h4>

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33587
