### PR TITLE
[#31603] Load observersmappings from content types instead from hardcoded

### DIFF
--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -28,9 +28,6 @@ class BannersTableBanner extends JTable
 	public function __construct(&$_db)
 	{
 		parent::__construct('#__banners', 'id', $_db);
-
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_banners.banner'));
-
 		$date = JFactory::getDate();
 		$this->created = $date->toSql();
 	}

--- a/administrator/components/com_banners/tables/client.php
+++ b/administrator/components/com_banners/tables/client.php
@@ -29,8 +29,6 @@ class BannersTableClient extends JTable
 	{
 		$this->checked_out_time = $_db->getNullDate();
 		parent::__construct('#__banner_clients', 'id', $_db);
-
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_banners.client'));
 	}
 
 	/**

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -25,9 +25,6 @@ class ContactTableContact extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__contact_details', 'id', $db);
-
-		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_contact.contact'));
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_contact.contact'));
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -23,9 +23,6 @@ class NewsfeedsTableNewsfeed extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__newsfeeds', 'id', $db);
-
-		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));
 	}
 
 	/**

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -26,8 +26,6 @@ class TagsTableTag extends JTableNested
 	public function __construct($db)
 	{
 		parent::__construct('#__tags', 'id', $db);
-
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_tags.tag'));
 	}
 
 	/**

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -28,8 +28,6 @@ class UsersTableNote extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__user_notes', 'id', $db);
-
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_users.note'));
 	}
 
 	/**

--- a/administrator/components/com_weblinks/tables/weblink.php
+++ b/administrator/components/com_weblinks/tables/weblink.php
@@ -26,9 +26,6 @@ class WeblinksTableWeblink extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__weblinks', 'id', $db);
-
-		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_weblinks.weblink'));
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_weblinks.weblink'));
 	}
 
 	/**

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -67,22 +67,3 @@ JLoader::register('JInstallerTemplate',  JPATH_PLATFORM . '/cms/installer/adapte
 JLoader::register('JExtension',  JPATH_PLATFORM . '/cms/installer/extension.php');
 JLoader::registerAlias('JAdministrator',  'JApplicationAdministrator');
 JLoader::registerAlias('JSite',  'JApplicationSite');
-
-// Register Observers:
-// Add Tags to Content, Contact, NewsFeeds, WebLinks and Categories: (this is the only link between them here!):
-JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
-JObserverMapper::addObserverClassToClass('JTableObserverTags', 'ContactTableContact', array('typeAlias' => 'com_contact.contact'));
-JObserverMapper::addObserverClassToClass('JTableObserverTags', 'NewsfeedsTableNewsfeed', array('typeAlias' => 'com_newsfeeds.newsfeed'));
-JObserverMapper::addObserverClassToClass('JTableObserverTags', 'WeblinksTableWeblink', array('typeAlias' => 'com_weblinks.weblink'));
-JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableCategory', array('typeAlias' => '{extension}.category'));
-
-// Register Observers for Version History
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'ContactTableContact', array('typeAlias' => 'com_contact.contact'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableContent', array('typeAlias' => 'com_content.article'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableCategory', array('typeAlias' => '{extension}.category'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'NewsfeedsTableNewsfeed', array('typeAlias' => 'com_newsfeeds.newsfeed'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'WeblinksTableWeblink', array('typeAlias' => 'com_weblinks.weblink'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'BannersTableBanner', array('typeAlias' => 'com_banners.banner'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'BannersTableClient', array('typeAlias' => 'com_banners.client'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'TagsTableTag', array('typeAlias' => 'com_tags.tag'));
-JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'UsersTableNote', array('typeAlias' => 'com_users.note'));

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -67,3 +67,22 @@ JLoader::register('JInstallerTemplate',  JPATH_PLATFORM . '/cms/installer/adapte
 JLoader::register('JExtension',  JPATH_PLATFORM . '/cms/installer/extension.php');
 JLoader::registerAlias('JAdministrator',  'JApplicationAdministrator');
 JLoader::registerAlias('JSite',  'JApplicationSite');
+
+// Register Observers:
+// Add Tags to Content, Contact, NewsFeeds, WebLinks and Categories: (this is the only link between them here!):
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'ContactTableContact', array('typeAlias' => 'com_contact.contact'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'NewsfeedsTableNewsfeed', array('typeAlias' => 'com_newsfeeds.newsfeed'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'WeblinksTableWeblink', array('typeAlias' => 'com_weblinks.weblink'));
+JObserverMapper::addObserverClassToClass('JTableObserverTags', 'JTableCategory', array('typeAlias' => '{extension}.category'));
+
+// Register Observers for Version History
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'ContactTableContact', array('typeAlias' => 'com_contact.contact'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableContent', array('typeAlias' => 'com_content.article'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableCategory', array('typeAlias' => '{extension}.category'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'NewsfeedsTableNewsfeed', array('typeAlias' => 'com_newsfeeds.newsfeed'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'WeblinksTableWeblink', array('typeAlias' => 'com_weblinks.weblink'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'BannersTableBanner', array('typeAlias' => 'com_banners.banner'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'BannersTableClient', array('typeAlias' => 'com_banners.client'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'TagsTableTag', array('typeAlias' => 'com_tags.tag'));
+JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'UsersTableNote', array('typeAlias' => 'com_users.note'));

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -134,8 +134,16 @@ class JApplicationCms extends JApplicationWeb
 		// Map the Observers, unless the config says not to do so.
 		if ($this->config->get('observersmapping') !== false)
 		{
-			$observersDefinitions = new JObserverDefinitions( JFactory::getDbo() );
-			$observersDefinitions->loadObserversMapping();
+			// We want caching ON and same cache for admin and site area, so that we can refresh cache in admin area:
+			$cacheOptions = array(
+				'caching'		=> true,
+				'cachebase'		=> JPATH_ADMINISTRATOR . '/cache'
+			);
+
+			$observersDefinitions = new JObserverDefinitions(JFactory::getDbo(), JCache::getInstance('output', $cacheOptions));
+
+			$forceCacheRefresh = ($this->getClientId() === 1);
+			$observersDefinitions->loadObserversMapping($forceCacheRefresh);
 		}
 	}
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -130,6 +130,13 @@ class JApplicationCms extends JApplicationWeb
 		{
 			$this->loadSession();
 		}
+
+		// Map the Observers, unless the config says not to do so.
+		if ($this->config->get('observersmapping') !== false)
+		{
+			$observersDefinitions = new JObserverDefinitions( JFactory::getDbo() );
+			$observersDefinitions->loadObserversMapping();
+		}
 	}
 
 	/**

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -101,6 +101,13 @@ class JApplicationCli extends JApplicationBase
 
 		// Set the current directory.
 		$this->set('cwd', getcwd());
+
+		// Map the Observers, unless the config says not to do so.
+		if ($this->config->get('observersmapping') !== false)
+		{
+			$observersDefinitions = new JObserverDefinitions( JFactory::getDbo() );
+			$observersDefinitions->loadObserversMapping();
+		}
 	}
 
 	/**

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -105,7 +105,7 @@ class JApplicationCli extends JApplicationBase
 		// Map the Observers, unless the config says not to do so.
 		if ($this->config->get('observersmapping') !== false)
 		{
-			$observersDefinitions = new JObserverDefinitions( JFactory::getDbo() );
+			$observersDefinitions = new JObserverDefinitions(JFactory::getDbo());
 			$observersDefinitions->loadObserversMapping();
 		}
 	}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -73,7 +73,7 @@ class JCache
 	 * @param   string  $type     The cache object type to instantiate
 	 * @param   array   $options  The array of options
 	 *
-	 * @return  JCache  A JCache object
+	 * @return  JCacheController  A JCache object
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/observer/definitions.php
+++ b/libraries/joomla/observer/definitions.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Observer
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * ${NAMESPACE}\ObserverDefinitions Class implementation
+ * 
+ */
+class JObserverDefinitions
+{
+	/**
+	 * @var JDatabaseDriver
+	 */
+	public $db;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   JDatabaseDriver  $db  A database connector object
+	 */
+	public function __construct( $db )
+	{
+		$this->db = $db;
+	}
+
+	/**
+	 * Loads Observers Mappings from JContentTypes (#__content_types table) and maps them
+	 *
+	 * @return  void
+	 *
+	 * @throws  RuntimeException
+	 */
+	public function loadObserversMapping()
+	{
+		/** @var JTableContenttype $contentType */
+		$contentType = JTable::getInstance('contenttype', 'JTable', array('dbo' => $this->db));
+
+		$mappings = $contentType->loadObserversMapping();
+
+		foreach ( $mappings as $map )
+		{
+			// JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableContent', array('typeAlias' => 'com_content.article'));
+			JObserverMapper::addObserverClassToClass($map->observerClass, $map->observableClass, $map->params);
+		}
+	}
+}

--- a/libraries/joomla/observer/definitions.php
+++ b/libraries/joomla/observer/definitions.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * ${NAMESPACE}\ObserverDefinitions Class implementation
+ * ObserverDefinitions Class implementation
  * 
  */
 class JObserverDefinitions
@@ -39,11 +39,33 @@ class JObserverDefinitions
 	 */
 	public function loadObserversMapping()
 	{
+		// Add mappers from the Content Types table:
+
 		/** @var JTableContenttype $contentType */
 		$contentType = JTable::getInstance('contenttype', 'JTable', array('dbo' => $this->db));
 
 		$mappings = $contentType->loadObserversMapping();
 
+		$this->addMappings($mappings);
+
+		// Add mappers from the Extensions table:
+
+		/** @var JTableContenttype $contentType */
+		$extension = JTable::getInstance('extension', 'JTable', array('dbo' => $this->db));
+
+		$mappings = $extension->loadObserversMapping();
+
+		$this->addMappings($mappings);
+	}
+
+	/**
+	 * Adds Observer $mappings to the Observer Mapper.
+	 *
+	 * @param   array  $mappings
+	 * @return  void
+	 */
+	protected function addMappings($mappings)
+	{
 		foreach ( $mappings as $map )
 		{
 			// JObserverMapper::addObserverClassToClass('JTableObserverContenthistory', 'JTableContent', array('typeAlias' => 'com_content.article'));

--- a/libraries/joomla/observer/definitions.php
+++ b/libraries/joomla/observer/definitions.php
@@ -16,46 +16,89 @@ defined('JPATH_PLATFORM') or die;
 class JObserverDefinitions
 {
 	/**
+	 * Database driver
+	 *
 	 * @var JDatabaseDriver
 	 */
-	public $db;
+	protected $db;
 
 	/**
-	 * Constructor
+	 * Cache controller (if any)
 	 *
-	 * @param   JDatabaseDriver  $db  A database connector object
+	 * @var JCacheController
 	 */
-	public function __construct( $db )
+	protected $cache;
+
+	/**
+	 * Constructor (DI-ready style)
+	 *
+	 * @param   JDatabaseInterface  $db     A database connector object
+	 * @param   JCacheController    $cache  Cache to use
+	 */
+	public function __construct(JDatabaseInterface $db, JCacheController $cache = null)
 	{
 		$this->db = $db;
+		$this->cache = $cache;
 	}
 
 	/**
 	 * Loads Observers Mappings from JContentTypes (#__content_types table) and maps them
 	 *
+	 * @param   boolean             $forceCacheRefresh  Force cache refresh
 	 * @return  void
 	 *
 	 * @throws  RuntimeException
 	 */
-	public function loadObserversMapping()
+	public function loadObserversMapping($forceCacheRefresh = true)
+	{
+		// Load cached mappers if cache exists and does not need to be refreshed:
+		if ($this->cache && !$forceCacheRefresh)
+		{
+			$cached = $this->cache->get('maps', 'observers');
+
+			if ($cached)
+			{
+				$this->addMappers(json_decode($cached));
+				return;
+			}
+		}
+
+		// Reload mappers from database (this is typically done in the administration area, specially after installations):
+		$mappings = $this->reloadMappers();
+
+		// Cache reloaded mappers if cache exists:
+		if ($this->cache)
+		{
+			$this->cache->store(json_encode($mappings), 'maps', 'observers');
+		}
+	}
+
+	/**
+	 * Reloads observers mappings from the Content Types table and from the from the Extensions table
+	 *
+	 * @return array
+	 */
+	protected function reloadMappers()
 	{
 		// Add mappers from the Content Types table:
 
 		/** @var JTableContenttype $contentType */
 		$contentType = JTable::getInstance('contenttype', 'JTable', array('dbo' => $this->db));
 
-		$mappings = $contentType->loadObserversMapping();
-
-		$this->addMappings($mappings);
+		$contentMappings = $contentType->loadObserversMapping();
 
 		// Add mappers from the Extensions table:
 
 		/** @var JTableContenttype $contentType */
 		$extension = JTable::getInstance('extension', 'JTable', array('dbo' => $this->db));
 
-		$mappings = $extension->loadObserversMapping();
+		$extensionsMappings = $extension->loadObserversMapping();
 
-		$this->addMappings($mappings);
+		$mappings = array_merge($contentMappings, $extensionsMappings);
+
+		$this->addMappers($mappings);
+
+		return $mappings;
 	}
 
 	/**
@@ -64,7 +107,7 @@ class JObserverDefinitions
 	 * @param   array  $mappings
 	 * @return  void
 	 */
-	protected function addMappings($mappings)
+	protected function addMappers($mappings)
 	{
 		foreach ( $mappings as $map )
 		{

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -204,7 +204,8 @@ class JTableExtension extends JTable
 		$query = $db->getQuery(true);
 		$query->select($db->quoteName('observers'))
 			->from($db->quoteName($this->_tbl))
-			->where($db->quoteName('observers') . ' <> ' . $db->quote(''));
+			->where($db->quoteName('observers') . ' <> ' . $db->quote(''))
+			->where($db->quoteName('enabled') . ' = 1');
 		$db->setQuery($query);
 
 		try

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -188,4 +188,41 @@ class JTableExtension extends JTable
 
 		return true;
 	}
+
+	/**
+	 * Loads Observers Mappings from #__extensions table and maps them
+	 *
+	 * @return  array
+	 *
+	 * @throws  RuntimeException
+	 *
+	 * @since 3.3.1
+	 */
+	public function loadObserversMapping()
+	{
+		$db = $this->_db;
+		$query = $db->getQuery(true);
+		$query->select($db->quoteName('observers'))
+			->from($db->quoteName($this->_tbl))
+			->where($db->quoteName('observers') . ' <> ' . $db->quote(''));
+		$db->setQuery($query);
+
+		try
+		{
+			$observers = $db->loadColumn('type_alias');
+		}
+		catch (RuntimeException $e)
+		{
+			// The TableContentType table has not yet been updated, let's keep the site working:
+			// This is from 3.1 and 3.2
+
+			return array();
+		}
+
+		foreach ( $observers as &$mapping ) {
+			$mapping = json_decode($mapping);
+		}
+
+		return $observers;
+	}
 }

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -29,9 +29,6 @@ class JTableCategory extends JTableNested
 	{
 		parent::__construct('#__categories', 'id', $db);
 
-		JTableObserverTags::createObserver($this, array('typeAlias' => '{extension}.category'));
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => '{extension}.category'));
-
 		$this->access = (int) JFactory::getConfig()->get('access');
 	}
 

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -30,8 +30,16 @@ class JTableContent extends JTable
 	{
 		parent::__construct('#__content', 'id', $db);
 
-		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_content.article'));
-		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_content.article'));
+		/*
+		 * This is left here for reference:
+		 *
+		 * This would set up the tags observer in $this from here (so not entirely decoupled):
+		 * JTableObserverTags::createObserver($this, array('typeAlias' => 'com_content.article'));
+		 *
+		 * But this makes the relation between content and tags completely external to Content as JTable is observable:
+		 * So we are doing this only once in libraries/cms.php:
+		 * JObserverFactory::addObserverClassToClass('JTableObserverTags', 'JTableContent', array('typeAlias' => 'com_content.article'));
+		 */
 	}
 
 	/**


### PR DESCRIPTION
This PR is proposed as a uncoupled alternative to the hard-coded-coupling PR https://github.com/joomla/joomla-cms/pull/1840 as a better fix for http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=31603 .

It works as is, so could be ready for merging in a 3.3.x, but of course it would be better to also add the 2 columns "observers" of `#__extensions` and `#__content_types` to all database types for complete usability of it within e.g. in a 3.x.0 (x=4 or 5 e.g.).

It has big advantages to hard couplings, that are detailed in all good books about software patterns.

(work done at "Get It Done" session at JAB14 and in the train on the way back home and shown to @mbabker and @Bakual same day)

Update: Also commented tracker and on corresponding commit that should be reverted for 3.3.1: https://github.com/joomla/joomla-cms/commit/2248368b28c41350180e926dd1b5ad70bc9f28b5#commitcomment-6609826
