### PR TITLE
*Multilanguage: Finder suggestions do not care about current language

### DIFF
--- a/components/com_finder/models/suggestions.php
+++ b/components/com_finder/models/suggestions.php
@@ -123,7 +123,15 @@ class FinderModelSuggestions extends JModelList
 		$this->setState('input', $input->request->get('q', '', 'string'));
 
 		// Set the query language
-		$lang = FinderIndexerHelper::getDefaultLanguage();
+		if (JLanguageMultilang::isEnabled())
+		{
+			$lang = JFactory::getLanguage()->getTag();
+		}
+		else
+		{
+			$lang = FinderIndexerHelper::getDefaultLanguage();
+		}
+
 		$lang = FinderIndexerHelper::getPrimaryLanguage($lang);
 		$this->setState('language', $lang);
 


### PR DESCRIPTION
Test Instructions:
Create a basic multilanguage site with articles in each language containing different text. To make it even more obvious enter terms starting with the same 3 letters in each article
Index with Smart Search.

Publish a Smart Search Module with param set to Show Search Suggestions.
On Front-end search for a word. The suggestions are always returning terms mapped to the default site language.

Patch and retest.
Now the Ajax suggestions will display and only display terms mapped to ALL languages (another bug there) or to the UI language.
