### PR TITLE
[#30925]: Hide 'plus' icon for empty subcategories

### DIFF
--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -32,7 +32,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 							<?php echo $item->numitems; ?>
 						</span>
 					<?php endif; ?>
-					<?php if (count($item->getChildren()) > 0) : ?>
+					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
 						<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>
@@ -44,7 +44,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<?php if (count($item->getChildren()) > 0) :?>
+				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) :?>
 					<div class="collapse fade" id="category-<?php echo $item->id;?>">
 						<?php
 						$this->items[$item->id] = $item->getChildren();

--- a/components/com_content/views/categories/tmpl/default_items.php
+++ b/components/com_content/views/categories/tmpl/default_items.php
@@ -33,7 +33,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 						<?php echo $item->numitems; ?>
 					</span>
 				<?php endif; ?>
-				<?php if (count($item->getChildren()) > 0) : ?>
+				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
 					<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			</h3>
@@ -48,7 +48,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 				<?php endif; ?>
 			<?php endif; ?>
 
-			<?php if (count($item->getChildren()) > 0) :?>
+			<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) :?>
 				<div class="collapse fade" id="category-<?php echo $item->id;?>">
 				<?php
 				$this->items[$item->id] = $item->getChildren();

--- a/components/com_content/views/category/tmpl/blog_children.php
+++ b/components/com_content/views/category/tmpl/blog_children.php
@@ -35,7 +35,7 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) : ?
 				<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($child->id)); ?>">
 				<?php echo $this->escape($child->title); ?></a>
 
-				<?php if (count($child->getChildren()) > 0) : ?>
+				<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
 					<a href="#category-<?php echo $child->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			</h3>
@@ -48,7 +48,7 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) : ?
 					</span>
 				<?php endif; ?>
 
-				<?php if (count($child->getChildren()) > 0) : ?>
+				<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
 					<a href="#category-<?php echo $child->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			<?php endif;?>
@@ -62,15 +62,13 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) : ?
 			<?php endif; ?>
 			<?php endif; ?>
 
-			<?php if (count($child->getChildren()) > 0) : ?>
+			<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
 			<div class="collapse fade" id="category-<?php echo $child->id; ?>">
 				<?php
 				$this->children[$child->id] = $child->getChildren();
 				$this->category = $child;
 				$this->maxLevel--;
-				if ($this->maxLevel != 0) :
-					echo $this->loadTemplate('children');
-				endif;
+				echo $this->loadTemplate('children');
 				$this->category = $child->getParent();
 				$this->maxLevel++;
 				?>

--- a/components/com_content/views/category/tmpl/default_children.php
+++ b/components/com_content/views/category/tmpl/default_children.php
@@ -36,7 +36,7 @@ $class = ' class="first"';
 				<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($child->id));?>">
 				<?php echo $this->escape($child->title); ?></a>
 
-				<?php if (count($child->getChildren()) > 0) : ?>
+				<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
 					<a href="#category-<?php echo $child->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			</h3>
@@ -49,7 +49,7 @@ $class = ' class="first"';
 					</span>
 				<?php endif; ?>
 
-				<?php if (count($child->getChildren()) > 0) : ?>
+				<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
 					<a href="#category-<?php echo $child->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			<?php endif;?>
@@ -62,15 +62,13 @@ $class = ' class="first"';
 				<?php endif; ?>
 			<?php endif; ?>
 
-			<?php if (count($child->getChildren()) > 0) :?>
+			<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) :?>
 			<div class="collapse fade" id="category-<?php echo $child->id;?>">
 				<?php
 				$this->children[$child->id] = $child->getChildren();
 				$this->category = $child;
 				$this->maxLevel--;
-				if ($this->maxLevel != 0) :
-					echo $this->loadTemplate('children');
-				endif;
+				echo $this->loadTemplate('children');
 				$this->category = $child->getParent();
 				$this->maxLevel++;
 				?>

--- a/components/com_newsfeeds/views/categories/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default_items.php
@@ -32,7 +32,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 							<?php echo $item->numitems; ?>
 						</span>
 					<?php endif; ?>
-					<?php if (count($item->getChildren()) > 0) : ?>
+					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
 						<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>
@@ -44,7 +44,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<?php if (count($item->getChildren()) > 0) :?>
+				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) :?>
 					<div class="collapse fade" id="category-<?php echo $item->id;?>">
 					<?php
 					$this->items[$item->id] = $item->getChildren();

--- a/components/com_weblinks/views/categories/tmpl/default_items.php
+++ b/components/com_weblinks/views/categories/tmpl/default_items.php
@@ -33,7 +33,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 							<?php echo $item->numitems; ?>
 						</span>
 					<?php endif; ?>
-					<?php if (count($item->getChildren()) > 0) : ?>
+					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
 						<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>
@@ -45,7 +45,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<?php if (count($item->getChildren()) > 0) :?>
+				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) :?>
 					<div class="collapse fade" id="category-<?php echo $item->id;?>">
 						<?php
 						$this->items[$item->id] = $item->getChildren();


### PR DESCRIPTION
Updated PR against the "staging" branch.

The 'plus' button for subcategories should only be displayed if there are subcategories that can be extended. 

JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30925
Old PR: #1699
