### PR TITLE
Notice prevents update check when error reporting is on

### DIFF
--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -98,8 +98,8 @@ class JUpdaterExtension extends JUpdateAdapter
 
 				// Check that the product matches and that the version matches (optionally a regexp)
 				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
-				if ($product == $this->currentUpdate->targetplatform['NAME']
-					&& isset($this->currentUpdate)
+				if (isset($this->currentUpdate)
+					&& $product == $this->currentUpdate->targetplatform['NAME']
 					&& preg_match('/' . $this->currentUpdate->targetplatform['VERSION'] . '/', $ver->RELEASE)
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -99,6 +99,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				// Check that the product matches and that the version matches (optionally a regexp)
 				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
 				if ($product == $this->currentUpdate->targetplatform['NAME']
+					&& isset($this->currentUpdate)
 					&& preg_match('/' . $this->currentUpdate->targetplatform['VERSION'] . '/', $ver->RELEASE)
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))


### PR DESCRIPTION
### Issue

When running Joomla on my local host or any other php environment that has the maximum or development error reporting enabled, the ajax request that the control panel received to determine whether there are updates available or not contains a php parser notice that prevents the JSON response to be interpreted correctly.
### Solution

The error happens in Line 97 of the libraries/joomla/adapters/extension.php. It needs to be checked whether `$this->currentUpdate` is null before checking it's values in the if statement.
