### PR TITLE
Fix folder testing for JFolder::copy

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -54,9 +54,9 @@ abstract class JFolder
 		{
 			throw new RuntimeException('Source folder not found', -1);
 		}
-		if (!self::exists($dest) && !$force)
+		if (self::exists($dest) && !$force)
 		{
-			throw new RuntimeException('Destination folder not found', -1);
+			throw new RuntimeException('Destination folder already exists', -1);
 		}
 
 		// Make sure the destination exists

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -54,7 +54,7 @@ abstract class JFolder
 		{
 			throw new RuntimeException('Source folder not found', -1);
 		}
-		if (self::exists($dest) && !$force)
+		if (!self::exists($dest) && !$force)
 		{
 			throw new RuntimeException('Destination folder not found', -1);
 		}


### PR DESCRIPTION
We have to throw the error that the folder does not exist (and we do not ask to force the operation) but the test make the inverse.

Thinking about it, I guess that the test is right but the error message is wrong.
