### PR TITLE
[#33907] JTable not considering the null-value for the primary key breaks JTable::reset()

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -129,6 +129,10 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		{
 			$key = (array) $key;
 		}
+		elseif (!$key)
+		{
+			$key = array();
+		}
 
 		$this->_tbl_keys = $key;
 

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -477,8 +477,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			}
 			else
 			{
-				// If we want the standard method, just return the first key.
-				return $this->_tbl_keys[0];
+				// If we want the standard method, just return the first key if there is any.
+				return current($this->_tbl_keys);
 			}
 		}
 
@@ -782,7 +782,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		}
 		else
 		{
-			$result = $this->_db->insertObject($this->_tbl, $this, $this->_tbl_keys[0]);
+			$result = $this->_db->insertObject($this->_tbl, $this, current($this->_tbl_keys));
 		}
 
 		// If the table is not set to track assets return true.


### PR DESCRIPTION
`JTable::_construct($table, $key, $db)` initialises several class fields such as `JTable::$_tbl_keys`. When the constructor parameter `$key` is properly initialised and assigned to the field `JTable::$_tbl_keys` overriding its default value the class field `JTable::$_tbl_keys` may get broken. Consider the case where the constructor parameter `$key` becomes null due to the null-value passed in for it. Through the assignment to `JTable::$_tbl_keys` that class fields value becomes null too which will cause trouble.

For example `JTable::reset()`, which executes an `in_array()` based on `JTable::$_tbl_keys`. This check then fails with the following error: 

in_array() expects parameter 2 to be array, null given in /libraries/joomla/table/table.php on line 563

because `JTable::$_tbl_keys` value is null.

This pull request extends the constructor to consider the null-value and initialise $key with an empty array in case the passed in value is null.

The related tracker item [#33907](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33907) can be found at [joomlacode.org](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33907).
