### PR TITLE
[#33942] Consistent use of clearfix in com_installer

### DIFF
--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -10,8 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-
-<div id="installer-database">
+<div id="installer-database" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=database');?>" method="post" name="adminForm" id="adminForm">
 
 	<?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('formbehavior.chosen', 'select');
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
-<div id="installer-discover">
+<div id="installer-discover" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=discover');?>" method="post" name="adminForm" id="adminForm">
 
 	<?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -19,8 +19,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $version = new JVersion;
 
 ?>
-
-<div id="installer-languages">
+<div id="installer-languages" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=languages');?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
-<div id="installer-manage">
+<div id="installer-manage" class="clearfix">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=manage');?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
 ?>
-<div id="installer-update">
+<div id="installer-update" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=update');?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/components/com_installer/views/warnings/tmpl/default.php
+++ b/administrator/components/com_installer/views/warnings/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<div id="installer-warnings">
+<div id="installer-warnings" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=warnings');?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">


### PR DESCRIPTION
At the moment many of the different views in com_installer are lacking a clearfix, which makes the content "jump". Try tabbing through the different views to see the issue. 

This PR adds a class="clearfix" to the different divs.

![clearfix](https://cloud.githubusercontent.com/assets/1738811/3558903/73857e02-0942-11e4-8eb8-27bbb38af42d.png)

vs.

![no-clearfix](https://cloud.githubusercontent.com/assets/1738811/3558902/7372ea08-0942-11e4-8d0a-d6acce06e630.png)

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33942&start=0
