### PR TITLE
[#33765] Add fast check for image orientation

### DIFF
--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -78,7 +78,8 @@ abstract class JImageHelper
 			'attributes' => $info[3],
 			'bits' => isset($info['bits']) ? $info['bits'] : null,
 			'channels' => isset($info['channels']) ? $info['channels'] : null,
-			'mime' => $info['mime']
+			'mime' => $info['mime'],
+			'orientation' => JImageHelper::getOrientation((int) $info[0], (int) $info[1]);
 		);
 
 		return $properties;

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -81,7 +81,7 @@ abstract class JImageHelper
 			'bits' => isset($info['bits']) ? $info['bits'] : null,
 			'channels' => isset($info['channels']) ? $info['channels'] : null,
 			'mime' => $info['mime'],
-			'orientation' => JImageHelper::getOrientation((int) $info[0], (int) $info[1]);
+			'orientation' => JImageHelper::getOrientation((int) $info[0], (int) $info[1])
 		);
 
 		return $properties;

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -95,7 +95,7 @@ abstract class JImageHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getOrientation($width, $height)
+	public static function getOrientation($width, $height)
 	{
 	    switch (true)
 	    {

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Mail
+ * @subpackage  Image
  *
  * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -14,26 +14,27 @@ defined('JPATH_PLATFORM') or die;
  * to the Joomla image routines.
  *
  * @package     Joomla.Platform
- * @subpackage  Mail
+ * @subpackage  Image
+	 *
  * @since       13.1
  */
 abstract class JImageHelper
 {
 	/**
 	 * @const  string
-	 * @since  13.1
+	 * @since  __DEPLOY_VERSION__
 	 */
 	const ORIENTATION_LANDSCAPE = 'landscape';
 
 	/**
 	 * @const  string
-	 * @since  13.1
+	 * @since  __DEPLOY_VERSION__
 	 */
 	const ORIENTATION_PORTRAIT = 'portrait';
 
 	/**
 	 * @const  string
-	 * @since  13.1
+	 * @since  __DEPLOY_VERSION__
 	 */
 	const ORIENTATION_SQUARE = 'square';
 
@@ -48,6 +49,7 @@ abstract class JImageHelper
 	 * @return  stdClass
 	 *
 	 * @since   11.3
+	 *
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
 	 */

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -19,4 +19,50 @@ defined('JPATH_PLATFORM') or die;
  */
 abstract class JMailHelper
 {
+	/**
+	 * Method to return a properties object for an image given a filesystem path.  The
+	 * result object has values for image width, height, type, attributes, mime type, bits,
+	 * and channels.
+	 *
+	 * @static
+	 * @param   string  $path  The filesystem path to the image for which to get properties.
+	 *
+	 * @return  stdClass
+	 *
+	 * @since   11.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public static function getImageFileProperties($path)
+	{
+		// Make sure the file exists.
+		if (!file_exists($path))
+		{
+			throw new InvalidArgumentException('The image file does not exist.');
+		}
+
+		// Get the image file information.
+		$info = getimagesize($path);
+
+		if (!$info)
+		{
+			// @codeCoverageIgnoreStart
+			throw new RuntimeException('Unable to get properties for the image.');
+
+			// @codeCoverageIgnoreEnd
+		}
+
+		// Build the response object.
+		$properties = (object) array(
+			'width' => $info[0],
+			'height' => $info[1],
+			'type' => $info[2],
+			'attributes' => $info[3],
+			'bits' => isset($info['bits']) ? $info['bits'] : null,
+			'channels' => isset($info['channels']) ? $info['channels'] : null,
+			'mime' => $info['mime']
+		);
+
+		return $properties;
+	}
 }

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -81,6 +81,7 @@ abstract class JImageHelper
 			'bits' => isset($info['bits']) ? $info['bits'] : null,
 			'channels' => isset($info['channels']) ? $info['channels'] : null,
 			'mime' => $info['mime'],
+			'filesize' => filesize($path),
 			'orientation' => JImageHelper::getOrientation((int) $info[0], (int) $info[1])
 		);
 

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Mail
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Image helper class, provides static methods to perform various tasks relevant
+ * to the Joomla image routines.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Mail
+ * @since       13.1
+ */
+abstract class JMailHelper
+{
+}

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -65,4 +65,32 @@ abstract class JMailHelper
 
 		return $properties;
 	}
+	
+	/**
+	 * Compare width and height integers to determine image orientation.
+	 *
+	 * @param  integer  $width
+	 * @param  integer  $height
+	 *
+	 * @return  mixed   Orientation string or null.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getOrientation($width, $height)
+	{
+	    switch (true)
+	    {
+	        case ($width > $height) :
+	            return self::ORIENTATION_LANDSCAPE;
+	
+	        case ($width < $height) :
+	            return self::ORIENTATION_PORTRAIT;
+	
+	        case ($width == $height) :
+	            return self::ORIENTATION_SQUARE;
+	
+	        default :
+	            return null;
+	    }
+	}
 }

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -15,8 +15,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @package     Joomla.Platform
  * @subpackage  Image
-	 *
- * @since       13.1
+ * *
+ * @since       __DEPLOY_VERSION__
  */
 abstract class JImageHelper
 {

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @package     Joomla.Platform
  * @subpackage  Image
- * *
+ *
  * @since       __DEPLOY_VERSION__
  */
 abstract class JImageHelper

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -17,8 +17,26 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Mail
  * @since       13.1
  */
-abstract class JMailHelper
+abstract class JImageHelper
 {
+	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_LANDSCAPE = 'landscape';
+
+	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_PORTRAIT = 'portrait';
+
+	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_SQUARE = 'square';
+
 	/**
 	 * Method to return a properties object for an image given a filesystem path.  The
 	 * result object has values for image width, height, type, attributes, mime type, bits,

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -48,7 +48,7 @@ abstract class JImageHelper
 	 *
 	 * @return  stdClass
 	 *
-	 * @since   11.3
+	 * @since   __DEPLOY_VERSION__
 	 *
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -43,8 +43,6 @@ abstract class JImageHelper
 	 * The result object has values for image width, height, type, attributes,
 	 * bits, channels, mime type, filesize and orientation.
 	 *
-	 * @static
-	 *
 	 * @param   string  $path  The filesystem path to the image for which to get properties.
 	 *
 	 * @return  stdClass
@@ -52,7 +50,7 @@ abstract class JImageHelper
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   3.4
 	 */
 	public static function getImageFileProperties($path)
 	{
@@ -83,39 +81,37 @@ abstract class JImageHelper
 			'channels' => isset($info['channels']) ? $info['channels'] : null,
 			'mime' => $info['mime'],
 			'filesize' => filesize($path),
-			'orientation' => JImageHelper::getOrientation((int) $info[0], (int) $info[1])
+			'orientation' => self::getOrientation((int) $info[0], (int) $info[1])
 		);
 
 		return $properties;
 	}
-	
+
 	/**
 	 * Compare width and height integers to determine image orientation.
 	 *
-	 * @static
+	 * @param   integer  $width    The width value to use for calculation
+	 * @param   integer  $height   The height value to use for calculation
 	 *
-	 * @param  integer  $width
-	 * @param  integer  $height
+	 * @return  mixed    Orientation string or null.
 	 *
-	 * @return  mixed   Orientation string or null.
-	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   3.4
 	 */
 	public static function getOrientation($width, $height)
 	{
-	    switch (true)
-	    {
-	        case ($width > $height) :
-	            return self::ORIENTATION_LANDSCAPE;
+		switch (true)
+		{
+		case ($width > $height) :
+			return self::ORIENTATION_LANDSCAPE;
 	
-	        case ($width < $height) :
-	            return self::ORIENTATION_PORTRAIT;
-	
-	        case ($width == $height) :
-	            return self::ORIENTATION_SQUARE;
-	
-	        default :
-	            return null;
-	    }
+		case ($width < $height) :
+			return self::ORIENTATION_PORTRAIT;
+
+		case ($width == $height) :
+			return self::ORIENTATION_SQUARE;
+
+		default :
+			return null;
+		}
 	}
 }

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -39,19 +39,20 @@ abstract class JImageHelper
 	const ORIENTATION_SQUARE = 'square';
 
 	/**
-	 * Method to return a properties object for an image given a filesystem path.  The
-	 * result object has values for image width, height, type, attributes, mime type, bits,
-	 * and channels.
+	 * Method to return a properties object for an image given a filesystem path.
+	 * The result object has values for image width, height, type, attributes,
+	 * bits, channels, mime type, filesize and orientation.
 	 *
 	 * @static
+	 *
 	 * @param   string  $path  The filesystem path to the image for which to get properties.
 	 *
 	 * @return  stdClass
 	 *
-	 * @since   __DEPLOY_VERSION__
-	 *
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getImageFileProperties($path)
 	{
@@ -90,6 +91,8 @@ abstract class JImageHelper
 	
 	/**
 	 * Compare width and height integers to determine image orientation.
+	 *
+	 * @static
 	 *
 	 * @param  integer  $width
 	 * @param  integer  $height

--- a/libraries/joomla/image/helper.php
+++ b/libraries/joomla/image/helper.php
@@ -90,8 +90,8 @@ abstract class JImageHelper
 	/**
 	 * Compare width and height integers to determine image orientation.
 	 *
-	 * @param   integer  $width    The width value to use for calculation
-	 * @param   integer  $height   The height value to use for calculation
+	 * @param   integer  $width   The width value to use for calculation
+	 * @param   integer  $height  The height value to use for calculation
 	 *
 	 * @return  mixed    Orientation string or null.
 	 *
@@ -103,7 +103,7 @@ abstract class JImageHelper
 		{
 		case ($width > $height) :
 			return self::ORIENTATION_LANDSCAPE;
-	
+
 		case ($width < $height) :
 			return self::ORIENTATION_PORTRAIT;
 

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -137,6 +137,7 @@ class JImage
 	 * Method to detect an whether image's orientation is landscape, portrait or square.
 	 * The orientation will be returned as string.
 	 *
+	 * @static
 	 * @return  mixed   Orientation string or null.
 	 *
 	 * @since   __DEPLOY_VERSION__

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -160,102 +160,78 @@ class JImage
 	}
 
 	/**
-	 * Method to detect if a given image's format is cubic (width equals height).
+	 * Method to detect an whether image's orientation is landscape, portrait or square.
+	 * The orientation will be returned as string.
 	 *
-	 * @param   string  $path  The filesystem path to the image for which to get properties.
+	 * @param   string  $path  The filesystem path to the image for which to get properties. (optional) If not passed in it is checked for a linked resource.
 	 *
-	 * @return  boolean
-	 *
-	 * @since   11.3
-	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
-	 */
-	public static function isCubic($path)
-	{
-		// Make sure the file exists.
-		if (!file_exists($path))
-		{
-			throw new InvalidArgumentException('The image file does not exist.');
-		}
-
-		// Get the image file information.
-		$info = getimagesize($path);
-
-		if (!$info)
-		{
-			// @codeCoverageIgnoreStart
-			throw new RuntimeException('Unable to get properties for the image.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
-		return (int) $info[0] == (int) $info[1];
-	}
-
-	/**
-	 * Method to detect if a given image's format is landscape (width is bigger than height).
-	 *
-	 * @param   string  $path  The filesystem path to the image for which to get properties.
-	 *
-	 * @return  boolean
+	 * @return  mixed   String the orientation or null.
 	 *
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
 	 */
-	public static function isLandscape($path)
+	public static function getOrientation($path = null)
 	{
-		// Make sure the file exists.
-		if (!file_exists($path))
+		// If this is an instance of JImage with a resource loaded, get width and height from the resource.
+		if ($path)
 		{
-			throw new InvalidArgumentException('The image file does not exist.');
+			// Make sure the file exists.
+			if (!file_exists($path))
+			{
+				throw new InvalidArgumentException('The image file does not exist.');
+			}
+
+			// Get the image file information.
+			$info = getimagesize($path);
+
+			if (!$info)
+			{
+				// @codeCoverageIgnoreStart
+				throw new RuntimeException('Unable to get properties for the image.');
+
+				// @codeCoverageIgnoreEnd
+			}
+
+			switch (true)
+			{
+				case ((int) $info[0] > (int) $info[1]) :
+					return 'landscape';
+
+				case ((int) $info[0] < (int) $info[1]) :
+					return 'portrait';
+
+				case ((int) $info[0] == (int) $info[1]) :
+					return 'square';
+
+				default :
+					return 'null';
+			}
 		}
-
-		// Get the image file information.
-		$info = getimagesize($path);
-
-		if (!$info)
+		elseif (isset($handle) && is_resource($handle) && (get_resource_type($handle) == 'gd'))
 		{
-			// @codeCoverageIgnoreStart
-			throw new RuntimeException('Unable to get properties for the image.');
+			$width  = $this->getWidth();
+			$height = $this->getHeight();
 
-			// @codeCoverageIgnoreEnd
+			switch (true)
+			{
+				case ($width > $height) :
+					return 'landscape';
+
+				case ($width < $height) :
+					return 'portrait';
+
+				case ($width == $height) :
+					return 'square';
+
+				default :
+					return 'null';
+			}
 		}
-
-		return (int) $info[0] > (int) $info[1];
-	}
-
-	/**
-	 * Method to detect if a given image's format is portrait (height is bigger than width).
-	 *
-	 * @param   string  $path  The filesystem path to the image for which to get properties.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   11.3
-	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
-	 */
-	public static function isPortrait($path)
-	{
-		// Make sure the file exists.
-		if (!file_exists($path))
+		else
 		{
-			throw new InvalidArgumentException('The image file does not exist.');
+			return null;
 		}
-
-		// Get the image file information.
-		$info = getimagesize($path);
-
-		if (!$info)
-		{
-			// @codeCoverageIgnoreStart
-			throw new RuntimeException('Unable to get properties for the image.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
-		return (int) $info[0] < (int) $info[1];
 	}
 
 	/**

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -125,11 +125,33 @@ class JImage
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
+	 *
 	 * @deprecated  4.0  Use JImageHelper::getImageFileProperties instead.
 	 */
 	public static function getImageFileProperties($path)
 	{
 		return JImageHelper::getImageFileProperties($path);
+	}
+	
+	/**
+	 * Method to detect an whether image's orientation is landscape, portrait or square.
+	 * The orientation will be returned as string.
+	 *
+	 * @return  mixed   Orientation string or null.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getOrientation()
+	{
+	    if ($this->isLoaded())
+	    {
+	        $width  = $this->getWidth();
+	        $height = $this->getHeight();
+	
+	        return JImageHelper::getOrientation($width, $height);
+	    }
+	
+	    return null;
 	}
 
 	/**

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -55,6 +55,24 @@ class JImage
 	const SCALE_FIT = 6;
 
 	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_LANDSCAPE = 'landscape';
+
+	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_PORTRAIT = 'portrait';
+
+	/**
+	 * @const  string
+	 * @since  13.1
+	 */
+	const ORIENTATION_SQUARE = 'square';
+
+	/**
 	 * @var    resource  The image resource handle.
 	 * @since  11.3
 	 */
@@ -196,13 +214,13 @@ class JImage
 			switch (true)
 			{
 				case ((int) $info[0] > (int) $info[1]) :
-					return 'landscape';
+					return JImage::ORIENTATION_LANDSCAPE;
 
 				case ((int) $info[0] < (int) $info[1]) :
-					return 'portrait';
+					return JImage::ORIENTATION_PORTRAIT;
 
 				case ((int) $info[0] == (int) $info[1]) :
-					return 'square';
+					return JImage::ORIENTATION_SQUARE;
 
 				default :
 					return 'null';
@@ -216,13 +234,13 @@ class JImage
 			switch (true)
 			{
 				case ($width > $height) :
-					return 'landscape';
+					return JImage::ORIENTATION_LANDSCAPE;
 
 				case ($width < $height) :
-					return 'portrait';
+					return JImage::ORIENTATION_PORTRAIT;
 
 				case ($width == $height) :
-					return 'square';
+					return JImage::ORIENTATION_SQUARE;
 
 				default :
 					return 'null';

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -160,6 +160,105 @@ class JImage
 	}
 
 	/**
+	 * Method to detect if a given image's format is cubic (width equals height).
+	 *
+	 * @param   string  $path  The filesystem path to the image for which to get properties.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   11.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public static function isCubic($path)
+	{
+		// Make sure the file exists.
+		if (!file_exists($path))
+		{
+			throw new InvalidArgumentException('The image file does not exist.');
+		}
+
+		// Get the image file information.
+		$info = getimagesize($path);
+
+		if (!$info)
+		{
+			// @codeCoverageIgnoreStart
+			throw new RuntimeException('Unable to get properties for the image.');
+
+			// @codeCoverageIgnoreEnd
+		}
+
+		return (int) $info[0] == (int) $info[1];
+	}
+
+	/**
+	 * Method to detect if a given image's format is landscape (width is bigger than height).
+	 *
+	 * @param   string  $path  The filesystem path to the image for which to get properties.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   11.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public static function isLandscape($path)
+	{
+		// Make sure the file exists.
+		if (!file_exists($path))
+		{
+			throw new InvalidArgumentException('The image file does not exist.');
+		}
+
+		// Get the image file information.
+		$info = getimagesize($path);
+
+		if (!$info)
+		{
+			// @codeCoverageIgnoreStart
+			throw new RuntimeException('Unable to get properties for the image.');
+
+			// @codeCoverageIgnoreEnd
+		}
+
+		return (int) $info[0] > (int) $info[1];
+	}
+
+	/**
+	 * Method to detect if a given image's format is portrait (height is bigger than width).
+	 *
+	 * @param   string  $path  The filesystem path to the image for which to get properties.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   11.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public static function isPortrait($path)
+	{
+		// Make sure the file exists.
+		if (!file_exists($path))
+		{
+			throw new InvalidArgumentException('The image file does not exist.');
+		}
+
+		// Get the image file information.
+		$info = getimagesize($path);
+
+		if (!$info)
+		{
+			// @codeCoverageIgnoreStart
+			throw new RuntimeException('Unable to get properties for the image.');
+
+			// @codeCoverageIgnoreEnd
+		}
+
+		return (int) $info[0] < (int) $info[1];
+	}
+
+	/**
 	 * Method to generate thumbnails from the current image. It allows
 	 * creation by resizing or cropping the original image.
 	 *

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -171,7 +171,7 @@ class JImage
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
 	 */
-	public static function getOrientation($path = null)
+	public function getOrientation($path = null)
 	{
 		// If this is an instance of JImage with a resource loaded, get width and height from the resource.
 		if ($path)
@@ -208,8 +208,7 @@ class JImage
 					return 'null';
 			}
 		}
-		// TODO - needs work because $handle won't be set when calling this method statically (see: #3568)
-		elseif (isset($handle) && is_resource($handle) && (get_resource_type($handle) == 'gd'))
+		elseif ($this->isLoaded())
 		{
 			$width  = $this->getWidth();
 			$height = $this->getHeight();

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -208,6 +208,7 @@ class JImage
 					return 'null';
 			}
 		}
+		// TODO - needs work because $handle won't be set when calling this method statically (see: #3568)
 		elseif (isset($handle) && is_resource($handle) && (get_resource_type($handle) == 'gd'))
 		{
 			$width  = $this->getWidth();

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -143,38 +143,11 @@ class JImage
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
+	 * @deprecated  4.0  Use JImageHelper::getImageFileProperties instead.
 	 */
 	public static function getImageFileProperties($path)
 	{
-		// Make sure the file exists.
-		if (!file_exists($path))
-		{
-			throw new InvalidArgumentException('The image file does not exist.');
-		}
-
-		// Get the image file information.
-		$info = getimagesize($path);
-
-		if (!$info)
-		{
-			// @codeCoverageIgnoreStart
-			throw new RuntimeException('Unable to get properties for the image.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
-		// Build the response object.
-		$properties = (object) array(
-			'width' => $info[0],
-			'height' => $info[1],
-			'type' => $info[2],
-			'attributes' => $info[3],
-			'bits' => isset($info['bits']) ? $info['bits'] : null,
-			'channels' => isset($info['channels']) ? $info['channels'] : null,
-			'mime' => $info['mime']
-		);
-
-		return $properties;
+		return JImageHelper::getImageFileProperties($path);
 	}
 
 	/**

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -246,10 +246,8 @@ class JImage
 					return 'null';
 			}
 		}
-		else
-		{
-			return null;
-		}
+		
+		return null;
 	}
 
 	/**

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -55,24 +55,6 @@ class JImage
 	const SCALE_FIT = 6;
 
 	/**
-	 * @const  string
-	 * @since  13.1
-	 */
-	const ORIENTATION_LANDSCAPE = 'landscape';
-
-	/**
-	 * @const  string
-	 * @since  13.1
-	 */
-	const ORIENTATION_PORTRAIT = 'portrait';
-
-	/**
-	 * @const  string
-	 * @since  13.1
-	 */
-	const ORIENTATION_SQUARE = 'square';
-
-	/**
 	 * @var    resource  The image resource handle.
 	 * @since  11.3
 	 */
@@ -148,79 +130,6 @@ class JImage
 	public static function getImageFileProperties($path)
 	{
 		return JImageHelper::getImageFileProperties($path);
-	}
-
-	/**
-	 * Method to detect an whether image's orientation is landscape, portrait or square.
-	 * The orientation will be returned as string.
-	 *
-	 * @param   string  $path  The filesystem path to the image for which to get properties. (optional) If not passed in it is checked for a linked resource.
-	 *
-	 * @return  mixed   String the orientation or null.
-	 *
-	 * @since   11.3
-	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
-	 */
-	public function getOrientation($path = null)
-	{
-		// If this is an instance of JImage with a resource loaded, get width and height from the resource.
-		if ($path)
-		{
-			// Make sure the file exists.
-			if (!file_exists($path))
-			{
-				throw new InvalidArgumentException('The image file does not exist.');
-			}
-
-			// Get the image file information.
-			$info = getimagesize($path);
-
-			if (!$info)
-			{
-				// @codeCoverageIgnoreStart
-				throw new RuntimeException('Unable to get properties for the image.');
-
-				// @codeCoverageIgnoreEnd
-			}
-
-			switch (true)
-			{
-				case ((int) $info[0] > (int) $info[1]) :
-					return JImage::ORIENTATION_LANDSCAPE;
-
-				case ((int) $info[0] < (int) $info[1]) :
-					return JImage::ORIENTATION_PORTRAIT;
-
-				case ((int) $info[0] == (int) $info[1]) :
-					return JImage::ORIENTATION_SQUARE;
-
-				default :
-					return 'null';
-			}
-		}
-		elseif ($this->isLoaded())
-		{
-			$width  = $this->getWidth();
-			$height = $this->getHeight();
-
-			switch (true)
-			{
-				case ($width > $height) :
-					return JImage::ORIENTATION_LANDSCAPE;
-
-				case ($width < $height) :
-					return JImage::ORIENTATION_PORTRAIT;
-
-				case ($width == $height) :
-					return JImage::ORIENTATION_SQUARE;
-
-				default :
-					return 'null';
-			}
-		}
-		
-		return null;
 	}
 
 	/**

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -114,15 +114,18 @@ class JImage
 	}
 
 	/**
-	 * Method to return a properties object for an image given a filesystem path.  The
-	 * result object has values for image width, height, type, attributes, mime type, bits,
-	 * and channels.
+	 * Method to return a properties object for an image given a filesystem path.
+	 * The result object has values for image width, height, type, attributes,
+	 * mime type, bits and channels.
+	 *
+	 * @static
 	 *
 	 * @param   string  $path  The filesystem path to the image for which to get properties.
 	 *
 	 * @return  stdClass
 	 *
 	 * @since   11.3
+	 *
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
 	 *
@@ -134,10 +137,11 @@ class JImage
 	}
 	
 	/**
-	 * Method to detect an whether image's orientation is landscape, portrait or square.
+	 * Method to detect whether an image's orientation is landscape, portrait or square.
 	 * The orientation will be returned as string.
 	 *
-	 * @static
+	 * @access  public
+	 *
 	 * @return  mixed   Orientation string or null.
 	 *
 	 * @since   __DEPLOY_VERSION__

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -118,8 +118,6 @@ class JImage
 	 * The result object has values for image width, height, type, attributes,
 	 * mime type, bits and channels.
 	 *
-	 * @static
-	 *
 	 * @param   string  $path  The filesystem path to the image for which to get properties.
 	 *
 	 * @return  stdClass
@@ -135,7 +133,7 @@ class JImage
 	{
 		return JImageHelper::getImageFileProperties($path);
 	}
-	
+
 	/**
 	 * Method to detect whether an image's orientation is landscape, portrait or square.
 	 * The orientation will be returned as string.
@@ -144,19 +142,19 @@ class JImage
 	 *
 	 * @return  mixed   Orientation string or null.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   3.4
 	 */
 	public function getOrientation()
 	{
-	    if ($this->isLoaded())
-	    {
-	        $width  = $this->getWidth();
-	        $height = $this->getHeight();
-	
-	        return JImageHelper::getOrientation($width, $height);
-	    }
-	
-	    return null;
+		if ($this->isLoaded())
+		{
+			$width  = $this->getWidth();
+			$height = $this->getHeight();
+
+			return JImageHelper::getOrientation($width, $height);
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Detecting an image's orientation (landscape, portrait, etc) may become a repetitive task when is comes to decide which values to set for width and height to the resize() method. I found my self in need to know if the images i process are in landscape or portrait or (rather rarly) in square format. As a first step i coded this check whereever i needed it which i found pretty unhandy. Querying this information from the JImage class statically like is possible with the getImageFileProperties() method was a very helpful faster solution.

At another stage (when preparing my view) i found myself again require to know an image's orientation to apply a CSS class. As can be seen the need for this information is there which is why i add this pull request including the 3 new methods: isCubic(), isLandscape(), isPortrait().

**Test Instructions** (mabe somebody experienced is willing to adopt it into the image test class?

```
1. Create the helper class file from this PR under JPATH_LIBRARIES . '/joomla/image/helper.php'

2. In JPATH_LIBRARIES . '/joomla/image/image.php' method `getImageFileProperties()` replace

// Build the response object.
$properties = (object) array(
    'width' => $info[0],
    'height' => $info[1],
    'type' => $info[2],
    'attributes' => $info[3],
    'bits' => isset($info['bits']) ? $info['bits'] : null,
    'channels' => isset($info['channels']) ? $info['channels'] : null,
    'mime' => $info['mime']
);

return $properties;

with

return JImageHelper::getImageFileProperties($path);

as wished by @dongilbert.

3. Take any file e.g. the currently active template's index.php and at the very top 
right below `defined('_JEXEC') or die;` paste this code:

// Define the file to use. 
// NOTE:   Make sure this file exists or use another path to an existing image file!
$file = JPATH_BASE . '/images/powered_by.png';

echo '<pre>file: ' . print_r($file, true) . '</pre>';
echo '<pre>' . print_r(str_repeat('_', 51), true) . '</pre>';

// Get instance of JImage.
$image = new JImage($file); // $image must be instance of JImage

// Get image properties calling static method from JImageHelper.
$props = JImageHelper::getImageFileProperties($file);   // $props must be an object

echo '<pre>props: ' . print_r($props, true) . '</pre>';
echo '<pre>' . print_r(str_repeat('_', 51), true) . '</pre>';

echo '<pre>' . print_r('Check for every property separately:', true) . '</pre>';
echo '<pre>' . print_r(str_repeat('_', 51), true) . '</pre>';

// Check the returned data contains all of these properties.
foreach (array(
   'width',
   'height',
   'type',
   'attributes',
   'bits',
   'channels',
   'mime',
   'filesize',
   'orientation') as $p
)
{
    if (array_key_exists($p, $props))
    {
        echo "<pre>{$p} is: " . print_r($props->$p, true) . '</pre>';
    }
    else
    {
        echo '<pre>' . print_r("\$props does not contain {$p}-data", true) . '</pre>';
    }
}

echo '<pre>' . print_r(str_repeat('_', 51), true) . '</pre>';
jexit('Done');

The expected output should be:

file: /path/to/joomla/images/powered_by.png
___________________________________________________
props: stdClass Object
(
    [width] => 150
    [height] => 35
    [type] => 3
    [attributes] => width="150" height="35"
    [bits] => 8
    [channels] => 
    [mime] => image/png
    [filesize] => 2301
    [orientation] => landscape
)
___________________________________________________
Check for every property separately:
___________________________________________________
width is: 150
height is: 35
type is: 3
attributes is: width="150" height="35"
bits is: 8
channels is: 
mime is: image/png
filesize is: 2301
orientation is: landscape
___________________________________________________
Done
```

Any feedback is welcome.
