### PR TITLE
JMailHelper:isEmailAddress checked the IPv4 and IPv6 address in the domain

### DIFF
--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -136,10 +136,8 @@ abstract class JMailHelper
 			return false;
 		}
 
-		// No problem if the domain looks like an IP address, ish
-		$regex = '/^[0-9\.]+$/';
-
-		if (preg_match($regex, $domain))
+		// No problem if the domain looks like an IPv4 and IPv6 address
+		if (inet_pton($domain))
 		{
 			return true;
 		}


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/724

Removes the '@' symbol from #724 
