### PR TITLE
[#33902] [imp] JArrayHelper::toObject allow non-recursive conversion

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -90,14 +90,15 @@ abstract class JArrayHelper
 	/**
 	 * Utility function to map an array to a stdClass object.
 	 *
-	 * @param   array   &$array  The array to map.
-	 * @param   string  $class   Name of the class to create
+	 * @param   array    &$array     The array to map.
+	 * @param   string   $class      Name of the class to create
+	 * @param   boolean  $recursive  Convert also any array inside the main array
 	 *
 	 * @return  object   The object mapped from the given array
 	 *
 	 * @since   11.1
 	 */
-	public static function toObject(&$array, $class = 'stdClass')
+	public static function toObject(&$array, $class = 'stdClass', $recursive = true)
 	{
 		$obj = null;
 
@@ -107,7 +108,7 @@ abstract class JArrayHelper
 
 			foreach ($array as $k => $v)
 			{
-				if (is_array($v))
+				if ($recursive && is_array($v))
 				{
 					$obj->$k = self::toObject($v, $class);
 				}
@@ -117,6 +118,7 @@ abstract class JArrayHelper
 				}
 			}
 		}
+
 		return $obj;
 	}
 


### PR DESCRIPTION
Tracker item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33902&start=0

The default mode of the function `JArrayHelper::toObject` is to recursively convert any subarray in another object of the same specified class. I would say this makes no sense in 99% of the times.

This PR adds a way to use the same function but without subarray conversion.

Let's say that you have an array like:

``` php
$array = array(
    'prop1' => 'value1',
    'prop2' => 'value2',
    'prop3' => array(
        'subprop1' => 'value1',
        'subprop2' => 'value2'
    )
);
```

Current conversion is used like:

``` php
$converted = JArrayHelper::toObject($array, 'JObject');
echo '<pre>';
print_r($converted);
echo '</pre>';
```

Result:

```
JObject Object
(
    [_errors:protected] => Array
        (
        )

    [prop1] => value1
    [prop2] => value2
    [prop3] => JObject Object
        (
            [_errors:protected] => Array
                (
                )

            [subprop1] => value1
            [subprop2] => value2
        )

)
```

As you see prop3 is converted to `JObject` too. That's most of the times a non-desired behavior but now it's forced.

I added a new parameter to the function with default = true to keep BC but allowing us to convert only the main array to the desired object keeping the rest children subarrays with their original values. So a call like:

``` php
$convertedNonRecursive = JArrayHelper::toObject($array, 'JObject', false);

echo '<pre>';
print_r($convertedNonRecursive);
echo '</pre>';
```

Will show:

```
JObject Object
(
    [_errors:protected] => Array
        (
        )

    [prop1] => value1
    [prop2] => value2
    [prop3] => Array
        (
            [subprop1] => value1
            [subprop2] => value2
        )

)
```
## Test instructions

`JArrayHelper::toObject` is mainly used in the models `getItem()` function so after applying the patch ensure that all is working. You can also use this sample code:

``` php
$array = array(
    'prop1' => 'value1',
    'prop2' => 'value2',
    'prop3' => array(
        'subprop1' => 'value1',
        'subprop2' => 'value2'
    )
);

$converted = JArrayHelper::toObject($array, 'JObject');
$convertedNonRecursive = JArrayHelper::toObject($array, 'JObject', false);

echo '<pre>';
print_r($converted);
print_r($convertedNonRecursive);
echo '</pre>';
```

That will show that the function is stil lBC and the new feature. 
