### PR TITLE
Update references to JRegistry for components folder

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 JTable::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/tables');
 
 /**
@@ -192,7 +194,7 @@ class BannersModelBanners extends JModelList
 
 			foreach ($this->cache['items'] as &$item)
 			{
-				$parameters = new JRegistry;
+				$parameters = new Registry;
 				$parameters->loadString($item->params);
 				$item->params = $parameters;
 			}

--- a/components/com_config/model/cms.php
+++ b/components/com_config/model/cms.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Prototype admin model.
  *
@@ -93,7 +95,7 @@ abstract class ConfigModelCms extends JModelDatabase
 		}
 		else
 		{
-			$this->state = new JRegistry;
+			$this->state = new Registry;
 		}
 
 		// Set the model dbo
@@ -121,7 +123,7 @@ abstract class ConfigModelCms extends JModelDatabase
 			$this->event_clean_cache = 'onContentCleanCache';
 		}
 
-		$state = new JRegistry($config);
+		$state = new Registry($config);
 
 		parent::__construct($state);
 	}

--- a/components/com_contact/models/categories.php
+++ b/components/com_contact/models/categories.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of contact categories.
  *
@@ -93,7 +95,7 @@ class ContactModelCategories extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 			if ($active)
 			{
 				$params->loadString($active->params);

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * @package     Joomla.Site
  * @subpackage  com_contact
@@ -92,7 +94,7 @@ class ContactModelCategory extends JModelList
 			$item = & $items[$i];
 			if (!isset($this->_params))
 			{
-				$params = new JRegistry;
+				$params = new Registry;
 				$params->loadString($item->params);
 				$item->params = $params;
 			}
@@ -235,7 +237,7 @@ class ContactModelCategory extends JModelList
 		$this->setState('list.filter', $app->input->getString('filter-search'));
 
 		// Get list ordering default from the parameters
-		$menuParams = new JRegistry;
+		$menuParams = new Registry;
 		if ($menu = $app->getMenu()->getActive())
 		{
 			$menuParams->loadString($menu->params);
@@ -290,7 +292,7 @@ class ContactModelCategory extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 
 			if ($active)
 			{

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * @package     Joomla.Site
  * @subpackage  com_contact
@@ -64,7 +66,7 @@ class ContactModelContact extends JModelForm
 	 *
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
-	 * 
+	 *
 	 * @return  JForm  A JForm object on success, false on failure
 	 * @since   1.6
 	 */
@@ -182,12 +184,12 @@ class ContactModelContact extends JModelForm
 				}
 
 				// Convert parameter fields to objects.
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->params);
 				$data->params = clone $this->getState('params');
 				$data->params->merge($registry);
 
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->metadata);
 				$data->metadata = $registry;
 
@@ -300,7 +302,7 @@ class ContactModelContact extends JModelForm
 				// So merge the contact parameters with the merged parameters
 				if ($this->getState('params')->get('show_contact_list'))
 				{
-					$registry = new JRegistry;
+					$registry = new Registry;
 					$registry->loadString($result->params);
 					$this->getState('params')->merge($registry);
 				}

--- a/components/com_contact/models/featured.php
+++ b/components/com_contact/models/featured.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * @package     Joomla.Site
  * @subpackage  com_contact
@@ -87,7 +89,7 @@ class ContactModelFeatured extends JModelList
 			$item = & $items[$i];
 			if (!isset($this->_params))
 			{
-				$params = new JRegistry;
+				$params = new Registry;
 				$params->loadString($item->params);
 				$item->params = $params;
 			}

--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 JFormHelper::loadRuleClass('email');
 
 /**
@@ -27,12 +29,12 @@ class JFormRuleContactEmail extends JFormRuleEmail
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		if (!parent::test($element, $value, $group, $input, $form))
 		{

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JFormRule for com_contact to make sure the message body contains no banned word.
  *
@@ -25,12 +27,12 @@ class JFormRuleContactEmailMessage extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_text');

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JFormRule for com_contact to make sure the subject contains no banned word.
  *
@@ -25,12 +27,12 @@ class JFormRuleContactEmailSubject extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
 		$banned = $params->get('banned_subject');

--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Contacts component
  *
@@ -52,7 +54,7 @@ class ContactViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug	= $item->alias ? ($item->id.':'.$item->alias) : $item->id;
-			$temp		= new JRegistry;
+			$temp		= new Registry;
 			$temp->loadString($item->params);
 			$item->params = clone($this->params);
 			$item->params->merge($temp);

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Frontpage View class
  *
@@ -59,7 +61,7 @@ class ContactViewFeatured extends JViewLegacy
 		{
 			$item       = &$items[$i];
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$temp       = new JRegistry;
+			$temp       = new Registry;
 
 			$temp->loadString($item->params);
 			$item->params = clone($params);

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Content Component HTML Helper
  *
@@ -21,10 +23,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to the create item page for the given category
 	 *
-	 * @param   object     $category  The category information
-	 * @param   JRegistry  $params    The item parameters
-	 * @param   array      $attribs   Optional attributes for the link
-	 * @param   boolean    $legacy    True to use legacy images, false to use icomoon based graphic
+	 * @param   object    $category  The category information
+	 * @param   Registry  $params    The item parameters
+	 * @param   array     $attribs   Optional attributes for the link
+	 * @param   boolean   $legacy    True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the create item link
 	 */
@@ -72,10 +74,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to the email item page for the given article
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object    $article  The article information
+	 * @param   Registry  $params   The item parameters
+	 * @param   array     $attribs  Optional attributes for the link
+	 * @param   boolean   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the email item link
 	 */
@@ -121,10 +123,10 @@ abstract class JHtmlIcon
 	 * This icon will not display in a popup window, nor if the article is trashed.
 	 * Edit access checks must be performed in the calling code.
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object    $article  The article information
+	 * @param   Registry  $params   The item parameters
+	 * @param   array     $attribs  Optional attributes for the link
+	 * @param   boolean   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string	The HTML for the article edit icon.
 	 * @since   1.6
@@ -207,10 +209,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a popup link to print an article
 	 *
-	 * @param   object     $article  The article information
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Optional attributes for the link
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object    $article  The article information
+	 * @param   Registry  $params   The item parameters
+	 * @param   array     $attribs  Optional attributes for the link
+	 * @param   boolean   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 */
@@ -252,10 +254,10 @@ abstract class JHtmlIcon
 	/**
 	 * Method to generate a link to print an article
 	 *
-	 * @param   object     $article  Not used, @deprecated for 4.0
-	 * @param   JRegistry  $params   The item parameters
-	 * @param   array      $attribs  Not used, @deprecated for 4.0
-	 * @param   boolean    $legacy   True to use legacy images, false to use icomoon based graphic
+	 * @param   object    $article  Not used, @deprecated for 4.0
+	 * @param   Registry  $params   The item parameters
+	 * @param   array     $attribs  Not used, @deprecated for 4.0
+	 * @param   boolean   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 */

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -149,7 +149,7 @@ class ContentHelperQuery
 	/**
 	 * Get join information for the voting query.
 	 *
-	 * @param   JRegistry	$param	An options object for the article.
+	 * @param   \Joomla\Registry\Registry  $params  An options object for the article.
 	 *
 	 * @return  array  	A named array with "select" and "join" keys.
 	 * @since   1.5

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Content Component Article Model
  *
@@ -169,13 +171,13 @@ class ContentModelArticle extends JModelItem
 				}
 
 				// Convert parameter fields to objects.
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->attribs);
 
 				$data->params = clone $this->getState('params');
 				$data->params->merge($registry);
 
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->metadata);
 				$data->metadata = $registry;
 

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of articles.
  *
@@ -547,7 +549,7 @@ class ContentModelArticles extends JModelList
 		// Convert the parameter fields into objects.
 		foreach ($items as &$item)
 		{
-			$articleParams = new JRegistry;
+			$articleParams = new Registry;
 			$articleParams->loadString($item->attribs);
 
 			// Unpack readmore and layout params
@@ -587,7 +589,7 @@ class ContentModelArticles extends JModelList
 				// Merge the selected article params
 				if (count($articleArray) > 0)
 				{
-					$articleParams = new JRegistry;
+					$articleParams = new Registry;
 					$articleParams->loadArray($articleArray);
 					$item->params->merge($articleParams);
 				}

--- a/components/com_content/models/categories.php
+++ b/components/com_content/models/categories.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of article categories.
  *
@@ -96,7 +98,7 @@ class ContentModelCategories extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 
 			if ($active)
 			{

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving a category, the articles associated with the category,
  * sibling, child and parent categories.
@@ -110,7 +112,7 @@ class ContentModelCategory extends JModelList
 
 		// Load the parameters. Merge Global and Menu Item params into new object
 		$params = $app->getParams();
-		$menuParams = new JRegistry;
+		$menuParams = new Registry;
 
 		if ($menu = $app->getMenu()->getActive())
 		{

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 // Base this model on the backend version.
 require_once JPATH_ADMINISTRATOR.'/components/com_content/models/article.php';
 
@@ -86,7 +88,7 @@ class ContentModelForm extends ContentModelArticle
 		$value = JArrayHelper::toObject($properties, 'JObject');
 
 		// Convert attrib field to Registry.
-		$value->params = new JRegistry;
+		$value->params = new Registry;
 		$value->params->loadString($value->attribs);
 
 		// Compute selected asset permissions.
@@ -140,7 +142,7 @@ class ContentModelForm extends ContentModelArticle
 		}
 
 		// Convert the metadata field to an array.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($value->metadata);
 		$value->metadata = $registry->toArray();
 

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Content component
  *
@@ -239,7 +241,7 @@ class ContentViewCategory extends JViewCategory
 
 		if (!is_object($this->category->metadata))
 		{
-			$this->category->metadata = new JRegistry($this->category->metadata);
+			$this->category->metadata = new Registry($this->category->metadata);
 		}
 
 		if (($app->get('MetaAuthor') == '1') && $this->category->get('author', ''))

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 JLoader::register('FinderHelperLanguage', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/language.php');
 
 /**
@@ -67,7 +69,7 @@ abstract class JHtmlFilter
 			// Initialize the filter parameters.
 			if ($filter)
 			{
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($filter->params);
 				$filter->params = $registry;
 			}
@@ -282,7 +284,7 @@ abstract class JHtmlFilter
 				// Initialize the filter parameters.
 				if ($filter)
 				{
-					$registry = new JRegistry;
+					$registry = new Registry;
 					$registry->loadString($filter->params);
 					$filter->params = $registry;
 				}

--- a/components/com_newsfeeds/models/categories.php
+++ b/components/com_newsfeeds/models/categories.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of newsfeed categories.
  *
@@ -93,7 +95,7 @@ class NewsfeedsModelCategories extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 			if ($active)
 			{
 				$params->loadString($active->params);

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Newsfeeds Component Category Model
  *
@@ -87,7 +89,7 @@ class NewsfeedsModelCategory extends JModelList
 		{
 			if (!isset($this->_params))
 			{
-				$params = new JRegistry;
+				$params = new Registry;
 				$item->params = $params;
 				$params->loadString($item->params);
 			}
@@ -236,7 +238,7 @@ class NewsfeedsModelCategory extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 
 			if ($active)
 			{

--- a/components/com_newsfeeds/models/newsfeed.php
+++ b/components/com_newsfeeds/models/newsfeed.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Newsfeeds Component Newsfeed Model
  *
@@ -127,12 +129,12 @@ class NewsfeedsModelNewsfeed extends JModelItem
 				}
 
 				// Convert parameter fields to objects.
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->params);
 				$data->params = clone $this->getState('params');
 				$data->params->merge($registry);
 
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($data->metadata);
 				$data->metadata = $registry;
 

--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Newsfeeds component
  *
@@ -52,7 +54,7 @@ class NewsfeedsViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug	= $item->alias ? ($item->id.':'.$item->alias) : $item->id;
-			$temp		= new JRegistry;
+			$temp		= new Registry;
 			$temp->loadString($item->params);
 			$item->params = clone($this->params);
 			$item->params->merge($temp);

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Newsfeeds component
  *
@@ -160,7 +162,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		// Get the newsfeed
 		$newsfeed = $item;
 
-		$temp = new JRegistry;
+		$temp = new Registry;
 		$temp->loadString($item->params);
 		$params->merge($temp);
 

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the search component
  *
@@ -48,7 +50,7 @@ class SearchViewSearch extends JViewLegacy
 		// Because the application sets a default page title, we need to get it right from the menu item itself
 		if (is_object($menu))
 		{
-			$menu_params = new JRegistry;
+			$menu_params = new Registry;
 			$menu_params->loadString($menu->params);
 
 			if (!$menu_params->get('page_title'))

--- a/components/com_tags/models/tags.php
+++ b/components/com_tags/models/tags.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving a list of tags.
  *
@@ -90,7 +92,7 @@ class TagsModelTags extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 			if ($active)
 			{
 				$params->loadString($active->params);

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Tags component
  *
@@ -74,7 +76,7 @@ class TagsViewTag extends JViewLegacy
 			// Prepare the data.
 			if (!empty($itemElement))
 			{
-				$temp = new JRegistry;
+				$temp = new Registry;
 				$temp->loadString($itemElement->params);
 				$itemElement->params = clone($params);
 				$itemElement->params->merge($temp);

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the Tags component
  *
@@ -66,7 +68,7 @@ class TagsViewTags extends JViewLegacy
 				}
 
 				// Prepare the data.
-				$temp = new JRegistry;
+				$temp = new Registry;
 				$temp->loadString($itemElement->params);
 				$itemElement->params = clone($params);
 				$itemElement->params->merge($temp);

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Profile model class for Users.
  *
@@ -131,7 +133,7 @@ class UsersModelProfile extends JModelForm
 			unset($this->data->password1);
 			unset($this->data->password2);
 
-			$registry = new JRegistry($this->data->params);
+			$registry = new Registry($this->data->params);
 			$this->data->params = $registry->toArray();
 
 			// Get the dispatcher and load the users plugins.

--- a/components/com_weblinks/models/categories.php
+++ b/components/com_weblinks/models/categories.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of article categories.
  *
@@ -93,7 +95,7 @@ class WeblinksModelCategories extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 			if ($active)
 			{
 				$params->loadString($active->params);

--- a/components/com_weblinks/models/category.php
+++ b/components/com_weblinks/models/category.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Weblinks Component Weblink Model
  *
@@ -86,7 +88,7 @@ class WeblinksModelCategory extends JModelList
 		{
 			if (!isset($this->_params))
 			{
-				$params = new JRegistry;
+				$params = new Registry;
 				$params->loadString($item->params);
 				$item->params = $params;
 			}
@@ -250,7 +252,7 @@ class WeblinksModelCategory extends JModelList
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
 
 			if ($active)
 			{

--- a/components/com_weblinks/views/category/view.html.php
+++ b/components/com_weblinks/views/category/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML View class for the WebLinks component
  *
@@ -44,7 +46,7 @@ class WeblinksViewCategory extends JViewCategory
 				$item->link = $item->url;
 			}
 
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString($item->params);
 			$item->params = clone($this->params);
 			$item->params->merge($temp);


### PR DESCRIPTION
Updates references to no longer present `JRegistry` to the namespaced `\Joomla\Registry\Registry`
