### PR TITLE
The htaccess file generated has a configuration error

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -402,7 +402,7 @@ ENDDATA;
 				{
 
 					JFolder::create($tempdir, 511);
-					JFile::write($tempdir . '/.htaccess', "order deny, allow\ndeny from all\nallow from none\n");
+					JFile::write($tempdir . '/.htaccess', "order deny,allow\ndeny from all\nallow from none\n");
 				}
 
 				// If it exists and it is unwritable, try creating a writable admintools subdirectory


### PR DESCRIPTION
The htaccess directive contains a typo that will result in an Internal Server Error on Apache hosts. 

order deny, allow -> order deny,allow

Docs:
http://httpd.apache.org/docs/current/mod/mod_access_compat.html

The apache lexer treats deny,allow and allow,deny as a single keyword
