### PR TITLE
Remove unnecessary reset()

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -733,8 +733,6 @@ abstract class JHtmlSelect
 	public static function radiolist($data, $name, $attribs = null, $optKey = 'value', $optText = 'text', $selected = null, $idtag = false,
 		$translate = false)
 	{
-		reset($data);
-
 		if (is_array($attribs))
 		{
 			$attribs = JArrayHelper::toString($attribs);


### PR DESCRIPTION
There is no need to call reset() in radiolist() function as the function does not use array pointer anywhere in the function. Also, as HHVM does not support calling reset() on an object, this also result in removing a warning when using this code in HHVM.
