### PR TITLE
[#33638] Redirect to homepage when pressing the language flag after page load

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -71,6 +71,7 @@ abstract class ModLanguagesHelper
 
 		$levels		= $user->getAuthorisedViewLevels();
 		$languages	= JLanguageHelper::getLanguages();
+		$activeLanguage = JFactory::getLanguage()->getTag();
 
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)
@@ -114,7 +115,11 @@ abstract class ModLanguagesHelper
 					}
 					else
 					{
-						if ($app->get('sef') == '1')
+						if ($language->lang_code == $activeLanguage)
+						{
+							$language->link = JUri::current();
+						}
+						elseif ($app->get('sef') == '1')
 						{
 							$itemid = isset($homes[$language->lang_code]) ? $homes[$language->lang_code]->id : $homes['*']->id;
 							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);


### PR DESCRIPTION
Joomla! Tracker Item [#33638](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33638&start=0)
# Executive summary

On a multilingual site the current language's flag will always get you back to the site's root instead of the currently loaded page.
# Details

Let's say you have a multilingual 3.2 site with French, Greek and English (default) installed.

If you change the language to French (by clicking on the French flag), once the page is loaded if you then click the French flag again, it redirects to the homepage. When you click on the other flags you are transferred correctly to the linked item.
# Issue tracking

The ModLanguagesHelper::getList assumes that if there is no associated item for a language it should link to the homepage. However the active item doesn't have an association to itself on its own language.
