### PR TITLE
Installing phpunit with pear is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ php:
 
 before_script:
   - composer self-update
-  - pyrus channel-discover pear.phpunit.de
-  - pyrus channel-discover pear.symfony.com
-  - pyrus install --force phpunit/DbUnit
+  - wget https://phar.phpunit.de/phpunit.phar
   - phpenv rehash
   - mysql -e 'create database joomla_ut;'
   - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
@@ -16,7 +14,7 @@ before_script:
   - psql -d joomla_ut -a -f tests/unit/suites/database/stubs/postgresql.sql
 
 script:
-  - phpunit --configuration travisci-phpunit.xml
+  - php phpunit.phar --configuration travisci-phpunit.xml
 
 branches:
   except:


### PR DESCRIPTION
This allows us to use the latest and greatest version of PHPUnit - currently we're on 4.0.17 - the limit now for pear. But this will put us on 4.1.0

See https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method
