### PR TITLE
[#33832] Fix error on com_joomlaupdate if update.joomla.org is not available.

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -240,7 +240,6 @@ class JUpdaterCollection extends JUpdateAdapter
 		$db = $this->parent->getDBO();
 
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
 
 		// JHttp transport throws an exception when there's no response.
 		try

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -375,8 +375,18 @@ class JUpdate extends JObject
 	public function loadFromXML($url)
 	{
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($url);
-		if (200 != $response->code)
+
+		// JHttp transport throws an exception when there's no reponse.
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $e)
+		{
+			$response = null;
+		}
+		
+		if ($response->code != 200)
 		{
 			// TODO: Add a 'mark bad' setting here somehow
 			JLog::add(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), JLog::WARNING, 'jerror');


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33832&start=0
### How to test
1. install Joomla 3.3.0
2. disable network (or use it without internet connection)
3. access the Joomla Updater
4. it send a error that he can't access update.joomla.org
5. apply patch
6. test again (possible clear the updater cache)
7. The "normal" Message by joomla (can not open the URL) apperars and the URL will "cached". (same behavior as in 2.5)
