### PR TITLE
Improve code quality

### DIFF
--- a/libraries/cms/table/contenttype.php
+++ b/libraries/cms/table/contenttype.php
@@ -108,11 +108,11 @@ class JTableContenttype extends JTable
 		$db = $this->_db;
 		$query = $db->getQuery(true);
 		$query->select($db->quoteName('type_id'))
-			->from($db->quoteName('#__content_types'))
+			->from($db->quoteName($this->_tbl))
 			->where($db->quoteName('type_alias') . ' = ' . $db->quote($typeAlias));
 		$db->setQuery($query);
 
-		return $db->loadResult($query);
+		return $db->loadResult();
 	}
 
 	/**


### PR DESCRIPTION
loadResult() doesn't take a parameter

`$this->_tbl` is an alias made in the constructor and should be used as a code quality measure
