### PR TITLE
Fix fatal upgrading from 3.1 to 3.2 in some cases

### DIFF
--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -38,6 +38,12 @@ class PlgSystemRemember extends JPlugin
 	 */
 	public function onAfterInitialise()
 	{
+		// Get the application if not done by JPlugin. This may happen during upgrades from Joomla 2.5 or 3.1.
+		if (!$this->app)
+		{
+			$this->app = JFactory::getApplication();
+		}
+
 		// No remember me for admin.
 		if ($this->app->isAdmin())
 		{


### PR DESCRIPTION
Fatal error: Call to a member function isAdmin() on a non-object in xxx/plugins/system/remember/remember.php on line 42

Found when upgrading a site from 3.1 to 3.2
