### PR TITLE
Made the Google Maps API key optional

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -549,11 +549,6 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function getHeader()
 	{
-		if (!$this->getOption('key'))
-		{
-			throw new UnexpectedValueException('A Google Maps API key is required.');
-		}
-
 		$zoom = $this->getZoom();
 		$center = $this->getCenter();
 		$maptype = $this->getMapType();
@@ -598,13 +593,13 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 			$onload = "function() {";
 			$onload .= 'var script = document.createElement("script");';
 			$onload .= 'script.type = "text/javascript";';
-			$onload .= "script.src = '{$scheme}://maps.googleapis.com/maps/api/js?key={$key}&sensor={$sensor}&callback={$asynccallback}';";
+			$onload .= "script.src = '{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}" : "") . "&sensor={$sensor}&callback={$asynccallback}';";
 			$onload .= 'document.body.appendChild(script);';
 			$onload .= '}';
 		}
 		else
 		{
-			$output = "<script type='text/javascript' src='{$scheme}://maps.googleapis.com/maps/api/js?key={$key}&sensor={$sensor}'>";
+			$output = "<script type='text/javascript' src='{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}" : "") . "&sensor={$sensor}'>";
 			$output .= '</script>';
 			$output .= '<script type="text/javascript">';
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -593,13 +593,13 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 			$onload = "function() {";
 			$onload .= 'var script = document.createElement("script");';
 			$onload .= 'script.type = "text/javascript";';
-			$onload .= "script.src = '{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}" : "") . "&sensor={$sensor}&callback={$asynccallback}';";
+			$onload .= "script.src = '{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}&" : "") . "sensor={$sensor}&callback={$asynccallback}';";
 			$onload .= 'document.body.appendChild(script);';
 			$onload .= '}';
 		}
 		else
 		{
-			$output = "<script type='text/javascript' src='{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}" : "") . "&sensor={$sensor}'>";
+			$output = "<script type='text/javascript' src='{$scheme}://maps.googleapis.com/maps/api/js?" . ($key ? "key={$key}&" : "") . "sensor={$sensor}'>";
 			$output .= '</script>';
 			$output .= '<script type="text/javascript">';
 

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -629,18 +629,6 @@ class JGoogleEmbedMapsTest extends TestCase
 	}
 
 	/**
-	 * Tests the getHeader method without a key
-	 *
-	 * @group	JGoogle
-	 * @expectedException UnexpectedValueException
-	 * @return void
-	 */
-	public function testGetHeaderException()
-	{
-		$this->object->getHeader();
-	}
-
-	/**
 	 * Tests the getBody method
 	 *
 	 * @group	JGoogle


### PR DESCRIPTION
With version 3 of the Google Maps API, the API key is optional for some functions (like displaying a normal map)
