### PR TITLE
[#33413] Fix media manager upload and subfolder creation

### DIFF
--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -70,7 +70,7 @@ $input = JFactory::getApplication()->input;
 			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index');?>" name="folderForm" id="folderForm" class="form-inline" method="post">
 					<div class="path">
 						<input type="text" id="folderpath" readonly="readonly" />
-						<input type="text" id="foldername" name="foldername"  />
+						<input type="text" id="foldername" name="foldername" class="update-folder" />
 						<input class="update-folder" type="hidden" name="folderbase" id="folderbase" value="<?php echo $this->state->folder; ?>" />
 						<button type="submit" class="btn"><i class="icon-folder-open"></i> <?php echo JText::_('COM_MEDIA_CREATE_FOLDER'); ?></button>
 					</div>

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -69,8 +69,8 @@ $input = JFactory::getApplication()->input;
 		<div id="collapseFolder" class="collapse">
 			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index');?>" name="folderForm" id="folderForm" class="form-inline" method="post">
 					<div class="path">
-						<input type="text" id="folderpath" readonly="readonly" />
-						<input type="text" id="foldername" name="foldername" class="update-folder" />
+						<input type="text" id="folderpath" readonly="readonly" class="update-folder" />
+						<input type="text" id="foldername" name="foldername" />
 						<input class="update-folder" type="hidden" name="folderbase" id="folderbase" value="<?php echo $this->state->folder; ?>" />
 						<button type="submit" class="btn"><i class="icon-folder-open"></i> <?php echo JText::_('COM_MEDIA_CREATE_FOLDER'); ?></button>
 					</div>

--- a/media/media/js/mediamanager.js
+++ b/media/media/js/mediamanager.js
@@ -42,10 +42,10 @@ var MediaManager = this.MediaManager = {
 
 		var folder = this.getFolder();
 		if (folder) {
-			this.updatepaths.each(function(path){ path.value =folder; });
+			this.updatepaths.each(function(path, el){ el.value =folder; });
 			this.folderpath.value = basepath+'/'+folder;
 		} else {
-			this.updatepaths.each(function(path){ path.value = ''; });
+			this.updatepaths.each(function(path, el){ el.value = ''; });
 			this.folderpath.value = basepath;
 		}
 


### PR DESCRIPTION
This is based on a comment from @illovo on #3551 and the forum post linked by him (it helps that I speak german _g_).
To me, it looks like indeed the correct fix to the issue.
- The JS code was trying to use the index instead of the actual value of the array and thus failed to update the hidden form fields.
- The readonly path field in the subfolder creation part was missing the `update-folder` class and thus the JS code didn't update it with the new path.
### Testing
- Try creating a subfolder in the media manager
- Try uploading a file to a subfolder in the media manager
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33413
