### PR TITLE
[#33731] Change width of Media tooltip

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -176,7 +176,7 @@ class JFormFieldMedia extends JFormField
 			$this->link          = (string) $this->element['link'];
 			$this->preview       = (string) $this->element['preview'];
 			$this->directory     = (string) $this->element['directory'];
-			$this->previewWidth  = isset($this->element['preview_width']) ? (int) $this->element['preview_width'] : 300;
+			$this->previewWidth  = isset($this->element['preview_width']) ? (int) $this->element['preview_width'] : 200;
 			$this->previewHeight = isset($this->element['preview_height']) ? (int) $this->element['preview_height'] : 200;
 		}
 


### PR DESCRIPTION
When adding an image, which is wider than 200px, through the media form field in backend, the image preview exceeds the tooltip box. This is because the Bootstrap tooltip container has a max-width of 200px.

I suggest that we change the current previewidth of 300px to 200px. See the solution here:

![old](https://cloud.githubusercontent.com/assets/1738811/3555760/23bdce28-091b-11e4-8cd4-e7ff7efee995.jpeg)

vs. 

![fixed](https://cloud.githubusercontent.com/assets/1738811/3555759/23bd934a-091b-11e4-9700-c6a4100dc684.jpeg)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33731&start=0
