### PR TITLE
[#33797] Wrong reurn page when article is checked out

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -171,6 +171,11 @@ class ContentControllerArticle extends JControllerForm
 	public function edit($key = null, $urlVar = 'a_id')
 	{
 		$result = parent::edit($key, $urlVar);
+		
+		 if (!$result)
+                {
+                   $this->setRedirect($this->getReturnPage());
+                }
 
 		return $result;
 	}


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33797

Joomla returns to "nowhere" when the article is checked out. Frontend must return to the page calling the edit.
Better would be to modify the legacy form controller to handle frontend correct and not as
Quote // Check-out failed, display a notice but allow the user to see the record.
