### PR TITLE
Sql optimise admin menu types branch

### DIFF
--- a/administrator/components/com_menus/models/menus.php
+++ b/administrator/components/com_menus/models/menus.php
@@ -160,10 +160,8 @@ class MenusModelMenus extends JModelList
 		$query = $db->getQuery(true);
 
 		// Select all fields from the table.
-		$query->select($this->getState('list.select', 'a.*'))
-			->from($db->quoteName('#__menu_types') . ' AS a')
-
-			->group('a.id, a.menutype, a.title, a.description');
+		$query->select($this->getState('list.select', 'DISTINCT a.id, a.menutype, a.title, a.description'))
+			->from($db->quoteName('#__menu_types') . ' AS a');
 
 		// Filter by search in title or menutype
 		if ($search = trim($this->getState('filter.search')))

--- a/administrator/components/com_menus/models/menus.php
+++ b/administrator/components/com_menus/models/menus.php
@@ -160,8 +160,9 @@ class MenusModelMenus extends JModelList
 		$query = $db->getQuery(true);
 
 		// Select all fields from the table.
-		$query->select($this->getState('list.select', 'DISTINCT a.id, a.menutype, a.title, a.description'))
-			->from($db->quoteName('#__menu_types') . ' AS a');
+		$query->select($this->getState('list.select', 'a.id, a.menutype, a.title, a.description'))
+			->from($db->quoteName('#__menu_types') . ' AS a')
+			->where('a.id > 0');
 
 		// Filter by search in title or menutype
 		if ($search = trim($this->getState('filter.search')))
@@ -169,9 +170,6 @@ class MenusModelMenus extends JModelList
 			$search = $db->quote('%' . $db->escape($search, true) . '%');
 			$query->where('(' . 'a.title LIKE ' . $search . ' OR a.menutype LIKE ' . $search . ')');
 		}
-
-		// Add the list ordering clause.
-		$query->order($db->escape($this->getState('list.ordering', 'a.id')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
 		return $query;
 	}

--- a/administrator/components/com_menus/models/menus.php
+++ b/administrator/components/com_menus/models/menus.php
@@ -171,6 +171,9 @@ class MenusModelMenus extends JModelList
 			$query->where('(' . 'a.title LIKE ' . $search . ' OR a.menutype LIKE ' . $search . ')');
 		}
 
+		// Add the list ordering clause.
+		$query->order($db->escape($this->getState('list.ordering', 'a.id')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
+
 		return $query;
 	}
 


### PR DESCRIPTION
## Testing Instructions:

In order to check the query execution log in to the admin console and click menu manager. Then the query triggers. To check how the PR works, first apply the PR via the Joomla! Patch Tester and then log in to the admin console and click menu manager.

![Menu Manager](https://cloud.githubusercontent.com/assets/1329674/3903334/9b212870-22ca-11e4-86d5-29598a04fe46.png)
### Original Query before the Optimization

``` sql
    SELECT a.*
    FROM #_menu_types AS a
    GROUP BY a.id, a.menutype, a.title, a.description
    ORDER BY a.id asc
```
### After the Optimization

``` sql
    SELECT a.id, a.menutype, a.title, a.description
    FROM #_menu_types AS a
    WHERE a.id > 0
    ORDER BY a.id asc
```
### Query Change Description

In this query group by clause has been removed. Also removed the `SELECT a.*` and instead added the corresponding fields to the select clause. Also added the `WHERE` clause in order to be able to use the `PRIMARY KEY` as the index.
