### PR TITLE
 Added marking of current item for aliases

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -26,7 +26,7 @@ foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;
 
-	if ($item->id == $active_id)
+	if (($item->id == $active_id) OR ($item->type=='alias' AND $item->params->get('aliasoptions')==$active_id))
 	{
 		$class .= ' current';
 	}

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -26,7 +26,7 @@ foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;
 
-	if (($item->id == $active_id) OR ($item->type=='alias' AND $item->params->get('aliasoptions')==$active_id))
+	if (($item->id == $active_id) OR ($item->type == 'alias' AND $item->params->get('aliasoptions') == $active_id))
 	{
 		$class .= ' current';
 	}


### PR DESCRIPTION
This will fix the problem with marking aliases to current page. Before this, if there are two links to one menu item in menu (on to component and one alias to that item) only one is marked as current. This is wrong, both of them point to the same position so both should be marked as current.
