### PR TITLE
Missed COM_USERS_RESET in en-GB.com_users.ini

### DIFF
--- a/language/en-GB/en-GB.com_users.ini
+++ b/language/en-GB/en-GB.com_users.ini
@@ -133,6 +133,7 @@ COM_USERS_REMIND_LIMIT_ERROR_N_HOURS_1="You have exceeded the maximum number of 
 COM_USERS_REMIND_REQUEST_FAILED="Reminder failed: %s"
 COM_USERS_REMIND_REQUEST_SUCCESS="Reminder successfully sent. Please check your mail."
 COM_USERS_REMIND_SUPERADMIN_ERROR="A Super User can't request a password reminder. Please contact another Super User or use an alternative method."
+COM_USERS_RESET="Password Reset"
 COM_USERS_RESET_COMPLETE_ERROR="Error completing password reset."
 COM_USERS_RESET_COMPLETE_FAILED="Completing reset password failed: %s"
 COM_USERS_RESET_COMPLETE_LABEL="To complete the password reset process, please enter a new password."


### PR DESCRIPTION
The constant COM_USERS_RESET is used in components\com_users\views\reset\view.html.php
