### PR TITLE
Add J3.3.0 password verification compatibility

### DIFF
--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -269,4 +269,37 @@ class JCrypt
 		// They are only identical strings if $result is exactly 0...
 		return $result === 0;
 	}
+	
+	/**
+	 * Tests for the availability of updated crypt().
+	 * Based on a method by Anthony Ferrera
+	 *
+	 * @return  boolean  Always returns true since 3.3
+	 *
+	 * @note    To be removed when PHP 5.3.7 or higher is the minimum supported version.
+	 * @see     https://github.com/ircmaxell/password_compat/blob/master/version-test.php
+	 * @since   3.2
+	 * @deprecated  4.0
+	 */
+	public static function hasStrongPasswordSupport()
+	{
+		// Verify that we are runing under PHP 5.3.10 to call bcrypt
+		if (version_compare(PHP_VERSION, '5.3.10', 'lt'))
+		{
+			// Othewise, return false when bcrypt os not present
+			return false;
+		}
+	   
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated without replacement.', JLog::WARNING, 'deprecated');
+
+		if (!defined('PASSWORD_DEFAULT'))
+		{
+			// Always make sure that the password hashing API has been defined.
+			include_once JPATH_ROOT . '/libraries/compat/password/lib/password.php';
+		}
+
+		return true;
+	}
+
 }


### PR DESCRIPTION
When sharing users between different joomla version, the password can be modified by joomla 3.3 that forbid joomla 2.5 to login.
Add this verification when PHP 5.3.10 is available, this make the compatibility available with J3.3

This change require to add the J3.3 /libraries/compat directory included in J2.5.20
