### PR TITLE
Add support for different plugin groups to com_ajax

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -116,7 +116,8 @@ elseif ($input->get('module'))
 	}
 }
 /*
- * Plugin support is based on the "Ajax" plugin group.
+ * Plugin support by default is based on the "Ajax" plugin group.
+ * An optional 'group' variable can be passed via the URL.
  *
  * The plugin event triggered is onAjaxFoo, where 'foo' is
  * the value of the 'plugin' variable passed via the URL
@@ -125,7 +126,8 @@ elseif ($input->get('module'))
  */
 elseif ($input->get('plugin'))
 {
-	JPluginHelper::importPlugin('ajax');
+	$group      = $input->get('group', 'ajax');
+	JPluginHelper::importPlugin($group);
 	$plugin     = ucfirst($input->get('plugin'));
 	$dispatcher = JEventDispatcher::getInstance();
 


### PR DESCRIPTION
Currently, `com_ajax` is hardcoded to load the "Ajax" plugin group.
This PR proposes to add support for a `group` URL parameter which tells com_ajax to import a custom plugin group. If omitted it will fall back to the ajax group.

The reason is that we may have for example a content plugin which uses Ajax functionality. With the current implementation it would neeed two plugins, one in the content group for the markup/whatever and a second one in the ajax group to process the AJAX requests. That doesn't make much sense.
#### Testing
- You can use the example plugin https://github.com/Joomla-Ajax-Interface/Ajax-Latest-Articles to see that nothing breaks when using `index.php?option=com_ajax&plugin=latestarticles&format=debug` (should give you a list of articles).
- To test the new group parameter you can add `&group=content` to the URL and see that the example plugin isn't triggered anymore (you get an empty array).
- Now you can copy the function `onAjaxLatestarticles` from the example plugin to a content plugin of your choice and it should work again.
