### PR TITLE
[#33180] Smart search filter can't list non-Latin categories

### DIFF
--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -31,7 +31,14 @@ class FinderHelperLanguage
 	{
 		$return = preg_replace('/[^a-zA-Z0-9]+/', '_', strtoupper($branchName));
 
-		return 'PLG_FINDER_QUERY_FILTER_BRANCH_P_' . $return;
+		if ($return != '_')
+		{
+			return 'PLG_FINDER_QUERY_FILTER_BRANCH_P_' . $return;
+		}
+		else
+		{
+			return $branchName;
+		}
 	}
 
 	/**


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33180&start=0

To test, create a category with non latin glyphs (For example: பன்-மொழி உதவிக்குறிப்புகள் )and an item in the category.
Then Index in SmartSearch.
Then Create a new filter in Smart Search: in the category dropdown, the new category will display as "All"

Patch and retest
