### PR TITLE
Incorrect SQL on deleting an article's associations

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -490,6 +490,7 @@ class ContentModelArticle extends JModelAdmin
 				}
 
 				$associations[$item->language] = $item->id;
+				$associations = array_filter($associations);
 
 				// Deleting old association for these items
 				$db = JFactory::getDbo();


### PR DESCRIPTION
#3556

J! 3.3 Stable
File : /administrator/components/com_content/models/article.php

For some reasons, it happens that the array
$associations[$item->language] = $item->id;
ends with a null element

Hence,
->where('id IN (' . implode(',', $associations) . ')');
leads to something like "id IN (3188, )"
which gives an error because of the ending comma.

Fix :
after the line :
$associations[$item->language] = $item->id;
add an array_filter :
$associations = array_filter($associations);
