### PR TITLE
[#30472] Cannot cancel Download Tracks in com_banners

### DIFF
--- a/administrator/components/com_banners/views/download/tmpl/default.php
+++ b/administrator/components/com_banners/views/download/tmpl/default.php
@@ -25,8 +25,9 @@ defined('_JEXEC') or die;
 			<?php echo $field->input; ?>
 		<?php endforeach; ?>
 		<div class="clr"></div>
-		<button type="button" class="btn" onclick="this.form.submit();window.top.setTimeout('window.parent.SqueezeBox.close()', 700);"><?php echo JText::_('COM_BANNERS_TRACKS_EXPORT'); ?></button>
-		<button type="button" class="btn" onclick="window.parent.SqueezeBox.close();"><?php echo JText::_('COM_BANNERS_CANCEL'); ?></button>
+		<!-- window.jQuery('#modal-export').modal('hide') -->
+		<button type="button" class="btn" onclick="this.form.submit();window.top.setTimeout('window.parent.Joomla.closeModalDialog()', 700);"><?php echo JText::_('COM_BANNERS_TRACKS_EXPORT'); ?></button>
+		<button type="button" class="btn" onclick="window.parent.Joomla.closeModalDialog();"><?php echo JText::_('COM_BANNERS_CANCEL'); ?></button>
 
 	</fieldset>
 </form>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -36,6 +36,11 @@ $sortFields = $this->getSortFields();
 		}
 		Joomla.tableOrdering(order, dirn, '');
 	}
+
+	Joomla.closeModalDialog = function()
+	{
+		window.jQuery('#modal-export').modal('hide');
+	}
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=tracks'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">


### PR DESCRIPTION
Joomla! Tracker Item [#30472](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30472&start=0)
# Executive summary

In the back-end, Banners, Track, Export the Cancel button doesn't work. Moreover, once you click on Download the modal doesn't automatically close.
# Issue analysis

The Javascript on the modal is referencing the no longer used Squeezebox. Since we are now using Bootstrap's modal we merely need to update the Javascript to use $(element).modal.close();
