### PR TITLE
[2.5] Wrong reurn page when article is checked out

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -144,7 +144,12 @@ class ContentControllerArticle extends JControllerForm
 	public function edit($key = null, $urlVar = 'a_id')
 	{
 		$result = parent::edit($key, $urlVar);
-
+		
+		if (!$result)
+		{
+			$this->setRedirect($this->getReturnPage());
+		}
+		
 		return $result;
 	}
 


### PR DESCRIPTION
Backport https://github.com/joomla/joomla-cms/pull/3683 to 2.5.x
