### PR TITLE
Impossible to bind a null value

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -628,7 +628,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			// Only process fields not in the ignore array.
 			if (!in_array($k, $ignore))
 			{
-				if (isset($src[$k]))
+				if(array_key_exists( $k, $src ))
 				{
 					$this->$k = $src[$k];
 				}


### PR DESCRIPTION
Fixes issue where it is impossible to bind a null value. For instance $table->bind( array( 'someid'=>null ) ); As isset determines if a variable is set and is not NULL. NULL values are needed where the INNODB foreign key is not set yet or needs to be cleared.
