### PR TITLE
[#34001] Don't queue empty messages in JApplication message queue

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -225,6 +225,12 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	public function enqueueMessage($msg, $type = 'message')
 	{
+		// Don't add empty messages.
+		if (!strlen($msg))
+		{
+			return;
+		}
+		
 		// For empty queue, if messages exists in the session, enqueue them first.
 		$this->getMessageQueue();
 


### PR DESCRIPTION
Take for instance `JModelAdmin::save()`. This method triggers two events while processing the store - event_before_save and event_after_save. The former event handlers' response is catched and evaluated. However, it is expected that the error that might have occured was thrown by the table object passed in. In fact the error should be expected from the dispatcher, since errors are either thrown directly by the plugin or set via `$this->subject->setError` by the event handler where subject is the JEventDispatcher object. So the error setting block for this example should rather be

```
// Trigger the onContentBeforeSave event.
$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, $table, $isNew));

if (in_array(false, $result, true))
{
   $this->setError($dispatcher->getError());
   return false;
}
```

This however might be one place where an empty entry is added to the queue. So this block should additionally check for the error's existance.

```
if (in_array(false, $result, true))
{
   if ($dispatcher->getError())
   {
      $this->setError($dispatcher->getError());
   }
}
```

I'm sure there are many more places where this kind of empty errors/messages are produced and added to the messageQueue. To circumvent this issue i added a check to drop empty entries as it makes no sense to render message containers with no content.

Please let me know, what you think about it!

Associated [Bug tracker item](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34001)
