### PR TITLE
Fix auto-offset 1px top offset

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -335,6 +335,8 @@ class JImage
 		if (is_null($top))
 		{
 			$top = round(($this->getHeight() - $height) / 2);
+
+			$top = $top < 0 ? 0 : $top;
 		}
 
 		// Sanitize left.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -336,7 +336,12 @@ class JImage
 		{
 			$top = round(($this->getHeight() - $height) / 2);
 
-			$top = $top < 0 ? 0 : $top;
+			if ($top < 0)
+			{
+				$height += $top;
+
+				$top    = 0;
+			}
 		}
 
 		// Sanitize left.


### PR DESCRIPTION
When calling JImage::crop() without passing in a value for $top, this offset is automatically calculated (same for $left - the left offset). I found the calculated top offset to be -1 in some cases - especially when JImage::resize() was applied first. I discovered that the calculation of the width and height values in JImage::prepareDimensions() is the reason. In my case i upload a file which is first resized and then cropped. Both methods receive the same height value (152px), because the input file is a portrait and i require a height of 152px. But the height value changes to 151px while the file passes JImage::resize(). I debugged the input- and output values just to find the place where the height is altered and found JImage::prepareDimension() to be the place - case SCALE_INSIDE. I could not yet figure out if its the rounding that works inaccurately.

As a consequence the created image always shows a 1px thick black line on its top border (due to the black imagefill color) indicating that imagecopy() starts pasting the pixels copied from the source image at the second row of the target image.

The suggested fix checks whether the calculated height offset value is 
