### PR TITLE
Fixing $query->setLimit

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1702,6 +1702,16 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 		if ($query instanceof JDatabaseQueryLimitable)
 		{
+			if (!$limit && $query->limit)
+			{
+				$limit = $query->limit;
+			}
+
+			if (!$offset && $query->offset)
+			{
+				$offset = $query->offset;
+			}
+
 			$query->setLimit($limit, $offset);
 		}
 		else


### PR DESCRIPTION
This should fix the issue raised with https://github.com/joomla/joomla-cms/issues/3940

Currently, `$query->setLimit()` is overriden by `$db->query()`. Making the method kind of useless.

This PR will make it so that `setQuery` checks if there is a limit or offset property set in the `$query` and uses that one if it's set and `setQuery` doesn't have an own value set already.

To test you can use the Ajax example plugin like described in the original Issue:
- Download https://github.com/Joomla-Ajax-Interface/Ajax-Latest-Articles/archive/875f1f4348b1e856539360dea4317097689db2c7.zip
- Install the plugin
- Use the URL `index.php?option=com_ajax&plugin=latestarticles&format=debug`
- Verify that the response from the plugin respects the parameter.
