### PR TITLE
[#34028] Fixed PHPMailer with attachment(s)

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -311,7 +311,7 @@ class JMail extends PHPMailer
 	}
 
 	/**
-	 * Add file attachments to the email
+	 * Add file attachment to the email
 	 *
 	 * @param   mixed  $path        Either a string or array of strings [filenames]
 	 * @param   mixed  $name       	Either a string or array of strings [names]
@@ -351,6 +351,39 @@ class JMail extends PHPMailer
 			{
 				parent::addAttachment($path, $name, $encoding, $type);
 			}
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Unset all file attachments from the email
+	 *
+	 * @return  JMail  Returns this object for chaining.
+	 *
+	 * @since   12.2
+	 */
+	public function clearAttachments()
+	{
+		parent::clearAttachments();
+
+		return $this;
+	}
+
+	/**
+	 * Unset file attachments specified by array index.
+	 *
+	 * @param   integer  $index     The numerical index of the attachment to remove
+	 *
+	 * @return  JMail  Returns this object for chaining.
+	 *
+	 * @since   12.2
+	 */
+	public function removeAttachment($index = 0)
+	{
+		if (isset($this->attachment[0]))
+		{
+			unset($this->attachment[0]);
 		}
 
 		return $this;

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -381,9 +381,9 @@ class JMail extends PHPMailer
 	 */
 	public function removeAttachment($index = 0)
 	{
-		if (isset($this->attachment[0]))
+		if (isset($this->attachment[$index]))
 		{
-			unset($this->attachment[0]);
+			unset($this->attachment[$index]);
 		}
 
 		return $this;

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -207,7 +207,7 @@ class JMail extends PHPMailer
 	 * @since   11.1
 	 * @throws  InvalidArgumentException
 	 */
-	protected function add($recipient, $name = '', $method = 'AddAddress')
+	protected function add($recipient, $name = '', $method = 'addAddress')
 	{
 		$method = lcfirst($method);
 

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -92,7 +92,6 @@ class JMail extends PHPMailer
 				}
 			}
 
-			// Don't suppress errors here! This will suppress PHP errors as well and might end up the user with a blank page rather than an error.
 			$result = parent::send();
 
 			if ($result == false)

--- a/libraries/phpmailer/LICENSE
+++ b/libraries/phpmailer/LICENSE
@@ -312,7 +312,7 @@ of these things:
     from a designated place, offer equivalent access to copy the above
     specified materials from the same place.
 
-    e) Verify that the user has already received a copy of these
+    e) verify that the user has already received a copy of these
     materials or that you have already sent this user a copy.
 
   For an executable, the required form of the "work that uses the
@@ -500,5 +500,3 @@ necessary.  Here is a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
-
-

--- a/libraries/phpmailer/PHPMailerAutoload.php
+++ b/libraries/phpmailer/PHPMailerAutoload.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPMailer SPL autoloader.
+ * PHP Version 5
+ * @package PHPMailer
+ * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author Brent R. Matzelle (original founder)
+ * @copyright 2012 - 2014 Marcus Bointon
+ * @copyright 2010 - 2012 Jim Jagielski
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @note This program is distributed in the hope that it will be useful - WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * PHPMailer SPL autoloader.
+ * @param string $classname The name of the class to load
+ */
+function PHPMailerAutoload($classname)
+{
+    //Can't use __DIR__ as it's only in PHP 5.3+
+    $filename = dirname(__FILE__).DIRECTORY_SEPARATOR.'class.'.strtolower($classname).'.php';
+    if (is_readable($filename)) {
+        require $filename;
+    }
+}
+
+if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
+    //SPL autoloading was introduced in PHP 5.1.2
+    if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+        spl_autoload_register('PHPMailerAutoload', true, true);
+    } else {
+        spl_autoload_register('PHPMailerAutoload');
+    }
+} else {
+    /**
+     * Fall back to traditional autoload for old PHP versions
+     * @param string $classname The name of the class to load
+     */
+    function __autoload($classname)
+    {
+        PHPMailerAutoload($classname);
+    }
+}

--- a/libraries/phpmailer/extras/EasyPeasyICS.php
+++ b/libraries/phpmailer/extras/EasyPeasyICS.php
@@ -1,0 +1,90 @@
+<?php
+
+/* ------------------------------------------------------------------------ */
+/* EasyPeasyICS
+/* ------------------------------------------------------------------------ */
+/* Manuel Reinhard, manu@sprain.ch
+/* Twitter: @sprain
+/* Web: www.sprain.ch
+/*
+/* Built with inspiration by
+/" http://stackoverflow.com/questions/1463480/how-can-i-use-php-to-dynamically-publish-an-ical-file-to-be-read-by-google-calend/1464355#1464355
+/* ------------------------------------------------------------------------ */
+/* History:
+/* 2010/12/17 - Manuel Reinhard - when it all started
+/* ------------------------------------------------------------------------ */  
+
+class EasyPeasyICS {
+
+	protected $calendarName;
+	protected $events = array();
+	
+
+	/**
+	 * Constructor
+	 * @param string $calendarName
+	 */	
+	public function __construct($calendarName=""){
+		$this->calendarName = $calendarName;
+	}//function
+
+
+	/**
+	 * Add event to calendar
+	 * @param string $calendarName
+	 */	
+	public function addEvent($start, $end, $summary="", $description="", $url=""){
+		$this->events[] = array(
+			"start" => $start,
+			"end"   => $end,
+			"summary" => $summary,
+			"description" => $description,
+			"url" => $url
+		);
+	}//function
+	
+	
+	public function render($output = true){
+		
+		//start Variable
+		$ics = "";
+	
+		//Add header
+		$ics .= "BEGIN:VCALENDAR
+METHOD:PUBLISH
+VERSION:2.0
+X-WR-CALNAME:".$this->calendarName."
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN";
+		
+		//Add events
+		foreach($this->events as $event){
+			$ics .= "
+BEGIN:VEVENT
+UID:". md5(uniqid(mt_rand(), true)) ."@EasyPeasyICS.php
+DTSTAMP:" . gmdate('Ymd').'T'. gmdate('His') . "Z
+DTSTART:".gmdate('Ymd', $event["start"])."T".gmdate('His', $event["start"])."Z
+DTEND:".gmdate('Ymd', $event["end"])."T".gmdate('His', $event["end"])."Z
+SUMMARY:".str_replace("\n", "\\n", $event['summary'])."
+DESCRIPTION:".str_replace("\n", "\\n", $event['description'])."
+URL;VALUE=URI:".$event['url']."
+END:VEVENT";
+		}//foreach
+		
+		
+		//Footer
+		$ics .= "
+END:VCALENDAR";
+
+
+		if ($output) {
+			//Output
+			header('Content-type: text/calendar; charset=utf-8');
+			header('Content-Disposition: inline; filename='.$this->calendarName.'.ics');
+			echo $ics;
+		} else {
+			return $ics;
+		}
+
+	}//function
+
+}//class

--- a/libraries/phpmailer/extras/class.html2text.php
+++ b/libraries/phpmailer/extras/class.html2text.php
@@ -1,0 +1,677 @@
+<?php
+/*************************************************************************
+ *                                                                       *
+ * Converts HTML to formatted plain text                                 *
+ *                                                                       *
+ * Portions Copyright (c) 2005-2007 Jon Abernathy <jon@chuggnutt.com>    *
+ *                                                                       *
+ * This script is free software; you can redistribute it and/or modify   *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * The GNU General Public License can be found at                        *
+ * http://www.gnu.org/copyleft/gpl.html.                                 *
+ *                                                                       *
+ * This script is distributed in the hope that it will be useful,        *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ *************************************************************************/
+
+/**
+ * Converts HTML to formatted plain text
+ */
+class Html2Text
+{
+    /**
+     * Contains the HTML content to convert.
+     *
+     * @type string
+     */
+    protected $html;
+
+    /**
+     * Contains the converted, formatted text.
+     *
+     * @type string
+     */
+    protected $text;
+
+    /**
+     * Maximum width of the formatted text, in columns.
+     *
+     * Set this value to 0 (or less) to ignore word wrapping
+     * and not constrain text to a fixed-width column.
+     *
+     * @type integer
+     */
+    protected $width = 70;
+
+    /**
+     * List of preg* regular expression patterns to search for,
+     * used in conjunction with $replace.
+     *
+     * @type array
+     * @see $replace
+     */
+    protected $search = array(
+        "/\r/",                                  // Non-legal carriage return
+        "/[\n\t]+/",                             // Newlines and tabs
+        '/<head[^>]*>.*?<\/head>/i',             // <head>
+        '/<script[^>]*>.*?<\/script>/i',         // <script>s -- which strip_tags supposedly has problems with
+        '/<style[^>]*>.*?<\/style>/i',           // <style>s -- which strip_tags supposedly has problems with
+        '/<p[^>]*>/i',                           // <P>
+        '/<br[^>]*>/i',                          // <br>
+        '/<i[^>]*>(.*?)<\/i>/i',                 // <i>
+        '/<em[^>]*>(.*?)<\/em>/i',               // <em>
+        '/(<ul[^>]*>|<\/ul>)/i',                 // <ul> and </ul>
+        '/(<ol[^>]*>|<\/ol>)/i',                 // <ol> and </ol>
+        '/(<dl[^>]*>|<\/dl>)/i',                 // <dl> and </dl>
+        '/<li[^>]*>(.*?)<\/li>/i',               // <li> and </li>
+        '/<dd[^>]*>(.*?)<\/dd>/i',               // <dd> and </dd>
+        '/<dt[^>]*>(.*?)<\/dt>/i',               // <dt> and </dt>
+        '/<li[^>]*>/i',                          // <li>
+        '/<hr[^>]*>/i',                          // <hr>
+        '/<div[^>]*>/i',                         // <div>
+        '/(<table[^>]*>|<\/table>)/i',           // <table> and </table>
+        '/(<tr[^>]*>|<\/tr>)/i',                 // <tr> and </tr>
+        '/<td[^>]*>(.*?)<\/td>/i',               // <td> and </td>
+        '/<span class="_html2text_ignore">.+?<\/span>/i'  // <span class="_html2text_ignore">...</span>
+    );
+
+    /**
+     * List of pattern replacements corresponding to patterns searched.
+     *
+     * @type array
+     * @see $search
+     */
+    protected $replace = array(
+        '',                                     // Non-legal carriage return
+        ' ',                                    // Newlines and tabs
+        '',                                     // <head>
+        '',                                     // <script>s -- which strip_tags supposedly has problems with
+        '',                                     // <style>s -- which strip_tags supposedly has problems with
+        "\n\n",                                 // <P>
+        "\n",                                   // <br>
+        '_\\1_',                                // <i>
+        '_\\1_',                                // <em>
+        "\n\n",                                 // <ul> and </ul>
+        "\n\n",                                 // <ol> and </ol>
+        "\n\n",                                 // <dl> and </dl>
+        "\t* \\1\n",                            // <li> and </li>
+        " \\1\n",                               // <dd> and </dd>
+        "\t* \\1",                              // <dt> and </dt>
+        "\n\t* ",                               // <li>
+        "\n-------------------------\n",        // <hr>
+        "<div>\n",                              // <div>
+        "\n\n",                                 // <table> and </table>
+        "\n",                                   // <tr> and </tr>
+        "\t\t\\1\n",                            // <td> and </td>
+        ""                                      // <span class="_html2text_ignore">...</span>
+    );
+
+    /**
+     * List of preg* regular expression patterns to search for,
+     * used in conjunction with $ent_replace.
+     *
+     * @type array
+     * @see $ent_replace
+     */
+    protected $ent_search = array(
+        '/&(nbsp|#160);/i',                      // Non-breaking space
+        '/&(quot|rdquo|ldquo|#8220|#8221|#147|#148);/i',
+        // Double quotes
+        '/&(apos|rsquo|lsquo|#8216|#8217);/i',   // Single quotes
+        '/&gt;/i',                               // Greater-than
+        '/&lt;/i',                               // Less-than
+        '/&(copy|#169);/i',                      // Copyright
+        '/&(trade|#8482|#153);/i',               // Trademark
+        '/&(reg|#174);/i',                       // Registered
+        '/&(mdash|#151|#8212);/i',               // mdash
+        '/&(ndash|minus|#8211|#8722);/i',        // ndash
+        '/&(bull|#149|#8226);/i',                // Bullet
+        '/&(pound|#163);/i',                     // Pound sign
+        '/&(euro|#8364);/i',                     // Euro sign
+        '/&(amp|#38);/i',                        // Ampersand: see _converter()
+        '/[ ]{2,}/',                             // Runs of spaces, post-handling
+    );
+
+    /**
+     * List of pattern replacements corresponding to patterns searched.
+     *
+     * @type array
+     * @see $ent_search
+     */
+    protected $ent_replace = array(
+        ' ',                                    // Non-breaking space
+        '"',                                    // Double quotes
+        "'",                                    // Single quotes
+        '>',
+        '<',
+        '(c)',
+        '(tm)',
+        '(R)',
+        '--',
+        '-',
+        '*',
+        '£',
+        'EUR',                                  // Euro sign. € ?
+        '|+|amp|+|',                            // Ampersand: see _converter()
+        ' ',                                    // Runs of spaces, post-handling
+    );
+
+    /**
+     * List of preg* regular expression patterns to search for
+     * and replace using callback function.
+     *
+     * @type array
+     */
+    protected $callback_search = array(
+        '/<(a) [^>]*href=("|\')([^"\']+)\2([^>]*)>(.*?)<\/a>/i', // <a href="">
+        '/<(h)[123456]( [^>]*)?>(.*?)<\/h[123456]>/i',           // h1 - h6
+        '/<(b)( [^>]*)?>(.*?)<\/b>/i',                           // <b>
+        '/<(strong)( [^>]*)?>(.*?)<\/strong>/i',                 // <strong>
+        '/<(th)( [^>]*)?>(.*?)<\/th>/i',                         // <th> and </th>
+    );
+
+    /**
+     * List of preg* regular expression patterns to search for in PRE body,
+     * used in conjunction with $pre_replace.
+     *
+     * @type array
+     * @see $pre_replace
+     */
+    protected $pre_search = array(
+        "/\n/",
+        "/\t/",
+        '/ /',
+        '/<pre[^>]*>/',
+        '/<\/pre>/'
+    );
+
+    /**
+     * List of pattern replacements corresponding to patterns searched for PRE body.
+     *
+     * @type array
+     * @see $pre_search
+     */
+    protected $pre_replace = array(
+        '<br>',
+        '&nbsp;&nbsp;&nbsp;&nbsp;',
+        '&nbsp;',
+        '',
+        ''
+    );
+
+    /**
+     * Temporary workspace used during PRE processing.
+     *
+     * @type string
+     */
+    protected $pre_content = '';
+
+    /**
+     * Contains a list of HTML tags to allow in the resulting text.
+     *
+     * @type string
+     * @see set_allowed_tags()
+     */
+    protected $allowed_tags = '';
+
+    /**
+     * Contains the base URL that relative links should resolve to.
+     *
+     * @type string
+     */
+    protected $url;
+
+    /**
+     * Indicates whether content in the $html variable has been converted yet.
+     *
+     * @type boolean
+     * @see $html, $text
+     */
+    protected $_converted = false;
+
+    /**
+     * Contains URL addresses from links to be rendered in plain text.
+     *
+     * @type array
+     * @see _build_link_list()
+     */
+    protected $_link_list = array();
+
+    /**
+     * Various configuration options (able to be set in the constructor)
+     *
+     * @type array
+     */
+    protected $_options = array(
+        // 'none'
+        // 'inline' (show links inline)
+        // 'nextline' (show links on the next line)
+        // 'table' (if a table of link URLs should be listed after the text.
+        'do_links' => 'inline',
+        //  Maximum width of the formatted text, in columns.
+        //  Set this value to 0 (or less) to ignore word wrapping
+        //  and not constrain text to a fixed-width column.
+        'width' => 70,
+    );
+
+    /**
+     * Constructor.
+     *
+     * If the HTML source string (or file) is supplied, the class
+     * will instantiate with that source propagated, all that has
+     * to be done it to call get_text().
+     *
+     * @param string $source HTML content
+     * @param boolean $from_file Indicates $source is a file to pull content from
+     * @param array $options Set configuration options
+     */
+    public function __construct($source = '', $from_file = false, $options = array())
+    {
+        $this->_options = array_merge($this->_options, $options);
+
+        if (!empty($source)) {
+            $this->set_html($source, $from_file);
+        }
+
+        $this->set_base_url();
+    }
+
+    /**
+     * Loads source HTML into memory, either from $source string or a file.
+     *
+     * @param string $source HTML content
+     * @param boolean $from_file Indicates $source is a file to pull content from
+     */
+    public function set_html($source, $from_file = false)
+    {
+        if ($from_file && file_exists($source)) {
+            $this->html = file_get_contents($source);
+        } else {
+            $this->html = $source;
+        }
+
+        $this->_converted = false;
+    }
+
+    /**
+     * Returns the text, converted from HTML.
+     *
+     * @return string
+     */
+    public function get_text()
+    {
+        if (!$this->_converted) {
+            $this->_convert();
+        }
+
+        return $this->text;
+    }
+
+    /**
+     * Prints the text, converted from HTML.
+     */
+    public function print_text()
+    {
+        print $this->get_text();
+    }
+
+    /**
+     * Alias to print_text(), operates identically.
+     *
+     * @see print_text()
+     */
+    public function p()
+    {
+        print $this->get_text();
+    }
+
+    /**
+     * Sets the allowed HTML tags to pass through to the resulting text.
+     *
+     * Tags should be in the form "<p>", with no corresponding closing tag.
+     * @param string $allowed_tags
+     */
+    public function set_allowed_tags($allowed_tags = '')
+    {
+        if (!empty($allowed_tags)) {
+            $this->allowed_tags = $allowed_tags;
+        }
+    }
+
+    /**
+     * Sets a base URL to handle relative links.
+     *
+     * @param string $url
+     */
+    public function set_base_url($url = '')
+    {
+        if (empty($url)) {
+            if (!empty($_SERVER['HTTP_HOST'])) {
+                $this->url = 'http://' . $_SERVER['HTTP_HOST'];
+            } else {
+                $this->url = '';
+            }
+        } else {
+            // Strip any trailing slashes for consistency (relative
+            // URLs may already start with a slash like "/file.html")
+            if (substr($url, -1) == '/') {
+                $url = substr($url, 0, -1);
+            }
+            $this->url = $url;
+        }
+    }
+
+    /**
+     * Workhorse function that does actual conversion (calls _converter() method).
+     */
+    protected function _convert()
+    {
+        // Variables used for building the link list
+        $this->_link_list = array();
+
+        $text = trim(stripslashes($this->html));
+
+        // Convert HTML to TXT
+        $this->_converter($text);
+
+        // Add link list
+        if (!empty($this->_link_list)) {
+            $text .= "\n\nLinks:\n------\n";
+            foreach ($this->_link_list as $idx => $url) {
+                $text .= '[' . ($idx + 1) . '] ' . $url . "\n";
+            }
+        }
+
+        $this->text = $text;
+
+        $this->_converted = true;
+    }
+
+    /**
+     * Workhorse function that does actual conversion.
+     *
+     * First performs custom tag replacement specified by $search and
+     * $replace arrays. Then strips any remaining HTML tags, reduces whitespace
+     * and newlines to a readable format, and word wraps the text to
+     * $this->_options['width'] characters.
+     *
+     * @param string $text Reference to HTML content string
+     */
+    protected function _converter(&$text)
+    {
+        // Convert <BLOCKQUOTE> (before PRE!)
+        $this->_convert_blockquotes($text);
+
+        // Convert <PRE>
+        $this->_convert_pre($text);
+
+        // Run our defined tags search-and-replace
+        $text = preg_replace($this->search, $this->replace, $text);
+
+        // Run our defined tags search-and-replace with callback
+        $text = preg_replace_callback($this->callback_search, array($this, '_preg_callback'), $text);
+
+        // Strip any other HTML tags
+        $text = strip_tags($text, $this->allowed_tags);
+
+        // Run our defined entities/characters search-and-replace
+        $text = preg_replace($this->ent_search, $this->ent_replace, $text);
+
+        // Replace known html entities
+        $text = html_entity_decode($text, ENT_QUOTES);
+
+        // Remove unknown/unhandled entities (this cannot be done in search-and-replace block)
+        $text = preg_replace('/&([a-zA-Z0-9]{2,6}|#[0-9]{2,4});/', '', $text);
+
+        // Convert "|+|amp|+|" into "&", need to be done after handling of unknown entities
+        // This properly handles situation of "&amp;quot;" in input string
+        $text = str_replace('|+|amp|+|', '&', $text);
+
+        // Bring down number of empty lines to 2 max
+        $text = preg_replace("/\n\s+\n/", "\n\n", $text);
+        $text = preg_replace("/[\n]{3,}/", "\n\n", $text);
+
+        // remove leading empty lines (can be produced by eg. P tag on the beginning)
+        $text = ltrim($text, "\n");
+
+        // Wrap the text to a readable format
+        // for PHP versions >= 4.0.2. Default width is 75
+        // If width is 0 or less, don't wrap the text.
+        if ($this->_options['width'] > 0) {
+            $text = wordwrap($text, $this->_options['width']);
+        }
+    }
+
+    /**
+     * Helper function called by preg_replace() on link replacement.
+     *
+     * Maintains an internal list of links to be displayed at the end of the
+     * text, with numeric indices to the original point in the text they
+     * appeared. Also makes an effort at identifying and handling absolute
+     * and relative links.
+     *
+     * @param string $link URL of the link
+     * @param string $display Part of the text to associate number with
+     * @param null $link_override
+     * @return string
+     */
+    protected function _build_link_list($link, $display, $link_override = null)
+    {
+        $link_method = ($link_override) ? $link_override : $this->_options['do_links'];
+        if ($link_method == 'none') {
+            return $display;
+        }
+
+
+        // Ignored link types
+        if (preg_match('!^(javascript:|mailto:|#)!i', $link)) {
+            return $display;
+        }
+
+        if (preg_match('!^([a-z][a-z0-9.+-]+:)!i', $link)) {
+            $url = $link;
+        } else {
+            $url = $this->url;
+            if (substr($link, 0, 1) != '/') {
+                $url .= '/';
+            }
+            $url .= "$link";
+        }
+
+        if ($link_method == 'table') {
+            if (($index = array_search($url, $this->_link_list)) === false) {
+                $index = count($this->_link_list);
+                $this->_link_list[] = $url;
+            }
+
+            return $display . ' [' . ($index + 1) . ']';
+        } elseif ($link_method == 'nextline') {
+            return $display . "\n[" . $url . ']';
+        } else { // link_method defaults to inline
+
+            return $display . ' [' . $url . ']';
+        }
+    }
+
+    /**
+     * Helper function for PRE body conversion.
+     *
+     * @param string $text HTML content
+     */
+    protected function _convert_pre(&$text)
+    {
+        // get the content of PRE element
+        while (preg_match('/<pre[^>]*>(.*)<\/pre>/ismU', $text, $matches)) {
+            $this->pre_content = $matches[1];
+
+            // Run our defined tags search-and-replace with callback
+            $this->pre_content = preg_replace_callback(
+                $this->callback_search,
+                array($this, '_preg_callback'),
+                $this->pre_content
+            );
+
+            // convert the content
+            $this->pre_content = sprintf(
+                '<div><br>%s<br></div>',
+                preg_replace($this->pre_search, $this->pre_replace, $this->pre_content)
+            );
+
+            // replace the content (use callback because content can contain $0 variable)
+            $text = preg_replace_callback(
+                '/<pre[^>]*>.*<\/pre>/ismU',
+                array($this, '_preg_pre_callback'),
+                $text,
+                1
+            );
+
+            // free memory
+            $this->pre_content = '';
+        }
+    }
+
+    /**
+     * Helper function for BLOCKQUOTE body conversion.
+     *
+     * @param string $text HTML content
+     */
+    protected function _convert_blockquotes(&$text)
+    {
+        if (preg_match_all('/<\/*blockquote[^>]*>/i', $text, $matches, PREG_OFFSET_CAPTURE)) {
+            $start = 0;
+            $taglen = 0;
+            $level = 0;
+            $diff = 0;
+            foreach ($matches[0] as $m) {
+                if ($m[0][0] == '<' && $m[0][1] == '/') {
+                    $level--;
+                    if ($level < 0) {
+                        $level = 0; // malformed HTML: go to next blockquote
+                    } elseif ($level > 0) {
+                        // skip inner blockquote
+                    } else {
+                        $end = $m[1];
+                        $len = $end - $taglen - $start;
+                        // Get blockquote content
+                        $body = substr($text, $start + $taglen - $diff, $len);
+
+                        // Set text width
+                        $p_width = $this->_options['width'];
+                        if ($this->_options['width'] > 0) $this->_options['width'] -= 2;
+                        // Convert blockquote content
+                        $body = trim($body);
+                        $this->_converter($body);
+                        // Add citation markers and create PRE block
+                        $body = preg_replace('/((^|\n)>*)/', '\\1> ', trim($body));
+                        $body = '<pre>' . htmlspecialchars($body) . '</pre>';
+                        // Re-set text width
+                        $this->_options['width'] = $p_width;
+                        // Replace content
+                        $text = substr($text, 0, $start - $diff)
+                            . $body . substr($text, $end + strlen($m[0]) - $diff);
+
+                        $diff = $len + $taglen + strlen($m[0]) - strlen($body);
+                        unset($body);
+                    }
+                } else {
+                    if ($level == 0) {
+                        $start = $m[1];
+                        $taglen = strlen($m[0]);
+                    }
+                    $level++;
+                }
+            }
+        }
+    }
+
+    /**
+     * Callback function for preg_replace_callback use.
+     *
+     * @param array $matches PREG matches
+     * @return string
+     */
+    protected function _preg_callback($matches)
+    {
+        switch (strtolower($matches[1])) {
+            case 'b':
+            case 'strong':
+                return $this->_toupper($matches[3]);
+            case 'th':
+                return $this->_toupper("\t\t" . $matches[3] . "\n");
+            case 'h':
+                return $this->_toupper("\n\n" . $matches[3] . "\n\n");
+            case 'a':
+                // override the link method
+                $link_override = null;
+                if (preg_match('/_html2text_link_(\w+)/', $matches[4], $link_override_match)) {
+                    $link_override = $link_override_match[1];
+                }
+                // Remove spaces in URL (#1487805)
+                $url = str_replace(' ', '', $matches[3]);
+
+                return $this->_build_link_list($url, $matches[5], $link_override);
+        }
+        return '';
+    }
+
+    /**
+     * Callback function for preg_replace_callback use in PRE content handler.
+     *
+     * @param array $matches PREG matches
+     * @return string
+     */
+    protected function _preg_pre_callback(
+        /** @noinspection PhpUnusedParameterInspection */
+        $matches)
+    {
+        return $this->pre_content;
+    }
+
+    /**
+     * Strtoupper function with HTML tags and entities handling.
+     *
+     * @param string $str Text to convert
+     * @return string Converted text
+     */
+    private function _toupper($str)
+    {
+        // string can contain HTML tags
+        $chunks = preg_split('/(<[^>]*>)/', $str, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+
+        // convert toupper only the text between HTML tags
+        foreach ($chunks as $idx => $chunk) {
+            if ($chunk[0] != '<') {
+                $chunks[$idx] = $this->_strtoupper($chunk);
+            }
+        }
+
+        return implode($chunks);
+    }
+
+    /**
+     * Strtoupper multibyte wrapper function with HTML entities handling.
+     * Forces mb_strtoupper-call to UTF-8.
+     *
+     * @param string $str Text to convert
+     * @return string Converted text
+     */
+    private function _strtoupper($str)
+    {
+        $str = html_entity_decode($str, ENT_COMPAT);
+
+        if (function_exists('mb_strtoupper'))
+            $str = mb_strtoupper($str, 'UTF-8');
+        else
+            $str = strtoupper($str);
+
+        $str = htmlspecialchars($str, ENT_COMPAT);
+
+        return $str;
+    }
+}

--- a/libraries/phpmailer/extras/htmlfilter.php
+++ b/libraries/phpmailer/extras/htmlfilter.php
@@ -1,0 +1,874 @@
+<?php
+/**
+ * htmlfilter.inc
+ * ---------------
+ * This set of functions allows you to filter html in order to remove
+ * any malicious tags from it. Useful in cases when you need to filter
+ * user input for any cross-site-scripting attempts.
+ *
+ * Copyright (C) 2002-2004 by Duke University
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.     See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ *
+ * @Author    Konstantin Riabitsev <icon@linux.duke.edu>
+ * @Author  Jim Jagielski <jim@jaguNET.com / jimjag@gmail.com>
+ */
+
+/**
+ * This function returns the final tag out of the tag name, an array
+ * of attributes, and the type of the tag. This function is called by
+ * tln_sanitize internally.
+ *
+ * @param string $tagname the name of the tag.
+ * @param array $attary the array of attributes and their values
+ * @param integer $tagtype The type of the tag (see in comments).
+ * @return string A string with the final tag representation.
+ */
+function tln_tagprint($tagname, $attary, $tagtype)
+{
+    if ($tagtype == 2) {
+        $fulltag = '</' . $tagname . '>';
+    } else {
+        $fulltag = '<' . $tagname;
+        if (is_array($attary) && sizeof($attary)) {
+            $atts = array();
+            while (list($attname, $attvalue) = each($attary)) {
+                array_push($atts, "$attname=$attvalue");
+            }
+            $fulltag .= ' ' . join(' ', $atts);
+        }
+        if ($tagtype == 3) {
+            $fulltag .= ' /';
+        }
+        $fulltag .= '>';
+    }
+    return $fulltag;
+}
+
+/**
+ * A small helper function to use with array_walk. Modifies a by-ref
+ * value and makes it lowercase.
+ *
+ * @param string $val a value passed by-ref.
+ * @return        void since it modifies a by-ref value.
+ */
+function tln_casenormalize(&$val)
+{
+    $val = strtolower($val);
+}
+
+/**
+ * This function skips any whitespace from the current position within
+ * a string and to the next non-whitespace value.
+ *
+ * @param string $body the string
+ * @param integer $offset the offset within the string where we should start
+ *                   looking for the next non-whitespace character.
+ * @return integer          the location within the $body where the next
+ *                   non-whitespace char is located.
+ */
+function tln_skipspace($body, $offset)
+{
+    preg_match('/^(\s*)/s', substr($body, $offset), $matches);
+    if (sizeof($matches[1])) {
+        $count = strlen($matches[1]);
+        $offset += $count;
+    }
+    return $offset;
+}
+
+/**
+ * This function looks for the next character within a string.    It's
+ * really just a glorified "strpos", except it catches the failures
+ * nicely.
+ *
+ * @param string $body   The string to look for needle in.
+ * @param integer $offset Start looking from this position.
+ * @param string $needle The character/string to look for.
+ * @return integer           location of the next occurrence of the needle, or
+ *                   strlen($body) if needle wasn't found.
+ */
+function tln_findnxstr($body, $offset, $needle)
+{
+    $pos = strpos($body, $needle, $offset);
+    if ($pos === false) {
+        $pos = strlen($body);
+    }
+    return $pos;
+}
+
+/**
+ * This function takes a PCRE-style regexp and tries to match it
+ * within the string.
+ *
+ * @param string $body   The string to look for needle in.
+ * @param integer $offset Start looking from here.
+ * @param string $reg       A PCRE-style regex to match.
+ * @return array|boolean  Returns a false if no matches found, or an array
+ *                   with the following members:
+ *                   - integer with the location of the match within $body
+ *                   - string with whatever content between offset and the match
+ *                   - string with whatever it is we matched
+ */
+function tln_findnxreg($body, $offset, $reg)
+{
+    $matches = array();
+    $retarr = array();
+    $preg_rule = '%^(.*?)(' . $reg . ')%s';
+    preg_match($preg_rule, substr($body, $offset), $matches);
+    if (!isset($matches[0])) {
+        $retarr = false;
+    } else {
+        $retarr[0] = $offset + strlen($matches[1]);
+        $retarr[1] = $matches[1];
+        $retarr[2] = $matches[2];
+    }
+    return $retarr;
+}
+
+/**
+ * This function looks for the next tag.
+ *
+ * @param string $body   String where to look for the next tag.
+ * @param integer $offset Start looking from here.
+ * @return array|boolean false if no more tags exist in the body, or
+ *                   an array with the following members:
+ *                   - string with the name of the tag
+ *                   - array with attributes and their values
+ *                   - integer with tag type (1, 2, or 3)
+ *                   - integer where the tag starts (starting "<")
+ *                   - integer where the tag ends (ending ">")
+ *                   first three members will be false, if the tag is invalid.
+ */
+function tln_getnxtag($body, $offset)
+{
+    if ($offset > strlen($body)) {
+        return false;
+    }
+    $lt = tln_findnxstr($body, $offset, '<');
+    if ($lt == strlen($body)) {
+        return false;
+    }
+    /**
+     * We are here:
+     * blah blah <tag attribute="value">
+     * \---------^
+     */
+    $pos = tln_skipspace($body, $lt + 1);
+    if ($pos >= strlen($body)) {
+        return array(false, false, false, $lt, strlen($body));
+    }
+    /**
+     * There are 3 kinds of tags:
+     * 1. Opening tag, e.g.:
+     *      <a href="blah">
+     * 2. Closing tag, e.g.:
+     *      </a>
+     * 3. XHTML-style content-less tag, e.g.:
+     *      <img src="blah"/>
+     */
+    switch (substr($body, $pos, 1)) {
+        case '/':
+            $tagtype = 2;
+            $pos++;
+            break;
+        case '!':
+            /**
+             * A comment or an SGML declaration.
+             */
+            if (substr($body, $pos + 1, 2) == '--') {
+                $gt = strpos($body, '-->', $pos);
+                if ($gt === false) {
+                    $gt = strlen($body);
+                } else {
+                    $gt += 2;
+                }
+                return array(false, false, false, $lt, $gt);
+            } else {
+                $gt = tln_findnxstr($body, $pos, '>');
+                return array(false, false, false, $lt, $gt);
+            }
+            break;
+        default:
+            /**
+             * Assume tagtype 1 for now. If it's type 3, we'll switch values
+             * later.
+             */
+            $tagtype = 1;
+            break;
+    }
+
+    /**
+     * Look for next [\W-_], which will indicate the end of the tag name.
+     */
+    $regary = tln_findnxreg($body, $pos, '[^\w\-_]');
+    if ($regary == false) {
+        return array(false, false, false, $lt, strlen($body));
+    }
+    list($pos, $tagname, $match) = $regary;
+    $tagname = strtolower($tagname);
+
+    /**
+     * $match can be either of these:
+     * '>'    indicating the end of the tag entirely.
+     * '\s' indicating the end of the tag name.
+     * '/'    indicating that this is type-3 xhtml tag.
+     *
+     * Whatever else we find there indicates an invalid tag.
+     */
+    switch ($match) {
+        case '/':
+            /**
+             * This is an xhtml-style tag with a closing / at the
+             * end, like so: <img src="blah"/>. Check if it's followed
+             * by the closing bracket. If not, then this tag is invalid
+             */
+            if (substr($body, $pos, 2) == '/>') {
+                $pos++;
+                $tagtype = 3;
+            } else {
+                $gt = tln_findnxstr($body, $pos, '>');
+                $retary = array(false, false, false, $lt, $gt);
+                return $retary;
+            }
+            //intentional fall-through
+        case '>':
+            return array($tagname, false, $tagtype, $lt, $pos);
+            break;
+        default:
+            /**
+             * Check if it's whitespace
+             */
+            if (preg_match('/\s/', $match)) {
+            } else {
+                /**
+                 * This is an invalid tag! Look for the next closing ">".
+                 */
+                $gt = tln_findnxstr($body, $lt, '>');
+                return array(false, false, false, $lt, $gt);
+            }
+    }
+
+    /**
+     * At this point we're here:
+     * <tagname     attribute='blah'>
+     * \-------^
+     *
+     * At this point we loop in order to find all attributes.
+     */
+    $attary = array();
+
+    while ($pos <= strlen($body)) {
+        $pos = tln_skipspace($body, $pos);
+        if ($pos == strlen($body)) {
+            /**
+             * Non-closed tag.
+             */
+            return array(false, false, false, $lt, $pos);
+        }
+        /**
+         * See if we arrived at a ">" or "/>", which means that we reached
+         * the end of the tag.
+         */
+        $matches = array();
+        preg_match('%^(\s*)(>|/>)%s', substr($body, $pos), $matches);
+        if (isset($matches[0]) && $matches[0]) {
+            /**
+             * Yep. So we did.
+             */
+            $pos += strlen($matches[1]);
+            if ($matches[2] == '/>') {
+                $tagtype = 3;
+                $pos++;
+            }
+            return array($tagname, $attary, $tagtype, $lt, $pos);
+        }
+
+        /**
+         * There are several types of attributes, with optional
+         * [:space:] between members.
+         * Type 1:
+         *     attrname[:space:]=[:space:]'CDATA'
+         * Type 2:
+         *     attrname[:space:]=[:space:]"CDATA"
+         * Type 3:
+         *     attr[:space:]=[:space:]CDATA
+         * Type 4:
+         *     attrname
+         *
+         * We leave types 1 and 2 the same, type 3 we check for
+         * '"' and convert to "&quot" if needed, then wrap in
+         * double quotes. Type 4 we convert into:
+         * attrname="yes".
+         */
+        $regary = tln_findnxreg($body, $pos, '[^\w\-_]');
+        if ($regary == false) {
+            /**
+             * Looks like body ended before the end of tag.
+             */
+            return array(false, false, false, $lt, strlen($body));
+        }
+        list($pos, $attname, $match) = $regary;
+        $attname = strtolower($attname);
+        /**
+         * We arrived at the end of attribute name. Several things possible
+         * here:
+         * '>'    means the end of the tag and this is attribute type 4
+         * '/'    if followed by '>' means the same thing as above
+         * '\s' means a lot of things -- look what it's followed by.
+         *        anything else means the attribute is invalid.
+         */
+        switch ($match) {
+            case '/':
+                /**
+                 * This is an xhtml-style tag with a closing / at the
+                 * end, like so: <img src="blah"/>. Check if it's followed
+                 * by the closing bracket. If not, then this tag is invalid
+                 */
+                if (substr($body, $pos, 2) == '/>') {
+                    $pos++;
+                    $tagtype = 3;
+                } else {
+                    $gt = tln_findnxstr($body, $pos, '>');
+                    $retary = array(false, false, false, $lt, $gt);
+                    return $retary;
+                }
+                //intentional fall-through
+            case '>':
+                $attary{$attname} = '"yes"';
+                return array($tagname, $attary, $tagtype, $lt, $pos);
+                break;
+            default:
+                /**
+                 * Skip whitespace and see what we arrive at.
+                 */
+                $pos = tln_skipspace($body, $pos);
+                $char = substr($body, $pos, 1);
+                /**
+                 * Two things are valid here:
+                 * '=' means this is attribute type 1 2 or 3.
+                 * \w means this was attribute type 4.
+                 * anything else we ignore and re-loop. End of tag and
+                 * invalid stuff will be caught by our checks at the beginning
+                 * of the loop.
+                 */
+                if ($char == '=') {
+                    $pos++;
+                    $pos = tln_skipspace($body, $pos);
+                    /**
+                     * Here are 3 possibilities:
+                     * "'"    attribute type 1
+                     * '"'    attribute type 2
+                     * everything else is the content of tag type 3
+                     */
+                    $quot = substr($body, $pos, 1);
+                    if ($quot == '\'') {
+                        $regary = tln_findnxreg($body, $pos + 1, '\'');
+                        if ($regary == false) {
+                            return array(false, false, false, $lt, strlen($body));
+                        }
+                        list($pos, $attval, $match) = $regary;
+                        $pos++;
+                        $attary{$attname} = '\'' . $attval . '\'';
+                    } else {
+                        if ($quot == '"') {
+                            $regary = tln_findnxreg($body, $pos + 1, '\"');
+                            if ($regary == false) {
+                                return array(false, false, false, $lt, strlen($body));
+                            }
+                            list($pos, $attval, $match) = $regary;
+                            $pos++;
+                            $attary{$attname} = '"' . $attval . '"';
+                        } else {
+                            /**
+                             * These are hateful. Look for \s, or >.
+                             */
+                            $regary = tln_findnxreg($body, $pos, '[\s>]');
+                            if ($regary == false) {
+                                return array(false, false, false, $lt, strlen($body));
+                            }
+                            list($pos, $attval, $match) = $regary;
+                            /**
+                             * If it's ">" it will be caught at the top.
+                             */
+                            $attval = preg_replace('/\"/s', '&quot;', $attval);
+                            $attary{$attname} = '"' . $attval . '"';
+                        }
+                    }
+                } else {
+                    if (preg_match('|[\w/>]|', $char)) {
+                        /**
+                         * That was attribute type 4.
+                         */
+                        $attary{$attname} = '"yes"';
+                    } else {
+                        /**
+                         * An illegal character. Find next '>' and return.
+                         */
+                        $gt = tln_findnxstr($body, $pos, '>');
+                        return array(false, false, false, $lt, $gt);
+                    }
+                }
+        }
+    }
+    /**
+     * The fact that we got here indicates that the tag end was never
+     * found. Return invalid tag indication so it gets stripped.
+     */
+    return array(false, false, false, $lt, strlen($body));
+}
+
+/**
+ * Translates entities into literal values so they can be checked.
+ *
+ * @param string $attvalue the by-ref value to check.
+ * @param string $regex    the regular expression to check against.
+ * @param boolean $hex        whether the entites are hexadecimal.
+ * @return boolean            True or False depending on whether there were matches.
+ */
+function tln_deent(&$attvalue, $regex, $hex = false)
+{
+    preg_match_all($regex, $attvalue, $matches);
+    if (is_array($matches) && sizeof($matches[0]) > 0) {
+        $repl = array();
+        for ($i = 0; $i < sizeof($matches[0]); $i++) {
+            $numval = $matches[1][$i];
+            if ($hex) {
+                $numval = hexdec($numval);
+            }
+            $repl{$matches[0][$i]} = chr($numval);
+        }
+        $attvalue = strtr($attvalue, $repl);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * This function checks attribute values for entity-encoded values
+ * and returns them translated into 8-bit strings so we can run
+ * checks on them.
+ *
+ * @param string $attvalue A string to run entity check against.
+ * @return             Void, modifies a reference value.
+ */
+function tln_defang(&$attvalue)
+{
+    /**
+     * Skip this if there aren't ampersands or backslashes.
+     */
+    if (strpos($attvalue, '&') === false
+        && strpos($attvalue, '\\') === false
+    ) {
+        return;
+    }
+    do {
+        $m = false;
+        $m = $m || tln_deent($attvalue, '/\&#0*(\d+);*/s');
+        $m = $m || tln_deent($attvalue, '/\&#x0*((\d|[a-f])+);*/si', true);
+        $m = $m || tln_deent($attvalue, '/\\\\(\d+)/s', true);
+    } while ($m == true);
+    $attvalue = stripslashes($attvalue);
+}
+
+/**
+ * Kill any tabs, newlines, or carriage returns. Our friends the
+ * makers of the browser with 95% market value decided that it'd
+ * be funny to make "java[tab]script" be just as good as "javascript".
+ *
+ * @param string $attvalue     The attribute value before extraneous spaces removed.
+ * @return     Void, modifies a reference value.
+ */
+function tln_unspace(&$attvalue)
+{
+    if (strcspn($attvalue, "\t\r\n\0 ") != strlen($attvalue)) {
+        $attvalue = str_replace(
+            array("\t", "\r", "\n", "\0", " "),
+            array('', '', '', '', ''),
+            $attvalue
+        );
+    }
+}
+
+/**
+ * This function runs various checks against the attributes.
+ *
+ * @param string $tagname            String with the name of the tag.
+ * @param array $attary            Array with all tag attributes.
+ * @param array $rm_attnames        See description for tln_sanitize
+ * @param array $bad_attvals        See description for tln_sanitize
+ * @param array $add_attr_to_tag See description for tln_sanitize
+ * @return                    Array with modified attributes.
+ */
+function tln_fixatts(
+    $tagname,
+    $attary,
+    $rm_attnames,
+    $bad_attvals,
+    $add_attr_to_tag
+) {
+    while (list($attname, $attvalue) = each($attary)) {
+        /**
+         * See if this attribute should be removed.
+         */
+        foreach ($rm_attnames as $matchtag => $matchattrs) {
+            if (preg_match($matchtag, $tagname)) {
+                foreach ($matchattrs as $matchattr) {
+                    if (preg_match($matchattr, $attname)) {
+                        unset($attary{$attname});
+                        continue;
+                    }
+                }
+            }
+        }
+        /**
+         * Remove any backslashes, entities, or extraneous whitespace.
+         */
+        tln_defang($attvalue);
+        tln_unspace($attvalue);
+
+        /**
+         * Now let's run checks on the attvalues.
+         * I don't expect anyone to comprehend this. If you do,
+         * get in touch with me so I can drive to where you live and
+         * shake your hand personally. :)
+         */
+        foreach ($bad_attvals as $matchtag => $matchattrs) {
+            if (preg_match($matchtag, $tagname)) {
+                foreach ($matchattrs as $matchattr => $valary) {
+                    if (preg_match($matchattr, $attname)) {
+                        /**
+                         * There are two arrays in valary.
+                         * First is matches.
+                         * Second one is replacements
+                         */
+                        list($valmatch, $valrepl) = $valary;
+                        $newvalue = preg_replace($valmatch, $valrepl, $attvalue);
+                        if ($newvalue != $attvalue) {
+                            $attary{$attname} = $newvalue;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    /**
+     * See if we need to append any attributes to this tag.
+     */
+    foreach ($add_attr_to_tag as $matchtag => $addattary) {
+        if (preg_match($matchtag, $tagname)) {
+            $attary = array_merge($attary, $addattary);
+        }
+    }
+    return $attary;
+}
+
+/**
+ *
+ * @param string $body                    The HTML you wish to filter
+ * @param array $tag_list                see description above
+ * @param array $rm_tags_with_content see description above
+ * @param array $self_closing_tags    see description above
+ * @param boolean $force_tag_closing    see description above
+ * @param array $rm_attnames            see description above
+ * @param array $bad_attvals            see description above
+ * @param array $add_attr_to_tag        see description above
+ * @return string                       Sanitized html safe to show on your pages.
+ */
+function tln_sanitize(
+    $body,
+    $tag_list,
+    $rm_tags_with_content,
+    $self_closing_tags,
+    $force_tag_closing,
+    $rm_attnames,
+    $bad_attvals,
+    $add_attr_to_tag
+) {
+    /**
+     * Normalize rm_tags and rm_tags_with_content.
+     */
+    $rm_tags = array_shift($tag_list);
+    @array_walk($tag_list, 'tln_casenormalize');
+    @array_walk($rm_tags_with_content, 'tln_casenormalize');
+    @array_walk($self_closing_tags, 'tln_casenormalize');
+    /**
+     * See if tag_list is of tags to remove or tags to allow.
+     * false  means remove these tags
+     * true      means allow these tags
+     */
+    $curpos = 0;
+    $open_tags = array();
+    $trusted = "<!-- begin tln_sanitized html -->\n";
+    $skip_content = false;
+    /**
+     * Take care of netscape's stupid javascript entities like
+     * &{alert('boo')};
+     */
+    $body = preg_replace('/&(\{.*?\};)/si', '&amp;\\1', $body);
+    while (($curtag = tln_getnxtag($body, $curpos)) != false) {
+        list($tagname, $attary, $tagtype, $lt, $gt) = $curtag;
+        $free_content = substr($body, $curpos, $lt - $curpos);
+        if ($skip_content == false) {
+            $trusted .= $free_content;
+        } else {
+        }
+        if ($tagname != false) {
+            if ($tagtype == 2) {
+                if ($skip_content == $tagname) {
+                    /**
+                     * Got to the end of tag we needed to remove.
+                     */
+                    $tagname = false;
+                    $skip_content = false;
+                } else {
+                    if ($skip_content == false) {
+                        if (isset($open_tags{$tagname}) &&
+                            $open_tags{$tagname} > 0
+                        ) {
+                            $open_tags{$tagname}--;
+                        } else {
+                            $tagname = false;
+                        }
+                    } else {
+                    }
+                }
+            } else {
+                /**
+                 * $rm_tags_with_content
+                 */
+                if ($skip_content == false) {
+                    /**
+                     * See if this is a self-closing type and change
+                     * tagtype appropriately.
+                     */
+                    if ($tagtype == 1
+                        && in_array($tagname, $self_closing_tags)
+                    ) {
+                        $tagtype = 3;
+                    }
+                    /**
+                     * See if we should skip this tag and any content
+                     * inside it.
+                     */
+                    if ($tagtype == 1
+                        && in_array($tagname, $rm_tags_with_content)
+                    ) {
+                        $skip_content = $tagname;
+                    } else {
+                        if (($rm_tags == false
+                                && in_array($tagname, $tag_list)) ||
+                            ($rm_tags == true
+                                && !in_array($tagname, $tag_list))
+                        ) {
+                            $tagname = false;
+                        } else {
+                            if ($tagtype == 1) {
+                                if (isset($open_tags{$tagname})) {
+                                    $open_tags{$tagname}++;
+                                } else {
+                                    $open_tags{$tagname} = 1;
+                                }
+                            }
+                            /**
+                             * This is where we run other checks.
+                             */
+                            if (is_array($attary) && sizeof($attary) > 0) {
+                                $attary = tln_fixatts(
+                                    $tagname,
+                                    $attary,
+                                    $rm_attnames,
+                                    $bad_attvals,
+                                    $add_attr_to_tag
+                                );
+                            }
+                        }
+                    }
+                } else {
+                }
+            }
+            if ($tagname != false && $skip_content == false) {
+                $trusted .= tln_tagprint($tagname, $attary, $tagtype);
+            }
+        } else {
+        }
+        $curpos = $gt + 1;
+    }
+    $trusted .= substr($body, $curpos, strlen($body) - $curpos);
+    if ($force_tag_closing == true) {
+        foreach ($open_tags as $tagname => $opentimes) {
+            while ($opentimes > 0) {
+                $trusted .= '</' . $tagname . '>';
+                $opentimes--;
+            }
+        }
+        $trusted .= "\n";
+    }
+    $trusted .= "<!-- end tln_sanitized html -->\n";
+    return $trusted;
+}
+
+// 
+// Use the nifty htmlfilter library
+//
+
+
+function HTMLFilter($body, $trans_image_path, $block_external_images = false)
+{
+
+    $tag_list = array(
+        false,
+        "object",
+        "meta",
+        "html",
+        "head",
+        "base",
+        "link",
+        "frame",
+        "iframe",
+        "plaintext",
+        "marquee"
+    );
+
+    $rm_tags_with_content = array(
+        "script",
+        "applet",
+        "embed",
+        "title",
+        "frameset",
+        "xmp",
+        "xml"
+    );
+
+    $self_closing_tags = array(
+        "img",
+        "br",
+        "hr",
+        "input",
+        "outbind"
+    );
+
+    $force_tag_closing = true;
+
+    $rm_attnames = array(
+        "/.*/" =>
+            array(
+                // "/target/i",
+                "/^on.*/i",
+                "/^dynsrc/i",
+                "/^data.*/i",
+                "/^lowsrc.*/i"
+            )
+    );
+
+    $bad_attvals = array(
+        "/.*/" =>
+            array(
+                "/^src|background/i" =>
+                    array(
+                        array(
+                            '/^([\'"])\s*\S+script\s*:.*([\'"])/si',
+                            '/^([\'"])\s*mocha\s*:*.*([\'"])/si',
+                            '/^([\'"])\s*about\s*:.*([\'"])/si'
+                        ),
+                        array(
+                            "\\1$trans_image_path\\2",
+                            "\\1$trans_image_path\\2",
+                            "\\1$trans_image_path\\2",
+                            "\\1$trans_image_path\\2"
+                        )
+                    ),
+                "/^href|action/i" =>
+                    array(
+                        array(
+                            '/^([\'"])\s*\S+script\s*:.*([\'"])/si',
+                            '/^([\'"])\s*mocha\s*:*.*([\'"])/si',
+                            '/^([\'"])\s*about\s*:.*([\'"])/si'
+                        ),
+                        array(
+                            "\\1#\\1",
+                            "\\1#\\1",
+                            "\\1#\\1",
+                            "\\1#\\1"
+                        )
+                    ),
+                "/^style/i" =>
+                    array(
+                        array(
+                            "/expression/i",
+                            "/binding/i",
+                            "/behaviou*r/i",
+                            "/include-source/i",
+                            '/position\s*:\s*absolute/i',
+                            '/url\s*\(\s*([\'"])\s*\S+script\s*:.*([\'"])\s*\)/si',
+                            '/url\s*\(\s*([\'"])\s*mocha\s*:.*([\'"])\s*\)/si',
+                            '/url\s*\(\s*([\'"])\s*about\s*:.*([\'"])\s*\)/si',
+                            '/(.*)\s*:\s*url\s*\(\s*([\'"]*)\s*\S+script\s*:.*([\'"]*)\s*\)/si'
+                        ),
+                        array(
+                            "idiocy",
+                            "idiocy",
+                            "idiocy",
+                            "idiocy",
+                            "",
+                            "url(\\1#\\1)",
+                            "url(\\1#\\1)",
+                            "url(\\1#\\1)",
+                            "url(\\1#\\1)",
+                            "url(\\1#\\1)",
+                            "\\1:url(\\2#\\3)"
+                        )
+                    )
+            )
+    );
+
+    if ($block_external_images) {
+        array_push(
+            $bad_attvals{'/.*/'}{'/^src|background/i'}[0],
+            '/^([\'\"])\s*https*:.*([\'\"])/si'
+        );
+        array_push(
+            $bad_attvals{'/.*/'}{'/^src|background/i'}[1],
+            "\\1$trans_image_path\\1"
+        );
+        array_push(
+            $bad_attvals{'/.*/'}{'/^style/i'}[0],
+            '/url\(([\'\"])\s*https*:.*([\'\"])\)/si'
+        );
+        array_push(
+            $bad_attvals{'/.*/'}{'/^style/i'}[1],
+            "url(\\1$trans_image_path\\1)"
+        );
+    }
+
+    $add_attr_to_tag = array(
+        "/^a$/i" =>
+            array('target' => '"_blank"')
+    );
+
+    $trusted = tln_sanitize(
+        $body,
+        $tag_list,
+        $rm_tags_with_content,
+        $self_closing_tags,
+        $force_tag_closing,
+        $rm_attnames,
+        $bad_attvals,
+        $add_attr_to_tag
+    );
+    return $trusted;
+}

--- a/libraries/phpmailer/extras/index.html
+++ b/libraries/phpmailer/extras/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/libraries/phpmailer/extras/ntlm_sasl_client.php
+++ b/libraries/phpmailer/extras/ntlm_sasl_client.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * ntlm_sasl_client.php
+ *
+ * @(#) $Id: ntlm_sasl_client.php,v 1.3 2004/11/17 08:00:37 mlemos Exp $
+ *
+ **
+ ** Source: http://www.phpclasses.org/browse/file/7495.html
+ ** License: BSD (http://www.phpclasses.org/package/1888-PHP-Single-API-for-standard-authentication-mechanisms.html)
+ ** Bundled with Permission
+ **
+ */
+
+define("SASL_NTLM_STATE_START",             0);
+define("SASL_NTLM_STATE_IDENTIFY_DOMAIN",   1);
+define("SASL_NTLM_STATE_RESPOND_CHALLENGE", 2);
+define("SASL_NTLM_STATE_DONE",              3);
+
+class ntlm_sasl_client_class
+{
+	var $credentials=array();
+	var $state=SASL_NTLM_STATE_START;
+
+	Function Initialize(&$client)
+	{
+		if(!function_exists($function="mcrypt_encrypt")
+		|| !function_exists($function="mhash"))
+		{
+			$extensions=array(
+				"mcrypt_encrypt"=>"mcrypt",
+				"mhash"=>"mhash"
+			);
+			$client->error="the extension ".$extensions[$function]." required by the NTLM SASL client class is not available in this PHP configuration";
+			return(0);
+		}
+		return(1);
+	}
+
+	Function ASCIIToUnicode($ascii)
+	{
+		for($unicode="",$a=0;$a<strlen($ascii);$a++)
+			$unicode.=substr($ascii,$a,1).chr(0);
+		return($unicode);
+	}
+
+	Function TypeMsg1($domain,$workstation)
+	{
+		$domain_length=strlen($domain);
+		$workstation_length=strlen($workstation);
+		$workstation_offset=32;
+		$domain_offset=$workstation_offset+$workstation_length;
+		return(
+			"NTLMSSP\0".
+			"\x01\x00\x00\x00".
+			"\x07\x32\x00\x00".
+			pack("v",$domain_length).
+			pack("v",$domain_length).
+			pack("V",$domain_offset).
+			pack("v",$workstation_length).
+			pack("v",$workstation_length).
+			pack("V",$workstation_offset).
+			$workstation.
+			$domain
+		);
+	}
+
+	Function NTLMResponse($challenge,$password)
+	{
+		$unicode=$this->ASCIIToUnicode($password);
+		$md4=mhash(MHASH_MD4,$unicode);
+		$padded=$md4.str_repeat(chr(0),21-strlen($md4));
+		$iv_size=mcrypt_get_iv_size(MCRYPT_DES,MCRYPT_MODE_ECB);
+		$iv=mcrypt_create_iv($iv_size,MCRYPT_RAND);
+		for($response="",$third=0;$third<21;$third+=7)
+		{
+			for($packed="",$p=$third;$p<$third+7;$p++)
+				$packed.=str_pad(decbin(ord(substr($padded,$p,1))),8,"0",STR_PAD_LEFT);
+			for($key="",$p=0;$p<strlen($packed);$p+=7)
+			{
+				$s=substr($packed,$p,7);
+				$b=$s.((substr_count($s,"1") % 2) ? "0" : "1");
+				$key.=chr(bindec($b));
+			}
+			$ciphertext=mcrypt_encrypt(MCRYPT_DES,$key,$challenge,MCRYPT_MODE_ECB,$iv);
+			$response.=$ciphertext;
+		}
+		return $response;
+	}
+
+	Function TypeMsg3($ntlm_response,$user,$domain,$workstation)
+	{
+		$domain_unicode=$this->ASCIIToUnicode($domain);
+		$domain_length=strlen($domain_unicode);
+		$domain_offset=64;
+		$user_unicode=$this->ASCIIToUnicode($user);
+		$user_length=strlen($user_unicode);
+		$user_offset=$domain_offset+$domain_length;
+		$workstation_unicode=$this->ASCIIToUnicode($workstation);
+		$workstation_length=strlen($workstation_unicode);
+		$workstation_offset=$user_offset+$user_length;
+		$lm="";
+		$lm_length=strlen($lm);
+		$lm_offset=$workstation_offset+$workstation_length;
+		$ntlm=$ntlm_response;
+		$ntlm_length=strlen($ntlm);
+		$ntlm_offset=$lm_offset+$lm_length;
+		$session="";
+		$session_length=strlen($session);
+		$session_offset=$ntlm_offset+$ntlm_length;
+		return(
+			"NTLMSSP\0".
+			"\x03\x00\x00\x00".
+			pack("v",$lm_length).
+			pack("v",$lm_length).
+			pack("V",$lm_offset).
+			pack("v",$ntlm_length).
+			pack("v",$ntlm_length).
+			pack("V",$ntlm_offset).
+			pack("v",$domain_length).
+			pack("v",$domain_length).
+			pack("V",$domain_offset).
+			pack("v",$user_length).
+			pack("v",$user_length).
+			pack("V",$user_offset).
+			pack("v",$workstation_length).
+			pack("v",$workstation_length).
+			pack("V",$workstation_offset).
+			pack("v",$session_length).
+			pack("v",$session_length).
+			pack("V",$session_offset).
+			"\x01\x02\x00\x00".
+			$domain_unicode.
+			$user_unicode.
+			$workstation_unicode.
+			$lm.
+			$ntlm
+		);
+	}
+
+	Function Start(&$client, &$message, &$interactions)
+	{
+		if($this->state!=SASL_NTLM_STATE_START)
+		{
+			$client->error="NTLM authentication state is not at the start";
+			return(SASL_FAIL);
+		}
+		$this->credentials=array(
+			"user"=>"",
+			"password"=>"",
+			"realm"=>"",
+			"workstation"=>""
+		);
+		$defaults=array();
+		$status=$client->GetCredentials($this->credentials,$defaults,$interactions);
+		if($status==SASL_CONTINUE)
+			$this->state=SASL_NTLM_STATE_IDENTIFY_DOMAIN;
+		Unset($message);
+		return($status);
+	}
+
+	Function Step(&$client, $response, &$message, &$interactions)
+	{
+		switch($this->state)
+		{
+			case SASL_NTLM_STATE_IDENTIFY_DOMAIN:
+				$message=$this->TypeMsg1($this->credentials["realm"],$this->credentials["workstation"]);
+				$this->state=SASL_NTLM_STATE_RESPOND_CHALLENGE;
+				break;
+			case SASL_NTLM_STATE_RESPOND_CHALLENGE:
+				$ntlm_response=$this->NTLMResponse(substr($response,24,8),$this->credentials["password"]);
+				$message=$this->TypeMsg3($ntlm_response,$this->credentials["user"],$this->credentials["realm"],$this->credentials["workstation"]);
+				$this->state=SASL_NTLM_STATE_DONE;
+				break;
+			case SASL_NTLM_STATE_DONE:
+				$client->error="NTLM authentication was finished without success";
+				return(SASL_FAIL);
+			default:
+				$client->error="invalid NTLM authentication step state";
+				return(SASL_FAIL);
+		}
+		return(SASL_CONTINUE);
+	}
+};
+
+?>

--- a/libraries/phpmailer/phpmailer.php
+++ b/libraries/phpmailer/phpmailer.php
@@ -1,2951 +1,3414 @@
 <?php
-/*~ class.phpmailer.php
-.---------------------------------------------------------------------------.
-|  Software: PHPMailer - PHP email class                                    |
-|   Version: 5.2.6                                                          |
-|      Site: https://github.com/PHPMailer/PHPMailer/                        |
-| ------------------------------------------------------------------------- |
-|    Admins: Marcus Bointon                                                 |
-|    Admins: Jim Jagielski                                                  |
-|   Authors: Andy Prevost (codeworxtech) codeworxtech@users.sourceforge.net |
-|          : Marcus Bointon (coolbru) phpmailer@synchromedia.co.uk          |
-|          : Jim Jagielski (jimjag) jimjag@gmail.com                        |
-|   Founder: Brent R. Matzelle (original founder)                           |
-| Copyright (c) 2010-2012, Jim Jagielski. All Rights Reserved.              |
-| Copyright (c) 2004-2009, Andy Prevost. All Rights Reserved.               |
-| Copyright (c) 2001-2003, Brent R. Matzelle                                |
-| ------------------------------------------------------------------------- |
-|   License: Distributed under the Lesser General Public License (LGPL)     |
-|            http://www.gnu.org/copyleft/lesser.html                        |
-| This program is distributed in the hope that it will be useful - WITHOUT  |
-| ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or     |
-| FITNESS FOR A PARTICULAR PURPOSE.                                         |
-'---------------------------------------------------------------------------'
-*/
-
 /**
- * PHPMailer - PHP email creation and transport class
- * NOTE: Requires PHP version 5 or later
+ * PHPMailer - PHP email creation and transport class.
+ * PHP Version 5
  * @package PHPMailer
- * @author Andy Prevost
- * @author Marcus Bointon
- * @author Jim Jagielski
+ * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author Brent R. Matzelle (original founder)
+ * @copyright 2012 - 2014 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @note This program is distributed in the hope that it will be useful - WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
  */
-
-if (version_compare(PHP_VERSION, '5.0.0', '<') ) {
-  exit("Sorry, PHPMailer will only run on PHP version 5 or greater!\n");
-}
 
 /**
- * PHP email creation and transport class
+ * PHPMailer - PHP email creation and transport class.
  * @package PHPMailer
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author Brent R. Matzelle (original founder)
  */
-class PHPMailer {
-
-  /////////////////////////////////////////////////
-  // PROPERTIES, PUBLIC
-  /////////////////////////////////////////////////
-
-  /**
-   * Email priority (1 = High, 3 = Normal, 5 = low).
-   * @var int
-   */
-  public $Priority          = 3;
-
-  /**
-   * Sets the CharSet of the message.
-   * @var string
-   */
-  public $CharSet           = 'iso-8859-1';
-
-  /**
-   * Sets the Content-type of the message.
-   * @var string
-   */
-  public $ContentType       = 'text/plain';
-
-  /**
-   * Sets the Encoding of the message. Options for this are
-   *  "8bit", "7bit", "binary", "base64", and "quoted-printable".
-   * @var string
-   */
-  public $Encoding          = '8bit';
-
-  /**
-   * Holds the most recent mailer error message.
-   * @var string
-   */
-  public $ErrorInfo         = '';
-
-  /**
-   * Sets the From email address for the message.
-   * @var string
-   */
-  public $From              = 'root@localhost';
-
-  /**
-   * Sets the From name of the message.
-   * @var string
-   */
-  public $FromName          = 'Root User';
-
-  /**
-   * Sets the Sender email (Return-Path) of the message.
-   * If not empty, will be sent via -f to sendmail or as 'MAIL FROM' in smtp mode.
-   * @var string
-   */
-  public $Sender            = '';
-
-  /**
-   * Sets the Return-Path of the message.  If empty, it will
-   * be set to either From or Sender.
-   * @var string
-   */
-  public $ReturnPath        = '';
-
-  /**
-   * Sets the Subject of the message.
-   * @var string
-   */
-  public $Subject           = '';
-
-  /**
-   * An HTML or plain text message body.
-   * If HTML then call IsHTML(true).
-   * @var string
-   */
-  public $Body              = '';
-
-  /**
-   * The plain-text message body.
-   * This body can be read by mail clients that do not have HTML email
-   * capability such as mutt & Eudora.
-   * Clients that can read HTML will view the normal Body.
-   * @var string
-   */
-  public $AltBody           = '';
-
-  /**
-   * An iCal message part body
-   * Only supported in simple alt or alt_inline message types
-   * To generate iCal events, use the bundled extras/EasyPeasyICS.php class or iCalcreator
-   * @link http://sprain.ch/blog/downloads/php-class-easypeasyics-create-ical-files-with-php/
-   * @link http://kigkonsult.se/iCalcreator/
-   * @var string
-   */
-  public $Ical              = '';
-
-  /**
-   * Stores the complete compiled MIME message body.
-   * @var string
-   * @access protected
-   */
-  protected $MIMEBody       = '';
-
-  /**
-   * Stores the complete compiled MIME message headers.
-   * @var string
-   * @access protected
-   */
-  protected $MIMEHeader     = '';
-
-  /**
-   * Stores the extra header list which CreateHeader() doesn't fold in
-   * @var string
-   * @access protected
-   */
-  protected $mailHeader     = '';
-
-  /**
-   * Sets word wrapping on the body of the message to a given number of
-   * characters.
-   * @var int
-   */
-  public $WordWrap          = 0;
-
-  /**
-   * Method to send mail: ("mail", "sendmail", or "smtp").
-   * @var string
-   */
-  public $Mailer            = 'mail';
-
-  /**
-   * Sets the path of the sendmail program.
-   * @var string
-   */
-  public $Sendmail          = '/usr/sbin/sendmail';
-
-  /**
-   * Determine if mail() uses a fully sendmail compatible MTA that
-   * supports sendmail's "-oi -f" options
-   * @var boolean
-   */
-  public $UseSendmailOptions	= true;
-
-  /**
-   * Path to PHPMailer plugins.  Useful if the SMTP class
-   * is in a different directory than the PHP include path.
-   * @var string
-   */
-  public $PluginDir         = '';
-
-  /**
-   * Sets the email address that a reading confirmation will be sent.
-   * @var string
-   */
-  public $ConfirmReadingTo  = '';
-
-  /**
-   * Sets the hostname to use in Message-Id and Received headers
-   * and as default HELO string. If empty, the value returned
-   * by SERVER_NAME is used or 'localhost.localdomain'.
-   * @var string
-   */
-  public $Hostname          = '';
-
-  /**
-   * Sets the message ID to be used in the Message-Id header.
-   * If empty, a unique id will be generated.
-   * @var string
-   */
-  public $MessageID         = '';
-
-  /**
-   * Sets the message Date to be used in the Date header.
-   * If empty, the current date will be added.
-   * @var string
-   */
-  public $MessageDate       = '';
-
-  /////////////////////////////////////////////////
-  // PROPERTIES FOR SMTP
-  /////////////////////////////////////////////////
-
-  /**
-   * Sets the SMTP hosts.
-   *
-   * All hosts must be separated by a
-   * semicolon.  You can also specify a different port
-   * for each host by using this format: [hostname:port]
-   * (e.g. "smtp1.example.com:25;smtp2.example.com").
-   * Hosts will be tried in order.
-   * @var string
-   */
-  public $Host          = 'localhost';
-
-  /**
-   * Sets the default SMTP server port.
-   * @var int
-   */
-  public $Port          = 25;
-
-  /**
-   * Sets the SMTP HELO of the message (Default is $Hostname).
-   * @var string
-   */
-  public $Helo          = '';
-
-  /**
-   * Sets connection prefix. Options are "", "ssl" or "tls"
-   * @var string
-   */
-  public $SMTPSecure    = '';
-
-  /**
-   * Sets SMTP authentication. Utilizes the Username and Password variables.
-   * @var bool
-   */
-  public $SMTPAuth      = false;
-
-  /**
-   * Sets SMTP username.
-   * @var string
-   */
-  public $Username      = '';
-
-  /**
-   * Sets SMTP password.
-   * @var string
-   */
-  public $Password      = '';
-
-  /**
-   *  Sets SMTP auth type. Options are LOGIN | PLAIN | NTLM | CRAM-MD5 (default LOGIN)
-   *  @var string
-   */
-  public $AuthType      = '';
-
-  /**
-   *  Sets SMTP realm.
-   *  @var string
-   */
-  public $Realm         = '';
-
-  /**
-   *  Sets SMTP workstation.
-   *  @var string
-   */
-  public $Workstation   = '';
-
-  /**
-   * Sets the SMTP server timeout in seconds.
-   * This function will not work with the win32 version.
-   * @var int
-   */
-  public $Timeout       = 10;
-
-  /**
-   * Sets SMTP class debugging on or off.
-   * @var bool
-   */
-  public $SMTPDebug     = false;
-
-  /**
-   * Sets the function/method to use for debugging output.
-   * Right now we only honor "echo" or "error_log"
-   * @var string
-   */
-  public $Debugoutput     = "echo";
-
-  /**
-   * Prevents the SMTP connection from being closed after each mail
-   * sending.  If this is set to true then to close the connection
-   * requires an explicit call to SmtpClose().
-   * @var bool
-   */
-  public $SMTPKeepAlive = false;
-
-  /**
-   * Provides the ability to have the TO field process individual
-   * emails, instead of sending to entire TO addresses
-   * @var bool
-   */
-  public $SingleTo      = false;
-
-  /**
-   * Should we generate VERP addresses when sending via SMTP?
-   * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
-   * @var bool
-   */
-  public $do_verp      = false;
-
-  /**
-   * If SingleTo is true, this provides the array to hold the email addresses
-   * @var bool
-   */
-  public $SingleToArray = array();
-
-  /**
-   * Should we allow sending messages with empty body?
-   * @var bool
-   */
-  public $AllowEmpty = false;
+class PHPMailer
+{
+    /**
+     * The PHPMailer Version number.
+     * @type string
+     */
+    public $Version = '5.2.8';
 
     /**
-   * Provides the ability to change the generic line ending
-   * NOTE: The default remains '\n'. We force CRLF where we KNOW
-   *        it must be used via self::CRLF
-   * @var string
-   */
-  public $LE              = "\n";
+     * Email priority.
+     * Options: 1 = High, 3 = Normal, 5 = low.
+     * @type integer
+     */
+    public $Priority = 3;
 
-   /**
-   * Used with DKIM Signing
-   * required parameter if DKIM is enabled
-   *
-   * domain selector example domainkey
-   * @var string
-   */
-  public $DKIM_selector   = '';
+    /**
+     * The character set of the message.
+     * @type string
+     */
+    public $CharSet = 'iso-8859-1';
 
-  /**
-   * Used with DKIM Signing
-   * required if DKIM is enabled, in format of email address 'you@yourdomain.com' typically used as the source of the email
-   * @var string
-   */
-  public $DKIM_identity   = '';
+    /**
+     * The MIME Content-type of the message.
+     * @type string
+     */
+    public $ContentType = 'text/plain';
 
-  /**
-   * Used with DKIM Signing
-   * optional parameter if your private key requires a passphras
-   * @var string
-   */
-  public $DKIM_passphrase   = '';
+    /**
+     * The message encoding.
+     * Options: "8bit", "7bit", "binary", "base64", and "quoted-printable".
+     * @type string
+     */
+    public $Encoding = '8bit';
 
-  /**
-   * Used with DKIM Singing
-   * required if DKIM is enabled, in format of email address 'domain.com'
-   * @var string
-   */
-  public $DKIM_domain     = '';
+    /**
+     * Holds the most recent mailer error message.
+     * @type string
+     */
+    public $ErrorInfo = '';
 
-  /**
-   * Used with DKIM Signing
-   * required if DKIM is enabled, path to private key file
-   * @var string
-   */
-  public $DKIM_private    = '';
+    /**
+     * The From email address for the message.
+     * @type string
+     */
+    public $From = 'root@localhost';
 
-  /**
-   * Callback Action function name.
-   * The function that handles the result of the send email action.
-   * It is called out by Send() for each email sent.
-   *
-   * Value can be:
-   * - 'function_name' for function names
-   * - 'Class::Method' for static method calls
-   * - array($object, 'Method') for calling methods on $object
-   * See http://php.net/is_callable manual page for more details.
-   *
-   * Parameters:
-   *   bool    $result        result of the send action
-   *   string  $to            email address of the recipient
-   *   string  $cc            cc email addresses
-   *   string  $bcc           bcc email addresses
-   *   string  $subject       the subject
-   *   string  $body          the email body
-   *   string  $from          email address of sender
-   * @var string
-   */
-  public $action_function = ''; //'callbackAction';
+    /**
+     * The From name of the message.
+     * @type string
+     */
+    public $FromName = 'Root User';
 
-  /**
-   * Sets the PHPMailer Version number
-   * @var string
-   */
-  public $Version         = '5.2.6';
+    /**
+     * The Sender email (Return-Path) of the message.
+     * If not empty, will be sent via -f to sendmail or as 'MAIL FROM' in smtp mode.
+     * @type string
+     */
+    public $Sender = '';
 
-  /**
-   * What to use in the X-Mailer header
-   * @var string NULL for default, whitespace for None, or actual string to use
-   */
-  public $XMailer         = '';
+    /**
+     * The Return-Path of the message.
+     * If empty, it will be set to either From or Sender.
+     * @type string
+     * @deprecated Email senders should never set a return-path header;
+     * it's the receiver's job (RFC5321 section 4.4), so this no longer does anything.
+     * @link https://tools.ietf.org/html/rfc5321#section-4.4 RFC5321 reference
+     */
+    public $ReturnPath = '';
 
-  /////////////////////////////////////////////////
-  // PROPERTIES, PRIVATE AND PROTECTED
-  /////////////////////////////////////////////////
+    /**
+     * The Subject of the message.
+     * @type string
+     */
+    public $Subject = '';
 
-  /**
-   * @var SMTP An instance of the SMTP sender class
-   * @access protected
-   */
-  protected   $smtp           = null;
-  /**
-   * @var array An array of 'to' addresses
-   * @access protected
-   */
-  protected   $to             = array();
-  /**
-   * @var array An array of 'cc' addresses
-   * @access protected
-   */
-  protected   $cc             = array();
-  /**
-   * @var array An array of 'bcc' addresses
-   * @access protected
-   */
-  protected   $bcc            = array();
-  /**
-   * @var array An array of reply-to name and address
-   * @access protected
-   */
-  protected   $ReplyTo        = array();
-  /**
-   * @var array An array of all kinds of addresses: to, cc, bcc, replyto
-   * @access protected
-   */
-  protected   $all_recipients = array();
-  /**
-   * @var array An array of attachments
-   * @access protected
-   */
-  protected   $attachment     = array();
-  /**
-   * @var array An array of custom headers
-   * @access protected
-   */
-  protected   $CustomHeader   = array();
-  /**
-   * @var string The message's MIME type
-   * @access protected
-   */
-  protected   $message_type   = '';
-  /**
-   * @var array An array of MIME boundary strings
-   * @access protected
-   */
-  protected   $boundary       = array();
-  /**
-   * @var array An array of available languages
-   * @access protected
-   */
-  protected   $language       = array();
-  /**
-   * @var integer The number of errors encountered
-   * @access protected
-   */
-  protected   $error_count    = 0;
-  /**
-   * @var string The filename of a DKIM certificate file
-   * @access protected
-   */
-  protected   $sign_cert_file = '';
-  /**
-   * @var string The filename of a DKIM key file
-   * @access protected
-   */
-  protected   $sign_key_file  = '';
-  /**
-   * @var string The password of a DKIM key
-   * @access protected
-   */
-  protected   $sign_key_pass  = '';
-  /**
-   * @var boolean Whether to throw exceptions for errors
-   * @access protected
-   */
-  protected   $exceptions     = false;
+    /**
+     * An HTML or plain text message body.
+     * If HTML then call isHTML(true).
+     * @type string
+     */
+    public $Body = '';
 
-  /////////////////////////////////////////////////
-  // CONSTANTS
-  /////////////////////////////////////////////////
+    /**
+     * The plain-text message body.
+     * This body can be read by mail clients that do not have HTML email
+     * capability such as mutt & Eudora.
+     * Clients that can read HTML will view the normal Body.
+     * @type string
+     */
+    public $AltBody = '';
 
-  const STOP_MESSAGE  = 0; // message only, continue processing
-  const STOP_CONTINUE = 1; // message?, likely ok to continue processing
-  const STOP_CRITICAL = 2; // message, plus full stop, critical error reached
-  const CRLF = "\r\n";     // SMTP RFC specified EOL
+    /**
+     * An iCal message part body.
+     * Only supported in simple alt or alt_inline message types
+     * To generate iCal events, use the bundled extras/EasyPeasyICS.php class or iCalcreator
+     * @link http://sprain.ch/blog/downloads/php-class-easypeasyics-create-ical-files-with-php/
+     * @link http://kigkonsult.se/iCalcreator/
+     * @type string
+     */
+    public $Ical = '';
 
-  /////////////////////////////////////////////////
-  // METHODS, VARIABLES
-  /////////////////////////////////////////////////
+    /**
+     * The complete compiled MIME message body.
+     * @access protected
+     * @type string
+     */
+    protected $MIMEBody = '';
 
-  /**
-   * Calls actual mail() function, but in a safe_mode aware fashion
-   * Also, unless sendmail_path points to sendmail (or something that
-   * claims to be sendmail), don't pass params (not a perfect fix,
-   * but it will do)
-   * @param string $to To
-   * @param string $subject Subject
-   * @param string $body Message Body
-   * @param string $header Additional Header(s)
-   * @param string $params Params
-   * @access private
-   * @return bool
-   */
-  private function mail_passthru($to, $subject, $body, $header, $params) {
-    if ( ini_get('safe_mode') || !($this->UseSendmailOptions) ) {
-        $rt = @mail($to, $this->EncodeHeader($this->SecureHeader($subject)), $body, $header);
-    } else {
-        $rt = @mail($to, $this->EncodeHeader($this->SecureHeader($subject)), $body, $header, $params);
+    /**
+     * The complete compiled MIME message headers.
+     * @type string
+     * @access protected
+     */
+    protected $MIMEHeader = '';
+
+    /**
+     * Extra headers that createHeader() doesn't fold in.
+     * @type string
+     * @access protected
+     */
+    protected $mailHeader = '';
+
+    /**
+     * Word-wrap the message body to this number of chars.
+     * @type integer
+     */
+    public $WordWrap = 0;
+
+    /**
+     * Which method to use to send mail.
+     * Options: "mail", "sendmail", or "smtp".
+     * @type string
+     */
+    public $Mailer = 'mail';
+
+    /**
+     * The path to the sendmail program.
+     * @type string
+     */
+    public $Sendmail = '/usr/sbin/sendmail';
+
+    /**
+     * Whether mail() uses a fully sendmail-compatible MTA.
+     * One which supports sendmail's "-oi -f" options.
+     * @type boolean
+     */
+    public $UseSendmailOptions = true;
+
+    /**
+     * Path to PHPMailer plugins.
+     * Useful if the SMTP class is not in the PHP include path.
+     * @type string
+     * @deprecated Should not be needed now there is an autoloader.
+     */
+    public $PluginDir = '';
+
+    /**
+     * The email address that a reading confirmation should be sent to.
+     * @type string
+     */
+    public $ConfirmReadingTo = '';
+
+    /**
+     * The hostname to use in Message-Id and Received headers
+     * and as default HELO string.
+     * If empty, the value returned
+     * by SERVER_NAME is used or 'localhost.localdomain'.
+     * @type string
+     */
+    public $Hostname = '';
+
+    /**
+     * An ID to be used in the Message-Id header.
+     * If empty, a unique id will be generated.
+     * @type string
+     */
+    public $MessageID = '';
+
+    /**
+     * The message Date to be used in the Date header.
+     * If empty, the current date will be added.
+     * @type string
+     */
+    public $MessageDate = '';
+
+    /**
+     * SMTP hosts.
+     * Either a single hostname or multiple semicolon-delimited hostnames.
+     * You can also specify a different port
+     * for each host by using this format: [hostname:port]
+     * (e.g. "smtp1.example.com:25;smtp2.example.com").
+     * Hosts will be tried in order.
+     * @type string
+     */
+    public $Host = 'localhost';
+
+    /**
+     * The default SMTP server port.
+     * @type integer
+     * @TODO Why is this needed when the SMTP class takes care of it?
+     */
+    public $Port = 25;
+
+    /**
+     * The SMTP HELO of the message.
+     * Default is $Hostname.
+     * @type string
+     * @see PHPMailer::$Hostname
+     */
+    public $Helo = '';
+
+    /**
+     * The secure connection prefix.
+     * Options: "", "ssl" or "tls"
+     * @type string
+     */
+    public $SMTPSecure = '';
+
+    /**
+     * Whether to use SMTP authentication.
+     * Uses the Username and Password properties.
+     * @type boolean
+     * @see PHPMailer::$Username
+     * @see PHPMailer::$Password
+     */
+    public $SMTPAuth = false;
+
+    /**
+     * SMTP username.
+     * @type string
+     */
+    public $Username = '';
+
+    /**
+     * SMTP password.
+     * @type string
+     */
+    public $Password = '';
+
+    /**
+     * SMTP auth type.
+     * Options are LOGIN (default), PLAIN, NTLM, CRAM-MD5
+     * @type string
+     */
+    public $AuthType = '';
+
+    /**
+     * SMTP realm.
+     * Used for NTLM auth
+     * @type string
+     */
+    public $Realm = '';
+
+    /**
+     * SMTP workstation.
+     * Used for NTLM auth
+     * @type string
+     */
+    public $Workstation = '';
+
+    /**
+     * The SMTP server timeout in seconds.
+     * @type integer
+     */
+    public $Timeout = 10;
+
+    /**
+     * SMTP class debug output mode.
+     * Options:
+     *   0: no output
+     *   1: commands
+     *   2: data and commands
+     *   3: as 2 plus connection status
+     *   4: low level data output
+     * @type integer
+     * @see SMTP::$do_debug
+     */
+    public $SMTPDebug = 0;
+
+    /**
+     * How to handle debug output.
+     * Options:
+     *   'echo': Output plain-text as-is, appropriate for CLI
+     *   'html': Output escaped, line breaks converted to <br>, appropriate for browser output
+     *   'error_log': Output to error log as configured in php.ini
+     * @type string
+     * @see SMTP::$Debugoutput
+     */
+    public $Debugoutput = 'echo';
+
+    /**
+     * Whether to keep SMTP connection open after each message.
+     * If this is set to true then to close the connection
+     * requires an explicit call to smtpClose().
+     * @type boolean
+     */
+    public $SMTPKeepAlive = false;
+
+    /**
+     * Whether to split multiple to addresses into multiple messages
+     * or send them all in one message.
+     * @type boolean
+     */
+    public $SingleTo = false;
+
+    /**
+     * Storage for addresses when SingleTo is enabled.
+     * @type array
+     * @TODO This should really not be public
+     */
+    public $SingleToArray = array();
+
+    /**
+     * Whether to generate VERP addresses on send.
+     * Only applicable when sending via SMTP.
+     * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
+     * @link http://www.postfix.org/VERP_README.html Postfix VERP info
+     * @type boolean
+     */
+    public $do_verp = false;
+
+    /**
+     * Whether to allow sending messages with an empty body.
+     * @type boolean
+     */
+    public $AllowEmpty = false;
+
+    /**
+     * The default line ending.
+     * @note The default remains "\n". We force CRLF where we know
+     *        it must be used via self::CRLF.
+     * @type string
+     */
+    public $LE = "\n";
+
+    /**
+     * DKIM selector.
+     * @type string
+     */
+    public $DKIM_selector = '';
+
+    /**
+     * DKIM Identity.
+     * Usually the email address used as the source of the email
+     * @type string
+     */
+    public $DKIM_identity = '';
+
+    /**
+     * DKIM passphrase.
+     * Used if your key is encrypted.
+     * @type string
+     */
+    public $DKIM_passphrase = '';
+
+    /**
+     * DKIM signing domain name.
+     * @example 'example.com'
+     * @type string
+     */
+    public $DKIM_domain = '';
+
+    /**
+     * DKIM private key file path.
+     * @type string
+     */
+    public $DKIM_private = '';
+
+    /**
+     * Callback Action function name.
+     *
+     * The function that handles the result of the send email action.
+     * It is called out by send() for each email sent.
+     *
+     * Value can be any php callable: http://www.php.net/is_callable
+     *
+     * Parameters:
+     *   boolean $result        result of the send action
+     *   string  $to            email address of the recipient
+     *   string  $cc            cc email addresses
+     *   string  $bcc           bcc email addresses
+     *   string  $subject       the subject
+     *   string  $body          the email body
+     *   string  $from          email address of sender
+     * @type string
+     */
+    public $action_function = '';
+
+    /**
+     * What to use in the X-Mailer header.
+     * Options: null for default, whitespace for none, or a string to use
+     * @type string
+     */
+    public $XMailer = '';
+
+    /**
+     * An instance of the SMTP sender class.
+     * @type SMTP
+     * @access protected
+     */
+    protected $smtp = null;
+
+    /**
+     * The array of 'to' addresses.
+     * @type array
+     * @access protected
+     */
+    protected $to = array();
+
+    /**
+     * The array of 'cc' addresses.
+     * @type array
+     * @access protected
+     */
+    protected $cc = array();
+
+    /**
+     * The array of 'bcc' addresses.
+     * @type array
+     * @access protected
+     */
+    protected $bcc = array();
+
+    /**
+     * The array of reply-to names and addresses.
+     * @type array
+     * @access protected
+     */
+    protected $ReplyTo = array();
+
+    /**
+     * An array of all kinds of addresses.
+     * Includes all of $to, $cc, $bcc, $replyto
+     * @type array
+     * @access protected
+     */
+    protected $all_recipients = array();
+
+    /**
+     * The array of attachments.
+     * @type array
+     * @access protected
+     */
+    protected $attachment = array();
+
+    /**
+     * The array of custom headers.
+     * @type array
+     * @access protected
+     */
+    protected $CustomHeader = array();
+
+    /**
+     * The most recent Message-ID (including angular brackets).
+     * @type string
+     * @access protected
+     */
+    protected $lastMessageID = '';
+
+    /**
+     * The message's MIME type.
+     * @type string
+     * @access protected
+     */
+    protected $message_type = '';
+
+    /**
+     * The array of MIME boundary strings.
+     * @type array
+     * @access protected
+     */
+    protected $boundary = array();
+
+    /**
+     * The array of available languages.
+     * @type array
+     * @access protected
+     */
+    protected $language = array();
+
+    /**
+     * The number of errors encountered.
+     * @type integer
+     * @access protected
+     */
+    protected $error_count = 0;
+
+    /**
+     * The S/MIME certificate file path.
+     * @type string
+     * @access protected
+     */
+    protected $sign_cert_file = '';
+
+    /**
+     * The S/MIME key file path.
+     * @type string
+     * @access protected
+     */
+    protected $sign_key_file = '';
+
+    /**
+     * The S/MIME password for the key.
+     * Used only if the key is encrypted.
+     * @type string
+     * @access protected
+     */
+    protected $sign_key_pass = '';
+
+    /**
+     * Whether to throw exceptions for errors.
+     * @type boolean
+     * @access protected
+     */
+    protected $exceptions = false;
+
+    /**
+     * Error severity: message only, continue processing
+     */
+    const STOP_MESSAGE = 0;
+
+    /**
+     * Error severity: message, likely ok to continue processing
+     */
+    const STOP_CONTINUE = 1;
+
+    /**
+     * Error severity: message, plus full stop, critical error reached
+     */
+    const STOP_CRITICAL = 2;
+
+    /**
+     * SMTP RFC standard line ending
+     */
+    const CRLF = "\r\n";
+
+    /**
+     * Constructor
+     * @param boolean $exceptions Should we throw external exceptions?
+     */
+    public function __construct($exceptions = false)
+    {
+        $this->exceptions = ($exceptions == true);
+        //Make sure our autoloader is loaded
+        if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
+            $autoload = spl_autoload_functions();
+            if ($autoload === false or !in_array('PHPMailerAutoload', $autoload)) {
+                require 'PHPMailerAutoload.php';
+            }
+        }
     }
-    return $rt;
-  }
 
-  /**
-   * Outputs debugging info via user-defined method
-   * @param string $str
-   */
-  protected function edebug($str) {
-    switch ($this->Debugoutput) {
-      case 'error_log':
-        error_log($str);
-        break;
-      case 'html':
-        //Cleans up output a bit for a better looking display that's HTML-safe
-        echo htmlentities(preg_replace('/[\r\n]+/', '', $str), ENT_QUOTES, $this->CharSet)."<br>\n";
-        break;
-      case 'echo':
-      default:
-        //Just echoes exactly what was received
-        echo $str;
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        if ($this->Mailer == 'smtp') { //close any open SMTP connection nicely
+            $this->smtpClose();
+        }
     }
-  }
 
-  /**
-   * Constructor
-   * @param boolean $exceptions Should we throw external exceptions?
-   */
-  public function __construct($exceptions = false) {
-    $this->exceptions = ($exceptions == true);
-  }
-
-  /**
-   * Destructor
-   */
-  public function __destruct() {
-      if ($this->Mailer == 'smtp') { //Close any open SMTP connection nicely
-          $this->SmtpClose();
-      }
-  }
-
-  /**
-   * Sets message type to HTML.
-   * @param bool $ishtml
-   * @return void
-   */
-  public function IsHTML($ishtml = true) {
-    if ($ishtml) {
-      $this->ContentType = 'text/html';
-    } else {
-      $this->ContentType = 'text/plain';
-    }
-  }
-
-  /**
-   * Sets Mailer to send message using SMTP.
-   * @return void
-   */
-  public function IsSMTP() {
-    $this->Mailer = 'smtp';
-  }
-
-  /**
-   * Sets Mailer to send message using PHP mail() function.
-   * @return void
-   */
-  public function IsMail() {
-    $this->Mailer = 'mail';
-  }
-
-  /**
-   * Sets Mailer to send message using the $Sendmail program.
-   * @return void
-   */
-  public function IsSendmail() {
-    if (!stristr(ini_get('sendmail_path'), 'sendmail')) {
-      $this->Sendmail = '/var/qmail/bin/sendmail';
-    }
-    $this->Mailer = 'sendmail';
-  }
-
-  /**
-   * Sets Mailer to send message using the qmail MTA.
-   * @return void
-   */
-  public function IsQmail() {
-    if (stristr(ini_get('sendmail_path'), 'qmail')) {
-      $this->Sendmail = '/var/qmail/bin/sendmail';
-    }
-    $this->Mailer = 'sendmail';
-  }
-
-  /////////////////////////////////////////////////
-  // METHODS, RECIPIENTS
-  /////////////////////////////////////////////////
-
-  /**
-   * Adds a "To" address.
-   * @param string $address
-   * @param string $name
-   * @return boolean true on success, false if address already used
-   */
-  public function AddAddress($address, $name = '') {
-    return $this->AddAnAddress('to', $address, $name);
-  }
-
-  /**
-   * Adds a "Cc" address.
-   * Note: this function works with the SMTP mailer on win32, not with the "mail" mailer.
-   * @param string $address
-   * @param string $name
-   * @return boolean true on success, false if address already used
-   */
-  public function AddCC($address, $name = '') {
-    return $this->AddAnAddress('cc', $address, $name);
-  }
-
-  /**
-   * Adds a "Bcc" address.
-   * Note: this function works with the SMTP mailer on win32, not with the "mail" mailer.
-   * @param string $address
-   * @param string $name
-   * @return boolean true on success, false if address already used
-   */
-  public function AddBCC($address, $name = '') {
-    return $this->AddAnAddress('bcc', $address, $name);
-  }
-
-  /**
-   * Adds a "Reply-to" address.
-   * @param string $address
-   * @param string $name
-   * @return boolean
-   */
-  public function AddReplyTo($address, $name = '') {
-    return $this->AddAnAddress('Reply-To', $address, $name);
-  }
-
-  /**
-   * Adds an address to one of the recipient arrays
-   * Addresses that have been added already return false, but do not throw exceptions
-   * @param string $kind One of 'to', 'cc', 'bcc', 'ReplyTo'
-   * @param string $address The email address to send to
-   * @param string $name
-   * @throws phpmailerException
-   * @return boolean true on success, false if address already used or invalid in some way
-   * @access protected
-   */
-  protected function AddAnAddress($kind, $address, $name = '') {
-    if (!preg_match('/^(to|cc|bcc|Reply-To)$/', $kind)) {
-      $this->SetError($this->Lang('Invalid recipient array').': '.$kind);
-      if ($this->exceptions) {
-        throw new phpmailerException('Invalid recipient array: ' . $kind);
-      }
-      if ($this->SMTPDebug) {
-        $this->edebug($this->Lang('Invalid recipient array').': '.$kind);
-      }
-      return false;
-    }
-    $address = trim($address);
-    $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
-    if (!$this->ValidateAddress($address)) {
-      $this->SetError($this->Lang('invalid_address').': '. $address);
-      if ($this->exceptions) {
-        throw new phpmailerException($this->Lang('invalid_address').': '.$address);
-      }
-      if ($this->SMTPDebug) {
-        $this->edebug($this->Lang('invalid_address').': '.$address);
-      }
-      return false;
-    }
-    if ($kind != 'Reply-To') {
-      if (!isset($this->all_recipients[strtolower($address)])) {
-        array_push($this->$kind, array($address, $name));
-        $this->all_recipients[strtolower($address)] = true;
-        return true;
-      }
-    } else {
-      if (!array_key_exists(strtolower($address), $this->ReplyTo)) {
-        $this->ReplyTo[strtolower($address)] = array($address, $name);
-      return true;
-    }
-  }
-  return false;
-}
-
-  /**
-   * Set the From and FromName properties
-   * @param string $address
-   * @param string $name
-   * @param boolean $auto Whether to also set the Sender address, defaults to true
-   * @throws phpmailerException
-   * @return boolean
-   */
-  public function SetFrom($address, $name = '', $auto = true) {
-    $address = trim($address);
-    $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
-    if (!$this->ValidateAddress($address)) {
-      $this->SetError($this->Lang('invalid_address').': '. $address);
-      if ($this->exceptions) {
-        throw new phpmailerException($this->Lang('invalid_address').': '.$address);
-      }
-      if ($this->SMTPDebug) {
-        $this->edebug($this->Lang('invalid_address').': '.$address);
-      }
-      return false;
-    }
-    $this->From = $address;
-    $this->FromName = $name;
-    if ($auto) {
-      if (empty($this->Sender)) {
-        $this->Sender = $address;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Check that a string looks roughly like an email address should
-   * Static so it can be used without instantiation, public so people can overload
-   * Conforms to RFC5322: Uses *correct* regex on which FILTER_VALIDATE_EMAIL is
-   * based; So why not use FILTER_VALIDATE_EMAIL? Because it was broken to
-   * not allow a@b type valid addresses :(
-   * @link http://squiloople.com/2009/12/20/email-address-validation/
-   * @copyright regex Copyright Michael Rushton 2009-10 | http://squiloople.com/ | Feel free to use and redistribute this code. But please keep this copyright notice.
-   * @param string $address The email address to check
-   * @return boolean
-   * @static
-   * @access public
-   */
-  public static function ValidateAddress($address) {
-      if (defined('PCRE_VERSION')) { //Check this instead of extension_loaded so it works when that function is disabled
-          if (version_compare(PCRE_VERSION, '8.0') >= 0) {
-              return (boolean)preg_match('/^(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){255,})(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){65,}@)((?>(?>(?>((?>(?>(?>\x0D\x0A)?[\t ])+|(?>[\t ]*\x0D\x0A)?[\t ]+)?)(\((?>(?2)(?>[\x01-\x08\x0B\x0C\x0E-\'*-\[\]-\x7F]|\\\[\x00-\x7F]|(?3)))*(?2)\)))+(?2))|(?2))?)([!#-\'*+\/-9=?^-~-]+|"(?>(?2)(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\x7F]))*(?2)")(?>(?1)\.(?1)(?4))*(?1)@(?!(?1)[a-z0-9-]{64,})(?1)(?>([a-z0-9](?>[a-z0-9-]*[a-z0-9])?)(?>(?1)\.(?!(?1)[a-z0-9-]{64,})(?1)(?5)){0,126}|\[(?:(?>IPv6:(?>([a-f0-9]{1,4})(?>:(?6)){7}|(?!(?:.*[a-f0-9][:\]]){8,})((?6)(?>:(?6)){0,6})?::(?7)?))|(?>(?>IPv6:(?>(?6)(?>:(?6)){5}:|(?!(?:.*[a-f0-9]:){6,})(?8)?::(?>((?6)(?>:(?6)){0,4}):)?))?(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(?>\.(?9)){3}))\])(?1)$/isD', $address);
-          } else {
-              //Fall back to an older regex that doesn't need a recent PCRE
-              return (boolean)preg_match('/^(?!(?>"?(?>\\\[ -~]|[^"])"?){255,})(?!(?>"?(?>\\\[ -~]|[^"])"?){65,}@)(?>[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*")(?>\.(?>[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*"))*@(?>(?![a-z0-9-]{64,})(?>[a-z0-9](?>[a-z0-9-]*[a-z0-9])?)(?>\.(?![a-z0-9-]{64,})(?>[a-z0-9](?>[a-z0-9-]*[a-z0-9])?)){0,126}|\[(?:(?>IPv6:(?>(?>[a-f0-9]{1,4})(?>:[a-f0-9]{1,4}){7}|(?!(?:.*[a-f0-9][:\]]){8,})(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,6})?::(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,6})?))|(?>(?>IPv6:(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){5}:|(?!(?:.*[a-f0-9]:){6,})(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,4})?::(?>(?:[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,4}):)?))?(?>25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(?>\.(?>25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}))\])$/isD', $address);
-          }
-      } else {
-          //No PCRE! Do something _very_ approximate!
-          //Check the address is 3 chars or longer and contains an @ that's not the first or last char
-          return (strlen($address) >= 3 and strpos($address, '@') >= 1 and strpos($address, '@') != strlen($address) - 1);
-      }
-  }
-
-  /////////////////////////////////////////////////
-  // METHODS, MAIL SENDING
-  /////////////////////////////////////////////////
-
-  /**
-   * Creates message and assigns Mailer. If the message is
-   * not sent successfully then it returns false.  Use the ErrorInfo
-   * variable to view description of the error.
-   * @throws phpmailerException
-   * @return bool
-   */
-  public function Send() {
-    try {
-      if(!$this->PreSend()) return false;
-      return $this->PostSend();
-    } catch (phpmailerException $e) {
-      $this->mailHeader = '';
-      $this->SetError($e->getMessage());
-      if ($this->exceptions) {
-        throw $e;
-      }
-      return false;
-    }
-  }
-
-  /**
-   * Prep mail by constructing all message entities
-   * @throws phpmailerException
-   * @return bool
-   */
-  public function PreSend() {
-    try {
-      $this->mailHeader = "";
-      if ((count($this->to) + count($this->cc) + count($this->bcc)) < 1) {
-        throw new phpmailerException($this->Lang('provide_address'), self::STOP_CRITICAL);
-      }
-
-      // Set whether the message is multipart/alternative
-      if(!empty($this->AltBody)) {
-        $this->ContentType = 'multipart/alternative';
-      }
-
-      $this->error_count = 0; // reset errors
-      $this->SetMessageType();
-      //Refuse to send an empty message unless we are specifically allowing it
-      if (!$this->AllowEmpty and empty($this->Body)) {
-        throw new phpmailerException($this->Lang('empty_message'), self::STOP_CRITICAL);
-      }
-
-      $this->MIMEHeader = $this->CreateHeader();
-      $this->MIMEBody = $this->CreateBody();
-
-      // To capture the complete message when using mail(), create
-      // an extra header list which CreateHeader() doesn't fold in
-      if ($this->Mailer == 'mail') {
-        if (count($this->to) > 0) {
-          $this->mailHeader .= $this->AddrAppend("To", $this->to);
+    /**
+     * Call mail() in a safe_mode-aware fashion.
+     * Also, unless sendmail_path points to sendmail (or something that
+     * claims to be sendmail), don't pass params (not a perfect fix,
+     * but it will do)
+     * @param string $to To
+     * @param string $subject Subject
+     * @param string $body Message Body
+     * @param string $header Additional Header(s)
+     * @param string $params Params
+     * @access private
+     * @return boolean
+     */
+    private function mailPassthru($to, $subject, $body, $header, $params)
+    {
+        //Check overloading of mail function to avoid double-encoding
+        if (ini_get('mbstring.func_overload') & 1) {
+            $subject = $this->secureHeader($subject);
         } else {
-          $this->mailHeader .= $this->HeaderLine("To", "undisclosed-recipients:;");
+            $subject = $this->encodeHeader($this->secureHeader($subject));
         }
-        $this->mailHeader .= $this->HeaderLine('Subject', $this->EncodeHeader($this->SecureHeader(trim($this->Subject))));
-      }
-
-      // digitally sign with DKIM if enabled
-      if (!empty($this->DKIM_domain) && !empty($this->DKIM_private) && !empty($this->DKIM_selector) && !empty($this->DKIM_domain) && file_exists($this->DKIM_private)) {
-        $header_dkim = $this->DKIM_Add($this->MIMEHeader . $this->mailHeader, $this->EncodeHeader($this->SecureHeader($this->Subject)), $this->MIMEBody);
-        $this->MIMEHeader = str_replace("\r\n", "\n", $header_dkim) . $this->MIMEHeader;
-      }
-
-      return true;
-
-    } catch (phpmailerException $e) {
-      $this->SetError($e->getMessage());
-      if ($this->exceptions) {
-        throw $e;
-      }
-      return false;
-    }
-  }
-
-  /**
-   * Actual Email transport function
-   * Send the email via the selected mechanism
-   * @throws phpmailerException
-   * @return bool
-   */
-  public function PostSend() {
-    try {
-      // Choose the mailer and send through it
-      switch($this->Mailer) {
-        case 'sendmail':
-          return $this->SendmailSend($this->MIMEHeader, $this->MIMEBody);
-        case 'smtp':
-          return $this->SmtpSend($this->MIMEHeader, $this->MIMEBody);
-        case 'mail':
-          return $this->MailSend($this->MIMEHeader, $this->MIMEBody);
-        default:
-          return $this->MailSend($this->MIMEHeader, $this->MIMEBody);
-      }
-    } catch (phpmailerException $e) {
-      $this->SetError($e->getMessage());
-      if ($this->exceptions) {
-        throw $e;
-      }
-      if ($this->SMTPDebug) {
-        $this->edebug($e->getMessage()."\n");
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Sends mail using the $Sendmail program.
-   * @param string $header The message headers
-   * @param string $body The message body
-   * @throws phpmailerException
-   * @access protected
-   * @return bool
-   */
-  protected function SendmailSend($header, $body) {
-    if ($this->Sender != '') {
-      $sendmail = sprintf("%s -oi -f%s -t", escapeshellcmd($this->Sendmail), escapeshellarg($this->Sender));
-    } else {
-      $sendmail = sprintf("%s -oi -t", escapeshellcmd($this->Sendmail));
-    }
-    if ($this->SingleTo === true) {
-      foreach ($this->SingleToArray as $val) {
-        if(!@$mail = popen($sendmail, 'w')) {
-          throw new phpmailerException($this->Lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+        if (ini_get('safe_mode') || !($this->UseSendmailOptions)) {
+            $result = @mail($to, $subject, $body, $header);
+        } else {
+            $result = @mail($to, $subject, $body, $header, $params);
         }
-        fputs($mail, "To: " . $val . "\n");
-        fputs($mail, $header);
-        fputs($mail, $body);
-        $result = pclose($mail);
-        // implement call back function if it exists
-        $isSent = ($result == 0) ? 1 : 0;
-        $this->doCallback($isSent, $val, $this->cc, $this->bcc, $this->Subject, $body);
-        if($result != 0) {
-          throw new phpmailerException($this->Lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+        return $result;
+    }
+
+    /**
+     * Output debugging info via user-defined method.
+     * Only if debug output is enabled.
+     * @see PHPMailer::$Debugoutput
+     * @see PHPMailer::$SMTPDebug
+     * @param string $str
+     */
+    protected function edebug($str)
+    {
+        if (!$this->SMTPDebug) {
+            return;
         }
-      }
-    } else {
-      if(!@$mail = popen($sendmail, 'w')) {
-        throw new phpmailerException($this->Lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
-      }
-      fputs($mail, $header);
-      fputs($mail, $body);
-      $result = pclose($mail);
-      // implement call back function if it exists
-      $isSent = ($result == 0) ? 1 : 0;
-      $this->doCallback($isSent, $this->to, $this->cc, $this->bcc, $this->Subject, $body);
-      if($result != 0) {
-        throw new phpmailerException($this->Lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Sends mail using the PHP mail() function.
-   * @param string $header The message headers
-   * @param string $body The message body
-   * @throws phpmailerException
-   * @access protected
-   * @return bool
-   */
-  protected function MailSend($header, $body) {
-    $toArr = array();
-    foreach($this->to as $t) {
-      $toArr[] = $this->AddrFormat($t);
-    }
-    $to = implode(', ', $toArr);
-
-    if (empty($this->Sender)) {
-      $params = " ";
-    } else {
-      $params = sprintf("-f%s", $this->Sender);
-    }
-    if ($this->Sender != '' and !ini_get('safe_mode')) {
-      $old_from = ini_get('sendmail_from');
-      ini_set('sendmail_from', $this->Sender);
-    }
-      $rt = false;
-    if ($this->SingleTo === true && count($toArr) > 1) {
-      foreach ($toArr as $val) {
-        $rt = $this->mail_passthru($val, $this->Subject, $body, $header, $params);
-        // implement call back function if it exists
-        $isSent = ($rt == 1) ? 1 : 0;
-        $this->doCallback($isSent, $val, $this->cc, $this->bcc, $this->Subject, $body);
-      }
-    } else {
-      $rt = $this->mail_passthru($to, $this->Subject, $body, $header, $params);
-      // implement call back function if it exists
-      $isSent = ($rt == 1) ? 1 : 0;
-      $this->doCallback($isSent, $to, $this->cc, $this->bcc, $this->Subject, $body);
-    }
-    if (isset($old_from)) {
-      ini_set('sendmail_from', $old_from);
-    }
-    if(!$rt) {
-      throw new phpmailerException($this->Lang('instantiate'), self::STOP_CRITICAL);
-    }
-    return true;
-  }
-
-  /**
-   * Sends mail via SMTP using PhpSMTP
-   * Returns false if there is a bad MAIL FROM, RCPT, or DATA input.
-   * @param string $header The message headers
-   * @param string $body The message body
-   * @throws phpmailerException
-   * @uses SMTP
-   * @access protected
-   * @return bool
-   */
-  protected function SmtpSend($header, $body) {
-    require_once $this->PluginDir . 'smtp.php';
-    $bad_rcpt = array();
-
-    if(!$this->SmtpConnect()) {
-      throw new phpmailerException($this->Lang('smtp_connect_failed'), self::STOP_CRITICAL);
-    }
-    $smtp_from = ($this->Sender == '') ? $this->From : $this->Sender;
-    if(!$this->smtp->Mail($smtp_from)) {
-      $this->SetError($this->Lang('from_failed') . $smtp_from . ' : ' .implode(',', $this->smtp->getError()));
-      throw new phpmailerException($this->ErrorInfo, self::STOP_CRITICAL);
-    }
-
-    // Attempt to send attach all recipients
-    foreach($this->to as $to) {
-      if (!$this->smtp->Recipient($to[0])) {
-        $bad_rcpt[] = $to[0];
-        // implement call back function if it exists
-        $isSent = 0;
-        $this->doCallback($isSent, $to[0], '', '', $this->Subject, $body);
-      } else {
-        // implement call back function if it exists
-        $isSent = 1;
-        $this->doCallback($isSent, $to[0], '', '', $this->Subject, $body);
-      }
-    }
-    foreach($this->cc as $cc) {
-      if (!$this->smtp->Recipient($cc[0])) {
-        $bad_rcpt[] = $cc[0];
-        // implement call back function if it exists
-        $isSent = 0;
-        $this->doCallback($isSent, '', $cc[0], '', $this->Subject, $body);
-      } else {
-        // implement call back function if it exists
-        $isSent = 1;
-        $this->doCallback($isSent, '', $cc[0], '', $this->Subject, $body);
-      }
-    }
-    foreach($this->bcc as $bcc) {
-      if (!$this->smtp->Recipient($bcc[0])) {
-        $bad_rcpt[] = $bcc[0];
-        // implement call back function if it exists
-        $isSent = 0;
-        $this->doCallback($isSent, '', '', $bcc[0], $this->Subject, $body);
-      } else {
-        // implement call back function if it exists
-        $isSent = 1;
-        $this->doCallback($isSent, '', '', $bcc[0], $this->Subject, $body);
-      }
-    }
-
-
-    if (count($bad_rcpt) > 0 ) { //Create error message for any bad addresses
-      $badaddresses = implode(', ', $bad_rcpt);
-      throw new phpmailerException($this->Lang('recipients_failed') . $badaddresses);
-    }
-    if(!$this->smtp->Data($header . $body)) {
-      throw new phpmailerException($this->Lang('data_not_accepted'), self::STOP_CRITICAL);
-    }
-    if($this->SMTPKeepAlive == true) {
-      $this->smtp->Reset();
-    } else {
-        $this->smtp->Quit();
-        $this->smtp->Close();
-    }
-    return true;
-  }
-
-  /**
-   * Initiates a connection to an SMTP server.
-   * Returns false if the operation failed.
-   * @param array $options An array of options compatible with stream_context_create()
-   * @uses SMTP
-   * @access public
-   * @throws phpmailerException
-   * @return bool
-   */
-  public function SmtpConnect($options = array()) {
-    if(is_null($this->smtp)) {
-      $this->smtp = new SMTP;
-    }
-
-    //Already connected?
-    if ($this->smtp->Connected()) {
-      return true;
-    }
-
-    $this->smtp->Timeout = $this->Timeout;
-    $this->smtp->do_debug = $this->SMTPDebug;
-    $this->smtp->Debugoutput = $this->Debugoutput;
-    $this->smtp->do_verp = $this->do_verp;
-    $index = 0;
-    $tls = ($this->SMTPSecure == 'tls');
-    $ssl = ($this->SMTPSecure == 'ssl');
-    $hosts = explode(';', $this->Host);
-    $lastexception = null;
-
-    foreach ($hosts as $hostentry) {
-      $hostinfo = array();
-      $host = $hostentry;
-      $port = $this->Port;
-      if (preg_match('/^(.+):([0-9]+)$/', $hostentry, $hostinfo)) { //If $hostentry contains 'address:port', override default
-        $host = $hostinfo[1];
-        $port = $hostinfo[2];
-      }
-      if ($this->smtp->Connect(($ssl ? 'ssl://':'').$host, $port, $this->Timeout, $options)) {
-        try {
-          if ($this->Helo) {
-            $hello = $this->Helo;
-          } else {
-            $hello = $this->ServerHostname();
-          }
-          $this->smtp->Hello($hello);
-
-          if ($tls) {
-            if (!$this->smtp->StartTLS()) {
-              throw new phpmailerException($this->Lang('connect_host'));
-            }
-            //We must resend HELO after tls negotiation
-            $this->smtp->Hello($hello);
-          }
-          if ($this->SMTPAuth) {
-            if (!$this->smtp->Authenticate($this->Username, $this->Password, $this->AuthType, $this->Realm, $this->Workstation)) {
-              throw new phpmailerException($this->Lang('authenticate'));
-            }
-          }
-          return true;
-        } catch (phpmailerException $e) {
-          $lastexception = $e;
-          //We must have connected, but then failed TLS or Auth, so close connection nicely
-          $this->smtp->Quit();
-        }
-      }
-    }
-    //If we get here, all connection attempts have failed, so close connection hard
-    $this->smtp->Close();
-    //As we've caught all exceptions, just report whatever the last one was
-    if ($this->exceptions and !is_null($lastexception)) {
-      throw $lastexception;
-    }
-    return false;
-  }
-
-  /**
-   * Closes the active SMTP session if one exists.
-   * @return void
-   */
-  public function SmtpClose() {
-    if ($this->smtp !== null) {
-      if($this->smtp->Connected()) {
-        $this->smtp->Quit();
-        $this->smtp->Close();
-      }
-    }
-  }
-
-  /**
-   * Sets the language for all class error messages.
-   * Returns false if it cannot load the language file.  The default language is English.
-   * @param string $langcode ISO 639-1 2-character language code (e.g. Portuguese: "br")
-   * @param string $lang_path Path to the language file directory
-   * @return bool
-   * @access public
-   */
-  function SetLanguage($langcode = 'en', $lang_path = 'language/') {
-    //Define full set of translatable strings
-    $PHPMAILER_LANG = array(
-      'authenticate'         => 'SMTP Error: Could not authenticate.',
-      'connect_host'         => 'SMTP Error: Could not connect to SMTP host.',
-      'data_not_accepted'    => 'SMTP Error: Data not accepted.',
-      'empty_message'        => 'Message body empty',
-      'encoding'             => 'Unknown encoding: ',
-      'execute'              => 'Could not execute: ',
-      'file_access'          => 'Could not access file: ',
-      'file_open'            => 'File Error: Could not open file: ',
-      'from_failed'          => 'The following From address failed: ',
-      'instantiate'          => 'Could not instantiate mail function.',
-      'invalid_address'      => 'Invalid address',
-      'mailer_not_supported' => ' mailer is not supported.',
-      'provide_address'      => 'You must provide at least one recipient email address.',
-      'recipients_failed'    => 'SMTP Error: The following recipients failed: ',
-      'signing'              => 'Signing Error: ',
-      'smtp_connect_failed'  => 'SMTP Connect() failed.',
-      'smtp_error'           => 'SMTP server error: ',
-      'variable_set'         => 'Cannot set or reset variable: '
-    );
-    //Overwrite language-specific strings. This way we'll never have missing translations - no more "language string failed to load"!
-    $l = true;
-    if ($langcode != 'en') { //There is no English translation file
-      $l = @include $lang_path.'phpmailer.lang-'.$langcode.'.php';
-    }
-    $this->language = $PHPMAILER_LANG;
-    return ($l == true); //Returns false if language not found
-  }
-
-  /**
-  * Return the current array of language strings
-  * @return array
-  */
-  public function GetTranslations() {
-    return $this->language;
-  }
-
-  /////////////////////////////////////////////////
-  // METHODS, MESSAGE CREATION
-  /////////////////////////////////////////////////
-
-  /**
-   * Creates recipient headers.
-   * @access public
-   * @param string $type
-   * @param array $addr
-   * @return string
-   */
-  public function AddrAppend($type, $addr) {
-    $addr_str = $type . ': ';
-    $addresses = array();
-    foreach ($addr as $a) {
-      $addresses[] = $this->AddrFormat($a);
-    }
-    $addr_str .= implode(', ', $addresses);
-    $addr_str .= $this->LE;
-
-    return $addr_str;
-  }
-
-  /**
-   * Formats an address correctly.
-   * @access public
-   * @param string $addr
-   * @return string
-   */
-  public function AddrFormat($addr) {
-    if (empty($addr[1])) {
-      return $this->SecureHeader($addr[0]);
-    } else {
-      return $this->EncodeHeader($this->SecureHeader($addr[1]), 'phrase') . " <" . $this->SecureHeader($addr[0]) . ">";
-    }
-  }
-
-  /**
-   * Wraps message for use with mailers that do not
-   * automatically perform wrapping and for quoted-printable.
-   * Original written by philippe.
-   * @param string $message The message to wrap
-   * @param integer $length The line length to wrap to
-   * @param boolean $qp_mode Whether to run in Quoted-Printable mode
-   * @access public
-   * @return string
-   */
-  public function WrapText($message, $length, $qp_mode = false) {
-    $soft_break = ($qp_mode) ? sprintf(" =%s", $this->LE) : $this->LE;
-    // If utf-8 encoding is used, we will need to make sure we don't
-    // split multibyte characters when we wrap
-    $is_utf8 = (strtolower($this->CharSet) == "utf-8");
-    $lelen = strlen($this->LE);
-    $crlflen = strlen(self::CRLF);
-
-    $message = $this->FixEOL($message);
-    if (substr($message, -$lelen) == $this->LE) {
-      $message = substr($message, 0, -$lelen);
-    }
-
-    $line = explode($this->LE, $message);   // Magic. We know FixEOL uses $LE
-    $message = '';
-    for ($i = 0 ;$i < count($line); $i++) {
-      $line_part = explode(' ', $line[$i]);
-      $buf = '';
-      for ($e = 0; $e<count($line_part); $e++) {
-        $word = $line_part[$e];
-        if ($qp_mode and (strlen($word) > $length)) {
-          $space_left = $length - strlen($buf) - $crlflen;
-          if ($e != 0) {
-            if ($space_left > 20) {
-              $len = $space_left;
-              if ($is_utf8) {
-                $len = $this->UTF8CharBoundary($word, $len);
-              } elseif (substr($word, $len - 1, 1) == "=") {
-                $len--;
-              } elseif (substr($word, $len - 2, 1) == "=") {
-                $len -= 2;
-              }
-              $part = substr($word, 0, $len);
-              $word = substr($word, $len);
-              $buf .= ' ' . $part;
-              $message .= $buf . sprintf("=%s", self::CRLF);
-            } else {
-              $message .= $buf . $soft_break;
-            }
-            $buf = '';
-          }
-          while (strlen($word) > 0) {
-            if ($length <= 0) {
+        switch ($this->Debugoutput) {
+            case 'error_log':
+                error_log($str);
                 break;
-            }
-            $len = $length;
-            if ($is_utf8) {
-              $len = $this->UTF8CharBoundary($word, $len);
-            } elseif (substr($word, $len - 1, 1) == "=") {
-              $len--;
-            } elseif (substr($word, $len - 2, 1) == "=") {
-              $len -= 2;
-            }
-            $part = substr($word, 0, $len);
-            $word = substr($word, $len);
-
-            if (strlen($word) > 0) {
-              $message .= $part . sprintf("=%s", self::CRLF);
-            } else {
-              $buf = $part;
-            }
-          }
-        } else {
-          $buf_o = $buf;
-          $buf .= ($e == 0) ? $word : (' ' . $word);
-
-          if (strlen($buf) > $length and $buf_o != '') {
-            $message .= $buf_o . $soft_break;
-            $buf = $word;
-          }
+            case 'html':
+                //Cleans up output a bit for a better looking display that's HTML-safe
+                echo htmlentities(preg_replace('/[\r\n]+/', '', $str), ENT_QUOTES, $this->CharSet) . "<br>\n";
+                break;
+            case 'echo':
+            default:
+                echo $str."\n";
         }
-      }
-      $message .= $buf . self::CRLF;
     }
-
-    return $message;
-  }
-
-  /**
-   * Finds last character boundary prior to maxLength in a utf-8
-   * quoted (printable) encoded string.
-   * Original written by Colin Brown.
-   * @access public
-   * @param string $encodedText utf-8 QP text
-   * @param int    $maxLength   find last character boundary prior to this length
-   * @return int
-   */
-  public function UTF8CharBoundary($encodedText, $maxLength) {
-    $foundSplitPos = false;
-    $lookBack = 3;
-    while (!$foundSplitPos) {
-      $lastChunk = substr($encodedText, $maxLength - $lookBack, $lookBack);
-      $encodedCharPos = strpos($lastChunk, "=");
-      if ($encodedCharPos !== false) {
-        // Found start of encoded character byte within $lookBack block.
-        // Check the encoded byte value (the 2 chars after the '=')
-        $hex = substr($encodedText, $maxLength - $lookBack + $encodedCharPos + 1, 2);
-        $dec = hexdec($hex);
-        if ($dec < 128) { // Single byte character.
-          // If the encoded char was found at pos 0, it will fit
-          // otherwise reduce maxLength to start of the encoded char
-          $maxLength = ($encodedCharPos == 0) ? $maxLength :
-          $maxLength - ($lookBack - $encodedCharPos);
-          $foundSplitPos = true;
-        } elseif ($dec >= 192) { // First byte of a multi byte character
-          // Reduce maxLength to split at start of character
-          $maxLength = $maxLength - ($lookBack - $encodedCharPos);
-          $foundSplitPos = true;
-        } elseif ($dec < 192) { // Middle byte of a multi byte character, look further back
-          $lookBack += 3;
-        }
-      } else {
-        // No encoded character found
-        $foundSplitPos = true;
-      }
-    }
-    return $maxLength;
-  }
-
-
-  /**
-   * Set the body wrapping.
-   * @access public
-   * @return void
-   */
-  public function SetWordWrap() {
-    if($this->WordWrap < 1) {
-      return;
-    }
-
-    switch($this->message_type) {
-      case 'alt':
-      case 'alt_inline':
-      case 'alt_attach':
-      case 'alt_inline_attach':
-        $this->AltBody = $this->WrapText($this->AltBody, $this->WordWrap);
-        break;
-      default:
-        $this->Body = $this->WrapText($this->Body, $this->WordWrap);
-        break;
-    }
-  }
-
-  /**
-   * Assembles message header.
-   * @access public
-   * @return string The assembled header
-   */
-  public function CreateHeader() {
-    $result = '';
-
-    // Set the boundaries
-    $uniq_id = md5(uniqid(time()));
-    $this->boundary[1] = 'b1_' . $uniq_id;
-    $this->boundary[2] = 'b2_' . $uniq_id;
-    $this->boundary[3] = 'b3_' . $uniq_id;
-
-    if ($this->MessageDate == '') {
-      $result .= $this->HeaderLine('Date', self::RFCDate());
-    } else {
-      $result .= $this->HeaderLine('Date', $this->MessageDate);
-    }
-
-    if ($this->ReturnPath) {
-      $result .= $this->HeaderLine('Return-Path', '<'.trim($this->ReturnPath).'>');
-    } elseif ($this->Sender == '') {
-      $result .= $this->HeaderLine('Return-Path', '<'.trim($this->From).'>');
-    } else {
-      $result .= $this->HeaderLine('Return-Path', '<'.trim($this->Sender).'>');
-    }
-
-    // To be created automatically by mail()
-    if($this->Mailer != 'mail') {
-      if ($this->SingleTo === true) {
-        foreach($this->to as $t) {
-          $this->SingleToArray[] = $this->AddrFormat($t);
-        }
-      } else {
-        if(count($this->to) > 0) {
-          $result .= $this->AddrAppend('To', $this->to);
-        } elseif (count($this->cc) == 0) {
-          $result .= $this->HeaderLine('To', 'undisclosed-recipients:;');
-        }
-      }
-    }
-
-    $from = array();
-    $from[0][0] = trim($this->From);
-    $from[0][1] = $this->FromName;
-    $result .= $this->AddrAppend('From', $from);
-
-    // sendmail and mail() extract Cc from the header before sending
-    if(count($this->cc) > 0) {
-      $result .= $this->AddrAppend('Cc', $this->cc);
-    }
-
-    // sendmail and mail() extract Bcc from the header before sending
-    if((($this->Mailer == 'sendmail') || ($this->Mailer == 'mail')) && (count($this->bcc) > 0)) {
-      $result .= $this->AddrAppend('Bcc', $this->bcc);
-    }
-
-    if(count($this->ReplyTo) > 0) {
-      $result .= $this->AddrAppend('Reply-To', $this->ReplyTo);
-    }
-
-    // mail() sets the subject itself
-    if($this->Mailer != 'mail') {
-      $result .= $this->HeaderLine('Subject', $this->EncodeHeader($this->SecureHeader($this->Subject)));
-    }
-
-    if($this->MessageID != '') {
-      $result .= $this->HeaderLine('Message-ID', $this->MessageID);
-    } else {
-      $result .= sprintf("Message-ID: <%s@%s>%s", $uniq_id, $this->ServerHostname(), $this->LE);
-    }
-    $result .= $this->HeaderLine('X-Priority', $this->Priority);
-    if ($this->XMailer == '') {
-        $result .= $this->HeaderLine('X-Mailer', 'PHPMailer '.$this->Version.' (https://github.com/PHPMailer/PHPMailer/)');
-    } else {
-      $myXmailer = trim($this->XMailer);
-      if ($myXmailer) {
-        $result .= $this->HeaderLine('X-Mailer', $myXmailer);
-      }
-    }
-
-    if($this->ConfirmReadingTo != '') {
-      $result .= $this->HeaderLine('Disposition-Notification-To', '<' . trim($this->ConfirmReadingTo) . '>');
-    }
-
-    // Add custom headers
-    for($index = 0; $index < count($this->CustomHeader); $index++) {
-      $result .= $this->HeaderLine(trim($this->CustomHeader[$index][0]), $this->EncodeHeader(trim($this->CustomHeader[$index][1])));
-    }
-    if (!$this->sign_key_file) {
-      $result .= $this->HeaderLine('MIME-Version', '1.0');
-      $result .= $this->GetMailMIME();
-    }
-
-    return $result;
-  }
-
-  /**
-   * Returns the message MIME.
-   * @access public
-   * @return string
-   */
-  public function GetMailMIME() {
-    $result = '';
-    switch($this->message_type) {
-      case 'inline':
-        $result .= $this->HeaderLine('Content-Type', 'multipart/related;');
-        $result .= $this->TextLine("\tboundary=\"" . $this->boundary[1].'"');
-        break;
-      case 'attach':
-      case 'inline_attach':
-      case 'alt_attach':
-      case 'alt_inline_attach':
-        $result .= $this->HeaderLine('Content-Type', 'multipart/mixed;');
-        $result .= $this->TextLine("\tboundary=\"" . $this->boundary[1].'"');
-        break;
-      case 'alt':
-      case 'alt_inline':
-        $result .= $this->HeaderLine('Content-Type', 'multipart/alternative;');
-        $result .= $this->TextLine("\tboundary=\"" . $this->boundary[1].'"');
-        break;
-      default:
-        // Catches case 'plain': and case '':
-        $result .= $this->TextLine('Content-Type: '.$this->ContentType.'; charset='.$this->CharSet);
-        break;
-    }
-    //RFC1341 part 5 says 7bit is assumed if not specified
-    if ($this->Encoding != '7bit') {
-      $result .= $this->HeaderLine('Content-Transfer-Encoding', $this->Encoding);
-    }
-
-    if($this->Mailer != 'mail') {
-      $result .= $this->LE;
-    }
-
-    return $result;
-  }
-
-  /**
-   * Returns the MIME message (headers and body). Only really valid post PreSend().
-   * @access public
-   * @return string
-   */
-  public function GetSentMIMEMessage() {
-    return $this->MIMEHeader . $this->mailHeader . self::CRLF . $this->MIMEBody;
-  }
-
-
-  /**
-   * Assembles the message body.  Returns an empty string on failure.
-   * @access public
-   * @throws phpmailerException
-   * @return string The assembled message body
-   */
-  public function CreateBody() {
-    $body = '';
-
-    if ($this->sign_key_file) {
-      $body .= $this->GetMailMIME().$this->LE;
-    }
-
-    $this->SetWordWrap();
-
-    switch($this->message_type) {
-      case 'inline':
-        $body .= $this->GetBoundary($this->boundary[1], '', '', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->AttachAll('inline', $this->boundary[1]);
-        break;
-      case 'attach':
-        $body .= $this->GetBoundary($this->boundary[1], '', '', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->AttachAll('attachment', $this->boundary[1]);
-        break;
-      case 'inline_attach':
-        $body .= $this->TextLine('--' . $this->boundary[1]);
-        $body .= $this->HeaderLine('Content-Type', 'multipart/related;');
-        $body .= $this->TextLine("\tboundary=\"" . $this->boundary[2].'"');
-        $body .= $this->LE;
-        $body .= $this->GetBoundary($this->boundary[2], '', '', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->AttachAll('inline', $this->boundary[2]);
-        $body .= $this->LE;
-        $body .= $this->AttachAll('attachment', $this->boundary[1]);
-        break;
-      case 'alt':
-        $body .= $this->GetBoundary($this->boundary[1], '', 'text/plain', '');
-        $body .= $this->EncodeString($this->AltBody, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->GetBoundary($this->boundary[1], '', 'text/html', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        if(!empty($this->Ical)) {
-          $body .= $this->GetBoundary($this->boundary[1], '', 'text/calendar; method=REQUEST', '');
-          $body .= $this->EncodeString($this->Ical, $this->Encoding);
-          $body .= $this->LE.$this->LE;
-        }
-        $body .= $this->EndBoundary($this->boundary[1]);
-        break;
-      case 'alt_inline':
-        $body .= $this->GetBoundary($this->boundary[1], '', 'text/plain', '');
-        $body .= $this->EncodeString($this->AltBody, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->TextLine('--' . $this->boundary[1]);
-        $body .= $this->HeaderLine('Content-Type', 'multipart/related;');
-        $body .= $this->TextLine("\tboundary=\"" . $this->boundary[2].'"');
-        $body .= $this->LE;
-        $body .= $this->GetBoundary($this->boundary[2], '', 'text/html', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->AttachAll('inline', $this->boundary[2]);
-        $body .= $this->LE;
-        $body .= $this->EndBoundary($this->boundary[1]);
-        break;
-      case 'alt_attach':
-        $body .= $this->TextLine('--' . $this->boundary[1]);
-        $body .= $this->HeaderLine('Content-Type', 'multipart/alternative;');
-        $body .= $this->TextLine("\tboundary=\"" . $this->boundary[2].'"');
-        $body .= $this->LE;
-        $body .= $this->GetBoundary($this->boundary[2], '', 'text/plain', '');
-        $body .= $this->EncodeString($this->AltBody, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->GetBoundary($this->boundary[2], '', 'text/html', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->EndBoundary($this->boundary[2]);
-        $body .= $this->LE;
-        $body .= $this->AttachAll('attachment', $this->boundary[1]);
-        break;
-      case 'alt_inline_attach':
-        $body .= $this->TextLine('--' . $this->boundary[1]);
-        $body .= $this->HeaderLine('Content-Type', 'multipart/alternative;');
-        $body .= $this->TextLine("\tboundary=\"" . $this->boundary[2].'"');
-        $body .= $this->LE;
-        $body .= $this->GetBoundary($this->boundary[2], '', 'text/plain', '');
-        $body .= $this->EncodeString($this->AltBody, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->TextLine('--' . $this->boundary[2]);
-        $body .= $this->HeaderLine('Content-Type', 'multipart/related;');
-        $body .= $this->TextLine("\tboundary=\"" . $this->boundary[3].'"');
-        $body .= $this->LE;
-        $body .= $this->GetBoundary($this->boundary[3], '', 'text/html', '');
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        $body .= $this->LE.$this->LE;
-        $body .= $this->AttachAll('inline', $this->boundary[3]);
-        $body .= $this->LE;
-        $body .= $this->EndBoundary($this->boundary[2]);
-        $body .= $this->LE;
-        $body .= $this->AttachAll('attachment', $this->boundary[1]);
-        break;
-      default:
-        // catch case 'plain' and case ''
-        $body .= $this->EncodeString($this->Body, $this->Encoding);
-        break;
-    }
-
-    if ($this->IsError()) {
-      $body = '';
-    } elseif ($this->sign_key_file) {
-      try {
-        if (!defined('PKCS7_TEXT')) {
-            throw new phpmailerException($this->Lang('signing').' OpenSSL extension missing.');
-        }
-        $file = tempnam(sys_get_temp_dir(), 'mail');
-        file_put_contents($file, $body); //TODO check this worked
-        $signed = tempnam(sys_get_temp_dir(), 'signed');
-        if (@openssl_pkcs7_sign($file, $signed, 'file://'.realpath($this->sign_cert_file), array('file://'.realpath($this->sign_key_file), $this->sign_key_pass), null)) {
-          @unlink($file);
-          $body = file_get_contents($signed);
-          @unlink($signed);
-        } else {
-          @unlink($file);
-          @unlink($signed);
-          throw new phpmailerException($this->Lang('signing').openssl_error_string());
-        }
-      } catch (phpmailerException $e) {
-        $body = '';
-        if ($this->exceptions) {
-          throw $e;
-        }
-      }
-    }
-    return $body;
-  }
-
-  /**
-   * Returns the start of a message boundary.
-   * @access protected
-   * @param string $boundary
-   * @param string $charSet
-   * @param string $contentType
-   * @param string $encoding
-   * @return string
-   */
-  protected function GetBoundary($boundary, $charSet, $contentType, $encoding) {
-    $result = '';
-    if($charSet == '') {
-      $charSet = $this->CharSet;
-    }
-    if($contentType == '') {
-      $contentType = $this->ContentType;
-    }
-    if($encoding == '') {
-      $encoding = $this->Encoding;
-    }
-    $result .= $this->TextLine('--' . $boundary);
-    $result .= sprintf("Content-Type: %s; charset=%s", $contentType, $charSet);
-    $result .= $this->LE;
-    $result .= $this->HeaderLine('Content-Transfer-Encoding', $encoding);
-    $result .= $this->LE;
-
-    return $result;
-  }
-
-  /**
-   * Returns the end of a message boundary.
-   * @access protected
-   * @param string $boundary
-   * @return string
-   */
-  protected function EndBoundary($boundary) {
-    return $this->LE . '--' . $boundary . '--' . $this->LE;
-  }
-
-  /**
-   * Sets the message type.
-   * @access protected
-   * @return void
-   */
-  protected function SetMessageType() {
-    $this->message_type = array();
-    if($this->AlternativeExists()) $this->message_type[] = "alt";
-    if($this->InlineImageExists()) $this->message_type[] = "inline";
-    if($this->AttachmentExists()) $this->message_type[] = "attach";
-    $this->message_type = implode("_", $this->message_type);
-    if($this->message_type == "") $this->message_type = "plain";
-  }
-
-  /**
-   * Returns a formatted header line.
-   * @access public
-   * @param string $name
-   * @param string $value
-   * @return string
-   */
-  public function HeaderLine($name, $value) {
-    return $name . ': ' . $value . $this->LE;
-  }
-
-  /**
-   * Returns a formatted mail line.
-   * @access public
-   * @param string $value
-   * @return string
-   */
-  public function TextLine($value) {
-    return $value . $this->LE;
-  }
-
-  /////////////////////////////////////////////////
-  // CLASS METHODS, ATTACHMENTS
-  /////////////////////////////////////////////////
-
-  /**
-   * Adds an attachment from a path on the filesystem.
-   * Returns false if the file could not be found
-   * or accessed.
-   * @param string $path Path to the attachment.
-   * @param string $name Overrides the attachment name.
-   * @param string $encoding File encoding (see $Encoding).
-   * @param string $type File extension (MIME) type.
-   * @throws phpmailerException
-   * @return bool
-   */
-  public function AddAttachment($path, $name = '', $encoding = 'base64', $type = '') {
-    try {
-      if ( !@is_file($path) ) {
-        throw new phpmailerException($this->Lang('file_access') . $path, self::STOP_CONTINUE);
-      }
-
-      //If a MIME type is not specified, try to work it out from the file name
-      if ($type == '') {
-        $type = self::filenameToType($path);
-      }
-
-      $filename = basename($path);
-      if ( $name == '' ) {
-        $name = $filename;
-      }
-
-      $this->attachment[] = array(
-        0 => $path,
-        1 => $filename,
-        2 => $name,
-        3 => $encoding,
-        4 => $type,
-        5 => false,  // isStringAttachment
-        6 => 'attachment',
-        7 => 0
-      );
-
-    } catch (phpmailerException $e) {
-      $this->SetError($e->getMessage());
-      if ($this->exceptions) {
-        throw $e;
-      }
-      if ($this->SMTPDebug) {
-        $this->edebug($e->getMessage()."\n");
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-  * Return the current array of attachments
-  * @return array
-  */
-  public function GetAttachments() {
-    return $this->attachment;
-  }
-
-  /**
-   * Attaches all fs, string, and binary attachments to the message.
-   * Returns an empty string on failure.
-   * @access protected
-   * @param string $disposition_type
-   * @param string $boundary
-   * @return string
-   */
-  protected function AttachAll($disposition_type, $boundary) {
-    // Return text of body
-    $mime = array();
-    $cidUniq = array();
-    $incl = array();
-
-    // Add all attachments
-    foreach ($this->attachment as $attachment) {
-      // CHECK IF IT IS A VALID DISPOSITION_FILTER
-      if($attachment[6] == $disposition_type) {
-        // Check for string attachment
-        $string = '';
-        $path = '';
-        $bString = $attachment[5];
-        if ($bString) {
-          $string = $attachment[0];
-        } else {
-          $path = $attachment[0];
-        }
-
-        $inclhash = md5(serialize($attachment));
-        if (in_array($inclhash, $incl)) { continue; }
-        $incl[]      = $inclhash;
-        $filename    = $attachment[1];
-        $name        = $attachment[2];
-        $encoding    = $attachment[3];
-        $type        = $attachment[4];
-        $disposition = $attachment[6];
-        $cid         = $attachment[7];
-        if ( $disposition == 'inline' && isset($cidUniq[$cid]) ) { continue; }
-        $cidUniq[$cid] = true;
-
-        $mime[] = sprintf("--%s%s", $boundary, $this->LE);
-        $mime[] = sprintf("Content-Type: %s; name=\"%s\"%s", $type, $this->EncodeHeader($this->SecureHeader($name)), $this->LE);
-        $mime[] = sprintf("Content-Transfer-Encoding: %s%s", $encoding, $this->LE);
-
-        if($disposition == 'inline') {
-          $mime[] = sprintf("Content-ID: <%s>%s", $cid, $this->LE);
-        }
-
-        //If a filename contains any of these chars, it should be quoted, but not otherwise: RFC2183 & RFC2045 5.1
-        //Fixes a warning in IETF's msglint MIME checker
-        if (preg_match('/[ \(\)<>@,;:\\"\/\[\]\?=]/', $name)) {
-          $mime[] = sprintf("Content-Disposition: %s; filename=\"%s\"%s", $disposition, $this->EncodeHeader($this->SecureHeader($name)), $this->LE.$this->LE);
-        } else {
-          $mime[] = sprintf("Content-Disposition: %s; filename=%s%s", $disposition, $this->EncodeHeader($this->SecureHeader($name)), $this->LE.$this->LE);
-        }
-
-        // Encode as string attachment
-        if($bString) {
-          $mime[] = $this->EncodeString($string, $encoding);
-          if($this->IsError()) {
-            return '';
-          }
-          $mime[] = $this->LE.$this->LE;
-        } else {
-          $mime[] = $this->EncodeFile($path, $encoding);
-          if($this->IsError()) {
-            return '';
-          }
-          $mime[] = $this->LE.$this->LE;
-        }
-      }
-    }
-
-    $mime[] = sprintf("--%s--%s", $boundary, $this->LE);
-
-    return implode("", $mime);
-  }
-
-  /**
-   * Encodes attachment in requested format.
-   * Returns an empty string on failure.
-   * @param string $path The full path to the file
-   * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
-   * @throws phpmailerException
-   * @see EncodeFile()
-   * @access protected
-   * @return string
-   */
-  protected function EncodeFile($path, $encoding = 'base64') {
-    try {
-      if (!is_readable($path)) {
-        throw new phpmailerException($this->Lang('file_open') . $path, self::STOP_CONTINUE);
-      }
-      $magic_quotes = get_magic_quotes_runtime();
-      if ($magic_quotes) {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-          set_magic_quotes_runtime(0);
-        } else {
-          ini_set('magic_quotes_runtime', 0);
-        }
-      }
-      $file_buffer  = file_get_contents($path);
-      $file_buffer  = $this->EncodeString($file_buffer, $encoding);
-      if ($magic_quotes) {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-          set_magic_quotes_runtime($magic_quotes);
-        } else {
-          ini_set('magic_quotes_runtime', $magic_quotes);
-        }
-      }
-      return $file_buffer;
-    } catch (Exception $e) {
-      $this->SetError($e->getMessage());
-      return '';
-    }
-  }
-
-  /**
-   * Encodes string to requested format.
-   * Returns an empty string on failure.
-   * @param string $str The text to encode
-   * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
-   * @access public
-   * @return string
-   */
-  public function EncodeString($str, $encoding = 'base64') {
-    $encoded = '';
-    switch(strtolower($encoding)) {
-      case 'base64':
-        $encoded = chunk_split(base64_encode($str), 76, $this->LE);
-        break;
-      case '7bit':
-      case '8bit':
-        $encoded = $this->FixEOL($str);
-        //Make sure it ends with a line break
-        if (substr($encoded, -(strlen($this->LE))) != $this->LE)
-          $encoded .= $this->LE;
-        break;
-      case 'binary':
-        $encoded = $str;
-        break;
-      case 'quoted-printable':
-        $encoded = $this->EncodeQP($str);
-        break;
-      default:
-        $this->SetError($this->Lang('encoding') . $encoding);
-        break;
-    }
-    return $encoded;
-  }
-
-  /**
-   * Encode a header string to best (shortest) of Q, B, quoted or none.
-   * @access public
-   * @param string $str
-   * @param string $position
-   * @return string
-   */
-  public function EncodeHeader($str, $position = 'text') {
-    $x = 0;
-
-    switch (strtolower($position)) {
-      case 'phrase':
-        if (!preg_match('/[\200-\377]/', $str)) {
-          // Can't use addslashes as we don't know what value has magic_quotes_sybase
-          $encoded = addcslashes($str, "\0..\37\177\\\"");
-          if (($str == $encoded) && !preg_match('/[^A-Za-z0-9!#$%&\'*+\/=?^_`{|}~ -]/', $str)) {
-            return ($encoded);
-          } else {
-            return ("\"$encoded\"");
-          }
-        }
-        $x = preg_match_all('/[^\040\041\043-\133\135-\176]/', $str, $matches);
-        break;
-      case 'comment':
-        $x = preg_match_all('/[()"]/', $str, $matches);
-        // Fall-through
-      case 'text':
-      default:
-        $x += preg_match_all('/[\000-\010\013\014\016-\037\177-\377]/', $str, $matches);
-        break;
-    }
-
-    if ($x == 0) { //There are no chars that need encoding
-      return ($str);
-    }
-
-    $maxlen = 75 - 7 - strlen($this->CharSet);
-    // Try to select the encoding which should produce the shortest output
-    if ($x > strlen($str)/3) { //More than a third of the content will need encoding, so B encoding will be most efficient
-      $encoding = 'B';
-      if (function_exists('mb_strlen') && $this->HasMultiBytes($str)) {
-        // Use a custom function which correctly encodes and wraps long
-        // multibyte strings without breaking lines within a character
-        $encoded = $this->Base64EncodeWrapMB($str, "\n");
-      } else {
-        $encoded = base64_encode($str);
-        $maxlen -= $maxlen % 4;
-        $encoded = trim(chunk_split($encoded, $maxlen, "\n"));
-      }
-    } else {
-      $encoding = 'Q';
-      $encoded = $this->EncodeQ($str, $position);
-      $encoded = $this->WrapText($encoded, $maxlen, true);
-      $encoded = str_replace('='.self::CRLF, "\n", trim($encoded));
-    }
-
-    $encoded = preg_replace('/^(.*)$/m', " =?".$this->CharSet."?$encoding?\\1?=", $encoded);
-    $encoded = trim(str_replace("\n", $this->LE, $encoded));
-
-    return $encoded;
-  }
-
-  /**
-   * Checks if a string contains multibyte characters.
-   * @access public
-   * @param string $str multi-byte text to wrap encode
-   * @return bool
-   */
-  public function HasMultiBytes($str) {
-    if (function_exists('mb_strlen')) {
-      return (strlen($str) > mb_strlen($str, $this->CharSet));
-    } else { // Assume no multibytes (we can't handle without mbstring functions anyway)
-      return false;
-    }
-  }
-
-  /**
-   * Correctly encodes and wraps long multibyte strings for mail headers
-   * without breaking lines within a character.
-   * Adapted from a function by paravoid at http://uk.php.net/manual/en/function.mb-encode-mimeheader.php
-   * @access public
-   * @param string $str multi-byte text to wrap encode
-   * @param string $lf string to use as linefeed/end-of-line
-   * @return string
-   */
-  public function Base64EncodeWrapMB($str, $lf=null) {
-    $start = "=?".$this->CharSet."?B?";
-    $end = "?=";
-    $encoded = "";
-    if ($lf === null) {
-      $lf = $this->LE;
-    }
-
-    $mb_length = mb_strlen($str, $this->CharSet);
-    // Each line must have length <= 75, including $start and $end
-    $length = 75 - strlen($start) - strlen($end);
-    // Average multi-byte ratio
-    $ratio = $mb_length / strlen($str);
-    // Base64 has a 4:3 ratio
-    $offset = $avgLength = floor($length * $ratio * .75);
-
-    for ($i = 0; $i < $mb_length; $i += $offset) {
-      $lookBack = 0;
-
-      do {
-        $offset = $avgLength - $lookBack;
-        $chunk = mb_substr($str, $i, $offset, $this->CharSet);
-        $chunk = base64_encode($chunk);
-        $lookBack++;
-      }
-      while (strlen($chunk) > $length);
-
-      $encoded .= $chunk . $lf;
-    }
-
-    // Chomp the last linefeed
-    $encoded = substr($encoded, 0, -strlen($lf));
-    return $encoded;
-  }
-
-  /**
-   * Encode string to RFC2045 (6.7) quoted-printable format
-   * @access public
-   * @param string $string The text to encode
-   * @param integer $line_max Number of chars allowed on a line before wrapping
-   * @return string
-   * @link PHP version adapted from http://www.php.net/manual/en/function.quoted-printable-decode.php#89417
-   */
-  public function EncodeQP($string, $line_max = 76) {
-    if (function_exists('quoted_printable_encode')) { //Use native function if it's available (>= PHP5.3)
-      return quoted_printable_encode($string);
-    }
-    //Fall back to a pure PHP implementation
-    $string = str_replace(array('%20', '%0D%0A.', '%0D%0A', '%'), array(' ', "\r\n=2E", "\r\n", '='), rawurlencode($string));
-    $string = preg_replace('/[^\r\n]{'.($line_max - 3).'}[^=\r\n]{2}/', "$0=\r\n", $string);
-    return $string;
-  }
-
-  /**
-   * Wrapper to preserve BC for old QP encoding function that was removed
-   * @see EncodeQP()
-   * @access public
-   * @param string $string
-   * @param integer $line_max
-   * @param bool $space_conv
-   * @return string
-   */
-  public function EncodeQPphp($string, $line_max = 76, $space_conv = false) {
-    return $this->EncodeQP($string, $line_max);
-  }
-
-  /**
-   * Encode string to q encoding.
-   * @link http://tools.ietf.org/html/rfc2047
-   * @param string $str the text to encode
-   * @param string $position Where the text is going to be used, see the RFC for what that means
-   * @access public
-   * @return string
-   */
-  public function EncodeQ($str, $position = 'text') {
-    //There should not be any EOL in the string
-    $pattern = '';
-    $encoded = str_replace(array("\r", "\n"), '', $str);
-    switch (strtolower($position)) {
-      case 'phrase':
-        $pattern = '^A-Za-z0-9!*+\/ -';
-        break;
-
-      case 'comment':
-        $pattern = '\(\)"';
-        //note that we don't break here!
-        //for this reason we build the $pattern without including delimiters and []
-
-      case 'text':
-      default:
-        //Replace every high ascii, control =, ? and _ characters
-        //We put \075 (=) as first value to make sure it's the first one in being converted, preventing double encode
-        $pattern = '\075\000-\011\013\014\016-\037\077\137\177-\377' . $pattern;
-        break;
-    }
-
-    if (preg_match_all("/[{$pattern}]/", $encoded, $matches)) {
-      foreach (array_unique($matches[0]) as $char) {
-        $encoded = str_replace($char, '=' . sprintf('%02X', ord($char)), $encoded);
-      }
-    }
-
-    //Replace every spaces to _ (more readable than =20)
-    return str_replace(' ', '_', $encoded);
-}
-
-
-  /**
-   * Adds a string or binary attachment (non-filesystem) to the list.
-   * This method can be used to attach ascii or binary data,
-   * such as a BLOB record from a database.
-   * @param string $string String attachment data.
-   * @param string $filename Name of the attachment.
-   * @param string $encoding File encoding (see $Encoding).
-   * @param string $type File extension (MIME) type.
-   * @return void
-   */
-  public function AddStringAttachment($string, $filename, $encoding = 'base64', $type = '') {
-    //If a MIME type is not specified, try to work it out from the file name
-    if ($type == '') {
-      $type = self::filenameToType($filename);
-    }
-    // Append to $attachment array
-    $this->attachment[] = array(
-      0 => $string,
-      1 => $filename,
-      2 => basename($filename),
-      3 => $encoding,
-      4 => $type,
-      5 => true,  // isStringAttachment
-      6 => 'attachment',
-      7 => 0
-    );
-  }
-
-  /**
-   * Add an embedded attachment from a file.
-   * This can include images, sounds, and just about any other document type.
-   * @param string $path Path to the attachment.
-   * @param string $cid Content ID of the attachment; Use this to reference
-   *        the content when using an embedded image in HTML.
-   * @param string $name Overrides the attachment name.
-   * @param string $encoding File encoding (see $Encoding).
-   * @param string $type File MIME type.
-   * @return bool True on successfully adding an attachment
-   */
-  public function AddEmbeddedImage($path, $cid, $name = '', $encoding = 'base64', $type = '') {
-    if ( !@is_file($path) ) {
-      $this->SetError($this->Lang('file_access') . $path);
-      return false;
-    }
-
-    //If a MIME type is not specified, try to work it out from the file name
-    if ($type == '') {
-      $type = self::filenameToType($path);
-    }
-
-    $filename = basename($path);
-    if ( $name == '' ) {
-      $name = $filename;
-    }
-
-    // Append to $attachment array
-    $this->attachment[] = array(
-      0 => $path,
-      1 => $filename,
-      2 => $name,
-      3 => $encoding,
-      4 => $type,
-      5 => false,  // isStringAttachment
-      6 => 'inline',
-      7 => $cid
-    );
-    return true;
-  }
-
-
-  /**
-   * Add an embedded stringified attachment.
-   * This can include images, sounds, and just about any other document type.
-   * Be sure to set the $type to an image type for images:
-   * JPEG images use 'image/jpeg', GIF uses 'image/gif', PNG uses 'image/png'.
-   * @param string $string The attachment binary data.
-   * @param string $cid Content ID of the attachment; Use this to reference
-   *        the content when using an embedded image in HTML.
-   * @param string $name
-   * @param string $encoding File encoding (see $Encoding).
-   * @param string $type MIME type.
-   * @return bool True on successfully adding an attachment
-   */
-  public function AddStringEmbeddedImage($string, $cid, $name = '', $encoding = 'base64', $type = '') {
-    //If a MIME type is not specified, try to work it out from the name
-    if ($type == '') {
-      $type = self::filenameToType($name);
-    }
-
-    // Append to $attachment array
-    $this->attachment[] = array(
-      0 => $string,
-      1 => $name,
-      2 => $name,
-      3 => $encoding,
-      4 => $type,
-      5 => true,  // isStringAttachment
-      6 => 'inline',
-      7 => $cid
-    );
-    return true;
-  }
-
-  /**
-   * Returns true if an inline attachment is present.
-   * @access public
-   * @return bool
-   */
-  public function InlineImageExists() {
-    foreach($this->attachment as $attachment) {
-      if ($attachment[6] == 'inline') {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Returns true if an attachment (non-inline) is present.
-   * @return bool
-   */
-  public function AttachmentExists() {
-    foreach($this->attachment as $attachment) {
-      if ($attachment[6] == 'attachment') {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Does this message have an alternative body set?
-   * @return bool
-   */
-  public function AlternativeExists() {
-    return !empty($this->AltBody);
-  }
-
-  /////////////////////////////////////////////////
-  // CLASS METHODS, MESSAGE RESET
-  /////////////////////////////////////////////////
-
-  /**
-   * Clears all recipients assigned in the TO array.  Returns void.
-   * @return void
-   */
-  public function ClearAddresses() {
-    foreach($this->to as $to) {
-      unset($this->all_recipients[strtolower($to[0])]);
-    }
-    $this->to = array();
-  }
-
-  /**
-   * Clears all recipients assigned in the CC array.  Returns void.
-   * @return void
-   */
-  public function ClearCCs() {
-    foreach($this->cc as $cc) {
-      unset($this->all_recipients[strtolower($cc[0])]);
-    }
-    $this->cc = array();
-  }
-
-  /**
-   * Clears all recipients assigned in the BCC array.  Returns void.
-   * @return void
-   */
-  public function ClearBCCs() {
-    foreach($this->bcc as $bcc) {
-      unset($this->all_recipients[strtolower($bcc[0])]);
-    }
-    $this->bcc = array();
-  }
-
-  /**
-   * Clears all recipients assigned in the ReplyTo array.  Returns void.
-   * @return void
-   */
-  public function ClearReplyTos() {
-    $this->ReplyTo = array();
-  }
-
-  /**
-   * Clears all recipients assigned in the TO, CC and BCC
-   * array.  Returns void.
-   * @return void
-   */
-  public function ClearAllRecipients() {
-    $this->to = array();
-    $this->cc = array();
-    $this->bcc = array();
-    $this->all_recipients = array();
-  }
-
-  /**
-   * Clears all previously set filesystem, string, and binary
-   * attachments.  Returns void.
-   * @return void
-   */
-  public function ClearAttachments() {
-    $this->attachment = array();
-  }
-
-  /**
-   * Clears all custom headers.  Returns void.
-   * @return void
-   */
-  public function ClearCustomHeaders() {
-    $this->CustomHeader = array();
-  }
-
-  /////////////////////////////////////////////////
-  // CLASS METHODS, MISCELLANEOUS
-  /////////////////////////////////////////////////
-
-  /**
-   * Adds the error message to the error container.
-   * @access protected
-   * @param string $msg
-   * @return void
-   */
-  protected function SetError($msg) {
-    $this->error_count++;
-    if ($this->Mailer == 'smtp' and !is_null($this->smtp)) {
-      $lasterror = $this->smtp->getError();
-      if (!empty($lasterror) and array_key_exists('smtp_msg', $lasterror)) {
-        $msg .= '<p>' . $this->Lang('smtp_error') . $lasterror['smtp_msg'] . "</p>\n";
-      }
-    }
-    $this->ErrorInfo = $msg;
-  }
-
-  /**
-   * Returns the proper RFC 822 formatted date.
-   * @access public
-   * @return string
-   * @static
-   */
-  public static function RFCDate() {
-    //Set the time zone to whatever the default is to avoid 500 errors
-    //Will default to UTC if it's not set properly in php.ini
-    date_default_timezone_set(@date_default_timezone_get());
-    return date('D, j M Y H:i:s O');
-  }
-
-  /**
-   * Returns the server hostname or 'localhost.localdomain' if unknown.
-   * @access protected
-   * @return string
-   */
-  protected function ServerHostname() {
-    if (!empty($this->Hostname)) {
-      $result = $this->Hostname;
-    } elseif (isset($_SERVER['SERVER_NAME'])) {
-      $result = $_SERVER['SERVER_NAME'];
-    } else {
-      $result = 'localhost.localdomain';
-    }
-
-    return $result;
-  }
-
-  /**
-   * Returns a message in the appropriate language.
-   * @access protected
-   * @param string $key
-   * @return string
-   */
-  protected function Lang($key) {
-    if(count($this->language) < 1) {
-      $this->SetLanguage('en'); // set the default language
-    }
-
-    if(isset($this->language[$key])) {
-      return $this->language[$key];
-    } else {
-      return 'Language string failed to load: ' . $key;
-    }
-  }
-
-  /**
-   * Returns true if an error occurred.
-   * @access public
-   * @return bool
-   */
-  public function IsError() {
-    return ($this->error_count > 0);
-  }
-
-  /**
-   * Changes every end of line from CRLF, CR or LF to $this->LE.
-   * @access public
-   * @param string $str String to FixEOL
-   * @return string
-   */
-  public function FixEOL($str) {
-	// condense down to \n
-	$nstr = str_replace(array("\r\n", "\r"), "\n", $str);
-	// Now convert LE as needed
-	if ($this->LE !== "\n") {
-		$nstr = str_replace("\n", $this->LE, $nstr);
-	}
-    return  $nstr;
-  }
-
-  /**
-   * Adds a custom header. $name value can be overloaded to contain
-   * both header name and value (name:value)
-   * @access public
-   * @param string $name custom header name
-   * @param string $value header value
-   * @return void
-   */
-  public function AddCustomHeader($name, $value=null) {
-	if ($value === null) {
-		// Value passed in as name:value
-		$this->CustomHeader[] = explode(':', $name, 2);
-	} else {
-		$this->CustomHeader[] = array($name, $value);
-	}
-  }
-
-  /**
-   * Creates a message from an HTML string, making modifications for inline images and backgrounds
-   * and creates a plain-text version by converting the HTML
-   * Overwrites any existing values in $this->Body and $this->AltBody
-   * @access public
-   * @param string $message HTML message string
-   * @param string $basedir baseline directory for path
-   * @param bool $advanced Whether to use the advanced HTML to text converter
-   * @return string $message
-   */
-  public function MsgHTML($message, $basedir = '', $advanced = false) {
-    preg_match_all("/(src|background)=[\"'](.*)[\"']/Ui", $message, $images);
-    if (isset($images[2])) {
-      foreach ($images[2] as $i => $url) {
-        // do not change urls for absolute images (thanks to corvuscorax)
-        if (!preg_match('#^[A-z]+://#', $url)) {
-          $filename = basename($url);
-          $directory = dirname($url);
-          if ($directory == '.') {
-            $directory = '';
-          }
-          $cid = md5($url).'@phpmailer.0'; //RFC2392 S 2
-          if (strlen($basedir) > 1 && substr($basedir, -1) != '/') {
-            $basedir .= '/';
-          }
-          if (strlen($directory) > 1 && substr($directory, -1) != '/') {
-            $directory .= '/';
-          }
-          if ($this->AddEmbeddedImage($basedir.$directory.$filename, $cid, $filename, 'base64', self::_mime_types(self::mb_pathinfo($filename, PATHINFO_EXTENSION)))) {
-            $message = preg_replace("/".$images[1][$i]."=[\"']".preg_quote($url, '/')."[\"']/Ui", $images[1][$i]."=\"cid:".$cid."\"", $message);
-          }
-        }
-      }
-    }
-    $this->IsHTML(true);
-    if (empty($this->AltBody)) {
-      $this->AltBody = 'To view this email message, open it in a program that understands HTML!' . "\n\n";
-    }
-    //Convert all message body line breaks to CRLF, makes quoted-printable encoding work much better
-    $this->Body = $this->NormalizeBreaks($message);
-    $this->AltBody = $this->NormalizeBreaks($this->html2text($message, $advanced));
-    return $this->Body;
-  }
 
     /**
-     * Convert an HTML string into a plain text version
-     * @param string $html The HTML text to convert
-     * @param bool $advanced Should this use the more complex html2text converter or just a simple one?
+     * Sets message type to HTML or plain.
+     * @param boolean $isHtml True for HTML mode.
+     * @return void
+     */
+    public function isHTML($isHtml = true)
+    {
+        if ($isHtml) {
+            $this->ContentType = 'text/html';
+        } else {
+            $this->ContentType = 'text/plain';
+        }
+    }
+
+    /**
+     * Send messages using SMTP.
+     * @return void
+     */
+    public function isSMTP()
+    {
+        $this->Mailer = 'smtp';
+    }
+
+    /**
+     * Send messages using PHP's mail() function.
+     * @return void
+     */
+    public function isMail()
+    {
+        $this->Mailer = 'mail';
+    }
+
+    /**
+     * Send messages using $Sendmail.
+     * @return void
+     */
+    public function isSendmail()
+    {
+        $ini_sendmail_path = ini_get('sendmail_path');
+
+        if (!stristr($ini_sendmail_path, 'sendmail')) {
+            $this->Sendmail = '/usr/sbin/sendmail';
+        } else {
+            $this->Sendmail = $ini_sendmail_path;
+        }
+        $this->Mailer = 'sendmail';
+    }
+
+    /**
+     * Send messages using qmail.
+     * @return void
+     */
+    public function isQmail()
+    {
+        $ini_sendmail_path = ini_get('sendmail_path');
+
+        if (!stristr($ini_sendmail_path, 'qmail')) {
+            $this->Sendmail = '/var/qmail/bin/qmail-inject';
+        } else {
+            $this->Sendmail = $ini_sendmail_path;
+        }
+        $this->Mailer = 'qmail';
+    }
+
+    /**
+     * Add a "To" address.
+     * @param string $address
+     * @param string $name
+     * @return boolean true on success, false if address already used
+     */
+    public function addAddress($address, $name = '')
+    {
+        return $this->addAnAddress('to', $address, $name);
+    }
+
+    /**
+     * Add a "CC" address.
+     * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
+     * @param string $address
+     * @param string $name
+     * @return boolean true on success, false if address already used
+     */
+    public function addCC($address, $name = '')
+    {
+        return $this->addAnAddress('cc', $address, $name);
+    }
+
+    /**
+     * Add a "BCC" address.
+     * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
+     * @param string $address
+     * @param string $name
+     * @return boolean true on success, false if address already used
+     */
+    public function addBCC($address, $name = '')
+    {
+        return $this->addAnAddress('bcc', $address, $name);
+    }
+
+    /**
+     * Add a "Reply-to" address.
+     * @param string $address
+     * @param string $name
+     * @return boolean
+     */
+    public function addReplyTo($address, $name = '')
+    {
+        return $this->addAnAddress('Reply-To', $address, $name);
+    }
+
+    /**
+     * Add an address to one of the recipient arrays.
+     * Addresses that have been added already return false, but do not throw exceptions
+     * @param string $kind One of 'to', 'cc', 'bcc', 'ReplyTo'
+     * @param string $address The email address to send to
+     * @param string $name
+     * @throws phpmailerException
+     * @return boolean true on success, false if address already used or invalid in some way
+     * @access protected
+     */
+    protected function addAnAddress($kind, $address, $name = '')
+    {
+        if (!preg_match('/^(to|cc|bcc|Reply-To)$/', $kind)) {
+            $this->setError($this->lang('Invalid recipient array') . ': ' . $kind);
+            $this->edebug($this->lang('Invalid recipient array') . ': ' . $kind);
+            if ($this->exceptions) {
+                throw new phpmailerException('Invalid recipient array: ' . $kind);
+            }
+            return false;
+        }
+        $address = trim($address);
+        $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+        if (!$this->validateAddress($address)) {
+            $this->setError($this->lang('invalid_address') . ': ' . $address);
+            $this->edebug($this->lang('invalid_address') . ': ' . $address);
+            if ($this->exceptions) {
+                throw new phpmailerException($this->lang('invalid_address') . ': ' . $address);
+            }
+            return false;
+        }
+        if ($kind != 'Reply-To') {
+            if (!isset($this->all_recipients[strtolower($address)])) {
+                array_push($this->$kind, array($address, $name));
+                $this->all_recipients[strtolower($address)] = true;
+                return true;
+            }
+        } else {
+            if (!array_key_exists(strtolower($address), $this->ReplyTo)) {
+                $this->ReplyTo[strtolower($address)] = array($address, $name);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set the From and FromName properties.
+     * @param string $address
+     * @param string $name
+     * @param boolean $auto Whether to also set the Sender address, defaults to true
+     * @throws phpmailerException
+     * @return boolean
+     */
+    public function setFrom($address, $name = '', $auto = true)
+    {
+        $address = trim($address);
+        $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+        if (!$this->validateAddress($address)) {
+            $this->setError($this->lang('invalid_address') . ': ' . $address);
+            $this->edebug($this->lang('invalid_address') . ': ' . $address);
+            if ($this->exceptions) {
+                throw new phpmailerException($this->lang('invalid_address') . ': ' . $address);
+            }
+            return false;
+        }
+        $this->From = $address;
+        $this->FromName = $name;
+        if ($auto) {
+            if (empty($this->Sender)) {
+                $this->Sender = $address;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Return the Message-ID header of the last email.
+     * Technically this is the value from the last time the headers were created,
+     * but it's also the message ID of the last sent message except in
+     * pathological cases.
      * @return string
      */
-  public function html2text($html, $advanced = false) {
-    if ($advanced) {
-      if (file_exists('extras/class.html2text.php')) {
-        require_once 'extras/class.html2text.php';
-	  }
-      $h = new html2text($html);
-      return $h->get_text();
+    public function getLastMessageID()
+    {
+        return $this->lastMessageID;
     }
-    return html_entity_decode(trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))), ENT_QUOTES, $this->CharSet);
-  }
 
-  /**
-   * Gets the MIME type of the embedded or inline image
-   * @param string $ext File extension
-   * @access public
-   * @return string MIME type of ext
-   * @static
-   */
-  public static function _mime_types($ext = '') {
-    $mimes = array(
-      'xl'    =>  'application/excel',
-      'hqx'   =>  'application/mac-binhex40',
-      'cpt'   =>  'application/mac-compactpro',
-      'bin'   =>  'application/macbinary',
-      'doc'   =>  'application/msword',
-      'word'  =>  'application/msword',
-      'class' =>  'application/octet-stream',
-      'dll'   =>  'application/octet-stream',
-      'dms'   =>  'application/octet-stream',
-      'exe'   =>  'application/octet-stream',
-      'lha'   =>  'application/octet-stream',
-      'lzh'   =>  'application/octet-stream',
-      'psd'   =>  'application/octet-stream',
-      'sea'   =>  'application/octet-stream',
-      'so'    =>  'application/octet-stream',
-      'oda'   =>  'application/oda',
-      'pdf'   =>  'application/pdf',
-      'ai'    =>  'application/postscript',
-      'eps'   =>  'application/postscript',
-      'ps'    =>  'application/postscript',
-      'smi'   =>  'application/smil',
-      'smil'  =>  'application/smil',
-      'mif'   =>  'application/vnd.mif',
-      'xls'   =>  'application/vnd.ms-excel',
-      'ppt'   =>  'application/vnd.ms-powerpoint',
-      'wbxml' =>  'application/vnd.wap.wbxml',
-      'wmlc'  =>  'application/vnd.wap.wmlc',
-      'dcr'   =>  'application/x-director',
-      'dir'   =>  'application/x-director',
-      'dxr'   =>  'application/x-director',
-      'dvi'   =>  'application/x-dvi',
-      'gtar'  =>  'application/x-gtar',
-      'php3'  =>  'application/x-httpd-php',
-      'php4'  =>  'application/x-httpd-php',
-      'php'   =>  'application/x-httpd-php',
-      'phtml' =>  'application/x-httpd-php',
-      'phps'  =>  'application/x-httpd-php-source',
-      'js'    =>  'application/x-javascript',
-      'swf'   =>  'application/x-shockwave-flash',
-      'sit'   =>  'application/x-stuffit',
-      'tar'   =>  'application/x-tar',
-      'tgz'   =>  'application/x-tar',
-      'xht'   =>  'application/xhtml+xml',
-      'xhtml' =>  'application/xhtml+xml',
-      'zip'   =>  'application/zip',
-      'mid'   =>  'audio/midi',
-      'midi'  =>  'audio/midi',
-      'mp2'   =>  'audio/mpeg',
-      'mp3'   =>  'audio/mpeg',
-      'mpga'  =>  'audio/mpeg',
-      'aif'   =>  'audio/x-aiff',
-      'aifc'  =>  'audio/x-aiff',
-      'aiff'  =>  'audio/x-aiff',
-      'ram'   =>  'audio/x-pn-realaudio',
-      'rm'    =>  'audio/x-pn-realaudio',
-      'rpm'   =>  'audio/x-pn-realaudio-plugin',
-      'ra'    =>  'audio/x-realaudio',
-      'wav'   =>  'audio/x-wav',
-      'bmp'   =>  'image/bmp',
-      'gif'   =>  'image/gif',
-      'jpeg'  =>  'image/jpeg',
-      'jpe'   =>  'image/jpeg',
-      'jpg'   =>  'image/jpeg',
-      'png'   =>  'image/png',
-      'tiff'  =>  'image/tiff',
-      'tif'   =>  'image/tiff',
-      'eml'   =>  'message/rfc822',
-      'css'   =>  'text/css',
-      'html'  =>  'text/html',
-      'htm'   =>  'text/html',
-      'shtml' =>  'text/html',
-      'log'   =>  'text/plain',
-      'text'  =>  'text/plain',
-      'txt'   =>  'text/plain',
-      'rtx'   =>  'text/richtext',
-      'rtf'   =>  'text/rtf',
-      'xml'   =>  'text/xml',
-      'xsl'   =>  'text/xml',
-      'mpeg'  =>  'video/mpeg',
-      'mpe'   =>  'video/mpeg',
-      'mpg'   =>  'video/mpeg',
-      'mov'   =>  'video/quicktime',
-      'qt'    =>  'video/quicktime',
-      'rv'    =>  'video/vnd.rn-realvideo',
-      'avi'   =>  'video/x-msvideo',
-      'movie' =>  'video/x-sgi-movie'
-    );
-    return (!isset($mimes[strtolower($ext)])) ? 'application/octet-stream' : $mimes[strtolower($ext)];
-  }
+    /**
+     * Check that a string looks like an email address.
+     * @param string $address The email address to check
+     * @param string $patternselect A selector for the validation pattern to use :
+     * * `auto` Pick strictest one automatically;
+     * * `pcre8` Use the squiloople.com pattern, requires PCRE > 8.0, PHP >= 5.3.2, 5.2.14;
+     * * `pcre` Use old PCRE implementation;
+     * * `php` Use PHP built-in FILTER_VALIDATE_EMAIL; same as pcre8 but does not allow 'dotless' domains;
+     * * `html5` Use the pattern given by the HTML5 spec for 'email' type form input elements.
+     * * `noregex` Don't use a regex: super fast, really dumb.
+     * @return boolean
+     * @static
+     * @access public
+     */
+    public static function validateAddress($address, $patternselect = 'auto')
+    {
+        if (!$patternselect or $patternselect == 'auto') {
+            if (defined('PCRE_VERSION')) { //Check this constant so it works when extension_loaded() is disabled
+                if (version_compare(PCRE_VERSION, '8.0') >= 0) {
+                    $patternselect = 'pcre8';
+                } else {
+                    $patternselect = 'pcre';
+                }
+            } else {
+                //Filter_var appeared in PHP 5.2.0 and does not require the PCRE extension
+                if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
+                    $patternselect = 'php';
+                } else {
+                    $patternselect = 'noregex';
+                }
+            }
+        }
+        switch ($patternselect) {
+            case 'pcre8':
+                /**
+                 * Uses the same RFC5322 regex on which FILTER_VALIDATE_EMAIL is based, but allows dotless domains.
+                 * @link http://squiloople.com/2009/12/20/email-address-validation/
+                 * @copyright 2009-2010 Michael Rushton
+                 * Feel free to use and redistribute this code. But please keep this copyright notice.
+                 */
+                return (boolean)preg_match(
+                    '/^(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){255,})(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){65,}@)' .
+                    '((?>(?>(?>((?>(?>(?>\x0D\x0A)?[\t ])+|(?>[\t ]*\x0D\x0A)?[\t ]+)?)(\((?>(?2)' .
+                    '(?>[\x01-\x08\x0B\x0C\x0E-\'*-\[\]-\x7F]|\\\[\x00-\x7F]|(?3)))*(?2)\)))+(?2))|(?2))?)' .
+                    '([!#-\'*+\/-9=?^-~-]+|"(?>(?2)(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\x7F]))*' .
+                    '(?2)")(?>(?1)\.(?1)(?4))*(?1)@(?!(?1)[a-z0-9-]{64,})(?1)(?>([a-z0-9](?>[a-z0-9-]*[a-z0-9])?)' .
+                    '(?>(?1)\.(?!(?1)[a-z0-9-]{64,})(?1)(?5)){0,126}|\[(?:(?>IPv6:(?>([a-f0-9]{1,4})(?>:(?6)){7}' .
+                    '|(?!(?:.*[a-f0-9][:\]]){8,})((?6)(?>:(?6)){0,6})?::(?7)?))|(?>(?>IPv6:(?>(?6)(?>:(?6)){5}:' .
+                    '|(?!(?:.*[a-f0-9]:){6,})(?8)?::(?>((?6)(?>:(?6)){0,4}):)?))?(25[0-5]|2[0-4][0-9]|1[0-9]{2}' .
+                    '|[1-9]?[0-9])(?>\.(?9)){3}))\])(?1)$/isD',
+                    $address
+                );
+            case 'pcre':
+                //An older regex that doesn't need a recent PCRE
+                return (boolean)preg_match(
+                    '/^(?!(?>"?(?>\\\[ -~]|[^"])"?){255,})(?!(?>"?(?>\\\[ -~]|[^"])"?){65,}@)(?>' .
+                    '[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*")' .
+                    '(?>\.(?>[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*"))*' .
+                    '@(?>(?![a-z0-9-]{64,})(?>[a-z0-9](?>[a-z0-9-]*[a-z0-9])?)(?>\.(?![a-z0-9-]{64,})' .
+                    '(?>[a-z0-9](?>[a-z0-9-]*[a-z0-9])?)){0,126}|\[(?:(?>IPv6:(?>(?>[a-f0-9]{1,4})(?>:' .
+                    '[a-f0-9]{1,4}){7}|(?!(?:.*[a-f0-9][:\]]){8,})(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,6})?' .
+                    '::(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,6})?))|(?>(?>IPv6:(?>[a-f0-9]{1,4}(?>:' .
+                    '[a-f0-9]{1,4}){5}:|(?!(?:.*[a-f0-9]:){6,})(?>[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,4})?' .
+                    '::(?>(?:[a-f0-9]{1,4}(?>:[a-f0-9]{1,4}){0,4}):)?))?(?>25[0-5]|2[0-4][0-9]|1[0-9]{2}' .
+                    '|[1-9]?[0-9])(?>\.(?>25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}))\])$/isD',
+                    $address
+                );
+            case 'html5':
+                /**
+                 * This is the pattern used in the HTML5 spec for validation of 'email' type form input elements.
+                 * @link http://www.whatwg.org/specs/web-apps/current-work/#e-mail-state-(type=email)
+                 */
+                return (boolean)preg_match(
+                    '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}' .
+                    '[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/sD',
+                    $address
+                );
+            case 'noregex':
+                //No PCRE! Do something _very_ approximate!
+                //Check the address is 3 chars or longer and contains an @ that's not the first or last char
+                return (strlen($address) >= 3
+                    and strpos($address, '@') >= 1
+                    and strpos($address, '@') != strlen($address) - 1);
+            case 'php':
+            default:
+                return (boolean)filter_var($address, FILTER_VALIDATE_EMAIL);
+        }
+    }
 
-  /**
-   * Try to map a file name to a MIME type, default to application/octet-stream
-   * @param string $filename A file name or full path, does not need to exist as a file
-   * @return string
-   * @static
-   */
-  public static function filenameToType($filename) {
-    //In case the path is a URL, strip any query string before getting extension
-    $qpos = strpos($filename, '?');
-    if ($qpos !== false) {
-      $filename = substr($filename, 0, $qpos);
+    /**
+     * Create a message and send it.
+     * Uses the sending method specified by $Mailer.
+     * @throws phpmailerException
+     * @return boolean false on error - See the ErrorInfo property for details of the error.
+     */
+    public function send()
+    {
+        try {
+            if (!$this->preSend()) {
+                return false;
+            }
+            return $this->postSend();
+        } catch (phpmailerException $exc) {
+            $this->mailHeader = '';
+            $this->setError($exc->getMessage());
+            if ($this->exceptions) {
+                throw $exc;
+            }
+            return false;
+        }
     }
-    $pathinfo = self::mb_pathinfo($filename);
-    return self::_mime_types($pathinfo['extension']);
-  }
 
-  /**
-   * Drop-in replacement for pathinfo(), but multibyte-safe, cross-platform-safe, old-version-safe.
-   * Works similarly to the one in PHP >= 5.2.0
-   * @link http://www.php.net/manual/en/function.pathinfo.php#107461
-   * @param string $path A filename or path, does not need to exist as a file
-   * @param integer|string $options Either a PATHINFO_* constant, or a string name to return only the specified piece, allows 'filename' to work on PHP < 5.2
-   * @return string|array
-   * @static
-   */
-  public static function mb_pathinfo($path, $options = null) {
-    $ret = array('dirname' => '', 'basename' => '', 'extension' => '', 'filename' => '');
-    $m = array();
-    preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $path, $m);
-    if(array_key_exists(1, $m)) {
-      $ret['dirname'] = $m[1];
-    }
-    if(array_key_exists(2, $m)) {
-      $ret['basename'] = $m[2];
-    }
-    if(array_key_exists(5, $m)) {
-      $ret['extension'] = $m[5];
-    }
-    if(array_key_exists(3, $m)) {
-      $ret['filename'] = $m[3];
-    }
-    switch($options) {
-      case PATHINFO_DIRNAME:
-      case 'dirname':
-        return $ret['dirname'];
-        break;
-      case PATHINFO_BASENAME:
-      case 'basename':
-        return $ret['basename'];
-        break;
-      case PATHINFO_EXTENSION:
-      case 'extension':
-        return $ret['extension'];
-        break;
-      case PATHINFO_FILENAME:
-      case 'filename':
-        return $ret['filename'];
-        break;
-      default:
-        return $ret;
-    }
-  }
+    /**
+     * Prepare a message for sending.
+     * @throws phpmailerException
+     * @return boolean
+     */
+    public function preSend()
+    {
+        try {
+            $this->mailHeader = '';
+            if ((count($this->to) + count($this->cc) + count($this->bcc)) < 1) {
+                throw new phpmailerException($this->lang('provide_address'), self::STOP_CRITICAL);
+            }
 
-  /**
-   * Set (or reset) Class Objects (variables)
-   *
-   * Usage Example:
-   * $page->set('X-Priority', '3');
-   *
-   * @access public
-   * @param string $name
-   * @param mixed $value
-   * NOTE: will not work with arrays, there are no arrays to set/reset
-   * @throws phpmailerException
-   * @return bool
-   * @todo Should this not be using __set() magic function?
-   */
-  public function set($name, $value = '') {
-    try {
-      if (isset($this->$name) ) {
-        $this->$name = $value;
-      } else {
-        throw new phpmailerException($this->Lang('variable_set') . $name, self::STOP_CRITICAL);
-      }
-    } catch (Exception $e) {
-      $this->SetError($e->getMessage());
-      if ($e->getCode() == self::STOP_CRITICAL) {
+            // Set whether the message is multipart/alternative
+            if (!empty($this->AltBody)) {
+                $this->ContentType = 'multipart/alternative';
+            }
+
+            $this->error_count = 0; // reset errors
+            $this->setMessageType();
+            // Refuse to send an empty message unless we are specifically allowing it
+            if (!$this->AllowEmpty and empty($this->Body)) {
+                throw new phpmailerException($this->lang('empty_message'), self::STOP_CRITICAL);
+            }
+
+            $this->MIMEHeader = $this->createHeader();
+            $this->MIMEBody = $this->createBody();
+
+            // To capture the complete message when using mail(), create
+            // an extra header list which createHeader() doesn't fold in
+            if ($this->Mailer == 'mail') {
+                if (count($this->to) > 0) {
+                    $this->mailHeader .= $this->addrAppend('To', $this->to);
+                } else {
+                    $this->mailHeader .= $this->headerLine('To', 'undisclosed-recipients:;');
+                }
+                $this->mailHeader .= $this->headerLine(
+                    'Subject',
+                    $this->encodeHeader($this->secureHeader(trim($this->Subject)))
+                );
+            }
+
+            // Sign with DKIM if enabled
+            if (!empty($this->DKIM_domain)
+                && !empty($this->DKIM_private)
+                && !empty($this->DKIM_selector)
+                && !empty($this->DKIM_domain)
+                && file_exists($this->DKIM_private)) {
+                $header_dkim = $this->DKIM_Add(
+                    $this->MIMEHeader . $this->mailHeader,
+                    $this->encodeHeader($this->secureHeader($this->Subject)),
+                    $this->MIMEBody
+                );
+                $this->MIMEHeader = rtrim($this->MIMEHeader, "\r\n ") . self::CRLF .
+                    str_replace("\r\n", "\n", $header_dkim) . self::CRLF;
+            }
+            return true;
+
+        } catch (phpmailerException $exc) {
+            $this->setError($exc->getMessage());
+            if ($this->exceptions) {
+                throw $exc;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Actually send a message.
+     * Send the email via the selected mechanism
+     * @throws phpmailerException
+     * @return boolean
+     */
+    public function postSend()
+    {
+        try {
+            // Choose the mailer and send through it
+            switch ($this->Mailer) {
+                case 'sendmail':
+                case 'qmail':
+                    return $this->sendmailSend($this->MIMEHeader, $this->MIMEBody);
+                case 'smtp':
+                    return $this->smtpSend($this->MIMEHeader, $this->MIMEBody);
+                case 'mail':
+                    return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
+                default:
+                    $sendMethod = $this->Mailer.'Send';
+                    if (method_exists($this, $sendMethod)) {
+                        return $this->$sendMethod($this->MIMEHeader, $this->MIMEBody);
+                    }
+
+                    return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
+            }
+        } catch (phpmailerException $exc) {
+            $this->setError($exc->getMessage());
+            $this->edebug($exc->getMessage());
+            if ($this->exceptions) {
+                throw $exc;
+            }
+        }
         return false;
-      }
     }
-    return true;
-  }
 
-  /**
-   * Strips newlines to prevent header injection.
-   * @access public
-   * @param string $str
-   * @return string
-   */
-  public function SecureHeader($str) {
-    return trim(str_replace(array("\r", "\n"), '', $str));
-  }
-
-  /**
-   * Normalize UNIX LF, Mac CR and Windows CRLF line breaks into a single line break format
-   * Defaults to CRLF (for message bodies) and preserves consecutive breaks
-   * @param string $text
-   * @param string $breaktype What kind of line break to use, defaults to CRLF
-   * @return string
-   * @access public
-   * @static
-   */
-  public static function NormalizeBreaks($text, $breaktype = "\r\n") {
-    return preg_replace('/(\r\n|\r|\n)/ms', $breaktype, $text);
-  }
-
-
-	/**
-   * Set the private key file and password to sign the message.
-   *
-   * @access public
-   * @param string $cert_filename
-   * @param string $key_filename
-   * @param string $key_pass Password for private key
-   */
-  public function Sign($cert_filename, $key_filename, $key_pass) {
-    $this->sign_cert_file = $cert_filename;
-    $this->sign_key_file = $key_filename;
-    $this->sign_key_pass = $key_pass;
-  }
-
-  /**
-   * Set the private key file and password to sign the message.
-   *
-   * @access public
-   * @param string $txt
-   * @return string
-   */
-  public function DKIM_QP($txt) {
-    $line = '';
-    for ($i = 0; $i < strlen($txt); $i++) {
-      $ord = ord($txt[$i]);
-      if ( ((0x21 <= $ord) && ($ord <= 0x3A)) || $ord == 0x3C || ((0x3E <= $ord) && ($ord <= 0x7E)) ) {
-        $line .= $txt[$i];
-      } else {
-        $line .= "=".sprintf("%02X", $ord);
-      }
+    /**
+     * Send mail using the $Sendmail program.
+     * @param string $header The message headers
+     * @param string $body The message body
+     * @see PHPMailer::$Sendmail
+     * @throws phpmailerException
+     * @access protected
+     * @return boolean
+     */
+    protected function sendmailSend($header, $body)
+    {
+        if ($this->Sender != '') {
+            if ($this->Mailer == 'qmail') {
+                $sendmail = sprintf('%s -f%s', escapeshellcmd($this->Sendmail), escapeshellarg($this->Sender));
+            } else {
+                $sendmail = sprintf('%s -oi -f%s -t', escapeshellcmd($this->Sendmail), escapeshellarg($this->Sender));
+            }
+        } else {
+            if ($this->Mailer == 'qmail') {
+                $sendmail = sprintf('%s', escapeshellcmd($this->Sendmail));
+            } else {
+                $sendmail = sprintf('%s -oi -t', escapeshellcmd($this->Sendmail));
+            }
+        }
+        if ($this->SingleTo === true) {
+            foreach ($this->SingleToArray as $toAddr) {
+                if (!@$mail = popen($sendmail, 'w')) {
+                    throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+                }
+                fputs($mail, 'To: ' . $toAddr . "\n");
+                fputs($mail, $header);
+                fputs($mail, $body);
+                $result = pclose($mail);
+                $this->doCallback(
+                    ($result == 0),
+                    array($toAddr),
+                    $this->cc,
+                    $this->bcc,
+                    $this->Subject,
+                    $body,
+                    $this->From
+                );
+                if ($result != 0) {
+                    throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+                }
+            }
+        } else {
+            if (!@$mail = popen($sendmail, 'w')) {
+                throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+            }
+            fputs($mail, $header);
+            fputs($mail, $body);
+            $result = pclose($mail);
+            $this->doCallback(($result == 0), $this->to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+            if ($result != 0) {
+                throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
+            }
+        }
+        return true;
     }
-    return $line;
-  }
 
-  /**
-   * Generate DKIM signature
-   *
-   * @access public
-   * @param string $s Header
-   * @throws phpmailerException
-   * @return string
-   */
-  public function DKIM_Sign($s) {
-    if (!defined('PKCS7_TEXT')) {
-        if ($this->exceptions) {
-            throw new phpmailerException($this->Lang("signing").' OpenSSL extension missing.');
+    /**
+     * Send mail using the PHP mail() function.
+     * @param string $header The message headers
+     * @param string $body The message body
+     * @link http://www.php.net/manual/en/book.mail.php
+     * @throws phpmailerException
+     * @access protected
+     * @return boolean
+     */
+    protected function mailSend($header, $body)
+    {
+        $toArr = array();
+        foreach ($this->to as $toaddr) {
+            $toArr[] = $this->addrFormat($toaddr);
+        }
+        $to = implode(', ', $toArr);
+
+        if (empty($this->Sender)) {
+            $params = ' ';
+        } else {
+            $params = sprintf('-f%s', $this->Sender);
+        }
+        if ($this->Sender != '' and !ini_get('safe_mode')) {
+            $old_from = ini_get('sendmail_from');
+            ini_set('sendmail_from', $this->Sender);
+        }
+        $result = false;
+        if ($this->SingleTo === true && count($toArr) > 1) {
+            foreach ($toArr as $toAddr) {
+                $result = $this->mailPassthru($toAddr, $this->Subject, $body, $header, $params);
+                $this->doCallback($result, array($toAddr), $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+            }
+        } else {
+            $result = $this->mailPassthru($to, $this->Subject, $body, $header, $params);
+            $this->doCallback($result, $this->to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+        }
+        if (isset($old_from)) {
+            ini_set('sendmail_from', $old_from);
+        }
+        if (!$result) {
+            throw new phpmailerException($this->lang('instantiate'), self::STOP_CRITICAL);
+        }
+        return true;
+    }
+
+    /**
+     * Get an instance to use for SMTP operations.
+     * Override this function to load your own SMTP implementation
+     * @return SMTP
+     */
+    public function getSMTPInstance()
+    {
+        if (!is_object($this->smtp)) {
+            $this->smtp = new SMTP;
+        }
+        return $this->smtp;
+    }
+
+    /**
+     * Send mail via SMTP.
+     * Returns false if there is a bad MAIL FROM, RCPT, or DATA input.
+     * Uses the PHPMailerSMTP class by default.
+     * @see PHPMailer::getSMTPInstance() to use a different class.
+     * @param string $header The message headers
+     * @param string $body The message body
+     * @throws phpmailerException
+     * @uses SMTP
+     * @access protected
+     * @return boolean
+     */
+    protected function smtpSend($header, $body)
+    {
+        $bad_rcpt = array();
+
+        if (!$this->smtpConnect()) {
+            throw new phpmailerException($this->lang('smtp_connect_failed'), self::STOP_CRITICAL);
+        }
+        $smtp_from = ($this->Sender == '') ? $this->From : $this->Sender;
+        if (!$this->smtp->mail($smtp_from)) {
+            $this->setError($this->lang('from_failed') . $smtp_from . ' : ' . implode(',', $this->smtp->getError()));
+            throw new phpmailerException($this->ErrorInfo, self::STOP_CRITICAL);
+        }
+
+        // Attempt to send to all recipients
+        foreach ($this->to as $to) {
+            if (!$this->smtp->recipient($to[0])) {
+                $bad_rcpt[] = $to[0];
+                $isSent = false;
+            } else {
+                $isSent = true;
+            }
+            $this->doCallback($isSent, array($to[0]), array(), array(), $this->Subject, $body, $this->From);
+        }
+        foreach ($this->cc as $cc) {
+            if (!$this->smtp->recipient($cc[0])) {
+                $bad_rcpt[] = $cc[0];
+                $isSent = false;
+            } else {
+                $isSent = true;
+            }
+            $this->doCallback($isSent, array(), array($cc[0]), array(), $this->Subject, $body, $this->From);
+        }
+        foreach ($this->bcc as $bcc) {
+            if (!$this->smtp->recipient($bcc[0])) {
+                $bad_rcpt[] = $bcc[0];
+                $isSent = false;
+            } else {
+                $isSent = true;
+            }
+            $this->doCallback($isSent, array(), array(), array($bcc[0]), $this->Subject, $body, $this->From);
+        }
+
+        // Only send the DATA command if we have viable recipients
+        if ((count($this->all_recipients) > count($bad_rcpt)) and !$this->smtp->data($header . $body)) {
+            throw new phpmailerException($this->lang('data_not_accepted'), self::STOP_CRITICAL);
+        }
+        if ($this->SMTPKeepAlive == true) {
+            $this->smtp->reset();
+        } else {
+            $this->smtp->quit();
+            $this->smtp->close();
+        }
+        if (count($bad_rcpt) > 0) { // Create error message for any bad addresses
+            throw new phpmailerException(
+                $this->lang('recipients_failed') . implode(', ', $bad_rcpt),
+                self::STOP_CONTINUE
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Initiate a connection to an SMTP server.
+     * Returns false if the operation failed.
+     * @param array $options An array of options compatible with stream_context_create()
+     * @uses SMTP
+     * @access public
+     * @throws phpmailerException
+     * @return boolean
+     */
+    public function smtpConnect($options = array())
+    {
+        if (is_null($this->smtp)) {
+            $this->smtp = $this->getSMTPInstance();
+        }
+
+        // Already connected?
+        if ($this->smtp->connected()) {
+            return true;
+        }
+
+        $this->smtp->setTimeout($this->Timeout);
+        $this->smtp->setDebugLevel($this->SMTPDebug);
+        $this->smtp->setDebugOutput($this->Debugoutput);
+        $this->smtp->setVerp($this->do_verp);
+        $hosts = explode(';', $this->Host);
+        $lastexception = null;
+
+        foreach ($hosts as $hostentry) {
+            $hostinfo = array();
+            if (!preg_match('/^((ssl|tls):\/\/)*([a-zA-Z0-9\.-]*):?([0-9]*)$/', trim($hostentry), $hostinfo)) {
+                // Not a valid host entry
+                continue;
+            }
+            // $hostinfo[2]: optional ssl or tls prefix
+            // $hostinfo[3]: the hostname
+            // $hostinfo[4]: optional port number
+            // The host string prefix can temporarily override the current setting for SMTPSecure
+            // If it's not specified, the default value is used
+            $prefix = '';
+            $tls = ($this->SMTPSecure == 'tls');
+            if ($hostinfo[2] == 'ssl' or ($hostinfo[2] == '' and $this->SMTPSecure == 'ssl')) {
+                $prefix = 'ssl://';
+                $tls = false; // Can't have SSL and TLS at once
+            } elseif ($hostinfo[2] == 'tls') {
+                $tls = true;
+                // tls doesn't use a prefix
+            }
+            $host = $hostinfo[3];
+            $port = $this->Port;
+            $tport = (integer)$hostinfo[4];
+            if ($tport > 0 and $tport < 65536) {
+                $port = $tport;
+            }
+            if ($this->smtp->connect($prefix . $host, $port, $this->Timeout, $options)) {
+                try {
+                    if ($this->Helo) {
+                        $hello = $this->Helo;
+                    } else {
+                        $hello = $this->serverHostname();
+                    }
+                    $this->smtp->hello($hello);
+
+                    if ($tls) {
+                        if (!$this->smtp->startTLS()) {
+                            throw new phpmailerException($this->lang('connect_host'));
+                        }
+                        // We must resend HELO after tls negotiation
+                        $this->smtp->hello($hello);
+                    }
+                    if ($this->SMTPAuth) {
+                        if (!$this->smtp->authenticate(
+                            $this->Username,
+                            $this->Password,
+                            $this->AuthType,
+                            $this->Realm,
+                            $this->Workstation
+                        )
+                        ) {
+                            throw new phpmailerException($this->lang('authenticate'));
+                        }
+                    }
+                    return true;
+                } catch (phpmailerException $exc) {
+                    $lastexception = $exc;
+                    // We must have connected, but then failed TLS or Auth, so close connection nicely
+                    $this->smtp->quit();
+                }
+            }
+        }
+        // If we get here, all connection attempts have failed, so close connection hard
+        $this->smtp->close();
+        // As we've caught all exceptions, just report whatever the last one was
+        if ($this->exceptions and !is_null($lastexception)) {
+            throw $lastexception;
+        }
+        return false;
+    }
+
+    /**
+     * Close the active SMTP session if one exists.
+     * @return void
+     */
+    public function smtpClose()
+    {
+        if ($this->smtp !== null) {
+            if ($this->smtp->connected()) {
+                $this->smtp->quit();
+                $this->smtp->close();
+            }
+        }
+    }
+
+    /**
+     * Set the language for error messages.
+     * Returns false if it cannot load the language file.
+     * The default language is English.
+     * @param string $langcode ISO 639-1 2-character language code (e.g. French is "fr")
+     * @param string $lang_path Path to the language file directory, with trailing separator (slash)
+     * @return boolean
+     * @access public
+     */
+    public function setLanguage($langcode = 'en', $lang_path = '')
+    {
+        // Define full set of translatable strings in English
+        $PHPMAILER_LANG = array(
+            'authenticate' => 'SMTP Error: Could not authenticate.',
+            'connect_host' => 'SMTP Error: Could not connect to SMTP host.',
+            'data_not_accepted' => 'SMTP Error: data not accepted.',
+            'empty_message' => 'Message body empty',
+            'encoding' => 'Unknown encoding: ',
+            'execute' => 'Could not execute: ',
+            'file_access' => 'Could not access file: ',
+            'file_open' => 'File Error: Could not open file: ',
+            'from_failed' => 'The following From address failed: ',
+            'instantiate' => 'Could not instantiate mail function.',
+            'invalid_address' => 'Invalid address',
+            'mailer_not_supported' => ' mailer is not supported.',
+            'provide_address' => 'You must provide at least one recipient email address.',
+            'recipients_failed' => 'SMTP Error: The following recipients failed: ',
+            'signing' => 'Signing Error: ',
+            'smtp_connect_failed' => 'SMTP connect() failed.',
+            'smtp_error' => 'SMTP server error: ',
+            'variable_set' => 'Cannot set or reset variable: '
+        );
+        if (empty($lang_path)) {
+            // Calculate an absolute path so it can work if CWD is not here
+            $lang_path = dirname(__FILE__). DIRECTORY_SEPARATOR . 'language'. DIRECTORY_SEPARATOR;
+        }
+        $foundlang = true;
+        $lang_file = $lang_path . 'phpmailer.lang-' . $langcode . '.php';
+        if ($langcode != 'en') { // There is no English translation file
+            // Make sure language file path is readable
+            if (!is_readable($lang_file)) {
+                $foundlang = false;
+            } else {
+                // Overwrite language-specific strings.
+                // This way we'll never have missing translations.
+                $foundlang = include $lang_file;
+            }
+        }
+        $this->language = $PHPMAILER_LANG;
+        return ($foundlang == true); // Returns false if language not found
+    }
+
+    /**
+     * Get the array of strings for the current language.
+     * @return array
+     */
+    public function getTranslations()
+    {
+        return $this->language;
+    }
+
+    /**
+     * Create recipient headers.
+     * @access public
+     * @param string $type
+     * @param array $addr An array of recipient,
+     * where each recipient is a 2-element indexed array with element 0 containing an address
+     * and element 1 containing a name, like:
+     * array(array('joe@example.com', 'Joe User'), array('zoe@example.com', 'Zoe User'))
+     * @return string
+     */
+    public function addrAppend($type, $addr)
+    {
+        $addresses = array();
+        foreach ($addr as $address) {
+            $addresses[] = $this->addrFormat($address);
+        }
+        return $type . ': ' . implode(', ', $addresses) . $this->LE;
+    }
+
+    /**
+     * Format an address for use in a message header.
+     * @access public
+     * @param array $addr A 2-element indexed array, element 0 containing an address, element 1 containing a name
+     *      like array('joe@example.com', 'Joe User')
+     * @return string
+     */
+    public function addrFormat($addr)
+    {
+        if (empty($addr[1])) { // No name provided
+            return $this->secureHeader($addr[0]);
+        } else {
+            return $this->encodeHeader($this->secureHeader($addr[1]), 'phrase') . ' <' . $this->secureHeader(
+                $addr[0]
+            ) . '>';
+        }
+    }
+
+    /**
+     * Word-wrap message.
+     * For use with mailers that do not automatically perform wrapping
+     * and for quoted-printable encoded messages.
+     * Original written by philippe.
+     * @param string $message The message to wrap
+     * @param integer $length The line length to wrap to
+     * @param boolean $qp_mode Whether to run in Quoted-Printable mode
+     * @access public
+     * @return string
+     */
+    public function wrapText($message, $length, $qp_mode = false)
+    {
+        $soft_break = ($qp_mode) ? sprintf(' =%s', $this->LE) : $this->LE;
+        // If utf-8 encoding is used, we will need to make sure we don't
+        // split multibyte characters when we wrap
+        $is_utf8 = (strtolower($this->CharSet) == 'utf-8');
+        $lelen = strlen($this->LE);
+        $crlflen = strlen(self::CRLF);
+
+        $message = $this->fixEOL($message);
+        if (substr($message, -$lelen) == $this->LE) {
+            $message = substr($message, 0, -$lelen);
+        }
+
+        $line = explode($this->LE, $message); // Magic. We know fixEOL uses $LE
+        $message = '';
+        for ($i = 0; $i < count($line); $i++) {
+            $line_part = explode(' ', $line[$i]);
+            $buf = '';
+            for ($e = 0; $e < count($line_part); $e++) {
+                $word = $line_part[$e];
+                if ($qp_mode and (strlen($word) > $length)) {
+                    $space_left = $length - strlen($buf) - $crlflen;
+                    if ($e != 0) {
+                        if ($space_left > 20) {
+                            $len = $space_left;
+                            if ($is_utf8) {
+                                $len = $this->utf8CharBoundary($word, $len);
+                            } elseif (substr($word, $len - 1, 1) == '=') {
+                                $len--;
+                            } elseif (substr($word, $len - 2, 1) == '=') {
+                                $len -= 2;
+                            }
+                            $part = substr($word, 0, $len);
+                            $word = substr($word, $len);
+                            $buf .= ' ' . $part;
+                            $message .= $buf . sprintf('=%s', self::CRLF);
+                        } else {
+                            $message .= $buf . $soft_break;
+                        }
+                        $buf = '';
+                    }
+                    while (strlen($word) > 0) {
+                        if ($length <= 0) {
+                            break;
+                        }
+                        $len = $length;
+                        if ($is_utf8) {
+                            $len = $this->utf8CharBoundary($word, $len);
+                        } elseif (substr($word, $len - 1, 1) == '=') {
+                            $len--;
+                        } elseif (substr($word, $len - 2, 1) == '=') {
+                            $len -= 2;
+                        }
+                        $part = substr($word, 0, $len);
+                        $word = substr($word, $len);
+
+                        if (strlen($word) > 0) {
+                            $message .= $part . sprintf('=%s', self::CRLF);
+                        } else {
+                            $buf = $part;
+                        }
+                    }
+                } else {
+                    $buf_o = $buf;
+                    $buf .= ($e == 0) ? $word : (' ' . $word);
+
+                    if (strlen($buf) > $length and $buf_o != '') {
+                        $message .= $buf_o . $soft_break;
+                        $buf = $word;
+                    }
+                }
+            }
+            $message .= $buf . self::CRLF;
+        }
+
+        return $message;
+    }
+
+    /**
+     * Find the last character boundary prior to $maxLength in a utf-8
+     * quoted (printable) encoded string.
+     * Original written by Colin Brown.
+     * @access public
+     * @param string $encodedText utf-8 QP text
+     * @param integer $maxLength   find last character boundary prior to this length
+     * @return integer
+     */
+    public function utf8CharBoundary($encodedText, $maxLength)
+    {
+        $foundSplitPos = false;
+        $lookBack = 3;
+        while (!$foundSplitPos) {
+            $lastChunk = substr($encodedText, $maxLength - $lookBack, $lookBack);
+            $encodedCharPos = strpos($lastChunk, '=');
+            if ($encodedCharPos !== false) {
+                // Found start of encoded character byte within $lookBack block.
+                // Check the encoded byte value (the 2 chars after the '=')
+                $hex = substr($encodedText, $maxLength - $lookBack + $encodedCharPos + 1, 2);
+                $dec = hexdec($hex);
+                if ($dec < 128) { // Single byte character.
+                    // If the encoded char was found at pos 0, it will fit
+                    // otherwise reduce maxLength to start of the encoded char
+                    $maxLength = ($encodedCharPos == 0) ? $maxLength :
+                        $maxLength - ($lookBack - $encodedCharPos);
+                    $foundSplitPos = true;
+                } elseif ($dec >= 192) { // First byte of a multi byte character
+                    // Reduce maxLength to split at start of character
+                    $maxLength = $maxLength - ($lookBack - $encodedCharPos);
+                    $foundSplitPos = true;
+                } elseif ($dec < 192) { // Middle byte of a multi byte character, look further back
+                    $lookBack += 3;
+                }
+            } else {
+                // No encoded character found
+                $foundSplitPos = true;
+            }
+        }
+        return $maxLength;
+    }
+
+    /**
+     * Set the body wrapping.
+     * @access public
+     * @return void
+     */
+    public function setWordWrap()
+    {
+        if ($this->WordWrap < 1) {
+            return;
+        }
+
+        switch ($this->message_type) {
+            case 'alt':
+            case 'alt_inline':
+            case 'alt_attach':
+            case 'alt_inline_attach':
+                $this->AltBody = $this->wrapText($this->AltBody, $this->WordWrap);
+                break;
+            default:
+                $this->Body = $this->wrapText($this->Body, $this->WordWrap);
+                break;
+        }
+    }
+
+    /**
+     * Assemble message headers.
+     * @access public
+     * @return string The assembled headers
+     */
+    public function createHeader()
+    {
+        $result = '';
+
+        // Set the boundaries
+        $uniq_id = md5(uniqid(time()));
+        $this->boundary[1] = 'b1_' . $uniq_id;
+        $this->boundary[2] = 'b2_' . $uniq_id;
+        $this->boundary[3] = 'b3_' . $uniq_id;
+
+        if ($this->MessageDate == '') {
+            $this->MessageDate = self::rfcDate();
+        }
+        $result .= $this->headerLine('Date', $this->MessageDate);
+
+
+        // To be created automatically by mail()
+        if ($this->SingleTo === true) {
+            if ($this->Mailer != 'mail') {
+                foreach ($this->to as $toaddr) {
+                    $this->SingleToArray[] = $this->addrFormat($toaddr);
+                }
+            }
+        } else {
+            if (count($this->to) > 0) {
+                if ($this->Mailer != 'mail') {
+                    $result .= $this->addrAppend('To', $this->to);
+                }
+            } elseif (count($this->cc) == 0) {
+                $result .= $this->headerLine('To', 'undisclosed-recipients:;');
+            }
+        }
+
+        $result .= $this->addrAppend('From', array(array(trim($this->From), $this->FromName)));
+
+        // sendmail and mail() extract Cc from the header before sending
+        if (count($this->cc) > 0) {
+            $result .= $this->addrAppend('Cc', $this->cc);
+        }
+
+        // sendmail and mail() extract Bcc from the header before sending
+        if ((
+                $this->Mailer == 'sendmail' or $this->Mailer == 'qmail' or $this->Mailer == 'mail'
+            )
+            and count($this->bcc) > 0
+        ) {
+            $result .= $this->addrAppend('Bcc', $this->bcc);
+        }
+
+        if (count($this->ReplyTo) > 0) {
+            $result .= $this->addrAppend('Reply-To', $this->ReplyTo);
+        }
+
+        // mail() sets the subject itself
+        if ($this->Mailer != 'mail') {
+            $result .= $this->headerLine('Subject', $this->encodeHeader($this->secureHeader($this->Subject)));
+        }
+
+        if ($this->MessageID != '') {
+            $this->lastMessageID = $this->MessageID;
+        } else {
+            $this->lastMessageID = sprintf('<%s@%s>', $uniq_id, $this->ServerHostname());
+        }
+        $result .= $this->HeaderLine('Message-ID', $this->lastMessageID);
+        $result .= $this->headerLine('X-Priority', $this->Priority);
+        if ($this->XMailer == '') {
+            $result .= $this->headerLine(
+                'X-Mailer',
+                'PHPMailer ' . $this->Version . ' (https://github.com/PHPMailer/PHPMailer/)'
+            );
+        } else {
+            $myXmailer = trim($this->XMailer);
+            if ($myXmailer) {
+                $result .= $this->headerLine('X-Mailer', $myXmailer);
+            }
+        }
+
+        if ($this->ConfirmReadingTo != '') {
+            $result .= $this->headerLine('Disposition-Notification-To', '<' . trim($this->ConfirmReadingTo) . '>');
+        }
+
+        // Add custom headers
+        for ($index = 0; $index < count($this->CustomHeader); $index++) {
+            $result .= $this->headerLine(
+                trim($this->CustomHeader[$index][0]),
+                $this->encodeHeader(trim($this->CustomHeader[$index][1]))
+            );
+        }
+        if (!$this->sign_key_file) {
+            $result .= $this->headerLine('MIME-Version', '1.0');
+            $result .= $this->getMailMIME();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the message MIME type headers.
+     * @access public
+     * @return string
+     */
+    public function getMailMIME()
+    {
+        $result = '';
+        $ismultipart = true;
+        switch ($this->message_type) {
+            case 'inline':
+                $result .= $this->headerLine('Content-Type', 'multipart/related;');
+                $result .= $this->textLine("\tboundary=\"" . $this->boundary[1] . '"');
+                break;
+            case 'attach':
+            case 'inline_attach':
+            case 'alt_attach':
+            case 'alt_inline_attach':
+                $result .= $this->headerLine('Content-Type', 'multipart/mixed;');
+                $result .= $this->textLine("\tboundary=\"" . $this->boundary[1] . '"');
+                break;
+            case 'alt':
+            case 'alt_inline':
+                $result .= $this->headerLine('Content-Type', 'multipart/alternative;');
+                $result .= $this->textLine("\tboundary=\"" . $this->boundary[1] . '"');
+                break;
+            default:
+                // Catches case 'plain': and case '':
+                $result .= $this->textLine('Content-Type: ' . $this->ContentType . '; charset=' . $this->CharSet);
+                $ismultipart = false;
+                break;
+        }
+        // RFC1341 part 5 says 7bit is assumed if not specified
+        if ($this->Encoding != '7bit') {
+            // RFC 2045 section 6.4 says multipart MIME parts may only use 7bit, 8bit or binary CTE
+            if ($ismultipart) {
+                if ($this->Encoding == '8bit') {
+                    $result .= $this->headerLine('Content-Transfer-Encoding', '8bit');
+                }
+                // The only remaining alternatives are quoted-printable and base64, which are both 7bit compatible
+            } else {
+                $result .= $this->headerLine('Content-Transfer-Encoding', $this->Encoding);
+            }
+        }
+
+        if ($this->Mailer != 'mail') {
+            $result .= $this->LE;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns the whole MIME message.
+     * Includes complete headers and body.
+     * Only valid post preSend().
+     * @see PHPMailer::preSend()
+     * @access public
+     * @return string
+     */
+    public function getSentMIMEMessage()
+    {
+        return $this->MIMEHeader . $this->mailHeader . self::CRLF . $this->MIMEBody;
+    }
+
+
+    /**
+     * Assemble the message body.
+     * Returns an empty string on failure.
+     * @access public
+     * @throws phpmailerException
+     * @return string The assembled message body
+     */
+    public function createBody()
+    {
+        $body = '';
+
+        if ($this->sign_key_file) {
+            $body .= $this->getMailMIME() . $this->LE;
+        }
+
+        $this->setWordWrap();
+
+        $bodyEncoding = $this->Encoding;
+        $bodyCharSet = $this->CharSet;
+        if ($bodyEncoding == '8bit' and !$this->has8bitChars($this->Body)) {
+            $bodyEncoding = '7bit';
+            $bodyCharSet = 'us-ascii';
+        }
+        $altBodyEncoding = $this->Encoding;
+        $altBodyCharSet = $this->CharSet;
+        if ($altBodyEncoding == '8bit' and !$this->has8bitChars($this->AltBody)) {
+            $altBodyEncoding = '7bit';
+            $altBodyCharSet = 'us-ascii';
+        }
+        switch ($this->message_type) {
+            case 'inline':
+                $body .= $this->getBoundary($this->boundary[1], $bodyCharSet, '', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->attachAll('inline', $this->boundary[1]);
+                break;
+            case 'attach':
+                $body .= $this->getBoundary($this->boundary[1], $bodyCharSet, '', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->attachAll('attachment', $this->boundary[1]);
+                break;
+            case 'inline_attach':
+                $body .= $this->textLine('--' . $this->boundary[1]);
+                $body .= $this->headerLine('Content-Type', 'multipart/related;');
+                $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
+                $body .= $this->LE;
+                $body .= $this->getBoundary($this->boundary[2], $bodyCharSet, '', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->attachAll('inline', $this->boundary[2]);
+                $body .= $this->LE;
+                $body .= $this->attachAll('attachment', $this->boundary[1]);
+                break;
+            case 'alt':
+                $body .= $this->getBoundary($this->boundary[1], $altBodyCharSet, 'text/plain', $altBodyEncoding);
+                $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->getBoundary($this->boundary[1], $bodyCharSet, 'text/html', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                if (!empty($this->Ical)) {
+                    $body .= $this->getBoundary($this->boundary[1], '', 'text/calendar; method=REQUEST', '');
+                    $body .= $this->encodeString($this->Ical, $this->Encoding);
+                    $body .= $this->LE . $this->LE;
+                }
+                $body .= $this->endBoundary($this->boundary[1]);
+                break;
+            case 'alt_inline':
+                $body .= $this->getBoundary($this->boundary[1], $altBodyCharSet, 'text/plain', $altBodyEncoding);
+                $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->textLine('--' . $this->boundary[1]);
+                $body .= $this->headerLine('Content-Type', 'multipart/related;');
+                $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
+                $body .= $this->LE;
+                $body .= $this->getBoundary($this->boundary[2], $bodyCharSet, 'text/html', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->attachAll('inline', $this->boundary[2]);
+                $body .= $this->LE;
+                $body .= $this->endBoundary($this->boundary[1]);
+                break;
+            case 'alt_attach':
+                $body .= $this->textLine('--' . $this->boundary[1]);
+                $body .= $this->headerLine('Content-Type', 'multipart/alternative;');
+                $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
+                $body .= $this->LE;
+                $body .= $this->getBoundary($this->boundary[2], $altBodyCharSet, 'text/plain', $altBodyEncoding);
+                $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->getBoundary($this->boundary[2], $bodyCharSet, 'text/html', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->endBoundary($this->boundary[2]);
+                $body .= $this->LE;
+                $body .= $this->attachAll('attachment', $this->boundary[1]);
+                break;
+            case 'alt_inline_attach':
+                $body .= $this->textLine('--' . $this->boundary[1]);
+                $body .= $this->headerLine('Content-Type', 'multipart/alternative;');
+                $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
+                $body .= $this->LE;
+                $body .= $this->getBoundary($this->boundary[2], $altBodyCharSet, 'text/plain', $altBodyEncoding);
+                $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->textLine('--' . $this->boundary[2]);
+                $body .= $this->headerLine('Content-Type', 'multipart/related;');
+                $body .= $this->textLine("\tboundary=\"" . $this->boundary[3] . '"');
+                $body .= $this->LE;
+                $body .= $this->getBoundary($this->boundary[3], $bodyCharSet, 'text/html', $bodyEncoding);
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                $body .= $this->LE . $this->LE;
+                $body .= $this->attachAll('inline', $this->boundary[3]);
+                $body .= $this->LE;
+                $body .= $this->endBoundary($this->boundary[2]);
+                $body .= $this->LE;
+                $body .= $this->attachAll('attachment', $this->boundary[1]);
+                break;
+            default:
+                // catch case 'plain' and case ''
+                $body .= $this->encodeString($this->Body, $bodyEncoding);
+                break;
+        }
+
+        if ($this->isError()) {
+            $body = '';
+        } elseif ($this->sign_key_file) {
+            try {
+                if (!defined('PKCS7_TEXT')) {
+                    throw new phpmailerException($this->lang('signing') . ' OpenSSL extension missing.');
+                }
+                // @TODO would be nice to use php://temp streams here, but need to wrap for PHP < 5.1
+                $file = tempnam(sys_get_temp_dir(), 'mail');
+                file_put_contents($file, $body); // @TODO check this worked
+                $signed = tempnam(sys_get_temp_dir(), 'signed');
+                if (@openssl_pkcs7_sign(
+                    $file,
+                    $signed,
+                    'file://' . realpath($this->sign_cert_file),
+                    array('file://' . realpath($this->sign_key_file), $this->sign_key_pass),
+                    null
+                )
+                ) {
+                    @unlink($file);
+                    $body = file_get_contents($signed);
+                    @unlink($signed);
+                } else {
+                    @unlink($file);
+                    @unlink($signed);
+                    throw new phpmailerException($this->lang('signing') . openssl_error_string());
+                }
+            } catch (phpmailerException $exc) {
+                $body = '';
+                if ($this->exceptions) {
+                    throw $exc;
+                }
+            }
+        }
+        return $body;
+    }
+
+    /**
+     * Return the start of a message boundary.
+     * @access protected
+     * @param string $boundary
+     * @param string $charSet
+     * @param string $contentType
+     * @param string $encoding
+     * @return string
+     */
+    protected function getBoundary($boundary, $charSet, $contentType, $encoding)
+    {
+        $result = '';
+        if ($charSet == '') {
+            $charSet = $this->CharSet;
+        }
+        if ($contentType == '') {
+            $contentType = $this->ContentType;
+        }
+        if ($encoding == '') {
+            $encoding = $this->Encoding;
+        }
+        $result .= $this->textLine('--' . $boundary);
+        $result .= sprintf('Content-Type: %s; charset=%s', $contentType, $charSet);
+        $result .= $this->LE;
+        // RFC1341 part 5 says 7bit is assumed if not specified
+        if ($encoding != '7bit') {
+            $result .= $this->headerLine('Content-Transfer-Encoding', $encoding);
+        }
+        $result .= $this->LE;
+
+        return $result;
+    }
+
+    /**
+     * Return the end of a message boundary.
+     * @access protected
+     * @param string $boundary
+     * @return string
+     */
+    protected function endBoundary($boundary)
+    {
+        return $this->LE . '--' . $boundary . '--' . $this->LE;
+    }
+
+    /**
+     * Set the message type.
+     * PHPMailer only supports some preset message types,
+     * not arbitrary MIME structures.
+     * @access protected
+     * @return void
+     */
+    protected function setMessageType()
+    {
+        $this->message_type = array();
+        if ($this->alternativeExists()) {
+            $this->message_type[] = 'alt';
+        }
+        if ($this->inlineImageExists()) {
+            $this->message_type[] = 'inline';
+        }
+        if ($this->attachmentExists()) {
+            $this->message_type[] = 'attach';
+        }
+        $this->message_type = implode('_', $this->message_type);
+        if ($this->message_type == '') {
+            $this->message_type = 'plain';
+        }
+    }
+
+    /**
+     * Format a header line.
+     * @access public
+     * @param string $name
+     * @param string $value
+     * @return string
+     */
+    public function headerLine($name, $value)
+    {
+        return $name . ': ' . $value . $this->LE;
+    }
+
+    /**
+     * Return a formatted mail line.
+     * @access public
+     * @param string $value
+     * @return string
+     */
+    public function textLine($value)
+    {
+        return $value . $this->LE;
+    }
+
+    /**
+     * Add an attachment from a path on the filesystem.
+     * Returns false if the file could not be found or read.
+     * @param string $path Path to the attachment.
+     * @param string $name Overrides the attachment name.
+     * @param string $encoding File encoding (see $Encoding).
+     * @param string $type File extension (MIME) type.
+     * @param string $disposition Disposition to use
+     * @throws phpmailerException
+     * @return boolean
+     */
+    public function addAttachment($path, $name = '', $encoding = 'base64', $type = '', $disposition = 'attachment')
+    {
+        try {
+            if (!@is_file($path)) {
+                throw new phpmailerException($this->lang('file_access') . $path, self::STOP_CONTINUE);
+            }
+
+            // If a MIME type is not specified, try to work it out from the file name
+            if ($type == '') {
+                $type = self::filenameToType($path);
+            }
+
+            $filename = basename($path);
+            if ($name == '') {
+                $name = $filename;
+            }
+
+            $this->attachment[] = array(
+                0 => $path,
+                1 => $filename,
+                2 => $name,
+                3 => $encoding,
+                4 => $type,
+                5 => false, // isStringAttachment
+                6 => $disposition,
+                7 => 0
+            );
+
+        } catch (phpmailerException $exc) {
+            $this->setError($exc->getMessage());
+            $this->edebug($exc->getMessage());
+            if ($this->exceptions) {
+                throw $exc;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Return the array of attachments.
+     * @return array
+     */
+    public function getAttachments()
+    {
+        return $this->attachment;
+    }
+
+    /**
+     * Attach all file, string, and binary attachments to the message.
+     * Returns an empty string on failure.
+     * @access protected
+     * @param string $disposition_type
+     * @param string $boundary
+     * @return string
+     */
+    protected function attachAll($disposition_type, $boundary)
+    {
+        // Return text of body
+        $mime = array();
+        $cidUniq = array();
+        $incl = array();
+
+        // Add all attachments
+        foreach ($this->attachment as $attachment) {
+            // Check if it is a valid disposition_filter
+            if ($attachment[6] == $disposition_type) {
+                // Check for string attachment
+                $string = '';
+                $path = '';
+                $bString = $attachment[5];
+                if ($bString) {
+                    $string = $attachment[0];
+                } else {
+                    $path = $attachment[0];
+                }
+
+                $inclhash = md5(serialize($attachment));
+                if (in_array($inclhash, $incl)) {
+                    continue;
+                }
+                $incl[] = $inclhash;
+                $name = $attachment[2];
+                $encoding = $attachment[3];
+                $type = $attachment[4];
+                $disposition = $attachment[6];
+                $cid = $attachment[7];
+                if ($disposition == 'inline' && isset($cidUniq[$cid])) {
+                    continue;
+                }
+                $cidUniq[$cid] = true;
+
+                $mime[] = sprintf('--%s%s', $boundary, $this->LE);
+                $mime[] = sprintf(
+                    'Content-Type: %s; name="%s"%s',
+                    $type,
+                    $this->encodeHeader($this->secureHeader($name)),
+                    $this->LE
+                );
+                // RFC1341 part 5 says 7bit is assumed if not specified
+                if ($encoding != '7bit') {
+                    $mime[] = sprintf('Content-Transfer-Encoding: %s%s', $encoding, $this->LE);
+                }
+
+                if ($disposition == 'inline') {
+                    $mime[] = sprintf('Content-ID: <%s>%s', $cid, $this->LE);
+                }
+
+                // If a filename contains any of these chars, it should be quoted,
+                // but not otherwise: RFC2183 & RFC2045 5.1
+                // Fixes a warning in IETF's msglint MIME checker
+                // Allow for bypassing the Content-Disposition header totally
+                if (!(empty($disposition))) {
+                    if (preg_match('/[ \(\)<>@,;:\\"\/\[\]\?=]/', $name)) {
+                        $mime[] = sprintf(
+                            'Content-Disposition: %s; filename="%s"%s',
+                            $disposition,
+                            $this->encodeHeader($this->secureHeader($name)),
+                            $this->LE . $this->LE
+                        );
+                    } else {
+                        $mime[] = sprintf(
+                            'Content-Disposition: %s; filename=%s%s',
+                            $disposition,
+                            $this->encodeHeader($this->secureHeader($name)),
+                            $this->LE . $this->LE
+                        );
+                    }
+                } else {
+                    $mime[] = $this->LE;
+                }
+
+                // Encode as string attachment
+                if ($bString) {
+                    $mime[] = $this->encodeString($string, $encoding);
+                    if ($this->isError()) {
+                        return '';
+                    }
+                    $mime[] = $this->LE . $this->LE;
+                } else {
+                    $mime[] = $this->encodeFile($path, $encoding);
+                    if ($this->isError()) {
+                        return '';
+                    }
+                    $mime[] = $this->LE . $this->LE;
+                }
+            }
+        }
+
+        $mime[] = sprintf('--%s--%s', $boundary, $this->LE);
+
+        return implode('', $mime);
+    }
+
+    /**
+     * Encode a file attachment in requested format.
+     * Returns an empty string on failure.
+     * @param string $path The full path to the file
+     * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
+     * @throws phpmailerException
+     * @see EncodeFile(encodeFile
+     * @access protected
+     * @return string
+     */
+    protected function encodeFile($path, $encoding = 'base64')
+    {
+        try {
+            if (!is_readable($path)) {
+                throw new phpmailerException($this->lang('file_open') . $path, self::STOP_CONTINUE);
+            }
+            $magic_quotes = get_magic_quotes_runtime();
+            if ($magic_quotes) {
+                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+                    set_magic_quotes_runtime(false);
+                } else {
+                    //Doesn't exist in PHP 5.4, but we don't need to check because
+                    //get_magic_quotes_runtime always returns false in 5.4+
+                    //so it will never get here
+                    ini_set('magic_quotes_runtime', 0);
+                }
+            }
+            $file_buffer = file_get_contents($path);
+            $file_buffer = $this->encodeString($file_buffer, $encoding);
+            if ($magic_quotes) {
+                if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+                    set_magic_quotes_runtime($magic_quotes);
+                } else {
+                    ini_set('magic_quotes_runtime', ($magic_quotes?'1':'0'));
+                }
+            }
+            return $file_buffer;
+        } catch (Exception $exc) {
+            $this->setError($exc->getMessage());
+            return '';
+        }
+    }
+
+    /**
+     * Encode a string in requested format.
+     * Returns an empty string on failure.
+     * @param string $str The text to encode
+     * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
+     * @access public
+     * @return string
+     */
+    public function encodeString($str, $encoding = 'base64')
+    {
+        $encoded = '';
+        switch (strtolower($encoding)) {
+            case 'base64':
+                $encoded = chunk_split(base64_encode($str), 76, $this->LE);
+                break;
+            case '7bit':
+            case '8bit':
+                $encoded = $this->fixEOL($str);
+                // Make sure it ends with a line break
+                if (substr($encoded, -(strlen($this->LE))) != $this->LE) {
+                    $encoded .= $this->LE;
+                }
+                break;
+            case 'binary':
+                $encoded = $str;
+                break;
+            case 'quoted-printable':
+                $encoded = $this->encodeQP($str);
+                break;
+            default:
+                $this->setError($this->lang('encoding') . $encoding);
+                break;
+        }
+        return $encoded;
+    }
+
+    /**
+     * Encode a header string optimally.
+     * Picks shortest of Q, B, quoted-printable or none.
+     * @access public
+     * @param string $str
+     * @param string $position
+     * @return string
+     */
+    public function encodeHeader($str, $position = 'text')
+    {
+        $matchcount = 0;
+        switch (strtolower($position)) {
+            case 'phrase':
+                if (!preg_match('/[\200-\377]/', $str)) {
+                    // Can't use addslashes as we don't know the value of magic_quotes_sybase
+                    $encoded = addcslashes($str, "\0..\37\177\\\"");
+                    if (($str == $encoded) && !preg_match('/[^A-Za-z0-9!#$%&\'*+\/=?^_`{|}~ -]/', $str)) {
+                        return ($encoded);
+                    } else {
+                        return ("\"$encoded\"");
+                    }
+                }
+                $matchcount = preg_match_all('/[^\040\041\043-\133\135-\176]/', $str, $matches);
+                break;
+            /** @noinspection PhpMissingBreakStatementInspection */
+            case 'comment':
+                $matchcount = preg_match_all('/[()"]/', $str, $matches);
+                // Intentional fall-through
+            case 'text':
+            default:
+                $matchcount += preg_match_all('/[\000-\010\013\014\016-\037\177-\377]/', $str, $matches);
+                break;
+        }
+
+        if ($matchcount == 0) { // There are no chars that need encoding
+            return ($str);
+        }
+
+        $maxlen = 75 - 7 - strlen($this->CharSet);
+        // Try to select the encoding which should produce the shortest output
+        if ($matchcount > strlen($str) / 3) {
+            // More than a third of the content will need encoding, so B encoding will be most efficient
+            $encoding = 'B';
+            if (function_exists('mb_strlen') && $this->hasMultiBytes($str)) {
+                // Use a custom function which correctly encodes and wraps long
+                // multibyte strings without breaking lines within a character
+                $encoded = $this->base64EncodeWrapMB($str, "\n");
+            } else {
+                $encoded = base64_encode($str);
+                $maxlen -= $maxlen % 4;
+                $encoded = trim(chunk_split($encoded, $maxlen, "\n"));
+            }
+        } else {
+            $encoding = 'Q';
+            $encoded = $this->encodeQ($str, $position);
+            $encoded = $this->wrapText($encoded, $maxlen, true);
+            $encoded = str_replace('=' . self::CRLF, "\n", trim($encoded));
+        }
+
+        $encoded = preg_replace('/^(.*)$/m', ' =?' . $this->CharSet . "?$encoding?\\1?=", $encoded);
+        $encoded = trim(str_replace("\n", $this->LE, $encoded));
+
+        return $encoded;
+    }
+
+    /**
+     * Check if a string contains multi-byte characters.
+     * @access public
+     * @param string $str multi-byte text to wrap encode
+     * @return boolean
+     */
+    public function hasMultiBytes($str)
+    {
+        if (function_exists('mb_strlen')) {
+            return (strlen($str) > mb_strlen($str, $this->CharSet));
+        } else { // Assume no multibytes (we can't handle without mbstring functions anyway)
+            return false;
+        }
+    }
+
+    /**
+     * Does a string contain any 8-bit chars (in any charset)?
+     * @param string $text
+     * @return boolean
+     */
+    public function has8bitChars($text)
+    {
+        return (boolean)preg_match('/[\x80-\xFF]/', $text);
+    }
+
+    /**
+     * Encode and wrap long multibyte strings for mail headers
+     * without breaking lines within a character.
+     * Adapted from a function by paravoid
+     * @link http://www.php.net/manual/en/function.mb-encode-mimeheader.php#60283
+     * @access public
+     * @param string $str multi-byte text to wrap encode
+     * @param string $linebreak string to use as linefeed/end-of-line
+     * @return string
+     */
+    public function base64EncodeWrapMB($str, $linebreak = null)
+    {
+        $start = '=?' . $this->CharSet . '?B?';
+        $end = '?=';
+        $encoded = '';
+        if ($linebreak === null) {
+            $linebreak = $this->LE;
+        }
+
+        $mb_length = mb_strlen($str, $this->CharSet);
+        // Each line must have length <= 75, including $start and $end
+        $length = 75 - strlen($start) - strlen($end);
+        // Average multi-byte ratio
+        $ratio = $mb_length / strlen($str);
+        // Base64 has a 4:3 ratio
+        $avgLength = floor($length * $ratio * .75);
+
+        for ($i = 0; $i < $mb_length; $i += $offset) {
+            $lookBack = 0;
+            do {
+                $offset = $avgLength - $lookBack;
+                $chunk = mb_substr($str, $i, $offset, $this->CharSet);
+                $chunk = base64_encode($chunk);
+                $lookBack++;
+            } while (strlen($chunk) > $length);
+            $encoded .= $chunk . $linebreak;
+        }
+
+        // Chomp the last linefeed
+        $encoded = substr($encoded, 0, -strlen($linebreak));
+        return $encoded;
+    }
+
+    /**
+     * Encode a string in quoted-printable format.
+     * According to RFC2045 section 6.7.
+     * @access public
+     * @param string $string The text to encode
+     * @param integer $line_max Number of chars allowed on a line before wrapping
+     * @return string
+     * @link http://www.php.net/manual/en/function.quoted-printable-decode.php#89417 Adapted from this comment
+     */
+    public function encodeQP($string, $line_max = 76)
+    {
+        if (function_exists('quoted_printable_encode')) { // Use native function if it's available (>= PHP5.3)
+            return $this->fixEOL(quoted_printable_encode($string));
+        }
+        // Fall back to a pure PHP implementation
+        $string = str_replace(
+            array('%20', '%0D%0A.', '%0D%0A', '%'),
+            array(' ', "\r\n=2E", "\r\n", '='),
+            rawurlencode($string)
+        );
+        $string = preg_replace('/[^\r\n]{' . ($line_max - 3) . '}[^=\r\n]{2}/', "$0=\r\n", $string);
+        return $this->fixEOL($string);
+    }
+
+    /**
+     * Backward compatibility wrapper for an old QP encoding function that was removed.
+     * @see PHPMailer::encodeQP()
+     * @access public
+     * @param string $string
+     * @param integer $line_max
+     * @param boolean $space_conv
+     * @return string
+     * @deprecated Use encodeQP instead.
+     */
+    public function encodeQPphp(
+        $string,
+        $line_max = 76,
+        /** @noinspection PhpUnusedParameterInspection */ $space_conv = false
+    ) {
+        return $this->encodeQP($string, $line_max);
+    }
+
+    /**
+     * Encode a string using Q encoding.
+     * @link http://tools.ietf.org/html/rfc2047
+     * @param string $str the text to encode
+     * @param string $position Where the text is going to be used, see the RFC for what that means
+     * @access public
+     * @return string
+     */
+    public function encodeQ($str, $position = 'text')
+    {
+        // There should not be any EOL in the string
+        $pattern = '';
+        $encoded = str_replace(array("\r", "\n"), '', $str);
+        switch (strtolower($position)) {
+            case 'phrase':
+                // RFC 2047 section 5.3
+                $pattern = '^A-Za-z0-9!*+\/ -';
+                break;
+            /** @noinspection PhpMissingBreakStatementInspection */
+            case 'comment':
+                // RFC 2047 section 5.2
+                $pattern = '\(\)"';
+                // intentional fall-through
+                // for this reason we build the $pattern without including delimiters and []
+            case 'text':
+            default:
+                // RFC 2047 section 5.1
+                // Replace every high ascii, control, =, ? and _ characters
+                $pattern = '\000-\011\013\014\016-\037\075\077\137\177-\377' . $pattern;
+                break;
+        }
+        $matches = array();
+        if (preg_match_all("/[{$pattern}]/", $encoded, $matches)) {
+            // If the string contains an '=', make sure it's the first thing we replace
+            // so as to avoid double-encoding
+            $eqkey = array_search('=', $matches[0]);
+            if ($eqkey !== false) {
+                unset($matches[0][$eqkey]);
+                array_unshift($matches[0], '=');
+            }
+            foreach (array_unique($matches[0]) as $char) {
+                $encoded = str_replace($char, '=' . sprintf('%02X', ord($char)), $encoded);
+            }
+        }
+        // Replace every spaces to _ (more readable than =20)
+        return str_replace(' ', '_', $encoded);
+    }
+
+
+    /**
+     * Add a string or binary attachment (non-filesystem).
+     * This method can be used to attach ascii or binary data,
+     * such as a BLOB record from a database.
+     * @param string $string String attachment data.
+     * @param string $filename Name of the attachment.
+     * @param string $encoding File encoding (see $Encoding).
+     * @param string $type File extension (MIME) type.
+     * @param string $disposition Disposition to use
+     * @return void
+     */
+    public function addStringAttachment(
+        $string,
+        $filename,
+        $encoding = 'base64',
+        $type = '',
+        $disposition = 'attachment'
+    ) {
+        // If a MIME type is not specified, try to work it out from the file name
+        if ($type == '') {
+            $type = self::filenameToType($filename);
+        }
+        // Append to $attachment array
+        $this->attachment[] = array(
+            0 => $string,
+            1 => $filename,
+            2 => basename($filename),
+            3 => $encoding,
+            4 => $type,
+            5 => true, // isStringAttachment
+            6 => $disposition,
+            7 => 0
+        );
+    }
+
+    /**
+     * Add an embedded (inline) attachment from a file.
+     * This can include images, sounds, and just about any other document type.
+     * These differ from 'regular' attachmants in that they are intended to be
+     * displayed inline with the message, not just attached for download.
+     * This is used in HTML messages that embed the images
+     * the HTML refers to using the $cid value.
+     * @param string $path Path to the attachment.
+     * @param string $cid Content ID of the attachment; Use this to reference
+     *        the content when using an embedded image in HTML.
+     * @param string $name Overrides the attachment name.
+     * @param string $encoding File encoding (see $Encoding).
+     * @param string $type File MIME type.
+     * @param string $disposition Disposition to use
+     * @return boolean True on successfully adding an attachment
+     */
+    public function addEmbeddedImage($path, $cid, $name = '', $encoding = 'base64', $type = '', $disposition = 'inline')
+    {
+        if (!@is_file($path)) {
+            $this->setError($this->lang('file_access') . $path);
+            return false;
+        }
+
+        // If a MIME type is not specified, try to work it out from the file name
+        if ($type == '') {
+            $type = self::filenameToType($path);
+        }
+
+        $filename = basename($path);
+        if ($name == '') {
+            $name = $filename;
+        }
+
+        // Append to $attachment array
+        $this->attachment[] = array(
+            0 => $path,
+            1 => $filename,
+            2 => $name,
+            3 => $encoding,
+            4 => $type,
+            5 => false, // isStringAttachment
+            6 => $disposition,
+            7 => $cid
+        );
+        return true;
+    }
+
+    /**
+     * Add an embedded stringified attachment.
+     * This can include images, sounds, and just about any other document type.
+     * Be sure to set the $type to an image type for images:
+     * JPEG images use 'image/jpeg', GIF uses 'image/gif', PNG uses 'image/png'.
+     * @param string $string The attachment binary data.
+     * @param string $cid Content ID of the attachment; Use this to reference
+     *        the content when using an embedded image in HTML.
+     * @param string $name
+     * @param string $encoding File encoding (see $Encoding).
+     * @param string $type MIME type.
+     * @param string $disposition Disposition to use
+     * @return boolean True on successfully adding an attachment
+     */
+    public function addStringEmbeddedImage(
+        $string,
+        $cid,
+        $name = '',
+        $encoding = 'base64',
+        $type = '',
+        $disposition = 'inline'
+    ) {
+        // If a MIME type is not specified, try to work it out from the name
+        if ($type == '') {
+            $type = self::filenameToType($name);
+        }
+
+        // Append to $attachment array
+        $this->attachment[] = array(
+            0 => $string,
+            1 => $name,
+            2 => $name,
+            3 => $encoding,
+            4 => $type,
+            5 => true, // isStringAttachment
+            6 => $disposition,
+            7 => $cid
+        );
+        return true;
+    }
+
+    /**
+     * Check if an inline attachment is present.
+     * @access public
+     * @return boolean
+     */
+    public function inlineImageExists()
+    {
+        foreach ($this->attachment as $attachment) {
+            if ($attachment[6] == 'inline') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if an attachment (non-inline) is present.
+     * @return boolean
+     */
+    public function attachmentExists()
+    {
+        foreach ($this->attachment as $attachment) {
+            if ($attachment[6] == 'attachment') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if this message has an alternative body set.
+     * @return boolean
+     */
+    public function alternativeExists()
+    {
+        return !empty($this->AltBody);
+    }
+
+    /**
+     * Clear all To recipients.
+     * @return void
+     */
+    public function clearAddresses()
+    {
+        foreach ($this->to as $to) {
+            unset($this->all_recipients[strtolower($to[0])]);
+        }
+        $this->to = array();
+    }
+
+    /**
+     * Clear all CC recipients.
+     * @return void
+     */
+    public function clearCCs()
+    {
+        foreach ($this->cc as $cc) {
+            unset($this->all_recipients[strtolower($cc[0])]);
+        }
+        $this->cc = array();
+    }
+
+    /**
+     * Clear all BCC recipients.
+     * @return void
+     */
+    public function clearBCCs()
+    {
+        foreach ($this->bcc as $bcc) {
+            unset($this->all_recipients[strtolower($bcc[0])]);
+        }
+        $this->bcc = array();
+    }
+
+    /**
+     * Clear all ReplyTo recipients.
+     * @return void
+     */
+    public function clearReplyTos()
+    {
+        $this->ReplyTo = array();
+    }
+
+    /**
+     * Clear all recipient types.
+     * @return void
+     */
+    public function clearAllRecipients()
+    {
+        $this->to = array();
+        $this->cc = array();
+        $this->bcc = array();
+        $this->all_recipients = array();
+    }
+
+    /**
+     * Clear all filesystem, string, and binary attachments.
+     * @return void
+     */
+    public function clearAttachments()
+    {
+        $this->attachment = array();
+    }
+
+    /**
+     * Clear all custom headers.
+     * @return void
+     */
+    public function clearCustomHeaders()
+    {
+        $this->CustomHeader = array();
+    }
+
+    /**
+     * Add an error message to the error container.
+     * @access protected
+     * @param string $msg
+     * @return void
+     */
+    protected function setError($msg)
+    {
+        $this->error_count++;
+        if ($this->Mailer == 'smtp' and !is_null($this->smtp)) {
+            $lasterror = $this->smtp->getError();
+            if (!empty($lasterror) and array_key_exists('smtp_msg', $lasterror)) {
+                $msg .= '<p>' . $this->lang('smtp_error') . $lasterror['smtp_msg'] . "</p>\n";
+            }
+        }
+        $this->ErrorInfo = $msg;
+    }
+
+    /**
+     * Return an RFC 822 formatted date.
+     * @access public
+     * @return string
+     * @static
+     */
+    public static function rfcDate()
+    {
+        // Set the time zone to whatever the default is to avoid 500 errors
+        // Will default to UTC if it's not set properly in php.ini
+        date_default_timezone_set(@date_default_timezone_get());
+        return date('D, j M Y H:i:s O');
+    }
+
+    /**
+     * Get the server hostname.
+     * Returns 'localhost.localdomain' if unknown.
+     * @access protected
+     * @return string
+     */
+    protected function serverHostname()
+    {
+        $result = 'localhost.localdomain';
+        if (!empty($this->Hostname)) {
+            $result = $this->Hostname;
+        } elseif (isset($_SERVER) and array_key_exists('SERVER_NAME', $_SERVER) and !empty($_SERVER['SERVER_NAME'])) {
+            $result = $_SERVER['SERVER_NAME'];
+        } elseif (function_exists('gethostname') && gethostname() !== false) {
+            $result = gethostname();
+        } elseif (php_uname('n') !== false) {
+            $result = php_uname('n');
+        }
+        return $result;
+    }
+
+    /**
+     * Get an error message in the current language.
+     * @access protected
+     * @param string $key
+     * @return string
+     */
+    protected function lang($key)
+    {
+        if (count($this->language) < 1) {
+            $this->setLanguage('en'); // set the default language
+        }
+
+        if (isset($this->language[$key])) {
+            return $this->language[$key];
+        } else {
+            return 'Language string failed to load: ' . $key;
+        }
+    }
+
+    /**
+     * Check if an error occurred.
+     * @access public
+     * @return boolean True if an error did occur.
+     */
+    public function isError()
+    {
+        return ($this->error_count > 0);
+    }
+
+    /**
+     * Ensure consistent line endings in a string.
+     * Changes every end of line from CRLF, CR or LF to $this->LE.
+     * @access public
+     * @param string $str String to fixEOL
+     * @return string
+     */
+    public function fixEOL($str)
+    {
+        // Normalise to \n
+        $nstr = str_replace(array("\r\n", "\r"), "\n", $str);
+        // Now convert LE as needed
+        if ($this->LE !== "\n") {
+            $nstr = str_replace("\n", $this->LE, $nstr);
+        }
+        return $nstr;
+    }
+
+    /**
+     * Add a custom header.
+     * $name value can be overloaded to contain
+     * both header name and value (name:value)
+     * @access public
+     * @param string $name Custom header name
+     * @param string $value Header value
+     * @return void
+     */
+    public function addCustomHeader($name, $value = null)
+    {
+        if ($value === null) {
+            // Value passed in as name:value
+            $this->CustomHeader[] = explode(':', $name, 2);
+        } else {
+            $this->CustomHeader[] = array($name, $value);
+        }
+    }
+
+    /**
+     * Create a message from an HTML string.
+     * Automatically makes modifications for inline images and backgrounds
+     * and creates a plain-text version by converting the HTML.
+     * Overwrites any existing values in $this->Body and $this->AltBody
+     * @access public
+     * @param string $message HTML message string
+     * @param string $basedir baseline directory for path
+     * @param boolean $advanced Whether to use the advanced HTML to text converter
+     * @return string $message
+     */
+    public function msgHTML($message, $basedir = '', $advanced = false)
+    {
+        preg_match_all('/(src|background)=["\'](.*)["\']/Ui', $message, $images);
+        if (isset($images[2])) {
+            foreach ($images[2] as $imgindex => $url) {
+                // do not change urls for absolute images (thanks to corvuscorax)
+                if (!preg_match('#^[A-z]+://#', $url)) {
+                    $filename = basename($url);
+                    $directory = dirname($url);
+                    if ($directory == '.') {
+                        $directory = '';
+                    }
+                    $cid = md5($url) . '@phpmailer.0'; // RFC2392 S 2
+                    if (strlen($basedir) > 1 && substr($basedir, -1) != '/') {
+                        $basedir .= '/';
+                    }
+                    if (strlen($directory) > 1 && substr($directory, -1) != '/') {
+                        $directory .= '/';
+                    }
+                    if ($this->addEmbeddedImage(
+                        $basedir . $directory . $filename,
+                        $cid,
+                        $filename,
+                        'base64',
+                        self::_mime_types(self::mb_pathinfo($filename, PATHINFO_EXTENSION))
+                    )
+                    ) {
+                        $message = preg_replace(
+                            '/' . $images[1][$imgindex] . '=["\']' . preg_quote($url, '/') . '["\']/Ui',
+                            $images[1][$imgindex] . '="cid:' . $cid . '"',
+                            $message
+                        );
+                    }
+                }
+            }
+        }
+        $this->isHTML(true);
+        // Convert all message body line breaks to CRLF, makes quoted-printable encoding work much better
+        $this->Body = $this->normalizeBreaks($message);
+        $this->AltBody = $this->normalizeBreaks($this->html2text($message, $advanced));
+        if (empty($this->AltBody)) {
+            $this->AltBody = 'To view this email message, open it in a program that understands HTML!' .
+                self::CRLF . self::CRLF;
+        }
+        return $this->Body;
+    }
+
+    /**
+     * Convert an HTML string into plain text.
+     * @param string $html The HTML text to convert
+     * @param boolean $advanced Should this use the more complex html2text converter or just a simple one?
+     * @return string
+     */
+    public function html2text($html, $advanced = false)
+    {
+        if ($advanced) {
+            require_once 'extras/class.html2text.php';
+            $htmlconverter = new html2text($html);
+            return $htmlconverter->get_text();
+        }
+        return html_entity_decode(
+            trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))),
+            ENT_QUOTES,
+            $this->CharSet
+        );
+    }
+
+    /**
+     * Get the MIME type for a file extension.
+     * @param string $ext File extension
+     * @access public
+     * @return string MIME type of file.
+     * @static
+     */
+    public static function _mime_types($ext = '')
+    {
+        $mimes = array(
+            'xl' => 'application/excel',
+            'hqx' => 'application/mac-binhex40',
+            'cpt' => 'application/mac-compactpro',
+            'bin' => 'application/macbinary',
+            'doc' => 'application/msword',
+            'word' => 'application/msword',
+            'class' => 'application/octet-stream',
+            'dll' => 'application/octet-stream',
+            'dms' => 'application/octet-stream',
+            'exe' => 'application/octet-stream',
+            'lha' => 'application/octet-stream',
+            'lzh' => 'application/octet-stream',
+            'psd' => 'application/octet-stream',
+            'sea' => 'application/octet-stream',
+            'so' => 'application/octet-stream',
+            'oda' => 'application/oda',
+            'pdf' => 'application/pdf',
+            'ai' => 'application/postscript',
+            'eps' => 'application/postscript',
+            'ps' => 'application/postscript',
+            'smi' => 'application/smil',
+            'smil' => 'application/smil',
+            'mif' => 'application/vnd.mif',
+            'xls' => 'application/vnd.ms-excel',
+            'ppt' => 'application/vnd.ms-powerpoint',
+            'wbxml' => 'application/vnd.wap.wbxml',
+            'wmlc' => 'application/vnd.wap.wmlc',
+            'dcr' => 'application/x-director',
+            'dir' => 'application/x-director',
+            'dxr' => 'application/x-director',
+            'dvi' => 'application/x-dvi',
+            'gtar' => 'application/x-gtar',
+            'php3' => 'application/x-httpd-php',
+            'php4' => 'application/x-httpd-php',
+            'php' => 'application/x-httpd-php',
+            'phtml' => 'application/x-httpd-php',
+            'phps' => 'application/x-httpd-php-source',
+            'js' => 'application/x-javascript',
+            'swf' => 'application/x-shockwave-flash',
+            'sit' => 'application/x-stuffit',
+            'tar' => 'application/x-tar',
+            'tgz' => 'application/x-tar',
+            'xht' => 'application/xhtml+xml',
+            'xhtml' => 'application/xhtml+xml',
+            'zip' => 'application/zip',
+            'mid' => 'audio/midi',
+            'midi' => 'audio/midi',
+            'mp2' => 'audio/mpeg',
+            'mp3' => 'audio/mpeg',
+            'mpga' => 'audio/mpeg',
+            'aif' => 'audio/x-aiff',
+            'aifc' => 'audio/x-aiff',
+            'aiff' => 'audio/x-aiff',
+            'ram' => 'audio/x-pn-realaudio',
+            'rm' => 'audio/x-pn-realaudio',
+            'rpm' => 'audio/x-pn-realaudio-plugin',
+            'ra' => 'audio/x-realaudio',
+            'wav' => 'audio/x-wav',
+            'bmp' => 'image/bmp',
+            'gif' => 'image/gif',
+            'jpeg' => 'image/jpeg',
+            'jpe' => 'image/jpeg',
+            'jpg' => 'image/jpeg',
+            'png' => 'image/png',
+            'tiff' => 'image/tiff',
+            'tif' => 'image/tiff',
+            'eml' => 'message/rfc822',
+            'css' => 'text/css',
+            'html' => 'text/html',
+            'htm' => 'text/html',
+            'shtml' => 'text/html',
+            'log' => 'text/plain',
+            'text' => 'text/plain',
+            'txt' => 'text/plain',
+            'rtx' => 'text/richtext',
+            'rtf' => 'text/rtf',
+            'vcf' => 'text/vcard',
+            'vcard' => 'text/vcard',
+            'xml' => 'text/xml',
+            'xsl' => 'text/xml',
+            'mpeg' => 'video/mpeg',
+            'mpe' => 'video/mpeg',
+            'mpg' => 'video/mpeg',
+            'mov' => 'video/quicktime',
+            'qt' => 'video/quicktime',
+            'rv' => 'video/vnd.rn-realvideo',
+            'avi' => 'video/x-msvideo',
+            'movie' => 'video/x-sgi-movie'
+        );
+        return (array_key_exists(strtolower($ext), $mimes) ? $mimes[strtolower($ext)]: 'application/octet-stream');
+    }
+
+    /**
+     * Map a file name to a MIME type.
+     * Defaults to 'application/octet-stream', i.e.. arbitrary binary data.
+     * @param string $filename A file name or full path, does not need to exist as a file
+     * @return string
+     * @static
+     */
+    public static function filenameToType($filename)
+    {
+        // In case the path is a URL, strip any query string before getting extension
+        $qpos = strpos($filename, '?');
+        if ($qpos !== false) {
+            $filename = substr($filename, 0, $qpos);
+        }
+        $pathinfo = self::mb_pathinfo($filename);
+        return self::_mime_types($pathinfo['extension']);
+    }
+
+    /**
+     * Multi-byte-safe pathinfo replacement.
+     * Drop-in replacement for pathinfo(), but multibyte-safe, cross-platform-safe, old-version-safe.
+     * Works similarly to the one in PHP >= 5.2.0
+     * @link http://www.php.net/manual/en/function.pathinfo.php#107461
+     * @param string $path A filename or path, does not need to exist as a file
+     * @param integer|string $options Either a PATHINFO_* constant,
+     *      or a string name to return only the specified piece, allows 'filename' to work on PHP < 5.2
+     * @return string|array
+     * @static
+     */
+    public static function mb_pathinfo($path, $options = null)
+    {
+        $ret = array('dirname' => '', 'basename' => '', 'extension' => '', 'filename' => '');
+        $pathinfo = array();
+        if (preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $path, $pathinfo)) {
+            if (array_key_exists(1, $pathinfo)) {
+                $ret['dirname'] = $pathinfo[1];
+            }
+            if (array_key_exists(2, $pathinfo)) {
+                $ret['basename'] = $pathinfo[2];
+            }
+            if (array_key_exists(5, $pathinfo)) {
+                $ret['extension'] = $pathinfo[5];
+            }
+            if (array_key_exists(3, $pathinfo)) {
+                $ret['filename'] = $pathinfo[3];
+            }
+        }
+        switch ($options) {
+            case PATHINFO_DIRNAME:
+            case 'dirname':
+                return $ret['dirname'];
+            case PATHINFO_BASENAME:
+            case 'basename':
+                return $ret['basename'];
+            case PATHINFO_EXTENSION:
+            case 'extension':
+                return $ret['extension'];
+            case PATHINFO_FILENAME:
+            case 'filename':
+                return $ret['filename'];
+            default:
+                return $ret;
+        }
+    }
+
+    /**
+     * Set or reset instance properties.
+     *
+     * Usage Example:
+     * $page->set('X-Priority', '3');
+     *
+     * @access public
+     * @param string $name
+     * @param mixed $value
+     * NOTE: will not work with arrays, there are no arrays to set/reset
+     * @throws phpmailerException
+     * @return boolean
+     * @TODO Should this not be using __set() magic function?
+     */
+    public function set($name, $value = '')
+    {
+        try {
+            if (isset($this->$name)) {
+                $this->$name = $value;
+            } else {
+                throw new phpmailerException($this->lang('variable_set') . $name, self::STOP_CRITICAL);
+            }
+        } catch (Exception $exc) {
+            $this->setError($exc->getMessage());
+            if ($exc->getCode() == self::STOP_CRITICAL) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Strip newlines to prevent header injection.
+     * @access public
+     * @param string $str
+     * @return string
+     */
+    public function secureHeader($str)
+    {
+        return trim(str_replace(array("\r", "\n"), '', $str));
+    }
+
+    /**
+     * Normalize line breaks in a string.
+     * Converts UNIX LF, Mac CR and Windows CRLF line breaks into a single line break format.
+     * Defaults to CRLF (for message bodies) and preserves consecutive breaks.
+     * @param string $text
+     * @param string $breaktype What kind of line break to use, defaults to CRLF
+     * @return string
+     * @access public
+     * @static
+     */
+    public static function normalizeBreaks($text, $breaktype = "\r\n")
+    {
+        return preg_replace('/(\r\n|\r|\n)/ms', $breaktype, $text);
+    }
+
+
+    /**
+     * Set the public and private key files and password for S/MIME signing.
+     * @access public
+     * @param string $cert_filename
+     * @param string $key_filename
+     * @param string $key_pass Password for private key
+     */
+    public function sign($cert_filename, $key_filename, $key_pass)
+    {
+        $this->sign_cert_file = $cert_filename;
+        $this->sign_key_file = $key_filename;
+        $this->sign_key_pass = $key_pass;
+    }
+
+    /**
+     * Quoted-Printable-encode a DKIM header.
+     * @access public
+     * @param string $txt
+     * @return string
+     */
+    public function DKIM_QP($txt)
+    {
+        $line = '';
+        for ($i = 0; $i < strlen($txt); $i++) {
+            $ord = ord($txt[$i]);
+            if (((0x21 <= $ord) && ($ord <= 0x3A)) || $ord == 0x3C || ((0x3E <= $ord) && ($ord <= 0x7E))) {
+                $line .= $txt[$i];
+            } else {
+                $line .= '=' . sprintf('%02X', $ord);
+            }
+        }
+        return $line;
+    }
+
+    /**
+     * Generate a DKIM signature.
+     * @access public
+     * @param string $signHeader
+     * @throws phpmailerException
+     * @return string
+     */
+    public function DKIM_Sign($signHeader)
+    {
+        if (!defined('PKCS7_TEXT')) {
+            if ($this->exceptions) {
+                throw new phpmailerException($this->lang('signing') . ' OpenSSL extension missing.');
+            }
+            return '';
+        }
+        $privKeyStr = file_get_contents($this->DKIM_private);
+        if ($this->DKIM_passphrase != '') {
+            $privKey = openssl_pkey_get_private($privKeyStr, $this->DKIM_passphrase);
+        } else {
+            $privKey = $privKeyStr;
+        }
+        if (openssl_sign($signHeader, $signature, $privKey)) {
+            return base64_encode($signature);
         }
         return '';
     }
-    $privKeyStr = file_get_contents($this->DKIM_private);
-    if ($this->DKIM_passphrase != '') {
-      $privKey = openssl_pkey_get_private($privKeyStr, $this->DKIM_passphrase);
-    } else {
-      $privKey = $privKeyStr;
-    }
-    if (openssl_sign($s, $signature, $privKey)) {
-      return base64_encode($signature);
-    }
-    return '';
-  }
 
-  /**
-   * Generate DKIM Canonicalization Header
-   *
-   * @access public
-   * @param string $s Header
-   * @return string
-   */
-  public function DKIM_HeaderC($s) {
-    $s = preg_replace("/\r\n\s+/", " ", $s);
-    $lines = explode("\r\n", $s);
-    foreach ($lines as $key => $line) {
-      list($heading, $value) = explode(":", $line, 2);
-      $heading = strtolower($heading);
-      $value = preg_replace("/\s+/", " ", $value) ; // Compress useless spaces
-      $lines[$key] = $heading.":".trim($value) ; // Don't forget to remove WSP around the value
-    }
-    $s = implode("\r\n", $lines);
-    return $s;
-  }
-
-  /**
-   * Generate DKIM Canonicalization Body
-   *
-   * @access public
-   * @param string $body Message Body
-   * @return string
-   */
-  public function DKIM_BodyC($body) {
-    if ($body == '') return "\r\n";
-    // stabilize line endings
-    $body = str_replace("\r\n", "\n", $body);
-    $body = str_replace("\n", "\r\n", $body);
-    // END stabilize line endings
-    while (substr($body, strlen($body) - 4, 4) == "\r\n\r\n") {
-      $body = substr($body, 0, strlen($body) - 2);
-    }
-    return $body;
-  }
-
-  /**
-   * Create the DKIM header, body, as new header
-   *
-   * @access public
-   * @param string $headers_line Header lines
-   * @param string $subject Subject
-   * @param string $body Body
-   * @return string
-   */
-  public function DKIM_Add($headers_line, $subject, $body) {
-    $DKIMsignatureType    = 'rsa-sha1'; // Signature & hash algorithms
-    $DKIMcanonicalization = 'relaxed/simple'; // Canonicalization of header/body
-    $DKIMquery            = 'dns/txt'; // Query method
-    $DKIMtime             = time() ; // Signature Timestamp = seconds since 00:00:00 - Jan 1, 1970 (UTC time zone)
-    $subject_header       = "Subject: $subject";
-    $headers              = explode($this->LE, $headers_line);
-    $from_header          = '';
-    $to_header            = '';
-    $current = '';
-    foreach($headers as $header) {
-      if (strpos($header, 'From:') === 0) {
-        $from_header = $header;
-        $current = 'from_header';
-      } elseif (strpos($header, 'To:') === 0) {
-        $to_header = $header;
-        $current = 'to_header';
-      } else {
-        if($current && strpos($header, ' =?') === 0){
-          $current .= $header;
-        } else {
-          $current = '';
+    /**
+     * Generate a DKIM canonicalization header.
+     * @access public
+     * @param string $signHeader Header
+     * @return string
+     */
+    public function DKIM_HeaderC($signHeader)
+    {
+        $signHeader = preg_replace('/\r\n\s+/', ' ', $signHeader);
+        $lines = explode("\r\n", $signHeader);
+        foreach ($lines as $key => $line) {
+            list($heading, $value) = explode(':', $line, 2);
+            $heading = strtolower($heading);
+            $value = preg_replace('/\s+/', ' ', $value); // Compress useless spaces
+            $lines[$key] = $heading . ':' . trim($value); // Don't forget to remove WSP around the value
         }
-      }
+        $signHeader = implode("\r\n", $lines);
+        return $signHeader;
     }
-    $from     = str_replace('|', '=7C', $this->DKIM_QP($from_header));
-    $to       = str_replace('|', '=7C', $this->DKIM_QP($to_header));
-    $subject  = str_replace('|', '=7C', $this->DKIM_QP($subject_header)) ; // Copied header fields (dkim-quoted-printable
-    $body     = $this->DKIM_BodyC($body);
-    $DKIMlen  = strlen($body) ; // Length of body
-    $DKIMb64  = base64_encode(pack("H*", sha1($body))) ; // Base64 of packed binary SHA-1 hash of body
-    $ident    = ($this->DKIM_identity == '')? '' : " i=" . $this->DKIM_identity . ";";
-    $dkimhdrs = "DKIM-Signature: v=1; a=" . $DKIMsignatureType . "; q=" . $DKIMquery . "; l=" . $DKIMlen . "; s=" . $this->DKIM_selector . ";\r\n".
-                "\tt=" . $DKIMtime . "; c=" . $DKIMcanonicalization . ";\r\n".
-                "\th=From:To:Subject;\r\n".
-                "\td=" . $this->DKIM_domain . ";" . $ident . "\r\n".
-                "\tz=$from\r\n".
-                "\t|$to\r\n".
-                "\t|$subject;\r\n".
-                "\tbh=" . $DKIMb64 . ";\r\n".
-                "\tb=";
-    $toSign   = $this->DKIM_HeaderC($from_header . "\r\n" . $to_header . "\r\n" . $subject_header . "\r\n" . $dkimhdrs);
-    $signed   = $this->DKIM_Sign($toSign);
-    return $dkimhdrs.$signed."\r\n";
-  }
 
-  /**
-   * Perform callback
-   * @param boolean $isSent
-   * @param string $to
-   * @param string $cc
-   * @param string $bcc
-   * @param string $subject
-   * @param string $body
-   * @param string $from
-   */
-  protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from = null) {
-    if (!empty($this->action_function) && is_callable($this->action_function)) {
-      $params = array($isSent, $to, $cc, $bcc, $subject, $body, $from);
-      call_user_func_array($this->action_function, $params);
+    /**
+     * Generate a DKIM canonicalization body.
+     * @access public
+     * @param string $body Message Body
+     * @return string
+     */
+    public function DKIM_BodyC($body)
+    {
+        if ($body == '') {
+            return "\r\n";
+        }
+        // stabilize line endings
+        $body = str_replace("\r\n", "\n", $body);
+        $body = str_replace("\n", "\r\n", $body);
+        // END stabilize line endings
+        while (substr($body, strlen($body) - 4, 4) == "\r\n\r\n") {
+            $body = substr($body, 0, strlen($body) - 2);
+        }
+        return $body;
     }
-  }
+
+    /**
+     * Create the DKIM header and body in a new message header.
+     * @access public
+     * @param string $headers_line Header lines
+     * @param string $subject Subject
+     * @param string $body Body
+     * @return string
+     */
+    public function DKIM_Add($headers_line, $subject, $body)
+    {
+        $DKIMsignatureType = 'rsa-sha1'; // Signature & hash algorithms
+        $DKIMcanonicalization = 'relaxed/simple'; // Canonicalization of header/body
+        $DKIMquery = 'dns/txt'; // Query method
+        $DKIMtime = time(); // Signature Timestamp = seconds since 00:00:00 - Jan 1, 1970 (UTC time zone)
+        $subject_header = "Subject: $subject";
+        $headers = explode($this->LE, $headers_line);
+        $from_header = '';
+        $to_header = '';
+        $current = '';
+        foreach ($headers as $header) {
+            if (strpos($header, 'From:') === 0) {
+                $from_header = $header;
+                $current = 'from_header';
+            } elseif (strpos($header, 'To:') === 0) {
+                $to_header = $header;
+                $current = 'to_header';
+            } else {
+                if ($current && strpos($header, ' =?') === 0) {
+                    $current .= $header;
+                } else {
+                    $current = '';
+                }
+            }
+        }
+        $from = str_replace('|', '=7C', $this->DKIM_QP($from_header));
+        $to = str_replace('|', '=7C', $this->DKIM_QP($to_header));
+        $subject = str_replace(
+            '|',
+            '=7C',
+            $this->DKIM_QP($subject_header)
+        ); // Copied header fields (dkim-quoted-printable)
+        $body = $this->DKIM_BodyC($body);
+        $DKIMlen = strlen($body); // Length of body
+        $DKIMb64 = base64_encode(pack('H*', sha1($body))); // Base64 of packed binary SHA-1 hash of body
+        $ident = ($this->DKIM_identity == '') ? '' : ' i=' . $this->DKIM_identity . ';';
+        $dkimhdrs = 'DKIM-Signature: v=1; a=' .
+            $DKIMsignatureType . '; q=' .
+            $DKIMquery . '; l=' .
+            $DKIMlen . '; s=' .
+            $this->DKIM_selector .
+            ";\r\n" .
+            "\tt=" . $DKIMtime . '; c=' . $DKIMcanonicalization . ";\r\n" .
+            "\th=From:To:Subject;\r\n" .
+            "\td=" . $this->DKIM_domain . ';' . $ident . "\r\n" .
+            "\tz=$from\r\n" .
+            "\t|$to\r\n" .
+            "\t|$subject;\r\n" .
+            "\tbh=" . $DKIMb64 . ";\r\n" .
+            "\tb=";
+        $toSign = $this->DKIM_HeaderC(
+            $from_header . "\r\n" . $to_header . "\r\n" . $subject_header . "\r\n" . $dkimhdrs
+        );
+        $signed = $this->DKIM_Sign($toSign);
+        return $dkimhdrs . $signed . "\r\n";
+    }
+
+    /**
+     * Allows for public read access to 'to' property.
+     * @access public
+     * @return array
+     */
+    public function getToAddresses()
+    {
+        return $this->to;
+    }
+
+    /**
+     * Allows for public read access to 'cc' property.
+     * @access public
+     * @return array
+     */
+    public function getCcAddresses()
+    {
+        return $this->cc;
+    }
+
+    /**
+     * Allows for public read access to 'bcc' property.
+     * @access public
+     * @return array
+     */
+    public function getBccAddresses()
+    {
+        return $this->bcc;
+    }
+
+    /**
+     * Allows for public read access to 'ReplyTo' property.
+     * @access public
+     * @return array
+     */
+    public function getReplyToAddresses()
+    {
+        return $this->ReplyTo;
+    }
+
+    /**
+     * Allows for public read access to 'all_recipients' property.
+     * @access public
+     * @return array
+     */
+    public function getAllRecipientAddresses()
+    {
+        return $this->all_recipients;
+    }
+
+    /**
+     * Perform a callback.
+     * @param boolean $isSent
+     * @param array $to
+     * @param array $cc
+     * @param array $bcc
+     * @param string $subject
+     * @param string $body
+     * @param string $from
+     */
+    protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from)
+    {
+        if (!empty($this->action_function) && is_callable($this->action_function)) {
+            $params = array($isSent, $to, $cc, $bcc, $subject, $body, $from);
+            call_user_func_array($this->action_function, $params);
+        }
+    }
 }
 
 /**
- * Exception handler for PHPMailer
+ * PHPMailer exception handler
  * @package PHPMailer
  */
-class phpmailerException extends Exception {
-  /**
-   * Prettify error message output
-   * @return string
-   */
-  public function errorMessage() {
-    $errorMsg = '<strong>' . $this->getMessage() . "</strong><br />\n";
-    return $errorMsg;
-  }
+class phpmailerException extends Exception
+{
+    /**
+     * Prettify error message output
+     * @return string
+     */
+    public function errorMessage()
+    {
+        $errorMsg = '<strong>' . $this->getMessage() . "</strong><br />\n";
+        return $errorMsg;
+    }
 }

--- a/libraries/phpmailer/pop3.php
+++ b/libraries/phpmailer/pop3.php
@@ -1,418 +1,397 @@
 <?php
-/*~ class.pop3.php
-.---------------------------------------------------------------------------.
-|  Software: PHPMailer - PHP email class                                    |
-|   Version: 5.2.6                                                          |
-|      Site: https://github.com/PHPMailer/PHPMailer/                        |
-| ------------------------------------------------------------------------- |
-|    Admins: Marcus Bointon                                                 |
-|    Admins: Jim Jagielski                                                  |
-|   Authors: Andy Prevost (codeworxtech) codeworxtech@users.sourceforge.net |
-|          : Marcus Bointon (coolbru) coolbru@users.sourceforge.net         |
-|          : Jim Jagielski (jimjag) jimjag@gmail.com                        |
-|   Founder: Brent R. Matzelle (original founder)                           |
-| Copyright (c) 2010-2012, Jim Jagielski. All Rights Reserved.              |
-| Copyright (c) 2004-2009, Andy Prevost. All Rights Reserved.               |
-| Copyright (c) 2001-2003, Brent R. Matzelle                                |
-| ------------------------------------------------------------------------- |
-|   License: Distributed under the Lesser General Public License (LGPL)     |
-|            http://www.gnu.org/copyleft/lesser.html                        |
-| This program is distributed in the hope that it will be useful - WITHOUT  |
-| ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or     |
-| FITNESS FOR A PARTICULAR PURPOSE.                                         |
-'---------------------------------------------------------------------------'
-*/
-
 /**
- * PHPMailer - PHP POP Before SMTP Authentication Class
- * NOTE: Designed for use with PHP version 5 and up
+ * PHPMailer POP-Before-SMTP Authentication Class.
+ * PHP Version 5
  * @package PHPMailer
- * @author Andy Prevost
- * @author Marcus Bointon
- * @author Jim Jagielski
+ * @link https://github.com/PHPMailer/PHPMailer/
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author Brent R. Matzelle (original founder)
+ * @copyright 2012 - 2014 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license http://www.gnu.org/copyleft/lesser.html Distributed under the Lesser General Public License (LGPL)
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @note This program is distributed in the hope that it will be useful - WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 /**
- * PHP POP-Before-SMTP Authentication Class
- *
- * Version 5.2.6
- *
- * @license: LGPL, see PHPMailer License
- *
- * Specifically for PHPMailer to allow POP before SMTP authentication.
- * Does not yet work with APOP - if you have an APOP account, contact Jim Jagielski
- * and we can test changes to this script.
- *
- * This class is based on the structure of the SMTP class originally authored by Chris Ryan
- *
- * This class is rfc 1939 compliant and implements all the commands
- * required for POP3 connection, authentication and disconnection.
- *
+ * PHPMailer POP-Before-SMTP Authentication Class.
+ * Specifically for PHPMailer to use for RFC1939 POP-before-SMTP authentication.
+ * Does not support APOP.
  * @package PHPMailer
- * @author Richard Davey (orig) <rich@corephp.co.uk>
- * @author Andy Prevost
- * @author Jim Jagielski
+ * @author Richard Davey (original author) <rich@corephp.co.uk>
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
  */
+class POP3
+{
+    /**
+     * The POP3 PHPMailer Version number.
+     * @type string
+     * @access public
+     */
+    public $Version = '5.2.8';
 
-class POP3 {
-  /**
-   * Default POP3 port
-   * @var int
-   */
-  public $POP3_PORT = 110;
+    /**
+     * Default POP3 port number.
+     * @type integer
+     * @access public
+     */
+    public $POP3_PORT = 110;
 
-  /**
-   * Default Timeout
-   * @var int
-   */
-  public $POP3_TIMEOUT = 30;
+    /**
+     * Default timeout in seconds.
+     * @type integer
+     * @access public
+     */
+    public $POP3_TIMEOUT = 30;
 
-  /**
-   * POP3 Carriage Return + Line Feed
-   * @var string
-   */
-  public $CRLF = "\r\n";
+    /**
+     * POP3 Carriage Return + Line Feed.
+     * @type string
+     * @access public
+     * @deprecated Use the constant instead
+     */
+    public $CRLF = "\r\n";
 
-  /**
-   * Displaying Debug warnings? (0 = now, 1+ = yes)
-   * @var int
-   */
-  public $do_debug = 2;
+    /**
+     * Debug display level.
+     * Options: 0 = no, 1+ = yes
+     * @type integer
+     * @access public
+     */
+    public $do_debug = 0;
 
-  /**
-   * POP3 Mail Server
-   * @var string
-   */
-  public $host;
+    /**
+     * POP3 mail server hostname.
+     * @type string
+     * @access public
+     */
+    public $host;
 
-  /**
-   * POP3 Port
-   * @var int
-   */
-  public $port;
+    /**
+     * POP3 port number.
+     * @type integer
+     * @access public
+     */
+    public $port;
 
-  /**
-   * POP3 Timeout Value
-   * @var int
-   */
-  public $tval;
+    /**
+     * POP3 Timeout Value in seconds.
+     * @type integer
+     * @access public
+     */
+    public $tval;
 
-  /**
-   * POP3 Username
-   * @var string
-   */
-  public $username;
+    /**
+     * POP3 username
+     * @type string
+     * @access public
+     */
+    public $username;
 
-  /**
-   * POP3 Password
-   * @var string
-   */
-  public $password;
+    /**
+     * POP3 password.
+     * @type string
+     * @access public
+     */
+    public $password;
 
-  /**
-   * Sets the POP3 PHPMailer Version number
-   * @var string
-   */
-  public $Version         = '5.2.6';
+    /**
+     * Resource handle for the POP3 connection socket.
+     * @type resource
+     * @access private
+     */
+    private $pop_conn;
 
-  /////////////////////////////////////////////////
-  // PROPERTIES, PRIVATE AND PROTECTED
-  /////////////////////////////////////////////////
+    /**
+     * Are we connected?
+     * @type boolean
+     * @access private
+     */
+    private $connected = false;
 
-  /**
-   * @var resource Resource handle for the POP connection socket
-   */
-  private $pop_conn;
-  /**
-   * @var boolean Are we connected?
-   */
-  private $connected;
-  /**
-   * @var array Error container
-   */
-  private $error;     //  Error log array
+    /**
+     * Error container.
+     * @type array
+     * @access private
+     */
+    private $errors = array();
 
-  /**
-   * Constructor, sets the initial values
-   * @access public
-   * @return POP3
-   */
-  public function __construct() {
-    $this->pop_conn  = 0;
-    $this->connected = false;
-    $this->error     = null;
-  }
+    /**
+     * Line break constant
+     */
+    const CRLF = "\r\n";
 
-  /**
-   * Combination of public events - connect, login, disconnect
-   * @access public
-   * @param string $host
-   * @param bool|int $port
-   * @param bool|int $tval
-   * @param string $username
-   * @param string $password
-   * @param int $debug_level
-   * @return bool
-   */
-  public function Authorise ($host, $port = false, $tval = false, $username, $password, $debug_level = 0) {
-    $this->host = $host;
-
-    //  If no port value is passed, retrieve it
-    if ($port == false) {
-      $this->port = $this->POP3_PORT;
-    } else {
-      $this->port = $port;
+    /**
+     * Simple static wrapper for all-in-one POP before SMTP
+     * @param $host
+     * @param boolean $port
+     * @param boolean $tval
+     * @param string $username
+     * @param string $password
+     * @param integer $debug_level
+     * @return boolean
+     */
+    public static function popBeforeSmtp(
+        $host,
+        $port = false,
+        $tval = false,
+        $username = '',
+        $password = '',
+        $debug_level = 0
+    ) {
+        $pop = new POP3;
+        return $pop->authorise($host, $port, $tval, $username, $password, $debug_level);
     }
 
-    //  If no port value is passed, retrieve it
-    if ($tval == false) {
-      $this->tval = $this->POP3_TIMEOUT;
-    } else {
-      $this->tval = $tval;
+    /**
+     * Authenticate with a POP3 server.
+     * A connect, login, disconnect sequence
+     * appropriate for POP-before SMTP authorisation.
+     * @access public
+     * @param string $host
+     * @param integer|boolean $port
+     * @param integer|boolean $tval
+     * @param string $username
+     * @param string $password
+     * @param integer $debug_level
+     * @return boolean
+     */
+    public function authorise($host, $port = false, $tval = false, $username = '', $password = '', $debug_level = 0)
+    {
+        $this->host = $host;
+        // If no port value provided, use default
+        if ($port === false) {
+            $this->port = $this->POP3_PORT;
+        } else {
+            $this->port = $port;
+        }
+        // If no timeout value provided, use default
+        if ($tval === false) {
+            $this->tval = $this->POP3_TIMEOUT;
+        } else {
+            $this->tval = $tval;
+        }
+        $this->do_debug = $debug_level;
+        $this->username = $username;
+        $this->password = $password;
+        //  Reset the error log
+        $this->errors = array();
+        //  connect
+        $result = $this->connect($this->host, $this->port, $this->tval);
+        if ($result) {
+            $login_result = $this->login($this->username, $this->password);
+            if ($login_result) {
+                $this->disconnect();
+                return true;
+            }
+        }
+        // We need to disconnect regardless of whether the login succeeded
+        $this->disconnect();
+        return false;
     }
 
-    $this->do_debug = $debug_level;
-    $this->username = $username;
-    $this->password = $password;
+    /**
+     * Connect to a POP3 server.
+     * @access public
+     * @param string $host
+     * @param integer|boolean $port
+     * @param integer $tval
+     * @return boolean
+     */
+    public function connect($host, $port = false, $tval = 30)
+    {
+        //  Are we already connected?
+        if ($this->connected) {
+            return true;
+        }
 
-    //  Refresh the error log
-    $this->error = null;
+        //On Windows this will raise a PHP Warning error if the hostname doesn't exist.
+        //Rather than suppress it with @fsockopen, capture it cleanly instead
+        set_error_handler(array($this, 'catchWarning'));
 
-    //  Connect
-    $result = $this->Connect($this->host, $this->port, $this->tval);
+        if ($port === false) {
+            $port = $this->POP3_PORT;
+        }
 
-    if ($result) {
-      $login_result = $this->Login($this->username, $this->password);
+        //  connect to the POP3 server
+        $this->pop_conn = fsockopen(
+            $host, //  POP3 Host
+            $port, //  Port #
+            $errno, //  Error Number
+            $errstr, //  Error Message
+            $tval
+        ); //  Timeout (seconds)
+        //  Restore the error handler
+        restore_error_handler();
 
-      if ($login_result) {
-        $this->Disconnect();
+        //  Did we connect?
+        if ($this->pop_conn === false) {
+            //  It would appear not...
+            $this->setError(array(
+                'error' => "Failed to connect to server $host on port $port",
+                'errno' => $errno,
+                'errstr' => $errstr
+            ));
+            return false;
+        }
 
-        return true;
-      }
+        //  Increase the stream time-out
+        stream_set_timeout($this->pop_conn, $tval, 0);
 
+        //  Get the POP3 server response
+        $pop3_response = $this->getResponse();
+        //  Check for the +OK
+        if ($this->checkResponse($pop3_response)) {
+            //  The connection is established and the POP3 server is talking
+            $this->connected = true;
+            return true;
+        }
+        return false;
     }
 
-    //  We need to disconnect regardless if the login succeeded
-    $this->Disconnect();
+    /**
+     * Log in to the POP3 server.
+     * Does not support APOP (RFC 2828, 4949).
+     * @access public
+     * @param string $username
+     * @param string $password
+     * @return boolean
+     */
+    public function login($username = '', $password = '')
+    {
+        if (!$this->connected) {
+            $this->setError('Not connected to POP3 server');
+        }
+        if (empty($username)) {
+            $username = $this->username;
+        }
+        if (empty($password)) {
+            $password = $this->password;
+        }
 
-    return false;
-  }
-
-  /**
-   * Connect to the POP3 server
-   * @access public
-   * @param string $host
-   * @param bool|int $port
-   * @param integer $tval
-   * @return boolean
-   */
-  public function Connect ($host, $port = false, $tval = 30) {
-    //  Are we already connected?
-    if ($this->connected) {
-      return true;
+        // Send the Username
+        $this->sendString("USER $username" . self::CRLF);
+        $pop3_response = $this->getResponse();
+        if ($this->checkResponse($pop3_response)) {
+            // Send the Password
+            $this->sendString("PASS $password" . self::CRLF);
+            $pop3_response = $this->getResponse();
+            if ($this->checkResponse($pop3_response)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    /*
-    On Windows this will raise a PHP Warning error if the hostname doesn't exist.
-    Rather than suppress it with @fsockopen, let's capture it cleanly instead
-    */
-
-    set_error_handler(array(&$this, 'catchWarning'));
-
-    //  Connect to the POP3 server
-    $this->pop_conn = fsockopen($host,    //  POP3 Host
-                  $port,    //  Port #
-                  $errno,   //  Error Number
-                  $errstr,  //  Error Message
-                  $tval);   //  Timeout (seconds)
-
-    //  Restore the error handler
-    restore_error_handler();
-
-    //  Does the Error Log now contain anything?
-    if ($this->error && $this->do_debug >= 1) {
-      $this->displayErrors();
+    /**
+     * Disconnect from the POP3 server.
+     * @access public
+     */
+    public function disconnect()
+    {
+        $this->sendString('QUIT');
+        //The QUIT command may cause the daemon to exit, which will kill our connection
+        //So ignore errors here
+        try {
+            @fclose($this->pop_conn);
+        } catch (Exception $e) {
+            //Do nothing
+        };
     }
 
-    //  Did we connect?
-    if ($this->pop_conn == false) {
-      //  It would appear not...
-      $this->error = array(
-        'error' => "Failed to connect to server $host on port $port",
-        'errno' => $errno,
-        'errstr' => $errstr
-      );
-
-      if ($this->do_debug >= 1) {
-        $this->displayErrors();
-      }
-
-      return false;
+    /**
+     * Get a response from the POP3 server.
+     * $size is the maximum number of bytes to retrieve
+     * @param integer $size
+     * @return string
+     * @access private
+     */
+    private function getResponse($size = 128)
+    {
+        $response = fgets($this->pop_conn, $size);
+        if ($this->do_debug >= 1) {
+            echo "Server -> Client: $response";
+        }
+        return $response;
     }
 
-    //  Increase the stream time-out
-
-    //  Check for PHP 4.3.0 or later
-    if (version_compare(phpversion(), '5.0.0', 'ge')) {
-      stream_set_timeout($this->pop_conn, $tval, 0);
-    } else {
-      //  Does not work on Windows
-      if (substr(PHP_OS, 0, 3) !== 'WIN') {
-        socket_set_timeout($this->pop_conn, $tval, 0);
-      }
+    /**
+     * Send raw data to the POP3 server.
+     * @param string $string
+     * @return integer
+     * @access private
+     */
+    private function sendString($string)
+    {
+        if ($this->pop_conn) {
+            if ($this->do_debug >= 2) { //Show client messages when debug >= 2
+                echo "Client -> Server: $string";
+            }
+            return fwrite($this->pop_conn, $string, strlen($string));
+        }
+        return 0;
     }
 
-    //  Get the POP3 server response
-    $pop3_response = $this->getResponse();
-
-    //  Check for the +OK
-    if ($this->checkResponse($pop3_response)) {
-      //  The connection is established and the POP3 server is talking
-      $this->connected = true;
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Login to the POP3 server (does not support APOP yet)
-   * @access public
-   * @param string $username
-   * @param string $password
-   * @return boolean
-   */
-  public function Login ($username = '', $password = '') {
-    if ($this->connected == false) {
-      $this->error = 'Not connected to POP3 server';
-
-      if ($this->do_debug >= 1) {
-        $this->displayErrors();
-      }
+    /**
+     * Checks the POP3 server response.
+     * Looks for for +OK or -ERR.
+     * @param string $string
+     * @return boolean
+     * @access private
+     */
+    private function checkResponse($string)
+    {
+        if (substr($string, 0, 3) !== '+OK') {
+            $this->setError(array(
+                'error' => "Server reported an error: $string",
+                'errno' => 0,
+                'errstr' => ''
+            ));
+            return false;
+        } else {
+            return true;
+        }
     }
 
-    if (empty($username)) {
-      $username = $this->username;
+    /**
+     * Add an error to the internal error store.
+     * Also display debug output if it's enabled.
+     * @param $error
+     */
+    private function setError($error)
+    {
+        $this->errors[] = $error;
+        if ($this->do_debug >= 1) {
+            echo '<pre>';
+            foreach ($this->errors as $error) {
+                print_r($error);
+            }
+            echo '</pre>';
+        }
     }
 
-    if (empty($password)) {
-      $password = $this->password;
+    /**
+     * POP3 connection error handler.
+     * @param integer $errno
+     * @param string $errstr
+     * @param string $errfile
+     * @param integer $errline
+     * @access private
+     */
+    private function catchWarning($errno, $errstr, $errfile, $errline)
+    {
+        $this->setError(array(
+            'error' => "Connecting to the POP3 server raised a PHP warning: ",
+            'errno' => $errno,
+            'errstr' => $errstr,
+            'errfile' => $errfile,
+            'errline' => $errline
+        ));
     }
-
-    $pop_username = "USER $username" . $this->CRLF;
-    $pop_password = "PASS $password" . $this->CRLF;
-
-    //  Send the Username
-    $this->sendString($pop_username);
-    $pop3_response = $this->getResponse();
-
-    if ($this->checkResponse($pop3_response)) {
-      //  Send the Password
-      $this->sendString($pop_password);
-      $pop3_response = $this->getResponse();
-
-      if ($this->checkResponse($pop3_response)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Disconnect from the POP3 server
-   * @access public
-   */
-  public function Disconnect () {
-    $this->sendString('QUIT');
-
-    fclose($this->pop_conn);
-  }
-
-  /////////////////////////////////////////////////
-  //  Private Methods
-  /////////////////////////////////////////////////
-
-  /**
-   * Get the socket response back.
-   * $size is the maximum number of bytes to retrieve
-   * @access private
-   * @param integer $size
-   * @return string
-   */
-  private function getResponse ($size = 128) {
-    $pop3_response = fgets($this->pop_conn, $size);
-
-    return $pop3_response;
-  }
-
-  /**
-   * Send a string down the open socket connection to the POP3 server
-   * @access private
-   * @param string $string
-   * @return integer
-   */
-  private function sendString ($string) {
-    $bytes_sent = fwrite($this->pop_conn, $string, strlen($string));
-
-    return $bytes_sent;
-  }
-
-  /**
-   * Checks the POP3 server response for +OK or -ERR
-   * @access private
-   * @param string $string
-   * @return boolean
-   */
-  private function checkResponse ($string) {
-    if (substr($string, 0, 3) !== '+OK') {
-      $this->error = array(
-        'error' => "Server reported an error: $string",
-        'errno' => 0,
-        'errstr' => ''
-      );
-
-      if ($this->do_debug >= 1) {
-        $this->displayErrors();
-      }
-
-      return false;
-    } else {
-      return true;
-    }
-
-  }
-
-  /**
-   * If debug is enabled, display the error message array
-   * @access private
-   */
-  private function displayErrors () {
-    echo '<pre>';
-
-    foreach ($this->error as $single_error) {
-      print_r($single_error);
-    }
-
-    echo '</pre>';
-  }
-
-  /**
-   * Takes over from PHP for the socket warning handler
-   * @access private
-   * @param integer $errno
-   * @param string $errstr
-   * @param string $errfile
-   * @param integer $errline
-   */
-  private function catchWarning ($errno, $errstr, $errfile, $errline) {
-    $this->error[] = array(
-      'error' => "Connecting to the POP3 server raised a PHP warning: ",
-      'errno' => $errno,
-      'errstr' => $errstr
-    );
-  }
-
-  //  End of class
 }

--- a/libraries/phpmailer/smtp.php
+++ b/libraries/phpmailer/smtp.php
@@ -1,1094 +1,941 @@
 <?php
-/*~ class.smtp.php
-.---------------------------------------------------------------------------.
-|  Software: PHPMailer - PHP email class                                    |
-|   Version: 5.2.6                                                          |
-|      Site: https://github.com/PHPMailer/PHPMailer/                        |
-| ------------------------------------------------------------------------- |
-|    Admins: Marcus Bointon                                                 |
-|    Admins: Jim Jagielski                                                  |
-|   Authors: Andy Prevost (codeworxtech) codeworxtech@users.sourceforge.net |
-|          : Marcus Bointon (coolbru) phpmailer@synchromedia.co.uk          |
-|          : Jim Jagielski (jimjag) jimjag@gmail.com                        |
-|   Founder: Brent R. Matzelle (original founder)                           |
-| Copyright (c) 2010-2012, Jim Jagielski. All Rights Reserved.              |
-| Copyright (c) 2004-2009, Andy Prevost. All Rights Reserved.               |
-| Copyright (c) 2001-2003, Brent R. Matzelle                                |
-| ------------------------------------------------------------------------- |
-|   License: Distributed under the Lesser General Public License (LGPL)     |
-|            http://www.gnu.org/copyleft/lesser.html                        |
-| This program is distributed in the hope that it will be useful - WITHOUT  |
-| ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or     |
-| FITNESS FOR A PARTICULAR PURPOSE.                                         |
-'---------------------------------------------------------------------------'
-*/
-
 /**
- * PHPMailer - PHP SMTP email transport class
- * NOTE: Designed for use with PHP version 5 and up
+ * PHPMailer RFC821 SMTP email transport class.
+ * PHP Version 5
  * @package PHPMailer
- * @author Andy Prevost
- * @author Marcus Bointon
- * @copyright 2004 - 2008 Andy Prevost
- * @author Jim Jagielski
+ * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
+ * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author Brent R. Matzelle (original founder)
+ * @copyright 2014 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
- * @license http://www.gnu.org/copyleft/lesser.html Distributed under the Lesser General Public License (LGPL)
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @note This program is distributed in the hope that it will be useful - WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 /**
- * PHP RFC821 SMTP client
- *
- * Implements all the RFC 821 SMTP commands except TURN which will always return a not implemented error.
- * SMTP also provides some utility methods for sending mail to an SMTP server.
- * @author Chris Ryan
+ * PHPMailer RFC821 SMTP email transport class.
+ * Implements RFC 821 SMTP commands and provides some utility methods for sending mail to an SMTP server.
  * @package PHPMailer
+ * @author Chris Ryan <unknown@example.com>
+ * @author Marcus Bointon <phpmailer@synchromedia.co.uk>
  */
-
-class SMTP {
-  /**
-   *  SMTP server port
-   *  @var int
-   */
-  public $SMTP_PORT = 25;
-
-  /**
-   *  SMTP reply line ending (don't change)
-   *  @var string
-   */
-  public $CRLF = "\r\n";
-
-  /**
-   *  Debug output level; 0 for no output
-   *  @var int
-   */
-  public $do_debug = 0;
-
-  /**
-   * Sets the function/method to use for debugging output.
-   * Right now we only honor 'echo', 'html' or 'error_log'
-   * @var string
-   */
-  public $Debugoutput     = 'echo';
-
-  /**
-   *  Sets VERP use on/off (default is off)
-   *  @var bool
-   */
-  public $do_verp = false;
-
-  /**
-   * Sets the SMTP timeout value for reads, in seconds
-   * @var int
-   */
-  public $Timeout         = 15;
-
-  /**
-   * Sets the SMTP timelimit value for reads, in seconds
-   * @var int
-   */
-  public $Timelimit       = 30;
-
-  /**
-   * Sets the SMTP PHPMailer Version number
-   * @var string
-   */
-  public $Version         = '5.2.6';
-
-  /////////////////////////////////////////////////
-  // PROPERTIES, PRIVATE AND PROTECTED
-  /////////////////////////////////////////////////
-
-  /**
-   * @var resource The socket to the server
-   */
-  protected $smtp_conn;
-  /**
-   * @var string Error message, if any, for the last call
-   */
-  protected $error;
-  /**
-   * @var string The reply the server sent to us for HELO
-   */
-  protected $helo_rply;
-
-  /**
-   * Outputs debugging info via user-defined method
-   * @param string $str
-   */
-  protected function edebug($str) {
-    switch ($this->Debugoutput) {
-      case 'error_log':
-        error_log($str);
-        break;
-      case 'html':
-        //Cleans up output a bit for a better looking display that's HTML-safe
-        echo htmlentities(preg_replace('/[\r\n]+/', '', $str), ENT_QUOTES, 'UTF-8')."<br>\n";
-        break;
-      case 'echo':
-      default:
-        //Just echoes exactly what was received
-        echo $str;
-    }
-  }
-
-  /**
-   * Initialize the class so that the data is in a known state.
-   * @access public
-   * @return SMTP
-   */
-  public function __construct() {
-    $this->smtp_conn = 0;
-    $this->error = null;
-    $this->helo_rply = null;
-
-    $this->do_debug = 0;
-  }
-
-  /////////////////////////////////////////////////
-  // CONNECTION FUNCTIONS
-  /////////////////////////////////////////////////
-
-  /**
-   * Connect to an SMTP server
-   *
-   * SMTP CODE SUCCESS: 220
-   * SMTP CODE FAILURE: 421
-   * @access public
-   * @param string $host SMTP server IP or host name
-   * @param int $port The port number to connect to, or use the default port if not specified
-   * @param int $timeout How long to wait for the connection to open
-   * @param array $options An array of options compatible with stream_context_create()
-   * @return bool
-   */
-  public function Connect($host, $port = 0, $timeout = 30, $options = array()) {
-    // Clear errors to avoid confusion
-    $this->error = null;
-
-    // Make sure we are __not__ connected
-    if($this->connected()) {
-      // Already connected, generate error
-      $this->error = array('error' => 'Already connected to a server');
-      return false;
-    }
-
-    if(empty($port)) {
-      $port = $this->SMTP_PORT;
-    }
-
-    // Connect to the SMTP server
-    $errno = 0;
-    $errstr = '';
-    $socket_context = stream_context_create($options);
-    //Need to suppress errors here as connection failures can be handled at a higher level
-    $this->smtp_conn = @stream_socket_client($host.":".$port, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $socket_context);
-
-    // Verify we connected properly
-    if(empty($this->smtp_conn)) {
-      $this->error = array('error' => 'Failed to connect to server',
-                           'errno' => $errno,
-                           'errstr' => $errstr);
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ": $errstr ($errno)");
-      }
-      return false;
-    }
-
-    // SMTP server can take longer to respond, give longer timeout for first read
-    // Windows does not have support for this timeout function
-    if(substr(PHP_OS, 0, 3) != 'WIN') {
-      $max = ini_get('max_execution_time');
-      if ($max != 0 && $timeout > $max) { // Don't bother if unlimited
-        @set_time_limit($timeout);
-      }
-      stream_set_timeout($this->smtp_conn, $timeout, 0);
-    }
-
-    // get any announcement
-    $announce = $this->get_lines();
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $announce);
-    }
-
-    return true;
-  }
-
-  /**
-   * Initiate a TLS communication with the server.
-   *
-   * SMTP CODE 220 Ready to start TLS
-   * SMTP CODE 501 Syntax error (no parameters allowed)
-   * SMTP CODE 454 TLS not available due to temporary reason
-   * @access public
-   * @return bool success
-   */
-  public function StartTLS() {
-    $this->error = null; # to avoid confusion
-
-    if(!$this->connected()) {
-      $this->error = array('error' => 'Called StartTLS() without being connected');
-      return false;
-    }
-
-    $this->client_send('STARTTLS' . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 220) {
-      $this->error =
-         array('error'     => 'STARTTLS not accepted from server',
-               'smtp_code' => $code,
-               'smtp_msg'  => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-
-    // Begin encrypted connection
-    if(!stream_socket_enable_crypto($this->smtp_conn, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Performs SMTP authentication.  Must be run after running the
-   * Hello() method.  Returns true if successfully authenticated.
-   * @access public
-   * @param string $username
-   * @param string $password
-   * @param string $authtype
-   * @param string $realm
-   * @param string $workstation
-   * @return bool
-   */
-  public function Authenticate($username, $password, $authtype='LOGIN', $realm='', $workstation='') {
-    if (empty($authtype)) {
-      $authtype = 'LOGIN';
-    }
-
-    switch ($authtype) {
-      case 'PLAIN':
-        // Start authentication
-        $this->client_send('AUTH PLAIN' . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 334) {
-          $this->error =
-            array('error' => 'AUTH not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-        // Send encoded username and password
-          $this->client_send(base64_encode("\0".$username."\0".$password) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 235) {
-          $this->error =
-            array('error' => 'Authentication not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-        break;
-      case 'LOGIN':
-        // Start authentication
-        $this->client_send('AUTH LOGIN' . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 334) {
-          $this->error =
-            array('error' => 'AUTH not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-
-        // Send encoded username
-        $this->client_send(base64_encode($username) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 334) {
-          $this->error =
-            array('error' => 'Username not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-
-        // Send encoded password
-        $this->client_send(base64_encode($password) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 235) {
-          $this->error =
-            array('error' => 'Password not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-        break;
-      case 'NTLM':
-        /*
-         * ntlm_sasl_client.php
-         ** Bundled with Permission
-         **
-         ** How to telnet in windows: http://technet.microsoft.com/en-us/library/aa995718%28EXCHG.65%29.aspx
-         ** PROTOCOL Documentation http://curl.haxx.se/rfc/ntlm.html#ntlmSmtpAuthentication
-         */
-        if (file_exists('extras/ntlm_sasl_client.php')) {
-         require_once 'extras/ntlm_sasl_client.php';
-        }
-        $temp = new stdClass();
-        $ntlm_client = new ntlm_sasl_client_class;
-        if(! $ntlm_client->Initialize($temp)){//let's test if every function its available
-            $this->error = array('error' => $temp->error);
-            if($this->do_debug >= 1) {
-                $this->edebug('You need to enable some modules in your php.ini file: ' . $this->error['error']);
-            }
-            return false;
-        }
-        $msg1 = $ntlm_client->TypeMsg1($realm, $workstation);//msg1
-
-        $this->client_send('AUTH NTLM ' . base64_encode($msg1) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 334) {
-            $this->error =
-                array('error' => 'AUTH not accepted from server',
-                      'smtp_code' => $code,
-                      'smtp_msg' => substr($rply, 4));
-            if($this->do_debug >= 1) {
-                $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-            }
-            return false;
-        }
-
-        $challenge = substr($rply, 3);//though 0 based, there is a white space after the 3 digit number....//msg2
-        $challenge = base64_decode($challenge);
-        $ntlm_res = $ntlm_client->NTLMResponse(substr($challenge, 24, 8), $password);
-        $msg3 = $ntlm_client->TypeMsg3($ntlm_res, $username, $realm, $workstation);//msg3
-        // Send encoded username
-        $this->client_send(base64_encode($msg3) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 235) {
-            $this->error =
-                array('error' => 'Could not authenticate',
-                      'smtp_code' => $code,
-                      'smtp_msg' => substr($rply, 4));
-            if($this->do_debug >= 1) {
-                $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-            }
-            return false;
-        }
-        break;
-      case 'CRAM-MD5':
-        // Start authentication
-        $this->client_send('AUTH CRAM-MD5' . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 334) {
-          $this->error =
-            array('error' => 'AUTH not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-
-        // Get the challenge
-        $challenge = base64_decode(substr($rply, 4));
-
-        // Build the response
-        $response = $username . ' ' . $this->hmac($challenge, $password);
-
-        // Send encoded credentials
-        $this->client_send(base64_encode($response) . $this->CRLF);
-
-        $rply = $this->get_lines();
-        $code = substr($rply, 0, 3);
-
-        if($code != 235) {
-          $this->error =
-            array('error' => 'Credentials not accepted from server',
-                  'smtp_code' => $code,
-                  'smtp_msg' => substr($rply, 4));
-          if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-          }
-          return false;
-        }
-        break;
-    }
-    return true;
-  }
-
-  /**
-   * Works like hash_hmac('md5', $data, $key) in case that function is not available
-   * @access protected
-   * @param string $data
-   * @param string $key
-   * @return string
-   */
-  protected function hmac($data, $key) {
-      if (function_exists('hash_hmac')) {
-          return hash_hmac('md5', $data, $key);
-      }
-
-      // The following borrowed from http://php.net/manual/en/function.mhash.php#27225
-
-      // RFC 2104 HMAC implementation for php.
-      // Creates an md5 HMAC.
-      // Eliminates the need to install mhash to compute a HMAC
-      // Hacked by Lance Rushing
-
-      $b = 64; // byte length for md5
-      if (strlen($key) > $b) {
-          $key = pack('H*', md5($key));
-      }
-      $key  = str_pad($key, $b, chr(0x00));
-      $ipad = str_pad('', $b, chr(0x36));
-      $opad = str_pad('', $b, chr(0x5c));
-      $k_ipad = $key ^ $ipad ;
-      $k_opad = $key ^ $opad;
-
-      return md5($k_opad  . pack('H*', md5($k_ipad . $data)));
-  }
-
-  /**
-   * Returns true if connected to a server otherwise false
-   * @access public
-   * @return bool
-   */
-  public function Connected() {
-    if(!empty($this->smtp_conn)) {
-      $sock_status = stream_get_meta_data($this->smtp_conn);
-      if($sock_status['eof']) {
-        // the socket is valid but we are not connected
-        if($this->do_debug >= 1) {
-            $this->edebug('SMTP -> NOTICE: EOF caught while checking if connected');
-        }
-        $this->Close();
-        return false;
-      }
-      return true; // everything looks good
-    }
-    return false;
-  }
-
-  /**
-   * Closes the socket and cleans up the state of the class.
-   * It is not considered good to use this function without
-   * first trying to use QUIT.
-   * @access public
-   * @return void
-   */
-  public function Close() {
-    $this->error = null; // so there is no confusion
-    $this->helo_rply = null;
-    if(!empty($this->smtp_conn)) {
-      // close the connection and cleanup
-      fclose($this->smtp_conn);
-      $this->smtp_conn = 0;
-    }
-  }
-
-  /////////////////////////////////////////////////
-  // SMTP COMMANDS
-  /////////////////////////////////////////////////
-
-  /**
-   * Issues a data command and sends the msg_data to the server
-   * finializing the mail transaction. $msg_data is the message
-   * that is to be send with the headers. Each header needs to be
-   * on a single line followed by a <CRLF> with the message headers
-   * and the message body being separated by and additional <CRLF>.
-   *
-   * Implements rfc 821: DATA <CRLF>
-   *
-   * SMTP CODE INTERMEDIATE: 354
-   *     [data]
-   *     <CRLF>.<CRLF>
-   *     SMTP CODE SUCCESS: 250
-   *     SMTP CODE FAILURE: 552, 554, 451, 452
-   * SMTP CODE FAILURE: 451, 554
-   * SMTP CODE ERROR  : 500, 501, 503, 421
-   * @access public
-   * @param string $msg_data
-   * @return bool
-   */
-  public function Data($msg_data) {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array(
-              'error' => 'Called Data() without being connected');
-      return false;
-    }
-
-    $this->client_send('DATA' . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 354) {
-      $this->error =
-        array('error' => 'DATA command not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-
-    /* the server is ready to accept data!
-     * according to rfc 821 we should not send more than 1000
-     * including the CRLF
-     * characters on a single line so we will break the data up
-     * into lines by \r and/or \n then if needed we will break
-     * each of those into smaller lines to fit within the limit.
-     * in addition we will be looking for lines that start with
-     * a period '.' and append and additional period '.' to that
-     * line. NOTE: this does not count towards limit.
+class SMTP
+{
+    /**
+     * The PHPMailer SMTP version number.
+     * @type string
      */
+    const VERSION = '5.2.8';
 
-    // normalize the line breaks so we know the explode works
-    $msg_data = str_replace("\r\n", "\n", $msg_data);
-    $msg_data = str_replace("\r", "\n", $msg_data);
-    $lines = explode("\n", $msg_data);
-
-    /* we need to find a good way to determine is headers are
-     * in the msg_data or if it is a straight msg body
-     * currently I am assuming rfc 822 definitions of msg headers
-     * and if the first field of the first line (':' sperated)
-     * does not contain a space then it _should_ be a header
-     * and we can process all lines before a blank "" line as
-     * headers.
+    /**
+     * SMTP line break constant.
+     * @type string
      */
+    const CRLF = "\r\n";
 
-    $field = substr($lines[0], 0, strpos($lines[0], ':'));
-    $in_headers = false;
-    if(!empty($field) && !strstr($field, ' ')) {
-      $in_headers = true;
+    /**
+     * The SMTP port to use if one is not specified.
+     * @type integer
+     */
+    const DEFAULT_SMTP_PORT = 25;
+
+    /**
+     * The maximum line length allowed by RFC 2822 section 2.1.1
+     * @type integer
+     */
+    const MAX_LINE_LENGTH = 998;
+
+    /**
+     * The PHPMailer SMTP Version number.
+     * @type string
+     * @deprecated Use the constant instead
+     * @see SMTP::VERSION
+     */
+    public $Version = '5.2.8';
+
+    /**
+     * SMTP server port number.
+     * @type integer
+     * @deprecated This is only ever used as a default value, so use the constant instead
+     * @see SMTP::DEFAULT_SMTP_PORT
+     */
+    public $SMTP_PORT = 25;
+
+    /**
+     * SMTP reply line ending.
+     * @type string
+     * @deprecated Use the constant instead
+     * @see SMTP::CRLF
+     */
+    public $CRLF = "\r\n";
+
+    /**
+     * Debug output level.
+     * Options:
+     * * `0` No output
+     * * `1` Commands
+     * * `2` Data and commands
+     * * `3` As 2 plus connection status
+     * * `4` Low-level data output
+     * @type integer
+     */
+    public $do_debug = 0;
+
+    /**
+     * How to handle debug output.
+     * Options:
+     * * `echo` Output plain-text as-is, appropriate for CLI
+     * * `html` Output escaped, line breaks converted to <br>, appropriate for browser output
+     * * `error_log` Output to error log as configured in php.ini
+     * @type string
+     */
+    public $Debugoutput = 'echo';
+
+    /**
+     * Whether to use VERP.
+     * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
+     * @link http://www.postfix.org/VERP_README.html Info on VERP
+     * @type boolean
+     */
+    public $do_verp = false;
+
+    /**
+     * The timeout value for connection, in seconds.
+     * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
+     * This needs to be quite high to function correctly with hosts using greetdelay as an anti-spam measure.
+     * @link http://tools.ietf.org/html/rfc2821#section-4.5.3.2
+     * @type integer
+     */
+    public $Timeout = 300;
+
+    /**
+     * The SMTP timelimit value for reads, in seconds.
+     * @type integer
+     */
+    public $Timelimit = 30;
+
+    /**
+     * The socket for the server connection.
+     * @type resource
+     */
+    protected $smtp_conn;
+
+    /**
+     * Error message, if any, for the last call.
+     * @type array
+     */
+    protected $error = array();
+
+    /**
+     * The reply the server sent to us for HELO.
+     * If null, no HELO string has yet been received.
+     * @type string|null
+     */
+    protected $helo_rply = null;
+
+    /**
+     * The most recent reply received from the server.
+     * @type string
+     */
+    protected $last_reply = '';
+
+    /**
+     * Output debugging info via a user-selected method.
+     * @param string $str Debug string to output
+     * @return void
+     */
+    protected function edebug($str)
+    {
+        switch ($this->Debugoutput) {
+            case 'error_log':
+                //Don't output, just log
+                error_log($str);
+                break;
+            case 'html':
+                //Cleans up output a bit for a better looking, HTML-safe output
+                echo htmlentities(
+                    preg_replace('/[\r\n]+/', '', $str),
+                    ENT_QUOTES,
+                    'UTF-8'
+                )
+                . "<br>\n";
+                break;
+            case 'echo':
+            default:
+                echo gmdate('Y-m-d H:i:s')."\t".trim($str)."\n";
+        }
     }
 
-    $max_line_length = 998; // used below; set here for ease in change
-
-    while(list(, $line) = @each($lines)) {
-      $lines_out = null;
-      if($line == '' && $in_headers) {
-        $in_headers = false;
-      }
-      // ok we need to break this line up into several smaller lines
-      while(strlen($line) > $max_line_length) {
-        $pos = strrpos(substr($line, 0, $max_line_length), ' ');
-
-        // Patch to fix DOS attack
-        if(!$pos) {
-          $pos = $max_line_length - 1;
-          $lines_out[] = substr($line, 0, $pos);
-          $line = substr($line, $pos);
+    /**
+     * Connect to an SMTP server.
+     * @param string $host SMTP server IP or host name
+     * @param integer $port The port number to connect to
+     * @param integer $timeout How long to wait for the connection to open
+     * @param array $options An array of options for stream_context_create()
+     * @access public
+     * @return boolean
+     */
+    public function connect($host, $port = null, $timeout = 30, $options = array())
+    {
+        static $streamok;
+        //This is enabled by default since 5.0.0 but some providers disable it
+        //Check this once and cache the result
+        if (is_null($streamok)) {
+            $streamok = function_exists('stream_socket_client');
+        }
+        // Clear errors to avoid confusion
+        $this->error = array();
+        // Make sure we are __not__ connected
+        if ($this->connected()) {
+            // Already connected, generate error
+            $this->error = array('error' => 'Already connected to a server');
+            return false;
+        }
+        if (empty($port)) {
+            $port = self::DEFAULT_SMTP_PORT;
+        }
+        // Connect to the SMTP server
+        if ($this->do_debug >= 3) {
+            $this->edebug("Connection: opening to $host:$port, t=$timeout, opt=".var_export($options, true));
+        }
+        $errno = 0;
+        $errstr = '';
+        if ($streamok) {
+            $socket_context = stream_context_create($options);
+            //Suppress errors; connection failures are handled at a higher level
+            $this->smtp_conn = @stream_socket_client(
+                $host . ":" . $port,
+                $errno,
+                $errstr,
+                $timeout,
+                STREAM_CLIENT_CONNECT,
+                $socket_context
+            );
         } else {
-          $lines_out[] = substr($line, 0, $pos);
-          $line = substr($line, $pos + 1);
+            //Fall back to fsockopen which should work in more places, but is missing some features
+            if ($this->do_debug >= 3) {
+                $this->edebug("Connection: stream_socket_client not available, falling back to fsockopen");
+            }
+            $this->smtp_conn = fsockopen(
+                $host,
+                $port,
+                $errno,
+                $errstr,
+                $timeout
+            );
+        }
+        // Verify we connected properly
+        if (!is_resource($this->smtp_conn)) {
+            $this->error = array(
+                'error' => 'Failed to connect to server',
+                'errno' => $errno,
+                'errstr' => $errstr
+            );
+            if ($this->do_debug >= 1) {
+                $this->edebug(
+                    'SMTP ERROR: ' . $this->error['error']
+                    . ": $errstr ($errno)"
+                );
+            }
+            return false;
+        }
+        if ($this->do_debug >= 3) {
+            $this->edebug('Connection: opened');
+        }
+        // SMTP server can take longer to respond, give longer timeout for first read
+        // Windows does not have support for this timeout function
+        if (substr(PHP_OS, 0, 3) != 'WIN') {
+            $max = ini_get('max_execution_time');
+            if ($max != 0 && $timeout > $max) { // Don't bother if unlimited
+                @set_time_limit($timeout);
+            }
+            stream_set_timeout($this->smtp_conn, $timeout, 0);
+        }
+        // Get any announcement
+        $announce = $this->get_lines();
+        if ($this->do_debug >= 2) {
+            $this->edebug('SERVER -> CLIENT: ' . $announce);
+        }
+        return true;
+    }
+
+    /**
+     * Initiate a TLS (encrypted) session.
+     * @access public
+     * @return boolean
+     */
+    public function startTLS()
+    {
+        if (!$this->sendCommand('STARTTLS', 'STARTTLS', 220)) {
+            return false;
+        }
+        // Begin encrypted connection
+        if (!stream_socket_enable_crypto(
+            $this->smtp_conn,
+            true,
+            STREAM_CRYPTO_METHOD_TLS_CLIENT
+        )) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Perform SMTP authentication.
+     * Must be run after hello().
+     * @see hello()
+     * @param string $username    The user name
+     * @param string $password    The password
+     * @param string $authtype    The auth type (PLAIN, LOGIN, NTLM, CRAM-MD5)
+     * @param string $realm       The auth realm for NTLM
+     * @param string $workstation The auth workstation for NTLM
+     * @access public
+     * @return boolean True if successfully authenticated.
+     */
+    public function authenticate(
+        $username,
+        $password,
+        $authtype = 'LOGIN',
+        $realm = '',
+        $workstation = ''
+    ) {
+        if (empty($authtype)) {
+            $authtype = 'LOGIN';
+        }
+        switch ($authtype) {
+            case 'PLAIN':
+                // Start authentication
+                if (!$this->sendCommand('AUTH', 'AUTH PLAIN', 334)) {
+                    return false;
+                }
+                // Send encoded username and password
+                if (!$this->sendCommand(
+                    'User & Password',
+                    base64_encode("\0" . $username . "\0" . $password),
+                    235
+                )
+                ) {
+                    return false;
+                }
+                break;
+            case 'LOGIN':
+                // Start authentication
+                if (!$this->sendCommand('AUTH', 'AUTH LOGIN', 334)) {
+                    return false;
+                }
+                if (!$this->sendCommand("Username", base64_encode($username), 334)) {
+                    return false;
+                }
+                if (!$this->sendCommand("Password", base64_encode($password), 235)) {
+                    return false;
+                }
+                break;
+            case 'NTLM':
+                /*
+                 * ntlm_sasl_client.php
+                 * Bundled with Permission
+                 *
+                 * How to telnet in windows:
+                 * http://technet.microsoft.com/en-us/library/aa995718%28EXCHG.65%29.aspx
+                 * PROTOCOL Docs http://curl.haxx.se/rfc/ntlm.html#ntlmSmtpAuthentication
+                 */
+                require_once 'extras/ntlm_sasl_client.php';
+                $temp = new stdClass();
+                $ntlm_client = new ntlm_sasl_client_class;
+                //Check that functions are available
+                if (!$ntlm_client->Initialize($temp)) {
+                    $this->error = array('error' => $temp->error);
+                    if ($this->do_debug >= 1) {
+                        $this->edebug(
+                            'You need to enable some modules in your php.ini file: '
+                            . $this->error['error']
+                        );
+                    }
+                    return false;
+                }
+                //msg1
+                $msg1 = $ntlm_client->TypeMsg1($realm, $workstation); //msg1
+
+                if (!$this->sendCommand(
+                    'AUTH NTLM',
+                    'AUTH NTLM ' . base64_encode($msg1),
+                    334
+                )
+                ) {
+                    return false;
+                }
+                //Though 0 based, there is a white space after the 3 digit number
+                //msg2
+                $challenge = substr($this->last_reply, 3);
+                $challenge = base64_decode($challenge);
+                $ntlm_res = $ntlm_client->NTLMResponse(
+                    substr($challenge, 24, 8),
+                    $password
+                );
+                //msg3
+                $msg3 = $ntlm_client->TypeMsg3(
+                    $ntlm_res,
+                    $username,
+                    $realm,
+                    $workstation
+                );
+                // send encoded username
+                return $this->sendCommand('Username', base64_encode($msg3), 235);
+            case 'CRAM-MD5':
+                // Start authentication
+                if (!$this->sendCommand('AUTH CRAM-MD5', 'AUTH CRAM-MD5', 334)) {
+                    return false;
+                }
+                // Get the challenge
+                $challenge = base64_decode(substr($this->last_reply, 4));
+
+                // Build the response
+                $response = $username . ' ' . $this->hmac($challenge, $password);
+
+                // send encoded credentials
+                return $this->sendCommand('Username', base64_encode($response), 235);
+        }
+        return true;
+    }
+
+    /**
+     * Calculate an MD5 HMAC hash.
+     * Works like hash_hmac('md5', $data, $key)
+     * in case that function is not available
+     * @param string $data The data to hash
+     * @param string $key  The key to hash with
+     * @access protected
+     * @return string
+     */
+    protected function hmac($data, $key)
+    {
+        if (function_exists('hash_hmac')) {
+            return hash_hmac('md5', $data, $key);
         }
 
-        /* if processing headers add a LWSP-char to the front of new line
-         * rfc 822 on long msg headers
-         */
-        if($in_headers) {
-          $line = "\t" . $line;
+        // The following borrowed from
+        // http://php.net/manual/en/function.mhash.php#27225
+
+        // RFC 2104 HMAC implementation for php.
+        // Creates an md5 HMAC.
+        // Eliminates the need to install mhash to compute a HMAC
+        // Hacked by Lance Rushing
+
+        $bytelen = 64; // byte length for md5
+        if (strlen($key) > $bytelen) {
+            $key = pack('H*', md5($key));
         }
-      }
-      $lines_out[] = $line;
+        $key = str_pad($key, $bytelen, chr(0x00));
+        $ipad = str_pad('', $bytelen, chr(0x36));
+        $opad = str_pad('', $bytelen, chr(0x5c));
+        $k_ipad = $key ^ $ipad;
+        $k_opad = $key ^ $opad;
 
-      // send the lines to the server
-      while(list(, $line_out) = @each($lines_out)) {
-        if(strlen($line_out) > 0)
-        {
-          if(substr($line_out, 0, 1) == '.') {
-            $line_out = '.' . $line_out;
-          }
+        return md5($k_opad . pack('H*', md5($k_ipad . $data)));
+    }
+
+    /**
+     * Check connection state.
+     * @access public
+     * @return boolean True if connected.
+     */
+    public function connected()
+    {
+        if (is_resource($this->smtp_conn)) {
+            $sock_status = stream_get_meta_data($this->smtp_conn);
+            if ($sock_status['eof']) {
+                // the socket is valid but we are not connected
+                if ($this->do_debug >= 1) {
+                    $this->edebug(
+                        'SMTP NOTICE: EOF caught while checking if connected'
+                    );
+                }
+                $this->close();
+                return false;
+            }
+            return true; // everything looks good
         }
-        $this->client_send($line_out . $this->CRLF);
-      }
-    }
-
-    // message data has been sent
-    $this->client_send($this->CRLF . '.' . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 250) {
-      $this->error =
-        array('error' => 'DATA not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Sends the HELO command to the smtp server.
-   * This makes sure that we and the server are in
-   * the same known state.
-   *
-   * Implements from rfc 821: HELO <SP> <domain> <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250
-   * SMTP CODE ERROR  : 500, 501, 504, 421
-   * @access public
-   * @param string $host
-   * @return bool
-   */
-  public function Hello($host = '') {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array(
-            'error' => 'Called Hello() without being connected');
-      return false;
-    }
-
-    // if hostname for HELO was not specified send default
-    if(empty($host)) {
-      // determine appropriate default to send to server
-      $host = 'localhost';
-    }
-
-    // Send extended hello first (RFC 2821)
-    if(!$this->SendHello('EHLO', $host)) {
-      if(!$this->SendHello('HELO', $host)) {
         return false;
-      }
     }
 
-    return true;
-  }
-
-  /**
-   * Sends a HELO/EHLO command.
-   * @access protected
-   * @param string $hello
-   * @param string $host
-   * @return bool
-   */
-  protected function SendHello($hello, $host) {
-    $this->client_send($hello . ' ' . $host . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER: ' . $rply);
-    }
-
-    if($code != 250) {
-      $this->error =
-        array('error' => $hello . ' not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-
-    $this->helo_rply = $rply;
-
-    return true;
-  }
-
-  /**
-   * Starts a mail transaction from the email address specified in
-   * $from. Returns true if successful or false otherwise. If True
-   * the mail transaction is started and then one or more Recipient
-   * commands may be called followed by a Data command.
-   *
-   * Implements rfc 821: MAIL <SP> FROM:<reverse-path> <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250
-   * SMTP CODE SUCCESS: 552, 451, 452
-   * SMTP CODE SUCCESS: 500, 501, 421
-   * @access public
-   * @param string $from
-   * @return bool
-   */
-  public function Mail($from) {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array(
-              'error' => 'Called Mail() without being connected');
-      return false;
-    }
-
-    $useVerp = ($this->do_verp ? ' XVERP' : '');
-    $this->client_send('MAIL FROM:<' . $from . '>' . $useVerp . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 250) {
-      $this->error =
-        array('error' => 'MAIL not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Sends the quit command to the server and then closes the socket
-   * if there is no error or the $close_on_error argument is true.
-   *
-   * Implements from rfc 821: QUIT <CRLF>
-   *
-   * SMTP CODE SUCCESS: 221
-   * SMTP CODE ERROR  : 500
-   * @access public
-   * @param bool $close_on_error
-   * @return bool
-   */
-  public function Quit($close_on_error = true) {
-    $this->error = null; // so there is no confusion
-
-    if(!$this->connected()) {
-      $this->error = array(
-              'error' => 'Called Quit() without being connected');
-      return false;
-    }
-
-    // send the quit command to the server
-    $this->client_send('quit' . $this->CRLF);
-
-    // get any good-bye messages
-    $byemsg = $this->get_lines();
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $byemsg);
-    }
-
-    $rval = true;
-    $e = null;
-
-    $code = substr($byemsg, 0, 3);
-    if($code != 221) {
-      // use e as a tmp var cause Close will overwrite $this->error
-      $e = array('error' => 'SMTP server rejected quit command',
-                 'smtp_code' => $code,
-                 'smtp_rply' => substr($byemsg, 4));
-      $rval = false;
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $e['error'] . ': ' . $byemsg);
-      }
-    }
-
-    if(empty($e) || $close_on_error) {
-      $this->Close();
-    }
-
-    return $rval;
-  }
-
-  /**
-   * Sends the command RCPT to the SMTP server with the TO: argument of $to.
-   * Returns true if the recipient was accepted false if it was rejected.
-   *
-   * Implements from rfc 821: RCPT <SP> TO:<forward-path> <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250, 251
-   * SMTP CODE FAILURE: 550, 551, 552, 553, 450, 451, 452
-   * SMTP CODE ERROR  : 500, 501, 503, 421
-   * @access public
-   * @param string $to
-   * @return bool
-   */
-  public function Recipient($to) {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array(
-              'error' => 'Called Recipient() without being connected');
-      return false;
-    }
-
-    $this->client_send('RCPT TO:<' . $to . '>' . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 250 && $code != 251) {
-      $this->error =
-        array('error' => 'RCPT not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Sends the RSET command to abort and transaction that is
-   * currently in progress. Returns true if successful false
-   * otherwise.
-   *
-   * Implements rfc 821: RSET <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250
-   * SMTP CODE ERROR  : 500, 501, 504, 421
-   * @access public
-   * @return bool
-   */
-  public function Reset() {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array('error' => 'Called Reset() without being connected');
-      return false;
-    }
-
-    $this->client_send('RSET' . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 250) {
-      $this->error =
-        array('error' => 'RSET failed',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Starts a mail transaction from the email address specified in
-   * $from. Returns true if successful or false otherwise. If True
-   * the mail transaction is started and then one or more Recipient
-   * commands may be called followed by a Data command. This command
-   * will send the message to the users terminal if they are logged
-   * in and send them an email.
-   *
-   * Implements rfc 821: SAML <SP> FROM:<reverse-path> <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250
-   * SMTP CODE SUCCESS: 552, 451, 452
-   * SMTP CODE SUCCESS: 500, 501, 502, 421
-   * @access public
-   * @param string $from
-   * @return bool
-   */
-  public function SendAndMail($from) {
-    $this->error = null; // so no confusion is caused
-
-    if(!$this->connected()) {
-      $this->error = array(
-          'error' => 'Called SendAndMail() without being connected');
-      return false;
-    }
-
-    $this->client_send('SAML FROM:' . $from . $this->CRLF);
-
-    $rply = $this->get_lines();
-    $code = substr($rply, 0, 3);
-
-    if($this->do_debug >= 2) {
-      $this->edebug('SMTP -> FROM SERVER:' . $rply);
-    }
-
-    if($code != 250) {
-      $this->error =
-        array('error' => 'SAML not accepted from server',
-              'smtp_code' => $code,
-              'smtp_msg' => substr($rply, 4));
-      if($this->do_debug >= 1) {
-        $this->edebug('SMTP -> ERROR: ' . $this->error['error'] . ': ' . $rply);
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * This is an optional command for SMTP that this class does not
-   * support. This method is here to make the RFC821 Definition
-   * complete for this class and __may__ be implimented in the future
-   *
-   * Implements from rfc 821: TURN <CRLF>
-   *
-   * SMTP CODE SUCCESS: 250
-   * SMTP CODE FAILURE: 502
-   * SMTP CODE ERROR  : 500, 503
-   * @access public
-   * @return bool
-   */
-  public function Turn() {
-    $this->error = array('error' => 'This method, TURN, of the SMTP '.
-                                    'is not implemented');
-    if($this->do_debug >= 1) {
-      $this->edebug('SMTP -> NOTICE: ' . $this->error['error']);
-    }
-    return false;
-  }
-
-  /**
-  * Sends data to the server
-  * @param string $data
-  * @access public
-  * @return Integer number of bytes sent to the server or FALSE on error
-  */
-  public function client_send($data) {
-      if ($this->do_debug >= 1) {
-          $this->edebug("CLIENT -> SMTP: $data");
-      }
-      return fwrite($this->smtp_conn, $data);
-  }
-
-  /**
-  * Get the current error
-  * @access public
-  * @return array
-  */
-  public function getError() {
-    return $this->error;
-  }
-
-  /////////////////////////////////////////////////
-  // INTERNAL FUNCTIONS
-  /////////////////////////////////////////////////
-
-  /**
-   * Read in as many lines as possible
-   * either before eof or socket timeout occurs on the operation.
-   * With SMTP we can tell if we have more lines to read if the
-   * 4th character is '-' symbol. If it is a space then we don't
-   * need to read anything else.
-   * @access protected
-   * @return string
-   */
-  protected function get_lines() {
-    $data = '';
-    $endtime = 0;
-    /* If for some reason the fp is bad, don't inf loop */
-    if (!is_resource($this->smtp_conn)) {
-      return $data;
-    }
-    stream_set_timeout($this->smtp_conn, $this->Timeout);
-    if ($this->Timelimit > 0) {
-      $endtime = time() + $this->Timelimit;
-    }
-    while(is_resource($this->smtp_conn) && !feof($this->smtp_conn)) {
-      $str = @fgets($this->smtp_conn, 515);
-      if($this->do_debug >= 4) {
-        $this->edebug("SMTP -> get_lines(): \$data was \"$data\"");
-        $this->edebug("SMTP -> get_lines(): \$str is \"$str\"");
-      }
-      $data .= $str;
-      if($this->do_debug >= 4) {
-        $this->edebug("SMTP -> get_lines(): \$data is \"$data\"");
-      }
-      // if 4th character is a space, we are done reading, break the loop
-      if(substr($str, 3, 1) == ' ') { break; }
-      // Timed-out? Log and break
-      $info = stream_get_meta_data($this->smtp_conn);
-      if ($info['timed_out']) {
-        if($this->do_debug >= 4) {
-          $this->edebug('SMTP -> get_lines(): timed-out (' . $this->Timeout . ' seconds)');
+    /**
+     * Close the socket and clean up the state of the class.
+     * Don't use this function without first trying to use QUIT.
+     * @see quit()
+     * @access public
+     * @return void
+     */
+    public function close()
+    {
+        $this->error = array();
+        $this->helo_rply = null;
+        if (is_resource($this->smtp_conn)) {
+            // close the connection and cleanup
+            fclose($this->smtp_conn);
+            if ($this->do_debug >= 3) {
+                $this->edebug('Connection: closed');
+            }
         }
-        break;
-      }
-      // Now check if reads took too long
-      if ($endtime) {
-        if (time() > $endtime) {
-          if($this->do_debug >= 4) {
-            $this->edebug('SMTP -> get_lines(): timelimit reached (' . $this->Timelimit . ' seconds)');
-          }
-          break;
-        }
-      }
     }
-    return $data;
-  }
 
+    /**
+     * Send an SMTP DATA command.
+     * Issues a data command and sends the msg_data to the server,
+     * finializing the mail transaction. $msg_data is the message
+     * that is to be send with the headers. Each header needs to be
+     * on a single line followed by a <CRLF> with the message headers
+     * and the message body being separated by and additional <CRLF>.
+     * Implements rfc 821: DATA <CRLF>
+     * @param string $msg_data Message data to send
+     * @access public
+     * @return boolean
+     */
+    public function data($msg_data)
+    {
+        if (!$this->sendCommand('DATA', 'DATA', 354)) {
+            return false;
+        }
+        /* The server is ready to accept data!
+         * According to rfc821 we should not send more than 1000 characters on a single line (including the CRLF)
+         * so we will break the data up into lines by \r and/or \n then if needed we will break each of those into
+         * smaller lines to fit within the limit.
+         * We will also look for lines that start with a '.' and prepend an additional '.'.
+         * NOTE: this does not count towards line-length limit.
+         */
+
+        // Normalize line breaks before exploding
+        $lines = explode("\n", str_replace(array("\r\n", "\r"), "\n", $msg_data));
+
+        /* To distinguish between a complete RFC822 message and a plain message body, we check if the first field
+         * of the first line (':' separated) does not contain a space then it _should_ be a header and we will
+         * process all lines before a blank line as headers.
+         */
+
+        $field = substr($lines[0], 0, strpos($lines[0], ':'));
+        $in_headers = false;
+        if (!empty($field) && strpos($field, ' ') === false) {
+            $in_headers = true;
+        }
+
+        foreach ($lines as $line) {
+            $lines_out = array();
+            if ($in_headers and $line == '') {
+                $in_headers = false;
+            }
+            // ok we need to break this line up into several smaller lines
+            //This is a small micro-optimisation: isset($str[$len]) is equivalent to (strlen($str) > $len)
+            while (isset($line[self::MAX_LINE_LENGTH])) {
+                //Working backwards, try to find a space within the last MAX_LINE_LENGTH chars of the line to break on
+                //so as to avoid breaking in the middle of a word
+                $pos = strrpos(substr($line, 0, self::MAX_LINE_LENGTH), ' ');
+                if (!$pos) { //Deliberately matches both false and 0
+                    //No nice break found, add a hard break
+                    $pos = self::MAX_LINE_LENGTH - 1;
+                    $lines_out[] = substr($line, 0, $pos);
+                    $line = substr($line, $pos);
+                } else {
+                    //Break at the found point
+                    $lines_out[] = substr($line, 0, $pos);
+                    //Move along by the amount we dealt with
+                    $line = substr($line, $pos + 1);
+                }
+                /* If processing headers add a LWSP-char to the front of new line
+                 * RFC822 section 3.1.1
+                 */
+                if ($in_headers) {
+                    $line = "\t" . $line;
+                }
+            }
+            $lines_out[] = $line;
+
+            // Send the lines to the server
+            foreach ($lines_out as $line_out) {
+                //RFC2821 section 4.5.2
+                if (!empty($line_out) and $line_out[0] == '.') {
+                    $line_out = '.' . $line_out;
+                }
+                $this->client_send($line_out . self::CRLF);
+            }
+        }
+
+        // Message data has been sent, complete the command
+        return $this->sendCommand('DATA END', '.', 250);
+    }
+
+    /**
+     * Send an SMTP HELO or EHLO command.
+     * Used to identify the sending server to the receiving server.
+     * This makes sure that client and server are in a known state.
+     * Implements RFC 821: HELO <SP> <domain> <CRLF>
+     * and RFC 2821 EHLO.
+     * @param string $host The host name or IP to connect to
+     * @access public
+     * @return boolean
+     */
+    public function hello($host = '')
+    {
+        // Try extended hello first (RFC 2821)
+        return (boolean)($this->sendHello('EHLO', $host) or $this->sendHello('HELO', $host));
+    }
+
+    /**
+     * Send an SMTP HELO or EHLO command.
+     * Low-level implementation used by hello()
+     * @see hello()
+     * @param string $hello The HELO string
+     * @param string $host The hostname to say we are
+     * @access protected
+     * @return boolean
+     */
+    protected function sendHello($hello, $host)
+    {
+        $noerror = $this->sendCommand($hello, $hello . ' ' . $host, 250);
+        $this->helo_rply = $this->last_reply;
+        return $noerror;
+    }
+
+    /**
+     * Send an SMTP MAIL command.
+     * Starts a mail transaction from the email address specified in
+     * $from. Returns true if successful or false otherwise. If True
+     * the mail transaction is started and then one or more recipient
+     * commands may be called followed by a data command.
+     * Implements rfc 821: MAIL <SP> FROM:<reverse-path> <CRLF>
+     * @param string $from Source address of this message
+     * @access public
+     * @return boolean
+     */
+    public function mail($from)
+    {
+        $useVerp = ($this->do_verp ? ' XVERP' : '');
+        return $this->sendCommand(
+            'MAIL FROM',
+            'MAIL FROM:<' . $from . '>' . $useVerp,
+            250
+        );
+    }
+
+    /**
+     * Send an SMTP QUIT command.
+     * Closes the socket if there is no error or the $close_on_error argument is true.
+     * Implements from rfc 821: QUIT <CRLF>
+     * @param boolean $close_on_error Should the connection close if an error occurs?
+     * @access public
+     * @return boolean
+     */
+    public function quit($close_on_error = true)
+    {
+        $noerror = $this->sendCommand('QUIT', 'QUIT', 221);
+        $err = $this->error; //Save any error
+        if ($noerror or $close_on_error) {
+            $this->close();
+            $this->error = $err; //Restore any error from the quit command
+        }
+        return $noerror;
+    }
+
+    /**
+     * Send an SMTP RCPT command.
+     * Sets the TO argument to $toaddr.
+     * Returns true if the recipient was accepted false if it was rejected.
+     * Implements from rfc 821: RCPT <SP> TO:<forward-path> <CRLF>
+     * @param string $toaddr The address the message is being sent to
+     * @access public
+     * @return boolean
+     */
+    public function recipient($toaddr)
+    {
+        return $this->sendCommand(
+            'RCPT TO',
+            'RCPT TO:<' . $toaddr . '>',
+            array(250, 251)
+        );
+    }
+
+    /**
+     * Send an SMTP RSET command.
+     * Abort any transaction that is currently in progress.
+     * Implements rfc 821: RSET <CRLF>
+     * @access public
+     * @return boolean True on success.
+     */
+    public function reset()
+    {
+        return $this->sendCommand('RSET', 'RSET', 250);
+    }
+
+    /**
+     * Send a command to an SMTP server and check its return code.
+     * @param string $command       The command name - not sent to the server
+     * @param string $commandstring The actual command to send
+     * @param integer|array $expect     One or more expected integer success codes
+     * @access protected
+     * @return boolean True on success.
+     */
+    protected function sendCommand($command, $commandstring, $expect)
+    {
+        if (!$this->connected()) {
+            $this->error = array(
+                'error' => "Called $command without being connected"
+            );
+            return false;
+        }
+        $this->client_send($commandstring . self::CRLF);
+
+        $reply = $this->get_lines();
+        $code = substr($reply, 0, 3);
+
+        if ($this->do_debug >= 2) {
+            $this->edebug('SERVER -> CLIENT: ' . $reply);
+        }
+
+        if (!in_array($code, (array)$expect)) {
+            $this->last_reply = null;
+            $this->error = array(
+                'error' => "$command command failed",
+                'smtp_code' => $code,
+                'detail' => substr($reply, 4)
+            );
+            if ($this->do_debug >= 1) {
+                $this->edebug(
+                    'SMTP ERROR: ' . $this->error['error'] . ': ' . $reply
+                );
+            }
+            return false;
+        }
+
+        $this->last_reply = $reply;
+        $this->error = array();
+        return true;
+    }
+
+    /**
+     * Send an SMTP SAML command.
+     * Starts a mail transaction from the email address specified in $from.
+     * Returns true if successful or false otherwise. If True
+     * the mail transaction is started and then one or more recipient
+     * commands may be called followed by a data command. This command
+     * will send the message to the users terminal if they are logged
+     * in and send them an email.
+     * Implements rfc 821: SAML <SP> FROM:<reverse-path> <CRLF>
+     * @param string $from The address the message is from
+     * @access public
+     * @return boolean
+     */
+    public function sendAndMail($from)
+    {
+        return $this->sendCommand('SAML', "SAML FROM:$from", 250);
+    }
+
+    /**
+     * Send an SMTP VRFY command.
+     * @param string $name The name to verify
+     * @access public
+     * @return boolean
+     */
+    public function verify($name)
+    {
+        return $this->sendCommand('VRFY', "VRFY $name", array(250, 251));
+    }
+
+    /**
+     * Send an SMTP NOOP command.
+     * Used to keep keep-alives alive, doesn't actually do anything
+     * @access public
+     * @return boolean
+     */
+    public function noop()
+    {
+        return $this->sendCommand('NOOP', 'NOOP', 250);
+    }
+
+    /**
+     * Send an SMTP TURN command.
+     * This is an optional command for SMTP that this class does not support.
+     * This method is here to make the RFC821 Definition complete for this class
+     * and _may_ be implemented in future
+     * Implements from rfc 821: TURN <CRLF>
+     * @access public
+     * @return boolean
+     */
+    public function turn()
+    {
+        $this->error = array(
+            'error' => 'The SMTP TURN command is not implemented'
+        );
+        if ($this->do_debug >= 1) {
+            $this->edebug('SMTP NOTICE: ' . $this->error['error']);
+        }
+        return false;
+    }
+
+    /**
+     * Send raw data to the server.
+     * @param string $data The data to send
+     * @access public
+     * @return integer|boolean The number of bytes sent to the server or false on error
+     */
+    public function client_send($data)
+    {
+        if ($this->do_debug >= 1) {
+            $this->edebug("CLIENT -> SERVER: $data");
+        }
+        return fwrite($this->smtp_conn, $data);
+    }
+
+    /**
+     * Get the latest error.
+     * @access public
+     * @return array
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * Get the last reply from the server.
+     * @access public
+     * @return string
+     */
+    public function getLastReply()
+    {
+        return $this->last_reply;
+    }
+
+    /**
+     * Read the SMTP server's response.
+     * Either before eof or socket timeout occurs on the operation.
+     * With SMTP we can tell if we have more lines to read if the
+     * 4th character is '-' symbol. If it is a space then we don't
+     * need to read anything else.
+     * @access protected
+     * @return string
+     */
+    protected function get_lines()
+    {
+        // If the connection is bad, give up straight away
+        if (!is_resource($this->smtp_conn)) {
+            return '';
+        }
+        $data = '';
+        $endtime = 0;
+        stream_set_timeout($this->smtp_conn, $this->Timeout);
+        if ($this->Timelimit > 0) {
+            $endtime = time() + $this->Timelimit;
+        }
+        while (is_resource($this->smtp_conn) && !feof($this->smtp_conn)) {
+            $str = @fgets($this->smtp_conn, 515);
+            if ($this->do_debug >= 4) {
+                $this->edebug("SMTP -> get_lines(): \$data was \"$data\"");
+                $this->edebug("SMTP -> get_lines(): \$str is \"$str\"");
+            }
+            $data .= $str;
+            if ($this->do_debug >= 4) {
+                $this->edebug("SMTP -> get_lines(): \$data is \"$data\"");
+            }
+            // If 4th character is a space, we are done reading, break the loop, micro-optimisation over strlen
+            if ((isset($str[3]) and $str[3] == ' ')) {
+                break;
+            }
+            // Timed-out? Log and break
+            $info = stream_get_meta_data($this->smtp_conn);
+            if ($info['timed_out']) {
+                if ($this->do_debug >= 4) {
+                    $this->edebug(
+                        'SMTP -> get_lines(): timed-out (' . $this->Timeout . ' sec)'
+                    );
+                }
+                break;
+            }
+            // Now check if reads took too long
+            if ($endtime and time() > $endtime) {
+                if ($this->do_debug >= 4) {
+                    $this->edebug(
+                        'SMTP -> get_lines(): timelimit reached ('.
+                        $this->Timelimit . ' sec)'
+                    );
+                }
+                break;
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Enable or disable VERP address generation.
+     * @param boolean $enabled
+     */
+    public function setVerp($enabled = false)
+    {
+        $this->do_verp = $enabled;
+    }
+
+    /**
+     * Get VERP address generation mode.
+     * @return boolean
+     */
+    public function getVerp()
+    {
+        return $this->do_verp;
+    }
+
+    /**
+     * Set debug output method.
+     * @param string $method The function/method to use for debugging output.
+     */
+    public function setDebugOutput($method = 'echo')
+    {
+        $this->Debugoutput = $method;
+    }
+
+    /**
+     * Get debug output method.
+     * @return string
+     */
+    public function getDebugOutput()
+    {
+        return $this->Debugoutput;
+    }
+
+    /**
+     * Set debug output level.
+     * @param integer $level
+     */
+    public function setDebugLevel($level = 0)
+    {
+        $this->do_debug = $level;
+    }
+
+    /**
+     * Get debug output level.
+     * @return integer
+     */
+    public function getDebugLevel()
+    {
+        return $this->do_debug;
+    }
+
+    /**
+     * Set SMTP timeout.
+     * @param integer $timeout
+     */
+    public function setTimeout($timeout = 0)
+    {
+        $this->Timeout = $timeout;
+    }
+
+    /**
+     * Get SMTP timeout.
+     * @return integer
+     */
+    public function getTimeout()
+    {
+        return $this->Timeout;
+    }
 }


### PR DESCRIPTION
I found the PHPMailer deployed (v5.2.6) unable to send mail with attachments (PDF in my case). Despite the correct settings (var_dumped the mailer object before calling `Send()`) i always receive empty emails (no body despite a body was set) and no attachment.
After several hours of playing around and breaking my head i decided to checkout the latest PHPMailer from github and try to send mail directly (without the use of JMail). And it worked right out of the box. Everything arrived as intended.

Since PHPMailer evolved (its v5.2.8 now) several slight changes where applied. Those relevant for Joomla! were part of my refactoring. In fact these changes are only case changes of the method names to call from PHPMailer and adding two more imports to the head of JMail. With these changes sending mail with and without attachments works properly (at least for me).

But i suppose the automated tests require some changes regarding the method name case changes.
