### PR TITLE
[#33811] Fix wincache notice

### DIFF
--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -61,13 +61,13 @@ class JCacheStorageWincache extends JCacheStorage
 		parent::getAll();
 
 		$allinfo = wincache_ucache_info();
-		$keys = $allinfo['cache_entries'];
-		$secret = $this->_hash;
-		$data = array();
+		$keys    = $allinfo['ucache_entries'];
+		$secret  = $this->_hash;
+		$data    = array();
 
 		foreach ($keys as $key)
 		{
-			$name = $key['key_name'];
+			$name    = $key['key_name'];
 			$namearr = explode('-', $name);
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
 			{


### PR DESCRIPTION
### Issue

Notice: Undefined index: cache_entries in JROOT\libraries\joomla\cache\storage\wincache.php on line 64 Warning: Invalid argument supplied for foreach() in JROOT\libraries\joomla\cache\storage\wincache.php on line 68
### Explanation

According to the PHP Docs for wincache_ucache_info():
http://www.php.net/manual/en/function.wincache-ucache-info.php

We have no index called "cache_entries" only a "ucache_entries"
### This PR
1. change "cache_entries" to "ucache_entries"
2. fix mirror CS
### Tracker:

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33811&start=0
