### PR TITLE
reverse order of modulpositions

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -665,6 +665,7 @@ class JDocumentHTML extends JDocument
 			}
 			// Reverse the last array so the jdocs are in forward order.
 			$template_tags_last = array_reverse($template_tags_last);
+			$template_tags_first = array_reverse($template_tags_first);
 
 			$this->_template_tags = $template_tags_first + $template_tags_last;
 		}


### PR DESCRIPTION
..I render dependent modules to different positions.
If the first module is rendered now, this saves as the output item in a variable. So the next module the item stored with do not append.

Now it would be the item with a newer date would stand at the bottom of the page.
Example:
I have a category with 20 entries and each modules are 5 entries, then the first five would be below and above the last.
