### PR TITLE
Fix Jenkins: Codestyle after https://github.com/joomla/joomla-cms/pull/3498

### DIFF
--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -36,6 +36,7 @@ class TagsViewTag extends JViewLegacy
 		$fromName         = $app->get('fromname');
 		$feedEmail        = $app->get('feed_email', 'author');
 		$document->editor = $fromName;
+
 		if ($feedEmail != "none")
 		{
 			$document->editorEmail = $siteEmail;
@@ -43,6 +44,7 @@ class TagsViewTag extends JViewLegacy
 
 		// Get some data from the model
 		$items    = $this->get('Items');
+
 		foreach ($items as $item)
 		{
 			// Strip HTML from feed item title
@@ -66,7 +68,7 @@ class TagsViewTag extends JViewLegacy
 			$feeditem->date        = $date;
 			$feeditem->category    = $title;
 			$feeditem->author      = $author;
-			
+
 			if ($feedEmail == 'site')
 			{
 				$item->authorEmail = $siteEmail;


### PR DESCRIPTION
Jenkins:

view.feed.php:69, SuperfluousWhitespace, Priorität: Hoch 

Whitespace found at end of line
No description available. Please upgrade to latest checkstyle version.
http://build.joomla.org/job/cms/lastBuild/checkstyleResult/
