### PR TITLE
[#30235] JSession::get() returns NULL under normal session operations  

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -474,7 +474,7 @@ class JSession implements IteratorAggregate
 		// Add prefix to namespace to avoid collisions
 		$namespace = '__' . $namespace;
 
-		if ($this->_state !== 'active' && $this->_state !== 'expired')
+		if ($this->_state === 'destroyed')
 		{
 			// @TODO :: generated error here
 			$error = null;


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30235

Angelika Reisiger was supplying a patch on joomlacode which has been patched here too now.
