### PR TITLE
[#33914] Fix ACL of redirect manager (J2.5)

### DIFF
--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -39,7 +39,7 @@ class RedirectModelLink extends JModelAdmin
 				return false;
 			}
 			$user = JFactory::getUser();
-			return $user->authorise('core.admin', 'com_redirect');
+			return $user->authorise('core.delete', 'com_redirect');
 
 	}
 
@@ -56,7 +56,7 @@ class RedirectModelLink extends JModelAdmin
 		$user = JFactory::getUser();
 
 		// Check the component since there are no categories or other assets.
-			return $user->authorise('core.admin', 'com_redirect');
+			return $user->authorise('core.edit.state', 'com_redirect');
 
 	}
 
@@ -145,7 +145,7 @@ class RedirectModelLink extends JModelAdmin
 		$comment = (!empty($comment)) ? $comment : JText::sprintf('COM_REDIRECT_REDIRECTED_ON', JHtml::_('date', time()));
 
 		// Access checks.
-		if (!$user->authorise('core.admin', 'com_redirect')) {
+		if (!$user->authorise('core.edit', 'com_redirect')) {
 			$pks = array();
 			$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'));
 			return false;


### PR DESCRIPTION
Currently several ACL checks are performed against the "core.admin" (Configure) action for the Redirect Manager, which isn't correct. This patch fixes the wrong checks.

JoomlaCode: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33914
Pull Request for Joomla 3: https://github.com/joomla/joomla-cms/pull/3888
## Test instructions:
- Create a new user group "Test" with Public as Parent Group
- Go to the Global Configuration, tab permissions, and allow "Admin Login" for this group
- Go to Users -> Access Levels, open level "Special" and assign the group "Test" to the level
- Go to the Redirect manager, click on the Options button, open the permissions tab and allow these actions for the "Test" user group:
  - "Access Administration Interface" 
  - "Edit" 
  - "Edit State"
  - "Delete"
- Create test user, assign to Test group only
- Login with test user
- Confirm that you can't:
  - change the state of a redirect item
  - empty the items that are in the trash
  - select one or more item(s), and update the Destination URL by using the "Destination URL" feature at the bottom of the page
- apply patch
- Confirm that your test user now can:
  - change the state of a redirect item (Edit State)
  - empty the items that are in the trash (Delete)
  - select one or more item(s), and update the Destination URL by using the "Destination URL" feature at the bottom of the page (Edit)
- Change the permissions for the mentioned actions, and confirm you can or con't perform above actions depending the ACL setting.

Thank you for testing!
