### PR TITLE
Nicer icon

### DIFF
--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -93,7 +93,7 @@ class AdminViewSysinfo extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		JToolbarHelper::title(JText::_('COM_ADMIN_SYSTEM_INFORMATION'), 'info systeminfo');
+		JToolbarHelper::title(JText::_('COM_ADMIN_SYSTEM_INFORMATION'), 'info-2 systeminfo');
 		JToolbarHelper::help('JHELP_SITE_SYSTEM_INFORMATION');
 	}
 }


### PR DESCRIPTION
Changed IcoMoon icon info to info-2 in com_admin sysinfo

![old](https://cloud.githubusercontent.com/assets/1738811/3555107/a6ed8ec6-0913-11e4-9b4e-eb7d27a73021.png)

vs.

![new](https://cloud.githubusercontent.com/assets/1738811/3555109/a6ffe670-0913-11e4-8bf1-90388f891077.png)
