### PR TITLE
Use set_charset instead of query to set the db connection charset

### DIFF
--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -624,7 +624,7 @@ class JDatabaseMySQL extends JDatabase
 	 */
 	public function setUTF()
 	{
-		return mysql_query("SET NAMES 'utf8'", $this->connection);
+		return mysql_set_charset('utf8', $this->connection);
 	}
 
 	/**

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -452,7 +452,7 @@ class JDatabaseMySQLi extends JDatabaseMySQL
 	 */
 	public function setUTF()
 	{
-		mysqli_query($this->connection, "SET NAMES 'utf8'");
+		mysqli_set_charset($this->connection, 'utf8');
 	}
 
 	/**


### PR DESCRIPTION
### Issue

Based on a forum post (http://forum.joomla.org/viewtopic.php?f=617&t=847166) there is an issue with `real_escape_string` in Joomla 2.5.
This is due to how we set up the connection charset.
On the PHP manual (http://www.php.net/manual/en/mysqli.set-charset.php) it says:

> This is the preferred way to change the charset. Using mysqli_query() to set it (such as SET NAMES utf8) is not recommended.

In J3.3 we don't have this issue because this change was already done somewhere during 3.0 alpha.
### Testing

According to the forum post, the issue can for example be seen if you use multibytes characters in a search/filter.
However it will not show if the database is set up to use utf8 charset in the connection by default (which today is standard). So it's enviroment related.
