### PR TITLE
PHP syntax error in comparison in users controller (frontend)

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -62,7 +62,7 @@ class UsersControllerUser extends UsersController
 		if (true === $app->login($credentials, $options))
 		{
 			// Success
-			if ($options['remember'] = true)
+			if ($options['remember'] == true)
 			{
 				$app->setUserState('rememberLogin', true);
 			}


### PR DESCRIPTION
Changed line 65 from :

if ($options['remember'] = true) to

if ($options['remember'] == true)

The comparison had syntax error and seems to turn into "remember" always whoever logged.

based on tracker issue #33735
