### PR TITLE
Change message type to 'error' when delete fail JControllerAdmin (legacy)

### DIFF
--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -133,7 +133,7 @@ class JControllerAdmin extends JControllerLegacy
 			}
 			else
 			{
-				$this->setMessage($model->getError());
+				$this->setMessage($model->getError(), 'error');
 			}
 		}
 		// Invoke the postDelete method to allow for the child class to access the model.


### PR DESCRIPTION
Change message type to 'error', instead of default 'message' when delete fails
