### PR TITLE
Fix of Parse error: syntax error - Error introduced in 2.5.21

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package		Joomla.Site
- * @subpackage	Contact
- * @copyright	Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @package        Joomla.Site
+ * @subpackage     Contact
+ * @copyright      Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license        GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
@@ -23,55 +23,66 @@ class ContactControllerContact extends JControllerForm
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Initialise variables.
-		$app	= JFactory::getApplication();
-		$model	= $this->getModel('contact');
+		$app    = JFactory::getApplication();
+		$model  = $this->getModel('contact');
 		$params = JComponentHelper::getParams('com_contact');
-		$stub	= JRequest::getString('id');
-		$id		= (int)$stub;
+		$stub   = JRequest::getString('id');
+		$id     = (int) $stub;
 
 		// Get the data from POST
 		$data = JRequest::getVar('jform', array(), 'post', 'array');
 
 		$contact = $model->getItem($id);
 
-
 		$params->merge($contact->params);
 
 		// Check for a valid session cookie
-		if($params->get('validate_session', 0)) {
-			if(JFactory::getSession()->getState() != 'active'){
+		if ($params->get('validate_session', 0))
+		{
+			if (JFactory::getSession()->getState() != 'active')
+			{
 				JError::raiseWarning(403, JText::_('COM_CONTACT_SESSION_INVALID'));
 
 				// Save the data in the session.
 				$app->setUserState('com_contact.contact.data', $data);
 
 				// Redirect back to the contact form.
-				$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id='.$stub, false));
+				$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id=' . $stub, false));
+
 				return false;
 			}
 		}
 
 		// Contact plugins
 		JPluginHelper::importPlugin('contact');
-		$dispatcher	= JDispatcher::getInstance();
+		$dispatcher = JDispatcher::getInstance();
 
 		// Validate the posted data.
 		$form = $model->getForm();
-		if (!$form) {
+
+		if (!$form)
+		{
 			JError::raiseError(500, $model->getError());
+
 			return false;
 		}
 
 		$validate = $model->validate($form, $data);
 
-		if ($validate === false) {
+		if ($validate === false)
+		{
 			// Get the validation messages.
-			$errors	= $model->getErrors();
+			$errors = $model->getErrors();
+
 			// Push up to three validation messages out to the user.
-			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++) {
-				if ($errors[$i] instanceof Exception) {
+			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)
+			{
+				if ($errors[$i] instanceof Exception)
+				{
 					$app->enqueueMessage($errors[$i]->getMessage(), 'warning');
-				} else {
+				}
+				else
+				{
 					$app->enqueueMessage($errors[$i], 'warning');
 				}
 			}
@@ -80,15 +91,18 @@ class ContactControllerContact extends JControllerForm
 			$app->setUserState('com_contact.contact.data', $data);
 
 			// Redirect back to the contact form.
-			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id='.$stub, false));
+			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id=' . $stub, false));
+
 			return false;
 		}
 
 		// Validation succeeded, continue with custom handlers
-		$results	= $dispatcher->trigger('onValidateContact', array(&$contact, &$data));
+		$results = $dispatcher->trigger('onValidateContact', array(&$contact, &$data));
 
-		foreach ($results as $result) {
-			if ($result instanceof Exception) {
+		foreach ($results as $result)
+		{
+			if ($result instanceof Exception)
+			{
 				return false;
 			}
 		}
@@ -98,25 +112,33 @@ class ContactControllerContact extends JControllerForm
 
 		// Send the email
 		$sent = false;
-		if (!$params->get('custom_reply')) {
+
+		if (!$params->get('custom_reply'))
+		{
 			$sent = $this->_sendEmail($data, $contact, $params->get('show_email_copy'));
 		}
 
 		// Set the success message if it was a success
-		if (!($sent instanceof Exception)) {
+		if (!($sent instanceof Exception))
+		{
 			$msg = JText::_('COM_CONTACT_EMAIL_THANKS');
-		} else {
-			$msg = '' ;
+		}
+		else
+		{
+			$msg = '';
 		}
 
 		// Flush the data from the session
 		$app->setUserState('com_contact.contact.data', null);
 
 		// Redirect if it is set in the parameters, otherwise redirect back to where we came from
-		if ($contact->params->get('redirect')) {
+		if ($contact->params->get('redirect'))
+		{
 			$this->setRedirect($contact->params->get('redirect'), $msg);
-		} else {
-			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id='.$stub, false), $msg);
+		}
+		else
+		{
+			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id=' . $stub, false), $msg);
 		}
 
 		return true;
@@ -124,51 +146,54 @@ class ContactControllerContact extends JControllerForm
 
 	private function _sendEmail($data, $contact, $copy_email_activated)
 	{
-			$app		= JFactory::getApplication();
-			$params 	= JComponentHelper::getParams('com_contact');
-			if ($contact->email_to == '' && $contact->user_id != 0) {
-				$contact_user = JUser::getInstance($contact->user_id);
-				$contact->email_to = $contact_user->get('email');
-			}
-			$mailfrom	= $app->getCfg('mailfrom');
-			$fromname	= $app->getCfg('fromname');
-			$sitename	= $app->getCfg('sitename');
-			$copytext 	= JText::sprintf('COM_CONTACT_COPYTEXT_OF', $contact->name, $sitename);
+		$app    = JFactory::getApplication();
+		$params = JComponentHelper::getParams('com_contact');
 
-			$name		= $data['contact_name'];
-			$email		= $data['contact_email'];
-			$subject	= $data['contact_subject'];
-			$body		= $data['contact_message'];
+		if ($contact->email_to == '' && $contact->user_id != 0)
+		{
+			$contact_user      = JUser::getInstance($contact->user_id);
+			$contact->email_to = $contact_user->get('email');
+		}
 
-			// Prepare email body
-			$prefix = JText::sprintf('COM_CONTACT_ENQUIRY_TEXT', JURI::base());
-			$body	= $prefix."\n".$name.' <'.$email.'>'."\r\n\r\n".stripslashes($body);
+		$mailfrom = $app->getCfg('mailfrom');
+		$fromname = $app->getCfg('fromname');
+		$sitename = $app->getCfg('sitename');
+		$copytext = JText::sprintf('COM_CONTACT_COPYTEXT_OF', $contact->name, $sitename);
+
+		$name    = $data['contact_name'];
+		$email   = $data['contact_email'];
+		$subject = $data['contact_subject'];
+		$body    = $data['contact_message'];
+
+		// Prepare email body
+		$prefix = JText::sprintf('COM_CONTACT_ENQUIRY_TEXT', JURI::base());
+		$body   = $prefix . "\n" . $name . ' <' . $email . '>' . "\r\n\r\n" . stripslashes($body);
+
+		$mail = JFactory::getMailer();
+		$mail->addRecipient($contact->email_to);
+		$mail->addReplyTo(array($email, $name));
+		$mail->setSender(array($mailfrom, $fromname));
+		$mail->setSubject($sitename . ': ' . $subject);
+		$mail->setBody($body);
+		$sent = $mail->Send();
+
+		// If we are supposed to copy the sender, do so.
+		// Check whether email copy function activated
+		if ($copy_email_activated == true && !empty($data['contact_email_copy']))
+		{
+			$copytext = JText::sprintf('COM_CONTACT_COPYTEXT_OF', $contact->name, $sitename);
+			$copytext .= "\r\n\r\n" . $body;
+			$copysubject = JText::sprintf('COM_CONTACT_COPYSUBJECT_OF', $subject);
 
 			$mail = JFactory::getMailer();
-			$mail->addRecipient($contact->email_to);
+			$mail->addRecipient($email);
 			$mail->addReplyTo(array($email, $name));
 			$mail->setSender(array($mailfrom, $fromname));
-			$mail->setSubject($sitename.': '.$subject);
-			$mail->setBody($body);
+			$mail->setSubject($copysubject);
+			$mail->setBody($copytext);
 			$sent = $mail->Send();
+		}
 
-			//If we are supposed to copy the sender, do so.
-
-			// check whether email copy function activated
-			if ($copy_email_activated == true && !empty($data['contact_email_copy']))
-				$copytext		= JText::sprintf('COM_CONTACT_COPYTEXT_OF', $contact->name, $sitename);
-				$copytext		.= "\r\n\r\n".$body;
-				$copysubject	= JText::sprintf('COM_CONTACT_COPYSUBJECT_OF', $subject);
-
-				$mail = JFactory::getMailer();
-				$mail->addRecipient($email);
-				$mail->addReplyTo(array($email, $name));
-				$mail->setSender(array($mailfrom, $fromname));
-				$mail->setSubject($copysubject);
-				$mail->setBody($copytext);
-				$sent = $mail->Send();
-			}
-
-			return $sent;
+		return $sent;
 	}
 }


### PR DESCRIPTION
Fix of **Parse error: syntax error, unexpected T_RETURN, expecting T_FUNCTION** which was introduced in version 2.5.21

Missing bracket after the if statement
if ($copy_email_activated == true && !empty($data['contact_email_copy']))
- code style optimizations

Reported by user y021ahe in the forum: http://forum.joomla.org/viewtopic.php?f=622&t=848531
