### PR TITLE
[#33781] Unable to select external URLs using the batch feature in menus to move ...

### DIFF
--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -77,7 +77,6 @@ abstract class JHtmlMenu
 				->select('a.id AS value, a.title AS text, a.level, a.menutype')
 				->from('#__menu AS a')
 				->where('a.parent_id > 0')
-				->where('a.type <> ' . $db->quote('url'))
 				->where('a.client_id = 0');
 
 			// Filter on the published state


### PR DESCRIPTION
...items

JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33781&start=50 (by Ruth Cheesley)

The static function _menuitems_ is only used for the batch process. There is no need to exclude the URL type because this type can also have children in the menu. With the exclusion the batch process usage for this constellation is impossible.
