### PR TITLE
[#33908] Require password reset can be skipped

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -130,22 +130,6 @@ class JApplicationAdministrator extends JApplicationCms
 			}
 		}
 
-		// Check if the user is required to reset their password
-		$user = JFactory::getUser();
-
-		if ($user->get('requireReset', 0) === '1')
-		{
-			if ($this->input->getCmd('option') != 'com_admin' && $this->input->getCmd('view') != 'profile' && $this->input->getCmd('layout') != 'edit')
-			{
-				if ($this->input->getCmd('task') != 'profile.save')
-				{
-					// Redirect to the profile edit page
-					$this->enqueueMessage(JText::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
-					$this->redirect(JRoute::_('index.php?option=com_admin&task=profile.edit&id=' . $user->id, false));
-				}
-			}
-		}
-
 		// Mark afterInitialise in the profiler.
 		JDEBUG ? $this->profiler->mark('afterInitialise') : null;
 
@@ -154,6 +138,15 @@ class JApplicationAdministrator extends JApplicationCms
 
 		// Mark afterRoute in the profiler.
 		JDEBUG ? $this->profiler->mark('afterRoute') : null;
+
+		/*
+		 * Check if the user is required to reset their password
+		 *
+		 * Before $this->route(); "option" and "view" can't be safely read using:
+		 * $this->input->getCmd('option'); or $this->input->getCmd('view');
+		 * ex: due of the sef urls
+		 */
+		$this->checkUserRequireReset('com_admin', 'profile', 'edit', 'profile.save,profile.apply');
 
 		// Dispatch the application
 		$this->dispatch();

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -290,6 +290,7 @@ class JApplicationCms extends JApplicationWeb
 			 * (can be configured using the file: configuration.php, or if extended, through the global configuration form)
 			 */
 			$name = $this->getName();
+
 			if ($this->get($name . '_reset_password_override', 0))
 			{
 				$option = $this->get($name . '_reset_password_option', '');

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -268,6 +268,62 @@ class JApplicationCms extends JApplicationWeb
 	}
 
 	/**
+	 * Check if the user is required to reset their password.
+	 *
+	 * If the user is required to reset their password will be redirected to the page that manage the password reset.
+	 *
+	 * @param   string $option The option that manage the password reset
+	 * @param   string $view The view that manage the password reset
+	 * @param   string $layout The layout of the view that manage the password reset
+	 * @param   string $tasks Permitted tasks
+	 */
+	protected function checkUserRequireReset($option, $view, $layout, $tasks)
+	{
+		if (JFactory::getUser()->get('requireReset', 0))
+		{
+			$redirect = false;
+
+			/*
+			 * By default user profile edit page is used.
+			 * That page allows you to change more than just the password and might not be the desired behavior.
+			 * This allows a developer to override the page that manage the password reset.
+			 * (can be configured using the file: configuration.php, or if extended, through the global configuration form)
+			 */
+			$name = $this->getName();
+			if ($this->get($name . '_reset_password_override', 0))
+			{
+				$option = $this->get($name . '_reset_password_option', '');
+				$view = $this->get($name . '_reset_password_view', '');
+				$layout = $this->get($name . '_reset_password_layout', '');
+				$tasks = explode(',', $this->get($name . '_reset_password_tasks', ''));
+			}
+
+			if ($this->input->getCmd('option', '') != $option || $this->input->getCmd('view', '') != $view || $this->input->getCmd('layout', '') != $layout)
+			{
+				// Requested a different page
+				$redirect = true;
+			}
+			else
+			{
+				$task = $this->input->getCmd('task', '');
+				// Empty task are always permitted
+				if (!empty($task) && array_search($task, $tasks) === false)
+				{
+					// Not permitted task
+					$redirect = true;
+				}
+			}
+
+			if ($redirect)
+			{
+				// Redirect to the profile edit page
+				$this->enqueueMessage(JText::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
+				$this->redirect(JRoute::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false));
+			}
+		}
+	}
+
+	/**
 	 * Gets a configuration value.
 	 *
 	 * @param   string  $varname  The name of the value to get.

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -307,6 +307,7 @@ class JApplicationCms extends JApplicationWeb
 			else
 			{
 				$task = $this->input->getCmd('task', '');
+
 				// Empty task are always permitted
 				if (!empty($task) && array_search($task, $tasks) === false)
 				{

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -195,22 +195,6 @@ final class JApplicationSite extends JApplicationCms
 		// Initialise the application
 		$this->initialiseApp();
 
-		// Check if the user is required to reset their password
-		$user = JFactory::getUser();
-
-		if ($user->get('requireReset', 0) === '1')
-		{
-			if ($this->input->getCmd('option') != 'com_users' && $this->input->getCmd('view') != 'profile' && $this->input->getCmd('layout') != 'edit')
-			{
-				if ($this->input->getCmd('task') != 'profile.save')
-				{
-					// Redirect to the profile edit page
-					$this->enqueueMessage(JText::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
-					$this->redirect(JRoute::_('index.php?option=com_users&view=profile&layout=edit'));
-				}
-			}
-		}
-
 		// Mark afterInitialise in the profiler.
 		JDEBUG ? $this->profiler->mark('afterInitialise') : null;
 
@@ -219,6 +203,15 @@ final class JApplicationSite extends JApplicationCms
 
 		// Mark afterRoute in the profiler.
 		JDEBUG ? $this->profiler->mark('afterRoute') : null;
+
+		/*
+		 * Check if the user is required to reset their password
+		 *
+		 * Before $this->route(); "option" and "view" can't be safely read using:
+		 * $this->input->getCmd('option'); or $this->input->getCmd('view');
+		 * ex: due of the sef urls
+		 */
+		$this->checkUserRequireReset('com_users', 'profile', 'edit', 'profile.save,profile.apply');
 
 		// Dispatch the application
 		$this->dispatch();


### PR DESCRIPTION
=== Require password Reset can be skipped ===
A user that must reset his password can avoid to be redirected to the profile page and access any page/task if the url contains the parameter layout=edit.

The check code was mostly duplicated on site and administrator application.
I have created a new method in class JAppilcationWeb that manage this check, every application can call this method specifying the page that manage the password reset.

In the site application this check must be done after the "route" because parameters 'option', 'view' and 'layout' can be placed anywhere in the url (due to sef urls).
For symmetry i also placed, in the administrator application, the call to the check method after the "route" method is called.

The page that manage the password reset can now be customized for each application using the configuration.php file.

=== How to reproduce the bug ===
Edit a user, and enable the flag "Require password Reset".
After user login to the backend side, he is required to change his password and he is redirected to http://...website.../administrator/index.php?option=com_admin&view=profile&layout=edit&id=473
Every attempt to browse a different page (even a logoff), ends with a redirection to che password change.
But if the user adds the query string &layout=edit he escapes from the password prompt and actually goes to item editing.
For example, supposing that the article with id=1 exists, write the following url:
http://...website.../administrator/index.php?option=com_content&task=article.edit&id=1&layout=edit
Note the query string &layout=edit at the end of the url

=== Links ===
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33908&start=0
