### PR TITLE
Class attributes are not included in mailcloak

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -74,7 +74,7 @@ class PlgContentEmailcloak extends JPlugin
 		if ($before !== "")
 		{
 			$before = str_replace("'", "\'", $before);
-			$jsEmail = str_replace("document.write('<a '", "document.write('<a {$before}'", $jsEmail);
+			$jsEmail = str_replace(".innerHTML += '<a '", ".innerHTML += '<a {$before}'", $jsEmail);
 		}
 
 		if ($after !== "")


### PR DESCRIPTION
Test a mail similar to:

```
<p><a class="btn btn-primary" href="mailto:anyone@mail.com>Contact Me</a></p>
```

before patch: no button.
After patch:
![screen shot 2014-07-24 at 19 25 24](https://cloud.githubusercontent.com/assets/869724/3691939/8efcbe4c-1357-11e4-83d9-9a2bee4dcc9e.png)
