### PR TITLE
[#33685] Featured article order now orders by a tertiary date

### DIFF
--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -103,7 +103,7 @@ class ContentHelperQuery
 				break;
 
 			case 'front' :
-				$orderby = 'a.featured DESC, fp.ordering';
+				$orderby = 'a.featured DESC, fp.ordering, ' . $queryDate . ' DESC ';
 				break;
 
 			default :


### PR DESCRIPTION
In the com_content artticle category blog, the featured articles order is "a.featured DESC, fp.ordering".  This orders the featured articles correctly, and places the non-featured articles below.  However, there is no ordering supplied for the non-featured articles.

I'd suggest a logical tertiary ordering is using the "date for ordering", thus supporting the use of features as forum-like sticky articles.

Changing to "a.featured DESC, fp.ordering, ' . $queryDate . ' DESC '".

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33685&start=0
