### PR TITLE
[#33917] fix for: #33917

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -92,6 +92,8 @@ final class JApplicationSite extends JApplicationCms
 			else
 			{
 				$this->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+				//stop the access to stuff you're not authorized to see
+		                throw new Exception( JText::_('JERROR_ALERTNOAUTHOR'), 401 );
 			}
 		}
 	}


### PR DESCRIPTION
As discussed on the issue tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33917&start=0

When a user attempts to access a URL they are not authorized to it is not sufficient to just show and error. Execution must be terminated as well. The fix is to throw an exception in a similar fashion to Joomla!2.x
