### PR TITLE
[#33899] Methods declared void must not return a value.

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -31,7 +31,7 @@ class PlgSystemSef extends JPlugin
 
 		if ($app->getName() != 'site' || $doc->getType() !== 'html')
 		{
-			return true;
+			return;
 		}
 
 		$router = $app::getRouter();


### PR DESCRIPTION
Methods declared void must not return a value.
Tracker http://code.joomla.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33899&start=0
