### PR TITLE
[#33815] Fix for com_tags - show tags title properly - option "show tag name" + p...

### DIFF
--- a/components/com_tags/views/tag/tmpl/default.php
+++ b/components/com_tags/views/tag/tmpl/default.php
@@ -21,7 +21,7 @@ $isSingleTag = (count($this->item) == 1);
 	<?php endif; ?>
 	<?php if ($this->params->get('show_tag_title', 1)) : ?>
 		<h2>
-			<?php echo JHtml::_('content.prepare', $this->document->title, '', 'com_tag.tag'); ?>
+			<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
 		</h2>
 	<?php endif; ?>
 	<?php // We only show a tag description if there is a single tag. ?>

--- a/components/com_tags/views/tag/tmpl/list.php
+++ b/components/com_tags/views/tag/tmpl/list.php
@@ -22,7 +22,7 @@ $n = count($this->items);
 	<?php endif; ?>
 	<?php if ($this->params->get('show_tag_title', 1)) : ?>
 		<h2>
-			<?php echo JHtml::_('content.prepare', $this->document->title, '', 'com_tag.tag'); ?>
+			<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
 		</h2>
 	<?php endif; ?>
 	<?php // We only show a tag description if there is a single tag. ?>

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -30,6 +30,8 @@ class TagsViewTag extends JViewLegacy
 
 	protected $params;
 
+	protected $tags_title;
+
 	/**
 	 * Execute and display a template script.
 	 *
@@ -111,13 +113,13 @@ class TagsViewTag extends JViewLegacy
 			}
 		}
 
-		$this->state      = &$state;
-		$this->items      = &$items;
-		$this->children   = &$children;
-		$this->parent     = &$parent;
-		$this->pagination = &$pagination;
-		$this->user       = &$user;
-		$this->item       = &$item;
+		$this->state      = $state;
+		$this->items      = $items;
+		$this->children   = $children;
+		$this->parent     = $parent;
+		$this->pagination = $pagination;
+		$this->user       = $user;
+		$this->item       = $item;
 
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
@@ -189,6 +191,9 @@ class TagsViewTag extends JViewLegacy
 		$menus		= $app->getMenu();
 		$title 		= null;
 
+		// Generate the tags title to use for page title, page heading and show tags title option
+		$this->getTagsTitle();
+
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
@@ -196,30 +201,30 @@ class TagsViewTag extends JViewLegacy
 		if ($menu)
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
+			$title = $this->params->get('page_title', $menu->title);
+
+			if ($menu->query['option'] != 'com_tags')
+			{
+				$this->params->set('page_subheading', $menu->title);
+			}
 		}
 		else
 		{
-			$this->params->def('page_heading', JText::_('COM_TAGS_DEFAULT_PAGE_TITLE'));
+			$this->params->def('page_heading', $this->tags_title);
+			$title = $this->tags_title;
 		}
-
-		if ($menu && ($menu->query['option'] != 'com_tags'))
-		{
-			$this->params->set('page_subheading', $menu->title);
-		}
-
-		$title = $this->state->params->get('page_title');
 
 		if (empty($title))
 		{
-			$title = $app->getCfg('sitename');
+			$title = $app->get('sitename');
 		}
-		elseif ($app->getCfg('sitename_pagetitles', 0) == 1)
+		elseif ($app->get('sitename_pagetitles', 0) == 1)
 		{
-			$title = JText::sprintf('JPAGETITLE', $app->getCfg('sitename'), $title);
+			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
 		}
-		elseif ($app->getCfg('sitename_pagetitles', 0) == 2)
+		elseif ($app->get('sitename_pagetitles', 0) == 2)
 		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->getCfg('sitename'));
+			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
 		}
 
 		$this->document->setTitle($title);
@@ -267,5 +272,27 @@ class TagsViewTag extends JViewLegacy
 			$attribs = array('type' => 'application/atom+xml', 'title' => 'Atom 1.0');
 			$this->document->addHeadLink(JRoute::_($link.'&type=atom'), 'alternate', 'rel', $attribs);
 		}
+	}
+
+	/**
+	 * Creates the tags title for the output
+	 *
+	 * @return bool
+	 */
+	protected function getTagsTitle()
+	{
+		$tags_title = array();
+
+		if (!empty($this->item))
+		{
+			foreach ($this->item as $item)
+			{
+				$tags_title[] = $item->title;
+			}
+		}
+
+		$this->tags_title = implode(' ', $tags_title);
+
+		return;
 	}
 }

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -285,9 +285,15 @@ class TagsViewTag extends JViewLegacy
 
 		if (!empty($this->item))
 		{
+			$user   = JFactory::getUser();
+			$groups = $user->getAuthorisedViewLevels();
+
 			foreach ($this->item as $item)
 			{
-				$tags_title[] = $item->title;
+				if (in_array($item->access, $groups))
+				{
+					$tags_title[] = $item->title;
+				}
 			}
 		}
 

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -192,7 +192,7 @@ class TagsViewTag extends JViewLegacy
 		$title 		= null;
 
 		// Generate the tags title to use for page title, page heading and show tags title option
-		$this->getTagsTitle();
+		$this->tags_title = $this->getTagsTitle();
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
@@ -297,8 +297,6 @@ class TagsViewTag extends JViewLegacy
 			}
 		}
 
-		$this->tags_title = implode(' ', $tags_title);
-
-		return;
+		return implode(' ', $tags_title);
 	}
 }


### PR DESCRIPTION
...age title

(plus some code optimizations - removed unneeded references and deprecated function call getCfg)

JoomlaCode Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33815&start=0

**How to test**

See JoomlaCode Tracker.

This fix adds the tags title to the page title (if no menu entry set) and the option "Show tag name" shows the correct name of the tags, not site title which is set in the global configuration.

If a menu entry is set, then the information from this entry is used. The tags component should now behave like the content component.
