### PR TITLE
[#34070] [2.5x] Import the user plugins for onUserLoginFailure

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -669,6 +669,9 @@ class JApplication extends JObject
 		$authenticate = JAuthentication::getInstance();
 		$response = $authenticate->authenticate($credentials, $options);
 
+		// Import the user plugin group.
+		JPluginHelper::importPlugin('user');
+
 		if ($response->status === JAuthentication::STATUS_SUCCESS)
 		{
 			// validate that the user should be able to login (different to being authenticated)
@@ -703,9 +706,6 @@ class JApplication extends JObject
 					}
 				}
 			}
-
-			// Import the user plugin group.
-			JPluginHelper::importPlugin('user');
 
 			// OK, the credentials are authenticated and user is authorised.  Lets fire the onLogin event.
 			$results = $this->triggerEvent('onUserLogin', array((array) $response, $options));


### PR DESCRIPTION
Backport https://github.com/joomla/joomla-cms/pull/2761 to Joomla 2.5

The onUserLoginFailure trigger is a user plugin method however on the failure code path, it isn't loaded. So this changes that to put it on the main code path ahead of the failure check.
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=34070&start=0
