### PR TITLE
[#33366] Log clientip

### DIFF
--- a/libraries/joomla/log/logger/formattedtext.php
+++ b/libraries/joomla/log/logger/formattedtext.php
@@ -34,7 +34,7 @@ class JLogLoggerFormattedtext extends JLogLogger
 	 * in all caps and be within curly brackets eg. {FOOBAR}.
 	 * @since  11.1
 	 */
-	protected $format = '{DATETIME}	{PRIORITY}	{CATEGORY}	{MESSAGE}';
+	protected $format = '{DATETIME}	{PRIORITY} {CLIENTIP}	{CATEGORY}	{MESSAGE}';
 
 	/**
 	 * @var    array  The parsed fields from the format string.


### PR DESCRIPTION
In logs/error.php adds the missing client IP column.

First reported here http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33366&start=0
