### PR TITLE
[#34065] Favor curl as HTTP transport

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -119,6 +119,13 @@ class JHttpFactory
 				$names[] = substr($fileName, 0, strrpos($fileName, '.'));
 			}
 		}
+		
+		// If curl is available set it to the first position
+		if ($key = array_search('curl', $names))
+		{
+			unset($names[$key]);
+			array_unshift($names, 'curl');
+		}
 
 		return $names;
 	}


### PR DESCRIPTION
As curl is the most powerful HTTP library it makes sense to prefer it as first HTTP transport option among the others. The tracker item can be found here
http://joomlacode.org/gf/project/joomla/tracker/JoomlaCode-Projects-Joomla-Browse-tracker/?action=TrackerItemEdit&tracker_item_id=34065
