### PR TITLE
Removed unnecessary info text if dob is deactivated

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -282,6 +282,11 @@ class PlgUserProfile extends JPlugin
 					&& $this->params->get('profile-require_' . $field, 1) == 0)
 				{
 					$form->removeField($field, 'profile');
+
+					if ($field == 'dob')
+					{
+						$form->removeField('dob_spacer', 'profile');
+					}
 				}
 
 				if ($this->params->get('profile-require_dob', 1) > 0)
@@ -300,6 +305,11 @@ class PlgUserProfile extends JPlugin
 				else
 				{
 					$form->removeField($field, 'profile');
+
+					if ($field == 'dob')
+					{
+						$form->removeField('dob_spacer', 'profile');
+					}
 				}
 
 				if ($this->params->get('register-require_dob', 1) > 0)
@@ -318,6 +328,11 @@ class PlgUserProfile extends JPlugin
 				else
 				{
 					$form->removeField($field, 'profile');
+
+					if ($field == 'dob')
+					{
+						$form->removeField('dob_spacer', 'profile');
+					}
 				}
 
 				if ($this->params->get('profile-require_dob', 1) > 0)


### PR DESCRIPTION
If you deactivate the date of birth in the profile plugin, the info text is still visible. (The date of birth entered should use the format Year-Month-Day, i.e. 0000-00-00)
