### PR TITLE
[#34036] Fix deleting in JHelperTags for #_ucm_content only entries

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -351,7 +351,17 @@ class JHelperTags extends JHelper
 		 */
 		$ucmContentTable = JTable::getInstance('Corecontent');
 
-		return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
+		// Avoid deleting complete UCM entries
+		if ($table instanceof JTableCorecontent)
+		{
+
+			return $result;
+		}
+		else
+		{
+
+			return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
+		}
 	}
 
 	/**

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -357,11 +357,8 @@ class JHelperTags extends JHelper
 
 			return $result;
 		}
-		else
-		{
 
-			return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
-		}
+		return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
 	}
 
 	/**


### PR DESCRIPTION
Hi,
Currently JHelperTags not considering about purely UCM data when deleting last tag. It's just remove entry from #_ucm_content table when saving after removing last tag.
This fix checks the whether $table type is JTableCorecontent and if so, not remove #_ucm_content entry.

 Issue Tracker Item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34036&start=0
