### PR TITLE
Allow case where sub-levels are JObject's

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -170,7 +170,24 @@ class JForm
 	protected function bindLevel($group, $data)
 	{
 		// Ensure the input data is an array.
-		settype($data, 'array');
+		if (is_object($data))
+		{
+			if ($data instanceof JRegistry)
+			{
+				// Handle a JRegistry.
+				$data = $data->toArray();
+			}
+			elseif ($data instanceof JObject)
+			{
+				// Handle a JObject.
+				$data = $data->getProperties();
+			}
+			else
+			{
+				// Handle other types of objects.
+				$data = (array) $data;
+			}
+		}
 
 		// Process the input data.
 		foreach ($data as $k => $v)


### PR DESCRIPTION
So in `JForm::bind` we deal with objects that are JRegistry, JObject or just an object. Here I port the same if block over to the bindLevel() function. So if a sub-element (such as params etc.) is also a JObject then it too can be processed in the same way.
