### PR TITLE
Fix unpacking tar files in PHP5.5

### DIFF
--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -168,10 +168,20 @@ class JArchiveTar implements JArchiveExtractable
 
 		while ($position < strlen($data))
 		{
-			$info = @unpack(
-				"a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/Ctypeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor",
-				substr($data, $position)
-			);
+			if (version_compare(PHP_VERSION, '5.5', '>='))
+			{
+				$info = @unpack(
+					"Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/Z8checksum/Ctypeflag/Z100link/Z6magic/Z2version/Z32uname/Z32gname/Z8devmajor/Z8devminor",
+					substr($data, $position)
+				);
+			}
+			else
+			{
+				$info = @unpack(
+					"a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/Ctypeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor",
+					substr($data, $position)
+				);
+			}
 
 			if (!$info)
 			{


### PR DESCRIPTION
This is already in the framework (https://github.com/joomla-framework/archive/commit/89d15271ac6e339657ca349d56226d550e94156c) and the was a change in b/c introduced in PHP 5.5
