### PR TITLE
[#32634] Fix the Facebook (Open graph) - joomla! Gzip problem

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -262,7 +262,7 @@ class JApplicationCms extends JApplicationWeb
 		}
 
 		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
-		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
+		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler') && ($_SERVER['HTTP_USER_AGENT'] != 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'))
 		{
 			$this->compress();
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -262,7 +262,7 @@ class JApplicationCms extends JApplicationWeb
 		}
 
 		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
-		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
+		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler') && ($_SERVER['HTTP_USER_AGENT'] != 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'))
 		{
 			$this->compress();
 
@@ -1066,7 +1066,7 @@ class JApplicationCms extends JApplicationWeb
 	public function toString($compress = false)
 	{
 		// Don't compress something if the server is going to do it anyway. Waste of time.
-		if ($compress && !ini_get('zlib.output_compression') && ini_get('output_handler') != 'ob_gzhandler')
+		if ($compress && !ini_get('zlib.output_compression') && ini_get('output_handler') != 'ob_gzhandler' && ($_SERVER['HTTP_USER_AGENT'] != 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'))
 		{
 			$this->compress();
 		}

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -263,7 +263,7 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
-		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
+		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler') && ($_SERVER['HTTP_USER_AGENT'] != 'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'))
 		{
 			$this->compress();
 		}


### PR DESCRIPTION
Facebook scraper gets only 40kb of data when scraping a page. If Gzip is enabled and the compressed page is more than that Facebook gets something that cannot decode (partial d/l returns code 206). This P/R checks if user agent is facebookexternalhit/1.1 and if so disables the gzip

Tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32634

There is another P/R #3643 with no code
