### PR TITLE
[#34000] Remove re-definition of table key name

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1125,11 +1125,9 @@ abstract class JModelAdmin extends JModelForm
 			return false;
 		}
 
-		$pkName = $table->getKeyName();
-
-		if (isset($table->$pkName))
+		if (isset($table->$key))
 		{
-			$this->setState($this->getName() . '.id', $table->$pkName);
+			$this->setState($this->getName() . '.id', $table->$key);
 		}
 		$this->setState($this->getName() . '.new', $isNew);
 


### PR DESCRIPTION
The table key name has already been assigned to `$key` in line 1064 and is good to be used again. There's no need to introduce another variable for the sake of model state update.

Associated [Bug tracker item](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34000)
