### PR TITLE
*Correcting tips and spacer display for the profile forms

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -206,9 +206,9 @@ class PlgUserProfile extends JPlugin
 			'tos',
 		);
 
-		//Change fields description when displayed in front-end
+		//Change fields description when displayed in front-end or back-end profile editing
 		$app = JFactory::getApplication();
-		if ($app->isSite())
+		if ($app->isSite() || $name == 'com_users.user' || $name == 'com_admin.profile')
 		{
 			$form->setFieldAttribute('address1', 'description', 'PLG_USER_PROFILE_FILL_FIELD_DESC_SITE', 'profile');
 			$form->setFieldAttribute('address2', 'description', 'PLG_USER_PROFILE_FILL_FIELD_DESC_SITE', 'profile');
@@ -250,6 +250,11 @@ class PlgUserProfile extends JPlugin
 				)
 				{
 					$form->removeField($field, 'profile');
+				}
+
+				if ($this->params->get('profile-require_dob', 1) > 0)
+				{
+					$form->setFieldAttribute('spacer', 'type', 'spacer', 'profile');
 				}
 			}
 			// Case registration


### PR DESCRIPTION
Enable the user profile plugin and define some fields as Optional, Required and Disabled in both possible sets
When editing a profile in admin, i.e.
1. from the user Manager by index.php?option=com_users&view=user&layout=edit&id= (id of user)
2. from the profile layout, i.e administrator/index.php?option=com_admin&view=profile&layout=edit&id= (id of user)

The tips displayed for each field are "Choose an option for the field -name_of_field-"
These are the tips which are used when editing the plugin and they should not show here.
What should display is
"If required, please fill this field"

Also the spacer indicating the necessary format for the Date of Birth field does not display as should when the DOB is not disabled.

I.e.
"The date of birth entered should use the format Year-Month-Day, i.e. 0000-00-00

This PR should solve these issues.
