### PR TITLE
Update robots.txt for SEO

### DIFF
--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -23,8 +23,7 @@ Disallow: /language/
 Disallow: /layouts/
 Disallow: /libraries/
 Disallow: /logs/
-# Disallow: /media/
 Disallow: /modules/
 Disallow: /plugins/
-# Disallow: /templates/
 Disallow: /tmp/
+

--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -23,16 +23,8 @@ Disallow: /language/
 Disallow: /layouts/
 Disallow: /libraries/
 Disallow: /logs/
-Disallow: /media/
+# Disallow: /media/
 Disallow: /modules/
 Disallow: /plugins/
-Disallow: /templates/
+# Disallow: /templates/
 Disallow: /tmp/
-
-# Filter exception to allow bots (in particular Google) to read .css and .js files for a better SEO
-# see https://github.com/joomla/joomla-cms/issues/3937
-
-Allowed: /templates/*.css$
-Allowed: /templates/*.js$
-Allowed: /media/*.css$
-Allowed: /media/*.js$

--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -29,3 +29,10 @@ Disallow: /plugins/
 Disallow: /templates/
 Disallow: /tmp/
 
+# Filter exception to allow bots (in particular Google) to read .css and .js files for a better SEO
+# see https://github.com/joomla/joomla-cms/issues/3937
+
+Allowed: /templates/*.css$
+Allowed: /templates/*.js$
+Allowed: /media/*.css$
+Allowed: /media/*.js$


### PR DESCRIPTION
Updated removing `templates` and `media` folder from robots.txt to allow crawlers to access properly CSS and js scripts. See https://github.com/joomla/joomla-cms/issues/3937
