### PR TITLE
Support adding a priority queue for JLayout paths

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -186,7 +186,7 @@ class JLayoutFile extends JLayoutBase
 		// Check if we have a priority queue instance and convert it to an array
 		if ($paths instanceof SplPriorityQueue)
 		{
-			$paths = $this->convertQueueToArray();
+			$paths = $this->convertQueueToArray($paths);
 		}
 
 		if (!empty($paths))

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -183,8 +183,13 @@ class JLayoutFile extends JLayoutBase
 	 */
 	public function addIncludePaths($paths)
 	{
-		if ($paths instanceof SplPriorityQueue && !$paths->isEmpty())
+		if ($paths instanceof SplPriorityQueue)
 		{
+			if ($paths->isEmpty())
+			{
+				return;
+			}
+
 			$pathArray = array();
 			$paths->top();
 

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -183,8 +183,10 @@ class JLayoutFile extends JLayoutBase
 	 */
 	public function addIncludePaths($paths)
 	{
+		// Check if we have a priority queue instance
 		if ($paths instanceof SplPriorityQueue)
 		{
+			// If there are no paths registered return
 			if ($paths->isEmpty())
 			{
 				return;
@@ -194,7 +196,7 @@ class JLayoutFile extends JLayoutBase
 			$paths->top();
 
 			// We start at the top and loop through each element of the Priority Queue
-			// and then add this array
+			// and then add this array to the front of the include paths array
 			while ($paths->valid())
 			{
 				$pathArray[] = $paths->current();

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -448,7 +448,7 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @since   3.3
 	 */
-	protected function convertQueueToArray($queue)
+	protected function convertQueueToArray(SplPriorityQueue $queue)
 	{
 		// Initialise the array
 		$items = array();

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -175,7 +175,7 @@ class JLayoutFile extends JLayoutBase
 	/**
 	 * Add one or more paths to include in layout search
 	 *
-	 * @param   string  $paths  The path or array of paths to search for layouts
+	 * @param   mixed  $paths  The path or array, or Priority queue of paths to search for layouts
 	 *
 	 * @return  void
 	 *
@@ -183,6 +183,22 @@ class JLayoutFile extends JLayoutBase
 	 */
 	public function addIncludePaths($paths)
 	{
+		if ($paths instanceof SplPriorityQueue && !$paths->isEmpty())
+		{
+			$pathArray = array();
+			$objPQ->top();
+
+			// We start at the top and loop through each element of the Priority Queue
+			// and then add this array
+			while ($paths->valid())
+			{
+				$pathArray[] = $paths->current();
+				$objPQ->next(); 
+			}
+
+			$this->includePaths = array_unique(array_merge($pathArray, $this->includePaths));
+		}
+
 		if (!empty($paths))
 		{
 			if (is_array($paths))

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -197,6 +197,8 @@ class JLayoutFile extends JLayoutBase
 			}
 
 			$this->includePaths = array_unique(array_merge($pathArray, $this->includePaths));
+
+			return;
 		}
 
 		if (!empty($paths))

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -183,29 +183,10 @@ class JLayoutFile extends JLayoutBase
 	 */
 	public function addIncludePaths($paths)
 	{
-		// Check if we have a priority queue instance
+		// Check if we have a priority queue instance and convert it to an array
 		if ($paths instanceof SplPriorityQueue)
 		{
-			// If there are no paths registered return
-			if ($paths->isEmpty())
-			{
-				return;
-			}
-
-			$pathArray = array();
-			$paths->top();
-
-			// We start at the top and loop through each element of the Priority Queue
-			// and then add this array to the front of the include paths array
-			while ($paths->valid())
-			{
-				$pathArray[] = $paths->current();
-				$paths->next(); 
-			}
-
-			$this->includePaths = array_unique(array_merge($pathArray, $this->includePaths));
-
-			return;
+			$paths = $this->convertQueueToArray();
 		}
 
 		if (!empty($paths))
@@ -456,5 +437,36 @@ class JLayoutFile extends JLayoutBase
 		$sublayout->includePaths = $this->includePaths;
 
 		return $sublayout->render($displayData);
+	}
+
+	/**
+	 * Render a layout with the same include paths & options
+	 *
+	 * @param   SplPriorityQueue  $queue  The SPL Priority Queue Item
+	 *
+	 * @return  array  An array of paths ordered ordered by priority
+	 *
+	 * @since   3.3
+	 */
+	protected function convertQueueToArray($queue)
+	{
+		// Initialise the array
+		$items = array();
+
+		// If there are no paths registered return empty array
+		if (!$queue->isEmpty())
+		{
+			$queue->top();
+		
+			// We start at the top and loop through each element of the Priority Queue
+			// and then add this item to the array
+			while ($queue->valid())
+			{
+				$items[] = $queue->current();
+				$queue->next(); 
+			}
+		}
+
+		return $items;
 	}
 }

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -186,14 +186,14 @@ class JLayoutFile extends JLayoutBase
 		if ($paths instanceof SplPriorityQueue && !$paths->isEmpty())
 		{
 			$pathArray = array();
-			$objPQ->top();
+			$paths->top();
 
 			// We start at the top and loop through each element of the Priority Queue
 			// and then add this array
 			while ($paths->valid())
 			{
 				$pathArray[] = $paths->current();
-				$objPQ->next(); 
+				$paths->next(); 
 			}
 
 			$this->includePaths = array_unique(array_merge($pathArray, $this->includePaths));


### PR DESCRIPTION
@phproberto see what you think
## Testing Instructions
1. Test current JLayouts continue to work as expected with no new issues
2. Test creating a JLayout in a weird file path and then add using a priority queue.
   berto see what you think
## Testing Instructions
1. Test current JLayouts continue to work as expected with no new issues
2. Test using a priority queue works
   e.g. Move the layout in /root/layouts/joomla/content/icons.php to a new location (not something that is currently recognized). Then edit the following https://github.com/joomla/joomla-cms/blob/staging/components/com_content/views/article/tmpl/default.php#L67

```
$layout = new JLayout('joomla.content.icons');
$paths = new SplPriorityQueue;
$paths->insert('path/to/new/location');
$layout->addIncludePaths($paths);
$layout->render(array('params' => $params, 'item' => $this->item, 'print' => false));
```

And the Jlayout should load from the location `path/to/new/location/joomla/content/icons.php`

If you want as a further test you can do the same thing except change $paths from being a `SplPriorityQueue` to being an array by changing the previous code to

```
$layout = new JLayout('joomla.content.icons');
$paths = array('path/to/new/location');
$layout->addIncludePaths($paths);
$layout->render(array('params' => $params, 'item' => $this->item, 'print' => false));
```

and checking this 'old' way of doing things also works as expected
## FAQ

The reason I made the private function is because in the future a setIncludePaths() function will likely be added that will need to utilise the same code and therefore I'm abstracting it away in a method in anticipation of this.
