### PR TITLE
[#33048] Wrong JText causes mixed string use

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -376,7 +376,7 @@ class UsersModelRegistration extends JModelForm
 		// Store the data.
 		if (!$user->save())
 		{
-			$this->setError($user->getError());
+			$this->setError('COM_USERS_REGISTRATION_SAVE_FAILED', $user->getError());
 			return false;
 		}
 


### PR DESCRIPTION
this change is regarding Joomla tracker issue [#33048] Wrong JText causes mixed string use
