### PR TITLE
Fix Copy Template and Rename File buttons if Hathor is uninstalled

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -1157,36 +1157,6 @@ class TemplatesModelTemplate extends JModelForm
 	}
 
 	/**
-	 * Check the admin template.
-	 *
-	 * @return  object  object containing the id of the template.
-	 *
-	 * @since   3.2
-	 */
-	public function getHathor()
-	{
-		$app = JFactory::getApplication();
-		$db = $this->getDbo();
-		$query = $db->getQuery(true);
-
-		$query->select('home');
-		$query->from('#__template_styles');
-		$query->where($db->quoteName('template') . ' = ' . $db->quote('hathor'));
-		$db->setQuery($query);
-
-		try
-		{
-			$result = $db->loadObject();
-		}
-		catch (RuntimeException $e)
-		{
-			$app->enqueueMessage($e->getMessage(), 'error');
-		}
-
-		return $result;
-	}
-
-	/**
 	 * Copy a file.
 	 *
 	 * @param   string  $newName    The name of the copied file

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -79,11 +79,6 @@ class TemplatesViewTemplate extends JViewLegacy
 	protected $font;
 
 	/**
-	 * For checking if the template is hathor
-	 */
-	protected $hathor;
-
-	/**
 	 * A nested array containing lst of files and folders
 	 */
 	protected $files;
@@ -111,7 +106,6 @@ class TemplatesViewTemplate extends JViewLegacy
 		$this->state    = $this->get('State');
 		$this->template = $this->get('Template');
 		$this->preview  = $this->get('Preview');
-		$this->hathor   = $this->get('Hathor');
 
 		$params       = JComponentHelper::getParams('com_templates');
 		$imageTypes   = explode(',', $params->get('image_formats'));
@@ -171,7 +165,8 @@ class TemplatesViewTemplate extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		JFactory::getApplication()->input->set('hidemainmenu', true);
+		$app   = JFactory::getApplication();
+		$app->input->set('hidemainmenu', true);
 		$canDo = JHelperContent::getActions('com_templates');
 
 		if ($canDo->get('core.edit') && $canDo->get('core.create') && $canDo->get('core.admin'))
@@ -218,8 +213,8 @@ class TemplatesViewTemplate extends JViewLegacy
 			}
 		}
 
-		// Add a copy template button (Hathor may not be available)
-		if (empty($this->hathor->home))
+		// Add a copy template button (Hathor override doesn't need the button)
+		if ($app->getTemplate() != 'hathor')
 		{
 			if ($showButton)
 			{
@@ -245,8 +240,8 @@ class TemplatesViewTemplate extends JViewLegacy
 			JToolbarHelper::modal('fileModal', 'icon-file', 'COM_TEMPLATES_BUTTON_FILE');
 		}
 
-		// Add a Rename file Button
-		if (empty($this->hathor->home))
+		// Add a Rename file Button (Hathor override doesn't need the button)
+		if ($app->getTemplate() != 'hathor')
 		{
 			if ($showButton && $this->type != 'home')
 			{

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -219,7 +219,7 @@ class TemplatesViewTemplate extends JViewLegacy
 		}
 
 		// Add a copy template button (Hathor may not be available)
-		if ($this->hathor && $this->hathor->home == 0)
+		if (empty($this->hathor->home))
 		{
 			if ($showButton)
 			{
@@ -246,7 +246,7 @@ class TemplatesViewTemplate extends JViewLegacy
 		}
 
 		// Add a Rename file Button
-		if ($this->hathor && $this->hathor->home == 0)
+		if (empty($this->hathor->home))
 		{
 			if ($showButton && $this->type != 'home')
 			{


### PR DESCRIPTION
Based on a JSE question: http://joomla.stackexchange.com/questions/2501/where-is-the-copy-template-button-in-template-manager-in-j3-3-1-after-update
### Issue

If you uninstall Hathor, the "Copy Template" and "Rename File" buttons in the template manager is no longer showing up. This is because the current check explicitely checks for `0`. The database query however returns `null` if Hathor is uninstalled.
The check is needed because Hathor has special overrides where those features are offered in a accordion instead of a button. Thus the button should be hidden if Hathor is the active template.
### Solution

Since we can get the active template name using the API `JFactory::getApplication()->getTemplate()` I have changed the code to use this, only showing the button if it's not "hathor".
I also removed the model method `getHathor` and the view property `hathor` because they are no longer needed. With this approach it should even use one less database query.
#### Testing
- Check in Hathor that the buttons still don't show.
- Switch to Isis and uninstall Hathor and check the presence of the mentioned buttons in the template manager (when you edit a template or a file).
