### PR TITLE
[#33838] Generate version of atom feed from JVersion

### DIFF
--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -116,15 +116,15 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		{
 			$version = new JVersion;
 
-			$versionDetails = ' version="' . $version->RELEASE . '"';
+			$versionHtmlEscaped = ' version="' . htmlspecialchars($version->RELEASE, ENT_COMPAT, 'UTF-8') . '"';
 		}
 		else
 		{
-			$versionDetails = '';
+			$versionHtmlEscaped = '';
 		}
 
 
-		$feed .= "	<generator uri=\"http://joomla.org\"" . $versionDetails  . ">" . $data->getGenerator() . "</generator>\n";
+		$feed .= "	<generator uri=\"http://joomla.org\"" . $versionHtmlEscaped  . ">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -124,7 +124,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		}
 
 
-		$feed .= "	<generator uri=\"http://joomla.org\"" . $versionDetails  . ">" . $data->getGenerator() . "</generator>\n";
+		$feed .= "	<generator uri=\"http://joomla.org\"" . htmlspecialchars($versionDetails, ENT_COMPAT, 'UTF-8')  . ">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -111,7 +111,10 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			}
 			$feed .= "	</author>\n";
 		}
-		$feed .= "	<generator uri=\"http://joomla.org\" version=\"1.6\">" . $data->getGenerator() . "</generator>\n";
+
+		$version = new JVersion;
+
+		$feed .= "	<generator uri=\"http://joomla.org\" version=\"" . $version->RELEASE . "\">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -124,7 +124,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		}
 
 
-		$feed .= "	<generator uri=\"http://joomla.org\"" . htmlspecialchars($versionDetails, ENT_COMPAT, 'UTF-8')  . ">" . $data->getGenerator() . "</generator>\n";
+		$feed .= "	<generator uri=\"http://joomla.org\"" . $versionDetails  . ">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -116,7 +116,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		{
 			$version = new JVersion;
 
-			$versionDetails = 'version="' . $version->RELEASE . '"';
+			$versionDetails = ' version="' . $version->RELEASE . '"';
 		}
 		else
 		{

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -112,9 +112,19 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			$feed .= "	</author>\n";
 		}
 
-		$version = new JVersion;
+		if ($app->get('MetaVersion', 0))
+		{
+			$version = new JVersion;
 
-		$feed .= "	<generator uri=\"http://joomla.org\" version=\"" . $version->RELEASE . "\">" . $data->getGenerator() . "</generator>\n";
+			$version = 'version="' . $version->RELEASE . '"';
+		}
+		else
+		{
+			$version = '';
+		}
+
+
+		$feed .= "	<generator uri=\"http://joomla.org\"" . $version  . ">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -116,15 +116,15 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		{
 			$version = new JVersion;
 
-			$version = 'version="' . $version->RELEASE . '"';
+			$versionDetails = 'version="' . $version->RELEASE . '"';
 		}
 		else
 		{
-			$version = '';
+			$versionDetails = '';
 		}
 
 
-		$feed .= "	<generator uri=\"http://joomla.org\"" . $version  . ">" . $data->getGenerator() . "</generator>\n";
+		$feed .= "	<generator uri=\"http://joomla.org\"" . $versionDetails  . ">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33838&start=0
## Testing Instructions

Check an atom feed of a component (e.g. article category view). Before patch the < generator > tag will show the version as 1.6. After patch it will show 3.3 (and pulls the version number from JVersion so will not need updating in the future)
