### PR TITLE
[#33742] [33742] Administrator lang strings overrides can't be deleted

### DIFF
--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -54,7 +54,7 @@ class LanguagesModelOverrides extends JModelList
 			return $this->cache[$store];
 		}
 
-		$client = in_array($this->state->get('filter.client'), array(0, 'site')) ? strtoupper('site') : strtoupper('administrator');
+		$client = in_array($this->state->get('filter.client'), array(0, 'site')) ? 'SITE' : 'ADMINISTRATOR';
 
 		// Parse the override.ini file in order to get the keys and strings
 		$filename = constant('JPATH_' . $client) . '/language/overrides/' . $this->getState('filter.language') . '.override.ini';
@@ -245,7 +245,7 @@ class LanguagesModelOverrides extends JModelList
 		require_once JPATH_COMPONENT.'/helpers/languages.php';
 
 		$filterclient = JFactory::getApplication()->getUserState('com_languages.overrides.filter.client');
-		$client = $filterclient == 0 ? strtoupper('site') : strtoupper('administrator');
+		$client = $filterclient == 0 ? 'SITE' : 'ADMINISTRATOR';
 
 		// Parse the override.ini file in oder to get the keys and strings
 		$filename = constant('JPATH_' . $client) . '/language/overrides/' . $this->getState('filter.language') . '.override.ini';

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -244,7 +244,8 @@ class LanguagesModelOverrides extends JModelList
 		jimport('joomla.filesystem.file');
 		require_once JPATH_COMPONENT.'/helpers/languages.php';
 
-		$client = in_array($this->state->get('filter.client'), array(0, 'site')) ? strtoupper('site') : strtoupper('administrator');
+		$filterclient = JFactory::getApplication()->getUserState('com_languages.overrides.filter.client');
+		$client = $filterclient == 0 ? strtoupper('site') : strtoupper('administrator');
 
 		// Parse the override.ini file in oder to get the keys and strings
 		$filename = constant('JPATH_' . $client) . '/language/overrides/' . $this->getState('filter.language') . '.override.ini';


### PR DESCRIPTION
Create new strings overrides for a site language AND for an admin language
administrator/index.php?option=com_languages&view=overrides

Try to delete the site language override. All is fine.
Try to delete the admin language override. Although the message displays that the string has been deleted, it is not and still showing in the manager.
The issue comes from the fact that the $client is not found and always null

This should solve the issue.
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33742&start=0
