### PR TITLE
	[#33880] Protostar template now shows top 3px in background colour.

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -96,7 +96,7 @@ else
 	<style type="text/css">
 		body.site
 		{
-			border-top: 3px solid <?php echo $this->params->get('templateColor'); ?>;
+			border-top: 3px solid <?php echo $this->params->get('templateBackgroundColor'); ?>;
 			background-color: <?php echo $this->params->get('templateBackgroundColor'); ?>
 		}
 		a


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33880&start=0.
(Observe the top 3 pixels of any Joomla page with Protostar template. Make sure background colour differs from
template colour to see the difference before/after fix.)
