### PR TITLE
[#33739] We don't need to require format

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -31,11 +31,6 @@ $format = strtolower($input->getWord('format'));
 $results = null;
 $parts = null;
 
-// Check for valid format
-if (!$format)
-{
-	$results = new InvalidArgumentException('Please specify response format other that HTML (json, raw, etc.)', 404);
-}
 /*
  * Module support.
  *
@@ -154,6 +149,7 @@ switch ($format)
 		break;
 
 	// Handle as raw format
+	case 'raw':
 	default:
 		// Output exception
 		if ($results instanceof Exception)

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -25,7 +25,7 @@ $app = JFactory::getApplication();
 $input = $app->input;
 
 // Requested format passed via URL
-$format = strtolower($input->getWord('format'));
+$format = strtolower($input->getWord('format', 'raw'));
 
 // Initialize default response and module name
 $results = null;

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -39,7 +39,7 @@ $parts = null;
  * (i.e. index.php?option=com_ajax&module=foo).
  *
  */
-elseif ($input->get('module'))
+if ($input->get('module'))
 {
 	$module       = $input->get('module');
 	$moduleObject = JModuleHelper::getModule('mod_' . $module, null);


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33739&start=0

Raw is already default in the switch/case and therefore isn't needed to be passed in. It also didn't throw an exception on introduction in 3.2 (so technically a b/c break when the exception was introduced)
