### PR TITLE
[#33722] Redirecting to SEF links when SEF is enabled

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -76,7 +76,17 @@ class PlgSystemRedirect extends JPlugin
 			// If a redirect exists and is published, permanently redirect.
 			if ($link and ($link->published == 1))
 			{
-				$app->redirect($link->new_url, true);
+				// When SEF is enabled saved non-SEF link should be redirected to SEF link.
+				if (JFactory::getConfig()->get('sef') == 1 && stristr($link->new_url, 'option=com_') == true)
+				{
+					// Site's URL is to be removed before applying JRoute.
+					$new_url = str_ireplace(JUri::base(), '', $link->new_url);
+					$app->redirect(JRoute::_($new_url));
+				}
+				else
+				{
+					$app->redirect($link->new_url, true);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Joomla! Issue Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33722&start=0

When creating redirects, usually non-SEF links are saved as they are universal (alias can be changed later; when SEF is switched off links are still valid) and easier to find (for instance by using JCE Editor to find links to articles). The problem with that is that on SEF site, non-SEF links are explored and displayed by search engines.
Here is a solution, how to detect non-SEF links and convert them to SEF ones.
