### PR TITLE
Fixed errrors stack containing no-value-items

### DIFF
--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -139,6 +139,9 @@ class JObject
 	 */
 	public function getError($i = null, $toString = true)
 	{
+		// Filter out entries with no value.
+		$this->_errors = array_filter($this->_errors);
+		
 		// Find the error
 		if ($i === null)
 		{


### PR DESCRIPTION
It happens the `JObject::_errors` stack is asked to add entries with no data.
Take for instance `JModelAdmin::save()`. This method triggers two events while processing the store - event_before_save and event_after_save. The former event handlers' response is catched and evaluated. However, it is expected that the error that might have occured was thrown by the table object passed in. In fact the error should be expected from the dispatcher, since errors are either thrown directly by the plugin or set via `$this->subject->setError` where subject is the JEventDispatcher object. So the error setting block should be

```
// Trigger the onContentBeforeSave event.
$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, $table, $isNew));

if (in_array(false, $result, true))
{
   $this->setError($dispatcher->getError());
   return false;
}
```

This however might be one place where empty entries are added to JObject::_errors. So this block should additionally check for the error's existance.

```
if (in_array(false, $result, true))
{
   if ($dispatcher->getError())
   {
      $this->setError($dispatcher->getError());
   }
}
```

I'm sure there are many more places where this kind of empty error entries are produces and set. To circumvent this issue i added a short filtering of `JObject::_errors` to drop empty entries and thus error boxes with no content to be shown to the user.

Please let me know, what you think about it!

**CLOSED** _(because this is the wrong file. Find active discussion and PR [here](https://github.com/joomla/joomla-cms/pull/3941))_
