### PR TITLE
[#33451] Check in front-end if article is associated

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -370,7 +370,10 @@ class ContentModelArticle extends JModelAdmin
 		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 
-		if ($app->isSite() && $assoc && $this->getState('article.id'))
+		// Check if article is associated
+		$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
+
+		if ($app->isSite() && $assoc && $this->getState('article.id') && !empty($associations))
 		{
 			$form->setFieldAttribute('language', 'readonly', 'true');
 			$form->setFieldAttribute('catid', 'readonly', 'true');

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -371,14 +371,18 @@ class ContentModelArticle extends JModelAdmin
 		$assoc = JLanguageAssociations::isEnabled();
 
 		// Check if article is associated
-		$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
-
-		if ($app->isSite() && $assoc && $this->getState('article.id') && !empty($associations))
+		if ($id && $app->isSite() && $assoc)
 		{
-			$form->setFieldAttribute('language', 'readonly', 'true');
-			$form->setFieldAttribute('catid', 'readonly', 'true');
-			$form->setFieldAttribute('language', 'filter', 'unset');
-			$form->setFieldAttribute('catid', 'filter', 'unset');
+			$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
+
+			// Make fields read only
+			if ($associations)
+			{
+				$form->setFieldAttribute('language', 'readonly', 'true');
+				$form->setFieldAttribute('catid', 'readonly', 'true');
+				$form->setFieldAttribute('language', 'filter', 'unset');
+				$form->setFieldAttribute('catid', 'filter', 'unset');
+			}
 		}
 
 		return $form;


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33451

In a multilanguage site, when associations are implemented in the Language Filter Plugin, it is impossible to edit the category and the language when editing the article in front-end. The fields are greyed.
This was implemented to prevent messing with existing associations as they can only be parametered in back-end. This even when the said article was not associated.

This PR changes the behavior by checking first if the article is associated. If not, the language and category will be editable.
