### PR TITLE
[#33430] Cleaning up datalist for JFormfieldText

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -141,10 +141,24 @@ abstract class JHtmlSelect
 	 *
 	 * @return  string  HTML for the select list
 	 *
-	 * @since   3.2
+	 * @since       3.2
+	 * @deprecated  4.0  Just create the <datalist> directly instead
 	 */
-	public static function suggestionlist($data, $optKey = 'value', $optText = 'text', $idtag, $translate = false)
+	public static function suggestionlist($data, $optKey = 'value', $optText = 'text', $idtag = null, $translate = false)
 	{
+		// Log deprecated message
+		JLog::add(
+			'JHtmlSelect::suggestionlist() is deprecated. Create the <datalist> tag directly instead.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
+		// Note: $idtag is requried but has to be an optional argument in the funtion call due to argument order
+		if (!$idtag)
+		{
+			throw new InvalidArgumentException('$idtag is a required argument in deprecated JHtmlSelect::suggestionlist');
+		}
+
 		// Set default options
 		$options = array_merge(JHtml::$formatOptions, array('format.depth' => 0, 'id' => false));
 

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -190,10 +190,12 @@ class JFormFieldText extends JFormField
 		JHtml::_('jquery.framework');
 		JHtml::_('script', 'system/html5fallback.js', false, true);
 
-		// Get the field options for the datalist.
 		$datalist = '';
 		$list     = '';
-		$options  = (array) $this->getOptions();
+
+		/* Get the field options for the datalist.
+		Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
+		$options  = (array) $this->getSuggestions();
 
 		if ($options)
 		{
@@ -226,7 +228,7 @@ class JFormFieldText extends JFormField
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   3.3
+	 * @since   3.4
 	 */
 	protected function getOptions()
 	{
@@ -260,13 +262,6 @@ class JFormFieldText extends JFormField
 	 */
 	protected function getSuggestions()
 	{
-		// Log deprecated message
-		JLog::add(
-			'JFormFieldText->getSuggestions() is deprecated. Use getOptions() instead.',
-			JLog::WARNING,
-			'deprecated'
-		);
-
 		return $this->getOptions();
 	}
 }

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -182,7 +182,6 @@ class JFormFieldText extends JFormField
 		$pattern      = !empty($this->pattern) ? ' pattern="' . $this->pattern . '"' : '';
 		$inputmode    = !empty($this->inputmode) ? ' inputmode="' . $this->inputmode . '"' : '';
 		$dirname      = !empty($this->dirname) ? ' dirname="' . $this->dirname . '"' : '';
-		$list         = '';
 
 		// Initialize JavaScript field attributes.
 		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
@@ -191,30 +190,45 @@ class JFormFieldText extends JFormField
 		JHtml::_('jquery.framework');
 		JHtml::_('script', 'system/html5fallback.js', false, true);
 
-		// Get the field suggestions.
-		$options = (array) $this->getSuggestions();
+		// Get the field options for the datalist.
+		$datalist = '';
+		$list     = '';
+		$options  = (array) $this->getOptions();
 
-		if (!empty($options))
+		if ($options)
 		{
-			$html[] = JHtml::_('select.suggestionlist', $options, 'value', 'text', $this->id . '_datalist"');
-			$list = ' list="' . $this->id . '_datalist"';
+			$datalist = '<datalist id="' . $this->id . '_datalist">';
+
+			foreach ($options as $option)
+			{
+				if (!$option->value)
+				{
+					continue;
+				}
+
+				$datalist .= '<option value="' . $option->value . '">' . $option->text . '</option>';
+			}
+
+			$datalist .= '</datalist>';
+			$list     = ' list="' . $this->id . '_datalist"';
 		}
 
 		$html[] = '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . $dirname . ' value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $list
 			. $hint . $onchange . $maxLength . $required . $autocomplete . $autofocus . $spellcheck . $inputmode . $pattern . ' />';
+		$html[] = $datalist;
 
 		return implode($html);
 	}
 
 	/**
-	 * Method to get the field suggestions.
+	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   11.1
+	 * @since   3.3
 	 */
-	protected function getSuggestions()
+	protected function getOptions()
 	{
 		$options = array();
 
@@ -233,8 +247,26 @@ class JFormFieldText extends JFormField
 			);
 		}
 
-		reset($options);
-
 		return $options;
+	}
+
+	/**
+	 * Method to get the field suggestions.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since       3.2
+	 * @deprecated  4.0  Use getOptions instead
+	 */
+	protected function getSuggestions()
+	{
+		// Log deprecated message
+		JLog::add(
+			'JFormFieldText->getSuggestions() is deprecated. Use getOptions() instead.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
+		return $this->getOptions();
 	}
 }


### PR DESCRIPTION
### Issue

There is a phpcs issue with the signature of `JHtmlSelect::suggestionlist()`. It contains a required `$idtag` after the optional `$optkey` and `$optText`, which essentially makes those two required as well.

Fixing this correct is basically not possible without creating a new function and proxy it.

The produced datalist also has some errors in it.
### Solution
- This PR will deprecate `JHtmlSelect::suggestionlist()` which was introduced with J3.2 to implement the `<datalist>` tag into the text formfield.
- The datalist will be created directly in the `getInput()` function of the formfield instead. It's a very simple code and the current usage of `JHtmlSelect::options()` within `JHtmlSelect::suggestionlist()` to generate the items created more problems and was basically overkill.
- Deprecated `getSuggestions()` in the text formfield and replaced it with `getOptions()` like we use in every other formfield. `getSuggestions()` is proxied to `getOptions()` in case someone was extending the class and actually used it.
### Testing

Add some options to a text field and see if the datalist works. For example change the title for the article form to

```
        <field name="title" type="text" label="JGLOBAL_TITLE"
            description="JFIELD_TITLE_DESC"
            class="input-xxlarge input-large-text"
            size="40"
            required="true" 
            >
            <option>Option1</option>
            <option value="Value2">Option2</option>
            <option value="Value3" />
        </field>
```

It should show a list with "suggestions" as soon as you start typing or click into the field.
Please note that the first option will not show because there is no value given. The second option will show with both the value and the text, depending on browser (Chrome shows the text rigth aligned a bit smaller). The third option will show the value only.
#### Remarks

This is based on a Codestyle PR and some discussions we had after it.
Unfortunately I forgot to do the PR then and now can't find the discussion anymore.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33430
#### Note

Same as https://github.com/joomla/joomla-cms/pull/3246 but against staging and rebased.
