### PR TITLE
Remove MooTools autofocus with jQuery autofocus

### DIFF
--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -46,11 +46,9 @@ $sitename = $app->get('sitename');
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
 	<script type="text/javascript">
-		window.addEvent('domready', function ()
-		{
-			document.getElementById('form-login').username.select();
-			document.getElementById('form-login').username.focus();
-		});
+       	    jQuery(function($) {
+            	$( "#form-login input[name='username']" ).focus();
+            });
 	</script>
 	<style type="text/css">
 		/* Responsive Styles */


### PR DESCRIPTION
MooTools autofocus and HTML5 autofocus do work on Chrome (and some other browsers) but don't in Firefox. In Firefox this is solved by removing the MooTools method and using jQuery instead. The J3 move from MooTools to jQuery is now also taken with this step. Works in Chrome, Firefox
