### PR TITLE
Fixed Warning in the ACL check

### DIFF
--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -34,7 +34,8 @@ class CategoriesViewCategory extends JViewLegacy
 		$this->form = $this->get('Form');
 		$this->item = $this->get('Item');
 		$this->state = $this->get('State');
-		$this->canDo = JHelperContent::getActions($this->state->get('category.extension'), 'category', $this->item->id);
+		$section = $this->state->get('category.section') ? $this->state->get('category.section') . '.' : '';
+		$this->canDo = JHelperContent::getActions($this->state->get('category.component'), $section . 'category', $this->item->id);
 		$this->assoc = $this->get('Assoc');
 
 		$input = JFactory::getApplication()->input;


### PR DESCRIPTION
Fixed Warning: Invalid argument supplied for foreach() in libraries/cms/helper/content.php on line 121 if you have a category with a section (e.g. option=com_categories&extension=com_foo.bar)
