### PR TITLE
Update default.php to gracefully handle templates with no xml data

### DIFF
--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -80,6 +80,21 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<tbody>
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
+		            <?php
+		                    if (!$item->xmldata){
+		                        $xmldata = new JObject;
+		                        $xmldata->set("version", "--");
+		                        $xmldata->set("creationDate", "--");
+		                    }else{
+		                        $xmldata = unserialize(serialize($item->xmldata));
+		                        if (!$xmldata->get('version')){
+		                            $xmldata->set("version", '--');
+		                        }
+		                        if (!$xmldata->get('creationDate')){
+		                            $xmldata->set("creationDate", '--');
+		                        }
+		                    }
+		            ?>
 				<td class="center">
 					<?php echo JHtml::_('templates.thumb', $item->element, $item->client_id); ?>
 				</td>
@@ -102,21 +117,21 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<?php echo $item->client_id == 0 ? JText::_('JSITE') : JText::_('JADMINISTRATOR'); ?>
 				</td>
 				<td class="center">
-					<?php echo $this->escape($item->xmldata->get('version')); ?>
+					<?php echo $this->escape($xmldata->get('version')); ?>
 				</td>
 				<td class="center">
-					<?php echo $this->escape($item->xmldata->get('creationDate')); ?>
+					<?php echo $this->escape($xmldata->get('creationDate')); ?>
 				</td>
 				<td>
-					<?php if ($author = $item->xmldata->get('author')) : ?>
+					<?php if ($author = $xmldata->get('author')) : ?>
 						<p><?php echo $this->escape($author); ?></p>
 					<?php else : ?>
 						&mdash;
 					<?php endif; ?>
-					<?php if ($email = $item->xmldata->get('authorEmail')) : ?>
+					<?php if ($email = $xmldata->get('authorEmail')) : ?>
 						<p><?php echo $this->escape($email); ?></p>
 					<?php endif; ?>
-					<?php if ($url = $item->xmldata->get('authorUrl')) : ?>
+					<?php if ($url = $xmldata->get('authorUrl')) : ?>
 						<p><a href="<?php echo $this->escape($url); ?>">
 							<?php echo $this->escape($url); ?></a></p>
 					<?php endif; ?>

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -81,12 +81,12 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
 		            <?php
+		                    $xmldata = new JRegistry;
 		                    if (!$item->xmldata){
-		                        $xmldata = new JObject;
 		                        $xmldata->set("version", "--");
 		                        $xmldata->set("creationDate", "--");
 		                    }else{
-		                        $xmldata = unserialize(serialize($item->xmldata));
+		                        $xmldata->loadObject($item->xmldata);
 		                        if (!$xmldata->get('version')){
 		                            $xmldata->set("version", '--');
 		                        }


### PR DESCRIPTION
The Hathor template manager fails to display the 'Templates' tab if the site contains a template without xml data (in my case ja_purity).  The problem occurs because this file tries to access $this->xmldata->get('version') without checking whether it is null.  My proposed fix tests for the case of null xmldata and creates a new object with the required fields.  In the case where the xmldata exists, the change creates a cloned object and ensures that the required fields aren't null.

Further down in the code, we access $xmldata, the new object, rather than $item->xmldata.
