### PR TITLE
Fix broken captcha and use class

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -83,9 +83,9 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 *
 	 * @since  2.5
 	 */
-	public function onDisplay($name, $class, $id = 'dynamic_recaptcha_1')
+	public function onDisplay($name, $id = 'dynamic_recaptcha_1', $class = '')
 	{
-		return '<div id="' . $id . '"></div>';
+		return '<div id="' . $id . '" ' . $class . '></div>';
 	}
 
 	/**

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -77,7 +77,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 *
 	 * @param   string  $name   The name of the field.
 	 * @param   string  $id     The id of the field.
-	 * @param   string  $class  The class of the field.
+	 * @param   string  $class  The class of the field. This should be passed as
+	 *                          e.g. 'class="required"'.
 	 *
 	 * @return  string  The HTML to be embedded in the form.
 	 *


### PR DESCRIPTION
Captcha was broken by this commit: https://github.com/joomla/joomla-cms/commit/acb7e30fd79ea1dc8a40aff858751ca4f52f8b40

which reversed the order of id and class for code style. To fix this i've given class a default empty string value and used it in the method
