### PR TITLE
Removed wrong default values in the google maps constructor

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -36,7 +36,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function __construct(JRegistry $options = null, JUri $uri = null, JHttp $http = null)
 	{
-		parent::__construct($options = null, $uri = null);
+		parent::__construct($option, $uri);
 		$this->http = $http ? $http : new JHttp($this->options);
 	}
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -36,7 +36,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function __construct(JRegistry $options = null, JUri $uri = null, JHttp $http = null)
 	{
-		parent::__construct($option, $uri);
+		parent::__construct($options, $uri);
 		$this->http = $http ? $http : new JHttp($this->options);
 	}
 


### PR DESCRIPTION
If you create a "JGoogleEmbedMaps" instance, all parameters will be ignored.

=> Apply patch => test again
