### PR TITLE
Deprecate MySQL driver based on deprecated PHP mysql extension

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -16,6 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Database
  * @see         http://dev.mysql.com/doc/
  * @since       12.1
+ * @deprecated  Will be removed when the minimum supported PHP version no longer includes the deprecated PHP `mysql` extension
  */
 class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 {

--- a/libraries/joomla/database/exporter/mysql.php
+++ b/libraries/joomla/database/exporter/mysql.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Database
  * @since       11.1
+ * @deprecated  Will be removed when the minimum supported PHP version no longer includes the deprecated PHP `mysql` extension
  */
 class JDatabaseExporterMysql extends JDatabaseExporterMysqli
 {

--- a/libraries/joomla/database/importer/mysql.php
+++ b/libraries/joomla/database/importer/mysql.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Database
  * @since       11.1
+ * @deprecated  Will be removed when the minimum supported PHP version no longer includes the deprecated PHP `mysql` extension
  */
 class JDatabaseImporterMysql extends JDatabaseImporterMysqli
 {

--- a/libraries/joomla/database/iterator/mysql.php
+++ b/libraries/joomla/database/iterator/mysql.php
@@ -16,6 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Database
  * @see         http://dev.mysql.com/doc/
  * @since       12.1
+ * @deprecated  Will be removed when the minimum supported PHP version no longer includes the deprecated PHP `mysql` extension
  */
 class JDatabaseIteratorMysql extends JDatabaseIterator
 {

--- a/libraries/joomla/database/query/mysql.php
+++ b/libraries/joomla/database/query/mysql.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Database
  * @since       11.1
+ * @deprecated  Will be removed when the minimum supported PHP version no longer includes the deprecated PHP `mysql` extension
  */
 class JDatabaseQueryMysql extends JDatabaseQueryMysqli
 {


### PR DESCRIPTION
In PHP 5.5, support for the original `mysql` extension [was deprecated](http://php.net/manual/en/migration55.deprecated.php).  This affects our base MySQL driver class as it implements this extension.  This PR will tag that class, and its supporting classes, as deprecated since PHP will presumably drop support for them at some point.

Future TODO - When PHP announces a version where this extension will be removed or become totally unsupported, the driver class should be updated to fail gracefully (through version checks and Exceptions) instead of throwing a fatal error due to the code not being present.
