### PR TITLE
Prevent sending of "remember-me" cookie deletion request when cookie not set

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -809,6 +809,7 @@ class JApplication extends JObject
 				// Use domain and path set in config for cookie if it exists.
 				$cookie_domain = $this->getCfg('cookie_domain', '');
 				$cookie_path = $this->getCfg('cookie_path', '/');
+				// Check for SSL connection
 				$secure = ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 				setcookie(self::getHash('JLOGIN_REMEMBER'), false, time() - 86400, $cookie_path, $cookie_domain, $secure, true);
 			}

--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -804,11 +804,14 @@ class JApplication extends JObject
 
 		if (!in_array(false, $results, true))
 		{
-			// Use domain and path set in config for cookie if it exists.
-			$cookie_domain = $this->getCfg('cookie_domain', '');
-			$cookie_path = $this->getCfg('cookie_path', '/');
-			setcookie(self::getHash('JLOGIN_REMEMBER'), false, time() - 86400, $cookie_path, $cookie_domain);
-
+			if (isset($_COOKIE[self::getHash('JLOGIN_REMEMBER')]))
+			{
+				// Use domain and path set in config for cookie if it exists.
+				$cookie_domain = $this->getCfg('cookie_domain', '');
+				$cookie_path = $this->getCfg('cookie_path', '/');
+				$secure = ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+				setcookie(self::getHash('JLOGIN_REMEMBER'), false, time() - 86400, $cookie_path, $cookie_domain, $secure, true);
+			}
 			return true;
 		}
 


### PR DESCRIPTION
The "remember-me" cookie is deletion request is sent even when the cookie was never set - e.g. if the "Remember me" functionality is disabled in the Joomla configuration.
#### Steps to reproduce the issue
1. Log into the back-end of Joomla (www.example.com/administrator/).
2. Open browser tools for checking headers received with server response
3. Log out of the back-end
4. Check headers sent by browser and received with server response to GET www.example.com/administrator/index.php?option=com_login&task=logout&2048602984502834069720345=1 (the one with the "303 See other" response)
#### Expected result

4.. The session cookie sent on the request is requested to be deleted in the response.
#### Actual result

4.. Additionally to the session cookie, another cookie (the "remember-me" cookie) which had not been present in the request is also deleted in the response.
#### System information (as much as possible)

PHP 5.3.6 on Apache on Linux
#### Additional comments

This seems to be Joomla 2.5.x specific (and 1.5.x before that). On Joomla 3.x the "remember-me" functionality has been rewritten and the issue does not seem to occur (checked on the demo site http://joomla32.cloudaccess.net/administrator/index.php?autologin=1&passwd=demo&username=demo).

Also: added the HTTPS and HttpOnly cookie flags, as "Cookies must be deleted with the same parameters as they were set with" according to https://php.net/manual/en/function.setcookie.php. And that is how the cookie is set - see lines 739 - 740.
