### PR TITLE
Correct number of records checked in show in the message to user after checked in success

### DIFF
--- a/administrator/components/com_weblinks/views/weblinks/view.html.php
+++ b/administrator/components/com_weblinks/views/weblinks/view.html.php
@@ -74,7 +74,8 @@ class WeblinksViewWeblinks extends JViewLegacy
 		{
 			JToolbarHelper::editList('weblink.edit');
 		}
-		if ($canDo->get('core.edit.state')) {
+		if ($canDo->get('core.edit.state')) 
+		{
 
 			JToolbarHelper::publish('weblinks.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('weblinks.unpublish', 'JTOOLBAR_UNPUBLISH', true);

--- a/libraries/cms/controller/admin.php
+++ b/libraries/cms/controller/admin.php
@@ -1,0 +1,630 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  Controller
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * Base class for a Joomla Administrator Controller.
+ * It implements basic methods such as: Create, Update, Delete, Publis, Check-in, Checkout..
+ *
+ * @package Joomla.CMS
+ * @subpackage Controller
+ * @since 3.5
+ */
+class JCmsControlleAdmin extends JCmsController
+{
+
+	/**
+	 * The URL view item variable.
+	 *
+	 * @var string
+	 */
+	protected $viewItem;
+
+	/**
+	 * The URL view list variable.
+	 *
+	 * @var string
+	 */
+	protected $viewList;
+
+	/**
+	 * Context, used to store user session data
+	 *
+	 * @var string
+	 */
+	protected $context;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config An optional associative array of configuration settings.
+	 *        	     	
+	 * @see JCmsControlleAdmin
+	 */
+	public function __construct(JInput $input = null, array $config = array())
+	{
+		parent::__construct($input, $config);
+		
+		$this->context = $this->option . '.' . $this->name;
+		
+		if (isset($config['view_item']))
+		{
+			$this->viewItem = $config['view_item'];
+		}
+		else
+		{
+			$this->viewItem = $this->name;
+		}
+		
+		if (isset($config['view_list']))
+		{
+			$this->viewList = $config['view_list'];
+		}
+		else
+		{
+			$this->viewList = JCmsInflector::pluralize($this->viewItem);
+		}
+		// Register tasks mapping
+		$this->registerTask('apply', 'save');
+		$this->registerTask('save2new', 'save');
+		$this->registerTask('save2copy', 'save');
+		$this->registerTask('unpublish', 'publish');
+		$this->registerTask('archive', 'publish');
+		$this->registerTask('trash', 'publish');
+		$this->registerTask('orderup', 'reorder');
+		$this->registerTask('orderdown', 'reorder');
+	}
+
+	/**
+	 * Display Form allows adding a new record
+	 */
+	public function add()
+	{
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		if ($model->canAdd($this->input->getArray()))
+		{
+			// Clear the record edit information from the session.
+			$this->app->setUserState($this->context . '.data', null);
+			$this->input->set('view', $this->viewItem);
+			$this->input->set('layout', 'edit');
+			$this->display();
+		}
+		else
+		{
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'), 'error');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+	}
+
+	/**
+	 * Display Form allows editing record
+	 */
+	public function edit()
+	{
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin'));
+		$id = $model->getState()->id;
+		if (!$id)
+		{
+			$cid = $model->getState()->cid;
+			$id = (int) $cid[0];
+		}
+		if (!$model->canEdit($id))
+		{
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		// Checkout the record before allowing edit
+		if ($model->checkin && !$model->checkout($id))
+		{
+			// Check-out failed, display a notice but allow the user to see the record.
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+			return false;
+		}
+		$this->holdEditId($this->context, $id);
+		$this->app->setUserState($this->context . '.data', null);
+		$this->input->set('view', $this->viewItem);
+		$this->input->set('layout', 'edit');
+		$this->display();
+	}
+
+	/**
+	 * Method to save a record.
+	 *
+	 * @return boolean True if successful, false otherwise.
+	 *        
+	 */
+	public function save()
+	{
+		// Check for request forgeries.
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin'));
+		$task = $this->getTask();
+		$data = $this->input->post->get('jform', array(), 'array');
+		$id = $this->input->getInt('id');
+		$data['id'] = $id;
+		// ACL check
+		if (!$model->canSave($data))
+		{
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		// The save2copy task needs to be handled slightly differently.
+		if ($task == 'save2copy')
+		{
+			// Check-in the original row.
+			if ($model->checkin && $model->checkin($id) === false)
+			{
+				// Check-in failed. Go back to the item and display a notice.
+				$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+				$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+				return false;
+			}
+			// Reset the ID and then treat the request as for Apply.
+			$data['id'] = 0;
+			$task = 'apply';
+		}
+		
+		// Validate the posted data.
+		// Sometimes the form needs some posted data, such as for plugins and modules.
+		$form = $model->getForm($data, false);
+		if (!$form)
+		{
+			$this->app->enqueueMessage($model->getError(), 'error');
+			return false;
+		}
+		// Test whether the data is valid.
+		$validData = $model->validate($form, $data);
+		
+		// Check for validation errors.
+		if ($validData === false)
+		{
+			// Get the validation messages.
+			$errors = $model->getErrors();
+			
+			// Push up to three validation messages out to the user.
+			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)
+			{
+				if ($errors[$i] instanceof Exception)
+				{
+					$this->app->enqueueMessage($errors[$i]->getMessage(), 'warning');
+				}
+				else
+				{
+					$this->app->enqueueMessage($errors[$i], 'warning');
+				}
+			}
+			
+			// Save the data in the session.
+			$this->app->setUserState($this->context . '.data', $data);
+			
+			// Redirect back to the edit screen.
+			$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+			
+			return false;
+		}
+		
+		if (!isset($validData['tags']))
+		{
+			$validData['tags'] = null;
+		}
+		
+		// Attempt to save the data.
+		if (!$model->save($validData, $this->input))
+		{
+			// Save the data in the session.
+			$this->app->setUserState($this->context . '.data', $validData);
+			// Redirect back to the edit screen.
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+			return false;
+		}
+		
+		// Save succeeded, so check-in the record.
+		if ($model->checkin && $model->checkin($validData['id']) === false)
+		{
+			// Save the data in the session.
+			$this->app->setUserState($this->context . '.data', $validData);
+			// Check-in failed, so go back to the record and display a notice.
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+			return false;
+		}
+		
+		if ($this->app->isSite() && $id == 0)
+		{
+			$langSuffix = '_SUBMIT_SAVE_SUCCESS';
+		}
+		else
+		{
+			$langSuffix = '_SAVE_SUCCESS';
+		}
+		$this->setMessage(JText::_(JFactory::getLanguage()->hasKey($this->languagePrefix . $langSuffix) ? $this->languagePrefix : 'JLIB_APPLICATION' . $langSuffix));
+				
+		// Redirect the user and adjust session state based on the chosen task.
+		switch ($task)
+		{
+			case 'apply':
+				// Set the record data in the session.
+				$id = $model->getState()->id;
+				$this->holdEditId($this->context, $id);
+				$this->app->setUserState($this->context . '.data', null);
+				$model->checkout($id);
+				// Redirect back to the edit screen.
+				$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+				break;
+			
+			case 'save2new':
+				// Clear the record id and data from the session.
+				$this->releaseEditId($this->context, $id);
+				$this->app->setUserState($this->context . '.data', null);
+				// Redirect back to the edit screen.
+				$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+				break;
+			
+			default:
+				// Clear the record id and data from the session.
+				$this->releaseEditId($this->context, $id);
+				$this->app->setUserState($this->context . '.data', null);
+				// Redirect to the list screen.
+				$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+				break;
+		}
+		return true;
+	}
+
+	/**
+	 * Method to cancel an edit.
+	 *
+	 * @param string $key The name of the primary key of the URL variable.
+	 *        	
+	 * @return boolean True if access level checks pass, false otherwise.
+	 *        
+	 */
+	public function cancel()
+	{
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		$id = $this->input->getInt('id');
+		// Attempt to check-in the current record.
+		if ($id && $model->checkin && $model->checkin($id) === false)
+		{
+			// Check-in failed, go back to the record and display a notice.
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewItemUrl($id), false));
+			return false;
+		}
+		// Clean the session data and redirect.
+		$this->releaseEditId($this->context, $id);
+		$this->app->setUserState($this->context . '.data', null);
+		$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+		return true;
+	}
+
+	/**
+	 * Method to save the submitted ordering values for records.
+	 *
+	 * @return boolean True on success
+	 *        
+	 */
+	public function saveorder()
+	{
+		// Check for request forgeries.
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		
+		// Get the input
+		$cid = $this->input->post->get('cid', array(), 'array');
+		$order = $this->input->post->get('order', array(), 'array');
+		
+		// Make sure there is atleast one items selected
+		if (count($cid) == 0)
+		{
+			$this->setMessage(JText::_($this->languagePrefix . '_ERROR_NO_ITEMS_SELECTED'), 'warning');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		// Sanitize the input
+		JArrayHelper::toInteger($cid);
+		JArrayHelper::toInteger($order);
+		
+		// Get the model
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		
+		// Save the ordering
+		$return = $model->saveorder($cid, $order);
+		
+		if ($return === false)
+		{
+			// Reorder failed
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_REORDER_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		else
+		{
+			// Reorder succeeded
+			$this->setMessage(JText::_('JLIB_APPLICATION_SUCCESS_ORDERING_SAVED'));
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return true;
+		}
+	}
+
+	/**
+	 * Changes the order of one or more records.
+	 *
+	 * @return boolean True on success
+	 *        
+	 */
+	public function reorder()
+	{
+		// Check for request forgeries.
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		$cid = $this->input->post->get('cid', array(), 'array');
+		
+		//Make sure there is atleast one item selected
+		if (count($cid) == 0)
+		{
+			$this->setMessage(JText::_($this->languagePrefix . '_ERROR_NO_ITEMS_SELECTED'), 'warning');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		$inc = ($this->getTask() == 'orderup') ? -1 : 1;
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		$return = $model->reorder($cid, $inc);
+		if ($return === false)
+		{
+			// Reorder failed.
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_REORDER_FAILED', $model->getError()), 'error');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		else
+		{
+			// Reorder succeeded.
+			$this->setMessage(JText::_('JLIB_APPLICATION_SUCCESS_ITEM_REORDERED'), 'message');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return true;
+		}
+	}
+
+	/**
+	 * Check in of one or more records.
+	 *
+	 * @return boolean True on success
+	 */
+	public function checkin()
+	{
+		// Check for request forgeries.
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		$cid = $this->input->post->get('cid', array(), 'array');
+		
+		//Make sure there is atleast one item selected
+		if (count($cid) == 0)
+		{
+			$this->setMessage(JText::_($this->languagePrefix . '_ERROR_NO_ITEMS_SELECTED'), 'warning');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		//Santinize the input
+		JArrayHelper::toInteger($cid);
+		
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin'));
+		$return = $model->checkin($cid);
+		if ($return === false)
+		{
+			// Checkin failed.
+			$message = JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError());
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false), $message, 'error');
+			return false;
+		}
+		else
+		{
+			// Checkin succeeded.
+			$message = JText::plural($this->languagePrefix . '_N_ITEMS_CHECKED_IN', count($cid));
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false), $message);
+			return true;
+		}
+	}
+
+	/**
+	 * Removes an item.
+	 *
+	 * @return void
+	 *
+	 */
+	public function delete()
+	{
+		// Check for request forgeries
+		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
+		// Get items to remove from the request.
+		$cid = $this->input->get('cid', array(), 'array');
+		
+		// Make sure there is at least one item selected
+		if (count($cid) == 0)
+		{
+			$this->setMessage(JText::_($this->languagePrefix . '_ERROR_NO_ITEMS_SELECTED'), 'warning');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		JArrayHelper::toInteger($cid);
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		// Remove the items.
+		if ($model->delete($cid))
+		{
+			$this->setMessage(JText::plural($this->languagePrefix . '_N_ITEMS_DELETED', count($cid)));
+		}
+		else
+		{
+			$this->setMessage($model->getError(), 'error');
+		}
+		
+		$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+	}
+
+	/**
+	 * Method to publish a list of items
+	 *
+	 * @return void
+	 */
+	public function publish()
+	{
+		// Check for request forgeries
+		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
+		// Get items to publish from the request.
+		$cid = $this->input->get('cid', array(), 'array');
+		$data = array('publish' => 1, 'unpublish' => 0, 'archive' => 2, 'trash' => -2, 'report' => -3);
+		$task = $this->getTask();
+		$value = JArrayHelper::getValue($data, $task, 0, 'int');
+		
+		// Make sure there is at least one item selected
+		if (count($cid) == 0)
+		{
+			$this->setMessage(JText::_($this->languagePrefix . '_ERROR_NO_ITEMS_SELECTED'), 'warning');
+			$this->setRedirect(JRoute::_($this->getViewListUrl(), false));
+			return false;
+		}
+		
+		//Santinize the input		
+		JArrayHelper::toInteger($cid);
+		
+		// Get the model.
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		try
+		{
+			$model->publish($cid, $value);
+			if ($value == 1)
+			{
+				$ntext = $this->languagePrefix . '_N_ITEMS_PUBLISHED';
+			}
+			elseif ($value == 0)
+			{
+				$ntext = $this->languagePrefix . '_N_ITEMS_UNPUBLISHED';
+			}
+			elseif ($value == 2)
+			{
+				$ntext = $this->languagePrefix . '_N_ITEMS_ARCHIVED';
+			}
+			else
+			{
+				$ntext = $this->languagePrefix . '_N_ITEMS_TRASHED';
+			}
+			$this->setMessage(JText::plural($ntext, count($cid)));
+		}
+		catch (Exception $e)
+		{
+			$this->setMessage($e->getMessage(), 'error');
+		}
+		$extension = $this->input->get('extension');
+		$extensionURL = ($extension) ? '&extension=' . $extension : '';
+		$this->setRedirect(JRoute::_($this->getViewListUrl() . $extensionURL, false));
+	}
+
+	/**
+	 * Method to save the submitted ordering values for records via AJAX.
+	 *
+	 * @return void
+	 */
+	public function saveOrderAjax()
+	{
+		// Get the input
+		$cid = $this->input->post->get('cid', array(), 'array');
+		$order = $this->input->post->get('order', array(), 'array');
+		// Sanitize the input
+		JArrayHelper::toInteger($cid);
+		JArrayHelper::toInteger($order);
+		// Get the model
+		$model = $this->getModel($this->name, array('default_model_class' => 'JCmsModelAdmin', 'ignore_request' => true));
+		// Save the ordering
+		$return = $model->saveorder($cid, $order);
+		if ($return)
+		{
+			echo "1";
+		}
+		// Close the application
+		$this->app->close();
+	}
+
+	/**
+	 * Get url of the page which display list of records
+	 *
+	 * @return string
+	 */
+	public function getViewListUrl()
+	{
+		return 'index.php?option=' . $this->option . '&view=' . $this->viewList;
+	}
+
+	/**
+	 * Get url of the page which allow adding/editing a record
+	 *
+	 * @param int $recordId        	
+	 * @param string $urlVar        	
+	 * @return string
+	 */
+	public function getViewItemUrl($recordId = null)
+	{
+		$url = 'index.php?option=' . $this->option . '&view=' . $this->viewItem;
+		if ($recordId)
+		{
+			$url .= '&id=' . $recordId;
+		}
+		return $url;
+	}
+
+	/**
+	 * Method to add a record ID to the edit list.
+	 *
+	 * @param string $context The context for the session storage.
+	 *        	
+	 * @param integer $id The ID of the record to add to the edit list.
+	 *        		         	
+	 * @return void
+	 */
+	protected function holdEditId($context, $id)
+	{
+		$values = (array) $this->app->getUserState($context . '.id');
+		// Add the id to the list if non-zero.
+		if (!empty($id))
+		{
+			array_push($values, (int) $id);
+			$values = array_unique($values);
+			$this->app->setUserState($context . '.id', $values);
+		}
+	}
+
+	/**
+	 * Method to check whether an ID is in the edit list.
+	 *
+	 * @param string $context The context for the session storage.
+	 *        	
+	 * @param integer $id The ID of the record to add to the edit list.
+	 *        	
+	 * @return void
+	 *
+	 */
+	protected function releaseEditId($context, $id)
+	{
+		$values = (array) $this->app->getUserState($context . '.id');
+		// Do a strict search of the edit list values.
+		$index = array_search((int) $id, $values, true);
+		if (is_int($index))
+		{
+			unset($values[$index]);
+			$this->app->setUserState($context . '.id', $values);
+		}
+	}
+}

--- a/libraries/cms/controller/controller.php
+++ b/libraries/cms/controller/controller.php
@@ -1,0 +1,576 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  Controller
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * Base class for a Joomla Controller
+ *
+ * Controller (Controllers are where you put all the actual code.) Provides basic
+ * functionality, such as rendering views (aka displaying templates).
+ *
+ * @package Joomla.CMS
+ * @subpackage Controller
+ * @since 3.5
+ */
+class JCmsController
+{
+
+	/**
+	 * Array which hold all the controller objects has been created
+	 *
+	 * @var Array
+	 */
+	protected static $instances = array();
+
+	/**
+	 * The application object.
+	 *
+	 * @var JApplicationBase
+	 */
+	protected $app;
+
+	/**
+	 * The input object.
+	 *
+	 * @var JInput
+	 */
+	protected $input;
+
+	/**
+	 * Full name of the component being dispatchaed com_foobar
+	 *
+	 * @var string
+	 */
+	protected $option;
+
+	/**
+	 * Name of the component, use as prefix for controller, model and view classes
+	 *
+	 * @var string
+	 */
+	protected $component;
+
+	/**
+	 * Name of the controller
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Class prefix used as prefix for controllers, models, views, tables class name
+	 *
+	 * @var string
+	 */
+	protected $classPrefix = null;
+
+	/**
+	 * Language prefix, used for language strings
+	 *
+	 * @var string
+	 */
+	protected $languagePrefix;
+
+	/**
+	 * The default view which will be rendered in case there is no view specified
+	 *
+	 * @var string
+	 */
+	protected $defaultView;
+
+	/**
+	 * Array of class methods
+	 *
+	 * @var array
+	 */
+	protected $methods;
+
+	/**
+	 * Array of class methods to call for a given task.
+	 *
+	 * @var array
+	 */
+	protected $taskMap = array();
+
+	/**
+	 * Current or most recently performed task.
+	 *
+	 * @var string
+	 */
+	protected $task;
+
+	/**
+	 * Redirect message.
+	 *
+	 * @var string
+	 */
+	protected $message;
+
+	/**
+	 * Redirect message type.
+	 *
+	 * @var string
+	 */
+	protected $messageType;
+
+	/**
+	 * URL for redirection.
+	 *
+	 * @var string
+	 */
+	protected $redirect;
+
+	/**
+	 * Method to get instance of a controller
+	 *
+	 * @param JInput $input        	
+	 * @param array $config        	
+	 *
+	 * @return JCmsController
+	 */
+	public static function getInstance(JInput $input = null, array $config = array())
+	{
+		$input = $input ? $input : JFactory::getApplication()->input;
+		$option = $input->getCmd('option');
+		$view = $input->getCmd('view');
+		$task = $input->get('task', '');
+		$pos = strpos($task, '.');
+		if ($pos !== false)
+		{
+			//In case task has dot in it, task need to have the format controllername.task
+			$view = substr($task, 0, $pos);
+			$task = substr($task, $pos + 1);
+			$input->set('view', $view);
+			$input->set('task', $task);
+		}
+		$component = substr($option, 4);
+		if (!isset(self::$instances[$component . $view]))
+		{
+			if (isset($config['class_prefix']))
+			{
+				$prefix = ucfirst($config['class_prefix']);
+			}
+			else
+			{
+				$prefix = ucfirst($component);
+			}
+			$config['class_prefix'] = $prefix;
+			if ($view)
+			{
+				$class = $prefix . 'Controller' . ucfirst(JCmsInflector::singularize($view));
+			}
+			else
+			{
+				$class = $prefix . 'Controller';
+			}
+			if (!class_exists($class))
+			{
+				if (isset($config['default_controller_class']))
+				{
+					$class = $config['default_controller_class'];
+				}
+				else
+				{
+					$class = 'JCmsController';
+				}
+			}
+			self::$instances[$option . $view] = new $class($input, $config);
+		}
+		return self::$instances[$option . $view];
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config An optional associative array of configuration settings.
+	 *        	
+	 */
+	public function __construct(JInput $input = null, array $config = array())
+	{
+		$this->app = JFactory::getApplication();
+		$this->input = $input;
+		$this->classPrefix = $config['class_prefix'];
+		$this->option = $input->get('option');
+		$this->component = substr($this->option, 4);
+		if (isset($config['name']))
+		{
+			$this->name = $config['name'];
+		}
+		else
+		{
+			$this->name = JCmsInflector::singularize($input->get('view'));
+			if (!$this->name)
+			{
+				$this->name = 'controller';
+			}
+		}
+		if (isset($config['language_prefix']))
+		{
+			$this->languagePrefix = $config['language_prefix'];
+		}
+		else
+		{
+			$this->languagePrefix = strtoupper($this->component);
+		}
+		if (isset($config['default_view']))
+		{
+			$this->defaultView = $config['default_view'];
+		}
+		else
+		{
+			$this->defaultView = $this->component;
+		}
+		// Build the default taskMap based on the class methods
+		$xMethods = get_class_methods('JCmsController');
+		$r = new ReflectionClass($this);
+		$rMethods = $r->getMethods(ReflectionMethod::IS_PUBLIC);
+		foreach ($rMethods as $rMethod)
+		{
+			$mName = $rMethod->getName();
+			if (!in_array($mName, $xMethods) || $mName == 'display')
+			{
+				$this->taskMap[strtolower($mName)] = $mName;
+				$this->methods[] = strtolower($mName);
+			}
+		}
+		
+		$this->task = $input->get('task', 'display');
+		if (isset($config['default_task']))
+		{
+			$this->registerTask('__default', $config['default_task']);
+		}
+		else
+		{
+			$this->registerTask('__default', 'display');
+		}
+	}
+
+	/**
+	 * Excute the given task
+	 *
+	 * @return JCmsController return itself to support changing
+	 */
+	public function execute()
+	{
+		$task = strtolower($this->task);
+		if (isset($this->taskMap[$task]))
+		{
+			$doTask = $this->taskMap[$task];
+		}
+		elseif (isset($this->taskMap['__default']))
+		{
+			$doTask = $this->taskMap['__default'];
+		}
+		else
+		{
+			throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_TASK_NOT_FOUND', $task), 404);
+		}
+		$this->$doTask();
+		
+		return $this;
+	}
+
+	/**
+	 * Method to display a view
+	 *
+	 * This function is provide as a default implementation, in most cases
+	 * you will need to override it in your own controllers.
+	 *
+	 * @param boolean $cachable If true, the view output will be cached
+	 *        	
+	 * @param array $urlparams An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+	 *        		        	
+	 * @return JCmsController A JCmsController object to support chaining.
+	 */
+	public function display($cachable = false, array $urlparams = array())
+	{
+		// Create the view object
+		$viewType = $this->input->get('type', 'html');
+		$viewName = $this->input->get('view', $this->defaultView);
+		$viewLayout = $this->input->get('layout', 'default');
+		$view = $this->getView($viewName, $viewType, $viewLayout);
+		
+		// If view has model, create the model, and assign it to the view
+		if ($view->hasModel)
+		{
+			$model = $this->getModel($viewName);
+			$view->setModel($model);
+		}
+		
+		// Display the view		
+		if ($cachable && $viewType != 'feed' && JFactory::getConfig()->get('caching') >= 1)
+		{
+			$cache = JFactory::getCache($this->option, 'view');
+			if (is_array($urlparams))
+			{
+				if (!empty($this->app->registeredurlparams))
+				{
+					$registeredurlparams = $this->app->registeredurlparams;
+				}
+				else
+				{
+					$registeredurlparams = new stdClass();
+				}
+				
+				foreach ($urlparams as $key => $value)
+				{
+					// Add your safe url parameters with variable type as value {@see JFilterInput::clean()}.
+					$registeredurlparams->$key = $value;
+				}
+				
+				$this->app->registeredurlparams = $registeredurlparams;
+			}
+			$cache->get($view, 'display');
+		}
+		else
+		{
+			$view->display();
+		}
+		return $this;
+	}
+
+	/**
+	 * Method to get a model object, loading it if required.
+	 *
+	 * @param string $name The model name. Optional. Default will be the controller name
+	 *        		
+	 * @param array $config Configuration array for model. Optional.
+	 *        	        	
+	 * @return JCmsModelAdmin The model.
+	 *        
+	 */
+	public function getModel($name = '', array $config = array())
+	{
+		// If name is not given, the model will has same name with controller
+		if (empty($name))
+		{
+			$name = $this->name;
+		}
+		
+		// Merge config array with default config values
+		$config += array(
+			'name' => $name, 
+			'option' => $this->option, 
+			'class_prefix' => $this->classPrefix, 
+			'language_prefix' => $this->languagePrefix);
+		
+		// Set the table prefix of the database table name
+		if (!isset($config['table_prefix']))
+		{
+			$config['table_prefix'] = '#__' . strtolower($this->component) . '_';
+		}
+		
+		// Set default model class in case it is not existed
+		if (!isset($config['default_model_class']))
+		{
+			if (JCmsInflector::isPlural($name))
+			{
+				$config['default_model_class'] = 'JCmsModelList';
+			}
+			else
+			{
+				if ($this->app->isAdmin())
+				{
+					$config['default_model_class'] = 'JCmsModelAdmin';
+					$defaultConfig['is_admin_model'] = true;
+				}
+				else
+				{
+					$config['default_model_class'] = 'JCmsModelItem';
+				}
+			}
+		}
+		
+		//Create model and auto populate model states
+		$model = JCmsModel::getInstance($name, $this->classPrefix . 'Model', $config);
+		if (!$model->ignoreRequest)
+		{
+			$model->set($this->input->getArray());
+		}
+		
+		return $model;
+	}
+
+	/**
+	 * Method to get instance of a view
+	 *
+	 * @param string $name The view name
+	 *        	
+	 * @param array $config Configuration array for view. Optional.
+	 *        	
+	 * @return JCmsView Reference to the view
+	 *        
+	 */
+	public function getView($name, $type = 'html', $layout = 'default', array $config = array())
+	{
+		// Merge config array with default config parameters
+		$config += array(
+			'name' => $name, 
+			'layout' => $layout, 
+			'option' => $this->option, 
+			'class_prefix' => $this->classPrefix, 
+			'language_prefix' => $this->languagePrefix);
+		
+		// Set the default paths for finding the layout if it is not specified in the $config array		
+		if (!isset($config['paths']))
+		{
+			$paths = new SplPriorityQueue();
+			$paths->insert($this->basePath . '/view/' . $name . '/tmpl', 0);
+			$paths->insert(JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/' . $this->option . '/' . $name, 1);
+			$config['paths'] = $paths;
+		}
+		
+		//Set default view class if class is not existed
+		if (!isset($config['default_view_class']))
+		{
+			if (JCmsInflector::isPlural($name))
+			{
+				$config['default_view_class'] = 'JCmsViewList';
+			}
+			else
+			{
+				$config['default_view_class'] = 'JCmsViewItem';
+			}
+		}
+		if ($this->app->isAdmin())
+		{
+			$config['is_admin_view'] = true;
+		}
+		$config['Itemid'] = $this->input->getInt('Itemid');
+		
+		return JCmsView::getInstance($name, $type, $this->classPrefix . 'View', $config);
+	}
+
+	/**
+	 * Sets the internal message that is passed with a redirect
+	 *
+	 * @param string $text Message to display on redirect.
+	 *        	
+	 * @param string $type Message type. Optional, defaults to 'message'.
+	 *        	
+	 * @return string Previous message
+	 *        
+	 */
+	public function setMessage($text, $type = 'message')
+	{
+		$previous = $this->message;
+		$this->message = $text;
+		$this->messageType = $type;
+		
+		return $previous;
+	}
+
+	/**
+	 * Set a URL for browser redirection.
+	 *
+	 * @param string $url URL to redirect to.
+	 *        	
+	 * @param string $msg Message to display on redirect. Optional, defaults to value set internally by controller, if any.
+	 *        	
+	 * @param string $type Message type. Optional, defaults to 'message' or the type set by a previous call to setMessage.
+	 *        	
+	 * @return JCmsController This object to support chaining.
+	 *        
+	 */
+	public function setRedirect($url, $msg = null, $type = null)
+	{
+		$this->redirect = $url;
+		if ($msg !== null)
+		{
+			// Controller may have set this directly
+			$this->message = $msg;
+		}
+		
+		// Ensure the type is not overwritten by a previous call to setMessage.
+		if (empty($type))
+		{
+			if (empty($this->messageType))
+			{
+				$this->messageType = 'message';
+			}
+		}
+		// If the type is explicitly set, set it.
+		else
+		{
+			$this->messageType = $type;
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Redirects the browser or returns false if no redirect is set.
+	 *
+	 * @return boolean False if no redirect exists.
+	 *        
+	 */
+	public function redirect()
+	{
+		if ($this->redirect)
+		{
+			$this->app->enqueueMessage($this->message, $this->messageType);
+			$this->app->redirect($this->redirect);
+		}
+		
+		return false;
+	}
+
+	/**
+	 * Get the last task that is being performed or was most recently performed.
+	 *
+	 * @return string The task that is being performed or was most recently performed.
+	 *        
+	 */
+	public function getTask()
+	{
+		return $this->task;
+	}
+
+	/**
+	 * Register (map) a task to a method in the class.
+	 *
+	 * @param string $task The task name
+	 *        	
+	 * @param string $method The name of the method in the derived class to perform for this task.
+	 *        	
+	 * @return JCmsController A JCmsController object to support chaining.
+	 *        
+	 */
+	public function registerTask($task, $method)
+	{
+		if (in_array(strtolower($method), $this->methods))
+		{
+			$this->taskMap[strtolower($task)] = $method;
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Get the application object.
+	 *
+	 * @return JApplicationBase The application object.
+	 *        
+	 */
+	public function getApplication()
+	{
+		return $this->app;
+	}
+
+	/**
+	 * Get the input object.
+	 *
+	 * @return JInput The input object.
+	 *        
+	 */
+	public function getInput()
+	{
+		return $this->input;
+	}
+}

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -123,19 +123,19 @@ abstract class JHtmlAccess
 	 *
 	 * @param   string   $name             The name of the checkbox controls array
 	 * @param   array    $selected         An array of the checked boxes
-	 * @param   boolean  $checkSuperAdmin  If false only super admins can add to super admin groups
+	 * @param   boolean  $checkSupeJCmsmin  If false only super admins can add to super admin groups
 	 *
 	 * @return  string
 	 *
 	 * @since   1.6
 	 */
-	public static function usergroups($name, $selected, $checkSuperAdmin = false)
+	public static function usergroups($name, $selected, $checkSupeJCmsmin = false)
 	{
 		static $count;
 
 		$count++;
 
-		$isSuperAdmin = JFactory::getUser()->authorise('core.admin');
+		$isSupeJCmsmin = JFactory::getUser()->authorise('core.admin');
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -153,8 +153,8 @@ abstract class JHtmlAccess
 		{
 			$item = &$groups[$i];
 
-			// If checkSuperAdmin is true, only add item if the user is superadmin or the group is not super admin
-			if ((!$checkSuperAdmin) || $isSuperAdmin || (!JAccess::checkGroup($item->id, 'core.admin')))
+			// If checkSupeJCmsmin is true, only add item if the user is supeJCmsmin or the group is not super admin
+			if ((!$checkSupeJCmsmin) || $isSupeJCmsmin || (!JAccess::checkGroup($item->id, 'core.admin')))
 			{
 				// Setup  the variable attributes.
 				$eid = $count . 'group_' . $item->id;

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -72,8 +72,8 @@ abstract class JHtmlBatch
 			. JHtml::_('select.options', JHtml::_('category.options', $extension))
 			. '</select>'
 			. '</div>'
-			. '<div id="batch-move-copy" class="control-group radio">'
-			. JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm')
+			. '<div id="batch-move-copy" class="control-group JCmsio">'
+			. JHtml::_('select.JCmsiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm')
 			. '</div>';
 	}
 

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -578,7 +578,7 @@ abstract class JHtmlBootstrap
 	 * @param   array   $params    An array of options for the tooltip.
 	 *                             Options for the tooltip can be:
 	 *                             - parent  selector  If selector then all collapsible elements under the specified parent will be closed when this
-	 *                                                 collapsible item is shown. (similar to traditional accordion behavior)
+	 *                                                 collapsible item is shown. (similar to tJCmsitional accordion behavior)
 	 *                             - toggle  boolean   Toggles the collapsible element on invocation
 	 *                             - active  string    Sets the active slide during load
 	 *

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -30,7 +30,7 @@ abstract class JHtmlSelect
 			'option.text.toHtml' => true, 'option.class' => 'class', 'option.onclick' => 'onclick'));
 
 	/**
-	 * Generates a yes/no radio list.
+	 * Generates a yes/no JCmsio list.
 	 *
 	 * @param   string  $name      The value of the HTML name attribute
 	 * @param   array   $attribs   Additional HTML attributes for the <select> tag
@@ -39,16 +39,16 @@ abstract class JHtmlSelect
 	 * @param   string  $no        Language key for no
 	 * @param   string  $id        The id for the field
 	 *
-	 * @return  string  HTML for the radio list
+	 * @return  string  HTML for the JCmsio list
 	 *
 	 * @since   1.5
-	 * @see     JFormFieldRadio
+	 * @see     JFormFieldJCmsio
 	 */
 	public static function booleanlist($name, $attribs = array(), $selected = null, $yes = 'JYES', $no = 'JNO', $id = false)
 	{
 		$arr = array(JHtml::_('select.option', '0', JText::_($no)), JHtml::_('select.option', '1', JText::_($yes)));
 
-		return JHtml::_('select.radiolist', $arr, $name, $attribs, 'value', 'text', (int) $selected, $id);
+		return JHtml::_('select.JCmsiolist', $arr, $name, $attribs, 'value', 'text', (int) $selected, $id);
 	}
 
 	/**
@@ -729,7 +729,7 @@ abstract class JHtmlSelect
 	}
 
 	/**
-	 * Generates an HTML radio list.
+	 * Generates an HTML JCmsio list.
 	 *
 	 * @param   array    $data       An array of objects
 	 * @param   string   $name       The value of the HTML name attribute
@@ -744,7 +744,7 @@ abstract class JHtmlSelect
 	 *
 	 * @since   1.5
 	 */
-	public static function radiolist($data, $name, $attribs = null, $optKey = 'value', $optText = 'text', $selected = null, $idtag = false,
+	public static function JCmsiolist($data, $name, $attribs = null, $optKey = 'value', $optText = 'text', $selected = null, $idtag = false,
 		$translate = false)
 	{
 		reset($data);
@@ -785,8 +785,8 @@ abstract class JHtmlSelect
 				$extra .= ((string) $k == (string) $selected ? ' checked="checked" ' : '');
 			}
 
-			$html .= "\n\t" . '<label for="' . $id . '" id="' . $id . '-lbl" class="radio">';
-			$html .= "\n\t\n\t" . '<input type="radio" name="' . $name . '" id="' . $id . '" value="' . $k . '" ' . $extra
+			$html .= "\n\t" . '<label for="' . $id . '" id="' . $id . '-lbl" class="JCmsio">';
+			$html .= "\n\t\n\t" . '<input type="JCmsio" name="' . $name . '" id="' . $id . '" value="' . $k . '" ' . $extra
 				. $attribs . ' >' . $t;
 			$html .= "\n\t" . '</label>';
 		}

--- a/libraries/cms/html/user.php
+++ b/libraries/cms/html/user.php
@@ -21,13 +21,13 @@ abstract class JHtmlUser
 	/**
 	 * Displays a list of user groups.
 	 *
-	 * @param   boolean  $includeSuperAdmin  true to include super admin groups, false to exclude them
+	 * @param   boolean  $includeSupeJCmsmin  true to include super admin groups, false to exclude them
 	 *
 	 * @return  array  An array containing a list of user groups.
 	 *
 	 * @since   2.5
 	 */
-	public static function groups($includeSuperAdmin = false)
+	public static function groups($includeSupeJCmsmin = false)
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -46,7 +46,7 @@ abstract class JHtmlUser
 		}
 
 		// Exclude super admin groups if requested
-		if (!$includeSuperAdmin)
+		if (!$includeSupeJCmsmin)
 		{
 			$filteredGroups = array();
 

--- a/libraries/cms/inflector/inflector.php
+++ b/libraries/cms/inflector/inflector.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * The JCmsInflector is a direct copy of Koowa's KInflector class, which
+ * is also licensed under the GPL v3. In its turn, it's an adaptation of the
+ * Akelos PHP Inflector which is a PHP port from a Ruby on Rails project.
+ */
+
+class JCmsInflector
+{
+	/**
+	 * Rules for pluralizing and singularizing of nouns.
+	 *
+	 * @var array
+     */
+	protected static $_rules = array(
+		'pluralization' => array(
+			'/move$/i' => 'moves', 
+			'/sex$/i' => 'sexes', 
+			'/child$/i' => 'children', 
+			'/man$/i' => 'men', 
+			'/foot$/i' => 'feet', 
+			'/person$/i' => 'people', 
+			'/taxon$/i' => 'taxa', 
+			'/(quiz)$/i' => '$1zes', 
+			'/^(ox)$/i' => '$1en', 
+			'/(m|l)ouse$/i' => '$1ice', 
+			'/(matr|vert|ind|suff)ix|ex$/i' => '$1ices', 
+			'/(x|ch|ss|sh)$/i' => '$1es', 
+			'/([^aeiouy]|qu)y$/i' => '$1ies', 
+			'/(?:([^f])fe|([lr])f)$/i' => '$1$2ves', 
+			'/sis$/i' => 'ses', 
+			'/([ti]|addend)um$/i' => '$1a', 
+			'/(alumn|formul)a$/i' => '$1ae', 
+			'/(buffal|tomat|her)o$/i' => '$1oes', 
+			'/(bu)s$/i' => '$1ses', 
+			'/(alias|status)$/i' => '$1es', 
+			'/(octop|vir)us$/i' => '$1i', 
+			'/(gen)us$/i' => '$1era', 
+			'/(ax|test)is$/i' => '$1es', 
+			'/s$/i' => 's', 
+			'/$/' => 's'), 
+		
+		'singularization' => array(
+			'/cookies$/i' => 'cookie', 
+			'/moves$/i' => 'move', 
+			'/sexes$/i' => 'sex', 
+			'/children$/i' => 'child', 
+			'/men$/i' => 'man', 
+			'/feet$/i' => 'foot', 
+			'/people$/i' => 'person', 
+			'/taxa$/i' => 'taxon', 
+			'/databases$/i' => 'database', 
+			'/(quiz)zes$/i' => '\1', 
+			'/(matr|suff)ices$/i' => '\1ix', 
+			'/(vert|ind)ices$/i' => '\1ex', 
+			'/^(ox)en/i' => '\1', 
+			'/(alias|status)es$/i' => '\1', 
+			'/(tomato|hero|buffalo)es$/i' => '\1', 
+			'/([octop|vir])i$/i' => '\1us', 
+			'/(gen)era$/i' => '\1us', 
+			'/(cris|^ax|test)es$/i' => '\1is', 
+			'/(shoe)s$/i' => '\1', 
+			'/(o)es$/i' => '\1', 
+			'/(bus)es$/i' => '\1', 
+			'/([m|l])ice$/i' => '\1ouse', 
+			'/(x|ch|ss|sh)es$/i' => '\1', 
+			'/(m)ovies$/i' => '\1ovie', 
+			'/(s)eries$/i' => '\1eries', 
+			'/([^aeiouy]|qu)ies$/i' => '\1y', 
+			'/([lr])ves$/i' => '\1f', 
+			'/(tive)s$/i' => '\1', 
+			'/(hive)s$/i' => '\1', 
+			'/([^f])ves$/i' => '\1fe', 
+			'/(^analy)ses$/i' => '\1sis', 
+			'/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis', 
+			'/([ti]|addend)a$/i' => '\1um', 
+			'/(alumn|formul)ae$/i' => '$1a', 
+			'/(n)ews$/i' => '\1ews', 
+			'/(.*)ss$/i' => '\1ss', 
+			'/(.*)s$/i' => '\1'), 
+		
+		'countable' => array(
+			'aircraft', 
+			'cannon', 
+			'deer', 
+			'equipment', 
+			'fish', 
+			'information', 
+			'money', 
+			'moose', 
+			'rice', 
+			'series', 
+			'sheep', 
+			'species', 
+			'swine'));
+
+	/**
+ 	 * Cache of pluralized and singularized nouns.
+	 *
+	 * @var array
+     */
+	protected static $_cache = array('singularized' => array(), 'pluralized' => array());
+
+	/**
+	 * Constructor
+	 *
+	 * Prevent creating instances of this class by making the contructor private
+	 */
+	private function __construct()
+	{
+	}
+
+	/**
+	 * Add a word to the cache, useful to make exceptions or to add words in
+	 * other languages
+	 *
+	 * @param	string	Singular word
+	 * @param 	string	Plural word
+	 */
+	public static function addWord($singular, $plural)
+	{
+		self::$_cache['pluralized'][$singular] = $plural;
+		self::$_cache['singularized'][$plural] = $singular;
+	}
+
+	/**
+	 * Singular English word to plural.
+	 *
+	 * @param 	string Word to pluralize
+	 * @return 	string Plural noun
+	 */
+	public static function pluralize($word)
+	{
+		//Get the cached noun of it exists
+		if (isset(self::$_cache['pluralized'][$word]))
+		{
+			return self::$_cache['pluralized'][$word];
+		}
+		
+		//Create the plural noun
+		if (in_array($word, self::$_rules['countable']))
+		{
+			$_cache['pluralized'][$word] = $word;
+			return $word;
+		}
+		
+		foreach (self::$_rules['pluralization'] as $regexp => $replacement)
+		{
+			$matches = null;
+			$plural = preg_replace($regexp, $replacement, $word, -1, $matches);
+			if ($matches > 0)
+			{
+				$_cache['pluralized'][$word] = $plural;
+				return $plural;
+			}
+		}
+		
+		return $word;
+	}
+
+	/**
+	 * Plural English word to singular.
+	 *
+	 * @param 	string Word to singularize.
+	 * @return 	string Singular noun
+	 */
+	public static function singularize($word)
+	{
+		//Get the cached noun of it exists
+		if (isset(self::$_cache['singularized'][$word]))
+		{
+			return self::$_cache['singularized'][$word];
+		}
+		
+		//Create the singular noun
+		if (in_array($word, self::$_rules['countable']))
+		{
+			$_cache['singularized'][$word] = $word;
+			return $word;
+		}
+		
+		foreach (self::$_rules['singularization'] as $regexp => $replacement)
+		{
+			$matches = null;
+			$singular = preg_replace($regexp, $replacement, $word, -1, $matches);
+			if ($matches > 0)
+			{
+				$_cache['singularized'][$word] = $singular;
+				return $singular;
+			}
+		}
+		
+		return $word;
+	}
+
+	/**
+	 * Returns given word as CamelCased
+	 *
+	 * Converts a word like "foo_bar" or "foo bar" to "FooBar". It
+	 * will remove non alphanumeric characters from the word, so
+	 * "who's online" will be converted to "WhoSOnline"
+	 *
+	 * @param   string 	$word    Word to convert to camel case
+	 * @return	string	UpperCamelCasedWord
+	 */
+	public static function camelize($word)
+	{
+		$word = preg_replace('/[^a-zA-Z0-9\s]/', ' ', $word);
+		$word = str_replace(' ', '', ucwords(strtolower(str_replace('_', ' ', $word))));
+		return $word;
+	}
+
+	/**
+	 * Converts a word "into_it_s_underscored_version"
+	 *
+	 * Convert any "CamelCased" or "ordinary Word" into an "underscored_word".
+	 *
+	 * @param    string    $word    Word to underscore
+	 * @return string Underscored word
+	 */
+	public static function underscore($word)
+	{
+		$word = preg_replace('/(\s)+/', '_', $word);
+		$word = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $word));
+		return $word;
+	}
+
+	/**
+	 * Convert any "CamelCased" word into an array of strings
+	 *
+	 * Returns an array of strings each of which is a substring of string formed
+	 * by splitting it at the camelcased letters.
+	 *
+	 * @param	string  Word to explode
+	 * @return 	array	Array of strings
+	 */
+	public static function explode($word)
+	{
+		$result = explode('_', self::underscore($word));
+		return $result;
+	}
+
+	/**
+	 * Convert  an array of strings into a "CamelCased" word
+	 *
+	 * @param  array    $words   Array to implode
+	 * @return string  UpperCamelCasedWord
+	 */
+	public static function implode($words)
+	{
+		$result = self::camelize(implode('_', $words));
+		return $result;
+	}
+
+	/**
+	 * Returns a human-readable string from $word
+	 *
+	 * Returns a human-readable string from $word, by replacing
+	 * underscores with a space, and by upper-casing the initial
+	 * character by default.
+	 *
+	 * @param    string    $word    String to "humanize"
+	 * @return string Human-readable word
+     */
+	public static function humanize($word)
+	{
+		$result = ucwords(strtolower(str_replace("_", " ", $word)));
+		return $result;
+	}
+
+	/**
+	 * Converts a class name to its table name according to Koowa
+	 * naming conventions.
+	 *
+	 * Converts "Person" to "people"
+	 *
+	 * @param  string    $className    Class name for getting related table_name.
+	 * @return string plural_table_name
+	 * @see classify
+	 */
+	public static function tableize($className)
+	{
+		$result = self::underscore($className);
+		
+		if (!self::isPlural($className))
+		{
+			$result = self::pluralize($result);
+		}
+		return $result;
+	}
+
+	/**
+	 * Converts a table name to its class name according to Koowa
+	 * naming conventions.
+	 *
+	 * Converts "people" to "Person"
+	 *
+	 * @see tableize
+	 * @param    string    $table_name    Table name for getting related ClassName.
+	 * @return string SingularClassName
+	 */
+	public static function classify($tableName)
+	{
+		$result = self::camelize(self::singularize($tableName));
+		return $result;
+	}
+
+	/**
+	 * Returns camelBacked version of a string.
+	 *
+	 * Same as camelize but first char is lowercased
+	 *
+	 * @param string $string
+	 * @return string
+	 * @see camelize
+	 */
+	public static function variablize($string)
+	{
+		$string = self::camelize(self::underscore($string));
+		$result = strtolower(substr($string, 0, 1));
+		$variable = preg_replace('/\\w/', $result, $string, 1);
+		return $variable;
+	}
+
+	/**
+	 * Check to see if an English word is singular
+	 *
+	 * @param string $string The word to check
+	 * @return boolean
+	 */
+	public static function isSingular($string)
+	{
+		// Check cache assuming the string is plural.
+		$singular = isset(self::$_cache['singularized'][$string]) ? self::$_cache['singularized'][$string] : null;
+		$plural = $singular && isset(self::$_cache['pluralized'][$singular]) ? self::$_cache['pluralized'][$singular] : null;
+		
+		if ($singular && $plural)
+		{
+			return $plural != $string;
+		}
+		
+		// If string is not in the cache, try to pluralize and singularize it.
+		return self::singularize(self::pluralize($string)) == $string;
+	}
+
+	/**
+	 * Check to see if an Enlish word is plural
+	 *
+	 * @param string $string
+	 * @return boolean
+	 */
+	public static function isPlural($string)
+	{
+		// Check cache assuming the string is singular.
+		$plural = isset(self::$_cache['pluralized'][$string]) ? self::$_cache['pluralized'][$string] : null;
+		$singular = $plural && isset(self::$_cache['singularized'][$plural]) ? self::$_cache['singularized'][$plural] : null;
+		
+		if ($plural && $singular)
+		{
+			return $singular != $string;
+		}
+		
+		// If string is not in the cache, try to singularize and pluralize it.
+		return self::pluralize(self::singularize($string)) == $string;
+	}
+
+	/**
+     * Gets a part of a CamelCased word by index
+     *
+     * Use a negative index to start at the last part of the word (-1 is the
+     * last part)
+     *
+     * @param   string  Word
+     * @param   integer Index of the part
+     * @param   string  Default value
+     */
+	public static function getPart($string, $index, $default = null)
+	{
+		$parts = self::explode($string);
+		
+		if ($index < 0)
+		{
+			$index = count($parts) + $index;
+		}
+		
+		return isset($parts[$index]) ? $parts[$index] : $default;
+	}
+}

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterComponent extends JAdapterInstance
+class JInstalleJCmsapterComponent extends JAdapterInstance
 {
 	/**
 	 * Copy of the XML manifest file
@@ -225,8 +225,8 @@ class JInstallerAdapterComponent extends JAdapterInstance
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			// Upgrade manually set or update function available or update tag detected
-			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
+			// UpgJCmse manually set or update function available or update tag detected
+			if ($this->parent->isUpgJCmse() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
 				|| $updateElement)
 			{
 				// Transfer control to the update function
@@ -1887,7 +1887,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterComponent instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterComponent instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -1895,6 +1895,6 @@ class JInstallerAdapterComponent extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerComponent extends JInstallerAdapterComponent
+class JInstallerComponent extends JInstalleJCmsapterComponent
 {
 }

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterFile extends JAdapterInstance
+class JInstalleJCmsapterFile extends JAdapterInstance
 {
 	/**
 	 * Install function routing
@@ -439,7 +439,7 @@ class JInstallerAdapterFile extends JAdapterInstance
 	{
 		// Set the overwrite setting
 		$this->parent->setOverwrite(true);
-		$this->parent->setUpgrade(true);
+		$this->parent->setUpgJCmse(true);
 		$this->route = 'update';
 
 		// ...and adds new files
@@ -808,7 +808,7 @@ class JInstallerAdapterFile extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterFile instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterFile instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -816,6 +816,6 @@ class JInstallerAdapterFile extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerFile extends JInstallerAdapterFile
+class JInstallerFile extends JInstalleJCmsapterFile
 {
 }

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterLanguage extends JAdapterInstance
+class JInstalleJCmsapterLanguage extends JAdapterInstance
 {
 	/**
 	 * Core language pack flag
@@ -161,8 +161,8 @@ class JInstallerAdapterLanguage extends JAdapterInstance
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			// Upgrade manually set or update tag detected
-			if ($this->parent->isUpgrade() || $updateElement)
+			// UpgJCmse manually set or update tag detected
+			if ($this->parent->isUpgJCmse() || $updateElement)
 			{
 				// Transfer control to the update function
 				return $this->update();
@@ -667,7 +667,7 @@ class JInstallerAdapterLanguage extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterLanguage instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterLanguage instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -675,6 +675,6 @@ class JInstallerAdapterLanguage extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerLanguage extends JInstallerAdapterLanguage
+class JInstallerLanguage extends JInstalleJCmsapterLanguage
 {
 }

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterLibrary extends JAdapterInstance
+class JInstalleJCmsapterLibrary extends JAdapterInstance
 {
 	/**
 	 * Custom loadLanguage method
@@ -83,16 +83,16 @@ class JInstallerAdapterLibrary extends JAdapterInstance
 
 		if ($result)
 		{
-			// Already installed, can we upgrade?
-			if ($this->parent->isOverwrite() || $this->parent->isUpgrade())
+			// Already installed, can we upgJCmse?
+			if ($this->parent->isOverwrite() || $this->parent->isUpgJCmse())
 			{
-				// We can upgrade, so uninstall the old one
+				// We can upgJCmse, so uninstall the old one
 				$installer = new JInstaller; // we don't want to compromise this instance!
 				$installer->uninstall('library', $result);
 			}
 			else
 			{
-				// Abort the install, no upgrade possible
+				// Abort the install, no upgJCmse possible
 				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_LIB_INSTALL_ALREADY_INSTALLED'));
 
 				return false;
@@ -466,7 +466,7 @@ class JInstallerAdapterLibrary extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterLibrary instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterLibrary instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -474,6 +474,6 @@ class JInstallerAdapterLibrary extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerLibrary extends JInstallerAdapterLibrary
+class JInstallerLibrary extends JInstalleJCmsapterLibrary
 {
 }

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterModule extends JAdapterInstance
+class JInstalleJCmsapterModule extends JAdapterInstance
 {
 	/**
 	 * Install function routing
@@ -258,21 +258,21 @@ class JInstallerAdapterModule extends JAdapterInstance
 		 * module is already installed or another module is using that
 		 * directory.
 		 * Check that this is either an issue where its not overwriting or it is
-		 * set to upgrade anyway
+		 * set to upgJCmse anyway
 		 */
 
-		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgrade()))
+		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgJCmse()))
 		{
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			// Upgrade manually set or update function available or update tag detected
-			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
+			// UpgJCmse manually set or update function available or update tag detected
+			if ($this->parent->isUpgJCmse() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
 				|| $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);
-				$this->parent->setUpgrade(true);
+				$this->parent->setUpgJCmse(true);
 
 				if ($id)
 				{
@@ -596,7 +596,7 @@ class JInstallerAdapterModule extends JAdapterInstance
 	{
 		// Set the overwrite setting
 		$this->parent->setOverwrite(true);
-		$this->parent->setUpgrade(true);
+		$this->parent->setUpgJCmse(true);
 
 		// Set the route for the install
 		$this->route = 'update';
@@ -1012,7 +1012,7 @@ class JInstallerAdapterModule extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterModule instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterModule instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -1020,6 +1020,6 @@ class JInstallerAdapterModule extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerModule extends JInstallerAdapterModule
+class JInstallerModule extends JInstalleJCmsapterModule
 {
 }

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -18,7 +18,7 @@ jimport('joomla.base.adapterinstance');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterPackage extends JAdapterInstance
+class JInstalleJCmsapterPackage extends JAdapterInstance
 {
 	/**
 	 * Method of system
@@ -120,8 +120,8 @@ class JInstallerAdapterPackage extends JAdapterInstance
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			// If $this->upgrade has already been set, or an update property exists in the manifest, update the extensions
-			if ($this->parent->isUpgrade() || $updateElement)
+			// If $this->upgJCmse has already been set, or an update property exists in the manifest, update the extensions
+			if ($this->parent->isUpgJCmse() || $updateElement)
 			{
 				// Use the update route for all packaged extensions
 				$this->route = 'update';
@@ -627,7 +627,7 @@ class JInstallerAdapterPackage extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterPackage instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterPackage instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -635,6 +635,6 @@ class JInstallerAdapterPackage extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerPackage extends JInstallerAdapterPackage
+class JInstallerPackage extends JInstalleJCmsapterPackage
 {
 }

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterPlugin extends JAdapterInstance
+class JInstalleJCmsapterPlugin extends JAdapterInstance
 {
 	/**
 	 * Install function routing
@@ -223,17 +223,17 @@ class JInstallerAdapterPlugin extends JAdapterInstance
 		$id = $db->loadResult();
 
 		// If it's on the fs...
-		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgrade()))
+		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgJCmse()))
 		{
 			$updateElement = $xml->update;
 
-			// Upgrade manually set or update function available or update tag detected
-			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
+			// UpgJCmse manually set or update function available or update tag detected
+			if ($this->parent->isUpgJCmse() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
 				|| $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);
-				$this->parent->setUpgrade(true);
+				$this->parent->setUpgJCmse(true);
 
 				if ($id)
 				{
@@ -576,7 +576,7 @@ class JInstallerAdapterPlugin extends JAdapterInstance
 	{
 		// Set the overwrite setting
 		$this->parent->setOverwrite(true);
-		$this->parent->setUpgrade(true);
+		$this->parent->setUpgJCmse(true);
 
 		// Set the route for the install
 		$this->route = 'update';
@@ -919,7 +919,7 @@ class JInstallerAdapterPlugin extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterPlugin instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterPlugin instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -927,6 +927,6 @@ class JInstallerAdapterPlugin extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerPlugin extends JInstallerAdapterPlugin
+class JInstallerPlugin extends JInstalleJCmsapterPlugin
 {
 }

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
  * @subpackage  Installer
  * @since       3.1
  */
-class JInstallerAdapterTemplate extends JAdapterInstance
+class JInstalleJCmsapterTemplate extends JAdapterInstance
 {
 	/**
 	 * Copy of the XML manifest file
@@ -162,16 +162,16 @@ class JInstallerAdapterTemplate extends JAdapterInstance
 		$this->parent->setPath('extension_root', $basePath . '/templates/' . $element);
 
 		// If it's on the fs...
-		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgrade()))
+		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgJCmse()))
 		{
 			$updateElement = $xml->update;
 
-			// Upgrade manually set or update tag detected
-			if ($this->parent->isUpgrade() || $updateElement)
+			// UpgJCmse manually set or update tag detected
+			if ($this->parent->isUpgJCmse() || $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);
-				$this->parent->setUpgrade(true);
+				$this->parent->setUpgJCmse(true);
 
 				if ($id)
 				{
@@ -651,7 +651,7 @@ class JInstallerAdapterTemplate extends JAdapterInstance
 }
 
 /**
- * Deprecated class placeholder. You should use JInstallerAdapterTemplate instead.
+ * Deprecated class placeholder. You should use JInstalleJCmsapterTemplate instead.
  *
  * @package     Joomla.Libraries
  * @subpackage  Installer
@@ -659,6 +659,6 @@ class JInstallerAdapterTemplate extends JAdapterInstance
  * @deprecated  4.0
  * @codeCoverageIgnore
  */
-class JInstallerTemplate extends JInstallerAdapterTemplate
+class JInstallerTemplate extends JInstalleJCmsapterTemplate
 {
 }

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -32,12 +32,12 @@ class JInstaller extends JAdapter
 	protected $paths = array();
 
 	/**
-	 * True if package is an upgrade
+	 * True if package is an upgJCmse
 	 *
 	 * @var    boolean
 	 * @since  3.1
 	 */
-	protected $upgrade = null;
+	protected $upgJCmse = null;
 
 	/**
 	 * The manifest trigger class
@@ -119,7 +119,7 @@ class JInstaller extends JAdapter
 	 */
 	public function __construct()
 	{
-		parent::__construct(__DIR__, 'JInstallerAdapter', __DIR__ . '/adapter');
+		parent::__construct(__DIR__, 'JInstalleJCmsapter', __DIR__ . '/adapter');
 
 		// Override the default adapter folder
 		$this->_adapterfolder = 'adapter';
@@ -207,37 +207,37 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Get the upgrade switch
+	 * Get the upgJCmse switch
 	 *
 	 * @return  boolean
 	 *
 	 * @since   3.1
 	 */
-	public function isUpgrade()
+	public function isUpgJCmse()
 	{
-		return $this->upgrade;
+		return $this->upgJCmse;
 	}
 
 	/**
-	 * Set the upgrade switch
+	 * Set the upgJCmse switch
 	 *
-	 * @param   boolean  $state  Upgrade switch state
+	 * @param   boolean  $state  UpgJCmse switch state
 	 *
-	 * @return  boolean  True if upgrade, false otherwise
+	 * @return  boolean  True if upgJCmse, false otherwise
 	 *
 	 * @since   3.1
 	 */
-	public function setUpgrade($state = false)
+	public function setUpgJCmse($state = false)
 	{
-		$tmp = $this->upgrade;
+		$tmp = $this->upgJCmse;
 
 		if ($state)
 		{
-			$this->upgrade = true;
+			$this->upgJCmse = true;
 		}
 		else
 		{
-			$this->upgrade = false;
+			$this->upgJCmse = false;
 		}
 
 		return $tmp;
@@ -1884,10 +1884,10 @@ class JInstaller extends JAdapter
 
 				if (!is_null($manifest))
 				{
-					// If the root method attribute is set to upgrade, allow file overwrite
-					if ((string) $manifest->attributes()->method == 'upgrade')
+					// If the root method attribute is set to upgJCmse, allow file overwrite
+					if ((string) $manifest->attributes()->method == 'upgJCmse')
 					{
-						$this->upgrade = true;
+						$this->upgJCmse = true;
 						$this->overwrite = true;
 					}
 

--- a/libraries/cms/model/admin.php
+++ b/libraries/cms/model/admin.php
@@ -1,0 +1,1006 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * Prototype admin model.
+ *
+ * @package Joomla.CMS
+ * @subpackage Model
+ */
+class JCmsModelAdmin extends JCmsModel
+{
+
+	/**
+	 * Context, used to get user session data and also trigger plugin
+	 *
+	 * @var string
+	 */
+	protected $context;
+
+	/**
+	 * The prefix to use with controller messages.
+	 *
+	 * @var string
+	 */
+	protected $languagePrefix = null;
+
+	/**
+	 * Array of form objects.
+	 *
+	 * @var array
+	 */
+	protected $forms = array();
+
+	/**
+	 * Need to process checkin on this model or not
+	 *
+	 * @var boolean
+	 */
+	public $checkin = false;
+
+	/**
+	 * The event to trigger after deleting the data.
+	 *
+	 * @var string
+	 */
+	protected $eventAfterDelete = null;
+
+	/**
+	 * The event to trigger after saving the data.
+	 *
+	 * @var string
+	 */
+	protected $eventAfterSave = null;
+
+	/**
+	 * The event to trigger before deleting the data.
+	 *
+	 * @var string
+	 */
+	protected $eventBeforeDelete = null;
+
+	/**
+	 * The event to trigger before saving the data.
+	 *
+	 * @var string
+	 */
+	protected $eventBeforeSave = null;
+
+	/**
+	 * The event to trigger after changing the published state of the data.
+	 *
+	 * @var string
+	 */
+	protected $eventChangeState = null;
+
+	/**
+	 * Name of plugin group which will be loaded to process the triggered event.
+	 * Default is component name
+	 *
+	 * @var string
+	 */
+	protected $pluginGroup = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config An optional associative array of configuration settings.
+	 *        	
+	 * @see JCmsModel
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+		
+		//Insert the default model states for admin
+		$this->state->insert('id', 'int', 0)->insert('cid', 'array', array());
+		
+		//Initialize the events
+		if (isset($config['event_after_delete']))
+		{
+			$this->eventAfterDelete = $config['event_after_delete'];
+		}
+		elseif (empty($this->eventAfterDelete))
+		{
+			$this->eventAfterDelete = 'onContentAfterDelete';
+		}
+		
+		if (isset($config['event_after_save']))
+		{
+			$this->eventAfterSave = $config['event_after_save'];
+		}
+		elseif (empty($this->eventAfterSave))
+		{
+			$this->eventAfterSave = 'onContentAfterSave';
+		}
+		
+		if (isset($config['event_before_delete']))
+		{
+			$this->eventBeforeDelete = $config['event_before_delete'];
+		}
+		elseif (empty($this->eventBeforeDelete))
+		{
+			$this->eventBeforeDelete = 'onContentBeforeDelete';
+		}
+		
+		if (isset($config['event_before_save']))
+		{
+			$this->eventBeforeSave = $config['event_before_save'];
+		}
+		elseif (empty($this->eventBeforeSave))
+		{
+			$this->eventBeforeSave = 'onContentBeforeSave';
+		}
+		
+		if (isset($config['event_change_state']))
+		{
+			$this->eventChangeState = $config['event_change_state'];
+		}
+		elseif (empty($this->eventChangeState))
+		{
+			$this->eventChangeState = 'onContentChangeState';
+		}
+		
+		// JText message prefix. Defaults to the name of component.
+		if (isset($config['language_prefix']))
+		{
+			$this->languagePrefix = strtoupper($config['language_prefix']);
+		}
+		elseif (empty($this->languagePrefix))
+		{
+			$this->languagePrefix = strtoupper(substr($this->option, 4));
+		}
+		
+		if (isset($config['plugin_group']))
+		{
+			$this->pluginGroup = $config['plugin_group'];
+		}
+		elseif (empty($this->pluginGroup))
+		{
+			//Plugin group should default to component name
+			$this->pluginGroup = substr($this->option, 4);
+		}
+		//Check to see whether we will process checkin for this model or not		
+		$fields = array_keys($this->db->getTableColumns($this->table));
+		if (in_array('checked_out', $fields) && in_array('checked_out_time', $fields))
+		{
+			$this->checkin = true;
+		}
+		
+		$this->context = $this->option . '.' . $this->name;
+	}
+
+	/**
+	 * Method for getting the form from the model.
+	 *
+	 * @param array $data Data for the form.
+	 *        	
+	 * @param boolean $loadData True if the form is to load its own data (default case), false if not.
+	 *        	
+	 * @return mixed A JForm object on success, false on failure
+	 *
+	 */
+	public function getForm($data = array(), $loadData = true)
+	{
+		// Get the form.
+		$form = $this->loadForm($this->context, $this->name, array('control' => 'jform', 'load_data' => $loadData));
+		
+		if (empty($form))
+		{
+			return false;
+		}
+		// We don't allows change ordering on the form
+		$form->setFieldAttribute('ordering', 'filter', 'unset');
+		
+		if (empty($data))
+		{
+			$data = $this->loadFormData();
+		}
+		if (!$this->canEditState((object) $data))
+		{
+			// Disable fields for display.
+			$form->setFieldAttribute('published', 'disabled', 'true');
+			$form->setFieldAttribute('published', 'filter', 'unset');
+		}
+		
+		return $form;
+	}
+
+	/**
+	 * Method to validate the form data.
+	 *
+	 * @param JForm $form The form to validate against.
+	 *        	
+	 * @param array $data The data to validate.
+	 *        	
+	 * @param string $group The name of the field group to validate.
+	 *        	
+	 * @return mixed Array of filtered data if valid, false otherwise.
+	 *
+	 * @see JFormRule
+	 * @see JFilterInput
+	 */
+	public function validate($form, $data, $group = null)
+	{
+		// Filter and validate the form data.
+		$data = $form->filter($data);
+		$return = $form->validate($data, $group);
+		
+		// Check for an error.
+		if ($return instanceof Exception)
+		{
+			$this->setError($return->getMessage());
+			return false;
+		}
+		
+		// Check the validation results.
+		if ($return === false)
+		{
+			// Get the validation messages from the form.
+			foreach ($form->getErrors() as $message)
+			{
+				$this->setError($message);
+			}
+			
+			return false;
+		}
+		
+		// Tags B/C break at 3.1.2
+		if (isset($data['metadata']['tags']) && !isset($data['tags']))
+		{
+			$data['tags'] = $data['metadata']['tags'];
+		}
+		
+		return $data;
+	}
+
+	/**
+	 * Method to get a single record.
+	 *
+	 * @param   integer  $pk  The id of the primary key.
+	 *
+	 * @return  mixed    Object on success, false on failure.
+	 *
+	 */
+	public function getItem($pk = null)
+	{
+		$pk = empty($pk) ? (int) $this->state->id : $pk;
+		$table = $this->getTable();
+		if ($pk > 0)
+		{
+			// Attempt to load the row.
+			$return = $table->load($pk);
+			
+			// Check for a table object error.
+			if ($return === false && $table->getError())
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+		
+		// Convert to the JObject before adding other data. ? Why ?
+		$properties = $table->getProperties(1);
+		$item = JArrayHelper::toObject($properties, 'JObject');
+		
+		if (property_exists($item, 'params'))
+		{
+			$registry = new JRegistry();
+			$registry->loadString($item->params);
+			$item->params = $registry->toArray();
+		}
+		
+		return $item;
+	}
+
+	/**
+	 * Method to save an object
+	 * 
+	 * @param array $data
+	 * @param JInput $input
+	 * @return boolean
+	 */
+	public function save($data, $input = null)
+	{
+		$dispatcher = JEventDispatcher::getInstance();
+		$table = $this->getTable();
+		$id = $this->state->id;
+		$isNew = true;
+		if ($input)
+		{
+			$task = $input->getCmd('task', '');
+		}
+		else
+		{
+			$task = '';
+		}
+		// Include the plugins for the on save events.
+		JPluginHelper::importPlugin($this->pluginGroup);
+		// Allow an exception to be thrown.
+		try
+		{
+			// Load the row if saving an existing record.
+			if ($id > 0)
+			{
+				$table->load($id);
+				$isNew = false;
+			}
+			// Bind the data.
+			if (!$table->bind($data))
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+			// Prepare the row for saving
+			$this->prepareTable($table, $task);
+			// Check the data.
+			if (!$table->check())
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+			// Trigger the onContentBeforeSave event.
+			$result = $dispatcher->trigger($this->eventBeforeSave, array($this->context, $table, $isNew));
+			if (in_array(false, $result, true))
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+			// Store the data.
+			if (!$table->store())
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+			// Clean the cache.
+			$this->cleanCache();
+			// Trigger the onContentAfterSave event.
+			$dispatcher->trigger($this->eventAfterSave, array($this->context, $table, $isNew));
+		}
+		catch (Exception $e)
+		{
+			$this->setError($e->getMessage());
+			return false;
+		}
+		$this->state->id = $table->id;
+		return true;
+	}
+
+	/**
+	 * Method to check-in a record or an array of record
+	 *
+	 * @param mixed $pks The ID of the primary key or an array of IDs
+	 *        	
+	 * @return mixed Boolean false if there is an error, otherwise the count of records checked in.
+	 */
+	public function checkin($pks = array())
+	{
+		$pks = (array) $pks;
+		$table = $this->getTable();
+		$count = 0;
+		// Check in all items.
+		foreach ($pks as $pk)
+		{
+			if ($table->load($pk))
+			{
+				if ($this->canCheckin($table))
+				{
+					if ($table->checked_out > 0)
+					{
+						if (!$table->checkin())
+						{
+							$this->setError($table->getError());
+							return false;
+						}
+						$count++;
+					}
+				}
+				else
+				{
+					$this->setError(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'));
+					return false;
+				}
+			}
+			else
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+		
+		return $count;
+	}
+
+	/**
+	 * Method to check-out a record.
+	 *
+	 * @param integer $pk The ID of the primary key.
+	 *        		
+	 * @return boolean True if successful, false if an error occurs.
+	 *        
+	 */
+	public function checkout($pk = null)
+	{
+		$pk = (!empty($pk)) ? $pk : (int) $this->state->id;
+		$table = $this->getTable();
+		if (!$table->load($pk))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+		
+		// If there is no checked_out or checked_out_time field, checkout is not needed and we just return true,
+		if (!$this->checkin)
+		{
+			return true;
+		}
+		
+		$user = JFactory::getUser();
+		
+		// Check if this is the user having previously checked out the row.
+		if (!$this->canCheckout($table))
+		{
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_CHECKOUT_USER_MISMATCH'));
+			return false;
+		}
+		// Attempt to check the row out.
+		if (!$table->checkout($user->get('id'), $pk))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+		
+		return true;
+	}
+
+	/**
+	 * Method to delete one or more records.
+	 *
+	 * @param array &$pks An array of record primary keys.
+	 *        	
+	 *        	
+	 * @return boolean True if successful, false if an error occurs.
+	 *        
+	 */
+	public function delete($pks)
+	{
+		$dispatcher = JEventDispatcher::getInstance();
+		$pks = (array) $pks;
+		$table = $this->getTable();
+		// Include the content plugins for the on delete events.
+		JPluginHelper::importPlugin($this->pluginGroup);
+		// Iterate the items to delete each one.
+		foreach ($pks as $i => $pk)
+		{
+			if ($table->load($pk))
+			{
+				if (!$this->canDelete($table))
+				{
+					$this->setError(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'));
+					return false;
+				}
+				// Trigger the onBeforeDelete event.
+				$result = $dispatcher->trigger($this->eventBeforeDelete, array($this->context, $table));
+				
+				if (in_array(false, $result, true))
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+				
+				if (!$table->delete($pk))
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+				// Trigger the onAfterDelete event.
+				$dispatcher->trigger($this->eventAfterDelete, array($this->context, $table));
+			}
+			else
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+		// Clear the component's cache
+		$this->cleanCache();
+		return true;
+	}
+
+	/**
+	 * Method to change the published state of one or more records.
+	 *
+	 * @param array $pks A list of the primary keys to change.
+	 *        	
+	 * @param integer $value The value of the published state.
+	 *        	
+	 * @return boolean True on success.
+	 */
+	public function publish($pks, $value = 1)
+	{
+		$dispatcher = JEventDispatcher::getInstance();
+		$userId = JFactory::getUser()->get('id');
+		$table = $this->getTable();
+		$pks = (array) $pks;
+		foreach ($pks as $pk)
+		{
+			if ($table->load($pk))
+			{
+				if (!$this->canEditState($table))
+				{
+					$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'));
+					return false;
+				}
+			}
+			else
+			{
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+		// Attempt to change the state of the records.
+		if (!$table->publish($pks, $value, $userId))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+		JPluginHelper::importPlugin($this->pluginGroup);
+		// Trigger the onContentChangeState event.
+		$result = $dispatcher->trigger($this->eventChangeState, array($this->context, $pks, $value));
+		if (in_array(false, $result, true))
+		{
+			$this->setError($table->getError());
+			return false;
+		}
+		
+		// Clear the component's cache
+		$this->cleanCache();
+		
+		return true;
+	}
+
+	/**
+	 * Method to adjust the ordering of a row.
+	 *
+	 * Returns NULL if the user did not have edit
+	 * privileges for any of the selected primary keys.
+	 *
+	 * @param integer $pks The ID of the primary key to move.
+	 *        	
+	 * @param integer $delta Increment, usually +1 or -1
+	 *        	
+	 * @return mixed False on failure or error, true on success, null if the $pk is empty (no items selected).
+	 *        
+	 */
+	public function reorder($pks, $delta = 0)
+	{
+		$table = $this->getTable();
+		$pks = (array) $pks;
+		$result = true;
+		
+		$allowed = true;
+		
+		foreach ($pks as $i => $pk)
+		{
+			$table->reset();
+			
+			if ($table->load($pk) && $this->checkout($pk))
+			{
+				$where = $this->getReorderConditions($table);
+				if (!$table->move($delta, $where))
+				{
+					$this->setError($table->getError());
+					unset($pks[$i]);
+					$result = false;
+				}
+				
+				$this->checkin($pk);
+			}
+			else
+			{
+				$this->setError($table->getError());
+				unset($pks[$i]);
+				$result = false;
+			}
+		}
+		
+		if ($allowed === false && empty($pks))
+		{
+			$result = null;
+		}
+		
+		// Clear the component's cache
+		if ($result == true)
+		{
+			$this->cleanCache();
+		}
+		
+		return $result;
+	}
+
+	/**
+	 * Saves the manually set order of records.
+	 *
+	 * @param array $pks An array of primary key ids.
+	 *        	
+	 * @param integer $order +1 or -1
+	 *        	
+	 * @return mixed
+	 *
+	 */
+	public function saveorder($pks = null, $order = null)
+	{
+		$table = $this->getTable();
+		$conditions = array();
+		// Update ordering values
+		foreach ($pks as $i => $pk)
+		{
+			$table->load((int) $pk);
+			if ($table->ordering != $order[$i])
+			{
+				$table->ordering = $order[$i];
+				if (!$table->store())
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+				// Remember to reorder within position and client_id
+				$condition = $this->getReorderConditions($table);
+				$found = false;
+				
+				foreach ($conditions as $cond)
+				{
+					if ($cond[1] == $condition)
+					{
+						$found = true;
+						break;
+					}
+				}
+				
+				if (!$found)
+				{
+					$conditions[] = array($table->id, $condition);
+				}
+			}
+		}
+		
+		// Execute reorder for each category.
+		foreach ($conditions as $cond)
+		{
+			$table->load($cond[0]);
+			$table->reorder($cond[1]);
+		}
+		
+		// Clear the component's cache
+		$this->cleanCache();
+		
+		return true;
+	}
+
+	/**
+	 * Method to check if you can add a new record.
+	 *
+	 * Extended classes can override this if necessary.
+	 *
+	 * @param array $data An array of input data.
+	 *        	        	
+	 * @return boolean
+	 *
+	 * @since 3.5
+	 */
+	public function canAdd(array $data = array())
+	{
+		$user = JFactory::getUser();
+		return ($user->authorise('core.create', $this->option) || count($user->getAuthorisedCategories($this->option, 'core.create')));
+	}
+
+	/**
+	 * Method to check if you can edit an existing record.
+	 *
+	 * Extended classes can override this if necessary.
+	 *
+	 * @param int $id ID of the record which you want to edit
+	 *        	
+	 * @return boolean
+	 *
+	 * @since 3.5
+	 */
+	public function canEdit($id)
+	{
+		return JFactory::getUser()->authorise('core.edit', $this->option);
+	}
+
+	/**
+	 * Method to check if you can save a record
+	 *
+	 * Extended classes can override this if necessary.
+	 *
+	 * @param array $data Form data
+	 *        	
+	 *        	
+	 * @return boolean
+	 *
+	 * @since 3.5
+	 */
+	public function canSave($data)
+	{
+		$id = $data['id'];
+		if ($id > 0)
+		{
+			return $this->canEdit($id);
+		}
+		else
+		{
+			return $this->canAdd();
+		}
+	}
+
+	/**
+	 * Method to test whether a record can be changed state by the current user.
+	 *
+	 * @param object $record The record being edited 
+	 *        	
+	 * @return boolean True if allowed to change the state of the record. Defaults to the permission for the component.
+	 */
+	protected function canEditState($record)
+	{
+		return JFactory::getUser()->authorise('core.edit.state', $this->option);
+	}
+
+	/**
+	 * Method to test whether a record can be checked in by the current user.
+	 *
+	 * @param object $record A record object.
+	 *        	
+	 * @return boolean True if allowed to check in the record.
+	 */
+	protected function canCheckin($record)
+	{
+		$user = JFactory::getUser();
+		if ($record->checked_out > 0 && $record->checked_out != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))
+		{
+			return false;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	/**
+	 * Method to test whether a record can be checked out by the current user.
+	 *
+	 * @param object $record A record object.
+	 *        	
+	 * @return boolean True if allowed to checkout the record.
+	 */
+	protected function canCheckout($record)
+	{
+		if ($record->checked_out > 0 && $record->checked_out != JFactory::getUser()->get('id'))
+		{
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+	/**
+	 * Method to check whether the current user is allowed to delete a record
+	 *
+	 * @param object $record the record being deleted
+	 *        	
+	 * @return boolean True if allowed to delete the record. Defaults to the permission for the component.
+	 *        
+	 */
+	protected function canDelete($record)
+	{
+		return JFactory::getUser()->authorise('core.delete', $this->option);
+	}
+
+	/**
+	 * Method to change the title & alias.
+	 *
+	 * @param integer $categoryId The id of the category.
+	 *        	
+	 * @param string $alias The alias.
+	 *        	
+	 * @param string $title The title.
+	 *        	
+	 * @return array Contains the modified title and alias.
+	 */
+	protected function generateNewTitle($categoryId, $alias, $title)
+	{
+		// Alter the title & alias
+		$table = $this->getTable();
+		while ($table->load(array('alias' => $alias, 'catid' => $categoryId)))
+		{
+			$title = JString::increment($title);
+			$alias = JString::increment($alias, 'dash');
+		}
+		
+		return array($title, $alias);
+	}
+
+	/**
+	 * A protected method to get a set of ordering conditions.
+	 *
+	 * @param JTable $table A JTable object.
+	 *        	
+	 * @return array An array of conditions to add to ordering queries.
+	 *        
+	 */
+	protected function getReorderConditions($table)
+	{
+		return array();
+	}
+
+	/**
+	 * Prepare and sanitise the table data prior to saving.
+	 *
+	 * @param JTable $table A reference to a JTable object.
+	 *        	
+	 * @return void
+	 *
+	 */
+	protected function prepareTable($table)
+	{
+	}
+
+	/**
+	 * Method to get a form object.
+	 *
+	 * @param string $name The name of the form.
+	 *
+	 * @param string $source The form source. Can be XML string if file flag is set to false.
+	 *
+	 * @param array $options Optional array of options for the form creation.
+	 *
+	 * @param boolean $clear Optional argument to force load a new form.
+	 *
+	 * @param string $xpath An optional xpath to search for the fields.
+	 *
+	 * @return mixed JForm object on success, False on error.
+	 *
+	 * @see JForm
+	 */
+	protected function loadForm($name, $source = null, $options = array(), $clear = false, $xpath = false)
+	{
+		// Handle the optional arguments.
+		$options['control'] = JArrayHelper::getValue($options, 'control', false);
+		
+		// Create a signature hash.
+		$hash = md5($source . serialize($options));
+		
+		// Check if we can use a previously loaded form.
+		if (isset($this->forms[$hash]) && !$clear)
+		{
+			return $this->forms[$hash];
+		}
+		
+		// Get the form.
+		JForm::addFormPath(JPATH_ADMINISTRATOR . '/components/' . $this->option . '/model/forms');
+		JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $this->option . '/model/fields');
+		
+		try
+		{
+			$form = JForm::getInstance($name, $source, $options, false, $xpath);
+			
+			if (isset($options['load_data']) && $options['load_data'])
+			{
+				// Get the data for the form.
+				$data = $this->loadFormData();
+			}
+			else
+			{
+				$data = array();
+			}
+			
+			// Allow for additional modification of the form, and events to be triggered.
+			// We pass the data because plugins may require it.
+			$this->preprocessForm($form, $data);
+			
+			// Load the data into the form after the plugins have operated.
+			$form->bind($data);
+		}
+		catch (Exception $e)
+		{
+			$this->setError($e->getMessage());
+			return false;
+		}
+		
+		// Store the form for later.
+		$this->forms[$hash] = $form;
+		
+		return $form;
+	}
+
+	/**
+	 * Method to get the data that should be injected in the form.
+	 *
+	 * @return array The default data is an empty array.
+	 *
+	 */
+	protected function loadFormData()
+	{
+		// Check the session for previously entered form data.
+		$data = JFactory::getApplication()->getUserState($this->context . '.data', array());
+		
+		if (empty($data))
+		{
+			$data = $this->getItem();
+		}
+		
+		return $data;
+	}
+
+	/**
+	 * Method to allow derived classes to preprocess the data.
+	 *
+	 * @param string $context The context identifier.
+	 *
+	 * @param mixed &$data The data to be processed. It gets altered directly.
+	 *
+	 * @return void
+	 */
+	protected function preprocessData($context, &$data)
+	{
+		// Get the dispatcher and load the users plugins.
+		$dispatcher = JEventDispatcher::getInstance();
+		JPluginHelper::importPlugin($this->pluginGroup);
+		// Trigger the data preparation event.
+		$results = $dispatcher->trigger('onContentPrepareData', array($context, $data));
+		
+		// Check for errors encountered while preparing the data.
+		if (count($results) > 0 && in_array(false, $results, true))
+		{
+			$this->setError($dispatcher->getError());
+		}
+	}
+
+	/**
+	 * Method to allow derived classes to preprocess the form.
+	 *
+	 * @param JForm $form A JForm object.
+	 *
+	 * @param mixed $data The data expected for the form.
+	 *
+	 * @param string $group The name of the plugin group to import (defaults to "content").
+	 *
+	 * @return void
+	 *
+	 * @see JFormField
+	 * @throws Exception if there is an error in the form event.
+	 */
+	protected function preprocessForm(JForm $form, $data, $group = 'content')
+	{
+		// Import the appropriate plugin group.
+		JPluginHelper::importPlugin($group);
+		
+		// Get the dispatcher.
+		$dispatcher = JEventDispatcher::getInstance();
+		
+		// Trigger the form preparation event.
+		$results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
+		
+		// Check for errors encountered while preparing the form.
+		if (count($results) && in_array(false, $results, true))
+		{
+			// Get the last error.
+			$error = $dispatcher->getError();
+			
+			if (!($error instanceof Exception))
+			{
+				throw new Exception($error);
+			}
+		}
+	}
+}

--- a/libraries/cms/model/list.php
+++ b/libraries/cms/model/list.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('_JEXEC') or die();
+
+/**
+ * Model class for handling lists of items.
+ *
+ * @package     Joomla.CMS
+ * @subpackage  Model
+ * @since       3.5
+ */
+class JCmsModelList extends JCmsModel
+{
+
+	/**
+	 * Name of state field name, usually be tbl.state or tbl.published
+	 * 
+	 * @var string
+	 */
+	protected $stateField;
+
+	/**
+	 * List of fields which will be used for searching data from database table
+	 *
+	 * @var array
+	 */
+	protected $searchFields = array();
+
+	/**
+	 * The query object used to get data
+	 *
+	 * @var JDatabaseQuery
+	 */
+	protected $query;
+
+	/**
+	 * List total
+	 *
+	 * @var integer
+	 */
+	protected $total;
+
+	/**
+	 * Model list data
+	 *
+	 * @var array
+	 */
+	protected $data;
+
+	/**
+	 * Pagination object
+	 *
+	 * @var JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * Instantiate the model.
+	 *
+	 * @param array $config configuration data for the model
+	 *        	  	
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+		$app = JFactory::getApplication();
+		$this->query = $this->db->getQuery(true);
+		$context = $this->option . '.' . $this->name . '.';
+		$table = $this->getTable();
+		$fields = array_keys($table->getFields());
+		if (in_array('ordering', $fields))
+		{
+			$defaultOrdering = 'tbl.ordering';
+		}
+		else
+		{
+			$defaultOrdering = 'tbl.id';
+		}
+		if (in_array('state', $fields))
+		{
+			$this->stateField = 'tbl.state';
+		}
+		else
+		{
+			$this->stateField = 'tbl.published';
+		}
+		if (isset($config['ignore_session']))
+		{
+			$this->state->insert('limit', 'int', $app->getCfg('list_limit'))
+				->insert('limitstart', 'int', 0)
+				->insert('filter_order', 'cmd', $defaultOrdering)
+				->insert('filter_order_Dir', 'word', 'asc')
+				->insert('filter_search', 'string')
+				->insert('filter_state', 'string')
+				->insert('filter_access', 'int', 0)
+				->insert('filter_language', 'string')
+				->insert('filter_tag', 'string', '');
+		}
+		else
+		{
+			$this->state->insert('limit', 'int', $app->getUserStateFromRequest($context . 'limit', 'limit', $app->getCfg('list_limit')))
+				->insert('limitstart', 'int', $app->getUserStateFromRequest($context . 'limitstart', 'limitstart', 0))
+				->insert('filter_order', 'cmd', $app->getUserStateFromRequest($context . 'filter_order', 'filter_order', $defaultOrdering))
+				->insert('filter_order_Dir', 'word', $app->getUserStateFromRequest($context . 'filter_order_Dir', 'filter_order_Dir', 'asc'))
+				->insert('filter_search', 'string', $app->getUserStateFromRequest($context . 'filter_search', 'filter_search'))
+				->insert('filter_state', 'string', $app->getUserStateFromRequest($context . 'filter_state', 'filter_state'))
+				->insert('filter_access', 'int', $app->getUserStateFromRequest($context . 'filter_access', 'filter_access'))
+				->insert('filter_language', 'string', $app->getUserStateFromRequest($context . 'filter_language', 'filter_language'))
+				->insert('filter_tag', 'string', $app->getUserStateFromRequest($context . 'filter_tag', 'filter_tag'));
+		}
+		
+		if (isset($config['search_fields']))
+		{
+			$this->searchFields = (array) $config['search_fields'];
+		}
+		else
+		{
+			// Build the search field array automatically, basically, we should search based on name, title, description if these fields are available			
+			if (in_array('name', $fields))
+			{
+				$this->searchFields[] = 'tbl.name';
+			}
+			if (in_array('title', $fields))
+			{
+				$this->searchFields[] = 'tbl.title';
+			}
+			if (in_array('alias', $fields))
+			{
+				$this->searchFields[] = 'tbl.alias';
+			}
+			if (in_array('description', $fields))
+			{
+				$this->searchFields[] = 'tbl.description';
+			}
+		}
+	}
+
+	/**
+	 * Get a list of items
+	 *
+	 * @return array
+	 */
+	public function getData()
+	{
+		if (empty($this->data))
+		{
+			$db = $this->getDbo();
+			$this->_buildQueryColumns()
+				->_buildQueryFrom()
+				->_buildQueryJoins()
+				->_buildQueryWhere()
+				->_buildQueryGroup()
+				->_buildQueryHaving()
+				->_buildQueryOrder();
+			$db->setQuery($this->query, $this->state->limitstart, $this->state->limit);
+			$this->data = $db->loadObjectList();
+		}
+		
+		return $this->data;
+	}
+
+	/**
+	 * Get total record
+	 *
+	 * @return integer Number of records
+	 *        
+	 */
+	public function getTotal()
+	{
+		if (empty($this->total))
+		{
+			$db = $this->getDbo();
+			$query = clone ($this->query);
+			$query->clear('select')
+				->clear('order')
+				->clear('limit')
+				->select('COUNT(*)');
+			$db->setQuery($query);
+			$this->total = (int) $db->loadResult();
+		}
+		
+		return $this->total;
+	}
+
+	/**
+	 * Get pagination object
+	 *
+	 * @return JPagination
+	 */
+	function getPagination()
+	{
+		// Lets load the content if it doesn't already exist
+		if (empty($this->pagination))
+		{
+			jimport('joomla.html.pagination');
+			$this->pagination = new JPagination($this->getTotal(), $this->state->limitstart, $this->state->limit);
+		}
+		
+		return $this->pagination;
+	}
+
+	/**
+	 * Builds SELECT columns list for the query
+	 */
+	protected function _buildQueryColumns()
+	{
+		$this->query->select(array('tbl.*'));
+		
+		return $this;
+	}
+
+	/**
+	 * Builds FROM tables list for the query
+	 */
+	protected function _buildQueryFrom()
+	{
+		$this->query->from($this->table . ' AS tbl');
+		
+		return $this;
+	}
+
+	/**
+	 * Builds LEFT JOINS clauses for the query
+	 */
+	protected function _buildQueryJoins()
+	{
+		return $this;
+	}
+
+	/**
+	 * Builds a WHERE clause for the query
+	 */
+	protected function _buildQueryWhere()
+	{
+		$user = JFactory::getUser();
+		$db = $this->getDbo();
+		$state = $this->state;
+		$query = $this->query;
+		if (is_numeric($state->filter_state))
+		{
+			$query->where($this->stateField . ' = ' . (int) $state->filter_state);
+		}
+		elseif ($state->filter_state === '')
+		{
+			$query->where('(' . $this->stateField . ' IN (0, 1))');
+		}
+		if ($state->filter_access)
+		{
+			$query->where('tbl.access = ' . (int) $state->filter_access);
+		}
+		
+		if (!$user->authorise('core.admin'))
+		{
+			$query->where('tbl.access IN (' . implode(',', $user->getAuthorisedViewLevels()) . ')');
+		}
+		
+		if ($state->filter_search)
+		{
+			if (stripos($state->search, 'id:') === 0)
+			{
+				$query->where('tbl.id = ' . (int) substr($state->filter_search, 3));
+			}
+			else
+			{
+				$search = $db->Quote('%' . $db->escape($state->filter_search, true) . '%', false);
+				if (is_array($this->searchFields))
+				{
+					$whereOr = array();
+					foreach ($this->searchFields as $searchField)
+					{
+						$whereOr[] = " LOWER($searchField) LIKE " . $search;
+					}
+					$query->where('(' . implode(' OR ', $whereOr) . ') ');
+				}
+			}
+		}
+		
+		if ($state->filter_language && $state->filter_language != '*')
+		{
+			$query->where('tbl.language IN (' . $db->Quote($state->filter_language) . ',' . $db->Quote('*') . ', "")');
+		}
+		
+		if (is_numeric($state->filter_tag))
+		{
+			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $state->filter_tag)
+			->join(
+				'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
+				. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+				. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote($this->option.'.'.JCmsInflector::singularize($this->name))
+			);
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Builds a GROUP BY clause for the query
+	 */
+	protected function _buildQueryGroup()
+	{
+		return $this;
+	}
+
+	/**
+	 * Builds a HAVING clause for the query
+	 */
+	protected function _buildQueryHaving()
+	{
+		return $this;
+	}
+
+	/**
+	 * Builds a generic ORDER BY clasue based on the model's state
+	 */
+	protected function _buildQueryOrder()
+	{
+		$sort = $this->state->filter_order;
+		$direction = strtoupper($this->state->filter_order_Dir);
+		if ($sort)
+		{
+			$this->query->order($sort . ' ' . $direction);
+		}
+	}
+}

--- a/libraries/cms/model/model.php
+++ b/libraries/cms/model/model.php
@@ -1,0 +1,500 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * Base class for a Joomla Model
+ * 
+ * @package Joomla.CMS
+ * @subpackage Model
+ * @since 3.5
+ */
+class JCmsModel
+{
+
+	/**
+	 * The model name
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Model state
+	 *
+	 * @var JCmsModelState
+	 */
+	protected $state;
+
+	/**
+	 * The database driver.
+	 *
+	 * @var JDatabaseDriver
+	 */
+	protected $db;
+
+	/**
+	 * 
+	 * Class prefix for model, table class name
+	 * 
+	 * @var string
+	 */
+	protected $classPrefix;
+
+	/**
+	 * The prefix of the database table
+	 *
+	 * @var string
+	 */
+	protected $tablePrefix;
+
+	/**
+	 * The name of the database table
+	 *
+	 * @var string
+	 */
+	protected $table;
+
+	/**
+	 * Ignore request or not
+	 *
+	 * @var boolean
+	 */
+	public $ignoreRequest = false;
+
+	/**
+	 * The URL option for the component.
+	 *
+	 * @var string
+	 */
+	protected $option = null;
+
+	/**
+	 * This is a front-end or back-end model.
+	 * We need this field to determine the state fields for the model list
+	 *
+	 * @var boolean
+	 */
+	protected $isAdminModel = false;
+
+	/**
+	 * An array of error messages or Exception objects.
+	 *
+	 * @var    array	 
+	 */
+	protected $errors = array();
+
+	/**
+	 * @param string $name The name of model to instantiate
+	 *        	
+	 * @param string $prefix Prefix for the model class name, ComponentnameModel
+	 *        	
+	 * @param array $config Configuration array for model
+	 *        	
+	 * @return JCmsModel A model object
+	 */
+	public static function getInstance($name, $prefix, $config = array())
+	{
+		$name = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
+		$class = ucfirst($prefix) . ucfirst($name);
+		if (!class_exists($class))
+		{
+			if (isset($config['default_model_class']))
+			{
+				$class = $config['default_model_class'];
+			}
+			else
+			{
+				$class = 'JCmsModel';
+			}
+		}
+		return new $class($config);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $config An array of configuration options
+	 *        	
+	 */
+	public function __construct($config = array())
+	{
+		if (isset($config['option']))
+		{
+			$this->option = $config['option'];
+		}
+		else
+		{
+			$className = get_class($this);
+			$pos = strpos($className, 'Model');
+			if ($pos !== false)
+			{
+				$this->option = 'com_' . substr($className, 0, $pos);
+			}
+			else
+			{
+				throw new Exception(JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
+			}
+		}
+		
+		if (isset($config['name']))
+		{
+			$this->name = $config['name'];
+		}
+		else
+		{
+			$className = get_class($this);
+			$pos = strpos($className, 'Model');
+			if ($pos !== false)
+			{
+				$this->name = substr($className, $pos + 5);
+			}
+			else
+			{
+				throw new Exception(JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
+			}
+		}
+		if (isset($config['db']))
+		{
+			$this->db = $config['db'];
+		}
+		else
+		{
+			$this->db = JFactory::getDbo();
+		}
+		// Set the model state
+		if (isset($config['state']))
+		{
+			$this->state = $config['state'];
+		}
+		else
+		{
+			$this->state = new JCmsModelState();
+		}
+		
+		if (isset($config['table_prefix']))
+		{
+			$this->tablePrefix = $config['table_prefix'];
+		}
+		else
+		{
+			$component = substr($this->option, 4);
+			$this->tablePrefix = '#__' . strtolower($component) . '_';
+		}
+		
+		if (isset($config['table']))
+		{
+			$this->table = $config['table'];
+		}
+		else
+		{
+			$this->table = $this->tablePrefix . strtolower(JCmsInflector::pluralize($this->name));
+		}
+		
+		if (isset($config['ignore_request']))
+		{
+			$this->ignoreRequest = $config['ignore_request'];
+		}
+		
+		if (!empty($config['is_admin_model']))
+		{
+			$this->isAdminModel = $config['is_admin_model'];
+		}
+		
+		if (isset($config['class_prefix']))
+		{
+			$this->classPrefix = $config['class_prefix'];
+		}
+		else
+		{
+			$component = substr($this->option, 4);
+			$this->classPrefix = ucfirst($component);
+		}
+		
+		//Add include path to find table class
+		JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $this->option . '/table');
+	}
+
+	/**
+	 * Get JTable object for the model
+	 *
+	 * @param string $name        	
+	 *
+	 * @return JTable
+	 */
+	public function getTable($name = '')
+	{
+		if (!$name)
+		{
+			$name = JCmsInflector::singularize($this->name);
+		}
+		$table = JTable::getInstance($name, $this->classPrefix . 'Table');
+		return $table;
+	}
+
+	/**
+	 * Set the model state properties
+	 *
+	 * @param string|array The name of the property, an array
+	 *        	
+	 * @param mixed The value of the property
+	 *        	
+	 * @return JCmsModel
+	 */
+	public function set($property, $value = null)
+	{
+		$changed = false;
+		if (is_array($property))
+		{
+			foreach ($property as $key => $value)
+			{
+				if (isset($this->state->$key) && $this->state->$key != $value)
+				{
+					$changed = true;
+					break;
+				}
+			}
+			
+			$this->state->setData($property);
+		}
+		else
+		{
+			if (isset($this->state->$property) && $this->state->$property != $value)
+			{
+				$changed = true;
+			}
+			
+			$this->state->$property = $value;
+		}
+		
+		if ($changed)
+		{
+			$limit = $this->state->limit;
+			if ($limit)
+			{
+				$offset = $this->state->limitstart;
+				$total = $this->getTotal();
+				
+				// If the offset is higher than the total recalculate the offset
+				if ($offset !== 0 && $total !== 0)
+				{
+					if ($offset >= $total)
+					{
+						$offset = floor(($total - 1) / $limit) * $limit;
+						$this->state->limitstart = $offset;
+					}
+				}
+			}
+			$this->data = null;
+			$this->total = null;
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Get the model state properties
+	 *
+	 * If no property name is given then the function will return an associative array of all properties.
+	 *
+	 * @param string $property The name of the property
+	 *        	
+	 * @param string $default The default value
+	 *        	
+	 * @return mixed <string, JCmsModelState>
+	 */
+	public function get($property = null, $default = null)
+	{
+		$result = $default;
+		
+		if (is_null($property))
+		{
+			$result = $this->state;
+		}
+		else
+		{
+			if (isset($this->state->$property))
+			{
+				$result = $this->state->$property;
+			}
+		}
+		
+		return $result;
+	}
+
+	/**
+	 * Reset all cached data and reset the model state to it's default
+	 *
+	 * @param boolean If TRUE use defaults when resetting. Default is TRUE
+	 *        	
+	 * @return JCmsModel
+	 */
+	public function reset($default = true)
+	{
+		$this->data = null;
+		$this->total = null;
+		$this->state->reset($default);
+		$this->query = $this->db->getQuery(true);
+		return $this;
+	}
+
+	/**
+	 * Method to get state object
+	 *
+	 * @return JCmsModelState The state object
+	 */
+	public function getState()
+	{
+		return $this->state;
+	}
+
+	/**
+	 * Get the dbo
+	 *
+	 * @return JDatabase
+	 */
+	public function getDbo()
+	{
+		return $this->db;
+	}
+
+	/**
+	 * Clean the cache
+	 *
+	 * @param   string   $group      The cache group
+	 * @param   integer  $client_id  The ID of the client
+	 *
+	 * @return  void
+	 *
+	 */
+	protected function cleanCache($group = null, $client_id = 0)
+	{
+		$conf = JFactory::getConfig();
+		$options = array(
+			'defaultgroup' => ($group) ? $group : (isset($this->option) ? $this->option : JFactory::getApplication()->input->get('option')), 
+			'cachebase' => ($client_id) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache'));
+		
+		$cache = JCache::getInstance('callback', $options);
+		$cache->clean();
+		// Trigger the onContentCleanCache event.
+		if (!empty($this->eventCleanCache))
+		{
+			$dispatcher = JEventDispatcher::getInstance();
+			$dispatcher->trigger($this->event_clean_cache, $options);
+		}
+	}
+
+	/**
+	 * Get the most recent error message.
+	 *
+	 * @param   integer  $i         Option error index.
+	 * @param   boolean  $toString  Indicates if JError objects should return their error message.
+	 *
+	 * @return  string   Error message
+	 *
+	 */
+	public function getError($i = null, $toString = true)
+	{
+		// Find the error
+		if ($i === null)
+		{
+			// Default, return the last message
+			$error = end($this->errors);
+		}
+		elseif (!array_key_exists($i, $this->errors))
+		{
+			// If $i has been specified but does not exist, return false
+			return false;
+		}
+		else
+		{
+			$error = $this->errors[$i];
+		}
+		
+		// Check if only the string is requested
+		if ($error instanceof Exception && $toString)
+		{
+			return (string) $error;
+		}
+		
+		return $error;
+	}
+
+	/**
+	 * Return all errors, if any.
+	 *
+	 * @return  array  Array of error messages or JErrors.
+	 *
+	 */
+	public function getErrors()
+	{
+		return $this->errors;
+	}
+
+	/**
+	 * Add an error message.
+	 *
+	 * @param   string  $error  Error message.
+	 *
+	 * @return  void
+	 */
+	public function setError($error)
+	{
+		array_push($this->errors, $error);
+	}
+
+	/**
+	 * Get a model state by name
+	 *
+	 * @param string The key name.
+	 *        	
+	 * @return string The corresponding value.
+	 */
+	public function __get($key)
+	{
+		return $this->get($key);
+	}
+
+	/**
+	 * Set a model state by name
+	 *
+	 * @param string The key name.
+	 *        	
+	 * @param mixed The value for the key
+	 *        	
+	 * @return void
+	 */
+	public function __set($key, $value)
+	{
+		$this->set($key, $value);
+	}
+
+	/**
+	 * Supports a simple form Fluent Interfaces.
+	 * Allows you to set states by
+	 * using the state name as the method name.
+	 *
+	 * For example : $model->filter_order('name')->filter_order_Dir('DESC')->limit(10)->getData();
+	 *
+	 * @param string Method name
+	 *        	
+	 * @param array Array containing all the arguments for the original call
+	 *        	
+	 * @return JCmsModel
+	 */
+	public function __call($method, $args)
+	{
+		if (isset($this->state->$method))
+		{
+			return $this->set($method, $args[0]);
+		}
+		
+		return null;
+	}
+}

--- a/libraries/cms/model/state.php
+++ b/libraries/cms/model/state.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Model State Class
+ *
+ * @package     Joomla.JCms
+ * @subpackage 	Model
+ */
+class JCmsModelState
+{
+
+	/**
+	 * The state data container
+	 *
+	 * @var array
+	 */
+	protected $data;
+
+	public function set($name, $value)
+	{
+		if (isset($this->data[$name]))
+		{
+			$this->data[$name]->value = $value;
+		}
+	}
+
+	/**
+	 * Retrieve data for a state
+	 *
+	 * @param
+	 *        	string Name of the state
+	 * @param
+	 *        	mixed Default value if no data has been set for that state
+	 *        	
+	 * @return mixed The state value
+	 */
+	public function get($name, $default = null)
+	{
+		$result = $default;
+		if (isset($this->data[$name]))
+		{
+			$result = $this->data[$name]->value;
+		}
+		
+		return $result;
+	}
+
+	/**
+	 * Insert a new state
+	 *
+	 * @param
+	 *        	string The name of the state
+	 * @param
+	 *        	mixed Filter, the name of filter which will be used to sanitize the state value using JFilterInput
+	 * @param
+	 *        	mixed The default value of the state
+	 *        	
+	 * @return JCmsModelState
+	 */
+	public function insert($name, $filter, $default = null)
+	{
+		$state = new stdClass();
+		$state->name = $name;
+		$state->filter = $filter;
+		$state->value = $default;
+		$state->default = $default;
+		$this->data[$name] = $state;
+		
+		return $this;
+	}
+
+	/**
+	 * Remove an existing state
+	 *
+	 * @param
+	 *        	string The name of the state which will be removed
+	 *        	
+	 * @return JCmsModelState
+	 */
+	public function remove($name)
+	{
+		unset($this->data[$name]);
+		return $this;
+	}
+
+	/**
+	 * Reset all state data and revert to the default state
+	 *
+	 * @param
+	 *        	boolean If TRUE use defaults when resetting. If FALSE then null value will be used.Default is TRUE
+	 *        	
+	 * @return JCmsModelState
+	 */
+	public function reset($default = true)
+	{
+		foreach ($this->data as $state)
+		{
+			$state->value = $default ? $state->default : null;
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Set the state data
+	 *
+	 * This function will only filter values if we have a value. If the value
+	 * is an empty string it will be filtered to NULL.
+	 *
+	 * @param
+	 *        	array An associative array of state values by name
+	 *        	
+	 * @return JCmsModelState
+	 */
+	public function setData(array $data)
+	{
+		$filterInput = JFilterInput::getInstance();
+		// Filter data
+		foreach ($data as $key => $value)
+		{
+			if (isset($this->data[$key]))
+			{
+				$filter = $this->data[$key]->filter;
+				
+				// Only filter if we have a value
+				if ($value !== null)
+				{
+					if ($value !== '')
+					{
+						$value = $filterInput->clean($value, $filter);
+					}
+					else
+					{
+						$value = null;
+					}											
+					$this->data[$key]->value = $value;
+				}
+			}
+		}
+		
+		return $this;
+	}
+
+	/**
+	 * Get the state data
+	 *
+	 * This function only returns states that have been been set.
+	 *        	
+	 * @return array An associative array of state values by name
+	 */
+	public function getData()
+	{
+		$data = array();
+		
+		foreach ($this->data as $name => $state)
+		{
+			$data[$name] = $state->value;
+		}
+		
+		return $data;
+	}
+
+	public function getDefault($name)
+	{
+		return $this->data[$name]->default;
+	}
+
+	/**
+	 * Magic method to get state value
+	 *
+	 * @param
+	 *        	string
+	 *        	
+	 * @return mixed
+	 */
+	public function __get($name)
+	{
+		return $this->get($name);
+	}
+
+	/**
+	 * Set state value
+	 *
+	 * @param
+	 *        	string The user-specified state name.
+	 * @param
+	 *        	mixed The user-specified state value.
+	 * @return void
+	 */
+	public function __set($name, $value)
+	{
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Test existence of a state variable
+	 *
+	 * @param
+	 *        	string
+	 * @return boolean
+	 */
+	public function __isset($name)
+	{
+		return isset($this->data[$name]);
+	}
+
+	/**
+	 * Unset a state value
+	 *
+	 * @param
+	 *        	string The column key.
+	 * @return void
+	 */
+	public function __unset($name)
+	{
+		if (isset($this->data[$name]))
+		{
+			$this->data[$name]->value = $this->data[$name]->default;
+		}
+	}
+}

--- a/libraries/cms/router/administrator.php
+++ b/libraries/cms/router/administrator.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Router
  * @since       1.5
  */
-class JRouterAdministrator extends JRouter
+class JRouteJCmsministrator extends JRouter
 {
 	/**
 	 * Function to convert a route to an internal URI.

--- a/libraries/cms/view/html.php
+++ b/libraries/cms/view/html.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Html view class
+ * 
+ * @package     Joomla.JCms
+ * @subpackage  ViewHtml
+ * @author	Ossolution Team
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('_JEXEC') or die();
+jimport('joomla.filesystem.path');
+
+class JCmsViewHtml extends JCmsView
+{
+
+	/**
+	 * Prefix of the language items used in the view
+	 *
+	 * @var string
+	 */
+	protected $languagePrefix;
+
+	/**
+	 * The view layout.
+	 *
+	 * @var string
+	 */
+	protected $layout = 'default';
+
+	/**
+	 * The paths queue.
+	 *
+	 * @var SplPriorityQueue
+	 */
+	protected $paths = array();
+
+	/**
+	 * Default Itemid variable value for the links in the view
+	 *
+	 * @var int
+	 */
+	public $Itemid;
+
+	/**
+	 * This is a front-end or back-end view.
+	 * We need this field to determine whether we need to addToolbar or build the filter
+	 *
+	 * @var boolean
+	 */
+	protected $isAdminView = false;
+
+	/**
+	 * Method to instantiate the view.
+	 *
+	 * @param $config A
+	 *        	named configuration array for object construction
+	 *        	
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+		
+		if (isset($config['layout']))
+		{
+			$this->layout = $config['layout'];
+		}
+		if (isset($config['language_prefix']))
+		{
+			$this->languagePrefix = $config['language_prefix'];
+		}
+		else
+		{
+			$this->languagePrefix = strtoupper($this->option);
+		}
+		if (isset($config['paths']))
+		{
+			$this->paths = $config['paths'];
+		}
+		else
+		{
+			$this->paths = new SplPriorityQueue();
+		}				
+		if (!empty($config['is_admin_view']))
+		{
+			$this->isAdminView = $config['is_admin_view'];
+		}
+		if (!empty($config['Itemid']))
+		{
+			$this->Itemid = $config['Itemid'];
+		}
+	}
+
+	/**
+	 * Display the view
+	 */
+	public function display()
+	{
+		echo $this->render();
+	}
+
+	/**
+	 * Magic toString method that is a proxy for the render method.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->render();
+	}
+
+	/**
+	 * Method to escape output.
+	 *
+	 * @param string $output
+	 *        	The output to escape.
+	 *        	
+	 * @return string The escaped output.
+	 */
+	public function escape($output)
+	{
+		return htmlspecialchars($output, ENT_COMPAT, 'UTF-8');
+	}
+
+	/**
+	 * Method to get the view layout.
+	 *
+	 * @return string The layout name.
+	 */
+	public function getLayout()
+	{
+		return $this->layout;
+	}
+
+	/**
+	 * Method to get the layout path.
+	 *
+	 * @param string $layout
+	 *        	The layout name.
+	 *        	
+	 * @return mixed The layout file name if found, false otherwise.
+	 */
+	public function getPath($layout)
+	{
+		// Get the layout file name.
+		$file = JPath::clean($layout . '.php');						
+		// Find the layout file path.
+		$path = JPath::find(clone ($this->paths), $file);		
+		return $path;
+	}
+
+	/**
+	 * Method to get the view paths.
+	 *
+	 * @return SplPriorityQueue The paths queue.
+	 *        
+	 */
+	public function getPaths()
+	{
+		return $this->paths;
+	}
+
+	/**
+	 * Method to render the view.
+	 *
+	 * @return string The rendered view.
+	 *        
+	 * @throws RuntimeException
+	 */
+	public function render()
+	{
+		// Get the layout path.
+		$path = $this->getPath($this->getLayout());
+		// Check if the layout path was found.
+		if (!$path)
+		{
+			throw new RuntimeException('Layout Path Not Found');
+		}
+		// Start an output buffer.
+		ob_start();
+		
+		// Load the layout.
+		include $path;
+		
+		// Get the layout contents.
+		$output = ob_get_clean();
+		
+		return $output;
+	}
+
+	/**
+	 * Load sub-template for the current layout
+	 *
+	 * @param string $template        	
+	 *
+	 * @throws RuntimeException
+	 * @return string The output of sub-layout
+	 */
+	public function loadTemplate($template, $data = array())
+	{
+		// Get the layout path.
+		$path = $this->getPath($this->getLayout() . '_' . $template);
+		// Check if the layout path was found.
+		if (!$path)
+		{
+			throw new RuntimeException('Layout Path Not Found');
+		}
+		extract($data);
+		// Start an output buffer.
+		ob_start();
+		// Load the layout.
+		include $path;
+		// Get the layout contents.
+		$output = ob_get_clean();
+		return $output;
+	}
+
+	/**
+	 * Method to set the view layout.
+	 *
+	 * @param string $layout
+	 *        	The layout name.
+	 *        	
+	 * @return JCmsViewHtml Method supports chaining.
+	 *        
+	 */
+	public function setLayout($layout)
+	{
+		$this->layout = $layout;
+		
+		return $this;
+	}
+
+	/**
+	 * Method to set the view paths.
+	 *
+	 * @param $paths The
+	 *        	paths queue.
+	 *        	
+	 * @return JCmsViewHtml Method supports chaining.
+	 *        
+	 */
+	public function setPaths($paths)
+	{
+		$this->paths = $paths;
+		return $this;
+	}
+}

--- a/libraries/cms/view/item.php
+++ b/libraries/cms/view/item.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('_JEXEC') or die();
+
+/**
+ * Joomla CMS Item View Class. This class is used to display details information of an item
+ * or display form allow add/editing items
+ *
+ * @package     Joomla.CMS
+ * @subpackage  View
+ * @since       3.5
+ */
+class JCmsViewItem extends JCmsViewHtml
+{
+
+	/**
+	 * The model state
+	 *
+	 * @var JCmsModelState
+	 */
+	protected $state;
+
+	/**
+	 * The record which is being added/edited
+	 *
+	 * @var Object
+	 */
+	protected $item;
+
+	/**
+	 * Hold actions which can be performed
+	 * 
+	 * @var JObject
+	 */
+	protected $canDo;
+
+	/**
+	 * Method to display the view
+	 * 
+	 * @see JCmsViewHtml::display()
+	 */
+	public function display()
+	{
+		$this->prepareView();
+		parent::display();
+	}
+
+	/**
+	 * Method to prepare all the data for the view before it is displayed
+	 */
+	protected function prepareView()
+	{
+		$this->state = $this->model->getState();
+		$this->item = $this->model->getData();
+		if ($this->isAdminView)
+		{
+			$this->form = $this->model->getForm();
+			$this->getActions($this->state);
+			$this->addToolbar();
+		}
+	}
+
+	/**
+	 * Get actions which users can perform
+	 *
+	 * @param JCmsModelState $state
+	 */
+	protected function getActions($state)
+	{
+		$helperClass = $this->classPrefix . 'Helper';
+		if (is_callable($helperClass . '::getActions'))
+		{
+			$this->canDo = call_user_func(array($helperClass, 'getActions'), $this->name, $state);
+		}
+		else
+		{
+			$this->canDo = call_user_func(array('JCmsComponentHelper', 'getActions'), $this->option, $this->name, $state);
+		}
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 */
+	protected function addToolbar()
+	{
+		$user = JFactory::getUser();
+		$isNew = ($this->item->id == 0);
+		if (isset($this->item->checked_out))
+		{
+			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+		}
+		else
+		{
+			$checkedOut = false;
+		}
+		$canDo = $this->canDo;
+		if ($this->item->id)
+		{
+			$toolbarTitle = $this->languagePrefix . '_' . $this->name . '_EDIT';
+		}
+		else
+		{
+			$toolbarTitle = $this->languagePrefix . '_' . $this->name . '_NEW';
+		}
+		JToolBarHelper::title(JText::_(strtoupper($toolbarTitle)));
+		// If not checked out, can save the item.
+		if (!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.create'))))
+		{
+			
+			JToolBarHelper::apply('apply', 'JTOOLBAR_APPLY');
+			JToolBarHelper::save('save', 'JTOOLBAR_SAVE');
+		}
+		
+		if (!$checkedOut && ($canDo->get('core.create')))
+		{
+			JToolBarHelper::custom('save2new', 'save-new.png', 'save-new_f2.png', 'JTOOLBAR_SAVE_AND_NEW', false);
+		}
+		
+		if (!$isNew && ($canDo->get('core.create')))
+		{
+			JToolbarHelper::save2copy('save2copy');
+		}
+		
+		if (empty($this->item->id))
+		{
+			JToolBarHelper::cancel('cancel', 'JTOOLBAR_CANCEL');
+		}
+		else
+		{
+			JToolBarHelper::cancel('cancel', 'JTOOLBAR_CLOSE');
+		}
+	}
+}

--- a/libraries/cms/view/list.php
+++ b/libraries/cms/view/list.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * View List class, used to render list of records from back-end of your component
+ * 
+ * @package     Joomla.JCms
+ * @subpackage  ViewList
+ * @author	Ossolution Team
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('_JEXEC') or die();
+class JCmsViewList extends JCmsViewHtml
+{
+
+	/**
+	 * The model state
+	 *
+	 * @var JCmsModelState
+	 */
+	protected $state;
+
+	/**
+	 * Hold actions which can be performed
+	 * @var JObject
+	 */
+	protected $canDo;
+
+	/**
+	 * List of records which will be displayed
+	 *
+	 * @var array
+	 */
+	protected $items;
+
+	/**
+	 * The pagination object
+	 *
+	 * @var JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * Method to instantiate the view.
+	 *
+	 * @param   array  $config The configuration data for the view
+	 *
+	 * @since  3.5
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+	}
+
+	/**
+	 * Method to display a view
+	 * 
+	 * @see JCmsViewHtml::display()
+	 */
+	public function display()
+	{
+		$this->prepareView();
+		$this->sidebar = JHtmlSidebar::render();
+		parent::display();
+	}
+
+	/**
+	 * Prepare the view before it is displayed
+	 * 
+	 */
+	protected function prepareView()
+	{
+		$this->state = $this->model->getState();
+		$this->items = $this->model->getData();
+		$this->pagination = $this->model->getPagination();
+		if ($this->isAdminView)
+		{
+			
+			$helperClass = $this->classPrefix . 'Helper';
+			if (is_callable($helperClass . '::addSubmenus'))
+			{
+				call_user_func(array($helperClass, 'addSubmenus'), $this->name);
+			}
+			else
+			{
+				call_user_func(array('JCmsComponentHelper', 'addSubmenus'), $this->name);
+			}
+			$this->getActions();
+			$this->addTitle();
+			$this->addToolbar();
+			$this->addFilters();
+		}
+	}
+
+	/**
+	 * Get actions which users can perform
+	 *
+	 * @return void        	
+	 */
+	protected function getActions()
+	{
+		$helperClass = $this->classPrefix . 'Helper';
+		if (is_callable($helperClass . '::getActions'))
+		{
+			$this->canDo = call_user_func(array($helperClass, 'getActions'), $this->name, $this->state);
+		}
+		else
+		{
+			$this->canDo = call_user_func(array('JCmsHelper', 'getActions'), $this->option, $this->name, $this->state);
+		}
+	}
+
+	/**
+	 * Method to add title to toolbar
+	 * 
+	 */
+	protected function addTitle()
+	{
+		JToolBarHelper::title(JText::_(strtoupper($this->languagePrefix . '_MANAGER_' . $this->name)), 'link ' . $this->name);
+	}
+
+	/**
+	 * Method to add sidebar filter
+	 */
+	protected function addFilters()
+	{
+		JHtmlSidebar::setAction('index.php?option=' . $this->option . '&view=' . $this->name);
+		
+		JHtmlSidebar::addFilter(JText::_('JOPTION_SELECT_PUBLISHED'), 'filter_state', 
+			JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->filter_state, true));
+		
+		JHtmlSidebar::addFilter(JText::_('JOPTION_SELECT_ACCESS'), 'filter_access', 
+			JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->filter_access));
+		
+		JHtmlSidebar::addFilter(JText::_('JOPTION_SELECT_LANGUAGE'), 'filter_language', 
+			JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->filter_language));
+		
+		JHtmlSidebar::addFilter(JText::_('JOPTION_SELECT_TAG'), 'filter_tag', 
+			JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->filter_tag));
+	}
+
+	/**
+	 * Method to add toolbar buttons
+	 * 
+	 */
+	protected function addToolbar()
+	{
+		$canDo = $this->canDo;
+		if ($canDo->get('core.create'))
+		{
+			JToolBarHelper::addNew('add', 'JTOOLBAR_NEW');
+		}
+		if ($canDo->get('core.edit') && isset($this->items[0]))
+		{
+			JToolBarHelper::editList('edit', 'JTOOLBAR_EDIT');
+		}
+		if ($canDo->get('core.delete') && isset($this->items[0]))
+		{
+			JToolBarHelper::deleteList(JText::_($this->languagePrefix . '_DELETE_CONFIRM'), 'delete');
+		}
+		if ($canDo->get('core.edit.state'))
+		{
+			if (isset($this->items[0]->published) || isset($this->items[0]->state))
+			{
+				JToolbarHelper::publish('publish', 'JTOOLBAR_PUBLISH', true);
+				JToolbarHelper::unpublish('unpublish', 'JTOOLBAR_UNPUBLISH', true);
+				
+				JToolbarHelper::archiveList('archive');
+				JToolbarHelper::checkin('checkin');
+			}
+		}
+		
+		if ($state->filter_state == -2 && $canDo->get('core.delete'))
+		{
+			JToolbarHelper::deleteList('', 'delete', 'JTOOLBAR_EMPTY_TRASH');
+		}
+		elseif ($canDo->get('core.edit.state'))
+		{
+			JToolbarHelper::trash('trash');
+		}
+		
+		if ($canDo->get('core.admin'))
+		{
+			JToolBarHelper::preferences($this->option);
+		}
+	}
+}

--- a/libraries/cms/view/view.php
+++ b/libraries/cms/view/view.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * @package     Joomla.CMS
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+defined('JPATH_PLATFORM') or die();
+
+/**
+ * Joomla CMS Base View Class
+ *
+ * @package     Joomla.CMS
+ * @subpackage  View
+ * @since       3.5
+ */
+abstract class JCmsView
+{
+
+	/**
+	 * Name of the view
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * The model object.
+	 *
+	 * @var JCmsModel
+	 */
+	protected $model;
+
+	/**
+	 * Full name of the component
+	 *
+	 * @var string
+	 */
+	protected $option;
+
+	/**
+	 * Some simple view doesn't have model associated with it, so we need this param
+	 * @var boolean
+	 */
+	public $hasModel = true;
+
+	/**
+	 * Prefix of class related to the view
+	 * 
+	 * @var string
+	 */
+	protected $classPrefix = null;
+
+	/**
+	 * Returns a View object, always creating it
+	 *
+	 * @param string $name The name of view to instantiate
+	 *        	
+	 * @param string $type The type of view to instantiate
+	 *        	
+	 * @param string $prefix Prefix for the view class name, ComponentnameView
+	 *        	
+	 * @param array $config Configuration array for view
+	 *        	
+	 *        	
+	 * @return JCmsView A view object
+	 *        
+	 */
+	public static function getInstance($name, $type, $prefix, array $config = array())
+	{
+		$class = ucfirst($prefix) . ucfirst($name) . ucfirst($type);
+		if (!class_exists($class))
+		{
+			if (isset($config['default_view_class']))
+			{
+				$class = $config['default_view_class'];
+			}
+			else
+			{
+				$class = 'JCmsView' . ucfirst($type);
+			}
+		}
+		return new $class($config);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $config A named configuration array for object construction.
+	 *        	
+	 */
+	public function __construct(array $config = array())
+	{
+		if (isset($config['name']))
+		{
+			$this->name = $config['name'];
+		}
+		else
+		{
+			$className = get_class($this);
+			$viewPos = strpos('View', $className);
+			if ($viewPos !== false)
+			{
+				$this->name = substr($className, $viewPos + 4);
+			}
+		}
+		if (isset($config['option']))
+		{
+			$this->option = $config['option'];
+		}
+		else
+		{
+			$className = get_class($this);
+			$viewPos = strpos('View', $className);
+			if ($viewPos !== false)
+			{
+				$this->option = substr($className, 0, $viewPos);
+			}
+		}
+		if (isset($config['has_model']))
+		{
+			$this->hasModel = $config['has_model'];
+		}
+		
+		if (isset($config['class_prefix']))
+		{
+			$this->classPrefix = $config['class_prefix'];
+		}
+		else 
+		{
+			$component = substr($this->option, 4);
+			$this->classPrefix = ucfirst($component);
+		}
+	}
+
+	/**
+	 * Get name of the current view
+	 *
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Set the model object
+	 *
+	 * @param JCmsModel $model        	
+	 */
+	public function setModel(JCmsModel $model)
+	{
+		$this->model = $model;
+	}
+
+	/**
+	 * Get the model object
+	 *
+	 * @return JCmsModel
+	 */
+	public function getModel()
+	{
+		return $this->model;
+	}
+
+	/**
+	 * Method to escape output.
+	 *
+	 * @param string $output The output to escape.
+	 *        	
+	 * @return string The escaped output.
+	 *        
+	 */
+	public function escape($output)
+	{
+		return $output;
+	}
+
+	/**
+	 *Empty display function, the child class must implemen it
+	 */
+	public function display()	
+	{
+		
+	}
+}

--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -337,7 +337,7 @@ class JControllerAdmin extends JControllerLegacy
 		else
 		{
 			// Checkin succeeded.
-			$message = JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($ids));
+			$message = JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', $return);
 			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
 			return true;
 		}

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -357,7 +357,7 @@ class JControllerForm extends JControllerLegacy
 	 * @since   12.2
 	 */
 	public function edit($key = null, $urlVar = null)
-	{
+	{		
 		$app   = JFactory::getApplication();
 		$model = $this->getModel();
 		$table = $model->getTable();


### PR DESCRIPTION
If we look at the checkin method in JModelAdmin, we can see that it returns the correct number of checked in record (via $count variable) when check in success. In some special case, this number might be different with the number of $ids pass to the method. So we need to replace count($ids) with $return to show the correct number of checked in records to users.
