### PR TITLE
[#32642] Warning if string is passed as $attrib

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -962,15 +962,22 @@ abstract class JHtml
 			$done = array();
 		}
 
-		$attribs['class'] = isset($attribs['class']) ? $attribs['class'] : 'input-medium';
-		$attribs['class'] = trim($attribs['class'] . ' hasTooltip');
-
-		$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
-		$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
-
 		if (is_array($attribs))
 		{
+			$attribs['class'] = isset($attribs['class']) ? $attribs['class'] : 'input-medium';
+			$attribs['class'] = trim($attribs['class'] . ' hasTooltip');
+
+			$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
+			$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
+			
 			$attribs = JArrayHelper::toString($attribs);
+		}
+		else
+		{
+			// @deprecated  4.0  Use an array instead of a string.
+			JLog::add('Passing a string as $attribs for JHtml::calendar is deprecated, use an array instead.', JLog::WARNING, 'deprecated');	
+		}
+		
 		}
 
 		static::_('bootstrap.tooltip');

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -947,7 +947,7 @@ abstract class JHtml
 	 * @param   string  $name     The name of the text field
 	 * @param   string  $id       The id of the text field
 	 * @param   string  $format   The date format
-	 * @param   array   $attribs  Additional HTML attributes
+	 * @param   mixed   $attribs  Additional HTML attributes
 	 *
 	 * @return  string  HTML markup for a calendar field
 	 *

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -964,7 +964,7 @@ abstract class JHtml
 
 		$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
 		$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
-		
+
 		if (is_array($attribs))
 		{
 			$attribs['class'] = isset($attribs['class']) ? $attribs['class'] : 'input-medium';

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -962,14 +962,14 @@ abstract class JHtml
 			$done = array();
 		}
 
+		$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
+		$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
+		
 		if (is_array($attribs))
 		{
 			$attribs['class'] = isset($attribs['class']) ? $attribs['class'] : 'input-medium';
 			$attribs['class'] = trim($attribs['class'] . ' hasTooltip');
 
-			$readonly = isset($attribs['readonly']) && $attribs['readonly'] == 'readonly';
-			$disabled = isset($attribs['disabled']) && $attribs['disabled'] == 'disabled';
-			
 			$attribs = JArrayHelper::toString($attribs);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -972,12 +972,7 @@ abstract class JHtml
 
 			$attribs = JArrayHelper::toString($attribs);
 		}
-		else
-		{
-			// @deprecated  4.0  Use an array instead of a string.
-			JLog::add('Passing a string as $attribs for JHtml::calendar is deprecated, use an array instead.', JLog::WARNING, 'deprecated');	
-		}
-		
+
 		static::_('bootstrap.tooltip');
 
 		// Format value when not '0000-00-00 00:00:00', otherwise blank it as it would result in 1970-01-01.

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -978,8 +978,6 @@ abstract class JHtml
 			JLog::add('Passing a string as $attribs for JHtml::calendar is deprecated, use an array instead.', JLog::WARNING, 'deprecated');	
 		}
 		
-		}
-
 		static::_('bootstrap.tooltip');
 
 		// Format value when not '0000-00-00 00:00:00', otherwise blank it as it would result in 1970-01-01.


### PR DESCRIPTION
Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32642

replace: https://github.com/joomla/joomla-cms/pull/2463
## How to test
### 1. way

1) BE --> Content --> Article Manager --> Add New Article --> Tab: Publishing
2) make sure the calendar works ok.
3) add into this file at this place: https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/html.php#L959

$attribs = 'example';

4) refresh the page
5) make sure that the calendar is broken
6) apply patch
7) redo 3)
8) refresh the page
9) make sure that all works as bevor
### Alternative way:

Code: <?php echo JHtml::calendar(null, 'test', 'id-test', '%Y-%m-%d', 'class="blah" readonly="true"'); ?>

Insert this code into a view or index.php of your template (i.e. some php file that is viewable). Note the 3 php errors. Apply the PR. Errors go away.
