### PR TITLE
[#33984] Getting a 500 when trying to sort users by User Group

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -50,7 +50,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
 				</th>
 				<th class="nowrap" width="25%">
-					<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_GROUPS', 'group_names', $listDirn, $listOrder); ?>
+					<?php echo JText::_('COM_USERS_HEADING_GROUPS'); ?>
 				</th>
 			</tr>
 		</thead>

--- a/administrator/templates/hathor/html/com_users/users/modal.php
+++ b/administrator/templates/hathor/html/com_users/users/modal.php
@@ -49,7 +49,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
 				</th>
 				<th class="nowrap width=25">
-					<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_GROUPS', 'group_names', $listDirn, $listOrder); ?>
+					<?php echo JText::_('COM_USERS_HEADING_GROUPS'); ?>
 				</th>
 			</tr>
 		</thead>


### PR DESCRIPTION
When choosing a user as author in the Publishing tab when editing an article for example, the modal presents 3 columns and allows sorting them by clicking on the headings.
If trying to sort by User Groups, we get a 500.
This is normal as this would never work as one can see in the Users Manager (multiple groups possible) where sorting is not implemented.
This patch lets just display the Heading without a grid.sort.

After patch:
![screen shot 2014-07-24 at 07 42 27](https://cloud.githubusercontent.com/assets/869724/3684123/7a852b28-12f5-11e4-9037-9d1d130f3d82.png)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33984&start=0
