### PR TITLE
[#33999] Fix scroll in modal

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit_positions.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_positions.php
@@ -25,7 +25,7 @@ $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 $attr = array(
 	'id'          => 'jform_position',
 	'list.select' => $this->item->position,
-	'list.attr'   => 'class="chzn-custom-value input-xlarge" '
+	'list.attr'   => 'class="chzn-custom-value" '
 	. 'data-custom_group_text="' . $customGroupText . '" '
 	. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
 	. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '


### PR DESCRIPTION
In administrator/index.php?option=com_menus&view=menus. Try clicking on a module in the dropdown and show the module settings in the modal. There is a horizontal scroll, since the position dropdown is too long:

![skrmbillede 2014-07-27 kl 13 23 38](https://cloud.githubusercontent.com/assets/1738811/3713726/8fa044f6-1580-11e4-9c2b-f94c79766284.png)

This PR removes input-xlarge from edit_positions.php. Which also has the side effect that the dropdown aligns nicer in the actual module view:

![skrmbillede 2014-07-27 kl 13 25 29](https://cloud.githubusercontent.com/assets/1738811/3713731/c3d35a6a-1580-11e4-9abf-717d6a010391.png)

Tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33999
