### PR TITLE
[#34041] JToolbar Popup button modal icon class not customizable

### DIFF
--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -14,10 +14,10 @@ JHtml::_('behavior.multiselect');
 JHtml::_('behavior.modal', 'a.modal');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user       = JFactory::getUser();
+$userId     = $user->get('id');
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
 $sortFields = $this->getSortFields();
 ?>
 <script type="text/javascript">
@@ -39,7 +39,7 @@ $sortFields = $this->getSortFields();
 
 	Joomla.closeModalDialog = function()
 	{
-		window.jQuery('#modal-export').modal('hide');
+		window.jQuery('#modal-download').modal('hide');
 	}
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=tracks'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_banners/views/tracks/view.html.php
+++ b/administrator/components/com_banners/views/tracks/view.html.php
@@ -33,9 +33,9 @@ class BannersViewTracks extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -48,8 +48,11 @@ class BannersViewTracks extends JViewLegacy
 		BannersHelper::addSubmenu('tracks');
 
 		$this->addToolbar();
+
 		require_once JPATH_COMPONENT . '/models/fields/bannerclient.php';
+
 		$this->sidebar = JHtmlSidebar::render();
+
 		parent::display($tpl);
 	}
 
@@ -69,7 +72,7 @@ class BannersViewTracks extends JViewLegacy
 		JToolbarHelper::title(JText::_('COM_BANNERS_MANAGER_TRACKS'), 'bookmark banners-tracks');
 
 		$bar = JToolBar::getInstance('toolbar');
-		$bar->appendButton('Popup', 'export', 'JTOOLBAR_EXPORT', 'index.php?option=com_banners&amp;view=download&amp;tmpl=component', 600, 300);
+		$bar->appendButton('Popup', 'download', 'JTOOLBAR_EXPORT', 'index.php?option=com_banners&amp;view=download&amp;tmpl=component', 600, 300);
 
 		if ($canDo->get('core.delete'))
 		{

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -15,6 +15,6 @@ $text   = $displayData['text'];
 $name   = $displayData['name'];
 ?>
 <button onclick="<?php echo $doTask; ?>" class="btn btn-small modal" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
-	<i class="icon-cog"></i>
+	<i class="<?php echo $class; ?>"></i>
 	<?php echo $text; ?>
 </button>


### PR DESCRIPTION
### How to test
1. Access the Backend Banner Manager 
2. Access the "Trackes" view
3. See the icon bevor the "Export" Button (icon-cog)
4. apply patch
5. see the download icon (icon-download)
### Why change export --> download

We have no icon-export see: http://www.nonr.nl/jui/index.php/icons

But a download icon (icon-download)
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34041&start=0
