### PR TITLE
Correcting missing Hathor css after PRs #4075 and # #4077

### DIFF
--- a/administrator/templates/hathor/css/colour_blue.css
+++ b/administrator/templates/hathor/css/colour_blue.css
@@ -1204,6 +1204,12 @@ a img.calendar {
 .icon-32-envelope {
 	background-image: url(../images/toolbar/icon-32-messaging.png);
 }
+.icon-32-download {
+	background-image: url(../images/toolbar/icon-32-export.png);
+}
+.icon-32-bars {
+	background-image: url(../images/toolbar/icon-32-stats.png);
+}
 .icon-48-categories {
 	background-image: url(../images/header/icon-48-category.png);
 }

--- a/administrator/templates/hathor/css/colour_brown.css
+++ b/administrator/templates/hathor/css/colour_brown.css
@@ -1204,6 +1204,12 @@ a img.calendar {
 .icon-32-envelope {
 	background-image: url(../images/toolbar/icon-32-messaging.png);
 }
+.icon-32-download {
+	background-image: url(../images/toolbar/icon-32-export.png);
+}
+.icon-32-bars {
+	background-image: url(../images/toolbar/icon-32-stats.png);
+}
 .icon-48-categories {
 	background-image: url(../images/header/icon-48-category.png);
 }

--- a/administrator/templates/hathor/css/colour_highcontrast.css
+++ b/administrator/templates/hathor/css/colour_highcontrast.css
@@ -1276,7 +1276,7 @@ a img.calendar {
 }
 
 .icon-32-print {
-    	background-image: url(../images/toolbar/icon-32-print.png);
+	background-image: url(../images/toolbar/icon-32-print.png);
 }
 
 .icon-32-batch {
@@ -1285,6 +1285,13 @@ a img.calendar {
 
 .icon-32-envelope {
 	background-image: url(../images/toolbar/icon-32-messaging.png);
+}
+.icon-32-download {
+	background-image: url(../images/toolbar/icon-32-export.png);
+}
+
+.icon-32-bars {
+	background-image: url(../images/toolbar/icon-32-stats.png);
 }
 
 /**

--- a/administrator/templates/hathor/css/colour_standard.css
+++ b/administrator/templates/hathor/css/colour_standard.css
@@ -1204,6 +1204,12 @@ a img.calendar {
 .icon-32-envelope {
 	background-image: url(../images/toolbar/icon-32-messaging.png);
 }
+.icon-32-download {
+	background-image: url(../images/toolbar/icon-32-export.png);
+}
+.icon-32-bars {
+	background-image: url(../images/toolbar/icon-32-stats.png);
+}
 .icon-48-categories {
 	background-image: url(../images/header/icon-48-category.png);
 }

--- a/administrator/templates/hathor/less/colour_baseline.less
+++ b/administrator/templates/hathor/less/colour_baseline.less
@@ -979,6 +979,14 @@ a img.calendar {
 	background-image: url(../images/toolbar/icon-32-messaging.png);
 }
 
+.icon-32-download {
+	background-image: url(../images/toolbar/icon-32-export.png);
+}
+
+.icon-32-bars {
+	background-image: url(../images/toolbar/icon-32-stats.png);
+}
+
 /**
  * Quick Icons
  * Also knows as Header Icons


### PR DESCRIPTION
The Stats and Download icons are missing in Hathor after #4075 and #4077.
This adds the necessary css.
