### PR TITLE
[#32285] Support JSON response in Internet Explorer < 10

### DIFF
--- a/libraries/joomla/document/json/json.php
+++ b/libraries/joomla/document/json/json.php
@@ -39,7 +39,15 @@ class JDocumentJSON extends JDocument
 		parent::__construct($options);
 
 		// Set mime type
-		$this->_mime = 'application/json';
+		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) 
+		{
+			$this->_mime = 'application/json';
+		}
+		else
+		{
+			// Internet Explorer < 10
+			$this->_mime = 'text/plain';
+		}
 
 		// Set document type
 		$this->_type = 'json';
@@ -60,7 +68,11 @@ class JDocumentJSON extends JDocument
 		$app = JFactory::getApplication();
 
 		$app->allowCache(false);
-		$app->setHeader('Content-disposition', 'attachment; filename="' . $this->getName() . '.json"', true);
+		if ($this->_mime == 'application/json') 
+		{
+			// Browser other than Internet Explorer < 10
+			$app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);
+		}
 
 		parent::render();
 

--- a/libraries/joomla/document/json/json.php
+++ b/libraries/joomla/document/json/json.php
@@ -39,14 +39,14 @@ class JDocumentJSON extends JDocument
 		parent::__construct($options);
 
 		// Set mime type
-		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false)
-		{
-			$this->_mime = 'application/json';
-		}
-		else
+		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') === false AND strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false)
 		{
 			// Internet Explorer < 10
 			$this->_mime = 'text/plain';
+		}
+		else
+		{
+			$this->_mime = 'application/json';
 		}
 
 		// Set document type

--- a/libraries/joomla/document/json/json.php
+++ b/libraries/joomla/document/json/json.php
@@ -39,7 +39,7 @@ class JDocumentJSON extends JDocument
 		parent::__construct($options);
 
 		// Set mime type
-		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) 
+		if (isset($_SERVER['HTTP_ACCEPT']) AND strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false)
 		{
 			$this->_mime = 'application/json';
 		}
@@ -68,7 +68,7 @@ class JDocumentJSON extends JDocument
 		$app = JFactory::getApplication();
 
 		$app->allowCache(false);
-		if ($this->_mime == 'application/json') 
+		if ($this->_mime == 'application/json')
 		{
 			// Browser other than Internet Explorer < 10
 			$app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);


### PR DESCRIPTION
Internet Explorer older than 10 does not accept
Content-Type: application/json
and would start to download response.

Also header Content-Disposition
would force IE to download response.

It would only occur if you would try to upload file by ajax in IE < 10, 
because IE 7 - 9 do not support uploading file with XHR.

To test it see a test module in Code Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32285

Related PR which are already outdated and closed:
https://github.com/joomla/joomla-cms/pull/2013
https://github.com/joomla/joomla-cms/pull/2166
