### PR TITLE
Fix - "Show Title" option in the administrator template Isis

### DIFF
--- a/administrator/templates/isis/html/modules.php
+++ b/administrator/templates/isis/html/modules.php
@@ -30,7 +30,7 @@ function modChrome_title($module, &$params, &$attribs)
 {
 	if ($module->content)
 	{
-		echo "<div class=\"module-title\"><h6>".$module->title."</h6></div>";
+		echo "<div class=\"module-title\"><h6>" . $module->title . "</h6></div>";
 		echo $module->content;
 	}
 }
@@ -47,14 +47,14 @@ function modChrome_well($module, &$params, &$attribs)
 {
 	if ($module->content)
 	{
-		$bootstrapSize  = (int) $params->get('bootstrap_size');
-		$moduleClass    = ($bootstrapSize) ? ' span' . $bootstrapSize : '';
+		$bootstrapSize = (int) $params->get('bootstrap_size');
+		$moduleClass   = ($bootstrapSize) ? ' span' . $bootstrapSize : '';
 
 		echo '<div class="well well-small' . $moduleClass . '">';
 
-		if($module->showtitle)
+		if ($module->showtitle)
 		{
-			echo '<h2 class="module-title nav-header">' . $module->title .'</h2>';
+			echo '<h2 class="module-title nav-header">' . $module->title . '</h2>';
 		}
 
 		echo $module->content;

--- a/administrator/templates/isis/html/modules.php
+++ b/administrator/templates/isis/html/modules.php
@@ -51,7 +51,12 @@ function modChrome_well($module, &$params, &$attribs)
 		$moduleClass    = ($bootstrapSize) ? ' span' . $bootstrapSize : '';
 
 		echo '<div class="well well-small' . $moduleClass . '">';
-		echo '<h2 class="module-title nav-header">' . $module->title .'</h2>';
+
+		if($module->showtitle)
+		{
+			echo '<h2 class="module-title nav-header">' . $module->title .'</h2>';
+		}
+
 		echo $module->content;
 		echo '</div>';
 	}


### PR DESCRIPTION
Currently this option for modules is not considered at all. With this small fix the title is displayed depending on the option.
### Testing
1. Go to "Extensions" - "Module Manager", switch the filter to "Administrator". Look for a module on the position "cpanel". 
2. Edit this module and set the option "Show title" to "Hide" and save.
3. Go then back to the control panel. You will still see the title of the module even though the option is deactivated.
4. Apply PR and see the title is gone.
