### PR TITLE
[#32086] Attach the category id to the final item instead of the first

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -171,7 +171,7 @@ class ContentRouter extends JComponentRouterBase
 
 			if (!$advanced && count($array))
 			{
-				$array[0] = (int) $catid . ':' . $array[0];
+				$array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
 			}
 
 			$segments = array_merge($segments, $array);


### PR DESCRIPTION
### Issue

So I am having an issue with the routing of categories that are child categories, since it seems that the entire category path is added to the url but the id value is not added in the final segment but instead in the second segment (after the view). The parser looks for it in the final segment, so it returns a 404 error, category not found.

Fix should be to change line 162 in the router as follows:

```
if (!$advanced && count($array))
{
    $array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
}
```

Basically change $array[0] to instead grab the last element. (This also makes more sense since it attaches the id to that actual category.)

If this can be confirmed as a bug, I'll submit the patch.
### Testing Instructions

Add a link to a category on the homepage or a non-com_content menu item like the following: index.php?option=com_content&view=category&id=XX. Have SEF Urls on so that the url is routed through JRoute.

Make sure that the category is a second level category or lower.

Resulting url will be like 'component/content/category/16-events/past-events' which will not be routed correctly, because the id is not actually in the final segment. (Note, 16 is the id for the "Past Events" category which is a child to the Events category.)
#### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32086
