### PR TITLE
[#34058] Wrong css-class in user-registration tooltip

### DIFF
--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -73,7 +73,7 @@ class JFormFieldTos extends JFormFieldRadio
 		{
 			$label .= ' title="'
 				. htmlspecialchars(
-				trim($text, ':') . '::' . ($this->translateDescription ? JText::_($this->description) : $this->description),
+				trim($text, ':') . '<br />' . ($this->translateDescription ? JText::_($this->description) : $this->description),
 				ENT_COMPAT, 'UTF-8'
 			) . '"';
 		}

--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -61,7 +61,7 @@ class JFormFieldTos extends JFormFieldRadio
 		JHtml::_('behavior.modal');
 
 		// Build the class for the label.
-		$class = !empty($this->description) ? 'hasTip' : '';
+		$class = !empty($this->description) ? 'hasTooltip' : '';
 		$class = $class . ' required';
 		$class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34058
After patch

![screen shot 2014-08-11 at 12 28 32](https://cloud.githubusercontent.com/assets/869724/3874485/4c297e40-2142-11e4-9ddd-2c6baf7e4ba8.png)
