### PR TITLE
Remove Possibility of Timing Attacks

### DIFF
--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -127,6 +127,8 @@ class JCryptPasswordSimple implements JCryptPassword
 	 */
 	public function verify($password, $hash)
 	{
+		// A nonce for double-HMAC comparison
+		$nonce = JCrypt::genRandomBytes(32);
 		// Check if the hash is a blowfish hash.
 		if (substr($hash, 0, 4) == '$2a$' || substr($hash, 0, 4) == '$2y$')
 		{
@@ -141,19 +143,31 @@ class JCryptPasswordSimple implements JCryptPassword
 
 			$hash = $type . substr($hash, 4);
 
-			return (crypt($password, $hash) === $hash);
+			// Use HMAC with a random key to make the comparison operation
+			// resistant to remote timing attacks
+			return (
+				hash_hmac('sha256', crypt($password, $hash), $nonce)
+					===
+				hash_hmac('sha256', $hash, $nonce)
+			);
 		}
 
 		// Check if the hash is an MD5 hash.
 		if (substr($hash, 0, 3) == '$1$')
 		{
-			return (crypt($password, $hash) === $hash);
+			// Use HMAC with a random key to make the comparison operation
+			// resistant to remote timing attacks
+			return (
+				hash_hmac('sha256', crypt($password, $hash), $nonce)
+					===
+				hash_hmac('sha256', $hash, $nonce)
+			);
 		}
 
 		// Check if the hash is a Joomla hash.
 		if (preg_match('#[a-z0-9]{32}:[A-Za-z0-9]{32}#', $hash) === 1)
 		{
-			return md5($password . substr($hash, 33)) == substr($hash, 0, 32);
+			return hash_hmac('sha256', md5($password . substr($hash, 33)), $nonce) === hash_hmac('sha256', substr($hash, 0, 32), $nonce);
 		}
 
 		return false;


### PR DESCRIPTION
https://www.isecpartners.com/blog/2011/february/double-hmac-verification.aspx

Let's not compare hashes in a way that creates cryptographic
side-channels.

When you compare two hashes with the `==` or `===` operators, PHP will
internally use `memcmp()` which returns false after the first byte fails
to match. This creates a side-channel (known in the literature as a
timing attack).

This patch uses hash_hmac() of the expected and supplied strings with a
random 32-byte nonce (a number to be used once) for each comparison,
thus making timing attacks useless. (The output for the comparison
operation is no longer attacker-controllable, so attempting to measure
the time an request takes to fail is useless.)
