### PR TITLE
[#28401] Display child categories of every selected Category in Module Articles Category

### DIFF
--- a/components/com_content/models/categories.php
+++ b/components/com_content/models/categories.php
@@ -34,8 +34,6 @@ class ContentModelCategories extends JModelList
 
 	private $_parent = null;
 
-	private $_items = null;
-
 	/**
 	 * Method to auto-populate the model state.
 	 *
@@ -91,7 +89,9 @@ class ContentModelCategories extends JModelList
 	 */
 	public function getItems($recursive = false)
 	{
-		if (!count($this->_items))
+		$store = $this->getStoreId();
+
+		if (!isset($this->cache[$store]))
 		{
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
@@ -110,14 +110,14 @@ class ContentModelCategories extends JModelList
 
 			if (is_object($this->_parent))
 			{
-				$this->_items = $this->_parent->getChildren($recursive);
+				$this->cache[$store] = $this->_parent->getChildren($recursive);
 			}
 			else {
-				$this->_items = false;
+				$this->cache[$store] = false;
 			}
 		}
 
-		return $this->_items;
+		return $this->cache[$store];
 	}
 
 	public function getParent()


### PR DESCRIPTION
Fix to display all child categories of every selected Category in Module Articles Category by correcting the use of cache in the Categories model class
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28401
