### PR TITLE
Forcing the alias tip to display below the label

### DIFF
--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -17,13 +17,15 @@ defined('_JEXEC') or die;
  * 	$for          : (string)  The id of the input this label is for
  * 	$required     : (boolean) True if a required field
  * 	$classes      : (array)   A list of classes
+ * 	$position     : (string)  The tooltip position. Bottom for alias
  */
 
-$text    = $displayData['text'];
-$desc    = $displayData['description'];
-$for     = $displayData['for'];
-$req     = $displayData['required'];
-$classes = array_filter((array) $displayData['classes']);
+$text		= $displayData['text'];
+$desc		= $displayData['description'];
+$for		= $displayData['for'];
+$req		= $displayData['required'];
+$classes	= array_filter((array) $displayData['classes']);
+$position	= $displayData['position'];
 
 $id = $for . '-lbl';
 $title = '';
@@ -43,6 +45,6 @@ if ($req)
 }
 
 ?>
-<label id="<?php echo $id; ?>" for="<?php echo $for; ?>" class="<?php echo implode(' ', $classes); ?>"<?php echo $title; ?>>
+<label id="<?php echo $id; ?>" for="<?php echo $for; ?>" class="<?php echo implode(' ', $classes); ?>"<?php echo $title; ?><?php echo $position; ?>>
 	<?php echo $text; ?><?php if ($req) : ?><span class="star">&#160;*</span><?php endif; ?>
 </label>

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -711,6 +711,8 @@ abstract class JFormField
 		// Get the label text from the XML element, defaulting to the element name.
 		$text = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
 		$text = $this->translateLabel ? JText::_($text) : $text;
+		// Forcing the Alias field to display the tip below
+		$position = $this->element['name'] == 'alias' ? ' data-placement="bottom" ' : '';
 
 		$description = ($this->translateDescription && !empty($this->description)) ? JText::_($this->description) : $this->description;
 
@@ -719,7 +721,8 @@ abstract class JFormField
 				'description' => $description,
 				'for'         => $this->id,
 				'required'    => (bool) $this->required,
-				'classes'     => explode(' ', $this->labelclass)
+				'classes'     => explode(' ', $this->labelclass),
+				'position'    => $position
 			);
 
 		return JLayoutHelper::render($this->renderLabelLayout, $displayData);


### PR DESCRIPTION
I propose this instead of https://github.com/joomla/joomla-cms/pull/3989 as I think the alias tip contains important information:
Result of patch will be:
![screen shot 2014-07-27 at 11 04 45](https://cloud.githubusercontent.com/assets/869724/3713463/20d045b6-156d-11e4-9ef2-db09d6feca92.png)
