### PR TITLE
[29550] disable escape_string_warning option postgres

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -126,6 +126,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
 		pg_query('SET standard_conforming_strings=off');
+		pg_query('SET escape_string_warning=off');
 	}
 
 	/**


### PR DESCRIPTION
With Joomla 3.0.1, using Postgresql 9.1, the following warning appears in PostgreSQL logs many many times:

WARNING: nonstandard use of \ in a string literal at character 187
HINT: Use the escape string syntax for backslashes, e.g., E'\'.

These warnings appears because Joomla use backslashes as escape characters (ie standard_conforming_strings is disabled).

This PR disables "escape_string_warning" option. This option is supported since PostgreSQL 8.1
