### PR TITLE
Fix Javascript error handling message during update

### DIFF
--- a/media/com_joomlaupdate/update.js
+++ b/media/com_joomlaupdate/update.js
@@ -93,7 +93,7 @@ function doAjax(data, successCallback, errorCallback)
 			var message = 'AJAX Loading Error: '+req.statusText;
 			if (joomlaupdate_error_callback != null)
 			{
-				joomlaupdate_error_callback(msg);
+				joomlaupdate_error_callback(message);
 			}
 		}
 	};


### PR DESCRIPTION
![joomlaupdatejserror](https://cloud.githubusercontent.com/assets/2002921/3539067/604c603c-0837-11e4-8d69-fbb03f33e59a.png)

Joomla issue tracker URL,
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33935
