### PR TITLE
JRoute::_() $ssl parameter doesn't work with "1" passed as string

### DIFF
--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -32,6 +32,7 @@ class JRoute
 	 * @param   string   $url    Absolute or Relative URI to Joomla resource.
 	 * @param   boolean  $xhtml  Replace & by &amp; for XML compilance.
 	 * @param   integer  $ssl    Secure state for the resolved URI.
+	 *                             0: (default) No change, use the protocol currently used in the request
 	 *                             1: Make URI secure using global secure site URI.
 	 *                             2: Make URI unsecure using the global unsecure site URI.
 	 *
@@ -82,7 +83,7 @@ class JRoute
 			}
 
 			// Determine which scheme we want.
-			$uri->setScheme(($ssl === 1 || $uri->isSSL()) ? 'https' : 'http');
+			$uri->setScheme(((int)$ssl === 1 || $uri->isSSL()) ? 'https' : 'http');
 			$uri->setHost($host_port[0]);
 			$uri->setPort($host_port[1]);
 			$scheme = array_merge($scheme, array('host', 'port', 'scheme'));


### PR DESCRIPTION
# Executive summary

See Joomla! forum post on [SSL issues with Joomla! 3.1](http://forum.joomla.org/viewtopic.php?f=710&t=847483) The same issue was verified by my client Ryan H. who has also confirmed the fix. Due to the way mod_login works when you have an HTTPS site and enabled mod_login's "Encrypt login form" most browsers will refuse to proceed (posting to unencrypted page from an encrypted page) and those which do allow you to proceed land you in potentially hot water as it's now possible for an intruder to perform a man-in-the-middle attack, completely negating the benefits of using HTTPS on your site. Furthermore, it's a low security issue of its own right as an HTTP site with optional HTTPS and mod_login's "Encrypt login form" set to Yes will result in the form being posted to an unencrypted (HTTP) URL, leaving the login form open to man-in-the-middle attacks.
# Technical Explanation

JRoute::_() has a third parameter $ssl which determines how JRoute should handle the resulting URL's protocol. 1 forces HTTPS, 2 forces HTTP and 0 leaves the protocol as it is. However, it doesn't recognise "1" passed as a string parameter. Coincidentally, mod_login passes this parameter as string when you set "Encrypt login form" to Yes. Due to this discrepancy in the code, if you have an HTTPS site _and_ set mod_login's "Encrypt login form" to Yes then JRoute tries to submit the login form to the unencrypted (HTTP) site as $ssl === 1 returns false, making JRoute treat the parameter as if it were 2 (force unencrypted). Big whoops!
