### PR TITLE
[#34044] xcache not working under J3.3.3

### DIFF
--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -247,13 +247,13 @@ class JCacheStorageXcache extends JCacheStorage
 			}
 
 			// We require a string with contents 0, not a null value because it is not set since that then defaults to On/True
-			if (($xcache_admin_enable_auth === '0'))
+			if ($xcache_admin_enable_auth === '0')
 			{
 				return true;
 			}
 
-			// In some enviorments empty is equivalent to Off; See #34044
-			if (empty($xcache_admin_enable_auth))
+			// In some enviorments empty is equivalent to Off; See JC: #34044 && Github: #4083
+			if ($xcache_admin_enable_auth === '')
 			{
 				return true;
 			}

--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -251,6 +251,13 @@ class JCacheStorageXcache extends JCacheStorage
 			{
 				return true;
 			}
+			
+			// In some enviorments empty is equivalent to Off; See #34044
+			if (empty($xcache_admin_enable_auth))
+			{
+				return true;
+			}
+			
 		}
 
 		// If the settings are not correct, give up

--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -251,13 +251,12 @@ class JCacheStorageXcache extends JCacheStorage
 			{
 				return true;
 			}
-			
+
 			// In some enviorments empty is equivalent to Off; See #34044
 			if (empty($xcache_admin_enable_auth))
 			{
 				return true;
 			}
-			
 		}
 
 		// If the settings are not correct, give up


### PR DESCRIPTION
### Why we need this spezial test?

In some envoirments ini_get('xcache.admin.enable_auth') is off but return empty. 
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=34044
