### PR TITLE
[#33921] Label layout

### DIFF
--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ * 	$text         : (string)  The label text
+ * 	$description  : (string)  An optional description to use in a tooltip
+ * 	$for          : (string)  The id of the input this label is for
+ * 	$required     : (boolean) True if a required field
+ * 	$classes      : (array)   A list of classes
+ */
+
+$text    = $displayData['text'];
+$desc    = $displayData['description'];
+$for     = $displayData['for'];
+$req     = $displayData['required'];
+$classes = array_filter((array) $displayData['classes']);
+
+$id = $for . '-lbl';
+$title = '';
+
+// If a description is specified, use it to build a tooltip.
+if (!empty($desc))
+{
+	JHtml::_('bootstrap.tooltip');
+	$classes[] = 'hasTooltip';
+	$title = ' title="' . JHtml::tooltipText(trim($text, ':'), $desc, 0) . '"';
+}
+
+// If required, there's a class for that.
+if ($req)
+{
+	$classes[] = 'required';
+}
+
+?>
+<label id="<?php echo $id; ?>" for="<?php echo $for; ?>" class="<?php echo implode(' ', $classes); ?>"<?php echo $title; ?>>
+	<?php echo $text; ?><?php if ($req) : ?><span class="star">&#160;*</span><?php endif; ?>
+</label>

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -312,6 +312,13 @@ abstract class JFormField
 	protected $renderLayout = 'joomla.form.renderfield';
 
 	/**
+	 * Layout to render the label
+	 *
+	 * @var  string
+	 */
+	protected $renderLabelLayout = 'joomla.form.renderlabel';
+
+	/**
 	 * Method to instantiate the form field object.
 	 *
 	 * @param   JForm  $form  The form to attach to the form field object.
@@ -696,45 +703,26 @@ abstract class JFormField
 	 */
 	protected function getLabel()
 	{
-		$label = '';
-
 		if ($this->hidden)
 		{
-			return $label;
+			return '';
 		}
 
 		// Get the label text from the XML element, defaulting to the element name.
 		$text = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
 		$text = $this->translateLabel ? JText::_($text) : $text;
 
-		// Build the class for the label.
-		$class = !empty($this->description) ? 'hasTooltip' : '';
-		$class = $this->required == true ? $class . ' required' : $class;
-		$class = !empty($this->labelclass) ? $class . ' ' . $this->labelclass : $class;
+		$description = ($this->translateDescription && !empty($this->description)) ? JText::_($this->description) : $this->description;
 
-		// Add the opening label tag and main attributes attributes.
-		$label .= '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '"';
+		$displayData = array(
+				'text'        => $text,
+				'description' => $description,
+				'for'         => $this->id,
+				'required'    => (bool) $this->required,
+				'classes'     => explode(' ', $this->labelclass)
+			);
 
-		// If a description is specified, use it to build a tooltip.
-		if (!empty($this->description))
-		{
-			// Don't translate discription if specified in the field xml.
-			$description = $this->translateDescription ? JText::_($this->description) : $this->description;
-			JHtml::_('bootstrap.tooltip');
-			$label .= ' title="' . JHtml::tooltipText(trim($text, ':'), $description, 0) . '"';
-		}
-
-		// Add the label text and closing tag.
-		if ($this->required)
-		{
-			$label .= '>' . $text . '<span class="star">&#160;*</span></label>';
-		}
-		else
-		{
-			$label .= '>' . $text . '</label>';
-		}
-
-		return $label;
+		return JLayoutHelper::render($this->renderLabelLayout, $displayData);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
@@ -204,12 +204,25 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
-		$equals = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" ' .
-			'title="<strong>Title</strong><br />The title.">Title<span class="star">&#160;*</span></label>';
+		$matcher = array(
+				'id'         => 'title_id-lbl',
+				'tag'        => 'label',
+				'attributes' => array(
+						'for'   => 'title_id',
+						'class' => 'hasTooltip required',
+						'title' => '<strong>Title</strong><br />The title.'
+					),
+				'content'    => 'regexp:/Title.*\*/',
+				'child'      => array(
+						'tag'        => 'span',
+						'attributes' => array('class' => 'star'),
+						'content'    => 'regexp:/\*/'
+					)
+			);
 
-		$this->assertThat(
+		$this->assertTag(
+			$matcher,
 			$field->getLabel(),
-			$this->equalTo($equals),
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 
@@ -223,9 +236,19 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
-		$this->assertThat(
+		$matcher = array(
+				'id'         => 'colours-lbl',
+				'tag'        => 'label',
+				'attributes' => array(
+						'for'   => 'colours',
+						'class' => ''
+					),
+				'content'    => 'colours'
+			);
+
+		$this->assertTag(
+			$matcher,
 			$field->getLabel(),
-			$this->equalTo('<label id="colours-lbl" for="colours" class="">colours</label>'),
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 
@@ -239,9 +262,8 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
-		$this->assertThat(
+		$this->assertEmpty(
 			$field->getLabel(),
-			$this->equalTo(''),
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 	}
@@ -360,13 +382,37 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
+		// Matcher for the 'label' attribute
+		$matcher = array(
+				'id'         => 'myId-lbl',
+				'tag'        => 'label',
+				'attributes' => array(
+						'for'   => 'myId',
+						'class' => 'hasTooltip',
+						'title' => '<strong>My Title</strong><br />The description.'
+					),
+				'content'    => 'regexp:/My Title/'
+			);
+
 		foreach ($expected as $attr => $value)
 		{
-			$this->assertThat(
-				$field->$attr,
-				$this->equalTo($value),
-				'Line:' . __LINE__ . ' The ' . $attr . ' property should be computed from the XML.'
-			);
+			// Label is html use assertTag()
+			if ($attr == 'label')
+			{
+				$this->assertTag(
+					$matcher,
+					$field->$attr,
+					'Line:' . __LINE__ . ' The ' . $attr . ' property should be computed from the XML.'
+				);
+			}
+			else
+			{
+				$this->assertThat(
+					$field->$attr,
+					$this->equalTo($value),
+					'Line:' . __LINE__ . ' The ' . $attr . ' property should be computed from the XML.'
+				);
+			}
 		}
 	}
 

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1169,12 +1169,25 @@ class JFormTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$expected = '<label id="title_id-lbl" for="title_id" class="hasTooltip required" ' .
-				'title="<strong>Title</strong><br />The title.">Title<span class="star">&#160;*</span></label>';
+		$matcher = array(
+				'id'         => 'title_id-lbl',
+				'tag'        => 'label',
+				'attributes' => array(
+						'for'   => 'title_id',
+						'class' => 'hasTooltip required',
+						'title' => '<strong>Title</strong><br />The title.'
+					),
+				'content'    => 'regexp:/Title.*\*/',
+				'child'      => array(
+						'tag'        => 'span',
+						'attributes' => array('class' => 'star'),
+						'content'    => 'regexp:/\*/'
+					)
+			);
 
-		$this->assertThat(
+		$this->assertTag(
+			$matcher,
 			$form->getLabel('title'),
-			$this->equalTo($expected),
 			'Line:' . __LINE__ . ' The method should return a simple label field.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldHiddenTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldHiddenTest.php
@@ -19,6 +19,34 @@ JFormHelper::loadFieldClass('hidden');
 class JFormFieldHiddenTest extends TestCase
 {
 	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->saveFactoryState();
+
+		JFactory::$application = $this->getMockCmsApp();
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return void
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::teardown();
+	}
+
+	/**
 	 * Test the getInput method.
 	 *
 	 * @return void
@@ -35,11 +63,8 @@ class JFormFieldHiddenTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldHidden($form);
-
-		$this->assertThat(
+		$this->assertEmpty(
 			$form->getLabel('hidden'),
-			$this->equalTo(''),
 			'Line:' . __LINE__ . ' The label of a hidden element should be nothing.'
 		);
 
@@ -51,11 +76,8 @@ class JFormFieldHiddenTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldHidden($form);
-
-		$this->assertThat(
+		$this->assertEmpty(
 			$form->getLabel('hidden'),
-			$this->equalTo(''),
 			'Line:' . __LINE__ . ' The label of a hidden element should be nothing.'
 		);
 
@@ -67,11 +89,19 @@ class JFormFieldHiddenTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldHidden($form);
+		$matcher = array(
+				'id'         => 'hidden-lbl',
+				'tag'        => 'label',
+				'attributes' => array(
+						'for'   => 'hidden',
+						'class' => ''
+					),
+				'content'    => 'regexp:/foo/'
+			);
 
-		$this->assertThat(
+		$this->assertTag(
+			$matcher,
 			$form->getLabel('hidden'),
-			$this->equalTo('<label id="hidden-lbl" for="hidden" class="">foo</label>'),
 			'Line:' . __LINE__ . ' The label of a non-hidden element should be some HTML.'
 		);
 	}


### PR DESCRIPTION
Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33921&start=0

Use layouts to render form field labels so that template designers can override them.
