### PR TITLE
[#32862] Removed // comments from bootstrap css.

### DIFF
--- a/media/jui/css/bootstrap.css
+++ b/media/jui/css/bootstrap.css
@@ -6135,8 +6135,6 @@ a.badge:focus {
 
 /* Joomla JUI NOTE: Original .modal definition has to be commented */
 
-// > Joomla JUI
-
 div.modal {
   position: fixed;
   top: 10%;
@@ -6172,11 +6170,7 @@ div.modal.fade.in {
   top: 10%;
 }
 
-// < Joomla JUI
-
 /* Joomla JUI NOTE: Original .modal definition has to be commented */
-
-// > Joomla JUI
 
 @media (max-width: 767px) {
   div.modal {
@@ -6202,5 +6196,3 @@ div.modal.fade.in {
     left: 10px;
   }
 }
-
-// < Joomla JUI


### PR DESCRIPTION
The // comments are not intended to be present in the css files.  They are
only present in the .less files to identify changes from standard bootstrap.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32862&start=0
