### PR TITLE
[#34035] Errors uninstalling partially a package & reinstalling it

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1870,7 +1870,7 @@ class JInstaller extends JAdapter
 		$allXmlFiles    = JFolder::files($this->getPath('source'), '.xml$', 1, true);
 
 		// Create an unique array of files ordered by priority
-		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
+		$xmlfiles = array_unique(@array_merge($parentXmlfiles, $allXmlFiles));
 
 		// If at least one XML file exists
 		if (!empty($xmlfiles))

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1870,7 +1870,7 @@ class JInstaller extends JAdapter
 		$allXmlFiles    = JFolder::files($this->getPath('source'), '.xml$', 1, true);
 
 		// Create an unique array of files ordered by priority
-		$xmlfiles = array_unique(@array_merge($parentXmlfiles, $allXmlFiles));
+		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
 
 		// If at least one XML file exists
 		if (!empty($xmlfiles))

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -507,7 +507,7 @@ abstract class JFolder
 		{
 			JLog::add(JText::sprintf('JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES', $path), JLog::WARNING, 'jerror');
 
-			return false;
+			return array();
 		}
 
 		// Compute the excludefilter string


### PR DESCRIPTION
Copy description from http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34035&start=0
### Issue

Errors uninstalling partially a package & reinstallint it (see how to reproduce) :
Into the Backend you will have the Warning messages :

**Warning**

JFolder: :files: Path is not a folder. Path: /administrator/components/com_mycomponent
JFolder: :files: Path is not a folder. Path: /administrator/components/com_ mycomponent
JInstaller: :Install: Cannot find XML setup file
JFolder: :files: Path is not a folder. Path: /components/com_ mycomponent
JFolder: :files: Path is not a folder. Path: /components/com_ mycomponent
JInstaller: :Install: Cannot find XML setup file

And into the apache error log :

Warning:  array_unique() expects parameter 1 to be array, null given in \site-joomla33\libraries\cms\installer\installer.php on line 1873, referer: http://localhost/site-joomla33/administrator/index.php?option=com_installer
### Testing

Have a Joomla package with a component and plugin

Uninstall the component ‘only’ (not the package) using Extensions/Manager (you will keep the package and plugin)

Reinstall the whole package (which include the extension: component & plugin)

You will have the error (displayed & error log)
