### PR TITLE
[#33473] itms-services schema not correctly handled

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -77,7 +77,7 @@ class PlgSystemSef extends JPlugin
 		$this->checkBuffer($buffer);
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
-		$protocols = '[a-zA-Z0-9]+:';
+		$protocols = '[a-zA-Z0-9\-]+:';
 		$regex     = '#(src|href|poster)="(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
 		$buffer    = preg_replace($regex, "$1=\"$base\$2\"", $buffer);
 		$this->checkBuffer($buffer);


### PR DESCRIPTION
See Joomla! Tracker [#33473](itms-services schema not correctly handled)
# Description

The itms-services schema is used to distribute ad-hoc iOS apps outside iTunes. When you use it on a normal link inside an article the front-end output is not correct when SEF is enabled and the System - SEF plugin enabled. If you disable SEF URLs or the System - SEF plugin the schema is rendered correctly.
# Testing instructions

With SEF URLs and the System - SEF plugin enabled (both enabled by default) just create a link like that on simple article: itms-services://localhost?action=download-manifest&url=http://loqi.me/app/Geoloqi.plist

_Wrong behaviour_
On the front-end the link is renamed to: /path-to-joomla-site/itms-services://localhost?action=download-manifest&url=http://loqi.me/app/Geoloqi.plist

_Expected behaviour_
The link target remains itms-services://localhost?action=download-manifest&url=http://loqi.me/app/Geoloqi.plist
# Problem identification

The $protocols regex in the System - SEF plugin only catches schemas which contain just alphanumeric characters and numbers. Since the Apple schema itms-services:// contains a dash it is not caught by the RegEx and gets prefixed with the absolute URL path to the site's root.
