### PR TITLE
[#33830] [imp] Improve the default view in com_joomlaupdate

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
+JHtml::_('formbehavior.chosen', 'select');
 
 ?>
 
@@ -98,7 +99,7 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD') ?>
 				</td>
 				<td>
-					<input type="text" name="ftp_pass" value="<?php echo $this->ftp['password'] ?>" />
+					<input type="password" name="ftp_pass" value="<?php echo $this->ftp['password'] ?>" />
 				</td>
 			</tr>
 			<tr id="row_ftp_directory" <?php echo $ftpFieldsDisplay ?>>
@@ -116,7 +117,7 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 					&nbsp;
 				</td>
 				<td>
-					<button class="submit" type="submit">
+					<button class="btn btn-primary" type="submit">
 						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLUPDATE') ?>
 					</button>
 				</td>


### PR DESCRIPTION
### Tracker:

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33830&start=0
### How to test
1. Install 3.3.0
2. switch update server to testing
3. See the update message on com_joomlaupdate
4. choose FTP (and enter a test PW)
5. see old_updater.jpg
6. apply patch (e.g. with Patchtester)
7. see the message again
8. see that the FTP Password imput is hidden
9. see: new_updater.jpg
#### Old updater view

![old_updater](https://cloud.githubusercontent.com/assets/2596554/3211205/708f29ee-ef09-11e3-9579-2e6a8aa099bf.JPG)
#### New updater view

![new_updater](https://cloud.githubusercontent.com/assets/2596554/3211206/70989b00-ef09-11e3-81a0-87a36f78bf6e.JPG)
