### PR TITLE
[#29831] Cache hit fix

### DIFF
--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -71,6 +71,17 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
+		// trigger hit of article
+		if ($vName == 'article' && $model = $this->getModel($vName))
+		{
+			$state = $model->getState();
+			$params = $state->get('params');
+			$offset = $state->get('list.offset');
+			if (!$params->get('intro_only') && $offset == 0) {
+				$model->hit();
+			}
+		}
+
 		parent::display($cachable, $safeurlparams);
 
 		return $this;

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -132,12 +132,6 @@ class ContentViewArticle extends JViewLegacy
 		$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$this->params, $offset));
 		$item->event->afterDisplayContent = trim(implode("\n", $results));
 
-		// Increment the hit counter of the article.
-		if (!$this->params->get('intro_only') && $offset == 0) {
-			$model = $this->getModel();
-			$model->hit();
-		}
-
 		//Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($this->item->params->get('pageclass_sfx'));
 


### PR DESCRIPTION
I was facing the same issue as this tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=11410&tracker_item_id=29831 which was closed as expected behavior.

This is a simple shift of the hit trigger from the view to the controller, which is run even when the basic cache is enabled.

If this is an acceptable improvement, I can add a similar change to the appropriate 3.x branch.
