### PR TITLE
[#33854] New module display strip_tags instead of escape

### DIFF
--- a/administrator/components/com_modules/views/select/tmpl/default.php
+++ b/administrator/components/com_modules/views/select/tmpl/default.php
@@ -23,8 +23,8 @@ $document = JFactory::getDocument();
 
 		$link	= 'index.php?option=com_modules&task=module.add&eid='. $item->extension_id;
 		$name	= $this->escape($item->name);
-		$desc	= JHTML::_('string.truncate', ($this->escape($item->desc)), 200);
-		$short_desc	= JHTML::_('string.truncate', ($this->escape($item->desc)), 90);
+		$desc	= JHTML::_('string.truncate', (strip_tags($item->desc)), 200);
+		$short_desc	= JHTML::_('string.truncate', (strip_tags($item->desc)), 90);
 	?>
 	<?php if ($document->direction != "rtl") : ?>
 	<li>


### PR DESCRIPTION
As an extension developer I sometimes include HTML in the description for better presentation in the administrator. When a new module is created the HTML is displayed in the new module screen which not only looks bad but does not provide the user a brief description of the module. I will create a pull request for the changes.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33854
