### PR TITLE
[#33340] vCard not downloading with cache activated

### DIFF
--- a/components/com_contact/views/contact/view.vcf.php
+++ b/components/com_contact/views/contact/view.vcf.php
@@ -38,7 +38,7 @@ class ContactViewContact extends JViewLegacy
 			return false;
 		}
 
-		JFactory::getDocument()->setMetaData('Content-Type', 'text/directory', true);
+		JFactory::getDocument()->setMimeEncoding('text/directory', true);
 
 		// Compute lastname, firstname and middlename
 		$item->name = trim($item->name);

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -474,6 +474,12 @@ class JCache
 			$document->setHeadData($data['head']);
 		}
 
+		// Get the document MIME encoding out of the cache
+		if (isset($data['mime_encoding']))
+		{
+			$document->setMimeEncoding($data['mime_encoding'], true);
+		}
+
 		// If the pathway buffer is set in the cache data, get it.
 		if (isset($data['pathway']) && is_array($data['pathway']))
 		{
@@ -642,6 +648,9 @@ class JCache
 				$cached['head'] = $document->getHeadData();
 			}
 		}
+
+		// Document MIME encoding
+		$cached['mime_encoding'] = $document->getMimeEncoding();
 
 		// Pathway data
 		if ($app->isSite() && $loptions['nopathway'] != 1)


### PR DESCRIPTION
Joomla! Issue Tracker item [#33340](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33340&start=0)
# Executive summary

Downloading a vCard from com_contacts returns a document in text/html encoding instead of text/directory. Even when it's fixed in the View, once the cache is turned on Joomla! still returns the data in text/html encoding.
# Problem tracking

There are two bugs in Joomla!.

The first bug is in com_contacts itself. The code is using $document->setMetaData instead of $document->setMimeEncoding to set the content type, resulting in the document not having the correct MIME encoding.

The second bug is missing functionality in JCache, namely the getWorkarounds and setWorkarounds methods. even though we cache all header information of the document we fail to save and restore the MIME encoding. This bug has far reaching consequences to any view returning data other than text/html including but not limited to vCard, RSS, Atom, CSS, Javascript, JSON and plain text. The core components only return HTML, RSS and Atom. Nobody spotted the bug because newsfeed clients will happily parse an RSS/Atom feed no matter the MIME encoding. However, this is a bug known for a long time to 3PDs who return non-HTML data, e.g. XML or JSON. This simple patch fixes this bug by storing the MIME encoding into the cache, like we should be doing all along.
