### PR TITLE
Replacing JRegistry with Joomla\Registry\Registry in some docblocs

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -255,7 +255,7 @@ class ConfigModelApplication extends ConfigModelForm
 	/**
 	 * Method to write the configuration to a file.
 	 *
-	 * @param   JRegistry  $config  A JRegistry object containing all global config data.
+	 * @param   Joomla\Registry\Registry  $config  A Registry object containing all global config data.
 	 *
 	 * @return	boolean  True on success, false on failure.
 	 *

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -462,8 +462,8 @@ class FinderIndexerHelper
 	/**
 	 * Method to process content text using the onContentPrepare event trigger.
 	 *
-	 * @param   string     $text    The content to process.
-	 * @param   JRegistry  $params  The parameters object. [optional]
+	 * @param   string                    $text    The content to process.
+	 * @param   Joomla\Registry\Registry  $params  The parameters object. [optional]
 	 *
 	 * @return  string  The processed content.
 	 *

--- a/administrator/modules/mod_latest/helper.php
+++ b/administrator/modules/mod_latest/helper.php
@@ -23,7 +23,7 @@ abstract class ModLatestHelper
 	/**
 	 * Get a list of articles.
 	 *
-	 * @param   JRegistry  &$params  The module parameters.
+	 * @param   Joomla\Registry\Registry  &$params  The module parameters.
 	 *
 	 * @return  mixed  An array of articles, or false on error.
 	 */
@@ -108,7 +108,7 @@ abstract class ModLatestHelper
 	/**
 	 * Get the alternate title for the module.
 	 *
-	 * @param   JRegistry  $params  The module parameters.
+	 * @param   Joomla\Registry\Registry  $params  The module parameters.
 	 *
 	 * @return  string  The alternate title for the module.
 	 */

--- a/administrator/modules/mod_logged/helper.php
+++ b/administrator/modules/mod_logged/helper.php
@@ -21,7 +21,7 @@ abstract class ModLoggedHelper
 	/**
 	 * Get a list of logged users.
 	 *
-	 * @param   JRegistry  &$params  The module parameters.
+	 * @param   Joomla\Registry\Registry  &$params  The module parameters.
 	 *
 	 * @return  mixed  An array of users, or false on error.
 	 *
@@ -69,7 +69,7 @@ abstract class ModLoggedHelper
 	/**
 	 * Get the alternate title for the module
 	 *
-	 * @param   JRegistry  $params  The module parameters.
+	 * @param   Joomla\Registry\Registry  $params  The module parameters.
 	 *
 	 * @return  string    The alternate title for the module.
 	 */

--- a/administrator/modules/mod_version/helper.php
+++ b/administrator/modules/mod_version/helper.php
@@ -21,7 +21,7 @@ abstract class ModVersionHelper
 	/**
 	 * Get the member items of the submenu.
 	 *
-	 * @param   JRegistry  &$params  The parameters object.
+	 * @param   Joomla\Registry\Registry  &$params  The parameters object.
 	 *
 	 * @return  string  String containing the current Joomla version based on the selected format.
 	 */

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -21,10 +21,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to the create item page for the given category
 	 *
-	 * @param   object     $category  The category information
-	 * @param   JRegistry  $params    The item parameters
-	 * @param   array      $attribs   Optional attributes for the link
-	 * @param   boolean    $legacy    True to use legacy images, false to use icomoon based graphic
+	 * @param   object                    $category  The category information
+	 * @param   Joomla\Registry\Registry  $params    The item parameters
+	 * @param   array                     $attribs   Optional attributes for the link
+	 * @param   boolean                   $legacy    True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the create item link
 	 */
@@ -72,10 +72,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to the email item page for the given article
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object                    $article  The article information
+	 * @param   Joomla\Registry\Registry  $params   The item parameters
+	 * @param   array                     $attribs  Optional attributes for the link
+	 * @param   boolean                   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the email item link
 	 */
@@ -121,10 +121,10 @@ abstract class JHtmlIcon
 	 * This icon will not display in a popup window, nor if the article is trashed.
 	 * Edit access checks must be performed in the calling code.
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object                    $article  The article information
+	 * @param   Joomla\Registry\Registry  $params   The item parameters
+	 * @param   array                     $attribs  Optional attributes for the link
+	 * @param   boolean                   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string	The HTML for the article edit icon.
 	 * @since   1.6
@@ -207,10 +207,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a popup link to print an article
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object                    $article  The article information
+	 * @param   Joomla\Registry\Registry  $params   The item parameters
+	 * @param   array                     $attribs  Optional attributes for the link
+	 * @param   boolean                   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 */
@@ -252,10 +252,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to print an article
 	 *
-	 * @param   object     $article  Not used, @deprecated for 4.0
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Not used, @deprecated for 4.0
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object                    $article  Not used, @deprecated for 4.0
+	 * @param   Joomla\Registry\Registry  $params   The item parameters
+	 * @param   array                     $attribs  Not used, @deprecated for 4.0
+	 * @param   boolean                   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 */

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -149,7 +149,7 @@ class ContentHelperQuery
 	/**
 	 * Get join information for the voting query.
 	 *
-	 * @param   JRegistry	$param	An options object for the article.
+	 * @param   Joomla\Registry\Registry  $params   An options object for the article.
 	 *
 	 * @return  array  	A named array with "select" and "join" keys.
 	 * @since   1.5

--- a/installation/view/complete/html.php
+++ b/installation/view/complete/html.php
@@ -21,7 +21,7 @@ class InstallationViewCompleteHtml extends JViewHtml
 	/**
 	 * The JConfiguration data if present
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.1
 	 */
 	protected $config;

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -25,7 +25,7 @@ class JApplicationAdministrator extends JApplicationCms
 	 *                          input object.  If the argument is a JInput object that object will become
 	 *                          the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
+	 *                          config object.  If the argument is a Registry object that object will become
 	 *                          the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
 	 *                          client object.  If the argument is a JApplicationWebClient object that object will become

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -92,7 +92,7 @@ class JApplicationCms extends JApplicationWeb
 	 *                          input object.  If the argument is a JInput object that object will become
 	 *                          the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
+	 *                          config object.  If the argument is a Registry object that object will become
 	 *                          the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
 	 *                          client object.  If the argument is a JApplicationWebClient object that object will become

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -43,7 +43,7 @@ final class JApplicationSite extends JApplicationCms
 	 *                          input object.  If the argument is a JInput object that object will become
 	 *                          the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
+	 *                          config object.  If the argument is a Registry object that object will become
 	 *                          the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
 	 *                          client object.  If the argument is a JApplicationWebClient object that object will become

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -81,9 +81,9 @@ class JComponentHelper
 	 * @param   string   $option  The option for the component.
 	 * @param   boolean  $strict  If set and the component does not exist, false will be returned
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Joomla\Registry\Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Joomla\Registry\Registry
 	 * @since   1.5
 	 */
 	public static function getParams($option, $strict = false)

--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -39,7 +39,7 @@ class JFormFieldTag extends JFormFieldList
 	/**
 	 * com_tags parameters
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.1
 	 */
 	protected $comParams = null;

--- a/libraries/cms/html/searchtools.php
+++ b/libraries/cms/html/searchtools.php
@@ -99,9 +99,9 @@ abstract class JHtmlSearchtools
 	/**
 	 * Function to receive & pre-process javascript options
 	 *
-	 * @param   mixed  $options  Associative array/JRegistry object with options
+	 * @param   mixed  $options  Associative array/Registry object with options
 	 *
-	 * @return  JRegistry        Options converted to JRegistry object
+	 * @return  Joomla\Registry\Registry  Options converted to Registry object
 	 */
 	private static function options2Jregistry($options)
 	{

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -22,7 +22,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Options object
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.2
 	 */
 	protected $options = null;
@@ -38,7 +38,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Set the options
 	 *
-	 * @param   mixed  $options  Array / JRegistry object with the options to load
+	 * @param   mixed  $options  Array / Registry object with the options to load
 	 *
 	 * @return  JLayoutBase  Instance of $this to allow chaining.
 	 *
@@ -67,7 +67,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Get the options
 	 *
-	 * @return  JRegistry  Object with the options
+	 * @return  Joomla\Registry\Registry  Object with the options
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -51,7 +51,7 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $layoutId  Dot separated path to the layout file, relative to base path
 	 * @param   string  $basePath  Base path to use when loading layout files
-	 * @param   mixed   $options   Optional custom options to load. JRegistry or array format [@since 3.2]
+	 * @param   mixed   $options   Optional custom options to load. Registry or array format [@since 3.2]
 	 *
 	 * @since   3.0
 	 */

--- a/libraries/cms/layout/helper.php
+++ b/libraries/cms/layout/helper.php
@@ -34,7 +34,7 @@ class JLayoutHelper
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
 	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
 	 * @param   string  $basePath     Base path to use when loading layout files
-	 * @param   mixed   $options      Optional custom options to load. JRegistry or array format
+	 * @param   mixed   $options      Optional custom options to load. Registry or array format
 	 *
 	 * @return  string
 	 *

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -80,9 +80,9 @@ class JLibraryHelper
 	 * @param   string   $element  Element of the library in the extensions table.
 	 * @param   boolean  $strict   If set and the library does not exist, false will be returned
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Joomla\Registry\Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Joomla\Registry\Registry
 	 * @since   3.2
 	 */
 	public static function getParams($element, $strict = false)
@@ -96,11 +96,11 @@ class JLibraryHelper
 	 * Save the parameters object for the library
 	 *
 	 * @param   string     $element  Element of the library in the extensions table.
-	 * @param   JRegistry  $params   Params to save
+	 * @param   Joomla\Registry\Registry  $params   Params to save
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Joomla\Registry\Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Joomla\Registry\Registry
 	 * @since   3.2
 	 */
 	public static function saveParams($element, $params)

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -301,7 +301,7 @@ class JMenu
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  JRegistry  A JRegistry object
+	 * @return  Joomla\Registry\Registry  A Registry object
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -19,9 +19,9 @@ defined('JPATH_PLATFORM') or die;
 abstract class JPlugin extends JEvent
 {
 	/**
-	 * A JRegistry object holding the parameters for the plugin
+	 * A Registry object holding the parameters for the plugin
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  1.5
 	 */
 	public $params = null;

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -21,7 +21,7 @@ use Joomla\Application\Cli\CliOutput;
 class JApplicationCli extends JApplicationBase
 {
 	/**
-	 * @var    JRegistry  The application configuration object.
+	 * @var    Joomla\Registry\Registry  The application configuration object.
 	 * @since  11.1
 	 */
 	protected $config;
@@ -45,7 +45,7 @@ class JApplicationCli extends JApplicationBase
 	 *                              input object.  If the argument is a JInputCli object that object will become
 	 *                              the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
+	 *                              config object.  If the argument is a Registry object that object will become
 	 *                              the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
 	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -97,7 +97,7 @@ class JApplicationDaemon extends JApplicationCli
 	 *                              input object.  If the argument is a JInputCli object that object will become
 	 *                              the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
+	 *                              config object.  If the argument is a Registry object that object will become
 	 *                              the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
 	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -43,7 +43,7 @@ class JApplicationWeb extends JApplicationBase
 	public $client;
 
 	/**
-	 * @var    JRegistry  The application configuration object.
+	 * @var    Joomla\Registry\Registry  The application configuration object.
 	 * @since  11.3
 	 */
 	protected $config;
@@ -85,7 +85,7 @@ class JApplicationWeb extends JApplicationBase
 	 *                          input object.  If the argument is a JInput object that object will become
 	 *                          the application's input object, otherwise a default input object is created.
 	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
+	 *                          config object.  If the argument is a Registry object that object will become
 	 *                          the application's config object, otherwise a default config object is created.
 	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
 	 *                          client object.  If the argument is a JApplicationWebClient object that object will become

--- a/libraries/joomla/data/data.php
+++ b/libraries/joomla/data/data.php
@@ -229,7 +229,7 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 	 * Dumps a data property.
 	 *
 	 * If recursion is set, this method will dump any object implementing JDumpable (like JData and JDataSet); it will
-	 * convert a JDate object to a string; and it will convert a JRegistry to an object.
+	 * convert a JDate object to a string; and it will convert a Registry to an object.
 	 *
 	 * @param   string            $property  The name of the data property.
 	 * @param   integer           $depth     The current depth of recursion (a value of 0 will ignore recursion).

--- a/libraries/joomla/facebook/facebook.php
+++ b/libraries/joomla/facebook/facebook.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 class JFacebook
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/facebook/oauth.php
+++ b/libraries/joomla/facebook/oauth.php
@@ -21,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 class JFacebookOAuth extends JOAuth2Client
 {
 	/**
-	 * @var JRegistry Options for the JFacebookOAuth object.
+	 * @var   Joomla\Registry\Registry  Options for the JFacebookOAuth object.
 	 * @since 13.1
 	 */
 	protected $options;

--- a/libraries/joomla/facebook/object.php
+++ b/libraries/joomla/facebook/object.php
@@ -22,7 +22,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JFacebookObject
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -130,15 +130,15 @@ abstract class JFactory
 	/**
 	 * Get a configuration object
 	 *
-	 * Returns the global {@link JRegistry} object, only creating it if it doesn't already exist.
+	 * Returns the global {@link Joomla\Registry\Registry} object, only creating it if it doesn't already exist.
 	 *
 	 * @param   string  $file       The path to the configuration file
 	 * @param   string  $type       The type of the configuration file
 	 * @param   string  $namespace  The namespace of the configuration file
 	 *
-	 * @return  JRegistry
+	 * @return  Joomla\Registry\Registry
 	 *
-	 * @see     JRegistry
+	 * @see     Joomla\Registry\Registry
 	 * @since   11.1
 	 */
 	public static function getConfig($file = null, $type = 'PHP', $namespace = '')
@@ -540,9 +540,9 @@ abstract class JFactory
 	 * @param   string  $type       The type of the configuration file.
 	 * @param   string  $namespace  The namespace of the configuration file.
 	 *
-	 * @return  JRegistry
+	 * @return  Joomla\Registry\Registry
 	 *
-	 * @see     JRegistry
+	 * @see     Joomla\Registry\Registry
 	 * @since   11.1
 	 */
 	protected static function createConfig($file, $type = 'PHP', $namespace = '')

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -28,8 +28,8 @@ jimport('joomla.utilities.arrayhelper');
 class JForm
 {
 	/**
-	 * The JRegistry data store for form fields during display.
-	 * @var    object
+	 * The Registry data store for form fields during display.
+	 * @var    Joomla\Registry\Registry
 	 * @since  11.1
 	 */
 	protected $data;
@@ -2249,7 +2249,7 @@ class JForm
 	/**
 	 * Getter for the form data
 	 *
-	 * @return   JRegistry  Object with the data
+	 * @return   Joomla\Registry\Registry  Object with the data
 	 *
 	 * @since    3.2
 	 */

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -41,7 +41,7 @@ defined('JPATH_PLATFORM') or die;
 class JGithub
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGithubObject
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/google/auth.php
+++ b/libraries/joomla/google/auth.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGoogleAuth
 {
 	/**
-	 * @var    JRegistry  Options for the Google authentication object.
+	 * @var    Joomla\Registry\Registry  Options for the Google authentication object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGoogleData
 {
 	/**
-	 * @var    JRegistry  Options for the Google data object.
+	 * @var    Joomla\Registry\Registry  Options for the Google data object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -20,7 +20,7 @@ jimport('joomla.environment.uri');
 abstract class JGoogleEmbed
 {
 	/**
-	 * @var    JRegistry  Options for the Google data object.
+	 * @var    Joomla\Registry\Registry  Options for the Google data object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/google/google.php
+++ b/libraries/joomla/google/google.php
@@ -22,7 +22,7 @@ defined('JPATH_PLATFORM') or die;
 class JGoogle
 {
 	/**
-	 * @var    JRegistry  Options for the Google object.
+	 * @var    Joomla\Registry\Registry  Options for the Google object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -62,9 +62,9 @@ class JGoogle
 	/**
 	 * Method to create JGoogleData objects
 	 *
-	 * @param   string     $name     Name of property to retrieve
-	 * @param   JRegistry  $options  Google options object.
-	 * @param   JAuth      $auth     The authentication client object.
+	 * @param   string                    $name     Name of property to retrieve
+	 * @param   Joomla\Registry\Registry  $options  Google options object.
+	 * @param   JAuth                     $auth     The authentication client object.
 	 *
 	 * @return  JGoogleData  Google data API object.
 	 *
@@ -102,8 +102,8 @@ class JGoogle
 	/**
 	 * Method to create JGoogleEmbed objects
 	 *
-	 * @param   string     $name     Name of property to retrieve
-	 * @param   JRegistry  $options  Google options object.
+	 * @param   string                    $name     Name of property to retrieve
+	 * @param   Joomla\Registry\Registry  $options  Google options object.
 	 *
 	 * @return  JGoogleEmbed  Google embed API object.
 	 *

--- a/libraries/joomla/http/http.php
+++ b/libraries/joomla/http/http.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttp
 {
 	/**
-	 * @var    JRegistry  Options for the HTTP client.
+	 * @var    Joomla\Registry\Registry  Options for the HTTP client.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttpTransportCurl implements JHttpTransport
 {
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Joomla\Registry\Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -25,7 +25,7 @@ class JHttpTransportSocket implements JHttpTransport
 	protected $connections;
 
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Joomla\Registry\Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttpTransportStream implements JHttpTransport
 {
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Joomla\Registry\Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/libraries/joomla/linkedin/linkedin.php
+++ b/libraries/joomla/linkedin/linkedin.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 class JLinkedin
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/linkedin/oauth.php
+++ b/libraries/joomla/linkedin/oauth.php
@@ -20,7 +20,7 @@ defined('JPATH_PLATFORM') or die();
 class JLinkedinOauth extends JOAuth1Client
 {
 	/**
-	* @var    JRegistry  Options for the JLinkedinOauth object.
+	* @var    Joomla\Registry\Registry  Options for the JLinkedinOauth object.
 	* @since  13.1
 	*/
 	protected $options;

--- a/libraries/joomla/linkedin/object.php
+++ b/libraries/joomla/linkedin/object.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JLinkedinObject
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/mediawiki/mediawiki.php
+++ b/libraries/joomla/mediawiki/mediawiki.php
@@ -27,7 +27,7 @@ defined('JPATH_PLATFORM') or die;
 class JMediawiki
 {
 	/**
-	 * @var    JRegistry  Options for the MediaWiki object.
+	 * @var    Joomla\Registry\Registry  Options for the MediaWiki object.
 	 * @since  12.1
 	 */
 	protected $options;

--- a/libraries/joomla/mediawiki/object.php
+++ b/libraries/joomla/mediawiki/object.php
@@ -20,7 +20,7 @@ abstract class JMediawikiObject
 {
 
 	/**
-	 * @var    JRegistry  Options for the MediaWiki object.
+	 * @var    Joomla\Registry\Registry  Options for the MediaWiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/model/base.php
+++ b/libraries/joomla/model/base.php
@@ -21,7 +21,7 @@ abstract class JModelBase implements JModel
 	/**
 	 * The model state.
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  12.1
 	 */
 	protected $state;
@@ -42,7 +42,7 @@ abstract class JModelBase implements JModel
 	/**
 	 * Get the model state.
 	 *
-	 * @return  JRegistry  The state object.
+	 * @return  Joomla\Registry\Registry  The state object.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/model/model.php
+++ b/libraries/joomla/model/model.php
@@ -21,7 +21,7 @@ interface JModel
 	/**
 	 * Get the model state.
 	 *
-	 * @return  JRegistry  The state object.
+	 * @return  Joomla\Registry\Registry  The state object.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/oauth1/client.php
+++ b/libraries/joomla/oauth1/client.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JOAuth1Client
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth1Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth1Client object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JOAuth2Client
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -21,7 +21,7 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	/**
 	 * Options for the JOpenstreetmapOauth object.
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/openstreetmap/object.php
+++ b/libraries/joomla/openstreetmap/object.php
@@ -21,7 +21,7 @@ abstract class JOpenstreetmapObject
 	/**
 	 * Options for the Openstreetmap object.
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -21,7 +21,7 @@ class JOpenstreetmap
 	/**
 	 * Options for the Openstreetmap object.
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  13.1
 	 */
 	protected $options;

--- a/libraries/joomla/twitter/oauth.php
+++ b/libraries/joomla/twitter/oauth.php
@@ -20,7 +20,7 @@ defined('JPATH_PLATFORM') or die();
 class JTwitterOAuth extends JOAuth1Client
 {
 	/**
-	* @var JRegistry Options for the JTwitterOauth object.
+	* @var   Joomla\Registry\Registry  Options for the JTwitterOauth object.
 	* @since 12.3
 	*/
 	protected $options;

--- a/libraries/joomla/twitter/object.php
+++ b/libraries/joomla/twitter/object.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JTwitterObject
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/twitter/twitter.php
+++ b/libraries/joomla/twitter/twitter.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die();
 class JTwitter
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -117,7 +117,7 @@ class JUser extends JObject
 	/**
 	 * User parameters
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  11.1
 	 */
 	public $params = null;
@@ -165,7 +165,7 @@ class JUser extends JObject
 	/**
 	 * User parameters
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  11.1
 	 */
 	protected $_params = null;

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -884,7 +884,7 @@ class JCategoryNode extends JObject
 	/**
 	 * Returns the category parameters
 	 *
-	 * @return  JRegistry
+	 * @return  Joomla\Registry\Registry
 	 *
 	 * @since   11.1
 	 */
@@ -903,7 +903,7 @@ class JCategoryNode extends JObject
 	/**
 	 * Returns the category metadata
 	 *
-	 * @return  JRegistry  A JRegistry object containing the metadata
+	 * @return  Joomla\Registry\Registry  A Registry object containing the metadata
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/legacy/view/categories.php
+++ b/libraries/legacy/view/categories.php
@@ -21,7 +21,7 @@ class JViewCategories extends JViewLegacy
 	/**
 	 * State data
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.2
 	 */
 	protected $state;

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -21,7 +21,7 @@ class JViewCategory extends JViewLegacy
 	/**
 	 * State data
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.2
 	 */
 	protected $state;

--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -21,7 +21,7 @@ class ModArchiveHelper
 	/**
 	 * Retrieve list of archived articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_articles_categories/helper.php
+++ b/modules/mod_articles_categories/helper.php
@@ -24,7 +24,7 @@ abstract class ModArticlesCategoriesHelper
 	/**
 	 * Get list of articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -28,7 +28,7 @@ abstract class ModArticlesCategoryHelper
 	/**
 	 * Get a list of articles from a specific category
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -25,7 +25,7 @@ abstract class ModArticlesLatestHelper
 	/**
 	 * Retrieve a list of article
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -26,7 +26,7 @@ abstract class ModArticlesNewsHelper
 	/**
 	 * Get a list of the latest articles from the article model
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -26,7 +26,7 @@ abstract class ModArticlesPopularHelper
 	/**
 	 * Get a list of popular articles from the articles model
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_banners/helper.php
+++ b/modules/mod_banners/helper.php
@@ -21,7 +21,7 @@ class ModBannersHelper
 	/**
 	 * Retrieve list of banners
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -21,7 +21,7 @@ class ModBreadCrumbsHelper
 	/**
 	 * Retrieve breadcrumb items
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_feed/helper.php
+++ b/modules/mod_feed/helper.php
@@ -21,7 +21,7 @@ class ModFeedHelper
 	/**
 	 * Retrieve feed information
 	 *
-	 * @param   JRegistry  $params  module parameters
+	 * @param   Joomla\Registry\Registry  $params  module parameters
 	 *
 	 * @return  JFeedReader|string
 	 */

--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -61,7 +61,7 @@ class ModFinderHelper
 	/**
 	 * Get Smart Search query object.
 	 *
-	 * @param   JRegistry  $params  Module parameters.
+	 * @param   Joomla\Registry\Registry  $params  Module parameters.
 	 *
 	 * @return  FinderIndexerQuery object
 	 *

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -24,7 +24,7 @@ abstract class ModLanguagesHelper
 	/**
 	 * Gets a list of available languages
 	 *
-	 * @param   JRegistry  &$params  module params
+	 * @param   Joomla\Registry\Registry  &$params  module params
 	 *
 	 * @return  array
 	 */

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -22,7 +22,7 @@ class ModLoginHelper
 	/**
 	 * Retrieve the url where the user should be returned after logging in
 	 *
-	 * @param   JRegistry  $params  module parameters
+	 * @param   Joomla\Registry\Registry  $params  module parameters
 	 * @param   string     $type    return type
 	 *
 	 * @return string

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -21,7 +21,7 @@ class ModMenuHelper
 	/**
 	 * Get a list of the menu items.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   Joomla\Registry\Registry  &$params  The module options.
 	 *
 	 * @return  array
 	 *
@@ -155,7 +155,7 @@ class ModMenuHelper
 	/**
 	 * Get base menu item.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   Joomla\Registry\Registry  &$params  The module options.
 	 *
 	 * @return   object
 	 *
@@ -185,7 +185,7 @@ class ModMenuHelper
 	/**
 	 * Get active menu item.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   Joomla\Registry\Registry  &$params  The module options.
 	 *
 	 * @return  object
 	 *

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -21,8 +21,8 @@ class ModRandomImageHelper
 	/**
 	 * Retrieves a random image
 	 *
-	 * @param   JRegistry  &$params  module parameters object
-	 * @param   array      $images   list of images
+	 * @param   Joomla\Registry\Registry  &$params  module parameters object
+	 * @param   array                     $images   list of images
 	 *
 	 * @return  mixed
 	 */
@@ -76,8 +76,8 @@ class ModRandomImageHelper
 	/**
 	 * Retrieves images from a specific folder
 	 *
-	 * @param   JRegistry  &$params  module params
-	 * @param   string     $folder   folder to get the images from
+	 * @param   Joomla\Registry\Registry  &$params  module params
+	 * @param   string                    $folder   folder to get the images from
 	 *
 	 * @return array
 	 */
@@ -130,7 +130,7 @@ class ModRandomImageHelper
 	/**
 	 * Get sanitized folder
 	 *
-	 * @param   JRegistry  &$params  module params objects
+	 * @param   Joomla\Registry\Registry  &$params  module params objects
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -23,7 +23,7 @@ abstract class ModRelatedItemsHelper
 	/**
 	 * Get a list of related articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -21,7 +21,7 @@ class ModStatsHelper
 	/**
 	 * Get list of stats
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  array
 	 */

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -21,7 +21,7 @@ abstract class ModTagsPopularHelper
 	/**
 	 * Get list of popular tags
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -21,7 +21,7 @@ abstract class ModTagssimilarHelper
 	/**
 	 * Get a list of tags
 	 *
-	 * @param   JRegistry  &$params  Module parameters
+	 * @param   Joomla\Registry\Registry  &$params  Module parameters
 	 *
 	 * @return  mixed                Results array / null
 	 */

--- a/tests/unit/suites/libraries/cms/help/JHelpTest.php
+++ b/tests/unit/suites/libraries/cms/help/JHelpTest.php
@@ -19,7 +19,7 @@ class JHelpTest extends TestCase
 	/**
 	 * The mock config object
 	 *
-	 * @var    JRegistry
+	 * @var    Joomla\Registry\Registry
 	 * @since  3.0
 	 */
 	protected $config;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookAlbumTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookAlbumTest.php
@@ -17,7 +17,7 @@
 class JFacebookAlbumTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookCheckinTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookCheckinTest.php
@@ -17,7 +17,7 @@
 class JFacebookCheckinTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookCommentTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookCommentTest.php
@@ -17,7 +17,7 @@
 class JFacebookCommentTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookEventTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookEventTest.php
@@ -17,7 +17,7 @@
 class JFacebookEventTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookGroupTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookGroupTest.php
@@ -17,7 +17,7 @@
 class JFacebookGroupTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookLinkTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookLinkTest.php
@@ -17,7 +17,7 @@
 class JFacebookLinkTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookNoteTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookNoteTest.php
@@ -17,7 +17,7 @@
 class JFacebookNoteTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookOauthTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookOauthTest.php
@@ -17,7 +17,7 @@
 class JFacebookOauthTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookObjectTest.php
@@ -19,7 +19,7 @@ require_once __DIR__ . '/stubs/JFacebookObjectMock.php';
 class JFacebookObjectTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookPhotoTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookPhotoTest.php
@@ -17,7 +17,7 @@
 class JFacebookPhotoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookPostTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookPostTest.php
@@ -17,7 +17,7 @@
 class JFacebookPostTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookStatusTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookStatusTest.php
@@ -17,7 +17,7 @@
 class JFacebookStatusTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookTest.php
@@ -17,7 +17,7 @@
 class JFacebookTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookUserTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookUserTest.php
@@ -17,7 +17,7 @@
 class JFacebookUserTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookVideoTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookVideoTest.php
@@ -17,7 +17,7 @@
 class JFacebookVideoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Joomla\Registry\Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubAccountTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubAccountTest.php
@@ -18,7 +18,7 @@
 class JGithubAccountTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubCommitsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubCommitsTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/github/commits.php';
 class JGitHubCommitsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubForksTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubForksTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/github/forks.php';
 class JGithubForksTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
@@ -18,7 +18,7 @@
 class JGithubGistsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubHooksTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubHooksTest.php
@@ -17,7 +17,7 @@
 class JGithubHooksTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubHttpTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubHttpTest.php
@@ -21,7 +21,7 @@ require_once JPATH_PLATFORM . '/joomla/http/transport/stream.php';
 class JGithubHttpTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubIssuesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubIssuesTest.php
@@ -18,7 +18,7 @@
 class JGithubIssuesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubMetaTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubMetaTest.php
@@ -17,7 +17,7 @@
 class JGithubMetaTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubMilestonesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubMilestonesTest.php
@@ -18,7 +18,7 @@
 class JGithubMilestonesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubObjectTest.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/stubs/JGithubObjectMock.php';
 class JGithubObjectTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageActivityTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageActivityTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageActivityTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageAuthorizationsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageAuthorizationsTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageAuthorizationsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/github/gists.php';
 class JGithubPackageGistsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageGitignoreTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageGitignoreTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageGitignoreTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageIssuesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageIssuesTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageIssuesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageMarkdownTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageMarkdownTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageMarkdownTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageOrgsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageOrgsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageOrgsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackagePullsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackagePullsTest.php
@@ -18,7 +18,7 @@
 class JGithubPackagePullsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageRepositoriesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageRepositoriesTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageSearchTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageSearchTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageSearchTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageUsersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageUsersTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageUsersTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubPullsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPullsTest.php
@@ -18,7 +18,7 @@
 class JGithubPullsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubRefsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubRefsTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/github/refs.php';
 class JGithubRefsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubStatusesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubStatusesTest.php
@@ -18,7 +18,7 @@
 class JGithubStatusesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubTest.php
@@ -20,7 +20,7 @@ require_once JPATH_PLATFORM . '/joomla/github/github.php';
 class JGithubTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/JGithubUsersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubUsersTest.php
@@ -18,7 +18,7 @@
 class JGithubUsersTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityEventsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityEventsTest.php
@@ -17,7 +17,7 @@
 class JGithubPackageActivityEventsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityNotificationsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityNotificationsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityStarringTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityStarringTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityWatchingTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityWatchingTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataBlobsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataBlobsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageDataBlobsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataCommitsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataCommitsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageDataCommitsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataRefsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataRefsTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageDataRefsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTagsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTagsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageDataTagsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTreesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTreesTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageDataTreesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesAssigneesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesAssigneesTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageIssuesAssigneesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesCommentsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesEventsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesEventsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageIssuesEventsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesLabelsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesLabelsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesMilestonesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesMilestonesTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageIssuesMilestonesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsMembersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsMembersTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsTeamsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsTeamsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/pulls/JGithubPackagePullsCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/pulls/JGithubPackagePullsCommentsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackagePullsCommentsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCollaboratorsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCollaboratorsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesCollaboratorsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCommentsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesCommentsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesContentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesContentsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesContentsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesDownloadsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesDownloadsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesDownloadsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesForksTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesForksTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/github/forks.php';
 class JGithubPackageRepositoriesForksTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesHooksTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesHooksTest.php
@@ -17,7 +17,7 @@
 class JGithubPackageRepositoriesHooksTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesKeysTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesKeysTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesMergingTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesMergingTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesStatusesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesStatusesTest.php
@@ -18,7 +18,7 @@
 class JGithubPackageRepositoriesStatusesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersEmailsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersEmailsTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageUsersEmailsTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersFollowersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersFollowersTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersKeysTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersKeysTest.php
@@ -5,7 +5,7 @@
 class JGithubPackageUsersKeysTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Joomla\Registry\Registry  Options for the GitHub object.
 	 * @since  11.4
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/google/JGoogleAuthOauth2Test.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleAuthOauth2Test.php
@@ -18,7 +18,7 @@ require_once JPATH_TESTS . '/suites/libraries/joomla/application/stubs/JApplicat
 class JGoogleAuthOauth2Test extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataAdsenseTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataAdsenseTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataAdsenseTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataCalendarTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataCalendarTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataCalendarTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaAlbumTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaAlbumTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPicasaAlbumTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaPhotoTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaPhotoTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPicasaPhotoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPicasaTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusActivitiesTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusActivitiesTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPlusActivitiesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusCommentsTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPlusCommentsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusPeopleTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusPeopleTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPlusPeopleTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPlusTest.php
@@ -16,7 +16,7 @@
 class JGoogleDataPlusTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedAnalyticsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedAnalyticsTest.php
@@ -16,7 +16,7 @@
 class JGoogleEmbedAnalyticsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -16,7 +16,7 @@
 class JGoogleEmbedMapsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleTest.php
@@ -16,7 +16,7 @@
 class JGoogleTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinCommunicationsTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinCommunicationsTest.php
@@ -18,7 +18,7 @@
 class JLinkedinCommunicationsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinCompaniesTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinCompaniesTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/companies.php';
 class JLinkedinCompaniesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinGroupsTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinGroupsTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/groups.php';
 class JLinkedinGroupsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinJobsTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinJobsTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/jobs.php';
 class JLinkedinJobsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinOAuthTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinOAuthTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/oauth.php';
 class JLinkedinOAuthTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinObjectTest.php
@@ -21,7 +21,7 @@ require_once __DIR__ . '/stubs/JLinkedinObjectMock.php';
 class JLinkedinObjectTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinPeopleTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinPeopleTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/people.php';
 class JLinkedinPeopleTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinStreamTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinStreamTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/stream.php';
 class JLinkedinStreamTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/linkedin/JLinkedinTest.php
+++ b/tests/unit/suites/libraries/joomla/linkedin/JLinkedinTest.php
@@ -19,7 +19,7 @@ require_once JPATH_PLATFORM . '/joomla/linkedin/linkedin.php';
 class JLinkedinTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Joomla\Registry\Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiCategoriesTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiCategoriesTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/categories.php';
 class JMediawikiCategoriesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiHttpTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiHttpTest.php
@@ -21,7 +21,7 @@ require_once JPATH_PLATFORM . '/joomla/http/transport/stream.php';
 class JMediawikiHttpTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiImagesTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiImagesTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/images.php';
 class JMediawikiImagesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiLinksTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiLinksTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/links.php';
 class JMediawikiLinksTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiObjectTest.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/stubs/JMediawikiObjectMock.php';
 class JMediawikiObjectTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiPagesTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiPagesTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/pages.php';
 class JMediawikiPagesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiSearchTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiSearchTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/search.php';
 class JMediawikiSearchTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiSitesTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiSitesTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/sites.php';
 class JMediawikiSitesTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiTest.php
@@ -20,7 +20,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/mediawiki.php';
 class JMediawikiTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiUsersTest.php
+++ b/tests/unit/suites/libraries/joomla/mediawiki/JMediawikiUsersTest.php
@@ -22,7 +22,7 @@ require_once JPATH_PLATFORM . '/joomla/mediawiki/users.php';
 class JMediawikiUsersTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Mediawiki object.
+	 * @var    Joomla\Registry\Registry  Options for the Mediawiki object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
+++ b/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
@@ -26,7 +26,7 @@ class JOAuth1ClientTest extends TestCase
 	protected $input;
 
 	/**
-	 * @var    JRegistry  Options for the OAuth object.
+	 * @var    Joomla\Registry\Registry  Options for the OAuth object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/oauth2/JOauth2ClientTest.php
+++ b/tests/unit/suites/libraries/joomla/oauth2/JOauth2ClientTest.php
@@ -17,7 +17,7 @@
 class JOAuth2ClientTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Joomla\Registry\Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapChangesetsTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapChangesetsTest.php
@@ -18,7 +18,7 @@
 class JOpenstreetmapChangesetsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapElementsTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapElementsTest.php
@@ -18,7 +18,7 @@
 class JOpenstreetmapElementsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapGpsTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapGpsTest.php
@@ -18,7 +18,7 @@
 class JOpenstreetmapGpsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapInfoTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapInfoTest.php
@@ -18,7 +18,7 @@
 class JOpenstreetmapInfoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapOauthTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapOauthTest.php
@@ -17,7 +17,7 @@
 class JOpenstreetmapOauthTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapObjectTest.php
@@ -20,7 +20,7 @@ include_once __DIR__ . '/stubs/JOpenstreetmapObjectMock.php';
 class JOpenstreetmapObjectTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapTest.php
@@ -17,7 +17,7 @@
 class JOpenstreetmapTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapUserTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapUserTest.php
@@ -18,7 +18,7 @@
 class JOpenstreetmapUserTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Openstreetmap object.
+	 * @var    Joomla\Registry\Registry  Options for the Openstreetmap object.
 	 * @since  13.1
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterBlockTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterBlockTest.php
@@ -18,7 +18,7 @@
 class JTwitterBlockTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since 12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterDirectmessagesTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterDirectmessagesTest.php
@@ -18,7 +18,7 @@
 class JTwitterDirectmessagesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterFavoritesTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterFavoritesTest.php
@@ -18,7 +18,7 @@
 class JTwitterFavoritesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterFriendsTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterFriendsTest.php
@@ -18,7 +18,7 @@
 class JTwitterFriendsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterHelpTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterHelpTest.php
@@ -18,7 +18,7 @@
 class JTwitterHelpTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterListsTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterListsTest.php
@@ -18,7 +18,7 @@
 class JTwitterListsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterOauthTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterOauthTest.php
@@ -19,7 +19,7 @@ include_once __DIR__ . '/../application/stubs/JApplicationWebInspector.php';
 class JTwitterOauthTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterObjectTest.php
@@ -20,7 +20,7 @@ include_once __DIR__ . '/stubs/JTwitterObjectMock.php';
 class JTwitterObjectTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterPlacesTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterPlacesTest.php
@@ -18,7 +18,7 @@
 class JTwitterPlacesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterProfileTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterProfileTest.php
@@ -18,7 +18,7 @@
 class JTwitterProfileTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterSearchTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterSearchTest.php
@@ -18,7 +18,7 @@
 class JTwitterSearchTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterStatusesTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterStatusesTest.php
@@ -18,7 +18,7 @@
 class JTwitterStatusesTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterTest.php
@@ -17,7 +17,7 @@
 class JTwitterTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterTrendsTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterTrendsTest.php
@@ -18,7 +18,7 @@
 class JTwitterTrendsTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/tests/unit/suites/libraries/joomla/twitter/JTwitterUsersTest.php
+++ b/tests/unit/suites/libraries/joomla/twitter/JTwitterUsersTest.php
@@ -18,7 +18,7 @@
 class JTwitterUsersTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Joomla\Registry\Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;


### PR DESCRIPTION
### Issue

Currently, IDEs like PHPStorm are showing errors for JRegistry objects because it can't find the class. This is actually correct because JRegistry doesn't exist anymore. It's now a namespaced class from the framework called `Joomla\Registry\Registry`.
You can still use `new JRegistry` to create a Registry object because we have some alias set up in our loader.
### Proposed Solution

As a first step I change the doc blocs so they point to the real class instead of the alias. Meaning I changed `JRegistry` to `Joomla\Registry\Registry`. That should allow IDEs to find it at least in some instances. Probably not in all places.
As I only change doc blocs, it should have no impact on the actual code at all.
### Testing

Test with your IDE if you get less warnings about undefined JRegistry class and its methods.
In the actual CMS, nothing should change at all.
### Future steps

There are still over 800 uses of `JRegistry` in the core code. I think creating new Registry objects would be easy to change as well to `new Joomla\Registry\Registry`.
I'm not yet sure how the type hinting has to be done. Maybe anyone already used that with namespaced objects?

Feedback welcome!
