### PR TITLE
[#32750] IE 10 - Isis -> Image can't be inserted via Image Button

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -780,13 +780,6 @@ class PlgEditorTinymce extends JPlugin
 
 			function jInsertEditorText( text, editor )
 			{
-				if (isBrowserIE())
-				{
-					if (window.parent.tinyMCE)
-					{
-						window.parent.tinyMCE.selectedInstance.selection.moveToBookmark(window.parent.global_ie_bookmark);
-					}
-				}
 				tinyMCE.execCommand('mceInsertContent', false, text);
 			}
 


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32750&start=0
same fix help here:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32814&start=0
### Testing
1. Use Internet Explorer 10 
2. edit or write an article
3. Click on Image button below
4. choose an image and click on insert.
5. Nothing happens.
6. apply patch
7. clean cache
8. redo 1-4 and make sure it work now.
### Joomla-Bugs.de Reference

http://www.joomla-bugs.de/forum/index.php?topic=496
http://www.joomla-bugs.de/forum/index.php?topic=501
