### PR TITLE
PHPUnit now does a phar installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ php:
 
 before_script:
   - composer self-update
-  - pyrus channel-discover pear.phpunit.de
-  - pyrus channel-discover pear.symfony.com
-  - pyrus install --force phpunit/DbUnit
   - phpenv rehash
   - mysql -e 'create database joomla_ut;'
   - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql


### PR DESCRIPTION
This allows us to use the latest and greatest version of PHPUnit - currently we're on 4.0.17 - the limit now for pear. But this will put us on the latest travis version (4.0.19 as of present writing)

It also means we don't have to unnecessarily install DBUnit

See https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method
and https://github.com/travis-ci/travis-ci/issues/2223#issuecomment-42401030
