### PR TITLE
[#33691] Union should not apply settings to the set

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -364,11 +364,6 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->where;
 				}
 
-				if ($this->union)
-				{
-					$query .= (string) $this->union;
-				}
-
 				if ($this->group)
 				{
 					$query .= (string) $this->group;
@@ -383,6 +378,12 @@ abstract class JDatabaseQuery
 				{
 					$query .= (string) $this->order;
 				}
+
+				if ($this->union)
+				{
+					$query .= (string) $this->union;
+				}
+
 				break;
 
 			case 'delete':


### PR DESCRIPTION
[#33691] http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33691&start=0

The union applied settings like group/having/order to the result set instead of the first select. This corrects that, they now apply to the first select.
Currently the query object doesn't support set settings. Use the string manipulation instead.
