### PR TITLE
Add ID to module view

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -135,7 +135,8 @@ JFactory::getDocument()->addScriptDeclaration($script);
 					'access',
 					'ordering',
 					'language',
-					'note'
+					'note',
+					'id'
 				);
 
 				?>


### PR DESCRIPTION
Based on a request in the mailing list which originated from the forums:
https://groups.google.com/d/msg/joomla-dev-cms/fRvI7qsedbU/VwJLzslLLIUJ
### What this does

This PR adds the module ID to the module edit view.
### Testing Instructions

Apply patch and see if the ID is now shown below the "note" field.

As for the position, if you have a better idea as to where to show it, I'm open :smile: 
