### PR TITLE
Mootools isn't used in the category blog layout

### DIFF
--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 $params = $displayData->params;
 $canEdit = $displayData->params->get('access-edit');
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
-JHtml::_('behavior.framework');
 ?>
 
 	<?php if ($params->get('show_title') || $displayData->state == 0 || ($params->get('show_author') && !empty($displayData->author ))) : ?>


### PR DESCRIPTION
This is a follow up PR from #3586. During testing we found that Mootools is still loaded in the blog layout.
### Testing
1. In Joomla 3.3 create a menu item for the articles category view using the blog layout.
2. Notice that /media/system/mootools-core.js and core.js gets loaded.
3. Apply PR and check that both files aren't loaded anymore.
4. Check that everything still works.
### Notice

If MooTools and core.js is still loaded, you may have to disable other modules like the login one.
