### PR TITLE
[#33026] Load custom.css (if exist) in Admin templates.

### DIFF
--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -36,6 +36,14 @@ else
 
 $doc->addStyleSheetVersion('templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
+// Load custom.css
+$file = 'templates/' . $this->template . '/css/custom.css';
+
+if (is_file($file))
+{
+	$doc->addStyleSheetVersion($file);
+}
+
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -24,6 +24,14 @@ $doc->addScriptVersion('templates/' . $this->template . '/js/template.js');
 // Add Stylesheets
 $doc->addStyleSheetVersion('templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
+// Load custom.css
+$file = 'templates/' . $this->template . '/css/custom.css';
+
+if (is_file($file))
+{
+	$doc->addStyleSheetVersion($file);
+}
+
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 


### PR DESCRIPTION
See [tracker #33026](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33026&start=0).

This change was previously submitted as #2684, and as per @bakual I am resubmitting it as a way to reopen it. The background to this is as follows:
1. A lot of Fabrik users want to make lists more compact - since there is no custom.css in the standard Joomla admin templates, at present we are using locale-based CSS i.e. en-gb.css (how weird is that!!!) to achieve this. Custom.css would be a more standard way of achieving this, and will be more convenient when developing a multi-country web-site where admin users might change locale frequently to test how it looks/works.
2. Clearly a user can change the basic css files for the template, however that will be overwritten when you apply a Joomla update.
3. It was previously suggested that the way to achieve this is to copy the template e.g. create my-isis and make changes to the CSS there. Copying an Admin template just to change small CSS seems to me to be a little over-kill - and will then provide a potential minefield of incompatibility where you are using a copy of an old template against an updated rest of Joomla, and a maintenance overhead to re-copy and reapply the css changes every time there is a joomla update.

This is a small and simple change with little risk, so I am not clear why there should be any issue with implementing it.
