### PR TITLE
[#33885] Add sort by title for category field

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -112,7 +112,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		}
 
 		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.extension, a.parent_id, a.published')
-			->order('a.lft ASC');
+			->order('a.title ASC, a.lft ASC');
 
 		// Get the options.
 		$db->setQuery($query);


### PR DESCRIPTION
### Issue (copied from JC)

Categories are not listed alphabetically in Article Manager: New Artilce
### Test Instructions (copied from JC)
- Goto Article Manager
- New Menu
- Category
- Drop down
- Categories are listes by object ID, not alphabet.
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33885
