### PR TITLE
[#29475] Check for safe_mode or open_basedir in the cURL adapter

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -139,8 +139,14 @@ class JHttpTransportCurl implements JHttpTransport
 		// Link: http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
 		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
 
-		// Follow redirects.
-		$options[CURLOPT_FOLLOWLOCATION] = (bool) $this->options->get('follow_location', true);
+		/*
+		 * Follow redirects if server config allows
+		 * @deprecated  safe_mode is removed in PHP 5.4, check will be dropped when PHP 5.3 support is dropped
+		 */
+		if (!ini_get('safe_mode') && !ini_get('open_basedir'))
+		{
+			$options[CURLOPT_FOLLOWLOCATION] = (bool) $this->options->get('follow_location', true);
+		}
 
 		// Proxy configuration
 		$config = JFactory::getConfig();


### PR DESCRIPTION
Certain environments with PHP's `safe_mode` or `open_basedir` options set can cause errors with the cURL adapter.  Users will get a message similar to `Warning: curl_setopt_array(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set in /libraries/joomla/http/transport/curl.php on line 159`.

Edit: Tracker - http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29475
