### PR TITLE
[#32527] Updated method signature for JStringNormalise::fromCamelCase

### DIFF
--- a/libraries/joomla/string/normalise.php
+++ b/libraries/joomla/string/normalise.php
@@ -36,7 +36,7 @@ abstract class JStringNormalise
 	 * @param   string   $input    The string input (ASCII only).
 	 * @param   boolean  $grouped  Optionally allows splitting on groups of uppercase characters.
 	 *
-	 * @return  string  The space separated string.
+	 * @return  mixed  The space separated string or an array of substrings if grouped is true.
 	 *
 	 * @since   12.1
 	 */


### PR DESCRIPTION
`preg_split` is returning an array.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32527&start=0
