### PR TITLE
[#33991] Missing colspan

### DIFF
--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -126,7 +126,7 @@ $sortFields = $this->getSortFields();
 			</thead>
 			<tfoot>
 				<tr>
-					<td colspan="10">
+					<td colspan="11">
 						<?php echo $this->pagination->getListFooter(); ?>
 					</td>
 				</tr>


### PR DESCRIPTION
Check /administrator/index.php?option=com_languages&view=languages. There is missing a colspan in the table footer.

This PR changes colspan="10" to colspan="11"

![colspan](https://cloud.githubusercontent.com/assets/1738811/3708871/c30a7f82-144a-11e4-8ed8-3f63d27718e2.png)

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33991
