### PR TITLE
*Mailcloak broken on images

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -229,7 +229,7 @@ class PlgContentEmailcloak extends JPlugin
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
 
 			// Ensure that attributes is not stripped out by email cloaking
-			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]);
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));


### PR DESCRIPTION
Inset an image in an article content.
Then add a mail adress to the image.
You will get this

![screen shot 2014-07-17 at 10 55 16](https://cloud.githubusercontent.com/assets/869724/3611011/070d03a6-0d95-11e4-8557-795a60eb6b0c.png)
What happens is that the < and > are converted to html entities.
This patch should solve it
