### PR TITLE
[#33344] Backport #3182

### DIFF
--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -86,10 +86,11 @@ abstract class JInstallerHelper
 			return false;
 		}
 
-		if (isset($response->headers['Content-Disposition']))
+		// Parse the Content-Disposition header to get the file name
+		if (isset($response->headers['Content-Disposition'])
+			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'], $parts))
 		{
-			$contentfilename = explode("\"", $response->headers['Content-Disposition']);
-			$target = $contentfilename[1];
+			$target = trim($parts[1], '"');
 		}
 
 		// Set the target path if not given


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/3182

The problem is that the current download system tries to read the filename from the Content-Disposition expecting that filename is quoted but that's not required. So in some sites (in this example from Github) the update fails.

This is the expected header by the system:
[Content-Disposition] => attachment; filename="plg_sys_mootable-1.1.1.zip"

This is the returned header from some sites: 
[Content-Disposition] => attachment; filename=plg_sys_mootable-1.1.1.zip

As you can see the filename comes without the double quotes. I replaced the file name detection to work with both systems because now it's based on the equal sign.

I provided a demo plugin to test the issue.

(see the 3.x tracker here:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33344
 to get the demo plugin)

Please attribute this to @phproberto when merging as it's all his code from 3.x
