### PR TITLE
[#33835] Allow stream connections to support proxies.

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -37,16 +37,6 @@ class JHttpFactory
 			$options = new Registry;
 		}
 
-		if (empty($adapters))
-		{
-			$config = JFactory::getConfig();
-
-			if ($config->get('proxy_enable'))
-			{
-				$adapters = 'curl';
-			}
-		}
-
 		if (!$driver = self::getAvailableDriver($options, $adapters))
 		{
 			throw new RuntimeException('No transport driver available.');

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -320,6 +320,6 @@ class JHttpTransportSocket implements JHttpTransport
 	 */
 	public static function isSupported()
 	{
-		return function_exists('fsockopen') && is_callable('fsockopen');
+		return function_exists('fsockopen') && is_callable('fsockopen') && !JFactory::getConfig()->get('proxy_enable');
 	}
 }

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -92,20 +92,6 @@ class JHttpTransportStream implements JHttpTransport
 			$headers['Content-Length'] = strlen($options['content']);
 		}
 
-		// Build the headers string for the request.
-		$headerString = null;
-
-		if (isset($headers))
-		{
-			foreach ($headers as $key => $value)
-			{
-				$headerString .= $key . ': ' . $value . "\r\n";
-			}
-
-			// Add the headers string into the stream context options array.
-			$options['header'] = trim($headerString, "\r\n");
-		}
-
 		// If an explicit timeout is given user it.
 		if (isset($timeout))
 		{
@@ -129,6 +115,44 @@ class JHttpTransportStream implements JHttpTransport
 		{
 			$options[$key] = $value;
 		}
+
+		// Add the proxy configuration, if any.
+		$config = JFactory::getConfig();
+
+		if ($config->get('proxy_enable'))
+		{
+			$options['proxy'] = $config->get('proxy_host') . ':' . $config->get('proxy_port');
+			$options['request_fulluri'] = true;
+
+			// Put any required authorization into the headers array to be handled later
+			// TODO: do we need to support any auth type other than Basic?
+			if ($user = $config->get('proxy_user'))
+			{
+				$auth = base64_encode($config->get('proxy_user') . ':' . $config->get('proxy_pass'));
+
+				$headers['Proxy-Authorization'] = 'Basic ' . $auth;
+			}
+		}
+
+		// Build the headers string for the request.
+		$headerEntries = null;
+
+		if (isset($headers))
+		{
+			foreach ($headers as $key => $value)
+			{
+				$headerEntries[] = $key . ': ' . $value;
+			}
+
+			// Add the headers string into the stream context options array.
+			$options['header'] = implode("\r\n", $headerEntries);
+		}
+
+		// Get the current context options.
+		$contextOptions = stream_context_get_options(stream_context_get_default());
+
+		// Add our options to the current ones, if any.
+		$contextOptions['http'] = isset($contextOptions['http']) ? array_merge($contextOptions['http'], $options) : $options;
 
 		// Create the stream context for the request.
 		$context = stream_context_create(


### PR DESCRIPTION
HTTP stream context settings are currently being created based only on the various options passed to the 'request' function. These settings should take precedence but any default stream context settings should be used as the base.
Also, stream transport can be used with a proxy so we don't need to require curl for proxy connections. Rather than simply switching to curl when a proxy is needed, transports that do not support proxies (only socket) should exclude themselves when a proxy is required.
Tracker: https://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33835&start=0
