### PR TITLE
Responsive tweaks to com_languages

### DIFF
--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -44,16 +44,16 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					<th>
 						<?php echo JText::_('COM_LANGUAGES_HEADING_DEFAULT'); ?>
 					</th>
-					<th>
+					<th class="hidden-phone">
 						<?php echo JText::_('JVERSION'); ?>
 					</th>
-					<th>
+					<th class="hidden-phone">
 						<?php echo JText::_('JDATE'); ?>
 					</th>
-					<th>
+					<th class="hidden-phone">
 						<?php echo JText::_('JAUTHOR'); ?>
 					</th>
-					<th>
+					<th class="hidden-phone">
 						<?php echo JText::_('COM_LANGUAGES_HEADING_AUTHOR_EMAIL'); ?>
 					</th>
 				</tr>
@@ -87,16 +87,16 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					<td align="center">
 						<?php echo JHtml::_('jgrid.isdefault', $row->published, $i, 'installed.', !$row->published && $canChange);?>
 					</td>
-					<td align="center">
+					<td align="center" class="hidden-phone">
 						<?php echo $this->escape($row->version); ?>
 					</td>
-					<td align="center">
+					<td align="center" class="hidden-phone">
 						<?php echo $this->escape($row->creationDate); ?>
 					</td>
-					<td align="center">
+					<td align="center" class="hidden-phone">
 						<?php echo $this->escape($row->author); ?>
 					</td>
-					<td align="center">
+					<td align="center" class="hidden-phone">
 						<?php echo JStringPunycode::emailToUTF8($this->escape($row->authorEmail)); ?>
 					</td>
 				</tr>

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -175,7 +175,7 @@ $sortFields = $this->getSortFields();
 						<?php endif; ?>
 						</span>
 					</td>
-					<td>
+					<td class="hidden-phone">
 						<?php echo $this->escape($item->title_native); ?>
 					</td>
 					<td class="center hidden-phone">

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -101,10 +101,10 @@ $sortFields = $this->getSortFields();
 					<th class="title">
 						<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 					</th>
-					<th class="title">
+					<th class="title hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'COM_LANGUAGES_HEADING_TITLE_NATIVE', 'a.title_native', $listDirn, $listOrder); ?>
 					</th>
-					<th width="5%" class="nowrap">
+					<th width="5%" class="nowrap hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'COM_LANGUAGES_FIELD_LANG_TAG_LABEL', 'a.lang_code', $listDirn, $listOrder); ?>
 					</th>
 					<th width="5%" class="nowrap">
@@ -116,10 +116,10 @@ $sortFields = $this->getSortFields();
 					<th width="5%" class="center nowrap">
 						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 					</th>
-					<th width="5%" class="nowrap">
+					<th width="5%" class="nowrap hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'COM_LANGUAGES_HOMEPAGE', '', $listDirn, $listOrder); ?>
 					</th>
-					<th width="1%" class="center nowrap">
+					<th width="1%" class="center nowrap hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.lang_id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>
@@ -178,7 +178,7 @@ $sortFields = $this->getSortFields();
 					<td>
 						<?php echo $this->escape($item->title_native); ?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php echo $this->escape($item->lang_code); ?>
 					</td>
 					<td class="center">
@@ -190,14 +190,14 @@ $sortFields = $this->getSortFields();
 					<td class="center">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php if ($item->home == '1') : ?>
 							<?php echo JText::_('JYES');?>
 						<?php else:?>
 							<?php echo JText::_('JNO');?>
 						<?php endif;?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php echo $this->escape($item->lang_id); ?>
 					</td>
 				</tr>


### PR DESCRIPTION
At the moment com_languages aren't presented very nice on small viewports. I've added a few class="hidden-phone" to the table elements:

![old](https://cloud.githubusercontent.com/assets/1738811/3562584/70c1a93c-09f8-11e4-9d87-fae3c265c57a.png)

vs.

![new](https://cloud.githubusercontent.com/assets/1738811/3562583/70ae7eca-09f8-11e4-9af1-e297719e4050.png)

The elements which are hidden on small viewports are: version, date, author and author email
