### PR TITLE
[#33760] JEditor errors on addCustomTag() call when using raw document

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -256,7 +256,11 @@ class JEditor extends JObject
 		}
 
 		$document = JFactory::getDocument();
-		$document->addCustomTag($return);
+		
+		if(method_exists($document, "addCustomTag"))
+		{
+			$document->addCustomTag($return);
+		}
 	}
 
 	/**

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -243,7 +243,7 @@ class JEditor extends JObject
 
 		$args['event'] = 'onInit';
 
-		$return = '';
+		$return    = '';
 		$results[] = $this->_editor->update($args);
 
 		foreach ($results as $result)
@@ -257,7 +257,7 @@ class JEditor extends JObject
 
 		$document = JFactory::getDocument();
 		
-		if(method_exists($document, "addCustomTag"))
+		if (method_exists($document, "addCustomTag"))
 		{
 			$document->addCustomTag($return);
 		}

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -256,7 +256,7 @@ class JEditor extends JObject
 		}
 
 		$document = JFactory::getDocument();
-		
+
 		if (method_exists($document, "addCustomTag"))
 		{
 			$document->addCustomTag($return);


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33760&start=0
### Description

addCustomTag is not a valid method for JDocumentRaw and generates an error if the URL contains "format=raw", which I use for displaying forms within an AJAX dialog (the form contains an editor widget).
### Code by Dan Cogliano
