### PR TITLE
[#33762] Module Articles Category not showing the heading

### DIFF
--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <?php if ($grouped) : ?>
 	<?php foreach ($list as $group_name => $group) : ?>
 	<li>
-		<h<?php echo $item_heading; ?>><?php echo $group_name; ?></h<?php echo $item_heading; ?>>
+		<<?php echo $item_heading; ?>><?php echo $group_name; ?></<?php echo $item_heading; ?>>
 		<ul>
 			<?php foreach ($group as $item) : ?>
 				<li>

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 <?php if ($grouped) : ?>
 	<?php foreach ($list as $group_name => $group) : ?>
 	<li>
+		<h<?php echo $item_heading; ?>><?php echo $group_name; ?></h<?php echo $item_heading; ?>>
 		<ul>
 			<?php foreach ($group as $item) : ?>
 				<li>


### PR DESCRIPTION
If you publish a Module Articles Category and in Grouping Options > parameter Article Grouping you select an option, for exemple "Year", you will see in frontend that the year is not shown.

This pull request solves the issue

JoomlaCode Tracker Item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33762&start=0 
