### PR TITLE
[#33974] Profile dob_spacer should not show when displaying profile in frontend

### DIFF
--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -22,32 +22,32 @@ foreach ($fieldsets as $group => $fieldset): // Iterate through the form fieldse
 	if (count($fields)):
 ?>
 <?php //if ($this->params->get('show_tags')) : ?>
-		<?php  //$this->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+		<?php //$this->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php //echo $this->tagLayout->render($this->tags); ?>
 	<?php // endif; ?>
 
-<fieldset id="users-profile-custom" class="users-profile-custom-<?php echo $group;?>">
-	<?php if (isset($fieldset->label)):// If the fieldset has a label set, display it as the legend.?>
+<fieldset id="users-profile-custom" class="users-profile-custom-<?php echo $group; ?>">
+	<?php if (isset($fieldset->label)): // If the fieldset has a label set, display it as the legend. ?>
 	<legend><?php echo JText::_($fieldset->label); ?></legend>
-	<?php endif;?>
+	<?php endif; ?>
 	<dl class="dl-horizontal">
-	<?php foreach ($fields as $field):
-		if (!$field->hidden) :?>
+	<?php foreach ($fields as $field) :
+		if (!$field->hidden && $field->fieldname != 'dob_spacer') : ?>
 		<dt><?php echo $field->title; ?></dt>
 		<dd>
-			<?php if (JHtml::isRegistered('users.'.$field->id)):?>
-				<?php echo JHtml::_('users.'.$field->id, $field->value);?>
-			<?php elseif (JHtml::isRegistered('users.'.$field->fieldname)):?>
-				<?php echo JHtml::_('users.'.$field->fieldname, $field->value);?>
-			<?php elseif (JHtml::isRegistered('users.'.$field->type)):?>
-				<?php echo JHtml::_('users.'.$field->type, $field->value);?>
-			<?php else:?>
-				<?php echo JHtml::_('users.value', $field->value);?>
-			<?php endif;?>
+			<?php if (JHtml::isRegistered('users.'.$field->id)) : ?>
+				<?php echo JHtml::_('users.'.$field->id, $field->value); ?>
+			<?php elseif (JHtml::isRegistered('users.'.$field->fieldname)) : ?>
+				<?php echo JHtml::_('users.'.$field->fieldname, $field->value); ?>
+			<?php elseif (JHtml::isRegistered('users.'.$field->type)) : ?>
+				<?php echo JHtml::_('users.'.$field->type, $field->value); ?>
+			<?php else : ?>
+				<?php echo JHtml::_('users.value', $field->value); ?>
+			<?php endif; ?>
 		</dd>
-		<?php endif;?>
-	<?php endforeach;?>
+		<?php endif; ?>
+	<?php endforeach; ?>
 	</dl>
 </fieldset>
-	<?php endif;?>
-<?php endforeach;?>
+	<?php endif; ?>
+<?php endforeach; ?>

--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -32,7 +32,7 @@ foreach ($fieldsets as $group => $fieldset): // Iterate through the form fieldse
 	<?php endif; ?>
 	<dl class="dl-horizontal">
 	<?php foreach ($fields as $field) :
-		if (!$field->hidden && $field->fieldname != 'dob_spacer') : ?>
+		if (!$field->hidden && $field->type != 'spacer') : ?>
 		<dt><?php echo $field->title; ?></dt>
 		<dd>
 			<?php if (JHtml::isRegistered('users.'.$field->id)) : ?>

--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -32,7 +32,7 @@ foreach ($fieldsets as $group => $fieldset): // Iterate through the form fieldse
 	<?php endif; ?>
 	<dl class="dl-horizontal">
 	<?php foreach ($fields as $field) :
-		if (!$field->hidden && $field->type != 'spacer') : ?>
+		if (!$field->hidden && $field->type != 'Spacer') : ?>
 		<dt><?php echo $field->title; ?></dt>
 		<dd>
 			<?php if (JHtml::isRegistered('users.'.$field->id)) : ?>


### PR DESCRIPTION
Log in frontend and display the user profile
index.php?option=com_users&view=profile&Itemid= (menu item id, 201 on default sample data)

Before patch, the tip displays (partly) and breaks alignment of date:
![profile_before](https://cloud.githubusercontent.com/assets/869724/3636809/ab4fb324-0fe2-11e4-8b3f-b805ad30f156.png)

After patch

![profile_after](https://cloud.githubusercontent.com/assets/869724/3636811/b42f1dcc-0fe2-11e4-8c13-a894f5de9977.png)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33974&start=0
