### PR TITLE
[#33876] Fix Search Filter activation in com_users

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -297,11 +297,11 @@ class UsersModelUsers extends JModelList
 		{
 			if ($active == '0')
 			{
-				$query->where('a.activation = ' . $db->quote(''));
+				$query->where('a.activation IN (' . $db->quote('') . ', 0)');
 			}
 			elseif ($active == '1')
 			{
-				$query->where($query->length('a.activation') . ' = 32');
+				$query->where($query->length('a.activation') . ' > 1');
 			}
 		}
 


### PR DESCRIPTION
In Search Tools, filter activation not working as expected.

Search Filter for activated users is not displaying super users as activation value is '0' in database.
This PR fixes it by adding 0 as a value for activated users.

Search Filter is not working for unactivated users (activation key is not anymore 32 characters length).
This PR fixes it by controlling if activation is > 1. (which means that an activation key has been generated)

Issue on Joomlacode : [http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33876](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33876)
