### PR TITLE
[#33814] Plugin SEF do not respect the custom attributes  

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -78,8 +78,8 @@ class PlgSystemSef extends JPlugin
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
 		$protocols = '[a-zA-Z0-9]+:';
-		$regex     = '#(src|href|poster)="(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
-		$buffer    = preg_replace($regex, "$1=\"$base\$2\"", $buffer);
+		$regex     = '#\s+(src|href|poster)="(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
+		$buffer    = preg_replace($regex, " $1=\"$base\$2\"", $buffer);
 		$this->checkBuffer($buffer);
 
 		$regex  = '#(onclick="window.open\(\')(?!/|' . $protocols . '|\#)([^/]+[^\']*?\')#m';


### PR DESCRIPTION
How to test:
put next code in article: `<div data-src="custom" data-href="another-custom" data-poster="custom"> </div>`
check the result in the browser inspector, there should not be any changes

Link:
[[#33814] Plugin SEF do not respect the custom attributes](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33814&start=0)
