### PR TITLE
Update JRegistry references in installation, layouts, modules, and plugins folders

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla! Installation Application class
  *
@@ -380,7 +382,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 		{
 			$template = new stdClass;
 			$template->template = 'template';
-			$template->params = new JRegistry;
+			$template->params = new Registry;
 			return $template;
 		}
 
@@ -550,10 +552,10 @@ final class InstallationApplicationWeb extends JApplicationCms
 			$session->start();
 		}
 
-		if (!$session->get('registry') instanceof JRegistry)
+		if (!$session->get('registry') instanceof Registry)
 		{
 			// Registry has been corrupted somehow
-			$session->set('registry', new JRegistry('session'));
+			$session->set('registry', new Registry('session'));
 		}
 
 		// Set the session object.

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Configuration setup model for the Joomla Core Installer.
  *
@@ -59,7 +61,7 @@ class InstallationModelConfiguration extends JModelBase
 	function _createConfiguration($options)
 	{
 		// Create a new registry to build the configuration options.
-		$registry = new JRegistry;
+		$registry = new Registry;
 
 		/* Site Settings */
 		$registry->set('offline', $options->site_offline);

--- a/installation/view/complete/html.php
+++ b/installation/view/complete/html.php
@@ -21,7 +21,7 @@ class InstallationViewCompleteHtml extends JViewHtml
 	/**
 	 * The JConfiguration data if present
 	 *
-	 * @var    JRegistry
+	 * @var    \Joomla\Registry\Registry
 	 * @since  3.1
 	 */
 	protected $config;

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
 ?>
@@ -16,7 +18,7 @@ JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/
 	<div class="tags">
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id')))) : ?>
-				<?php $tagParams = new JRegistry($tag->params); ?>
+				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
 				<span class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">
 					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . '-' . $tag->alias)) ?>" class="<?php echo $link_class; ?>">

--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -9,10 +9,12 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 $list = $displayData['list'];
 $pages = $list['pages'];
 
-$options = new JRegistry($displayData['options']);
+$options = new Registry($displayData['options']);
 
 $showLimitBox   = $options->get('showLimitBox', true);
 $showPagesLinks = $options->get('showPagesLinks', true);

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 $data = $displayData;
 
 // Receive overridable options
@@ -16,7 +18,7 @@ $data['options'] = !empty($data['options']) ? $data['options'] : array();
 
 if (is_array($data['options']))
 {
-	$data['options'] = new JRegistry($data['options']);
+	$data['options'] = new Registry($data['options']);
 }
 
 // Options

--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -21,7 +21,7 @@ class ModArchiveHelper
 	/**
 	 * Retrieve list of archived articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_articles_categories/helper.php
+++ b/modules/mod_articles_categories/helper.php
@@ -24,7 +24,7 @@ abstract class ModArticlesCategoriesHelper
 	/**
 	 * Get list of articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -28,7 +28,7 @@ abstract class ModArticlesCategoryHelper
 	/**
 	 * Get a list of articles from a specific category
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   \Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -25,7 +25,7 @@ abstract class ModArticlesLatestHelper
 	/**
 	 * Retrieve a list of article
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -26,7 +26,7 @@ abstract class ModArticlesNewsHelper
 	/**
 	 * Get a list of the latest articles from the article model
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   \Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -26,7 +26,7 @@ abstract class ModArticlesPopularHelper
 	/**
 	 * Get a list of popular articles from the articles model
 	 *
-	 * @param   JRegistry  &$params  object holding the models parameters
+	 * @param   \Joomla\Registry\Registry  &$params  object holding the models parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_banners/helper.php
+++ b/modules/mod_banners/helper.php
@@ -21,7 +21,7 @@ class ModBannersHelper
 	/**
 	 * Retrieve list of banners
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  mixed
 	 */

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -21,7 +21,7 @@ class ModBreadCrumbsHelper
 	/**
 	 * Retrieve breadcrumb items
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_feed/helper.php
+++ b/modules/mod_feed/helper.php
@@ -21,7 +21,7 @@ class ModFeedHelper
 	/**
 	 * Retrieve feed information
 	 *
-	 * @param   JRegistry  $params  module parameters
+	 * @param   \Joomla\Registry\Registry  $params  module parameters
 	 *
 	 * @return  JFeedReader|string
 	 */

--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -57,7 +57,7 @@ class ModFinderHelper
 	/**
 	 * Get Smart Search query object.
 	 *
-	 * @param   JRegistry  $params  Module parameters.
+	 * @param   \Joomla\Registry\Registry  $params  Module parameters.
 	 *
 	 * @return  FinderIndexerQuery object
 	 *

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -24,7 +24,7 @@ abstract class ModLanguagesHelper
 	/**
 	 * Gets a list of available languages
 	 *
-	 * @param   JRegistry  &$params  module params
+	 * @param   \Joomla\Registry\Registry  &$params  module params
 	 *
 	 * @return  array
 	 */

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -22,8 +22,8 @@ class ModLoginHelper
 	/**
 	 * Retrieve the url where the user should be returned after logging in
 	 *
-	 * @param   JRegistry  $params  module parameters
-	 * @param   string     $type    return type
+	 * @param   \Joomla\Registry\Registry  $params  module parameters
+	 * @param   string                     $type    return type
 	 *
 	 * @return string
 	 */

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -21,7 +21,7 @@ class ModMenuHelper
 	/**
 	 * Get a list of the menu items.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   \Joomla\Registry\Registry  &$params  The module options.
 	 *
 	 * @return  array
 	 *
@@ -155,9 +155,9 @@ class ModMenuHelper
 	/**
 	 * Get base menu item.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   \Joomla\Registry\Registry  &$params  The module options.
 	 *
-	 * @return   object
+	 * @return  object
 	 *
 	 * @since	3.0.2
 	 */
@@ -185,7 +185,7 @@ class ModMenuHelper
 	/**
 	 * Get active menu item.
 	 *
-	 * @param   JRegistry  &$params  The module options.
+	 * @param   \Joomla\Registry\Registry  &$params  The module options.
 	 *
 	 * @return  object
 	 *

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -21,8 +21,8 @@ class ModRandomImageHelper
 	/**
 	 * Retrieves a random image
 	 *
-	 * @param   JRegistry  &$params  module parameters object
-	 * @param   array      $images   list of images
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters object
+	 * @param   array                      $images   list of images
 	 *
 	 * @return  mixed
 	 */
@@ -76,8 +76,8 @@ class ModRandomImageHelper
 	/**
 	 * Retrieves images from a specific folder
 	 *
-	 * @param   JRegistry  &$params  module params
-	 * @param   string     $folder   folder to get the images from
+	 * @param   \Joomla\Registry\Registry  &$params  module params
+	 * @param   string                     $folder   folder to get the images from
 	 *
 	 * @return array
 	 */
@@ -130,9 +130,9 @@ class ModRandomImageHelper
 	/**
 	 * Get sanitized folder
 	 *
-	 * @param   JRegistry  &$params  module params objects
+	 * @param   \Joomla\Registry\Registry  &$params  module params objects
 	 *
-	 * @return mixed
+	 * @return  mixed
 	 */
 	public static function getFolder(&$params)
 	{

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -23,7 +23,7 @@ abstract class ModRelatedItemsHelper
 	/**
 	 * Get a list of related articles
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return array
 	 */

--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -21,7 +21,7 @@ class ModStatsHelper
 	/**
 	 * Get list of stats
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  array
 	 */

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -21,7 +21,7 @@ abstract class ModTagsPopularHelper
 	/**
 	 * Get list of popular tags
 	 *
-	 * @param   JRegistry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return mixed
 	 */

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -21,7 +21,7 @@ abstract class ModTagssimilarHelper
 	/**
 	 * Get a list of tags
 	 *
-	 * @param   JRegistry  &$params  Module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  Module parameters
 	 *
 	 * @return  mixed                Results array / null
 	 */

--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Contact Plugin
  *
@@ -46,7 +48,7 @@ class PlgContentContact extends JPlugin
 		}
 
 		// Return if we don't have valid params or don't link the author
-		if (!($params instanceof JRegistry) || !$params->get('link_author'))
+		if (!($params instanceof Registry) || !$params->get('link_author'))
 		{
 			return true;
 		}

--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
 /**
@@ -264,11 +266,11 @@ class PlgFinderCategories extends FinderIndexerAdapter
 		$extension = ucfirst(substr($item->extension, 4));
 
 		// Initialize the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = $registry;
 
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->metadata);
 		$item->metadata = $registry;
 

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
 /**
@@ -259,7 +261,7 @@ class PlgFinderContacts extends FinderIndexerAdapter
 		$item->setLanguage();
 
 		// Initialize the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = $registry;
 

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
 /**
@@ -252,12 +254,12 @@ class PlgFinderContent extends FinderIndexerAdapter
 		}
 
 		// Initialise the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = JComponentHelper::getParams('com_content', true);
 		$item->params->merge($registry);
 
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->metadata);
 		$item->metadata = $registry;
 

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
 /**
@@ -260,11 +262,11 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 		$item->setLanguage();
 
 		// Initialize the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = $registry;
 
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->metadata);
 		$item->metadata = $registry;
 

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 // Load the base adapter.
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
@@ -215,12 +217,12 @@ class PlgFinderTags extends FinderIndexerAdapter
 		$item->setLanguage();
 
 		// Initialize the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = JComponentHelper::getParams('com_tags', true);
 		$item->params->merge($registry);
 
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->metadata);
 		$item->metadata = $registry;
 

--- a/plugins/finder/weblinks/weblinks.php
+++ b/plugins/finder/weblinks/weblinks.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Registry\Registry;
+
 // Load the base adapter.
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
 
@@ -253,11 +255,11 @@ class PlgFinderWeblinks extends FinderIndexerAdapter
 		$item->setLanguage();
 
 		// Initialise the item parameters.
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->params);
 		$item->params = $registry;
 
-		$registry = new JRegistry;
+		$registry = new Registry;
 		$registry->loadString($item->metadata);
 		$item->metadata = $registry;
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 
 JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
@@ -407,7 +409,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		if ($this->params->get('automatic_change', '1') == '1' && key_exists('params', $user))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadString($user['params']);
 			self::$user_lang_code = $registry->get('language');
 
@@ -436,7 +438,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		if ($this->params->get('automatic_change', '1') == '1' && key_exists('params', $user) && $success)
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadString($user['params']);
 			$lang_code = $registry->get('language');
 

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla User plugin
  *
@@ -96,7 +98,7 @@ class PlgUserJoomla extends JPlugin
 					 * 	1. User frontend language
 					 * 	2. User backend language
 					 */
-					$userParams = new JRegistry($user['params']);
+					$userParams = new Registry($user['params']);
 					$userLocale = $userParams->get('language', $userParams->get('admin_language', $defaultLocale));
 
 					if ($userLocale != $defaultLocale)


### PR DESCRIPTION
Updates references to no longer present `JRegistry` to the namespaced `\Joomla\Registry\Registry`
