### PR TITLE
[#32922] Quick fix for tracker item

### DIFF
--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 foreach ($list as $item) :
 
 ?>
-	<li <?php if ($_SERVER['PHP_SELF'] == JRoute::_(ContentHelperRoute::getCategoryRoute($item->id))) echo ' class="active"';?>> <?php $levelup = $item->level - $startLevel - 1; ?>
+	<li <?php if ($_SERVER['REQUEST_URI'] == JRoute::_(ContentHelperRoute::getCategoryRoute($item->id))) echo ' class="active"';?>> <?php $levelup = $item->level - $startLevel - 1; ?>
 		<h<?php echo $params->get('item_heading') + $levelup; ?>>
 		<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id)); ?>">
 		<?php echo $item->title;?><?php if($params->get('numitems')): ?>


### PR DESCRIPTION
A quick fix for the tracker item, proposed by izy:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=32922

Original report from joomlacode pasted below

How to reproduce the problem and/or test the patch::
1. Turn on mod_articles_categories (now current category has "active" class) 2. Turn on link rewrite (SEF). (now the class disappears)
Successful Tests:
Easy:
Summary
In articles categories module (mod_articles_categories) active category doesn't have "active" class, when SEF is on
Details
This line doesn't work with SEF on:

< li <?php if ($_SERVER['PHP_SELF'] == JRoute::_(ContentHelperRoute::getCategoryRoute($item->id))) echo ' class="active"';?>> <?php $levelup = $item->level - $startLevel - 1; ?>
