### PR TITLE
[bug] Fix - Email copy to own address doesn't work since 2.5.21

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -179,7 +179,7 @@ class ContactControllerContact extends JControllerForm
 
 		// If we are supposed to copy the sender, do so.
 		// Check whether email copy function activated
-		if ($copy_email_activated == true && !empty($data['contact_email_copy']))
+		if ($copy_email_activated == true && isset($data['contact_email_copy']))
 		{
 			$copytext = JText::sprintf('COM_CONTACT_COPYTEXT_OF', $contact->name, $sitename);
 			$copytext .= "\r\n\r\n" . $body;

--- a/components/com_contact/models/forms/contact.xml
+++ b/components/com_contact/models/forms/contact.xml
@@ -47,6 +47,7 @@
 			description="COM_CONTACT_CONTACT_EMAIL_A_COPY_DESC"
 			label="COM_CONTACT_CONTACT_EMAIL_A_COPY_LABEL"
 			default="0"
+			value="1"
 		/>
 
 	</fieldset>


### PR DESCRIPTION
Related to 
[bug] [33848] Fix fatal error when sending contact form (https://github.com/joomla/joomla-cms/pull/3763)

**How to test**
- Use Joomla! version 2.5.22 and create a contact - set a link to the contact with a form in the menu
- Fill out the form with some sample data (but correct email address), activate the checkbox "Send copy to yourself" and click on send
- You will never receive a copy of this email because the value of this checkbox input field is empty
- Add patch and try it again
