### PR TITLE
Cloak only in HTML mode

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -31,7 +31,7 @@ class PlgContentEmailcloak extends JPlugin
 	public function onContentPrepare($context, &$row, &$params, $page = 0)
 	{
 		// Don't run this plugin when the content is being indexed
-		if ($context == 'com_finder.indexer')
+		if ($context == 'com_finder.indexer' || JFactory::getDocument()->getType() != 'html')
 		{
 			return true;
 		}


### PR DESCRIPTION
On raw or json requests (format=raw) the cloaking javascript code is injected into the response which can lead to a strange behavior. For example the whole page turns into whit with only the mail address displayed. This bug was discoverd while using the free version of DPCalendar https://joomla.digital-peak.com/products/dpcalendar.
