### PR TITLE
[#33865] Use $app->enqueueMessage instead of JError and SOME_ERROR_CODE

### DIFF
--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -42,6 +42,9 @@ function admin_postinstall_eaccelerator_condition()
  */
 function admin_postinstall_eaccelerator_action()
 {
+	// Get a handle to the Joomla! application object
+	$app  = JFactory::getApplication();
+	
 	$prev = new JConfig;
 	$prev = JArrayHelper::fromObject($prev);
 
@@ -64,7 +67,7 @@ function admin_postinstall_eaccelerator_action()
 	// Attempt to make the file writeable if using FTP.
 	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0644'))
 	{
-		JError::raiseNotice('SOME_ERROR_CODE', JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'));
+		$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'warning');
 	}
 
 	// Attempt to write the configuration file as a PHP class named JConfig.
@@ -72,7 +75,7 @@ function admin_postinstall_eaccelerator_action()
 
 	if (!JFile::write($file, $configuration))
 	{
-		JFactory::getApplication()->enqueueMessage(JText::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
+		$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
 
 		return;
 	}
@@ -80,6 +83,5 @@ function admin_postinstall_eaccelerator_action()
 	// Attempt to make the file unwriteable if using FTP.
 	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))
 	{
-		JError::raiseNotice('SOME_ERROR_CODE', JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'));
+		$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'warning');
 	}
-}

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -123,7 +123,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$asset->check() || !$asset->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					$app->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
 					return;
 				}
@@ -155,7 +155,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$extension->check() || !$extension->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					$app->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
 					return;
 				}

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -133,7 +133,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	 *
 	 * @return  void
 	 *
-	 * @since	3.0
+	 * @since   3.0
 	 */
 	public function purge()
 	{
@@ -155,7 +155,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	 *
 	 * @return  JoomlaupdateControllerUpdate  This object to support chaining.
 	 *
-	 * @since	2.5.4
+	 * @since   2.5.4
 	 */
 	public function display($cachable = false, $urlparams = array())
 	{
@@ -204,7 +204,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 				// Add credentials to the session
 				if (!JClientHelper::setCredentials('ftp', $user, $pass))
 				{
-					JError::raiseWarning('SOME_ERROR_CODE', JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
+					JFactory::getApplication()->enqueueMessage(JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'), 'warning');
 				}
 			}
 		}

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -21,16 +21,16 @@ class ContentModelArticle extends JModelItem
 	/**
 	 * Model context string.
 	 *
-	 * @var        string
+	 * @var  string
 	 */
 	protected $_context = 'com_content.article';
 
 	/**
 	 * Method to auto-populate the model state.
 	 *
-	 * Note. Calling getState in this method will result in recursion.
+	 * @note Calling getState in this method will result in recursion.
 	 *
-	 * @since   1.6
+	 * @since  1.6
 	 *
 	 * @return void
 	 */
@@ -278,6 +278,9 @@ class ContentModelArticle extends JModelItem
 	 */
 	public function storeVote($pk = 0, $rate = 0)
 	{
+		// Get a handle to the Joomla! application object
+		$app = JFactory::getApplication();
+
 		if ($rate >= 1 && $rate <= 5 && $pk > 0)
 		{
 			$userIP = $_SERVER['REMOTE_ADDR'];
@@ -301,7 +304,7 @@ class ContentModelArticle extends JModelItem
 			}
 			catch (RuntimeException $e)
 			{
-				JError::raiseWarning(500, $e->getMessage());
+				$app->enqueueMessage($e->getMessage(), 'warning');
 
 				return false;
 			}
@@ -325,7 +328,7 @@ class ContentModelArticle extends JModelItem
 				}
 				catch (RuntimeException $e)
 				{
-					JError::raiseWarning(500, $e->getMessage());
+					$app->enqueueMessage($e->getMessage(), 'warning');
 
 					return false;
 				}
@@ -352,7 +355,7 @@ class ContentModelArticle extends JModelItem
 					}
 					catch (RuntimeException $e)
 					{
-						JError::raiseWarning(500, $e->getMessage());
+						$app->enqueueMessage($e->getMessage(), 'warning');
 
 						return false;
 					}
@@ -366,7 +369,7 @@ class ContentModelArticle extends JModelItem
 			return true;
 		}
 
-		JError::raiseWarning('SOME_ERROR_CODE', JText::sprintf('COM_CONTENT_INVALID_RATING', $rate), "JModelArticle::storeVote($rate)");
+		$app->enqueueMessage(JText::sprintf('COM_CONTENT_INVALID_RATING', $rate), 'warning');
 
 		return false;
 	}

--- a/libraries/cms/toolbar/toolbar.php
+++ b/libraries/cms/toolbar/toolbar.php
@@ -263,7 +263,6 @@ class JToolbar
 
 		if (!class_exists($buttonClass) && !class_exists($buttonClassOld))
 		{
-			// @todo remove code: return	JError::raiseError('SOME_ERROR_CODE', "Module file $buttonFile does not contain class $buttonClass.");
 			return false;
 		}
 


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33865&start=0
### Open Point

Here:
https://github.com/zero-24/joomla-cms/blob/patch-9/libraries/joomla/client/helper.php#L222-229

we use

``` php
if (class_exists('JError'))
{
$return = JError::raiseWarning('SOME_ERROR_CODE', JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
}
else
{
throw new InvalidArgumentException('Invalid user credentials');
}
```

can this replaced by

``` php
throw new InvalidArgumentException(JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
```

Or should we replace the JERROR Statment with

``` php
JFactory::getApplication()->enqueueMessage();
```
