### PR TITLE
fix the xpath for field selection so that fieldset//fields//field is supported once again.

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1594,10 +1594,10 @@ class JForm
 		/*
 		 * Get an array of <field /> elements that are underneath a <fieldset /> element
 		 * with the appropriate name attribute, and also any <field /> elements with
-		 * the appropriate fieldset attribute. To allow repeatable elements only immediate
-		 * field descendants of the fieldset are selected.
+		 * the appropriate fieldset attribute. To allow repeatable elements only fields
+		 * which are not descendants of other fields are selected.
 		 */
-		$fields = $this->xml->xpath('//fieldset[@name="' . $name . '"]/field | //field[@fieldset="' . $name . '"]');
+		$fields = $this->xml->xpath('(//fieldset[@name="' . $name . '"]//field | //field[@fieldset="' . $name . '"])[not(ancestor::field)]');
 
 		return $fields;
 	}


### PR DESCRIPTION
We lost this functionality in Joomla 3 because we want to be able to nest <field> within <field> for the purpose of making repeatable fields. This is a better xpath that avoids selecting <field> tags that are nested within other <field> tags but does select them in any other structure. In other words, this will work again:

``` xml
<fieldset>
    <fields>
        <field />
    </fields>
</fieldset>
```
