### PR TITLE
Responsive tweaks to com_installer > manage

### DIFF
--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -68,19 +68,19 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<th>
 						<?php echo JHtml::_('grid.sort', 'COM_INSTALLER_HEADING_TYPE', 'type', $listDirn, $listOrder); ?>
 					</th>
-					<th width="10%" class="center">
+					<th width="10%" class="center hidden-phone">
 						<?php echo JText::_('JVERSION'); ?>
 					</th>
-					<th width="10%">
+					<th width="10%" class="hidden-phone">
 						<?php echo JText::_('JDATE'); ?>
 					</th>
-					<th width="15%">
+					<th width="15%" class="hidden-phone">
 						<?php echo JText::_('JAUTHOR'); ?>
 					</th>
-					<th>
+					<th class="hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'COM_INSTALLER_HEADING_FOLDER', 'folder', $listDirn, $listOrder); ?>
 					</th>
-					<th width="10">
+					<th width="10" class="hidden-phone">
 						<?php echo JHtml::_('grid.sort', 'COM_INSTALLER_HEADING_ID', 'extension_id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>
@@ -116,21 +116,21 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<td class="center">
 						<?php echo JText::_('COM_INSTALLER_TYPE_' . $item->type); ?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php echo @$item->version != '' ? $item->version : '&#160;'; ?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php echo @$item->creationDate != '' ? $item->creationDate : '&#160;'; ?>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<span class="editlinktip hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_INSTALLER_AUTHOR_INFORMATION'), $item->author_info, 0); ?>">
 							<?php echo @$item->author != '' ? $item->author : '&#160;'; ?>
 						</span>
 					</td>
-					<td class="center">
+					<td class="center hidden-phone">
 						<?php echo @$item->folder != '' ? $item->folder : JText::_('COM_INSTALLER_TYPE_NONAPPLICABLE'); ?>
 					</td>
-					<td>
+					<td class="hidden-phone">
 						<?php echo $item->extension_id ?>
 					</td>
 				</tr>


### PR DESCRIPTION
com_installer > Manage doesn't work well on small viewports. This PR adds hidden-phone to the following columns: version, date, author, folder and ID
# Before patch

![skaermbillede 2014-08-12 kl 15 47 11](https://cloud.githubusercontent.com/assets/1738811/3891163/680fedac-2227-11e4-8eee-1944fa0a084f.png)
# After patch

![skrmbillede 2014-08-12 kl 15 47 24](https://cloud.githubusercontent.com/assets/1738811/3891164/6810213c-2227-11e4-8a9c-61d449686474.png)
