### PR TITLE
[Fix][#33829] Use 404 response codes when server URL rewriting is enabled

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -858,7 +858,21 @@ class JControllerLegacy extends JObject
 			}
 			else
 			{
-				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND', $name, $type, $prefix), 500);
+				$response = 500;
+				$app = JFactory::getApplication();
+				if ($app->get('sef_rewrite')) {
+
+					/*
+					 * With URL rewriting enabled on the server, all client
+					 * requests for non-existent files are being forwarded to
+					 * Joomla.  Return a 404 response here and assume the client
+					 * was requesting a non-existent file for which there is no
+					 * view type that matches the file's extension (the most
+					 * likely scenario).
+					 */
+					$response = 404;
+				}
+				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND', $name, $type, $prefix), $response);
 			}
 		}
 


### PR DESCRIPTION
_This pull request is based on comments made in an earlier request (#3739) which will now be closed._
# 

Joomla Code Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33829&start=0

 How to test:

Install Joomla 3.3.0 with some sample data on an apache server.

In the Site Settings, enable:
1. Search Engine Friendly URLs
2. Use URL rewriting
3. Adds Suffix to URL

Rename htaccess.txt to .htaccess to enable URL rewriting on the server.

Enter a URL for a non-existent file (assume the Joomla installation is at http://example.com):
http://examle.com/images/missing-file.pdf

The expected response is a "404" (not found) error.

The actual response is a "500" (internal server error) response.  This response is misleading.  There has been no "server error" -- it's simply a case of the client requesting a file that was not found on the server.

The issue is further exacerbated with the recent merging of pull request #488, because now any missing file with any file extension will be redirected to Joomla.  If the file ends with anything other than ".html", the response will likely be 500 rather than 404.

This problem also affects the Redirect component.  Although redirects can be created for missing files, the redirects will not be honored.  An example redirect:

http://examle.com/images/missing-file.pdf -> http://example.com/index.php

Such a redirect will fail because it would only be honored when a 404 error condition is encountered.

This issue is probably the same as issue #30344, but that was closed due to inactivity.
