### PR TITLE
[#33688] JApplicationCms::getRouter is a static method

### DIFF
--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -76,7 +76,7 @@ class FinderViewSearch extends JViewLegacy
 		if (strpos($this->query->input, '"'))
 		{
 			// Get the application router.
-			$router =& $app->getRouter();
+			$router =& $app::getRouter();
 
 			// Fix the q variable in the URL.
 			if ($router->getVar('q') !== $this->query->input)

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -1018,7 +1018,7 @@ class JApplicationCms extends JApplicationWeb
 		// Get the full request URI.
 		$uri = clone JUri::getInstance();
 
-		$router = $this->getRouter();
+		$router = static::getRouter();
 		$result = $router->parse($uri);
 
 		foreach ($result as $key => $value)

--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -44,7 +44,8 @@ class JRoute
 		if (!self::$_router)
 		{
 			// Get the router.
-			self::$_router = JFactory::getApplication()->getRouter();
+			$app = JFactory::getApplication();
+			self::$_router = $app::getRouter();
 
 			// Make sure that we have our router
 			if (!self::$_router)

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -30,7 +30,7 @@ class ModLoginHelper
 	public static function getReturnURL($params, $type)
 	{
 		$app	= JFactory::getApplication();
-		$router = $app->getRouter();
+		$router = $app::getRouter();
 		$url = null;
 
 		if ($itemid = $params->get($type))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -58,7 +58,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		if (!self::$default_lang)
 		{
 			$app = JFactory::getApplication();
-			$router = $app->getRouter();
+			$router = $app::getRouter();
 
 			if ($app->isSite())
 			{
@@ -152,7 +152,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		{
 			self::$tag = JFactory::getLanguage()->getTag();
 
-			$router = $app->getRouter();
+			$router = $app::getRouter();
 
 			// Attach build rules for language SEF.
 			$router->attachBuildRule(array($this, 'buildRule'));

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -34,7 +34,7 @@ class PlgSystemSef extends JPlugin
 			return true;
 		}
 
-		$router = $app->getRouter();
+		$router = $app::getRouter();
 
 		$uri     = clone JUri::getInstance();
 		$domain  = $this->params->get('domain');


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33688&start=0

We need to grab the JRouterSite/JRouterAdministrator object in various places in Joomla. And currently the function is a static function. But we're not calling it statically - and with the PHPUnit upgrade travis has just done that's suddenly become important as we can't mock the static methods. So we now _must_ call this correctly for the unit tests to function (see https://github.com/joomla/joomla-cms/pull/3550)
## Testing
- Check that routing in frontend & backend still work (SEF URLs on & off)
- Check the com_finder frontend search view still works and generates the correct URLS
- Check internal links (that would use JRoute) work as expected. i.e. going from category view to single article view.
- Check login module redirection url works
- Check language filter plugin still works
