### PR TITLE
Fixes the usergroups not being updated after saving the user profile.

### DIFF
--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -135,18 +135,8 @@ class AdminModelProfile extends UsersModelUser
 			unset($data['username']);
 		}
 
-		// Bind the data.
-		if (!$user->bind($data))
-		{
-			$this->setError($user->getError());
-
-			return false;
-		}
-
-		$user->groups = null;
-
 		// Store the data.
-		if (!$user->save())
+		if (!$user->save($data))
 		{
 			$this->setError($user->getError());
 

--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -135,8 +135,16 @@ class AdminModelProfile extends UsersModelUser
 			unset($data['username']);
 		}
 
+		// Bind the data.
+		if (!$user->bind($data))
+		{
+			$this->setError($user->getError());
+
+			return false;
+		}
+
 		// Store the data.
-		if (!$user->save($data))
+		if (!$user->save())
 		{
 			$this->setError($user->getError());
 


### PR DESCRIPTION
A few things happening here. First I removed the bind() part because the save() method does a bind automatically. Second I removed the nullifying of the user groups as this is handled in the JTableUser store() method.
