### PR TITLE
Add information about branches to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,15 @@ All contributions are welcome to be submitted for review for inclusion in the Jo
 3) After submitting the item to the Joomlacode tracker, add a link to the Joomlacode tracker item and the GitHub issue or pull request.
 
 Please be patient as not all items will be tested immediately (remember, all bug testing for the Joomla! CMS is done by volunteers) and be receptive to feedback about your code.
+
+#### Branches
+Pull Requests should usually be made for the `staging` branch as this contains the most recent version of the code.
+There are other branches available which server specific purposes.
+
+| Branch | Purpose |
+| ------ | ------- |
+| staging | Current codebase. |
+| master | Each commit made to staging gets tested if it passes unit tests and codestyle rules and then merged into master. This is done automatically. |
+| 2.5.x | Branch for the Joomla 2.5.x series. Currently in maintenance mode with EOL end of 2014. No new features are accepted here. |
+| 3.2.x | Branch for the Joomla 3.2.x series. Currently in security mode with EOL Oct 2014. Only security issues are fixed. |
+| 3.4-dev | Branch for the next minor Joomla version. New backward compatible features go into this branch. Commits to staging will be applied to this branch as well. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please be patient as not all items will be tested immediately (remember, all bug
 
 #### Branches
 Pull Requests should usually be made for the `staging` branch as this contains the most recent version of the code.
-There are other branches available which server specific purposes.
+There are other branches available which serve specific purposes.
 
 | Branch | Purpose |
 | ------ | ------- |


### PR DESCRIPTION
During the bug squad session at JAB14 there was some confusion about which branch to use.

I think we can add this information to the contributing.md file. A link to this file ("guidelines for contributing") is shown whenever someones wants to open a Pull Request. See this screenshot:
![guidelines](https://cloud.githubusercontent.com/assets/1018684/3171727/a81e48aa-ebca-11e3-8f36-62fd7d54bf7a.png)

I'm sure this can be improved with other information as well.
