### PR TITLE
[#34020] Allowing cloaking when image and text or Image and email

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -128,6 +128,9 @@ class PlgContentEmailcloak extends JPlugin
 		// Any Image link
 		$searchImage	=	"(<img[^>]+>)";
 
+		// Any image link + any text
+		$searchAny	= '(<img[^>]+>)+((?:[\x20-\x7f]|[\xA1-\xFF]|[\xC2-\xDF][\x80-\xBF]|[\xE0-\xEF][\x80-\xBF]{2}|[\xF0-\xF4][\x80-\xBF]{3})[^<>]+)';
+
 		/*
 		 * Search and fix derivatives of link code <a href="http://mce_host/ourdirectory/email@example.org"
 		 * >email@example.org</a>. This happens when inserting an email in TinyMCE, cancelling its suggestion to add
@@ -236,6 +239,26 @@ class PlgContentEmailcloak extends JPlugin
 		}
 
 		/*
+		 * Search for derivatives of link code <a href="mailto:email@example.org">
+		 * <img anything>any text</a>
+		 */
+		$pattern = $this->_getPattern($searchEmail, $searchAny);
+
+		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
+		{
+			$mail = $regs[2][0];
+			$mailText = $regs[4][0] . ($regs[5][0]);
+
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
+
+			// Replace the found address with the js cloaked email
+			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
+		}
+
+		/*
 		 * Search for derivatives of link code <a href="mailto:email@example.org?
 		 * subject=Text">email@example.org</a>
 		 */
@@ -292,6 +315,30 @@ class PlgContentEmailcloak extends JPlugin
 		{
 			$mail = $regs[1][0] . $regs[2][0] . $regs[3][0];
 			$mailText = $regs[5][0];
+
+			// Needed for handling of Body parameter
+			$mail = str_replace('&amp;', '&', $mail);
+
+			// Check to see if mail text is different from mail addy
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));
+
+			// Replace the found address with the js cloaked email
+			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
+		}
+
+		/*
+		 * Search for derivatives of link code
+		* <a href="mailto:email@amail.com?subject=Text"><img anything>any text</a>
+		*/
+		$pattern = $this->_getPattern($searchEmailLink, $searchAny);
+
+		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
+		{
+			$mail = $regs[1][0] . $regs[2][0] . $regs[3][0];
+			$mailText = $regs[4][0] . $regs[5][0] . $regs[6][0];
 
 			// Needed for handling of Body parameter
 			$mail = str_replace('&amp;', '&', $mail);

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -128,9 +128,6 @@ class PlgContentEmailcloak extends JPlugin
 		// Any Image link
 		$searchImage	=	"(<img[^>]+>)";
 
-		// Any image link + any text
-		$searchAny	= '(<img[^>]+>)+((?:[\x20-\x7f]|[\xA1-\xFF]|[\xC2-\xDF][\x80-\xBF]|[\xE0-\xEF][\x80-\xBF]{2}|[\xF0-\xF4][\x80-\xBF]{3})[^<>]+)';
-
 		/*
 		 * Search and fix derivatives of link code <a href="http://mce_host/ourdirectory/email@example.org"
 		 * >email@example.org</a>. This happens when inserting an email in TinyMCE, cancelling its suggestion to add
@@ -242,7 +239,7 @@ class PlgContentEmailcloak extends JPlugin
 		 * Search for derivatives of link code <a href="mailto:email@example.org">
 		 * <img anything>any text</a>
 		 */
-		$pattern = $this->_getPattern($searchEmail, $searchAny);
+		$pattern = $this->_getPattern($searchEmail, ($searchImage . $searchText));
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{
@@ -331,9 +328,9 @@ class PlgContentEmailcloak extends JPlugin
 
 		/*
 		 * Search for derivatives of link code
-		* <a href="mailto:email@amail.com?subject=Text"><img anything>any text</a>
-		*/
-		$pattern = $this->_getPattern($searchEmailLink, $searchAny);
+		 * <a href="mailto:email@amail.com?subject=Text"><img anything>any text</a>
+		 */
+		$pattern = $this->_getPattern($searchEmailLink, ($searchImage . $searchText));
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -237,6 +237,26 @@ class PlgContentEmailcloak extends JPlugin
 
 		/*
 		 * Search for derivatives of link code <a href="mailto:email@example.org">
+		 * <img anything>email@example.org</a>
+		 */
+		$pattern = $this->_getPattern($searchEmail, ($searchImage . $searchEmail));
+
+		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
+		{
+			$mail = $regs[2][0];
+			$mailText = $regs[4][0] . ($regs[5][0]);
+
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
+
+			// Replace the found address with the js cloaked email
+			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
+		}
+
+		/*
+		 * Search for derivatives of link code <a href="mailto:email@example.org">
 		 * <img anything>any text</a>
 		 */
 		$pattern = $this->_getPattern($searchEmail, ($searchImage . $searchText));
@@ -318,6 +338,30 @@ class PlgContentEmailcloak extends JPlugin
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
+
+			// Ensure that attributes is not stripped out by email cloaking
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));
+
+			// Replace the found address with the js cloaked email
+			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
+		}
+
+		/*
+		 * Search for derivatives of link code
+		 * <a href="mailto:email@amail.com?subject=Text"><img anything>email@amail.com</a>
+		 */
+		$pattern = $this->_getPattern($searchEmailLink, ($searchImage . $searchEmail));
+
+		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
+		{
+			$mail = $regs[1][0] . $regs[2][0] . $regs[3][0];
+			$mailText = $regs[4][0] . $regs[5][0] . $regs[6][0];
+
+			// Needed for handling of Body parameter
+			$mail = str_replace('&amp;', '&', $mail);
+
+			// Check to see if mail text is different from mail addy
+			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
 
 			// Ensure that attributes is not stripped out by email cloaking
 			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/3955#issuecomment-50634158
Test with

```
<p><a href="mailto:info@mysite.com"><img style="margin: 0px 3px 0px 0px; float:left; width:21px; height:21px;" title="Email to me" src="images/powered_by.png" alt="An email" width="21" height="21" /> Contact us</a><p>
```

and

```
<p><a href="mailto:info@mysite.com?subject=A Text"><img style="margin: 0px 3px 0px 0px; float:left; width:21px; height:21px;" title="Email to me" src="images/powered_by.png" alt="An email" width="21" height="21" /> Contact us</a><p>
```

Will have to be added also to:
https://github.com/joomla/joomla-cms/pull/3967

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34020&start=0
