### PR TITLE
[#33849] Proposed change for email sender info in com_contact to better combat spam

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -172,7 +172,7 @@ class ContactControllerContact extends JControllerForm
 			$mail = JFactory::getMailer();
 			$mail->addRecipient($contact->email_to);
 			$mail->addReplyTo(array($email, $name));
-			$mail->setSender(array($mailfrom, $fromname));
+			$mail->setSender(array($email, $name));
 			$mail->setSubject($sitename . ': ' . $subject);
 			$mail->setBody($body);
 			$sent = $mail->Send();


### PR DESCRIPTION
The default behaviour of the contacts component is to use the site's
name and email address as the sender of all contact email that gets
sent via com_contact forms with a reply-to set to the actual sender. If
we leave it like this, then antispam filters cannot be trained to
distinguish spam from regular email. The proposed change is to use the
actual sender's name and email address in all the email's headers (from
& reply-to).

Issue raised here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33849
