### PR TITLE
[#11578] Mail cloak broken when text contains non-ascii

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -77,9 +77,7 @@ abstract class JHtmlEmail
 			}
 			else
 			{
-				$replacement .= "\n document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy" . $rand . " + '\'>';";
-				$replacement .= "\n document.getElementById('cloak$rand').innerHTML += 'addy" . $rand . "';";
-				$replacement .= "\n document.getElementById('cloak$rand').innerHTML += '<\/a>';";
+				$replacement .= "\n document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy" . $rand . " + '\'>' +addy" . $rand . "+'<\/a>';";
 			}
 		}
 		else

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -123,7 +123,7 @@ class PlgContentEmailcloak extends JPlugin
 		$searchEmailLink = $searchEmail . '([?&][\x20-\x7f][^"<>]+)';
 
 		// Any Text
-		$searchText = '([\x20-\x7f][^<>]+)';
+		$searchText = '((?:[\x20-\x7f]|[\xA1-\xFF]|[\xC2-\xDF][\x80-\xBF]|[\xE0-\xEF][\x80-\xBF]{2}|[\xF0-\xF4][\x80-\xBF]{3})[^<>]+)';
 
 		// Any Image link
 		$searchImage	=	"(<img[^>]+>)";


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33956&start=0

Add in an article a mail of type:

```
<p><a href="mailto:admin@mysite.com">été</a></p>
```

The cloaking will not work.
Patch and test again.

Same issue in 2.5. This had been solved a long time ago in 1.5:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=11578
See: https://github.com/joomla/joomla-cms/pull/3718#issuecomment-49133477

Remains to solve the case when an address is entered as

```
<p>ete@mysite.com</p>
```

which was working before https://github.com/joomla/joomla-cms/pull/3718
