### PR TITLE
[#34025] Batch copy feature should not copy hits value

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -114,6 +114,9 @@ class ContentModelArticle extends JModelAdmin
 
 			// Reset the ID because we are making a copy
 			$table->id = 0;
+			
+			// Reset hits because we are making a copy
+ 			$table->hits = 0;			
 
 			// New category ID
 			$table->catid = $categoryId;


### PR DESCRIPTION
Copied article should have 0 hits because this is a new article and nobody have seen it yet. 

Joomla Tracker Item (I've reported this bug for Joomla 3.3, but it present in Joomla 2.5 too):
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34025&start=0

PR for Joomla 3.3:
https://github.com/joomla/joomla-cms/pull/4050
