### PR TITLE
[#33868] Only show published content in mod_tags_popular

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -81,7 +81,7 @@ abstract class ModTagsPopularHelper
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
-			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id')) 
+			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id'))
 			->order($order_value . ' ' . $order_direction);
 
 		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -82,9 +82,8 @@ abstract class ModTagsPopularHelper
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
 			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id')) 
-
 			->order($order_value . ' ' . $order_direction);
-		
+
 		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));
 		// Only return tags connected to published articles
 		$query->where($db->quoteName('c.core_state') . ' = 1')

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -81,14 +81,15 @@ abstract class ModTagsPopularHelper
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
-			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias') . ' AND ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id')) 
+			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id')) 
 
 			->order($order_value . ' ' . $order_direction);
 		
+		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));
 		// Only return tags connected to published articles
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where($db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate)
-			->where($db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate);
+			->where('(' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate . ')')
+			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate . ')');
 		$db->setQuery($query, 0, $maximum);
 		$results = $db->loadObjectList();
 

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -33,6 +33,8 @@ abstract class ModTagsPopularHelper
 		$timeframe		= $params->get('timeframe', 'alltime');
 		$maximum		= $params->get('maximum', 5);
 		$order_value	= $params->get('order_value', 'count');
+		$nowDate		= $db->quote(JFactory::getDate()->toSql());
+		$nullDate		= $db->quote($db->getNullDate());
 
 		if ($order_value == 'rand()')
 		{
@@ -54,7 +56,7 @@ abstract class ModTagsPopularHelper
 				)
 			)
 			->group($db->quoteName(array('tag_id', 'title', 'access', 'alias')))
-			->from($db->quoteName('#__contentitem_tag_map'))
+			->from($db->quoteName('#__contentitem_tag_map', 'm'))
 			->where($db->quoteName('t.access') . ' IN (' . $groups . ')');
 
 		// Only return published tags
@@ -75,11 +77,16 @@ abstract class ModTagsPopularHelper
 
 		if ($timeframe != 'alltime')
 		{
-			$now = new JDate;
-			$query->where($db->quoteName('tag_date') . ' > ' . $query->dateAdd($now->toSql('date'), '-1', strtoupper($timeframe)));
+			$query->where($db->quoteName('tag_date') . ' > ' . $query->dateAdd($nowDate, '-1', strtoupper($timeframe)));
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
+			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias') . ' AND ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id') . 
+					// Only return tags connected to published articles
+					' AND ' . $db->quoteName('c.core_state') . ' = 1'.
+					' AND (' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate . ')'.
+					' AND (' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate . ')')
+			
 			->order($order_value . ' ' . $order_direction);
 		$db->setQuery($query, 0, $maximum);
 		$results = $db->loadObjectList();

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -86,9 +86,9 @@ abstract class ModTagsPopularHelper
 			->order($order_value . ' ' . $order_direction);
 		
 		// Only return tags connected to published articles
-		$query->where($db->quoteName('c.core_state') . ' = 1'.
-					' AND (' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate . ')'.
-					' AND (' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate . ')');
+		$query->where($db->quoteName('c.core_state') . ' = 1')
+			->where($db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate)
+			->where($db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate);
 		$db->setQuery($query, 0, $maximum);
 		$results = $db->loadObjectList();
 

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -81,13 +81,14 @@ abstract class ModTagsPopularHelper
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
-			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias') . ' AND ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id') . 
-					// Only return tags connected to published articles
-					' AND ' . $db->quoteName('c.core_state') . ' = 1'.
-					' AND (' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate . ')'.
-					' AND (' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate . ')')
-			
+			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias') . ' AND ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id')) 
+
 			->order($order_value . ' ' . $order_direction);
+		
+		// Only return tags connected to published articles
+		$query->where($db->quoteName('c.core_state') . ' = 1'.
+					' AND (' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate . ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $nowDate . ')'.
+					' AND (' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate . ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $nowDate . ')');
 		$db->setQuery($query, 0, $maximum);
 		$results = $db->loadObjectList();
 


### PR DESCRIPTION
The "Popular Tags" module shows tags from all tagged items, regardless of their respective publishing status. If you have an article that is not published yet tagged with "Tag1", this tag shows in "Popular Tags" with 1 article, but if you click on the link for the article list, no article is shown.
### Testing instructions:
1. Create a mod_tags_popular module (optionally: enable "Display number of items")
2. Create a taggable item (e.g. an article) and tag it.
3. Set the item's status to "unpublished".
   - Look at the module's output in frontend.
4. Set the item to published, but with a future publish date.
   - Look at the module's output in frontend.
5. Set the item to published, but with a past de-publish date.
   - Look at the module's output in frontend.
6. Apply the patch and repeat steps 3-5.

Please be aware that there are more taggable item types than just articles. I tested it with articles and contacts without any problems. And please have a short look at the SQL query, too, to ensure, that everything is correct here. Thanks!

JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33868
