### PR TITLE
[#33819] Fix for emailcloak plugin for cloaking email addresses with a plus chara...

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -117,7 +117,7 @@ class PlgContentEmailcloak extends JPlugin
 		$mode = $this->params->def('mode', 1);
 
 		// Example: any@example.org
-		$searchEmail = '([\w\.\-]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))';
+		$searchEmail = '([\w\.\-\+]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))';
 
 		// Example: any@example.org?subject=anyText
 		$searchEmailLink = $searchEmail . '([?&][\x20-\x7f][^"<>]+)';


### PR DESCRIPTION
...cter (+) properly

JoomlaCode entry: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33819&start=0

**How to test:**
1. Create article with following email addresses:
   test@example.com
   test+test@example.com
   test+@example.com
   +test@example.com
2. Load the article in the front end (of course the emailcloak plugin has to be activated). You will see that the addresses are not cloaked properly. If you deactivate JavaScript, then it is even clearer which parts are only considered by the plugin.
3. Add fix and reload the page. Each address will be cloaked completely and properly.

Further information: http://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-email-address
