### PR TITLE
[#33945] Fix an empty icons div in some article views

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -64,7 +64,9 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	</div>
 	<?php endif; ?>
 	<?php if (!$this->print) : ?>
-		<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+		<?php if ($this->params->get('show_print_icon') || $this->params->get('show_email_icon')) : ?>
+			<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+		<?php endif; ?>
 	<?php else : ?>
 		<?php if ($useDefList) : ?>
 			<div id="pop-print" class="btn hidden-print">

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -64,7 +64,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	</div>
 	<?php endif; ?>
 	<?php if (!$this->print) : ?>
-		<?php if ($this->params->get('show_print_icon') || $this->params->get('show_email_icon')) : ?>
+		<?php if ($canEdit || $this->params->get('show_print_icon') || $this->params->get('show_email_icon')) : ?>
 			<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
 		<?php endif; ?>
 	<?php else : ?>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -64,7 +64,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	</div>
 	<?php endif; ?>
 	<?php if (!$this->print) : ?>
-		<?php if ($canEdit || $this->params->get('show_print_icon') || $this->params->get('show_email_icon')) : ?>
+		<?php if ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon')) : ?>
 			<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
 		<?php endif; ?>
 	<?php else : ?>

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -22,7 +22,9 @@ $info    = $params->get('info_block_position', 0);
 
 <?php echo JLayoutHelper::render('joomla.content.blog_style_default_item_title', $this->item); ?>
 
-<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+<?php if ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon')) : ?>
+	<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+<?php endif; ?>
 
 <?php if ($params->get('show_tags') && !empty($this->item->tags->itemTags)) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.tags', $this->item->tags->itemTags); ?>

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -44,7 +44,9 @@ $info    = $this->item->params->get('info_block_position', 0);
 	<span class="label label-warning"><?php echo JText::_('JEXPIRED'); ?></span>
 <?php endif; ?>
 
-<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+<?php if ($canEdit || $params->get('show_print_icon') || $params->get('show_email_icon')) : ?>
+	<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
+<?php endif; ?>
 
 <?php // Todo Not that elegant would be nice to group the params ?>
 <?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')


### PR DESCRIPTION
## Summary

When "Show Print Icon" and "Show Email Icon" both are set to "Hide" in the parameters and you do not have an "edit" rights, still an empty div class="icons" is displayed in some article views. This patch will fix it.
## How to reproduce the problem and test the patch:
1. Login to BE and proceed to "Content" -> "Article manager".
2. Click on "Options" and on the first tab "Article" set "Show Print Icon" and "Show Email Icon" both to "Hide". Be sure that the same is set up in the "Menu" parameters and that you do not have an "edit" rights.
3. Proceed to Single Article, Article Category Blog, Featured Articles views and notice that an empty div class="icons" is displayed.
4. Apply the patch. Notice that the div class="icons" is not displayed.
5. Set "Show Print Icon" and/or "Show Email Icon" to "Show". Be sure that the same is set up in the "Menu" parameters. Notice that the icons are displayed as expected.
6. Set "Show Print Icon" and "Show Email Icon" both to "Hide" and give yourself  an "edit" rights. Notice that the icon is displayed as expected.

[#33945](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33945)

Thanks @proweb for reporting the bug.
