### PR TITLE
[#32854] Use JLayout to render debug backtrace and add backtrace in isis template error.php

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -226,6 +226,9 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
 						</blockquote>
 						<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
+						<?php if ($this->debug):?>
+							<?php echo $this->renderBacktrace(); ?>
+						<?php endif; ?>
 						<!-- End Content -->
 					</div>
 			</div>

--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/** @var $displayData array */
+$class = isset($displayData['class']) ? $displayData['class'] : 'table table-striped table-bordered';
+$backtraceList = $displayData['backtrace'];
+?>
+<table cellpadding="0" cellspacing="0" class="Table <?php echo $class ?>">
+	<tr>
+		<td colspan="3" class="TD">
+			<strong>Call stack</strong>
+		</td>
+	</tr>
+
+	<tr>
+		<td class="TD">
+			<strong>#</strong>
+		</td>
+		<td class="TD">
+			<strong>Function</strong>
+		</td>
+		<td class="TD">
+			<strong>Location</strong>
+		</td>
+	</tr>
+
+	<?php foreach ($backtraceList as $k => $backtrace): ?>
+	<tr>
+		<td class="TD">
+			<?php echo $k + 1; ?>
+		</td>
+
+		<?php if (isset($backtrace['class'])): ?>
+		<td class="TD">
+			<?php echo $backtrace['class'] . $backtrace['type'] . $backtrace['function'] . '()'; ?>
+		</td>
+		<?php else: ?>
+		<td class="TD">
+			<?php echo $backtrace['function'] . '()'; ?>
+		</td>
+		<?php endif; ?>
+
+		<?php if (isset($backtrace['file'])): ?>
+		<td class="TD">
+			<?php echo $backtrace['file'] . ':' . $backtrace['line'] ?>
+		</td>
+		<?php else: ?>
+		<td class="TD">
+			&#160;
+		</td>
+		<?php endif; ?>
+	</tr>
+	<?php endforeach; ?>
+</table>

--- a/layouts/joomla/error/index.html
+++ b/layouts/joomla/error/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -149,48 +149,13 @@ class JDocumentError extends JDocument
 	 */
 	public function renderBacktrace()
 	{
-		$contents = null;
 		$backtrace = $this->_error->getTrace();
-		if (is_array($backtrace))
+
+		if (!$backtrace || !is_array($backtrace))
 		{
-			ob_start();
-			$j = 1;
-			echo '<table cellpadding="0" cellspacing="0" class="Table">';
-			echo '	<tr>';
-			echo '		<td colspan="3" class="TD"><strong>Call stack</strong></td>';
-			echo '	</tr>';
-			echo '	<tr>';
-			echo '		<td class="TD"><strong>#</strong></td>';
-			echo '		<td class="TD"><strong>Function</strong></td>';
-			echo '		<td class="TD"><strong>Location</strong></td>';
-			echo '	</tr>';
-			for ($i = count($backtrace) - 1; $i >= 0; $i--)
-			{
-				echo '	<tr>';
-				echo '		<td class="TD">' . $j . '</td>';
-				if (isset($backtrace[$i]['class']))
-				{
-					echo '	<td class="TD">' . $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()</td>';
-				}
-				else
-				{
-					echo '	<td class="TD">' . $backtrace[$i]['function'] . '()</td>';
-				}
-				if (isset($backtrace[$i]['file']))
-				{
-					echo '		<td class="TD">' . $backtrace[$i]['file'] . ':' . $backtrace[$i]['line'] . '</td>';
-				}
-				else
-				{
-					echo '		<td class="TD">&#160;</td>';
-				}
-				echo '	</tr>';
-				$j++;
-			}
-			echo '</table>';
-			$contents = ob_get_contents();
-			ob_end_clean();
+			return '';
 		}
-		return $contents;
+
+		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $backtrace));
 	}
 }

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1613,55 +1613,12 @@ class PlgSystemDebug extends JPlugin
 	{
 		$backtrace = $error->getTrace();
 
-		$html = array();
-
-		if (is_array($backtrace))
+		if (!$backtrace || !is_array($backtrace))
 		{
-			$j = 1;
-
-			$html[] = '<table cellpadding="0" cellspacing="0">';
-
-			$html[] = '<tr>';
-			$html[] = '<td colspan="3"><strong>Call stack</strong></td>';
-			$html[] = '</tr>';
-
-			$html[] = '<tr>';
-			$html[] = '<th>#</th>';
-			$html[] = '<th>Function</th>';
-			$html[] = '<th>Location</th>';
-			$html[] = '</tr>';
-
-			for ($i = count($backtrace) - 1; $i >= 0; $i--)
-			{
-				$link = '&#160;';
-
-				if (isset($backtrace[$i]['file']))
-				{
-					$link = $this->formatLink($backtrace[$i]['file'], $backtrace[$i]['line']);
-				}
-
-				$html[] = '<tr>';
-				$html[] = '<td>' . $j . '</td>';
-
-				if (isset($backtrace[$i]['class']))
-				{
-					$html[] = '<td>' . $backtrace[$i]['class'] . $backtrace[$i]['type'] . $backtrace[$i]['function'] . '()</td>';
-				}
-				else
-				{
-					$html[] = '<td>' . $backtrace[$i]['function'] . '()</td>';
-				}
-
-				$html[] = '<td>' . $link . '</td>';
-
-				$html[] = '</tr>';
-				$j++;
-			}
-
-			$html[] = '</table>';
+			return '';
 		}
 
-		return implode('', $html);
+		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $backtrace));
 	}
 
 	/**


### PR DESCRIPTION
This is same as #2626 but direct to `staging` branch.
## Introduction

In current time, we use `setError()`, `getError()` and `JError::raiseError()` in component to send error message.

However, if we use throw `Exception`, the debug plugin will not render backtrace for developer. It only work when we use `JError::raiseError()`.

It's because we have this code in: https://github.com/joomla/joomla-cms/blob/master/plugins/system/debug/debug.php#L213

``` php
if (JDEBUG)
        {
            if (JError::getErrors())
            {
                $html[] = $this->display('errors');
            }
```

To detect whether display errors or not. When we throw an exception, the `JError::getErrors()` will return null that backtrace will not rendered.
## The Modification

I added backtrace layout in `layouts/error/backtrace.php` and now, debug plugin & isis template both include this layout. It will help developers know how errors occurred.
## How to Test
1. Go to `Global Configuration`, enable the debug mode.
2. Then type `index.php?option=foo` in browser, you will see the error page.
## Screenshot

![p2013-12-01-3](https://f.cloud.github.com/assets/1639206/1650232/eb7e84cc-5a73-11e3-996e-81446b8b5845.jpg)

![p-2014-06-14-3](https://cloud.githubusercontent.com/assets/1639206/3278790/fcf7423a-f3d3-11e3-83da-e5b952a5464c.jpg)

JTracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32854&start=0
