### PR TITLE
Fixed wrong order of "UNION" and "ORDER BY"

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -374,14 +374,14 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->having;
 				}
 
-				if ($this->order)
-				{
-					$query .= (string) $this->order;
-				}
-
 				if ($this->union)
 				{
 					$query .= (string) $this->union;
+				}
+
+				if ($this->order)
+				{
+					$query .= (string) $this->order;
 				}
 
 				break;


### PR DESCRIPTION
If you use UNION with ORDER BY, UNION is needed first and after that ORDER BY to sort the result.
