### PR TITLE
Apply content plug-ins to user note body (modal)

### DIFF
--- a/administrator/components/com_users/views/notes/tmpl/modal.php
+++ b/administrator/components/com_users/views/notes/tmpl/modal.php
@@ -45,7 +45,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 			<div class="clr"></div>
 			<div class="ubody">
-				<?php echo $item->body; ?>
+				<?php echo JHtml::_( 'content.prepare', $item->body ); ?>
 			</div>
 		</li>
 	<?php endforeach; ?>


### PR DESCRIPTION
Displaying user notes from the User Manager modal box.. does not apply content plug-ins preparation...
Go to the User Manager.
Click on "Displays n notes" (to open the modal)
You'll find content plug-ins code... not properly prepared/rendered. (if exists..)
