### PR TITLE
[#34027] Add ability to override the renderer [New feature 3.x]

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -275,13 +275,12 @@ class JDocument
 
 		if (empty(self::$instances[$signature]))
 		{
-			$app      = JFactory::getApplication();
-			$template = $app->getTemplate();
+			$template = JFactory::getApplication()->getTemplate();
 			$type     = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$ntype    = null;
 
 			// Determine the path and class
-			$class = 'JDocument' . $type;
+			$class    = 'JDocument' . $type;
 
 			if (!class_exists($class))
 			{
@@ -1015,12 +1014,11 @@ class JDocument
 	public function loadRenderer($type)
 	{
 		$class = 'JDocumentRenderer' . $type;
-		$app = JFactory::getApplication();
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
-			$template = $app->getTemplate();
+			$template = JFactory::getApplication()->getTemplate();
 
 			if (file_exists(JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1022,7 +1022,7 @@ class JDocument
 
 			if (file_exists(JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path =  JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path = JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -128,6 +128,14 @@ class JDocument
 	public $_profile = '';
 
 	/**
+	 * The full path to active template index.php
+	 *
+	 * @var    string
+	 * @since  3.4
+	 */
+	public $_file = '';
+
+	/**
 	 * Array of linked scripts
 	 *
 	 * @var    array
@@ -275,9 +283,16 @@ class JDocument
 
 		if (empty(self::$instances[$signature]))
 		{
+			$app = JFactory::getApplication();
+			$template = $app->getTemplate();
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
+
+			if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+			{
+				$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+			}
 
 			// Check if the document type exists
 			if (!file_exists($path))
@@ -292,10 +307,15 @@ class JDocument
 
 			if (!class_exists($class))
 			{
-				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
-
-				if (file_exists($path))
+				if (file_exists(__DIR__ . '/' . $type . '/' . $type . '.php') || file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
 				{
+					$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+
+					if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+					{
+						$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+					}
+
 					require_once $path;
 				}
 				else
@@ -1007,10 +1027,25 @@ class JDocument
 	public function loadRenderer($type)
 	{
 		$class = 'JDocumentRenderer' . $type;
+		$app = JFactory::getApplication();
 
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
+
+			if (!empty($this->_file) && file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			{
+				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+			}
+			else
+			{
+				$template = $app->getTemplate();
+
+				if (file_exists( JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+				{
+					$path =  JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				}
+			}
 
 			if (file_exists($path))
 			{

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1041,9 +1041,9 @@ class JDocument
 			{
 				$template = $app->getTemplate();
 
-				if (file_exists( JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+				if (file_exists( JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 				{
-					$path =  JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+					$path =  JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 				}
 			}
 

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -128,14 +128,6 @@ class JDocument
 	public $_profile = '';
 
 	/**
-	 * The full path to active template index.php
-	 *
-	 * @var    string
-	 * @since  3.4
-	 */
-	public $_file = '';
-
-	/**
 	 * Array of linked scripts
 	 *
 	 * @var    array
@@ -307,7 +299,7 @@ class JDocument
 
 			if (!class_exists($class))
 			{
-				if (file_exists(__DIR__ . '/' . $type . '/' . $type . '.php') || file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
+				if (file_exists(__DIR__ . '/' . $type . '/' . $type . '.php'))
 				{
 					$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 
@@ -1032,19 +1024,11 @@ class JDocument
 		if (!class_exists($class))
 		{
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
+			$template = $app->getTemplate();
 
-			if (!empty($this->_file) && file_exists(dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if (file_exists( JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path = dirname($this->_file) . '/document/' . $this->_type . '/renderer/' . $type . '.php';
-			}
-			else
-			{
-				$template = $app->getTemplate();
-
-				if (file_exists( JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
-				{
-					$path =  JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
-				}
+				$path =  JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -1026,9 +1026,9 @@ class JDocument
 			$path = __DIR__ . '/' . $this->_type . '/renderer/' . $type . '.php';
 			$template = $app->getTemplate();
 
-			if (file_exists( JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
+			if (file_exists(JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php'))
 			{
-				$path =  JPATH_THEMES .'/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
+				$path =  JPATH_THEMES . '/' . $template . '/document/' . $this->_type . '/renderer/' . $type . '.php';
 			}
 
 			if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -275,10 +275,10 @@ class JDocument
 
 		if (empty(self::$instances[$signature]))
 		{
-			$app = JFactory::getApplication();
+			$app      = JFactory::getApplication();
 			$template = $app->getTemplate();
-			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
-			$ntype = null;
+			$type     = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
+			$ntype    = null;
 
 			// Determine the path and class
 			$class = 'JDocument' . $type;
@@ -296,10 +296,10 @@ class JDocument
 				{
 					// Default to the raw format
 					$ntype = $type;
-					$type = 'raw';
+					$type  = 'raw';
 					$class = 'JDocument' . $type;
-					
-					$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+
+					$path  = __DIR__ . '/' . $type . '/' . $type . '.php';
 				}
 
 				if (file_exists($path))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -278,36 +278,32 @@ class JDocument
 			$app = JFactory::getApplication();
 			$template = $app->getTemplate();
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
-			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 			$ntype = null;
-
-			if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
-			{
-				$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
-			}
-
-			// Check if the document type exists
-			if (!file_exists($path))
-			{
-				// Default to the raw format
-				$ntype = $type;
-				$type = 'raw';
-			}
 
 			// Determine the path and class
 			$class = 'JDocument' . $type;
 
 			if (!class_exists($class))
 			{
-				if (file_exists(__DIR__ . '/' . $type . '/' . $type . '.php'))
+				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+
+				if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
 				{
+					$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
+				}
+				// Check if the document type exists
+				elseif (!file_exists($path))
+				{
+					// Default to the raw format
+					$ntype = $type;
+					$type = 'raw';
+					$class = 'JDocument' . $type;
+					
 					$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+				}
 
-					if (file_exists(JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php'))
-					{
-						$path = JPATH_THEMES . '/' . $template . '/' . 'document' . '/' . $type . '/' . $type . '.php';
-					}
-
+				if (file_exists($path))
+				{
 					require_once $path;
 				}
 				else

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -18,23 +18,34 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	protected $object;
 
 	/**
-	 * Sets up the fixture, for example, open a network connection.
-	 * This method is called before a test is executed.
+	 * Setup for testing.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1.4
 	 */
 	protected function setUp()
 	{
 		parent::setUp();
 
+		$this->saveFactoryState();
+		JFactory::$application = $app;
+
 		$this->object = new JDocument;
 	}
 
 	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   3.1.4
 	 */
 	protected function tearDown()
 	{
 		JDocument::$_buffer = null;
+		$this->restoreFactoryState();
 
 		parent::tearDown();
 	}

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -28,6 +28,10 @@ class JDocumentTest extends TestCase
 	{
 		parent::setUp();
 
+		// Set up the mock application and mock the getTemplate method
+		$app = $this->getMockCmsApp();
+		$app->expects($this->any())->method('getTemplate')->willReturn('foobar');
+
 		$this->saveFactoryState();
 		JFactory::$application = $app;
 

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -10,7 +10,7 @@
 /**
  * Test class for JDocument.
  */
-class JDocumentTest extends PHPUnit_Framework_TestCase
+class JDocumentTest extends TestCase
 {
 	/**
 	 * @var  JDocument


### PR DESCRIPTION
# Scope

In Joomla! if you want to override something you have to put it in the active template directory (e.g.: the layouts goes in (active template)/html/layouts).
This PR introduces the ability to override the whole rendering code in the template by copying (and modifying per your preferences) the /libraries/joomla/document directory.

It shouldn't rise any backward compatibility issues (except that the directory [active template]/document might be in use?).
# What you can do if this gets accepted?

Because renderers are the place where the code gets from arrays and strings to actual html, xml, raw, feed or json, you can do pretty much whatever you want.
Some examples of creative code that can be put in the renderers:
Put custom code in renderer html (eg minifier, remove <JDoc )
Create custom code for head (e.g.. scripts and css concatenation and minification, custom metas, scripts to bottom, etc)
Mess around with the error page and feed in creative ways
Or go all the way and get mustache or twig in the template
# Why?

Because this is one area that if you want to override and use your own logic you have to do it through a plugin (this is way easier and cleaner).
Right now if you want to override the default renderers of Joomla! you have to use a plugin like https://gist.github.com/dongilbert/3237387 from @dongilbert 
But then again templates should not depend on plugins
# Test instructions:

Apply the patch
assuming selected template: protostar
create directory named document in /templates/protostar
copy the folder html from /libraries/joomla/document to protostar/document
So you have /templates/protostar/document/html/html.php
edit html.php (in protostar foolder...)
In the last function _fetchTemplate()
replace the line before return so it will be like
`$this->_template = $this->_loadTemplate($directory . '/' . $template, $file). '<!-- comment -->’;`
(Add a comment after the document)
Refresh the page, see the source at the bottom you should have <!-- comment -->
You just overrided the render!

Feature tracker: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34027

This one replaces PR #4052 
