### PR TITLE
[#33761] Fix attribs from being truncated when many are stored

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -335,7 +335,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   `publish_down` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `images` text NOT NULL,
   `urls` text NOT NULL,
-  `attribs` varchar(5120) NOT NULL,
+  `attribs` text NOT NULL,
   `version` int(10) unsigned NOT NULL DEFAULT 1,
   `ordering` int(11) NOT NULL DEFAULT 0,
   `metakey` text NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -323,7 +323,7 @@ CREATE TABLE "#__content" (
   "publish_down" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "images" text NOT NULL,
   "urls" text NOT NULL,
-  "attribs" varchar(5120) NOT NULL,
+  "attribs" text NOT NULL,
   "version" bigint DEFAULT 1 NOT NULL,
   "ordering" bigint DEFAULT 0 NOT NULL,
   "metakey" text NOT NULL,


### PR DESCRIPTION
## How to reproduce the problem and/or test the patch::

Joomla attributes has a varchar 5120 set to it. If you create a custom field that stores to this table it won't save the full amount. Need to change from varchar to text.
## Summary

Attribs doesn't support large amounts of data for #__content
Details
Joomla attributes has a varchar 5120 set to it. If you create a custom field that stores to this table it won't save the full amount. Need to change from varchar to text.
In install file change

`attribs` varchar(5120) NOT NULL,
to

`attribs` text NOT NULL,
