### PR TITLE
[#33768] Fix IDE Problems with JRegistry

### DIFF
--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -1,0 +1,22 @@
+<?php
+/**
+* @package Joomla.Platform
+* @subpackage Registry
+*
+* @copyright Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+* @license GNU General Public License version 2 or later; see LICENSE
+*/
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+* JRegistry class
+*
+* @package Joomla.Platform
+* @subpackage Registry
+* @since 11.1
+*/
+class JRegistry extends \Joomla\Registry\Registry
+{
+  // Only B/C for IDEs
+}


### PR DESCRIPTION
### How to reproduce

1) just open any file with JRegistry used in phpstorm or NetBeans or eclipse.
2) See that with CRL or CMD hover and click you can't access the class and (at least in phpstorm, they are displayed as yellow errors)
3) apply this patch
4) and all those warnings disappear and you can control-click on it to access the definition

Thanks @beat
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33768&start=0
