### PR TITLE
[#34027] Add ability to override the renderer [New feature]

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -285,9 +285,20 @@ class JDocument
 
 		if (empty(self::$instances[$signature]))
 		{
+			$app = JFactory::getApplication();
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
+
+			if ($app->isSite())
+			{
+				$templateDir = JPATH_ROOT . '/templates/' . $app->getTemplate();
+
+				if (file_exists(dirname($templateDir) . '/document/' . $type . '/renderer/' . $type . '.php'))
+				{
+					$path = dirname($templateDir) . '/document/' . $type . '/renderer/' . $type . '.php';
+				}
+			}
 
 			// Check if the document type exists
 			if (!file_exists($path))
@@ -1014,15 +1025,14 @@ class JDocument
 	public function loadRenderer($type)
 	{
 		$class = 'JDocumentRenderer' . $type;
-		$file = $this->_file;
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (file_exists(dirname($file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if (file_exists(dirname($this->_file;) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path = dirname($file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path = dirname($this->_file;) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -290,16 +290,6 @@ class JDocument
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
 
-			if ($app->isSite())
-			{
-				$templateDir = JPATH_ROOT . '/templates/' . $app->getTemplate();
-
-				if (file_exists(dirname($templateDir) . '/document/' . $type . '/renderer/' . $type . '.php'))
-				{
-					$path = dirname($templateDir) . '/document/' . $type . '/renderer/' . $type . '.php';
-				}
-			}
-
 			// Check if the document type exists
 			if (!file_exists($path))
 			{
@@ -314,6 +304,14 @@ class JDocument
 			if (!class_exists($class))
 			{
 				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+
+				if ($app->isSite())
+				{
+					if (file_exists(JPATH_ROOT . '/templates/' . $app->getTemplate() . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+					{
+						$path = JPATH_ROOT . '/templates/' . $app->getTemplate() . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+					}
+				}
 
 				if (file_exists($path))
 				{

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1011,9 +1011,9 @@ class JDocument
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (is_dir(pathinfo($this->_file)['dirname'].'/document'))
+			if (is_dir(dirname($this->_file) . '/document'))
 			{
-				$path = pathinfo($this->_file)['dirname'] . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -130,6 +130,14 @@ class JDocument
 	public $_profile = '';
 
 	/**
+	 * The full path to active template index.php
+	 *
+	 * @var    string
+	 * @since  3.4
+	 */
+	public $_file = '';
+
+	/**
 	 * Array of linked scripts
 	 *
 	 * @var    array
@@ -1011,7 +1019,7 @@ class JDocument
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (is_dir(dirname($this->_file) . '/document'))
+			if (is_dir(dirname($this->_file) . '/document/' . $this->_type . '/renderer'))
 			{
 				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1011,6 +1011,11 @@ class JDocument
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
+			if (is_dir(pathinfo($this->_file)['dirname'].'/document'))
+			{
+				$path = pathinfo($this->_file)['dirname'] . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+			}
+
 			if (file_exists($path))
 			{
 				require_once $path;

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -135,7 +135,7 @@ class JDocument
 	 * @var    string
 	 * @since  3.4
 	 */
-	public $_file = '';
+	public $file = '';
 
 	/**
 	 * Array of linked scripts
@@ -1019,7 +1019,7 @@ class JDocument
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (is_dir(dirname($this->_file) . '/document/' . $this->_type . '/renderer'))
+			if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
 				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -135,7 +135,7 @@ class JDocument
 	 * @var    string
 	 * @since  3.4
 	 */
-	public $file = '';
+	public $_file = '';
 
 	/**
 	 * Array of linked scripts
@@ -1030,9 +1030,9 @@ class JDocument
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (file_exists(dirname($this->_file;) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path = dirname($this->_file;) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -130,14 +130,6 @@ class JDocument
 	public $_profile = '';
 
 	/**
-	 * The full path to active template index.php
-	 *
-	 * @var    string
-	 * @since  3.4
-	 */
-	public $_file = '';
-
-	/**
 	 * Array of linked scripts
 	 *
 	 * @var    array

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -286,9 +286,19 @@ class JDocument
 		if (empty(self::$instances[$signature]))
 		{
 			$app = JFactory::getApplication();
+			$template = $app->getTemplate();
+			$site = $app->isSite();
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
+
+			if ($site)
+			{
+				if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+				{
+					$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+				}
+			}
 
 			// Check if the document type exists
 			if (!file_exists($path))
@@ -305,11 +315,11 @@ class JDocument
 			{
 				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 
-				if ($app->isSite())
+				if ($site)
 				{
-					if (file_exists(JPATH_ROOT . '/templates/' . $app->getTemplate() . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+					if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
 					{
-						$path = JPATH_ROOT . '/templates/' . $app->getTemplate() . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+						$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
 					}
 				}
 

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -279,17 +279,13 @@ class JDocument
 		{
 			$app = JFactory::getApplication();
 			$template = $app->getTemplate();
-			$site = $app->isSite();
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
 
-			if ($site)
+			if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
 			{
-				if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
-				{
-					$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
-				}
+				$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
 			}
 
 			// Check if the document type exists
@@ -307,12 +303,9 @@ class JDocument
 			{
 				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 
-				if ($site)
+				if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
 				{
-					if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
-					{
-						$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
-					}
+					$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
 				}
 
 				if (file_exists($path))
@@ -1024,19 +1017,17 @@ class JDocument
 	 */
 	public function loadRenderer($type)
 	{
-		$app = JFactory::getApplication();
 		$class = 'JDocumentRenderer' . $type;
+		$app = JFactory::getApplication();
+		$template = $app->getTemplate();
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if ($app->isSite())
+			if (file_exists(JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
-				{
-					$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
-				}
+				$path = JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1014,14 +1014,15 @@ class JDocument
 	public function loadRenderer($type)
 	{
 		$class = 'JDocumentRenderer' . $type;
+		$file = $this->_file;
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if (file_exists(dirname($file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path = dirname($file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1024,15 +1024,19 @@ class JDocument
 	 */
 	public function loadRenderer($type)
 	{
+		$app = JFactory::getApplication();
 		$class = 'JDocumentRenderer' . $type;
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 
-			if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if ($app->isSite())
 			{
-				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				if (file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+				{
+					$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				}
 			}
 
 			if (file_exists($path))

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -785,7 +785,6 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testLoadRenderer()
 	{
-		$this->object->_file = 'path to template';
 		$this->object->setType('html');
 		$renderer = $this->object->loadRenderer('head');
 		$this->assertThat(
@@ -802,7 +801,6 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testLoadRendererException()
 	{
-		$this->object->_file = 'path to template';
 		$this->object->setType('html');
 		$this->object->loadRenderer('unknown');
 	}

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -785,6 +785,7 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testLoadRenderer()
 	{
+		$this->object->_file = 'path to template';
 		$this->object->setType('html');
 		$renderer = $this->object->loadRenderer('head');
 		$this->assertThat(
@@ -801,6 +802,7 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testLoadRendererException()
 	{
+		$this->object->_file = 'path to template';
 		$this->object->setType('html');
 		$this->object->loadRenderer('unknown');
 	}


### PR DESCRIPTION
In Joomla! if you want to override something you have to put it in the active template directory (e.g.: the layouts goes in (active template)/html/layouts).
This PR introduces the ability to override the whole rendering process in the template by copying (and modifying per your preferences) the /libraries/joomla/document directory.

It shouldn't rise any backward compatibility issues (except that the directory [active template]/document might be in use?).

What this PR might provide to Joomla! devs/users?
Flexibility on the way that the template renders the data (the inner logic). e.g. someone may use `echo $this->getBuffer('modules', 'menu', array('menu', 'html5'));` and remove the `<jdoc.. >` parser.

Why?
Because this is one area that if you want to override and use your own logic you have to do it through a plugin (this is way easier and cleaner)

Feature tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34027
