### PR TITLE
Improve handling of "Date of Birth" (dob) infotext in user profile plugin

### DIFF
--- a/layouts/plugins/user/profile/fields/dob.php
+++ b/layouts/plugins/user/profile/fields/dob.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  */
 extract($displayData);
 
-// Closing the opening .control-group and .control-label div so we can add out info text on own line ?>
+// Closing the opening .control-group and .control-label div so we can add our info text on own line ?>
 </div><div class="controls"><?php echo $text; ?></div></div>
 <?php // Creating new .control-group and .control-label for the actual field ?>
 <div class="control-group"><div class="control-label">

--- a/layouts/plugins/user/profile/fields/dob.php
+++ b/layouts/plugins/user/profile/fields/dob.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * $text  string  infotext to be displayed
+ */
+extract($displayData);
+
+// Closing the opening .control-group and .control-label div so we can add out info text on own line ?>
+</div><div class="controls"><?php echo $text; ?></div></div>
+<?php // Creating new .control-group and .control-label for the actual field ?>
+<div class="control-group"><div class="control-label">

--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -16,7 +16,7 @@ JFormHelper::loadFieldClass('calendar');
  *
  * @package     Joomla.Plugin
  * @subpackage  User.profile
- * @since       3.3.3
+ * @since       3.3.4
  */
 class JFormFieldDob extends JFormFieldCalendar
 {
@@ -24,7 +24,7 @@ class JFormFieldDob extends JFormFieldCalendar
 	 * The form field type.
 	 *
 	 * @var    string
-	 * @since  2.5.5
+	 * @since  3.3.4
 	 */
 	protected $type = 'Dob';
 
@@ -33,7 +33,7 @@ class JFormFieldDob extends JFormFieldCalendar
 	 *
 	 * @return  string  The field label markup.
 	 *
-	 * @since   3.3.3
+	 * @since   3.3.4
 	 */
 	protected function getLabel()
 	{

--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -45,13 +45,9 @@ class JFormFieldDob extends JFormFieldCalendar
 
 		if ($text)
 		{
-			// Closing the opening control-label div so we can add out info text on own line
-			$info = '</div><div class="controls">' . $text . '</div></div>';
-
-			// Creating new control-group for the actual field
-			$info .= '<div class="control-group"><div class="control-label">';
-
-			$label = $info . $label;
+			$layout = new JLayoutFile('plugins.user.profile.fields.dob');
+			$info   = $layout->render(array('text' => $text));
+			$label  = $info . $label;
 		}
 
 		return $label;

--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  User.profile
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+JFormHelper::loadFieldClass('calendar');
+
+/**
+ * Provides input for "Date of Birth" field
+ *
+ * @package     Joomla.Plugin
+ * @subpackage  User.profile
+ * @since       3.3.3
+ */
+class JFormFieldDob extends JFormFieldCalendar
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  2.5.5
+	 */
+	protected $type = 'Dob';
+
+	/**
+	 * Method to get the field label markup.
+	 *
+	 * @return  string  The field label markup.
+	 *
+	 * @since   3.3.3
+	 */
+	protected function getLabel()
+	{
+		$label = parent::getLabel();
+
+		// Get the info text from the XML element, defaulting to empty.
+		$text = $this->element['info'] ? (string) $this->element['info'] : '';
+		$text = $this->translateLabel ? JText::_($text) : $text;
+
+		if ($text)
+		{
+			// Closing the opening control-label div so we can add out info text on own line
+			$info = '</div><div class="controls">' . $text . '</div></div>';
+
+			// Creating new control-group for the actual field
+			$info .= '<div class="control-group"><div class="control-label">';
+
+			$label = $info . $label;
+		}
+
+		return $label;
+	}
+}

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -76,8 +76,8 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 				$db->setQuery(
 					'SELECT profile_key, profile_value FROM #__user_profiles' .
-						' WHERE user_id = ' . (int) $userId . " AND profile_key LIKE 'profile.%'" .
-						' ORDER BY ordering'
+					' WHERE user_id = ' . (int) $userId . " AND profile_key LIKE 'profile.%'" .
+					' ORDER BY ordering'
 				);
 
 				try
@@ -282,16 +282,6 @@ class PlgUserProfile extends JPlugin
 					&& $this->params->get('profile-require_' . $field, 1) == 0)
 				{
 					$form->removeField($field, 'profile');
-
-					if ($field == 'dob')
-					{
-						$form->removeField('dob_spacer', 'profile');
-					}
-				}
-
-				if ($this->params->get('profile-require_dob', 1) > 0)
-				{
-					$form->setFieldAttribute('spacer', 'type', 'spacer', 'profile');
 				}
 			}
 			// Case registration
@@ -305,16 +295,6 @@ class PlgUserProfile extends JPlugin
 				else
 				{
 					$form->removeField($field, 'profile');
-
-					if ($field == 'dob')
-					{
-						$form->removeField('dob_spacer', 'profile');
-					}
-				}
-
-				if ($this->params->get('register-require_dob', 1) > 0)
-				{
-					$form->setFieldAttribute('spacer', 'type', 'spacer', 'profile');
 				}
 			}
 			// Case profile in site or admin
@@ -328,16 +308,6 @@ class PlgUserProfile extends JPlugin
 				else
 				{
 					$form->removeField($field, 'profile');
-
-					if ($field == 'dob')
-					{
-						$form->removeField('dob_spacer', 'profile');
-					}
-				}
-
-				if ($this->params->get('profile-require_dob', 1) > 0)
-				{
-					$form->setFieldAttribute('spacer', 'type', 'spacer', 'profile');
 				}
 			}
 		}
@@ -458,7 +428,7 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 				$db->setQuery(
 					'DELETE FROM #__user_profiles WHERE user_id = ' . $userId .
-						" AND profile_key LIKE 'profile.%'"
+					" AND profile_key LIKE 'profile.%'"
 				);
 
 				$db->execute();

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -76,8 +76,8 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 				$db->setQuery(
 					'SELECT profile_key, profile_value FROM #__user_profiles' .
-					' WHERE user_id = ' . (int) $userId . " AND profile_key LIKE 'profile.%'" .
-					' ORDER BY ordering'
+						' WHERE user_id = ' . (int) $userId . " AND profile_key LIKE 'profile.%'" .
+						' ORDER BY ordering'
 				);
 
 				try
@@ -428,7 +428,7 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 				$db->setQuery(
 					'DELETE FROM #__user_profiles WHERE user_id = ' . $userId .
-					" AND profile_key LIKE 'profile.%'"
+						" AND profile_key LIKE 'profile.%'"
 				);
 
 				$db->execute();

--- a/plugins/user/profile/profiles/profile.xml
+++ b/plugins/user/profile/profiles/profile.xml
@@ -105,6 +105,7 @@
 				type="dob"
 				label="PLG_USER_PROFILE_FIELD_DOB_LABEL"
 				description="PLG_USER_PROFILE_FIELD_DOB_DESC"
+				info="PLG_USER_PROFILE_SPACER_DOB"
 				format="%Y-%m-%d"
 				filter="server_utc"
 			/>

--- a/plugins/user/profile/profiles/profile.xml
+++ b/plugins/user/profile/profiles/profile.xml
@@ -100,13 +100,9 @@
 				rows="5"
 				filter="safehtml"
 			/>
-			<field name="dob_spacer" type="spacer"
-				class="text"
-				label="PLG_USER_PROFILE_SPACER_DOB"
-			/>
 			<field
 				name="dob"
-				type="calendar"
+				type="dob"
 				label="PLG_USER_PROFILE_FIELD_DOB_LABEL"
 				description="PLG_USER_PROFILE_FIELD_DOB_DESC"
 				format="%Y-%m-%d"


### PR DESCRIPTION
### Issue

Currently, the user - profile plugin uses a separate spacer field to display an info text for the "date of birth" (dob) field.
This makes it necessary to add some specific codechecks for when that spacer field should be shown or hidden. Like done in #4043.
### Proposal

This PR moves the dob field and the infotext into a custom formfield and removes the special code for the dob_spacer field.
### Questions

While trying this solution I wondered why we even have this info text separated. I think best place would actually be the tooltip, which is exactly meant for that kind of information.
The plugin currently overrides the description set in the profile.xml with a hardcoded and quite useless text. I'm not sure why that is but I guess it's for historical reasons, maybe before there was a separate profile.xml file?

Does anyone know why this was done like this?
