### PR TITLE
[#33568] Remove mootools from com_content category view

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;?>
 $params = $this->item->params;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 $canEdit = $this->item->params->get('access-edit');
-JHtml::_('behavior.framework');
 ?>
 <?php if ($this->item->state == 0 || strtotime($this->item->publish_up) > strtotime(JFactory::getDate())
 	|| ((strtotime($this->item->publish_down) < strtotime(JFactory::getDate())) && $this->item->publish_down != '0000-00-00 00:00:00' )) : ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.framework');
-
 // Create some shortcuts.
 $params		= &$this->item->params;
 $n			= count($this->items);

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -73,6 +73,7 @@ abstract class JHtmlGrid
 	 */
 	public static function sort($title, $order, $direction = 'asc', $selected = 0, $task = null, $new_direction = 'asc', $tip = '')
 	{
+		JHtml::_('behavior.core');
 		JHtml::_('bootstrap.tooltip');
 
 		$direction = strtolower($direction);


### PR DESCRIPTION
### Issue

Today, the articles category view still loads MooTools, but it isn't needed anymore.
However the core.js JavaScript file is still needed for the sorting function within the default layout (the blog one doesn't has this).
### Solution

Currently, the layouts use `JHtml::_('behavior.framework);` which loads MooTools together with core.js. So far this was the only way to load core.js while using the Joomla API. With Joomla 3.3 we have now a new method  (`JHtml::_('behavior.core);`) to load core.js which will no longer load MooTools.

This PR makes removes the `behavior.framework` calls from the layouts and adds the `behavior.core` call to `JHtml::_('grid.sort')` which is the method that actually needs core.js.
### Testing Instructions

Create two menu items for an article category view. Once for the default layout and once for the blog one.
Make sure everything works as before while MooTools is no longer loaded.
If MooTools is still loaded after applying the patch, you may have to disable some modules or plugins because they may be loading MooTools.
**Important: This works only in Joomla 3.3!**
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33568
#### Note

Same as https://github.com/joomla/joomla-cms/pull/3410 but against staging and rebased.
