### PR TITLE
[#33930] Fix addTaxonomy and getTaxonomy

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -379,7 +379,7 @@ class FinderIndexerResult
 		if ($branch !== null && isset($this->taxonomy[$branch]))
 		{
 			// Filter the input.
-			$branch = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,]+#mui', ' ', $branch);
+			$branch = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,_]+#mui', ' ', $branch);
 
 			return $this->taxonomy[$branch];
 		}
@@ -402,7 +402,7 @@ class FinderIndexerResult
 	public function addTaxonomy($branch, $title, $state = 1, $access = 1)
 	{
 		// Filter the input.
-		$branch = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,]+#mui', ' ', $branch);
+		$branch = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,_]+#mui', ' ', $branch);
 
 		// Create the taxonomy node.
 		$node = new JObject;


### PR DESCRIPTION
A FinderIndexerResult may contain taxonomies. These are collected within named arrays unter the taxonomies-property like

``` ruby
[taxonomy:protected] => Array
(
   [collection1] => Array
   (
      [2] => JObject Object
      (
         [title]  => 2
         [state]  => 1
         [access] => 1
      )
   [collection2] => Array
   (
      [THE_NAME] => JObject Object
      (
         [title]  => THE_NAME
         [state]  => 1
         [access] => 1
      )
   )
   [YET ANOTHER COLLECTION] => Array     // underscores are replaces by blanks
   (
      [ANOTHER_NAME] => JObject Object   // underscores preserved
      (
         [title]  => ANOTHER_NAME
         [state]  => 1
         [access] => 1
      )
   )
)
```

As can be seen every taxonomy item (collection1, collection2, YET ANOTHER COLLECTION) is an array containing 1+ JObjects. Also we can see that taxonomy names and JObject names might contain underscores.

Now the problem is, that underscores in taxonomy names are replaced by blanks while those in the JObject names are not (see: YET ANOTHER COLLECTION vs. ANOTHER_NAME). This is a big problem when using translation keys for taxonomy names like in my case. As the underscores are replaces the keys are broken, the indexer creates taxonomies other than wished and the search doesn't find them.

The solution for this issue is to not replace underscores. Why should they be replaced at all when they're allowed for all other names and titles!?

The PR extends the regular expression to preserve underscores in taxonomy names.

[associated tracker item](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33930)
