### PR TITLE
[#33834] Fixed JForm::bind for nested JObject argument

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -129,8 +129,8 @@ class JForm
 			}
 			elseif ($data instanceof JObject)
 			{
-				// Handle a JObject.
-				$data = $data->getProperties();
+				// Handle a JObject. Getting just the properties won't work. We need to convert any nested JObject too.
+				$data = JArrayHelper::fromObject($data);
 			}
 			else
 			{


### PR DESCRIPTION
JForm::bind method was relying on getProperties() which returned only the attributes of the given object. However in case one of these attributes happens to be a JObject instance itself, then JForm::bindLevel would fail there.
In particular model's getItem function tends to return a nested JObject always.

JArrayHelper call would take care of JObject to Array conversion recursively.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33834&start=0
