### PR TITLE
[#34056] indexer does not work properly in languages with different decimal notation

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -599,7 +599,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. str_replace(',', '.', (string) $token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 			);


### PR DESCRIPTION
[#34056] indexer does not work properly in languages with different decimal notation

== Reproduce

Have a joomla site in a language that uses comma instead of a dot for decimal places (ex: Portuguese).

Turn on search indexer content plugin.

Edit a content item in the frontend and save.
It will appear an sql error like this

Column count doesn't match value count at row 1 SQL=INSERT INTO `29i8c_finder_tokens` (`term`,`stem`,`common`,`phrase`,`weight`,`context`,`language`) VALUES ('a', 'a', 0, 0, 0,0667, 1, 'pt')

Note the "0,0667" it should be "0.0667" and the error is there.
