### PR TITLE
 [#33700] Fix for "duplicate key on insert detected" errors  in FinderIndexerHelper::addContentType

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -276,8 +276,11 @@ class FinderIndexerHelper
 		$db->setQuery($query);
 		$db->execute();
 
+		// Add the new type entry to the types hash
+		$types[$title] = (object)array("id" => $db->insertid(), "title" => $title, "mime" => $mime);
+		
 		// Return the new id.
-		return (int) $db->insertid();
+		return (int) $types[$title]->id;
 	}
 
 	/**


### PR DESCRIPTION
When indexing content via a finder plugin which may have multiple mime types (e.g. document management systems, pdf, doc, zip etc.), adding a new mime type will work, but if another document with the same mime type exists, consecutive getting the type id results in a duplicate insert in table #__finder_types.
This is due to that the static method variable $types is initialized on the first call of the method and does not take in account mime types inserted after initialization.

The fix adds the newly inserted mime type into $types hash, so that calling this method againg with the same mimetype results in a positive lookup within the hash.
