### PR TITLE
Proposed change for email sender info (com_contact)

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -172,7 +172,7 @@ class ContactControllerContact extends JControllerForm
 			$mail = JFactory::getMailer();
 			$mail->addRecipient($contact->email_to);
 			$mail->addReplyTo(array($email, $name));
-			$mail->setSender(array($mailfrom, $fromname));
+			$mail->setSender(array($email, $name));
 			$mail->setSubject($sitename . ': ' . $subject);
 			$mail->setBody($body);
 			$sent = $mail->Send();


### PR DESCRIPTION
The default behaviour of the contacts component is to use the site's name and email address as the sender of all contact email that gets sent via com_contact forms with a reply-to set to the actual sender. If we leave it like this, then antispam filters cannot be trained to distinguish spam from regular email. The proposed change is to use the actual sender's name and email address in all the email's headers (from & reply-to).

It's a one liner as you can see.
