### PR TITLE
Fix Parse error: syntax error, unexpected T_STATIC

### DIFF
--- a/libraries/joomla/html/html/email.php
+++ b/libraries/joomla/html/html/email.php
@@ -58,7 +58,7 @@ abstract class JHtmlEmail
 			if ($text)
 			{
 				// Convert text - here is the right place
-				$text = static::_convertEncoding($text);
+				$text = self::_convertEncoding($text);
 
 				if ($email)
 				{


### PR DESCRIPTION
Parse error: syntax error, unexpected T_STATIC in JROOT/libraries/joomla/html/html/email.php on line 61
