### PR TITLE
[#33842] Fixed, the atom feed does not convert relative URLs to absolute URLs.

### DIFF
--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -79,6 +79,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		{
 			$feed .= " xml:lang=\"" . $data->language . "\"";
 		}
+
 		$feed .= ">\n";
 		$feed .= "	<title type=\"text\">" . $feed_title . "</title>\n";
 		$feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->description, ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
@@ -97,6 +98,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 				$feed .= "	<category term=\"" . htmlspecialchars($data->category, ENT_COMPAT, 'UTF-8') . "\" />\n";
 			}
 		}
+
 		$feed .= "	<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . "\"/>\n";
 		$feed .= "	<id>" . str_replace(' ', '%20', $data->getBase()) . "</id>\n";
 		$feed .= "	<updated>" . htmlspecialchars($now->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
@@ -105,18 +107,20 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		{
 			$feed .= "	<author>\n";
 			$feed .= "		<name>" . $data->editor . "</name>\n";
+
 			if ($data->editorEmail != "")
 			{
 				$feed .= "		<email>" . htmlspecialchars($data->editorEmail, ENT_COMPAT, 'UTF-8') . "</email>\n";
 			}
+
 			$feed .= "	</author>\n";
 		}
+
 		$feed .= "	<generator uri=\"http://joomla.org\" version=\"1.6\">" . $data->getGenerator() . "</generator>\n";
 		$feed .= '	<link rel="self" type="application/atom+xml" href="' . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
-
 			if (!preg_match('/[\x80-\xFF]/', $data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
@@ -158,12 +162,13 @@ class JDocumentRendererAtom extends JDocumentRenderer
 				{
 					$feed .= "			<email>" . htmlspecialchars($data->items[$i]->authorEmail, ENT_COMPAT, 'UTF-8') . "</email>\n";
 				}
+
 				$feed .= "		</author>\n";
 			}
 
 			if ($data->items[$i]->description != "")
 			{
-				$feed .= "		<summary type=\"html\">" . htmlspecialchars($data->items[$i]->description, ENT_COMPAT, 'UTF-8') . "</summary>\n";
+				$feed .= "		<summary type=\"html\">" . htmlspecialchars($this->_relToAbs($data->items[$i]->description), ENT_COMPAT, 'UTF-8') . "</summary>\n";
 				$feed .= "		<content type=\"html\">" . htmlspecialchars($data->items[$i]->description, ENT_COMPAT, 'UTF-8') . "</content>\n";
 			}
 
@@ -187,10 +192,12 @@ class JDocumentRendererAtom extends JDocumentRenderer
 				$feed .= "		<link rel=\"enclosure\" href=\"" . $data->items[$i]->enclosure->url . "\" type=\""
 					. $data->items[$i]->enclosure->type . "\"  length=\"" . $data->items[$i]->enclosure->length . "\" />\n";
 			}
+
 			$feed .= "	</entry>\n";
 		}
 
 		$feed .= "</feed>\n";
+
 		return $feed;
 	}
 }

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -108,6 +108,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 			{
 				$feed .= "			<description><![CDATA[" . $data->image->description . "]]></description>\n";
 			}
+
 			$feed .= "		</image>\n";
 		}
 
@@ -181,7 +182,6 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 		for ($i = 0, $count = count($data->items); $i < $count; $i++)
 		{
-
 			if (!preg_match('/[\x80-\xFF]/', $data->items[$i]->link))
 			{
 				$itemlink = $data->items[$i]->link;
@@ -195,6 +195,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 			{
 				$itemlink = str_replace(' ', '%20', $url . $itemlink);
 			}
+
 			$feed .= "		<item>\n";
 			$feed .= "			<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
 			$feed .= "			<link>" . str_replace(' ', '%20', $itemlink) . "</link>\n";
@@ -263,25 +264,10 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 			$feed .= "		</item>\n";
 		}
+
 		$feed .= "	</channel>\n";
 		$feed .= "</rss>\n";
+
 		return $feed;
-	}
-
-	/**
-	 * Convert links in a text from relative to absolute
-	 *
-	 * @param   string  $text  The text processed
-	 *
-	 * @return  string   Text with converted links
-	 *
-	 * @since   11.1
-	 */
-	public function _relToAbs($text)
-	{
-		$base = JUri::base();
-		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
-
-		return $text;
 	}
 }

--- a/libraries/joomla/document/renderer.php
+++ b/libraries/joomla/document/renderer.php
@@ -72,4 +72,22 @@ class JDocumentRenderer
 	{
 		return $this->_mime;
 	}
+
+	/**
+	 * Convert links in a text from relative to absolute
+	 *
+	 * @param   string  $text  The text processed
+	 *
+	 * @return  string   Text with converted links
+	 *
+	 * @since   11.1
+	 */
+	protected function _relToAbs($text)
+	{
+		$base = JUri::base();
+		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
+
+		return $text;
+	}
+
 }


### PR DESCRIPTION
The atom feed, as opposed to the rss feed, does not convert relative URLs to absolute URLs and causes broken links. This PR fixes the issue.

JC tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33842
