### PR TITLE
Sql optimise new index merged branch

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-08-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-08-18.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `#__languages` ADD INDEX `idx_published_ordering` (`published`,`ordering`);
+ALTER TABLE `#__session` DROP PRIMARY KEY, ADD PRIMARY KEY (session_id(32));
+ALTER TABLE `#__session` DROP INDEX `time`, ADD INDEX `time` (time(10));
+ALTER TABLE `#__template_styles` ADD INDEX `idx_client_id` (`client_id`);
+ALTER TABLE `#__contentitem_tag_map` ADD INDEX `idx_alias_item_id` (`type_alias`,`content_item_id`);
+ALTER TABLE `#__extensions` ADD INDEX `idx_type_ordering` (`type`,`ordering`);
+ALTER TABLE `#__menu` ADD INDEX `idx_client_id_published_lft` (`client_id`,`published`,`lft`);
+ALTER TABLE `#__viewlevels` ADD INDEX `idx_ordering_title` (`ordering`,`title`);

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -437,7 +437,7 @@ CREATE TABLE IF NOT EXISTS `#__contentitem_tag_map` (
   KEY `idx_tag` (`tag_id`),
   KEY `idx_type` (`type_id`),
   KEY `idx_core_content_id` (`core_content_id`),
-	KEY 'idx_alias_item_id' ('type_alias','content_item_id')
+  KEY 'idx_alias_item_id' ('type_alias','content_item_id')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Maps items from content tables to tags';
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1557,9 +1557,9 @@ CREATE TABLE IF NOT EXISTS `#__session` (
   `data` mediumtext,
   `userid` int(11) DEFAULT 0,
   `username` varchar(150) DEFAULT '',
-  PRIMARY KEY (`session_id`),
+  PRIMARY KEY (`session_id`(100)),
   KEY `userid` (`userid`),
-  KEY `time` (`time`)
+  KEY `time` (`time`(10))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1,4 +1,4 @@
-SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
 
 --
@@ -1196,8 +1196,9 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   UNIQUE KEY `idx_image` (`image`),
   UNIQUE KEY `idx_langcode` (`lang_code`),
   KEY `idx_access` (`access`),
-  KEY `idx_ordering` (`ordering`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  KEY `idx_ordering` (`ordering`),
+  KEY 'idx_published_ordering' ('published','ordering')
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `#__languages`

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1561,7 +1561,7 @@ CREATE TABLE IF NOT EXISTS `#__session` (
   `data` mediumtext,
   `userid` int(11) DEFAULT 0,
   `username` varchar(150) DEFAULT '',
-  PRIMARY KEY (`session_id`(100)),
+  PRIMARY KEY (`session_id`(32)),
   KEY `userid` (`userid`),
   KEY `time` (`time`(10))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -478,8 +478,9 @@ CREATE TABLE IF NOT EXISTS `#__extensions` (
   PRIMARY KEY (`extension_id`),
   KEY `element_clientid` (`element`,`client_id`),
   KEY `element_folder_clientid` (`element`,`folder`,`client_id`),
-  KEY `extension` (`type`,`element`,`folder`,`client_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=10000;
+  KEY `extension` (`type`,`element`,`folder`,`client_id`),
+  KEY 'idx_type_ordering' ('type','ordering')
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=10000;
 
 --
 -- Dumping data for table `#__extensions`

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1632,8 +1632,9 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
   `params` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_template` (`template`),
-  KEY `idx_home` (`home`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=9;
+  KEY `idx_home` (`home`),
+  KEY 'idx_client_id' ('client_id')
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=9;
 
 --
 -- Dumping data for table `#__template_styles`

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -436,7 +436,8 @@ CREATE TABLE IF NOT EXISTS `#__contentitem_tag_map` (
   KEY `idx_date_id` (`tag_date`,`tag_id`),
   KEY `idx_tag` (`tag_id`),
   KEY `idx_type` (`type_id`),
-  KEY `idx_core_content_id` (`core_content_id`)
+  KEY `idx_core_content_id` (`core_content_id`),
+	KEY 'idx_alias_item_id' ('type_alias','content_item_id')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Maps items from content tables to tags';
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1247,8 +1247,9 @@ CREATE TABLE IF NOT EXISTS `#__menu` (
   KEY `idx_left_right` (`lft`,`rgt`),
   KEY `idx_alias` (`alias`),
   KEY `idx_path` (`path`(255)),
-  KEY `idx_language` (`language`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=102;
+  KEY `idx_language` (`language`),
+  KEY 'idx_client_id_published_lft' ('client_id','published','lft')
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=102;
 
 --
 -- Dumping data for table `#__menu`

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1965,8 +1965,9 @@ CREATE TABLE IF NOT EXISTS `#__viewlevels` (
   `ordering` int(11) NOT NULL DEFAULT 0,
   `rules` varchar(5120) NOT NULL COMMENT 'JSON encoded access control.',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_assetgroup_title_lookup` (`title`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=7;
+  UNIQUE KEY `idx_assetgroup_title_lookup` (`title`),
+  KEY `idx_ordering_title` (`ordering`,`title`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=7;
 
 --
 -- Dumping data for table `#__viewlevels`

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -477,8 +477,7 @@ final class JApplicationSite extends JApplicationCms
 				->select('id, home, template, s.params')
 				->from('#__template_styles as s')
 				->where('s.client_id = 0')
-				->where('e.enabled = 1')
-				->join('LEFT', '#__extensions as e ON e.element=s.template AND e.type=' . $db->quote('template') . ' AND e.client_id=s.client_id');
+				->join('LEFT', '#__extensions as e ON e.element=s.template AND e.type=' . $db->quote('template') . ' AND e.client_id=0 AND e.enabled = 1');
 
 			$db->setQuery($query);
 			$templates = $db->loadObjectList('id');

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -417,7 +417,40 @@ class JHelperTags extends JHelper
 
 		if ($getTagData)
 		{
-			$query->select($db->quoteName('t') . '.*');
+			$query->select(
+				array(
+					'id',
+					'parent_id',
+					'lft',
+					'rgt',
+					'level',
+					'path',
+					'title',
+					'alias',
+					'note',
+					'description',
+					'published',
+					'checked_out',
+					'checked_out_time',
+					'access',
+					'params',
+					'metadesc',
+					'metakey',
+					'metadata',
+					'created_user_id',
+					'created_time',
+					'created_by_alias',
+					'modified_user_id',
+					'modified_time',
+					'images',
+					'urls',
+					'hits',
+					'language',
+					'version',
+					'publish_up',
+					'publish_down'
+				)
+			);
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags') . ' AS t ' . ' ON ' . $db->quoteName('m.tag_id') . ' = ' . $db->quoteName('t.id'));

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -42,8 +42,9 @@ abstract class JHtmlAccess
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.title AS text')
+			->select('a.id AS value, a.title AS text')
 			->from('#__viewlevels AS a')
+			->where('a.id <> 0')
 			->order('a.ordering ASC')
 			->order($db->quoteName('title') . ' ASC');
 

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -45,7 +45,7 @@ abstract class JHtmlAccess
 			->select('a.id AS value, a.title AS text')
 			->from('#__viewlevels AS a')
 			->where('a.ordering > -1')
-			->where('a.title > "" ')
+			->where('a.title <> "" ')
 			->order('a.ordering')
 			->order($db->quoteName('title'));
 

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -44,9 +44,10 @@ abstract class JHtmlAccess
 		$query = $db->getQuery(true)
 			->select('a.id AS value, a.title AS text')
 			->from('#__viewlevels AS a')
-			->where('a.id <> 0')
-			->order('a.ordering ASC')
-			->order($db->quoteName('title') . ' ASC');
+			->where('a.ordering > -1')
+			->where('a.title > "" ')
+			->order('a.ordering')
+			->order($db->quoteName('title'));
 
 		// Get the options.
 		$db->setQuery($query);

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -42,10 +42,9 @@ abstract class JHtmlAccess
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select($db->quoteName('a.id', 'value') . ', ' . $db->quoteName('a.title', 'text'))
-			->from($db->quoteName('#__viewlevels', 'a'))
-			->group($db->quoteName(array('a.id', 'a.title', 'a.ordering')))
-			->order($db->quoteName('a.ordering') . ' ASC')
+			->select('DISTINCT a.id AS value, a.title AS text')
+			->from('#__viewlevels AS a')
+			->order('a.ordering ASC')
 			->order($db->quoteName('title') . ' ASC');
 
 		// Get the options.

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -43,11 +43,11 @@ abstract class JHtmlAccess
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select('a.id AS value, a.title AS text')
-			->from('#__viewlevels AS a')
-			->where('a.ordering > -1')
-			->where('a.title <> "" ')
-			->order('a.ordering')
-			->order($db->quoteName('title'));
+			->from($db->qn('#__viewlevels', 'a'))
+			->where($db->qn('a.ordering') . ' > -1')
+			->where($db->qn('a.title') . ' != ""')
+			->order($db->qn('a.ordering'))
+			->order($db->qn('title'));
 
 		// Get the options.
 		$db->setQuery($query);

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -155,7 +155,8 @@ class JLanguageHelper
 				{
 					$db = JFactory::getDbo();
 					$query = $db->getQuery(true)
-						->select('*')
+						->select('lang_id,lang_code,title,title_native,sef,image,description,metakey,metadesc,
+						sitename,published,access,ordering')
 						->from('#__languages')
 						->where('published=1')
 						->order('ordering ASC');

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -155,8 +155,23 @@ class JLanguageHelper
 				{
 					$db = JFactory::getDbo();
 					$query = $db->getQuery(true)
-						->select('lang_id,lang_code,title,title_native,sef,image,description,metakey,metadesc,
-						sitename,published,access,ordering')
+						->select(
+							array(
+								'lang_id',
+								'lang_code',
+								'title',
+								'title_native',
+								'sef',
+								'image',
+								'description',
+								'metakey',
+								'metadesc',
+								'sitename',
+								'published',
+								'access',
+								'ordering'
+							)
+						)
 						->from('#__languages')
 						->where('published=1')
 						->order('ordering ASC');


### PR DESCRIPTION
## Testing Instructions:

This PR consists all the PRs merged in to this one regarding the index additions. Two approaches can be followed in order to test this PR. One is in an already installed site and one is for fresh distributions.
#### For already installed sites

For already installed sites first apply the PR and then add follow the bellow commands in order to add the indexes manually to the database
- Index added to #_languages table (_You can see this query execution when you access the site_)

`ALTER TABLE #__languages ADD INDEX 'idx_published_ordering' ('published','ordering');` (#11)

**Related Query Before changes**

``` sql
  SELECT *
  FROM #__languages
  WHERE published=1
  ORDER BY ordering ASC
```

**Related Query Before changes**

``` sql
  SELECT lang_id,lang_code,title,title_native,sef,image,description,
                 metakey,metadesc,sitename,published,access,ordering
  FROM #__languages
  WHERE published=1
  ORDER BY ordering ASC
```

---
- Index added to #_session table (_Query executes every time a user access a page_)

`ALTER TABLE #__session DROP PRIMARY KEY, ADD PRIMARY KEY(session_id(32))` ( #8 )
`ALTER TABLE #__session DROP INDEX time, ADD INDEX time(time(10))`

**Index Description**
This Index added in order to speed up the session update query allowing the sub string index usages

---
- Index added to #_template_styles table (_You can see this query execution when you access the site_)

`ALTER TABLE #__template_styles ADD INDEX idx_client_id('client_id')`  ( #13 )

**Index Description**
Without applying this index the below query cannot use any index to retrieve the rows from the database. After applying this index it clearly shows in the explanation section that the query uses the index to retrieve the rows

**Related Query**

``` sql
    SELECT id, home, template, s.params 
    FROM #__template_styles as s 
    LEFT JOIN #__extensions as e 
    ON e.element=s.template 
    AND e.type='template' 
    AND e.client_id=s.client_id 
    WHERE s.client_id = 0 AND e.enabled = 1
```

---
- Index added to #__contentitem_tag_map table (_You can see this query execution when you access the site_)

`ALTER TABLE #__contentitem_tag_map ADD INDEX idx_alias_item_id ('type_alias','content_item_id')`  ( #14 )

**Index Description**
Without applying this index the below query cannot use any index to retrieve the rows from the database. After applying this index it clearly shows in the explanation section that the query uses the index to retrieve the rows. Also one another change did relevant to this index changes. Which is removing the `t.*` from the relevant query and adding the table fields instead. This change can be found (#14) and please refer to that PR also.

 **Related Query Before changes**

``` sql
    SELECT m.tag_id,t.*
    FROM #__contentitem_tag_map AS m
    INNER JOIN #__tags AS t ON m.tag_id = t.id
    WHERE m.type_alias = 'com_content.article' AND m.content_item_id = 5196 AND t.published = 1
    AND t.access IN (1,1,5)
```

**Related Query After changes**

``` sql
    SELECT m.tag_id,'id',t.parent_id,t.lft,t.rgt,t.level,t.path,t.title,t.alias,t.note,t.description,t.published,
    t.checked_out,t.checked_out_time,t.access,t.params,t.metadesc,t.metakey,t.metadata,
    t.created_user_id,t.created_time,t.created_by_alias,t.modified_user_id,t.modified_time,
    t.images,t.urls,t.hits,t.language,t.version,t.publish_up,t.publish_down
    FROM #__contentitem_tag_map AS m
    INNER JOIN #__tags AS t ON m.tag_id = t.id
    WHERE m.type_alias = 'com_content.article' AND m.content_item_id = 5196 AND t.published = 1
    AND t.access IN (1,1,5)
```

---
- Index added to #_extensions table (_You can see this query execution when you access the site_)

`ALTER TABLE #__extensions ADD INDEX 'idx_type_ordering' ('type','ordering')` ( #16 )

**Index Description**
Without applying this index the below query uses `filesort` to retrieve the rows from the database, which is an expensive retrieval operation. After applying this index it clearly shows in the explanation section that the query uses the index to retrieve the rows except the `filesort`.

**Related Query**

``` sql
    SELECT folder AS type, element AS name, params
    FROM #_extensions
    WHERE enabled >= 1
    AND type ='plugin'
    AND state >= 0
    AND access IN (1,1,5)
    ORDER BY ordering
```

---
- Index added to #_menu table (_You can see this query execution when you access the site_)

`ALTER TABLE #__menu ADD INDEX 'idx_client_id_published_lft' ('client_id','published','lft')` ( #17 )

**Index Description**
Without applying this index the below query uses `filesort` to retrieve the rows from the database, which is an expensive retrieval operation. After applying this index it clearly shows in the explanation section that the query uses the index to retrieve the rows except the `filesort`.

**Related Query**

``` sql
    FROM #_menu AS m
    LEFT JOIN #_extensions AS e
    ON m.component_id = e.extension_id
    WHERE m.published = 1
    AND m.parent_id > 0
    AND m.client_id = 0
    ORDER BY m.lft
```

---
- Index added to #__viewlevels table
  (_query Executes when clicking on the add new category in the admin console_)

![Add New Category](https://cloud.githubusercontent.com/assets/1329674/3926574/a08d6d36-23f2-11e4-9e90-57f017940161.png)

`ALTER TABLE #__viewlevels 
            ADD INDEX`idx_ordering_title`(`ordering`,`title`)`(  #21 )

**Index Description**
Without applying this index the below query uses `filesort` to retrieve the rows from the database, which is an expensive retrieval operation. After applying this index it clearly shows in the explanation section that the query uses the index to retrieve the rows except the `filesort`. Also changed the `JROOT/libraries/cms/html/access.php` file's query which is shown below by removing the `GROUP BY` clause since the `PRIMARY KEY` includes in the selected fields. And this reduce the execution time

**Related Query Before Change**

``` sql
    SELECT a.id AS value, a.title AS text
    FROM ltzvy_viewlevels AS a
    GROUP BY a.id, a.title, a.ordering
    ORDER BY a.ordering ASC,`title` ASC
```

**Related Query After Change**

``` sql
    SELECT a.id AS value, a.title AS text
    FROM ltzvy_viewlevels AS a
    ORDER BY a.ordering ASC,`title` ASC
```
