### PR TITLE
[#32744] All Modules type Articles Categories using same category

### DIFF
--- a/modules/mod_articles_categories/mod_articles_categories.php
+++ b/modules/mod_articles_categories/mod_articles_categories.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 // Include the helper functions only once
 require_once __DIR__ . '/helper.php';
 
+JLoader::register('JCategoryNode', JPATH_BASE . '/libraries/legacy/categories/categories.php');
+
 $cacheid = md5(serialize($module->module));
 
 $cacheparams = new stdClass;

--- a/modules/mod_articles_categories/mod_articles_categories.php
+++ b/modules/mod_articles_categories/mod_articles_categories.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/helper.php';
 
 JLoader::register('JCategoryNode', JPATH_BASE . '/libraries/legacy/categories/categories.php');
 
-$cacheid = md5(serialize($module->module));
+$cacheid = md5($module->id);
 
 $cacheparams = new stdClass;
 $cacheparams->cachemode = 'id';


### PR DESCRIPTION
Server reporting function under Global Config says:

Fatal error: main(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition &quot;JCategoryNode&quot; of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide a __autoload() function to load the class definition in /home/public_html/modules/mod_articles_categories/mod_articles_categories.php on line 29

and here is line 29's code says:

Code:
24 . $list = JModuleHelper::moduleCache($module, $params, $cacheparams);
25. 
26. if (!empty($list))
27. {
28.   $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
29.   $startLevel = reset($list)->getParent()->level;
30.   require JModuleHelper::getLayoutPath('mod_articles_categories', $params-  >get('layout', 'default'));
31. }
## Test Instructions

Create and publish only one module type articles categories will make menu single contact blank.

Create and publish more than one module type article categories (using different categories): blank menu single contact and all modules this type display only one category.
