### PR TITLE
Session cookie flags update ("secure" and "httpOnly" added where missing)

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -523,7 +523,8 @@ class JSession extends JObject
 				if (JRequest::getVar($session_name))
 				{
 					session_id(JRequest::getVar($session_name));
-					setcookie($session_name, '', time() - 3600);
+					$cookie = session_get_cookie_params();
+					setcookie($session_name, '', time() - 42000, $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httponly']);
 				}
 			}
 		}
@@ -562,10 +563,8 @@ class JSession extends JObject
 		 */
 		if (isset($_COOKIE[session_name()]))
 		{
-			$config = JFactory::getConfig();
-			$cookie_domain = $config->get('cookie_domain', '');
-			$cookie_path = $config->get('cookie_path', '/');
-			setcookie(session_name(), '', time() - 42000, $cookie_path, $cookie_domain);
+			$cookie = session_get_cookie_params();
+			setcookie(session_name(), '', time() - 42000, $cookie['path'], $cookie['domain'], $cookie['secure'], $cookie['httponly']);
 		}
 
 		session_unset();
@@ -721,7 +720,7 @@ class JSession extends JObject
 		{
 			$cookie['path'] = $config->get('cookie_path');
 		}
-		session_set_cookie_params($cookie['lifetime'], $cookie['path'], $cookie['domain'], $cookie['secure']);
+		session_set_cookie_params($cookie['lifetime'], $cookie['path'], $cookie['domain'], $cookie['secure'], true);
 	}
 
 	/**


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Using a tool which is able to display the "httpOnly" flag of a received cookie (an intercepting proxy or the Firebug Firefox add-on (I assume; the built-in Firefox console can't)), log-in and log-out of a site's back-end.
#### Expected result
1. Both, the session cookie is "set" and "delete" requests received as part of the server response have the "httpOnly" flag set.
#### Actual result
1. The "httpOnly" flag is not set.
#### System information (as much as possible)

PHP 5.3.6 on Apache on Linux
#### Additional comments

Added the "secure" and "httpOnly" flags to the cookie "delete" requests as well, as "Cookies must be deleted with the same parameters as they were set with" according to https://php.net/manual/en/function.setcookie.php.
