### PR TITLE
Don't assume M as suffix for size configuration values in admin/com_media

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -53,9 +53,9 @@ class MediaControllerFile extends JControllerLegacy
 
 		if (
 			$_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024) ||
-			$_SERVER['CONTENT_LENGTH'] > (int) (ini_get('upload_max_filesize')) * 1024 * 1024 ||
-			$_SERVER['CONTENT_LENGTH'] > (int) (ini_get('post_max_size')) * 1024 * 1024 ||
-			$_SERVER['CONTENT_LENGTH'] > (int) (ini_get('memory_limit')) * 1024 * 1024
+			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('upload_max_filesize')) ||
+			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('post_max_size')) ||
+			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('memory_limit'))
 		)
 		{
 			$response = array(
@@ -177,6 +177,26 @@ class MediaControllerFile extends JControllerLegacy
 
 			echo json_encode($response);
 			return;
+		}
+	}
+
+	/**
+	 * Small helper function that properly converts any
+	 * configuration options to their byte representation.
+	 *
+	 * @see http://www.php.net/manual/en/function.ini-get.php
+	 *
+	 * @param  string|integer $val The value to be converted to bytes.
+	 * @return integer             The calculated bytes value from the input.
+	 */
+	private function toBytes($val)
+	{
+		switch ($val[strlen($val) - 1])
+		{
+			case 'M': case 'm': return (int) $val * 1048576;
+			case 'K': case 'k': return (int) $val * 1024;
+			case 'G': case 'g': return (int) $val * 1073741824;
+			default: return $val;
 		}
 	}
 }

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -53,9 +53,9 @@ class MediaControllerFile extends JControllerLegacy
 
 		if (
 			$_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024) ||
-			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('upload_max_filesize')) ||
-			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('post_max_size')) ||
-			$_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('memory_limit'))
+			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('upload_max_filesize')) ||
+			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('post_max_size')) ||
+			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('memory_limit'))
 		)
 		{
 			$response = array(

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -179,24 +179,4 @@ class MediaControllerFile extends JControllerLegacy
 			return;
 		}
 	}
-
-	/**
-	 * Small helper function that properly converts any
-	 * configuration options to their byte representation.
-	 *
-	 * @see http://www.php.net/manual/en/function.ini-get.php
-	 *
-	 * @param  string|integer $val The value to be converted to bytes.
-	 * @return integer             The calculated bytes value from the input.
-	 */
-	private function toBytes($val)
-	{
-		switch ($val[strlen($val) - 1])
-		{
-			case 'M': case 'm': return (int) $val * 1048576;
-			case 'K': case 'k': return (int) $val * 1024;
-			case 'G': case 'g': return (int) $val * 1073741824;
-			default: return $val;
-		}
-	}
 }

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -51,11 +51,14 @@ class MediaControllerFile extends JControllerLegacy
 		$file   = $this->input->files->get('Filedata', '', 'array');
 		$folder = $this->input->get('folder', '', 'path');
 
+		// Instantiate the media helper
+		$mediaHelper = new JHelperMedia();
+
 		if (
 			$_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024) ||
-			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('upload_max_filesize')) ||
-			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('post_max_size')) ||
-			$_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('memory_limit'))
+			$_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('upload_max_filesize')) ||
+			$_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('post_max_size')) ||
+			$_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('memory_limit'))
 		)
 		{
 			$response = array(

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -279,24 +279,4 @@ class MediaControllerFile extends JControllerLegacy
 
 		return $ret;
 	}
-
-	/**
-	 * Small helper function that properly converts any
-	 * configuration options to their byte representation.
-	 *
-	 * @see http://www.php.net/manual/en/function.ini-get.php
-	 *
-	 * @param  string|integer $val The value to be converted to bytes.
-	 * @return integer             The calculated bytes value from the input.
-	 */
-	private function toBytes($val)
-	{
-		switch ($val[strlen($val) - 1])
-		{
-			case 'M': case 'm': return (int) $val * 1048576;
-			case 'K': case 'k': return (int) $val * 1024;
-			case 'G': case 'g': return (int) $val * 1073741824;
-			default: return $val;
-		}
-	}
 }

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -61,10 +61,10 @@ class MediaControllerFile extends JControllerLegacy
 		if (($params->get('upload_maxsize', 0) * 1024 * 1024) != 0)
 		{
 			if (
-				$_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024)
-				|| $_SERVER['CONTENT_LENGTH'] > (int) (ini_get('upload_max_filesize')) * 1024 * 1024
-				|| $_SERVER['CONTENT_LENGTH'] > (int) (ini_get('post_max_size')) * 1024 * 1024
-				|| (($_SERVER['CONTENT_LENGTH'] > (int) (ini_get('memory_limit')) * 1024 * 1024) && ((int) (ini_get('memory_limit')) != -1))
+				$_SERVER['CONTENT_LENGTH'] > $params->get('upload_maxsize', 0) * 1024 * 1024
+				|| $_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('upload_max_filesize'))
+				|| $_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('post_max_size'))
+				|| (($_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('memory_limit'))) && ((int) (ini_get('memory_limit')) != -1))
 			)
 			{
 				JError::raiseWarning(100, JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));
@@ -278,5 +278,25 @@ class MediaControllerFile extends JControllerLegacy
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Small helper function that properly converts any
+	 * configuration options to their byte representation.
+	 *
+	 * @see http://www.php.net/manual/en/function.ini-get.php
+	 *
+	 * @param  string|integer $val The value to be converted to bytes.
+	 * @return integer             The calculated bytes value from the input.
+	 */
+	private function toBytes($val)
+	{
+		switch ($val[strlen($val) - 1])
+		{
+			case 'M': case 'm': return (int) $val * 1048576;
+			case 'K': case 'k': return (int) $val * 1024;
+			case 'G': case 'g': return (int) $val * 1073741824;
+			default: return $val;
+		}
 	}
 }

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -62,9 +62,9 @@ class MediaControllerFile extends JControllerLegacy
 		{
 			if (
 				$_SERVER['CONTENT_LENGTH'] > $params->get('upload_maxsize', 0) * 1024 * 1024
-				|| $_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('upload_max_filesize'))
-				|| $_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('post_max_size'))
-				|| (($_SERVER['CONTENT_LENGTH'] > $this->toBytes(ini_get('memory_limit'))) && ((int) (ini_get('memory_limit')) != -1))
+				|| $_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('upload_max_filesize'))
+				|| $_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('post_max_size'))
+				|| (($_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('memory_limit'))) && ((int) (ini_get('memory_limit')) != -1))
 			)
 			{
 				JError::raiseWarning(100, JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -60,11 +60,12 @@ class MediaControllerFile extends JControllerLegacy
 
 		if (($params->get('upload_maxsize', 0) * 1024 * 1024) != 0)
 		{
+			$mediaHelper = new JHelperMedia();
 			if (
 				$_SERVER['CONTENT_LENGTH'] > $params->get('upload_maxsize', 0) * 1024 * 1024
-				|| $_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('upload_max_filesize'))
-				|| $_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('post_max_size'))
-				|| (($_SERVER['CONTENT_LENGTH'] > MediaHelper::toBytes(ini_get('memory_limit'))) && ((int) (ini_get('memory_limit')) != -1))
+				|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('upload_max_filesize'))
+				|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('post_max_size'))
+				|| (($_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('memory_limit'))) && ((int) (ini_get('memory_limit')) != -1))
 			)
 			{
 				JError::raiseWarning(100, JText::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'));

--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -125,25 +125,4 @@ abstract class MediaHelper
 
 		return $mediaHelper->countFiles($dir);
 	}
-
-	/**
-	 * Small helper function that properly converts any
-	 * configuration options to their byte representation.
-	 *
-	 * @link http://www.php.net/manual/en/function.ini-get.php
-	 *
-	 * @param  string|integer $val The value to be converted to bytes.
-	 *
-	 * @return integer             The calculated bytes value from the input.
-	 *
-	 * @since 3.3
-	 * @deprecated 4.0 Use JHelperMedia::toBytes instead
-	 */
-	public static function toBytes($val)
-	{
-		JLog::add('MediaHelper::toBytes() is deprecated. Use JHelperMedia::toBytes() instead.', JLog::WARNING, 'deprecated');
-		$mediaHelper = new JHelperMedia;
-
-		return $mediaHelper->toBytes($val);
-	}
 }

--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -125,4 +125,25 @@ abstract class MediaHelper
 
 		return $mediaHelper->countFiles($dir);
 	}
+
+	/**
+	 * Small helper function that properly converts any
+	 * configuration options to their byte representation.
+	 *
+	 * @link http://www.php.net/manual/en/function.ini-get.php
+	 *
+	 * @param  string|integer $val The value to be converted to bytes.
+	 *
+	 * @return integer             The calculated bytes value from the input.
+	 *
+	 * @since 3.3
+	 * @deprecated 4.0 Use JHelperMedia::toBytes instead
+	 */
+	public static function toBytes($val)
+	{
+		JLog::add('MediaHelper::toBytes() is deprecated. Use JHelperMedia::toBytes() instead.', JLog::WARNING, 'deprecated');
+		$mediaHelper = new JHelperMedia;
+
+		return $mediaHelper->toBytes($val);
+	}
 }

--- a/libraries/cms/helper/media.php
+++ b/libraries/cms/helper/media.php
@@ -285,4 +285,34 @@ class JHelperMedia
 
 		return array($total_file, $total_dir);
 	}
+
+	/**
+	 * Small helper function that properly converts any
+	 * configuration options to their byte representation.
+	 *
+	 * @link http://www.php.net/manual/en/function.ini-get.php
+	 *
+	 * @param  string|integer $val The value to be converted to bytes.
+	 *
+	 * @return integer             The calculated bytes value from the input.
+	 *
+	 * @since 3.3
+	 */
+	public function toBytes($val)
+	{
+		switch ($val[strlen($val) - 1])
+		{
+			case 'M':
+			case 'm':
+				return (int) $val * 1048576;
+			case 'K':
+			case 'k':
+				return (int) $val * 1024;
+			case 'G':
+			case 'g':
+				return (int) $val * 1073741824;
+			default:
+				return $val;
+		}
+	}
 }


### PR DESCRIPTION
Instead take the possible values defined in the php configuration into
account (k,m,g and upper case as well). The function is the optimized
version found on php.net but using brackets and `strlen()` to access the
last character instead of `substr()`.

This change fixes an upload issue in the MediaManager when any
configuration setting uses something different than the assumed 'M/m'
suffix. A small example should make this clearer:
Imagine 'memory_limit' being set to '1G'.
`(int) (ini_get('memory_limit')) * 1024 * 1024` would resolve to
1048576 Bytes (~=1M), a value (almost certainly) being lower than
most of the media files an average user would like to upload. ;-)
