### PR TITLE
[#32200] Removing false error_reporting setting in the installer

### DIFF
--- a/installation/application/framework.php
+++ b/installation/application/framework.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
  * Joomla system checks.
  */
 
-error_reporting(E_ALL);
 const JDEBUG = false;
 @ini_set('magic_quotes_runtime', 0);
 


### PR DESCRIPTION
This is a PR for this JC item: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=32200&start=25
