### PR TITLE
[#32092] [feature] Nested submenus for top menu in protostar

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8300,6 +8300,22 @@ body {
 	padding: 8px 10px;
 	color: #FFFFFF;
 }
+.navigation .nav li li .nav-child {
+	left: auto;
+	right: 100%;
+}
+.navigation .nav li li .nav-child:before {
+	left: auto;
+	right: -7px;
+	border-left: 7px solid rgba(0,0,0,0.2);
+	border-right-width: 0;
+}
+.navigation .nav li li .nav-child:after {
+	left: auto;
+	right: -6px;
+	border-left: 6px solid #ffffff;
+	border-right-width: 0;
+}
 .container-logo {
 	padding-top: 6px;
 	float: left;

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -358,6 +358,22 @@ body {
 	padding: 8px 10px;
 	color: #FFFFFF;
 }
+.navigation .nav li li .nav-child {
+	left: auto;
+	right: 100%;
+}
+.navigation .nav li li .nav-child:before {
+	left: auto;
+	right: -7px;
+	border-left: 7px solid rgba(0,0,0,0.2);
+	border-right-width: 0;
+}
+.navigation .nav li li .nav-child:after {
+	left: auto;
+	right: -6px;
+	border-left: 6px solid #ffffff;
+	border-right-width: 0;
+}
 .container-logo {
 	padding-top: 6px;
 	float: left;

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -364,6 +364,23 @@ direction:rtl;
 	padding: 8px 10px;
 	color: #FFFFFF;
 }
+.navigation .nav li li .nav-child {
+	left: auto;
+	right: 100%;
+	
+	&:before {
+		left: auto;
+		right: -7px;
+		border-left: 7px solid rgba(0, 0, 0, 0.2);
+		border-right-width: 0;
+	}
+	&:after {
+		left: auto;
+		right: -6px;
+		border-left: 6px solid #ffffff;
+		border-right-width: 0;
+	}
+}
 .container-logo {
 	padding-top: 6px;
 	float: left;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7187,14 +7187,16 @@ figcaption {
 	color: #333;
 	white-space: nowrap;
 }
-.navigation .nav > li {
+.navigation .nav li {
 	position: relative;
 }
 .navigation .nav > li:hover > .nav-child,
-.navigation .nav > li > a:focus + .nav-child {
+.navigation .nav > li > a:focus + .nav-child,
+.navigation .nav li li:hover > .nav-child,
+.navigation .nav li li > a:focus + .nav-child {
 	display: block;
 }
-.navigation .nav-child:before {
+.navigation .nav > li > .nav-child .nav-child:before {
 	position: absolute;
 	top: -7px;
 	left: 9px;
@@ -7205,7 +7207,7 @@ figcaption {
 	border-bottom-color: rgba(0,0,0,0.2);
 	content: '';
 }
-.navigation .nav-child:after {
+.navigation .nav > li > .nav-child .nav-child:after {
 	position: absolute;
 	top: -6px;
 	left: 10px;
@@ -7213,6 +7215,30 @@ figcaption {
 	border-right: 6px solid transparent;
 	border-bottom: 6px solid #ffffff;
 	border-left: 6px solid transparent;
+	content: '';
+}
+.navigation .nav li li .nav-child {
+	top: -4px;
+	left: 102%;
+}
+.navigation .nav li li .nav-child:before {
+	position: absolute;
+	top: 9px;
+	left: -7px;
+	display: inline-block;
+	border-top: 7px solid transparent;
+	border-right: 7px solid rgba(0,0,0,0.2);
+	border-bottom: 7px solid transparent;
+	content: '';
+}
+.navigation .nav li li .nav-child:after {
+	position: absolute;
+	top: 10px;
+	left: -6px;
+	display: inline-block;
+	border-top: 6px solid transparent;
+	border-right: 6px solid #ffffff;
+	border-bottom: 6px solid transparent;
 	content: '';
 }
 .navigation .nav-child li > a:hover,

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7218,7 +7218,7 @@ figcaption {
 	content: '';
 }
 .navigation .nav li li .nav-child {
-	top: -6px;
+	top: -8px;
 	left: 100%;
 }
 .navigation .nav li li .nav-child:before {

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7196,7 +7196,7 @@ figcaption {
 .navigation .nav li li > a:focus + .nav-child {
 	display: block;
 }
-.navigation .nav > li > .nav-child .nav-child:before {
+.navigation .nav > li > .nav-child:before {
 	position: absolute;
 	top: -7px;
 	left: 9px;
@@ -7207,7 +7207,7 @@ figcaption {
 	border-bottom-color: rgba(0,0,0,0.2);
 	content: '';
 }
-.navigation .nav > li > .nav-child .nav-child:after {
+.navigation .nav > li > .nav-child:after {
 	position: absolute;
 	top: -6px;
 	left: 10px;
@@ -7218,8 +7218,8 @@ figcaption {
 	content: '';
 }
 .navigation .nav li li .nav-child {
-	top: -4px;
-	left: 102%;
+	top: -6px;
+	left: 100%;
 }
 .navigation .nav li li .nav-child:before {
 	position: absolute;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -318,33 +318,62 @@ figcaption {
 			white-space: nowrap;
 		}
 	}
-	.nav > li {
+	.nav li {
 		position: relative;
 	}
 	.nav > li:hover > .nav-child,
-	.nav > li > a:focus + .nav-child, {
+	.nav > li > a:focus + .nav-child,
+	.nav li li:hover > .nav-child,
+	.nav li li > a:focus + .nav-child {
 		display: block;
 	}
-	.nav-child:before {
-	  position: absolute;
-	  top: -7px;
-	  left: 9px;
-	  display: inline-block;
-	  border-right: 7px solid transparent;
-	  border-bottom: 7px solid #ccc;
-	  border-left: 7px solid transparent;
-	  border-bottom-color: rgba(0, 0, 0, 0.2);
-	  content: '';
+	.nav > li > .nav-child {
+		.nav-child:before {
+		  position: absolute;
+		  top: -7px;
+		  left: 9px;
+		  display: inline-block;
+		  border-right: 7px solid transparent;
+		  border-bottom: 7px solid #ccc;
+		  border-left: 7px solid transparent;
+		  border-bottom-color: rgba(0, 0, 0, 0.2);
+		  content: '';
+		}
+		.nav-child:after {
+		  position: absolute;
+		  top: -6px;
+		  left: 10px;
+		  display: inline-block;
+		  border-right: 6px solid transparent;
+		  border-bottom: 6px solid #ffffff;
+		  border-left: 6px solid transparent;
+		  content: '';
+		}
 	}
-	.nav-child:after {
-	  position: absolute;
-	  top: -6px;
-	  left: 10px;
-	  display: inline-block;
-	  border-right: 6px solid transparent;
-	  border-bottom: 6px solid #ffffff;
-	  border-left: 6px solid transparent;
-	  content: '';
+	.nav li li .nav-child {
+		top: -4px;
+		left: 102%;
+
+		&:before {
+			position: absolute;
+			top: 9px;
+			left: -7px;
+			display: inline-block;
+			border-top: 7px solid transparent;
+			border-right: 7px solid rgba(0, 0, 0, 0.2);
+			border-bottom: 7px solid transparent;
+			content: '';
+		}
+		&:after {
+			position: absolute;
+			top: 10px;
+			left: -6px;
+			display: inline-block;
+			border-top: 6px solid transparent;
+			border-right: 6px solid #ffffff;
+			border-bottom: 6px solid transparent;
+			content: '';
+		}
 	}
 }
 

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -328,7 +328,7 @@ figcaption {
 		display: block;
 	}
 	.nav > li > .nav-child {
-		.nav-child:before {
+		&:before {
 		  position: absolute;
 		  top: -7px;
 		  left: 9px;
@@ -339,7 +339,7 @@ figcaption {
 		  border-bottom-color: rgba(0, 0, 0, 0.2);
 		  content: '';
 		}
-		.nav-child:after {
+		&:after {
 		  position: absolute;
 		  top: -6px;
 		  left: 10px;
@@ -351,8 +351,8 @@ figcaption {
 		}
 	}
 	.nav li li .nav-child {
-		top: -4px;
-		left: 102%;
+		top: -8px;
+		left: 100%;
 
 		&:before {
 			position: absolute;


### PR DESCRIPTION
# Description

This enables protostar to display nav-pills menus with two or more levels of submenus. 
# Testing instructions
1. Create a menu with more than two levels in backend or use one of the ones provided with sample data. In my pictures, I used the "About Joomla" menu from sample data.
2. Create a menu module
   - Type: Menu
   - Position: position-1
   - Select Menu: Your menu from step 1
   - Start level: 1
   - End level: all
   - Show Sub-menu Items: Yes
3. Save / publish the module.
4. Set Protostar as your frontend template.
5. Hover over the menu items in frontend. The first level of sub-items will be shown, but nothing beyond that.
6. Apply the PR
7. Now, all levels should be accessible in the dropdown menu.
   JoomlaCode item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32092
   Old PR: https://github.com/joomla/joomla-cms/pull/2073
