### PR TITLE
[#33850] You can't set a config array in the Application

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -544,8 +544,9 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	protected function initialiseApp($options = array())
 	{
-		// Set the configuration in the API.
-		$this->config = JFactory::getConfig();
+		// Get the configuration set in the API. Recursively merge it in. Note this will take
+		// Priority over any intialized values.
+		$this->config->merge(JFactory::getConfig(), true);
 
 		// Check that we were given a language in the array (since by default may be blank).
 		if (isset($options['language']))

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -307,8 +307,14 @@ class JApplicationCms extends JApplicationWeb
 	 * @since   3.2
 	 * @throws  RuntimeException
 	 */
-	public static function getInstance($name = null)
+	public static function getInstance($name = null, $config)
 	{
+		// If we have an array or a standard class convert it to a JRegistry object
+		if ((is_array($config) || is_object($config)) && !($config instanceof JRegistry))
+		{
+			$config = new JRegistry($config);
+		}
+
 		if (empty(static::$instances[$name]))
 		{
 			// Create a JApplicationCms object.
@@ -319,7 +325,7 @@ class JApplicationCms extends JApplicationWeb
 				throw new RuntimeException(JText::sprintf('JLIB_APPLICATION_ERROR_APPLICATION_LOAD', $name), 500);
 			}
 
-			static::$instances[$name] = new $classname;
+			static::$instances[$name] = new $classname(null, $config);
 		}
 
 		return static::$instances[$name];

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -310,7 +310,7 @@ class JApplicationCms extends JApplicationWeb
 	public static function getInstance($name = null, $config = null)
 	{
 		// If we have an array or a standard class for the config convert it to a JRegistry object
-		if ($config && (is_array($config) || is_object($config)) && !($config instanceof JRegistry))
+		if ((is_array($config) || is_object($config)) && !($config instanceof JRegistry))
 		{
 			$config = new JRegistry($config);
 		}

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -307,10 +307,10 @@ class JApplicationCms extends JApplicationWeb
 	 * @since   3.2
 	 * @throws  RuntimeException
 	 */
-	public static function getInstance($name = null, $config)
+	public static function getInstance($name = null, $config = null)
 	{
-		// If we have an array or a standard class convert it to a JRegistry object
-		if ((is_array($config) || is_object($config)) && !($config instanceof JRegistry))
+		// If we have an array or a standard class for the config convert it to a JRegistry object
+		if ($config && (is_array($config) || is_object($config)) && !($config instanceof JRegistry))
 		{
 			$config = new JRegistry($config);
 		}

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -104,12 +104,13 @@ abstract class JFactory
 	 *
 	 * @param   mixed   $id      A client identifier or name.
 	 * @param   array   $config  An optional associative array of configuration settings.
-	 * @param   string  $prefix  Application prefix
+	 * @param   string  $prefix  Application prefix (@deprecated)
 	 *
 	 * @return  JApplicationCms object
 	 *
 	 * @see     JApplication
 	 * @since   11.1
+	 * @note    The prefix parameter is deprecated and will be removed in Joomla 4
 	 * @throws  Exception
 	 */
 	public static function getApplication($id = null, array $config = array(), $prefix = 'J')
@@ -121,7 +122,7 @@ abstract class JFactory
 				throw new Exception('Application Instantiation Error', 500);
 			}
 
-			self::$application = JApplicationCms::getInstance($id);
+			self::$application = JApplicationCms::getInstance($id, $config);
 		}
 
 		return self::$application;

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -172,7 +172,7 @@ class JApplication extends JApplicationBase
 	 */
 	public static function getInstance($client, $config = array(), $prefix = 'J')
 	{
-		return JApplicationCms::getInstance($client);
+		return JApplicationCms::getInstance($client, $config);
 	}
 
 	/**


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33850&start=0

Allow the `$config` param to continue to work from the JFactory::getApplication() function or the legacy JApplication::getInstance() function.

JApplicationCms has a `$config` param in the constructor but not in the `getInstance()` function. This PR adds that support in and stops the config from being immediately overwritten when the app is initalised. Note that the config (from `JFactory::getConfig()` still takes priority over anything initialised in the app's constructor however.

For testing instructions see the tracker item
