### PR TITLE
[#30790] Correct spelling of the X-Frame-Options header on Joomla 2.5

### DIFF
--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -671,7 +671,7 @@ abstract class JHtmlBehavior
 		$document->addStyleDeclaration('html { display:none }');
 		$document->addScriptDeclaration($js);
 
-		JResponse::setHeader('X-Frames-Options', 'SAME-ORIGIN');
+		JResponse::setHeader('X-Frame-Options', 'SAMEORIGIN');
 
 		self::$loaded[__METHOD__] = true;
 	}


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Open the Joomla back-end log-in page (www.example.com/administrator/)
2. Using browser tools (e.g. the Firefox web console), check headers received with server response to GET www.example.com/administrator/
#### Expected result
1. "X-Frame-Options: SAMEORIGIN" is received
#### Actual result
1. "X-Frames-Options: SAME-ORIGIN" is received
#### System information (as much as possible)

PHP 5.3.6 on Apache on Linux
#### Additional comments

What should be server header "X-Frame-Options: SAMEORIGIN" is sent as "X-Frames-Options: SAME-ORIGIN" on Joomla 2.5.24. (I.e. both, header name AND its value are misspelled.)

Note: This was fixed on "master" with http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=30790, but not on Joomla 2.5.x.
