### PR TITLE
[#33816] Cache incorrectly always overrides ID URL param

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -699,12 +699,22 @@ class JCache
 		}
 
 		// Platform defaults
-		$registeredurlparams->format = 'WORD';
-		$registeredurlparams->option = 'WORD';
-		$registeredurlparams->view = 'WORD';
-		$registeredurlparams->layout = 'WORD';
-		$registeredurlparams->tpl = 'CMD';
-		$registeredurlparams->id = 'INT';
+		$defaulturlparams = array(
+			'format' 	=> 'WORD',
+			'option' 	=> 'WORD',
+			'view' 		=> 'WORD',
+			'layout' 	=> 'WORD',
+			'tpl' 		=> 'CMD',
+			'id' 		=> 'INT'
+		);
+		
+		// Use platform defaults if parameter doesn't already exist.
+		foreach($defaulturlparams as $param => $type)
+		{
+			if (!property_exists($registeredurlparams, $param)) {
+				$registeredurlparams->$param = $type;
+			}
+		}
 
 		$safeuriaddon = new stdClass;
 

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -697,10 +697,6 @@ class JCache
 		{
 			$registeredurlparams = $app->registeredurlparams;
 		}
-		else
-		{
-			$registeredurlparams = new stdClass;
-		}
 
 		// Platform defaults
 		$defaulturlparams = array(

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -697,6 +697,10 @@ class JCache
 		{
 			$registeredurlparams = $app->registeredurlparams;
 		}
+		else
+		{
+			$registeredurlparams = new stdClass;
+		}
 
 		// Platform defaults
 		$defaulturlparams = array(
@@ -711,7 +715,8 @@ class JCache
 		// Use platform defaults if parameter doesn't already exist.
 		foreach($defaulturlparams as $param => $type)
 		{
-			if (!property_exists($registeredurlparams, $param)) {
+			if (!property_exists($registeredurlparams, $param))
+			{
 				$registeredurlparams->$param = $type;
 			}
 		}


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33816&start=0

ID can be not INT, so pages using arrays or string in ID receive same cache key.
