### PR TITLE
[fix] Missing comma in #3677 breaks backend login

### DIFF
--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -23,6 +23,8 @@ class LoginModelLogin extends JModelLegacy
 	 *
 	 * Note. Calling getState in this method will result in recursion.
 	 *
+	 * @return  void
+	 *
 	 * @since   1.6
 	 */
 	protected function populateState()
@@ -34,7 +36,7 @@ class LoginModelLogin extends JModelLegacy
 
 		$credentials = array(
 			'username' => $input->$method->get('username', '', 'USERNAME'),
-			'password' => $input->$method->get('passwd', '', 'RAW')
+			'password' => $input->$method->get('passwd', '', 'RAW'),
 			'secretkey' => $input->$method->get('secretkey', '', 'RAW'),
 		);
 		$this->setState('credentials', $credentials);
@@ -43,6 +45,7 @@ class LoginModelLogin extends JModelLegacy
 		if ($return = $input->$method->get('return', '', 'BASE64'))
 		{
 			$return = base64_decode($return);
+
 			if (!JUri::isInternal($return))
 			{
 				$return = '';
@@ -80,7 +83,7 @@ class LoginModelLogin extends JModelLegacy
 			if (!$title || $modules[$i]->title == $title)
 			{
 				$result = $modules[$i];
-				break; // Found it
+				break;
 			}
 		}
 
@@ -111,7 +114,7 @@ class LoginModelLogin extends JModelLegacy
 	 * This is put in as a failsafe to avoid super user lock out caused by an unpublished
 	 * login module or by a module set to have a viewing access level that is not Public.
 	 *
-	 * @param   string  $name   The name of the module
+	 * @param   string  $module  The name of the module
 	 *
 	 * @return  array
 	 *
@@ -164,6 +167,7 @@ class LoginModelLogin extends JModelLegacy
 			catch (RuntimeException $e)
 			{
 				JError::raiseWarning(500, JText::sprintf('JLIB_APPLICATION_ERROR_MODULE_LOAD', $e->getMessage()));
+
 				return $loginmodule;
 			}
 


### PR DESCRIPTION
In https://github.com/joomla/joomla-cms/pull/3677 there is a missing comma that breaks the backend login.

![error_ra](https://cloud.githubusercontent.com/assets/1119272/3217880/1d01bc98-efe4-11e3-98cd-bdd17f0e961d.png)
