### PR TITLE
[#33822] "Similar Tags" module ignores access permissions for tagged articles

### DIFF
--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -82,7 +82,7 @@ abstract class ModTagssimilarHelper
 
 		$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
 		$query->where('t.access IN (' . $groups . ')');
-		$query->where('cc.core_access IN (' . $groups . ') OR (cc.core_access = 0)');
+		$query->where('(cc.core_access IN (' . $groups . ') OR cc.core_access = 0)');
 
 		// Don't show current item
 		$query->where('(' . $db->quoteName('m.content_item_id') . ' <> ' . $id . ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -78,10 +78,12 @@ abstract class ModTagssimilarHelper
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON m.tag_id = t.id')
 			->join('INNER', $db->quoteName('#__ucm_content', 'cc') . ' ON m.core_content_id = cc.core_content_id')
-			->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias');
+			->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias')
+			->join('INNER', $db->quoteName('#__content', 'cn') . ' ON m.content_item_id = cn.id');
 
 		$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
 		$query->where('t.access IN (' . $groups . ')');
+		$query->where('cn.access IN (' . $groups . ')');
 
 		// Don't show current item
 		$query->where('(' . $db->quoteName('m.content_item_id') . ' <> ' . $id . ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -78,12 +78,11 @@ abstract class ModTagssimilarHelper
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON m.tag_id = t.id')
 			->join('INNER', $db->quoteName('#__ucm_content', 'cc') . ' ON m.core_content_id = cc.core_content_id')
-			->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias')
-			->join('INNER', $db->quoteName('#__content', 'cn') . ' ON m.content_item_id = cn.id');
+			->join('INNER', $db->quoteName('#__content_types', 'ct') . ' ON m.type_alias = ct.type_alias');
 
 		$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
 		$query->where('t.access IN (' . $groups . ')');
-		$query->where('cn.access IN (' . $groups . ')');
+		$query->where('cc.core_access IN (' . $groups . ')');
 
 		// Don't show current item
 		$query->where('(' . $db->quoteName('m.content_item_id') . ' <> ' . $id . ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -82,7 +82,7 @@ abstract class ModTagssimilarHelper
 
 		$query->where($db->quoteName('m.tag_id') . ' IN (' . $tagsToMatch . ')');
 		$query->where('t.access IN (' . $groups . ')');
-		$query->where('cc.core_access IN (' . $groups . ')');
+		$query->where('cc.core_access IN (' . $groups . ') OR (cc.core_access = 0)');
 
 		// Don't show current item
 		$query->where('(' . $db->quoteName('m.content_item_id') . ' <> ' . $id . ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');


### PR DESCRIPTION
Bug reported by Thomas Schmitz:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33822&start=0

The fix also checks the access level of the corresponding articles.

How to reproduce bug (from JoomlaCode entry):

1) Create a tag 
2) Assign the tag to an article with "Public" access and another article with "Registered" access 
3) Now an unregistered user will see a link to both articles with the "Similar Tag" module
