### PR TITLE
[#32055] Add advanced parameters to module chromes

### DIFF
--- a/administrator/templates/isis/html/modules.php
+++ b/administrator/templates/isis/html/modules.php
@@ -47,17 +47,23 @@ function modChrome_well($module, &$params, &$attribs)
 {
 	if ($module->content)
 	{
+		$moduleTag     = $params->get('module_tag', 'div');
 		$bootstrapSize = (int) $params->get('bootstrap_size');
 		$moduleClass   = ($bootstrapSize) ? ' span' . $bootstrapSize : '';
+		$headerTag     = htmlspecialchars($params->get('header_tag', 'h2'));
 
-		echo '<div class="well well-small' . $moduleClass . '">';
+		// Temporarily store header class in variable
+		$headerClass   = $params->get('header_class');
+		$headerClass   = ($headerClass) ? ' ' . htmlspecialchars($headerClass) : '';
 
-		if ($module->showtitle)
-		{
-			echo '<h2 class="module-title nav-header">' . $module->title . '</h2>';
-		}
+		echo '<' . $moduleTag . ' class="well well-small' . $moduleClass . '">';
 
-		echo $module->content;
-		echo '</div>';
+			if ($module->showtitle)
+			{
+				echo '<' . $headerTag . ' class="module-title nav-header' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
+			}
+
+			echo $module->content;
+		echo '</' . $moduleTag . '>';
 	}
 }

--- a/administrator/templates/system/html/modules.php
+++ b/administrator/templates/system/html/modules.php
@@ -18,7 +18,7 @@ function modChrome_none($module, &$params, &$attribs)
 }
 
 /*
- * html5 (chosen html5 tag and font headder tags)
+ * html5 (chosen html5 tag and font header tags)
  */
 function modChrome_html5($module, &$params, &$attribs)
 {
@@ -47,17 +47,28 @@ function modChrome_html5($module, &$params, &$attribs)
 
 /*
  * xhtml (divs and font header tags)
+ * With the new advanced parameter it does the same as the html5 chrome
  */
 function modChrome_xhtml($module, &$params, &$attribs)
 {
+	$moduleTag      = $params->get('module_tag', 'div');
+	$headerTag      = htmlspecialchars($params->get('header_tag', 'h3'));
+	$bootstrapSize  = (int) $params->get('bootstrap_size', 0);
+	$moduleClass    = $bootstrapSize != 0 ? ' span' . $bootstrapSize : '';
+
+	// Temporarily store header class in variable
+	$headerClass    = $params->get('header_class');
+	$headerClass    = ($headerClass) ? ' class="' . htmlspecialchars($headerClass) . '"' : '';
+
 	$content = trim($module->content);
+
 	if (!empty ($content)) : ?>
-		<div class="module<?php echo htmlspecialchars($params->get('moduleclass_sfx')); ?>">
-		<?php if ($module->showtitle != 0) : ?>
-			<h3><?php echo $module->title; ?></h3>
-		<?php endif; ?>
+		<<?php echo $moduleTag; ?> class="module<?php echo htmlspecialchars($params->get('moduleclass_sfx')) . $moduleClass; ?>">
+			<?php if ($module->showtitle != 0) : ?>
+				<<?php echo $headerTag . $headerClass . '>' . $module->title; ?></<?php echo $headerTag; ?>>
+			<?php endif; ?>
 			<?php echo $content; ?>
-		</div>
+		</<?php echo $moduleTag; ?>>
 	<?php endif;
 }
 

--- a/templates/protostar/html/modules.php
+++ b/templates/protostar/html/modules.php
@@ -36,15 +36,23 @@ function modChrome_no($module, &$params, &$attribs)
 
 function modChrome_well($module, &$params, &$attribs)
 {
+	$moduleTag     = $params->get('module_tag', 'div');
+	$bootstrapSize = (int) $params->get('bootstrap_size', 0);
+	$moduleClass   = $bootstrapSize != 0 ? ' span' . $bootstrapSize : '';
+	$headerTag     = htmlspecialchars($params->get('header_tag', 'h3'));
+	$headerClass   = htmlspecialchars($params->get('header_class', 'page-header'));
+
 	if ($module->content)
 	{
-		echo "<div class=\"well " . htmlspecialchars($params->get('moduleclass_sfx')) . "\">";
-		if ($module->showtitle)
-		{
-			echo "<h3 class=\"page-header\">" . $module->title . "</h3>";
-		}
-		echo $module->content;
-		echo "</div>";
+		echo '<' . $moduleTag . ' class="well ' . htmlspecialchars($params->get('moduleclass_sfx')) . $moduleClass . '">';
+
+			if ($module->showtitle)
+			{
+				echo '<' . $headerTag . ' class="' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
+			}
+
+			echo $module->content;
+		echo '</' . $moduleTag . '>';
 	}
 }
 ?>

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -18,7 +18,7 @@ function modChrome_none($module, &$params, &$attribs)
 }
 
 /*
- * html5 (chosen html5 tag and font headder tags)
+ * html5 (chosen html5 tag and font header tags)
  */
 function modChrome_html5($module, &$params, &$attribs)
 {
@@ -28,8 +28,8 @@ function modChrome_html5($module, &$params, &$attribs)
 	$moduleClass    = $bootstrapSize != 0 ? ' span' . $bootstrapSize : '';
 
 	// Temporarily store header class in variable
-	$headerClass	= $params->get('header_class');
-	$headerClass	= !empty($headerClass) ? ' class="' . htmlspecialchars($headerClass) . '"' : '';
+	$headerClass    = $params->get('header_class');
+	$headerClass    = !empty($headerClass) ? ' class="' . htmlspecialchars($headerClass) . '"' : '';
 
 	if (!empty ($module->content)) : ?>
 		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx')) . $moduleClass; ?>">
@@ -83,17 +83,27 @@ function modChrome_horz($module, &$params, &$attribs)
 }
 
 /*
- * xhtml (divs and font headder tags)
+ * xhtml (divs and font header tags)
+ * With the new advanced parameter it does the same as the html5 chrome
  */
 function modChrome_xhtml($module, &$params, &$attribs)
 {
+	$moduleTag      = $params->get('module_tag', 'div');
+	$headerTag      = htmlspecialchars($params->get('header_tag', 'h3'));
+	$bootstrapSize  = (int) $params->get('bootstrap_size', 0);
+	$moduleClass    = $bootstrapSize != 0 ? ' span' . $bootstrapSize : '';
+
+	// Temporarily store header class in variable
+	$headerClass    = $params->get('header_class');
+	$headerClass    = ($headerClass) ? ' class="' . htmlspecialchars($headerClass) . '"' : '';
+
 	if (!empty ($module->content)) : ?>
-		<div class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx')); ?>">
-		<?php if ((bool) $module->showtitle) : ?>
-			<h3><?php echo $module->title; ?></h3>
-		<?php endif; ?>
+		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx')) . $moduleClass; ?>">
+			<?php if ((bool) $module->showtitle) : ?>
+				<<?php echo $headerTag . $headerClass . '>' . $module->title; ?></<?php echo $headerTag; ?>>
+			<?php endif; ?>
 			<?php echo $module->content; ?>
-		</div>
+		</<?php echo $moduleTag; ?>>
 	<?php endif;
 }
 


### PR DESCRIPTION
### Issue

Each module has some general parameters in the "Advanced" tab:
- Module Tag
- Bootstrap Size
- Header Tag
- Header Class

This parameters are meant to be supported by the templates module chromes. However most chromes don't support this parameters. The only one which currently supports it is the `html5` chrome. You can test this by setting the "Module Style" to `html5`.
### Proposal

This PR adds this parameters to some more chromes where it makes sense.
For Isis and Protostar this is the `well` chrome and for the system chromes it's the `xhtml` chrome.
With this new parameters, the `xhtml` chrome actually does the exact same thing as the `html5` one.
### Testing

After applying the patch, play around with the advanced settings and see if it works.
Also make sure nothing changes in appearance as long as you don't change the module settings.
#### Tracker

This is an alternative solution for the issue raised with http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32055
