### PR TITLE
Batch copy feature should not copy hits value

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -89,6 +89,9 @@ class ContentModelArticle extends JModelAdmin
 
 			// Reset the ID because we are making a copy
 			$this->table->id = 0;
+			
+			// Reset hits because we are making a copy
+			$this->table->hits = 0;
 
 			// New category ID
 			$this->table->catid = $categoryId;


### PR DESCRIPTION
Copied article should have 0 hits because this is a new article and nobody have seen it yet.
