### PR TITLE
[#34082] [FIX] Updater fails to find updates from extension.xml after update from Joomla 2.5.22 to 2.5.24

### DIFF
--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -95,7 +95,7 @@ class JUpdaterExtension extends JUpdateAdapter
 					&& preg_match('/' . $this->current_update->targetplatform['VERSION'] . '/', $ver->RELEASE))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
-					if (!isset($this->current_update->php_minimum) || version_compare(PHP_VERSION, $this->current_update->php_minimum->_data, '>='))
+					if (!isset($this->current_update->php_minimum) || version_compare(PHP_VERSION, $this->current_update->php_minimum, '>='))
 					{
 						$phpMatch = true;
 					}
@@ -106,7 +106,7 @@ class JUpdaterExtension extends JUpdateAdapter
 							'JLIB_INSTALLER_AVAILABLE_UPDATE_PHP_VERSION',
 							$this->current_update->name,
 							$this->current_update->version,
-							$this->current_update->php_minimum->_data,
+							$this->current_update->php_minimum,
 							PHP_VERSION
 						);
 

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -123,7 +123,7 @@ class JUpdaterExtension extends JUpdateAdapter
 					{
 						if (isset($this->latest))
 						{
-							if (version_compare($this->current_update->version->_data, $this->latest->version->_data, '>') == 1)
+							if (version_compare($this->current_update->version, $this->latest->version, '>') == 1)
 							{
 								$this->latest = $this->current_update;
 							}

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -223,7 +223,7 @@ class JUpdate extends JObject
 					&& preg_match('/' . $this->_current_update->targetplatform->version . '/', $ver->RELEASE))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
-					if (!isset($this->_current_update->php_minimum) || version_compare(PHP_VERSION, $this->_current_update->php_minimum, '>='))
+					if (!isset($this->_current_update->php_minimum) || version_compare(PHP_VERSION, $this->_current_update->php_minimum->_data, '>='))
 					{
 						$phpMatch = true;
 					}

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -236,7 +236,7 @@ class JUpdate extends JObject
 					{
 						if (isset($this->_latest))
 						{
-							if (version_compare($this->_current_update->version>_data, $this->_latest->version->_data, '>') == 1)
+							if (version_compare($this->_current_update->version->_data, $this->_latest->version->_data, '>') == 1)
 							{
 								$this->_latest = $this->_current_update;
 							}

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -223,7 +223,7 @@ class JUpdate extends JObject
 					&& preg_match('/' . $this->_current_update->targetplatform->version . '/', $ver->RELEASE))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
-					if (!isset($this->_current_update->php_minimum) || version_compare(PHP_VERSION, $this->_current_update->php_minimum->_data, '>='))
+					if (!isset($this->_current_update->php_minimum) || version_compare(PHP_VERSION, $this->_current_update->php_minimum, '>='))
 					{
 						$phpMatch = true;
 					}
@@ -236,7 +236,7 @@ class JUpdate extends JObject
 					{
 						if (isset($this->_latest))
 						{
-							if (version_compare($this->_current_update->version->_data, $this->_latest->version->_data, '>') == 1)
+							if (version_compare($this->_current_update->version, $this->_latest->version, '>') == 1)
 							{
 								$this->_latest = $this->_current_update;
 							}

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -236,7 +236,7 @@ class JUpdate extends JObject
 					{
 						if (isset($this->_latest))
 						{
-							if (version_compare($this->_current_update->version, $this->_latest->version, '>') == 1)
+							if (version_compare($this->_current_update->version>_data, $this->_latest->version->_data, '>') == 1)
 							{
 								$this->_latest = $this->_current_update;
 							}


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=34082

Since 2.5.23 or https://github.com/joomla/joomla-cms/commit/73f560137fba04cf41394dbb725050bebf964080 Extensions that use more than one `<update>` tag in the update stream can't update via auto updater.
Example: http://vi-solutions.de/updates/visforms/extension.xml
If the last version is on the top (in the first `<update>` tag) or we have only one `<update>` tag all is good and the updates will be find.

This Patch will fix it.
