### PR TITLE
JAccess::checkGroup() doesn't work without an $asset

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -141,10 +141,9 @@ class JAccess
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			// TODO: $rootId doesn't seem to be used!
 			$db = JFactory::getDbo();
 			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
-			$rootId = $assets->getRootId();
+			$asset = $assets->getRootId();
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.


### PR DESCRIPTION
# Executive summary

JAccess::checkGroup() does not work when the optional third argument $asset is not defined. This is in stark contrast with the docblock which states that it "Defaults to the global asset node."
# Technical explanation

The root caused is a botched copy-pasted if-block spanning lines 144-147. It was copied from lines 101-104 except the last line `$asset = $rootId` was never copied. As a result, whenever $asset is empty we look into the `#__assets` table, get the root asset ID... and never use it. This causes null to always be returned, even if the given group does have the requested global privilege enabled.

The solution is to merely change line 144 from `$rootId = $assets->getRootId();` to `$asset = $assets->getRootId();` as it was intended.
# Testing

Unless you are using the affected method in your own custom code you will not be able to reproduce this issue. Apparently everyone was avoiding to use checkGroup because it's buggy but nobody figured out why.
