### PR TITLE
Remove the notice from JBrowser

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -461,7 +461,6 @@ class JBrowser
 		// Can't identify browser version
 		$this->majorVersion = 0;
 		$this->minorVersion = 0;
-		JLog::add("Can't identify browser version. Agent: " . $this->agent, JLog::NOTICE);
 	}
 
 	/**


### PR DESCRIPTION
## Abstract

Each time Joomla cannot detect a browser type, a visible warning will appear in Front end. The issue tracker is filled with endless bug reports for all type of obscure browsers.

![image](https://cloud.githubusercontent.com/assets/1197635/3714397/07f9f724-15a6-11e4-9c7a-0eeaeda84d99.png)
## Proposed solution

I don't know any use for the logger / notice that appears. So I propose to remove it completely.
## Testing instructions

Try to change your user agent (with a browser extension or something) to something obscure. The warning should appear. Keep on trying till you find one.

Apply patch.

See that the notice is gone.
