### PR TITLE
[#34057] html characters are escaped in check-out tooltip

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -342,8 +342,8 @@ abstract class JHtmlJGrid
 		$inactive_title = JHtml::tooltipText(JText::_('JLIB_HTML_CHECKED_OUT'), $text, 0);
 
 		return static::action(
-			$i, 'checkin', $prefix, JText::_('JLIB_HTML_CHECKED_OUT'), $active_title, $inactive_title, true, 'checkedout',
-			'checkedout', $enabled, false, $checkbox
+			$i, 'checkin', $prefix, JText::_('JLIB_HTML_CHECKED_OUT'), html_entity_decode($active_title), html_entity_decode($inactive_title),
+			true, 'checkedout', 'checkedout', $enabled, false, $checkbox
 		);
 	}
 

--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -342,8 +342,8 @@ abstract class JHtmlJGrid
 		$inactive_title = JHtml::tooltipText(JText::_('JLIB_HTML_CHECKED_OUT'), $text, 0);
 
 		return static::action(
-			$i, 'checkin', $prefix, JText::_('JLIB_HTML_CHECKED_OUT'), html_entity_decode($active_title), html_entity_decode($inactive_title),
-			true, 'checkedout', 'checkedout', $enabled, false, $checkbox
+			$i, 'checkin', $prefix, JText::_('JLIB_HTML_CHECKED_OUT'), html_entity_decode($active_title, ENT_QUOTES, 'UTF-8'),
+			html_entity_decode($inactive_title, ENT_QUOTES, 'UTF-8'), true, 'checkedout', 'checkedout', $enabled, false, $checkbox
 		);
 	}
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34057
Before:

![screen shot 2014-08-11 at 11 01 18_before](https://cloud.githubusercontent.com/assets/869724/3873782/74b94c7e-2137-11e4-93eb-51e10940e84c.png)

After

![screen shot 2014-08-11 at 11 00 30_after](https://cloud.githubusercontent.com/assets/869724/3873789/7f391de6-2137-11e4-8f44-75dfdfafbda1.png)
