### PR TITLE
Fixing bugs for emailcloak plugin

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -103,7 +103,7 @@ class plgContentEmailcloak extends JPlugin
 		$mode = $this->params->def('mode', 1);
 
 		// any@email.address.com
-		$searchEmail = '([\w\.\-]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-z0-9\-]{2,4}))';
+		$searchEmail = '([\w\.\-\+]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))';
 		// any@email.address.com?subject=anyText
 		$searchEmailLink = $searchEmail . '([?&][\x20-\x7f][^"<>]+)';
 		// anyText

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -459,6 +459,7 @@ class plgContentEmailcloak extends JPlugin
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));
 		}
+		
 		return true;
 	}
 }

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -64,13 +64,13 @@ class plgContentEmailcloak extends JPlugin
 		if ($before !== "")
 		{
 			$before = str_replace("'", "\'", $before);
-			$jsEmail = str_replace("document.write('<a '", "document.write('<a {$before}'", $jsEmail);
+			$jsEmail = str_replace(".innerHTML += '<a '", ".innerHTML += '<a {$before}'", $jsEmail);
 		}
 
 		if ($after !== "")
 		{
 			$after = str_replace("'", "\'", $after);
-			$jsEmail = str_replace("'\'>');", "'\'{$after}>');", $jsEmail);
+			$jsEmail = str_replace("'\'>'", "'\'{$after}>'", $jsEmail);
 		}
 
 		return $jsEmail;

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -45,11 +45,37 @@ class plgContentEmailcloak extends JPlugin
 	 * @return	string	A regular expression that matches a link containing the parameters.
 	 */
 	protected function _getPattern ($link, $text) {
-		$pattern = '~(?:<a [\w "\'=\@\.\-]*href\s*=\s*"mailto:'
-			. $link . '"[\w "\'=\@\.\-]*)>' . $text . '</a>~i';
+		$pattern = '~(?:<a ([\w "\'=\@\.\-:;]*)href\s*=\s*"mailto:'
+			. $link . '"([\w "\'=\@\.\-:;]*))>' . $text . '</a>~i';
 		return $pattern;
 	}
 
+	/**
+	 * Adds an attributes to the js cloaked email.
+	 *
+	 * @param   string  $jsEmail  Js cloaked email.
+	 * @param   string  $before   Attributes before email.
+	 * @param   string  $after    Attributes after email.
+	 *
+	 * @return string Js cloaked email with attributes.
+	 */
+	protected function _addAttributesToEmail($jsEmail, $before, $after)
+	{
+		if ($before !== "")
+		{
+			$before = str_replace("'", "\'", $before);
+			$jsEmail = str_replace("document.write('<a '", "document.write('<a {$before}'", $jsEmail);
+		}
+
+		if ($after !== "")
+		{
+			$after = str_replace("'", "\'", $after);
+			$jsEmail = str_replace("'\'>');", "'\'{$after}>');", $jsEmail);
+		}
+
+		return $jsEmail;
+	}
+	
 	/**
 	 * Cloak all emails in text from spambots via Javascript.
 	 *
@@ -94,11 +120,14 @@ class plgContentEmailcloak extends JPlugin
 		$pattern = $this->_getPattern($searchEmail, $searchEmail);
 		$pattern = str_replace('"mailto:', '"http://mce_host([\x20-\x7f][^<>]+/)', $pattern);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[2][0];
-			$mailText = $regs[3][0];
+			$mail = $regs[3][0];
+			$mailText = $regs[5][0];
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -112,11 +141,14 @@ class plgContentEmailcloak extends JPlugin
 		$pattern = $this->_getPattern($searchEmail, $searchText);
 		$pattern = str_replace('"mailto:', '"http://mce_host([\x20-\x7f][^<>]+/)', $pattern);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[2][0];
-			$mailText = $regs[3][0];
+			$mail = $regs[3][0];
+			$mailText = $regs[5][0];
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -128,11 +160,14 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmail, $searchEmail);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0];
-			$mailText = $regs[2][0];
+			$mail = $regs[2][0];
+			$mailText = $regs[4][0];
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -144,10 +179,13 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmail, $searchText);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0];
-			$mailText = $regs[2][0];
+			$mail = $regs[2][0];
+			$mailText = $regs[4][0];
 
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -159,10 +197,13 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmail, $searchImage);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0];
-			$mailText = $regs[2][0];
+			$mail = $regs[2][0];
+			$mailText = $regs[4][0];
 
-			$replacement = html_entity_decode(JHtml::_('email.cloak', $mail, $mode, $mailText, 0));
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -174,13 +215,17 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmailLink, $searchEmail);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0] . $regs[2][0];
-			$mailText = $regs[3][0];
+			$mail = $regs[2][0] . $regs[3][0];
+			$mailText = $regs[5][0];
+
 			// Needed for handling of Body parameter
 			$mail = str_replace('&amp;', '&', $mail);
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -192,12 +237,16 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmailLink, $searchText);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0] . $regs[2][0];
-			$mailText = $regs[3][0];
+			$mail = $regs[2][0] . $regs[3][0];
+			$mailText = $regs[5][0];
+
 			// Needed for handling of Body parameter
 			$mail = str_replace('&amp;', '&', $mail);
 
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = $this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]);
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -209,14 +258,17 @@ class plgContentEmailcloak extends JPlugin
 		 */
 		$pattern = $this->_getPattern($searchEmailLink, $searchImage);
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-			$mail = $regs[1][0] . $regs[2][0];
-			$mailText = $regs[3][0];
+			$mail = $regs[1][0] . $regs[2][0] . $regs[3][0];
+			$mailText = $regs[5][0];
 
 			// Needed for handling of Body parameter
 			$mail = str_replace('&amp;', '&', $mail);
 
 			// Check to see if mail text is different from mail addy
-			$replacement = html_entity_decode(JHtml::_('email.cloak', $mail, $mode, $mailText, 0));
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));


### PR DESCRIPTION
Hi everyone!

This PR tries to adapt changes that were made to the 3.x version of the emailcloak plugin. These changes fixed several bugs, so they should be implemented in 2.5.x, too. One of these bugs is #3956, which was fixed for 3.x yesterday. 
As I don't have much time to test this PR right now, I ask you to test this thoroughly, so that we don't have to release three more versions until mailcloaking works again. I'll test the PR tonight or tomorrow by myself. But because this fixes some major and urgent bugs, I'm proposing it only rarely tested.
## Testing instructions

Please test **all** variants to use this plugin (every of them with javascript enabled and disabled):
1. `<a href="http://mce_host/ourdirectory/email@example.org">email@example.org</a>`
2. `<a href="http://mce_host/ourdirectory/email@example.org">text</a>`
3. `<a href="mailto:email@example.org">email@example.org</a>`
4. `<a href="mailto:email@example.org">text</a>`
5. `<a href="mailto:email@example.org"><img src="..." /></a>`
6. `<a href="mailto:email@example.org?subject=Text">email@example.org</a>`
7. `<a href="mailto:email@example.org?subject=Text">text</a>`
8. `<a href="mailto:email@example.org?subject=Text"><img src="..." /></a>`
9. plain `email@example.org`
...and please test all of these variants with attributes, such as class and style attributes before and after the href attribute.
