### PR TITLE
Update behavior.php - Fixed: broken menu tooltip.

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -279,9 +279,8 @@ abstract class JHtmlBehavior
 			 $('$selector').each(function() {
 				var title = $(this).attr('title');
 				if (title) {
-					var parts = title.split('::', 2);
-					$(this).data('tip:title', parts[0]);
-					$(this).data('tip:text', parts[1]);
+					this.store('tip:title', parts[0]);
+					this.store('tip:text', parts[1]);
 				}
 			});
 			var JTooltips = new Tips($('$selector').get(), $options);

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -279,6 +279,7 @@ abstract class JHtmlBehavior
 			 $('$selector').each(function() {
 				var title = $(this).attr('title');
 				if (title) {
+					var parts = title.split('::', 2);
 					this.store('tip:title', parts[0]);
 					this.store('tip:text', parts[1]);
 				}


### PR DESCRIPTION
For menu Items the "Link Title Attribute" was nor resolved correctly. It contained the text an the path. 
