### PR TITLE
[#32645] Fixes #32645 Trailing hyphen is removed in JHTML::_('select.options')

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -665,10 +665,10 @@ abstract class JHtmlSelect
 			else
 			{
 				// If no string after hyphen - take hyphen out
-				$splitText = preg_split('/ -[\s]*/', $text, 2, PREG_SPLIT_NO_EMPTY);
-				$text = isset($splitText[0]) ? $splitText[0] : '';
+				$splitText = explode(' - ', $text, 2);
+				$text = $splitText[0];
 
-				if (!empty($splitText[1]))
+				if (isset($splitText[1]) && $splitText[1] != "" && !preg_match('/^[\s]+$/', $splitText[1]))
 				{
 					$text .= ' - ' . $splitText[1];
 				}

--- a/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
@@ -222,11 +222,11 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 				),
 			),
 			array(
-				"<option value=\"1\" class=\"foo bar\" style=\"color:red;\">&nbsp;Test</option>\n",
+				"<option value=\"1\" class=\"foo bar\" style=\"color:red;\">-&nbsp;Test -</option>\n",
 				array(
 					array(
 						'value' => '1',
-						'text' => '&nbsp;Test -         ',
+						'text' => '-&nbsp;Test -',
 						'label' => 'My Label',
 						'id' => 'myId',
 						'attrs' => array('class' => "foo bar",'style' => 'color:red;',),
@@ -348,7 +348,7 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider  getGenericlistData
 	 * @since         3.2
-	*/
+	 */
 	public function testGenericlist($expected, $data, $name, $attribs = null, $optKey = 'value', $optText = 'text',
 		$selected = null, $idtag = false, $translate = false)
 	{


### PR DESCRIPTION
### Issue

A list option similar to `- select value -` is currently truncated to `- select value` when built using JHtmlSelect::options (like in JHtmlSelect::genericlist or the list formfield).
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32645
