### PR TITLE
[#33176] Categories acl (administrator) not work with section. Thanks Andrea Tosti

### DIFF
--- a/administrator/components/com_categories/categories.php
+++ b/administrator/components/com_categories/categories.php
@@ -12,7 +12,11 @@ JHtml::_('behavior.tabstate');
 
 $input = JFactory::getApplication()->input;
 
-if (!JFactory::getUser()->authorise('core.manage', $input->get('extension')))
+//If you have a url like this: com_categories&view=categories&extension=com_example.example_cat
+$parts = explode('.', $input->get('extension'));
+$component = $parts[0];
+
+if (!JFactory::getUser()->authorise('core.manage', $component))
 {
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }


### PR DESCRIPTION
Joomla! Tracker [#33176](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33176)

This PR reverts the deletion of a variable that is required and supersedes PR gh-2824
