### PR TITLE
[#34040] Fixed PHP Warning

### DIFF
--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -956,21 +956,28 @@ abstract class JString
 	 */
 	public static function parse_url($url)
 	{
-		$result = array();
+		$result = false;
+
 		// Build arrays of values we need to decode before parsing
-		$entities = array('%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%25', '%23', '%5B',
-			'%5D');
-		$replacements = array('!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "%", "#", "[", "]");
+		$entities = array('%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D');
+		$replacements = array('!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "#", "[", "]");
+
 		// Create encoded URL with special URL characters decoded so it can be parsed
 		// All other characters will be encoded
 		$encodedURL = str_replace($entities, $replacements, urlencode($url));
+
 		// Parse the encoded URL
 		$encodedParts = parse_url($encodedURL);
+
 		// Now, decode each value of the resulting array
-		foreach ($encodedParts as $key => $value)
+		if ($encodedParts)
 		{
-			$result[$key] = urldecode($value);
+			foreach ($encodedParts as $key => $value)
+			{
+				$result[$key] = urldecode(str_replace($replacements, $entities, $value));
+			}
 		}
+
 		return $result;
 	}
 }


### PR DESCRIPTION
PHP Warning:  Invalid argument supplied for foreach() in libraries/joomla/string/string.php on line 970

In addition, under no circumstance the function was able to return null.
I've updated the function to reflect its description and return false in case of badly formed URL.

http://code.joomla.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34040&start=0
