### PR TITLE
Backport JUser::getInstance(0) fix from Joomla 3

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -264,6 +264,13 @@ class JUser extends JObject
 			$id = $identifier;
 		}
 
+		// If the $id is zero, just return an empty JUser.
+		// Note: don't cache this user because it'll have a new ID on save!
+		if ($id === 0)
+		{
+			return new JUser;
+		}
+
 		if (empty(self::$instances[$id]))
 		{
 			$user = new JUser($id);


### PR DESCRIPTION
This PR proposes to backport to 2.5.x `Juser::getInstance(0);` fix form Joomla 3.0 Commit https://github.com/joomla/joomla-cms/commit/c7c3722157456f1ea29732b51728006a2ae509a8 (which is an import including Joomla Platform Commit https://github.com/joomla/joomla-platform/commit/0afde04facc74d6c3bc11e854bd250d0dffa0da3#diff-5954647dc2fd6222bf4424b083506d75 ).

This is triggering a bug in Joomla when someone tries to get an instance of JUser(0) when not logged-in.

To reproduce the bug:
- Add line `JUser::getInstance();` to a plugin that gets loaded, go to Joomla backend, log-in and see that UserAccessLevels are wrong as caching happens here: https://github.com/joomla/joomla-cms/blob/2.5.x/libraries/joomla/user/user.php#L452 . Moreover if that JUser gets saved it would auto-create a new user, according to the comment.

Both Kunena and CB projects ran into this 2.5-only bug during beta tests these last months.

A simple code review will show that this is a no-brainer, and could be a potential security issue if Joomla or an extension tries to instanciate JUser id 0 this way.
