### PR TITLE
Update references to JRegistry for libraries folder

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla! Administrator Application class
  *
@@ -21,19 +23,19 @@ class JApplicationAdministrator extends JApplicationCms
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
-	 *                          input object.  If the argument is a JInput object that object will become
-	 *                          the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
-	 *                          the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
-	 *                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
+	 *                                          input object.  If the argument is a JInput object that object will become
+	 *                                          the application's input object, otherwise a default input object is created.
+	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
+	 *                                          config object.  If the argument is a Registry object that object will become
+	 *                                          the application's config object, otherwise a default config object is created.
+	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
+	 *                                          the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   3.2
 	 */
-	public function __construct(JInput $input = null, JRegistry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
 	{
 		// Register the application name
 		$this->_name = 'administrator';
@@ -212,12 +214,12 @@ class JApplicationAdministrator extends JApplicationCms
 		$template = $db->loadObject();
 
 		$template->template = JFilterInput::getInstance()->clean($template->template, 'cmd');
-		$template->params = new JRegistry($template->params);
+		$template->params = new Registry($template->params);
 
 		if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
 		{
 			$this->enqueueMessage(JText::_('JERROR_ALERTNOTEMPLATE'), 'error');
-			$template->params = new JRegistry;
+			$template->params = new Registry;
 			$template->template = 'isis';
 		}
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla! CMS Application class
  *
@@ -88,19 +90,19 @@ class JApplicationCms extends JApplicationWeb
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
-	 *                          input object.  If the argument is a JInput object that object will become
-	 *                          the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
-	 *                          the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
-	 *                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
+	 *                                          input object.  If the argument is a JInput object that object will become
+	 *                                          the application's input object, otherwise a default input object is created.
+	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
+	 *                                          config object.  If the argument is a Registry object that object will become
+	 *                                          the application's config object, otherwise a default config object is created.
+	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
+	 *                                          the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   3.2
 	 */
-	public function __construct(JInput $input = null, JRegistry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
 	{
 		parent::__construct($input, $config, $client);
 
@@ -145,7 +147,7 @@ class JApplicationCms extends JApplicationWeb
 
 		if ($session->isNew())
 		{
-			$session->set('registry', new JRegistry('session'));
+			$session->set('registry', new Registry('session'));
 			$session->set('user', new JUser);
 		}
 	}
@@ -530,7 +532,7 @@ class JApplicationCms extends JApplicationWeb
 		$template = new stdClass;
 
 		$template->template = 'system';
-		$template->params   = new JRegistry;
+		$template->params   = new Registry;
 
 		if ($params)
 		{

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla! Site Application class
  *
@@ -39,19 +41,19 @@ final class JApplicationSite extends JApplicationCms
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
-	 *                          input object.  If the argument is a JInput object that object will become
-	 *                          the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
-	 *                          the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
-	 *                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
+	 *                                          input object.  If the argument is a JInput object that object will become
+	 *                                          the application's input object, otherwise a default input object is created.
+	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
+	 *                                          config object.  If the argument is a Registry object that object will become
+	 *                                          the application's config object, otherwise a default config object is created.
+	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
+	 *                                          the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   3.2
 	 */
-	public function __construct(JInput $input = null, JRegistry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
 	{
 		// Register the application name
 		$this->_name = 'site';
@@ -345,7 +347,7 @@ final class JApplicationSite extends JApplicationCms
 			// Lets cascade the parameters if we have menu item parameters
 			if (is_object($menu))
 			{
-				$temp = new JRegistry;
+				$temp = new Registry;
 				$temp->loadString($menu->params);
 				$params[$hash]->merge($temp);
 				$title = $menu->title;
@@ -480,7 +482,7 @@ final class JApplicationSite extends JApplicationCms
 
 			foreach ($templates as &$template)
 			{
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($template->params);
 				$template->params = $registry;
 
@@ -796,13 +798,13 @@ final class JApplicationSite extends JApplicationCms
 			$this->template = new stdClass;
 			$this->template->template = $template;
 
-			if ($styleParams instanceof JRegistry)
+			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;
 			}
 			else
 			{
-				$this->template->params = new JRegistry($styleParams);
+				$this->template->params = new Registry($styleParams);
 			}
 		}
 	}

--- a/libraries/cms/captcha/captcha.php
+++ b/libraries/cms/captcha/captcha.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla! Captcha base object
  *
@@ -228,7 +230,7 @@ class JCaptcha extends JObject
 			throw new RuntimeException(JText::sprintf('JLIB_CAPTCHA_ERROR_PLUGIN_NOT_FOUND', $name));
 		}
 
-		$params = new JRegistry($plugin->params);
+		$params = new Registry($plugin->params);
 		$plugin->params = $params;
 
 		// Build captcha plugin classname

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Component helper class
  *
@@ -48,7 +50,7 @@ class JComponentHelper
 			{
 				$result = new stdClass;
 				$result->enabled = $strict ? false : true;
-				$result->params = new JRegistry;
+				$result->params = new Registry;
 			}
 		}
 		else
@@ -81,9 +83,9 @@ class JComponentHelper
 	 * @param   string   $option  The option for the component.
 	 * @param   boolean  $strict  If set and the component does not exist, false will be returned
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Registry
 	 * @since   1.5
 	 */
 	public static function getParams($option, $strict = false)
@@ -415,7 +417,7 @@ class JComponentHelper
 		// Convert the params to an object.
 		if (is_string(static::$components[$option]->params))
 		{
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString(static::$components[$option]->params);
 			static::$components[$option]->params = $temp;
 		}

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JEditor class to handle WYSIWYG editors
  *
@@ -508,7 +510,7 @@ class JEditor extends JObject
 
 		// Get the plugin
 		$plugin = JPluginHelper::getPlugin('editors', $this->_name);
-		$params = new JRegistry;
+		$params = new Registry;
 		$params->loadString($plugin->params);
 		$params->loadArray($config);
 		$plugin->params = $params;

--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -39,7 +39,7 @@ class JFormFieldTag extends JFormFieldList
 	/**
 	 * com_tags parameters
 	 *
-	 * @var    JRegistry
+	 * @var    \Joomla\Registry\Registry
 	 * @since  3.1
 	 */
 	protected $comParams = null;

--- a/libraries/cms/form/rule/captcha.php
+++ b/libraries/cms/form/rule/captcha.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Framework.
  *
@@ -26,14 +28,14 @@ class JFormRuleCaptcha extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   2.5
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$plugin    = $element['plugin'] ?: JFactory::getApplication()->getParams()->get('captcha', JFactory::getConfig()->get('captcha', 0));
 		$namespace = $element['namespace'] ?: $form->getName();

--- a/libraries/cms/form/rule/notequals.php
+++ b/libraries/cms/form/rule/notequals.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -28,7 +30,7 @@ class JFormRuleNotequals extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
@@ -37,7 +39,7 @@ class JFormRuleNotequals extends JFormRule
 	 * @throws  InvalidArgumentException
 	 * @throws  UnexpectedValueException
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$field = (string) $element['field'];
 

--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -28,7 +30,7 @@ class JFormRulePassword extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
@@ -37,7 +39,7 @@ class JFormRulePassword extends JFormRule
 	 * @throws  InvalidArgumentException
 	 * @throws  UnexpectedValueException
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$meter		= isset($this->element['strengthmeter'])  ? ' meter="0"' : '1';
 		$threshold	= isset($this->element['threshold']) ? (int) $this->element['threshold'] : 66;

--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Utility class for form related behaviors
  *
@@ -83,14 +85,14 @@ abstract class JHtmlFormbehavior
 	 *
 	 * If debugging mode is on an uncompressed version of AJAX Chosen is included for easier debugging.
 	 *
-	 * @param   JRegistry  $options  Options in a JRegistry object
-	 * @param   mixed      $debug    Is debugging mode on? [optional]
+	 * @param   Registry  $options  Options in a Registry object
+	 * @param   mixed     $debug    Is debugging mode on? [optional]
 	 *
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public static function ajaxchosen(JRegistry $options, $debug = null)
+	public static function ajaxchosen(Registry $options, $debug = null)
 	{
 		// Retrieve options/defaults
 		$selector       = $options->get('selector', '.tagfield');

--- a/libraries/cms/html/searchtools.php
+++ b/libraries/cms/html/searchtools.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Searchtools elements.
  *
@@ -76,7 +78,7 @@ abstract class JHtmlSearchtools
 			$options['formSelector'] = $selector;
 
 			// Generate options with default values
-			$options = static::options2Jregistry($options);
+			$options = static::optionsToRegistry($options);
 
 			$doc = JFactory::getDocument();
 			$script = "
@@ -99,21 +101,21 @@ abstract class JHtmlSearchtools
 	/**
 	 * Function to receive & pre-process javascript options
 	 *
-	 * @param   mixed  $options  Associative array/JRegistry object with options
+	 * @param   mixed  $options  Associative array/Registry object with options
 	 *
-	 * @return  JRegistry        Options converted to JRegistry object
+	 * @return  Registry         Options converted to Registry object
 	 */
-	private static function options2Jregistry($options)
+	private static function optionsToRegistry($options)
 	{
 		// Support options array
 		if (is_array($options))
 		{
-			$options = new JRegistry($options);
+			$options = new Registry($options);
 		}
 
-		if (!($options instanceof Jregistry))
+		if (!($options instanceof Registry))
 		{
-			$options = new JRegistry;
+			$options = new Registry;
 		}
 
 		return $options;

--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Utility class for tags
  *
@@ -169,7 +171,7 @@ abstract class JHtmlTag
 		$minTermLength = (int) $params->get("min_term_length");
 
 		// Tags field ajax
-		$chosenAjaxSettings = new JRegistry(
+		$chosenAjaxSettings = new Registry(
 			array(
 				'selector'      => $selector,
 				'type'          => 'GET',

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 jimport('joomla.base.adapterinstance');
 jimport('joomla.filesystem.folder');
 
@@ -520,7 +522,7 @@ class JInstallerAdapterLanguage extends JAdapterInstance
 
 		foreach ($users as $user)
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadString($user->params);
 
 			if ($registry->get($param_name) == $element)

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Utitlity class for associations in multilang
  *
@@ -127,7 +129,7 @@ class JLanguageAssociations
 
 				if (!empty($plugin))
 				{
-					$params = new JRegistry($plugin->params);
+					$params = new Registry($plugin->params);
 					$enabled  = (boolean) $params->get('item_associations', true);
 				}
 

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Base class for rendering a display layout
  *
@@ -22,7 +24,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Options object
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  3.2
 	 */
 	protected $options = null;
@@ -38,7 +40,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Set the options
 	 *
-	 * @param   mixed  $options  Array / JRegistry object with the options to load
+	 * @param   array|Registry  $options  Array / Registry object with the options to load
 	 *
 	 * @return  JLayoutBase  Instance of $this to allow chaining.
 	 *
@@ -46,19 +48,19 @@ class JLayoutBase implements JLayout
 	 */
 	public function setOptions($options = null)
 	{
-		// Received JRegistry
-		if ($options instanceof JRegistry)
+		// Received Registry
+		if ($options instanceof Registry)
 		{
 			$this->options = $options;
 		}
 		// Received array
 		elseif (is_array($options))
 		{
-			$this->options = new JRegistry($options);
+			$this->options = new Registry($options);
 		}
 		else
 		{
-			$this->options = new JRegistry;
+			$this->options = new Registry;
 		}
 
 		return $this;
@@ -67,14 +69,14 @@ class JLayoutBase implements JLayout
 	/**
 	 * Get the options
 	 *
-	 * @return  JRegistry  Object with the options
+	 * @return  Registry  Object with the options
 	 *
 	 * @since   3.2
 	 */
 	public function getOptions()
 	{
-		// Always return a JRegistry instance
-		if (!($this->options instanceof JRegistry))
+		// Always return a Registry instance
+		if (!($this->options instanceof Registry))
 		{
 			$this->resetOptions();
 		}

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -51,7 +51,7 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $layoutId  Dot separated path to the layout file, relative to base path
 	 * @param   string  $basePath  Base path to use when loading layout files
-	 * @param   mixed   $options   Optional custom options to load. JRegistry or array format [@since 3.2]
+	 * @param   mixed   $options   Optional custom options to load. Registry or array format [@since 3.2]
 	 *
 	 * @since   3.0
 	 */

--- a/libraries/cms/layout/helper.php
+++ b/libraries/cms/layout/helper.php
@@ -34,7 +34,7 @@ class JLayoutHelper
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
 	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
 	 * @param   string  $basePath     Base path to use when loading layout files
-	 * @param   mixed   $options      Optional custom options to load. JRegistry or array format
+	 * @param   mixed   $options      Optional custom options to load. Registry or array format
 	 *
 	 * @return  string
 	 *

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Library helper class
  *
@@ -52,7 +54,7 @@ class JLibraryHelper
 		{
 			$result = new stdClass;
 			$result->enabled = $strict ? false : true;
-			$result->params = new JRegistry;
+			$result->params = new Registry;
 		}
 
 		return $result;
@@ -80,9 +82,9 @@ class JLibraryHelper
 	 * @param   string   $element  Element of the library in the extensions table.
 	 * @param   boolean  $strict   If set and the library does not exist, false will be returned
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Registry
 	 * @since   3.2
 	 */
 	public static function getParams($element, $strict = false)
@@ -95,12 +97,12 @@ class JLibraryHelper
 	/**
 	 * Save the parameters object for the library
 	 *
-	 * @param   string     $element  Element of the library in the extensions table.
-	 * @param   JRegistry  $params   Params to save
+	 * @param   string    $element  Element of the library in the extensions table.
+	 * @param   Registry  $params   Params to save
 	 *
-	 * @return  JRegistry  A JRegistry object.
+	 * @return  Registry  A Registry object.
 	 *
-	 * @see     JRegistry
+	 * @see     Registry
 	 * @since   3.2
 	 */
 	public static function saveParams($element, $params)
@@ -175,7 +177,7 @@ class JLibraryHelper
 		// Convert the params to an object.
 		if (is_string(static::$libraries[$element]->params))
 		{
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString(static::$libraries[$element]->params);
 			static::$libraries[$element]->params = $temp;
 		}

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JMenu class
  *
@@ -71,7 +73,7 @@ class JMenu
 			}
 
 			// Decode the item params
-			$result = new JRegistry;
+			$result = new Registry;
 			$result->loadString($item->params);
 			$item->params = $result;
 		}
@@ -239,7 +241,7 @@ class JMenu
 	 * Gets menu items by attribute
 	 *
 	 * @param   mixed    $attributes  The field name(s).
-	 * @param   mixed    $values      The value(s) of the field. If an array, need to match field names 
+	 * @param   mixed    $values      The value(s) of the field. If an array, need to match field names
 	 *                                each attribute may have multiple values to lookup for.
 	 * @param   boolean  $firstonly   If true, only returns the first item found
 	 *
@@ -301,7 +303,7 @@ class JMenu
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  JRegistry  A JRegistry object
+	 * @return  Registry  A Registry object
 	 *
 	 * @since   1.5
 	 */
@@ -313,7 +315,7 @@ class JMenu
 		}
 		else
 		{
-			return new JRegistry;
+			return new Registry;
 		}
 	}
 

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Module helper class
  *
@@ -166,7 +168,7 @@ abstract class JModuleHelper
 		$app->scope = $module->module;
 
 		// Get module parameters
-		$params = new JRegistry;
+		$params = new Registry;
 		$params->loadString($module->params);
 
 		// Get the template

--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JPlugin Class
  *
@@ -19,9 +21,9 @@ defined('JPATH_PLATFORM') or die;
 abstract class JPlugin extends JEvent
 {
 	/**
-	 * A JRegistry object holding the parameters for the plugin
+	 * A Registry object holding the parameters for the plugin
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  1.5
 	 */
 	public $params = null;
@@ -65,13 +67,13 @@ abstract class JPlugin extends JEvent
 		// Get the parameters.
 		if (isset($config['params']))
 		{
-			if ($config['params'] instanceof JRegistry)
+			if ($config['params'] instanceof Registry)
 			{
 				$this->params = $config['params'];
 			}
 			else
 			{
-				$this->params = new JRegistry;
+				$this->params = new Registry;
 				$this->params->loadString($config['params']);
 			}
 		}

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Core content table
  *
@@ -46,35 +48,35 @@ class JTableCorecontent extends JTable
 	{
 		if (isset($array['core_params']) && is_array($array['core_params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['core_params']);
 			$array['core_params'] = (string) $registry;
 		}
 
 		if (isset($array['core_metadata']) && is_array($array['core_metadata']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['core_metadata']);
 			$array['core_metadata'] = (string) $registry;
 		}
 
 		if (isset($array['core_images']) && is_array($array['core_images']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['core_images']);
 			$array['core_images'] = (string) $registry;
 		}
 
 		if (isset($array['core_urls']) && is_array($array['core_urls']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['core_urls']);
 			$array['core_urls'] = (string) $registry;
 		}
 
 		if (isset($array['core_body']) && is_array($array['core_body']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['core_body']);
 			$array['core_body'] = (string) $registry;
 		}

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Cli\CliOutput;
+use Joomla\Registry\Registry;
 
 /**
  * Base class for a Joomla! command line application.
@@ -21,7 +22,7 @@ use Joomla\Application\Cli\CliOutput;
 class JApplicationCli extends JApplicationBase
 {
 	/**
-	 * @var    JRegistry  The application configuration object.
+	 * @var    Registry  The application configuration object.
 	 * @since  11.1
 	 */
 	protected $config;
@@ -41,21 +42,21 @@ class JApplicationCli extends JApplicationBase
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
-	 *                              input object.  If the argument is a JInputCli object that object will become
-	 *                              the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
-	 *                              the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become
-	 *                              the application's event dispatcher, if it is null then the default event dispatcher
-	 *                              will be created based on the application's loadDispatcher() method.
+	 * @param   JInputCli  $input              An optional argument to provide dependency injection for the application's
+	 *                                         input object.  If the argument is a JInputCli object that object will become
+	 *                                         the application's input object, otherwise a default input object is created.
+	 * @param   Registry  $config              An optional argument to provide dependency injection for the application's
+	 *                                         config object.  If the argument is a Registry object that object will become
+	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JEventDispatcher  $dispatcher  An optional argument to provide dependency injection for the application's
+	 *                                         event dispatcher.  If the argument is a JEventDispatcher object that object will become
+	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                         will be created based on the application's loadDispatcher() method.
 	 *
 	 * @see     JApplicationBase::loadDispatcher()
 	 * @since   11.1
 	 */
-	public function __construct(JInputCli $input = null, JRegistry $config = null, JEventDispatcher $dispatcher = null)
+	public function __construct(JInputCli $input = null, Registry $config = null, JEventDispatcher $dispatcher = null)
 	{
 		// Close the application if we are not executed from the command line.
 		// @codeCoverageIgnoreStart
@@ -80,14 +81,14 @@ class JApplicationCli extends JApplicationBase
 		}
 
 		// If a config object is given use it.
-		if ($config instanceof JRegistry)
+		if ($config instanceof Registry)
 		{
 			$this->config = $config;
 		}
 		// Instantiate a new configuration object.
 		else
 		{
-			$this->config = new JRegistry;
+			$this->config = new Registry;
 		}
 
 		$this->loadDispatcher($dispatcher);

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -11,8 +11,10 @@ defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.filesystem.folder');
 
+use Joomla\Registry\Registry;
+
 /**
- * Class to turn JCli applications into daemons.  It requires CLI and PCNTL support built into PHP.
+ * Class to turn JApplicationCli applications into daemons.  It requires CLI and PCNTL support built into PHP.
  *
  * @package     Joomla.Platform
  * @subpackage  Application
@@ -93,21 +95,21 @@ class JApplicationDaemon extends JApplicationCli
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
-	 *                              input object.  If the argument is a JInputCli object that object will become
-	 *                              the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
-	 *                              the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become
-	 *                              the application's event dispatcher, if it is null then the default event dispatcher
-	 *                              will be created based on the application's loadDispatcher() method.
+	 * @param   JInputCli  $input              An optional argument to provide dependency injection for the application's
+	 *                                         input object.  If the argument is a JInputCli object that object will become
+	 *                                         the application's input object, otherwise a default input object is created.
+	 * @param   Registry  $config              An optional argument to provide dependency injection for the application's
+	 *                                         config object.  If the argument is a Registry object that object will become
+	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JEventDispatcher  $dispatcher  An optional argument to provide dependency injection for the application's
+	 *                                         event dispatcher.  If the argument is a JEventDispatcher object that object will become
+	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                         will be created based on the application's loadDispatcher() method.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException
 	 */
-	public function __construct(JInputCli $input = null, JRegistry $config = null, JEventDispatcher $dispatcher = null)
+	public function __construct(JInputCli $input = null, Registry $config = null, JEventDispatcher $dispatcher = null)
 	{
 		// Verify that the process control extension for PHP is available.
 		// @codeCoverageIgnoreStart

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Base class for a Joomla! Web application.
  *
@@ -43,7 +45,7 @@ class JApplicationWeb extends JApplicationBase
 	public $client;
 
 	/**
-	 * @var    JRegistry  The application configuration object.
+	 * @var    Registry  The application configuration object.
 	 * @since  11.3
 	 */
 	protected $config;
@@ -81,19 +83,19 @@ class JApplicationWeb extends JApplicationBase
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
-	 *                          input object.  If the argument is a JInput object that object will become
-	 *                          the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
-	 *                          the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
-	 *                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
+	 *                                          input object.  If the argument is a JInput object that object will become
+	 *                                          the application's input object, otherwise a default input object is created.
+	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
+	 *                                          config object.  If the argument is a Registry object that object will become
+	 *                                          the application's config object, otherwise a default config object is created.
+	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
+	 *                                          the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JInput $input = null, JRegistry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
 	{
 		// If a input object is given use it.
 		if ($input instanceof JInput)
@@ -107,14 +109,14 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// If a config object is given use it.
-		if ($config instanceof JRegistry)
+		if ($config instanceof Registry)
 		{
 			$this->config = $config;
 		}
 		// Instantiate a new configuration object.
 		else
 		{
-			$this->config = new JRegistry;
+			$this->config = new Registry;
 		}
 
 		// If a client object is given use it.
@@ -1090,7 +1092,7 @@ class JApplicationWeb extends JApplicationBase
 
 		if ($session->isNew())
 		{
-			$session->set('registry', new JRegistry('session'));
+			$session->set('registry', new Registry('session'));
 			$session->set('user', new JUser);
 		}
 	}

--- a/libraries/joomla/data/data.php
+++ b/libraries/joomla/data/data.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JData is a class that is used to store data but allowing you to access the data
  * by mimicking the way PHP handles class properties.
@@ -229,7 +231,7 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 	 * Dumps a data property.
 	 *
 	 * If recursion is set, this method will dump any object implementing JDumpable (like JData and JDataSet); it will
-	 * convert a JDate object to a string; and it will convert a JRegistry to an object.
+	 * convert a JDate object to a string; and it will convert a Registry to an object.
 	 *
 	 * @param   string            $property  The name of the data property.
 	 * @param   integer           $depth     The current depth of recursion (a value of 0 will ignore recursion).
@@ -261,7 +263,7 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 				$value = (string) $value;
 			}
 			// Check if the object is a registry.
-			elseif ($value instanceof JRegistry)
+			elseif ($value instanceof Registry)
 			{
 				$value = $value->toObject();
 			}

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 jimport('joomla.utilities.utility');
 
 /**
@@ -628,7 +630,7 @@ class JDocumentHTML extends JDocument
 		// Assign the variables
 		$this->template = $template;
 		$this->baseurl = JUri::base(true);
-		$this->params = isset($params['params']) ? $params['params'] : new JRegistry;
+		$this->params = isset($params['params']) ? $params['params'] : new Registry;
 
 		// Load
 		$this->_template = $this->_loadTemplate($directory . '/' . $template, $file);

--- a/libraries/joomla/document/html/renderer/module.php
+++ b/libraries/joomla/document/html/renderer/module.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JDocument Module renderer
  *
@@ -70,13 +72,13 @@ class JDocumentRendererModule extends JDocumentRenderer
 		}
 
 		// Get module parameters
-		$params = new JRegistry;
+		$params = new Registry;
 		$params->loadString($module->params);
 
 		// Use parameters from template
 		if (isset($attribs['params']))
 		{
-			$template_params = new JRegistry;
+			$template_params = new Registry;
 			$template_params->loadString(html_entity_decode($attribs['params'], ENT_COMPAT, 'UTF-8'));
 			$params->merge($template_params);
 			$module = clone $module;

--- a/libraries/joomla/facebook/facebook.php
+++ b/libraries/joomla/facebook/facebook.php
@@ -7,7 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-defined('JPATH_PLATFORM') or die();
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
 
 /**
  * Joomla Platform class for interacting with a Facebook API instance.
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 class JFacebook
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -112,15 +114,15 @@ class JFacebook
 	 * Constructor.
 	 *
 	 * @param   JFacebookOAuth  $oauth    OAuth client.
-	 * @param   JRegistry       $options  Facebook options object.
+	 * @param   Registry        $options  Facebook options object.
 	 * @param   JHttp           $client   The HTTP client object.
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JFacebookOAuth $oauth = null, JRegistry $options = null, JHttp $client = null)
+	public function __construct(JFacebookOAuth $oauth = null, Registry $options = null, JHttp $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JHttp($this->options);
 
 		// Setup the default API url if not already set.

--- a/libraries/joomla/facebook/oauth.php
+++ b/libraries/joomla/facebook/oauth.php
@@ -7,37 +7,37 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-defined('JPATH_PLATFORM') or die();
+defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
 
 /**
  * Joomla Platform class for generating Facebook API access token.
  *
  * @package     Joomla.Platform
  * @subpackage  Facebook
- *
  * @since       13.1
  */
 class JFacebookOAuth extends JOAuth2Client
 {
 	/**
-	 * @var JRegistry Options for the JFacebookOAuth object.
-	 * @since 13.1
+	 * @var    Registry Options for the JFacebookOAuth object.
+	 * @since  13.1
 	 */
 	protected $options;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  JFacebookOauth options object.
-	 * @param   JHttp      $client   The HTTP client object.
-	 * @param   JInput     $input    The input object.
+	 * @param   Registry  $options  JFacebookOauth options object.
+	 * @param   JHttp     $client   The HTTP client object.
+	 * @param   JInput    $input    The input object.
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JInput $input = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JInput $input = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 
 		// Setup the authentication and token urls if not already set.
 		$this->options->def('authurl', 'http://www.facebook.com/dialog/oauth');

--- a/libraries/joomla/facebook/object.php
+++ b/libraries/joomla/facebook/object.php
@@ -7,22 +7,21 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+defined('JPATH_PLATFORM') or die;
 
-defined('JPATH_PLATFORM') or die();
-
+use Joomla\Registry\Registry;
 
 /**
  * Facebook API object class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  Facebook
- *
  * @since       13.1
  */
 abstract class JFacebookObject
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -42,15 +41,15 @@ abstract class JFacebookObject
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry       $options  Facebook options object.
+	 * @param   Registry        $options  Facebook options object.
 	 * @param   JHttp           $client   The HTTP client object.
 	 * @param   JFacebookOAuth  $oauth    The OAuth client.
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JFacebookOAuth $oauth = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JFacebookOAuth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JHttp($this->options);
 		$this->oauth = $oauth;
 	}

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -8,6 +8,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform Factory class
  *
@@ -130,15 +132,15 @@ abstract class JFactory
 	/**
 	 * Get a configuration object
 	 *
-	 * Returns the global {@link JRegistry} object, only creating it if it doesn't already exist.
+	 * Returns the global {@link JConfig} object, only creating it if it doesn't already exist.
 	 *
 	 * @param   string  $file       The path to the configuration file
 	 * @param   string  $type       The type of the configuration file
 	 * @param   string  $namespace  The namespace of the configuration file
 	 *
-	 * @return  JRegistry
+	 * @return  Registry
 	 *
-	 * @see     JRegistry
+	 * @see     Registry
 	 * @since   11.1
 	 */
 	public static function getConfig($file = null, $type = 'PHP', $namespace = '')
@@ -540,9 +542,9 @@ abstract class JFactory
 	 * @param   string  $type       The type of the configuration file.
 	 * @param   string  $namespace  The namespace of the configuration file.
 	 *
-	 * @return  JRegistry
+	 * @return  Registry
 	 *
-	 * @see     JRegistry
+	 * @see     Registry
 	 * @since   11.1
 	 */
 	protected static function createConfig($file, $type = 'PHP', $namespace = '')
@@ -553,7 +555,7 @@ abstract class JFactory
 		}
 
 		// Create the registry with a default namespace of config
-		$registry = new JRegistry;
+		$registry = new Registry;
 
 		// Sanitize the namespace.
 		$namespace = ucfirst((string) preg_replace('/[^A-Z_]/i', '', $namespace));

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 jimport('joomla.filesystem.path');
 jimport('joomla.utilities.arrayhelper');
 
@@ -28,14 +30,16 @@ jimport('joomla.utilities.arrayhelper');
 class JForm
 {
 	/**
-	 * The JRegistry data store for form fields during display.
-	 * @var    object
+	 * The Registry data store for form fields during display.
+	 *
+	 * @var    Registry
 	 * @since  11.1
 	 */
 	protected $data;
 
 	/**
 	 * The form object errors array.
+	 *
 	 * @var    array
 	 * @since  11.1
 	 */
@@ -43,6 +47,7 @@ class JForm
 
 	/**
 	 * The name of the form instance.
+	 *
 	 * @var    string
 	 * @since  11.1
 	 */
@@ -50,6 +55,7 @@ class JForm
 
 	/**
 	 * The form object options for use in rendering and validation.
+	 *
 	 * @var    array
 	 * @since  11.1
 	 */
@@ -57,6 +63,7 @@ class JForm
 
 	/**
 	 * The form XML definition.
+	 *
 	 * @var    SimpleXMLElement
 	 * @since  11.1
 	 */
@@ -64,6 +71,7 @@ class JForm
 
 	/**
 	 * Form instances.
+	 *
 	 * @var    array
 	 * @since  11.1
 	 */
@@ -71,6 +79,7 @@ class JForm
 
 	/**
 	 * Alows extensions to implement repeating elements
+	 *
 	 * @var    mixed
 	 * @since  3.2
 	 */
@@ -89,8 +98,8 @@ class JForm
 		// Set the name for the form.
 		$this->name = $name;
 
-		// Initialise the JRegistry data.
-		$this->data = new JRegistry;
+		// Initialise the Registry data.
+		$this->data = new Registry;
 
 		// Set the options if specified.
 		$this->options['control'] = isset($options['control']) ? $options['control'] : false;
@@ -122,9 +131,9 @@ class JForm
 		// Convert the input to an array.
 		if (is_object($data))
 		{
-			if ($data instanceof JRegistry)
+			if ($data instanceof Registry)
 			{
-				// Handle a JRegistry.
+				// Handle a Registry.
 				$data = $data->toArray();
 			}
 			elseif ($data instanceof JObject)
@@ -206,8 +215,8 @@ class JForm
 			return false;
 		}
 
-		$input = new JRegistry($data);
-		$output = new JRegistry;
+		$input = new Registry($data);
+		$output = new Registry;
 
 		// Get the fields for which to filter the data.
 		$fields = $this->findFieldsByGroup($group);
@@ -943,7 +952,7 @@ class JForm
 	public function reset($xml = false)
 	{
 		unset($this->data);
-		$this->data = new JRegistry;
+		$this->data = new Registry;
 
 		if ($xml)
 		{
@@ -1164,7 +1173,7 @@ class JForm
 		$return = true;
 
 		// Create an input registry object from the data to validate.
-		$input = new JRegistry($data);
+		$input = new Registry($data);
 
 		// Get the fields for which to validate the data.
 		$fields = $this->findFieldsByGroup($group);
@@ -1923,7 +1932,7 @@ class JForm
 	 * @param   SimpleXMLElement  $element  The XML element object representation of the form field.
 	 * @param   string            $group    The optional dot-separated form group path on which to find the field.
 	 * @param   mixed             $value    The optional value to use as the default for the field.
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate
 	 *                                      against the entire form.
 	 *
 	 * @return  mixed  Boolean true if field value is valid, Exception on failure.
@@ -1932,7 +1941,7 @@ class JForm
 	 * @throws  InvalidArgumentException
 	 * @throws  UnexpectedValueException
 	 */
-	protected function validateField(SimpleXMLElement $element, $group = null, $value = null, JRegistry $input = null)
+	protected function validateField(SimpleXMLElement $element, $group = null, $value = null, Registry $input = null)
 	{
 		$valid = true;
 
@@ -2249,7 +2258,7 @@ class JForm
 	/**
 	 * Getter for the form data
 	 *
-	 * @return   JRegistry  Object with the data
+	 * @return   Registry  Object with the data
 	 *
 	 * @since    3.2
 	 */

--- a/libraries/joomla/form/rule.php
+++ b/libraries/joomla/form/rule.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 // Detect if we have full UTF-8 and unicode PCRE support.
 if (!defined('JCOMPAT_UNICODE_PROPERTIES'))
 {
@@ -48,7 +50,7 @@ class JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
@@ -56,7 +58,7 @@ class JFormRule
 	 * @since   11.1
 	 * @throws  UnexpectedValueException if rule is invalid.
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Check for a valid regex.
 		if (empty($this->regex))

--- a/libraries/joomla/form/rule/color.php
+++ b/libraries/joomla/form/rule/color.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -26,14 +28,14 @@ class JFormRuleColor extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.2
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$value = trim($value);
 

--- a/libraries/joomla/form/rule/email.php
+++ b/libraries/joomla/form/rule/email.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -35,14 +37,14 @@ class JFormRuleEmail extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/libraries/joomla/form/rule/equals.php
+++ b/libraries/joomla/form/rule/equals.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -28,7 +30,7 @@ class JFormRuleEquals extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
@@ -37,7 +39,7 @@ class JFormRuleEquals extends JFormRule
 	 * @throws  InvalidArgumentException
 	 * @throws  UnexpectedValueException
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		$field = (string) $element['field'];
 

--- a/libraries/joomla/form/rule/options.php
+++ b/libraries/joomla/form/rule/options.php
@@ -8,6 +8,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  * Requires the value entered be one of the options in a field of type="list"
@@ -26,14 +28,14 @@ class JFormRuleOptions extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Check each value and return true if we get a match
 		foreach ($element->option as $option)

--- a/libraries/joomla/form/rule/rules.php
+++ b/libraries/joomla/form/rule/rules.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -26,14 +28,14 @@ class JFormRuleRules extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Get the possible field actions and the ones posted to validate them.
 		$fieldActions = self::getFieldActions($element);

--- a/libraries/joomla/form/rule/tel.php
+++ b/libraries/joomla/form/rule/tel.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform
  *
@@ -26,14 +28,14 @@ class JFormRuleTel extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -26,7 +28,7 @@ class JFormRuleUrl extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
@@ -35,7 +37,7 @@ class JFormRuleUrl extends JFormRule
 	 * @link    http://www.w3.org/Addressing/URL/url-spec.txt
 	 * @see	    JString
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');

--- a/libraries/joomla/form/rule/username.php
+++ b/libraries/joomla/form/rule/username.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Form Rule class for the Joomla Platform.
  *
@@ -26,14 +28,14 @@ class JFormRuleUsername extends JFormRule
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
 	 *                                      full field name would end up being "bar[foo]".
-	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
 	 */
-	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Get the database object and a new query object.
 		$db = JFactory::getDbo();

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with a GitHub server instance.
  *
@@ -41,7 +43,7 @@ defined('JPATH_PLATFORM') or die;
 class JGithub
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Registry  Options for the GitHub object.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -68,14 +70,14 @@ class JGithub
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  GitHub options object.
+	 * @param   Registry     $options  GitHub options object.
 	 * @param   JGithubHttp  $client   The HTTP client object.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JRegistry $options = null, JGithubHttp $client = null)
+	public function __construct(Registry $options = null, JGithubHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JGithubHttp($this->options);
 
 		// Setup the default API url if not already set.

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP client class for connecting to a GitHub instance.
  *
@@ -39,12 +41,12 @@ class JGithubHttp extends JHttp
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry       $options    Client options object.
+	 * @param   Registry        $options    Client options object.
 	 * @param   JHttpTransport  $transport  The HTTP transport object.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
+	public function __construct(Registry $options = null, JHttpTransport $transport = null)
 	{
 		// Call the JHttp constructor to setup the object.
 		parent::__construct($options, $transport);

--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * GitHub API object class for the Joomla Platform.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGithubObject
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Registry  Options for the GitHub object.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -33,14 +35,14 @@ abstract class JGithubObject
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  GitHub options object.
+	 * @param   Registry    $options  GitHub options object.
 	 * @param   JGithubHttp  $client   The HTTP client object.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JRegistry $options = null, JGithubHttp $client = null)
+	public function __construct(Registry $options = null, JGithubHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JGithubHttp($this->options);
 	}
 

--- a/libraries/joomla/google/auth.php
+++ b/libraries/joomla/google/auth.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGoogleAuth
 {
 	/**
-	 * @var    JRegistry  Options for the Google authentication object.
+	 * @var    \Joomla\Registry\Registry  Options for the Google authentication object.
 	 * @since  12.3
 	 */
 	protected $options;

--- a/libraries/joomla/google/auth/oauth2.php
+++ b/libraries/joomla/google/auth/oauth2.php
@@ -8,6 +8,9 @@
  */
 
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
 jimport('joomla.oauth.v2client');
 
 /**
@@ -28,14 +31,14 @@ class JGoogleAuthOauth2 extends JGoogleAuth
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry      $options  JGoogleAuth options object.
+	 * @param   Registry       $options  JGoogleAuth options object.
 	 * @param   JOAuth2Client  $client   OAuth client for Google authentication.
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JOAuth2Client $client = null)
+	public function __construct(Registry $options = null, JOAuth2Client $client = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JOAuth2Client($this->options);
 	}
 

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google API data class for the Joomla Platform.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JGoogleData
 {
 	/**
-	 * @var    JRegistry  Options for the Google data object.
+	 * @var    Registry  Options for the Google data object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -33,14 +35,14 @@ abstract class JGoogleData
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object.
+	 * @param   Registry     $options  Google options object.
 	 * @param   JGoogleAuth  $auth     Google data http client object.
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->auth = isset($auth) ? $auth : new JGoogleAuthOauth2($this->options);
 	}
 

--- a/libraries/joomla/google/data/adsense.php
+++ b/libraries/joomla/google/data/adsense.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Adsense data class for the Joomla Platform.
  *
@@ -21,12 +23,12 @@ class JGoogleDataAdsense extends JGoogleData
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		parent::__construct($options, $auth);
 
@@ -45,6 +47,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
+	 * @throws  UnexpectedValueException
 	 */
 	public function getAccount($accountID, $subaccounts = true)
 	{
@@ -77,7 +80,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listAccounts($options = array(), $maxpages = 1)
 	{
@@ -105,7 +108,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listClients($accountID, $options = array(), $maxpages = 1)
 	{
@@ -133,6 +136,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
+	 * @throws  UnexpectedValueException
 	 */
 	public function getUnit($accountID, $adclientID, $adunitID)
 	{
@@ -169,7 +173,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listUnitChannels($accountID, $adclientID, $adunitID, $options = array(), $maxpages = 1)
 	{
@@ -198,6 +202,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
+	 * @throws  UnexpectedValueException
 	 */
 	public function getChannel($accountID, $adclientID, $channelID)
 	{
@@ -233,7 +238,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listChannels($accountID, $adclientID, $options = array(), $maxpages = 1)
 	{
@@ -264,7 +269,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listChannelUnits($accountID, $adclientID, $channelID, $options = array(), $maxpages = 1)
 	{
@@ -294,7 +299,7 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function listUrlChannels($accountID, $adclientID, $options = array(), $maxpages = 1)
 	{
@@ -325,7 +330,8 @@ class JGoogleDataAdsense extends JGoogleData
 	 * @return  mixed  Data from Google
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  InvalidArgumentException
+	 * @throws  UnexpectedValueException
 	 */
 	public function generateReport($accountID, $start, $end = false, $options = array(), $maxpages = 1)
 	{

--- a/libraries/joomla/google/data/calendar.php
+++ b/libraries/joomla/google/data/calendar.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Calendar data class for the Joomla Platform.
  *
@@ -21,12 +23,12 @@ class JGoogleDataCalendar extends JGoogleData
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		parent::__construct($options, $auth);
 

--- a/libraries/joomla/google/data/picasa.php
+++ b/libraries/joomla/google/data/picasa.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Picasa data class for the Joomla Platform.
  *
@@ -21,12 +23,12 @@ class JGoogleDataPicasa extends JGoogleData
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		parent::__construct($options, $auth);
 

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Picasa data class for the Joomla Platform.
  *
@@ -28,12 +30,12 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 	 * Constructor.
 	 *
 	 * @param   SimpleXMLElement  $xml      XML from Google
-	 * @param   JRegistry         $options  Google options object
+	 * @param   Registry          $options  Google options object
 	 * @param   JGoogleAuth       $auth     Google data http client object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(SimpleXMLElement $xml, Registry $options = null, JGoogleAuth $auth = null)
 	{
 		$this->xml = $xml;
 
@@ -53,7 +55,9 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 	 * @return  boolean  Success or failure.
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  Exception
+	 * @throws  RuntimeException
+	 * @throws  UnexpectedValueException
 	 */
 	public function delete($match = '*')
 	{

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Picasa data class for the Joomla Platform.
  *
@@ -28,12 +30,12 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 	 * Constructor.
 	 *
 	 * @param   SimpleXMLElement  $xml      XML from Google
-	 * @param   JRegistry         $options  Google options object
+	 * @param   Registry          $options  Google options object
 	 * @param   JGoogleAuth       $auth     Google data http client object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(SimpleXMLElement $xml, Registry $options = null, JGoogleAuth $auth = null)
 	{
 		$this->xml = $xml;
 
@@ -53,7 +55,9 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 	 * @return  boolean  Success or failure.
 	 *
 	 * @since   12.3
-	 * @throws UnexpectedValueException
+	 * @throws  Exception
+	 * @throws  RuntimeException
+	 * @throws  UnexpectedValueException
 	 */
 	public function delete($match = '*')
 	{

--- a/libraries/joomla/google/data/plus.php
+++ b/libraries/joomla/google/data/plus.php
@@ -9,12 +9,14 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google+ data class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  Google
- * @since       1234
+ * @since       12.3
  */
 class JGoogleDataPlus extends JGoogleData
 {
@@ -39,12 +41,12 @@ class JGoogleDataPlus extends JGoogleData
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		// Setup the default API url if not already set.
 		$options->def('api.url', 'https://www.googleapis.com/plus/v1/');

--- a/libraries/joomla/google/data/plus/activities.php
+++ b/libraries/joomla/google/data/plus/activities.php
@@ -9,24 +9,26 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google+ data class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  Google
- * @since       1234
+ * @since       12.3
  */
 class JGoogleDataPlusActivities extends JGoogleData
 {
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 	parent::__construct($options, $auth);
 
@@ -49,7 +51,7 @@ class JGoogleDataPlusActivities extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function listActivities($userId, $collection, $fields = null, $max = 10, $token = null, $alt = null)
 	{
@@ -103,7 +105,7 @@ class JGoogleDataPlusActivities extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function getActivity($id, $fields = null, $alt = null)
 	{
@@ -147,7 +149,7 @@ class JGoogleDataPlusActivities extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function search($query, $fields = null, $language = null, $max = 10, $order = null, $token = null)
 	{

--- a/libraries/joomla/google/data/plus/comments.php
+++ b/libraries/joomla/google/data/plus/comments.php
@@ -9,24 +9,26 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google+ data class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  Google
- * @since       1234
+ * @since       12.3
  */
 class JGoogleDataPlusComments extends JGoogleData
 {
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		parent::__construct($options, $auth);
 
@@ -49,7 +51,7 @@ class JGoogleDataPlusComments extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function listComments($activityId, $fields = null, $max = 20, $order = null, $token = null, $alt = null)
 	{
@@ -109,7 +111,7 @@ class JGoogleDataPlusComments extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function getComment($id, $fields = null)
 	{

--- a/libraries/joomla/google/data/plus/people.php
+++ b/libraries/joomla/google/data/plus/people.php
@@ -9,24 +9,26 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google+ data class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  Google
- * @since       1234
+ * @since       12.3
  */
 class JGoogleDataPlusPeople extends JGoogleData
 {
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry    $options  Google options object
+	 * @param   Registry     $options  Google options object
 	 * @param   JGoogleAuth  $auth     Google data http client object
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
 		parent::__construct($options, $auth);
 
@@ -44,7 +46,7 @@ class JGoogleDataPlusPeople extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function getPeople($id, $fields = null)
 	{
@@ -80,7 +82,7 @@ class JGoogleDataPlusPeople extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function search($query, $fields = null, $language = null, $max = 10, $token = null)
 	{
@@ -134,7 +136,7 @@ class JGoogleDataPlusPeople extends JGoogleData
 	 *
 	 * @return  mixed  Data from Google
 	 *
-	 * @since   1234
+	 * @since   12.3
 	 */
 	public function listByActivity($activityId, $collection, $fields = null, $max = 10, $token = null)
 	{

--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -8,6 +8,9 @@
  */
 
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
 jimport('joomla.environment.uri');
 
 /**
@@ -20,7 +23,7 @@ jimport('joomla.environment.uri');
 abstract class JGoogleEmbed
 {
 	/**
-	 * @var    JRegistry  Options for the Google data object.
+	 * @var    Registry  Options for the Google data object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -34,14 +37,14 @@ abstract class JGoogleEmbed
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Google options object
-	 * @param   JUri       $uri      URL of the page being rendered
+	 * @param   Registry  $options  Google options object
+	 * @param   JUri      $uri      URL of the page being rendered
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JUri $uri = null)
+	public function __construct(Registry $options = null, JUri $uri = null)
 	{
-		$this->options = $options ? $options : new JRegistry;
+		$this->options = $options ? $options : new Registry;
 		$this->uri = $uri ? $uri : new JUri;
 	}
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Google Maps embed class for the Joomla Platform.
  *
@@ -18,7 +20,6 @@ defined('JPATH_PLATFORM') or die;
  */
 class JGoogleEmbedMaps extends JGoogleEmbed
 {
-
 	/**
 	 * @var    JHttp  The HTTP client object to use in sending HTTP requests.
 	 * @since  12.3
@@ -28,13 +29,13 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Google options object
-	 * @param   JUri       $uri      URL of the page being rendered
-	 * @param   JHttp      $http     Http client for geocoding requests
+	 * @param   Registry  $options  Google options object
+	 * @param   JUri      $uri      URL of the page being rendered
+	 * @param   JHttp     $http     Http client for geocoding requests
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JUri $uri = null, JHttp $http = null)
+	public function __construct(Registry $options = null, JUri $uri = null, JHttp $http = null)
 	{
 		parent::__construct($options, $uri);
 		$this->http = $http ? $http : new JHttp($this->options);

--- a/libraries/joomla/google/google.php
+++ b/libraries/joomla/google/google.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with the Google APIs.
  *
@@ -22,13 +24,13 @@ defined('JPATH_PLATFORM') or die;
 class JGoogle
 {
 	/**
-	 * @var    JRegistry  Options for the Google object.
+	 * @var    Registry  Options for the Google object.
 	 * @since  12.3
 	 */
 	protected $options;
 
 	/**
-	 * @var    JAuth  The authentication client object to use in sending authenticated HTTP requests.
+	 * @var    JGoogleAuth  The authentication client object to use in sending authenticated HTTP requests.
 	 * @since  12.3
 	 */
 	protected $auth;
@@ -48,23 +50,23 @@ class JGoogle
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Google options object.
-	 * @param   JAuth      $auth     The authentication client object.
+	 * @param   Registry     $options  Google options object.
+	 * @param   JGoogleAuth  $auth     The authentication client object.
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(Registry $options = null, JGoogleAuth $auth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->auth  = isset($auth) ? $auth : new JGoogleAuthOauth2($this->options);
 	}
 
 	/**
 	 * Method to create JGoogleData objects
 	 *
-	 * @param   string     $name     Name of property to retrieve
-	 * @param   JRegistry  $options  Google options object.
-	 * @param   JAuth      $auth     The authentication client object.
+	 * @param   string       $name     Name of property to retrieve
+	 * @param   Registry     $options  Google options object.
+	 * @param   JGoogleAuth  $auth     The authentication client object.
 	 *
 	 * @return  JGoogleData  Google data API object.
 	 *
@@ -102,8 +104,8 @@ class JGoogle
 	/**
 	 * Method to create JGoogleEmbed objects
 	 *
-	 * @param   string     $name     Name of property to retrieve
-	 * @param   JRegistry  $options  Google options object.
+	 * @param   string    $name     Name of property to retrieve
+	 * @param   Registry  $options  Google options object.
 	 *
 	 * @return  JGoogleEmbed  Google embed API object.
 	 *

--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP factory class.
  *
@@ -21,8 +23,8 @@ class JHttpFactory
 	/**
 	 * method to receive Http instance.
 	 *
-	 * @param   JRegistry  $options   Client options object.
-	 * @param   mixed      $adapters  Adapter (string) or queue of adapters (array) to use for communication.
+	 * @param   Registry  $options   Client options object.
+	 * @param   mixed     $adapters  Adapter (string) or queue of adapters (array) to use for communication.
 	 *
 	 * @return  JHttp      Joomla Http class
 	 *
@@ -30,11 +32,11 @@ class JHttpFactory
 	 *
 	 * @since   12.1
 	 */
-	public static function getHttp(JRegistry $options = null, $adapters = null)
+	public static function getHttp(Registry $options = null, $adapters = null)
 	{
 		if (empty($options))
 		{
-			$options = new JRegistry;
+			$options = new Registry;
 		}
 
 		if (empty($adapters))
@@ -58,14 +60,14 @@ class JHttpFactory
 	/**
 	 * Finds an available http transport object for communication
 	 *
-	 * @param   JRegistry  $options  Option for creating http transport object
-	 * @param   mixed      $default  Adapter (string) or queue of adapters (array) to use
+	 * @param   Registry  $options  Option for creating http transport object
+	 * @param   mixed     $default  Adapter (string) or queue of adapters (array) to use
 	 *
 	 * @return  JHttpTransport Interface sub-class
 	 *
 	 * @since   12.1
 	 */
-	public static function getAvailableDriver(JRegistry $options, $default = null)
+	public static function getAvailableDriver(Registry $options, $default = null)
 	{
 		if (is_null($default))
 		{

--- a/libraries/joomla/http/http.php
+++ b/libraries/joomla/http/http.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP client class.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttp
 {
 	/**
-	 * @var    JRegistry  Options for the HTTP client.
+	 * @var    Registry  Options for the HTTP client.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -33,15 +35,15 @@ class JHttp
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry       $options    Client options object. If the registry contains any headers.* elements,
+	 * @param   Registry        $options    Client options object. If the registry contains any headers.* elements,
 	 *                                      these will be added to the request headers.
 	 * @param   JHttpTransport  $transport  The HTTP transport object.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
+	public function __construct(Registry $options = null, JHttpTransport $transport = null)
 	{
-		$this->options   = isset($options) ? $options : new JRegistry;
+		$this->options   = isset($options) ? $options : new Registry;
 		$this->transport = isset($transport) ? $transport : JHttpFactory::getAvailableDriver($this->options);
 	}
 

--- a/libraries/joomla/http/transport.php
+++ b/libraries/joomla/http/transport.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP transport class interface.
  *
@@ -21,11 +23,11 @@ interface JHttpTransport
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Client options object.
+	 * @param   Registry  $options  Client options object.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JRegistry $options);
+	public function __construct(Registry $options);
 
 	/**
 	 * Send a request to the server and return a JHttpResponse object with the response.

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP transport class for using cURL.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttpTransportCurl implements JHttpTransport
 {
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -27,13 +29,13 @@ class JHttpTransportCurl implements JHttpTransport
 	/**
 	 * Constructor. CURLOPT_FOLLOWLOCATION must be disabled when open_basedir or safe_mode are enabled.
 	 *
-	 * @param   JRegistry  $options  Client options object.
+	 * @param   Registry  $options  Client options object.
 	 *
 	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
 	 * @since   11.3
 	 * @throws  RuntimeException
 	 */
-	public function __construct(JRegistry $options)
+	public function __construct(Registry $options)
 	{
 		if (!function_exists('curl_init') || !is_callable('curl_init'))
 		{

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP transport class for using sockets directly.
  *
@@ -25,7 +27,7 @@ class JHttpTransportSocket implements JHttpTransport
 	protected $connections;
 
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -33,12 +35,12 @@ class JHttpTransportSocket implements JHttpTransport
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Client options object.
+	 * @param   Registry  $options  Client options object.
 	 *
 	 * @since   11.3
 	 * @throws  RuntimeException
 	 */
-	public function __construct(JRegistry $options)
+	public function __construct(Registry $options)
 	{
 		if (!self::isSupported())
 		{

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP transport class for using PHP streams.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttpTransportStream implements JHttpTransport
 {
 	/**
-	 * @var    JRegistry  The client options.
+	 * @var    Registry  The client options.
 	 * @since  11.3
 	 */
 	protected $options;
@@ -27,12 +29,12 @@ class JHttpTransportStream implements JHttpTransport
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  Client options object.
+	 * @param   Registry  $options  Client options object.
 	 *
 	 * @since   11.3
 	 * @throws  RuntimeException
 	 */
-	public function __construct(JRegistry $options)
+	public function __construct(Registry $options)
 	{
 		// Verify that URLs can be used with fopen();
 		if (!ini_get('allow_url_fopen'))

--- a/libraries/joomla/keychain/keychain.php
+++ b/libraries/joomla/keychain/keychain.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Keychain
  * @since       12.3
  */
-class JKeychain extends JRegistry
+class JKeychain extends \Joomla\Registry\Registry
 {
 	/**
 	 * @var    string  Method to use for encryption.

--- a/libraries/joomla/linkedin/linkedin.php
+++ b/libraries/joomla/linkedin/linkedin.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with a Linkedin API instance.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 class JLinkedin
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -76,15 +78,15 @@ class JLinkedin
 	 * Constructor.
 	 *
 	 * @param   JLinkedinOauth  $oauth    OAuth object
-	 * @param   JRegistry       $options  Linkedin options object.
+	 * @param   Registry        $options  Linkedin options object.
 	 * @param   JHttp           $client   The HTTP client object.
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JLinkedinOauth $oauth = null, JRegistry $options = null, JHttp $client = null)
+	public function __construct(JLinkedinOauth $oauth = null, Registry $options = null, JHttp $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JHttp($this->options);
 
 		// Setup the default API url if not already set.

--- a/libraries/joomla/linkedin/oauth.php
+++ b/libraries/joomla/linkedin/oauth.php
@@ -9,18 +9,19 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for generating Linkedin API access token.
  *
  * @package     Joomla.Platform
  * @subpackage  Linkedin
- *
  * @since       13.1
  */
 class JLinkedinOauth extends JOAuth1Client
 {
 	/**
-	* @var    JRegistry  Options for the JLinkedinOauth object.
+	* @var    Registry  Options for the JLinkedinOauth object.
 	* @since  13.1
 	*/
 	protected $options;
@@ -28,15 +29,15 @@ class JLinkedinOauth extends JOAuth1Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  JLinkedinOauth options object.
-	 * @param   JHttp      $client   The HTTP client object.
-	 * @param   JInput     $input    The input object
+	 * @param   Registry  $options  JLinkedinOauth options object.
+	 * @param   JHttp     $client   The HTTP client object.
+	 * @param   JInput    $input    The input object
 	 *
-	 * @since 13.1
+	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JInput $input = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JInput $input = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 
 		$this->options->def('accessTokenURL', 'https://www.linkedin.com/uas/oauth/accessToken');
 		$this->options->def('authenticateURL', 'https://www.linkedin.com/uas/oauth/authenticate');

--- a/libraries/joomla/linkedin/object.php
+++ b/libraries/joomla/linkedin/object.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Linkedin API object class for the Joomla Platform.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JLinkedinObject
 {
 	/**
-	 * @var    JRegistry  Options for the Linkedin object.
+	 * @var    Registry  Options for the Linkedin object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -39,15 +41,15 @@ abstract class JLinkedinObject
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry       $options  Linkedin options object.
+	 * @param   Registry        $options  Linkedin options object.
 	 * @param   JHttp           $client   The HTTP client object.
 	 * @param   JLinkedinOAuth  $oauth    The OAuth client.
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JLinkedinOAuth $oauth = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JLinkedinOAuth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JHttp($this->options);
 		$this->oauth = $oauth;
 	}

--- a/libraries/joomla/mediawiki/http.php
+++ b/libraries/joomla/mediawiki/http.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTTP client class for connecting to a MediaWiki instance.
  *
@@ -21,15 +23,15 @@ class JMediawikiHttp extends JHttp
 	/**
      * Constructor.
      *
-     * @param   JRegistry       $options    Client options object.
+     * @param   Registry       $options    Client options object.
      * @param   JHttpTransport  $transport  The HTTP transport object.
      *
      * @since   12.3
      */
-	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
+	public function __construct(Registry $options = null, JHttpTransport $transport = null)
 	{
 		// Override the JHttp contructor to use JHttpTransportStream.
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.

--- a/libraries/joomla/mediawiki/mediawiki.php
+++ b/libraries/joomla/mediawiki/mediawiki.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with a Mediawiki server instance.
  *
@@ -27,7 +29,7 @@ defined('JPATH_PLATFORM') or die;
 class JMediawiki
 {
 	/**
-	 * @var    JRegistry  Options for the MediaWiki object.
+	 * @var    Registry  Options for the MediaWiki object.
 	 * @since  12.1
 	 */
 	protected $options;
@@ -83,14 +85,14 @@ class JMediawiki
 	/**
      * Constructor.
      *
-     * @param   JRegistry       $options  MediaWiki options object.
+     * @param   Registry        $options  MediaWiki options object.
      * @param   JMediawikiHttp  $client   The HTTP client object.
      *
      * @since   12.3
      */
-	public function __construct(JRegistry $options = null, JMediawikiHttp $client = null)
+	public function __construct(Registry $options = null, JMediawikiHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JMediawikiHttp($this->options);
 	}
 

--- a/libraries/joomla/mediawiki/object.php
+++ b/libraries/joomla/mediawiki/object.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * MediaWiki API object class for the Joomla Platform.
  *
@@ -18,9 +20,8 @@ defined('JPATH_PLATFORM') or die;
  */
 abstract class JMediawikiObject
 {
-
 	/**
-	 * @var    JRegistry  Options for the MediaWiki object.
+	 * @var    Registry  Options for the MediaWiki object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -34,14 +35,14 @@ abstract class JMediawikiObject
 	/**
      * Constructor.
      *
-     * @param   JRegistry       $options  Mediawiki options object.
+     * @param   Registry        $options  Mediawiki options object.
      * @param   JMediawikiHttp  $client   The HTTP client object.
      *
      * @since   12.3
      */
-	public function __construct(JRegistry $options = null, JMediawikiHttp $client = null)
+	public function __construct(Registry $options = null, JMediawikiHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JMediawikiHttp($this->options);
 	}
 

--- a/libraries/joomla/model/base.php
+++ b/libraries/joomla/model/base.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform Base Model Class
  *
@@ -21,7 +23,7 @@ abstract class JModelBase implements JModel
 	/**
 	 * The model state.
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  12.1
 	 */
 	protected $state;
@@ -29,11 +31,11 @@ abstract class JModelBase implements JModel
 	/**
 	 * Instantiate the model.
 	 *
-	 * @param   JRegistry  $state  The model state.
+	 * @param   Registry  $state  The model state.
 	 *
 	 * @since   12.1
 	 */
-	public function __construct(JRegistry $state = null)
+	public function __construct(Registry $state = null)
 	{
 		// Setup the model.
 		$this->state = isset($state) ? $state : $this->loadState();
@@ -42,7 +44,7 @@ abstract class JModelBase implements JModel
 	/**
 	 * Get the model state.
 	 *
-	 * @return  JRegistry  The state object.
+	 * @return  Registry  The state object.
 	 *
 	 * @since   12.1
 	 */
@@ -54,13 +56,13 @@ abstract class JModelBase implements JModel
 	/**
 	 * Set the model state.
 	 *
-	 * @param   JRegistry  $state  The state object.
+	 * @param   Registry  $state  The state object.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function setState(JRegistry $state)
+	public function setState(Registry $state)
 	{
 		$this->state = $state;
 	}
@@ -68,12 +70,12 @@ abstract class JModelBase implements JModel
 	/**
 	 * Load the model state.
 	 *
-	 * @return  JRegistry  The state object.
+	 * @return  Registry  The state object.
 	 *
 	 * @since   12.1
 	 */
 	protected function loadState()
 	{
-		return new JRegistry;
+		return new Registry;
 	}
 }

--- a/libraries/joomla/model/database.php
+++ b/libraries/joomla/model/database.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform Database Model Class
  *
@@ -29,12 +31,12 @@ abstract class JModelDatabase extends JModelBase
 	/**
 	 * Instantiate the model.
 	 *
-	 * @param   JRegistry        $state  The model state.
+	 * @param   Registry         $state  The model state.
 	 * @param   JDatabaseDriver  $db     The database adpater.
 	 *
 	 * @since   12.1
 	 */
-	public function __construct(JRegistry $state = null, JDatabaseDriver $db = null)
+	public function __construct(Registry $state = null, JDatabaseDriver $db = null)
 	{
 		parent::__construct($state);
 

--- a/libraries/joomla/model/model.php
+++ b/libraries/joomla/model/model.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform Model Interface
  *
@@ -21,7 +23,7 @@ interface JModel
 	/**
 	 * Get the model state.
 	 *
-	 * @return  JRegistry  The state object.
+	 * @return  Registry  The state object.
 	 *
 	 * @since   12.1
 	 */
@@ -30,11 +32,11 @@ interface JModel
 	/**
 	 * Set the model state.
 	 *
-	 * @param   JRegistry  $state  The state object.
+	 * @param   Registry  $state  The state object.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function setState(JRegistry $state);
+	public function setState(Registry $state);
 }

--- a/libraries/joomla/oauth1/client.php
+++ b/libraries/joomla/oauth1/client.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with an OAuth 1.0 and 1.0a server.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JOAuth1Client
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth1Client object.
+	 * @var    Registry  Options for the JOAuth1Client object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -57,7 +59,7 @@ abstract class JOAuth1Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry        $options      OAuth1Client options object.
+	 * @param   Registry         $options      OAuth1Client options object.
 	 * @param   JHttp            $client       The HTTP client object.
 	 * @param   JInput           $input        The input object
 	 * @param   JApplicationWeb  $application  The application object
@@ -65,10 +67,10 @@ abstract class JOAuth1Client
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JInput $input = null, JApplicationWeb $application = null,
+	public function __construct(Registry $options = null, JHttp $client = null, JInput $input = null, JApplicationWeb $application = null,
 		$version = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : JHttpFactory::getHttp($this->options);
 		$this->input = isset($input) ? $input : JFactory::getApplication()->input;
 		$this->application = isset($application) ? $application : new JApplicationWeb;

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with an OAuth 2.0 server.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 class JOAuth2Client
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Registry  Options for the JOAuth2Client object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -45,16 +47,16 @@ class JOAuth2Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry        $options      JOAuth2Client options object
+	 * @param   Registry         $options      JOAuth2Client options object
 	 * @param   JHttp            $http         The HTTP client object
 	 * @param   JInput           $input        The input object
 	 * @param   JApplicationWeb  $application  The application object
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JHttp $http = null, JInput $input = null, JApplicationWeb $application = null)
+	public function __construct(Registry $options = null, JHttp $http = null, JInput $input = null, JApplicationWeb $application = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->http = isset($http) ? $http : new JHttp($this->options);
 		$this->input = isset($input) ? $input : JFactory::getApplication()->input;
 		$this->application = isset($application) ? $application : new JApplicationWeb;

--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for generating Openstreetmap API access token.
  *
@@ -21,7 +23,7 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	/**
 	 * Options for the JOpenstreetmapOauth object.
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  13.1
 	 */
 	protected $options;
@@ -29,15 +31,15 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry  $options  JOpenstreetmapOauth options object.
-	 * @param   JHttp      $client   The HTTP client object.
-	 * @param   JInput     $input    The input object
+	 * @param   Registry  $options  JOpenstreetmapOauth options object.
+	 * @param   JHttp     $client   The HTTP client object.
+	 * @param   JInput    $input    The input object
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JInput $input = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JInput $input = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 
 		$this->options->def('accessTokenURL', 'http://www.openstreetmap.org/oauth/access_token');
 		$this->options->def('authoriseURL', 'http://www.openstreetmap.org/oauth/authorize');

--- a/libraries/joomla/openstreetmap/object.php
+++ b/libraries/joomla/openstreetmap/object.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Openstreetmap API object class for the Joomla Platform
  *
@@ -21,7 +23,7 @@ abstract class JOpenstreetmapObject
 	/**
 	 * Options for the Openstreetmap object.
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  13.1
 	 */
 	protected $options;
@@ -45,15 +47,15 @@ abstract class JOpenstreetmapObject
 	/**
 	 * Constructor
 	 *
-	 * @param   JRegistry            &$options  Openstreetmap options object.
+	 * @param   Registry             &$options  Openstreetmap options object.
 	 * @param   JHttp                $client    The HTTP client object.
 	 * @param   JOpenstreetmapOauth  $oauth     Openstreetmap oauth client
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JRegistry &$options = null, JHttp $client = null, JOpenstreetmapOauth $oauth = null)
+	public function __construct(Registry &$options = null, JHttp $client = null, JOpenstreetmapOauth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JHttp($this->options);
 		$this->oauth = $oauth;
 	}

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interact with Openstreetmap API.
  *
@@ -21,7 +23,7 @@ class JOpenstreetmap
 	/**
 	 * Options for the Openstreetmap object.
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  13.1
 	 */
 	protected $options;
@@ -61,7 +63,7 @@ class JOpenstreetmap
 	/**
 	 * Openstreetmap API object for GPS.
 	 *
-	 * @var   JOpenstreetmapGps
+	 * @var    JOpenstreetmapGps
 	 * @since  13.1
 	 */
 	protected $gps;
@@ -86,15 +88,15 @@ class JOpenstreetmap
 	 * Constructor.
 	 *
 	 * @param   JOpenstreetmapOauth  $oauth    Openstreetmap oauth client
-	 * @param   JRegistry            $options  Openstreetmap options object
+	 * @param   Registry             $options  Openstreetmap options object
 	 * @param   JHttp                $client   The HTTP client object
 	 *
 	 * @since   13.1
 	 */
-	public function __construct(JOpenstreetmapOauth $oauth = null, JRegistry $options = null, JHttp $client = null)
+	public function __construct(JOpenstreetmapOauth $oauth = null, Registry $options = null, JHttp $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JHttp($this->options);
 
 		// Setup the default API url if not already set.

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -9,9 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Extension table
- * Replaces plugins table
  *
  * @package     Joomla.Platform
  * @subpackage  Table
@@ -67,14 +68,14 @@ class JTableExtension extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}
 
 		if (isset($array['control']) && is_array($array['control']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['control']);
 			$array['control'] = (string) $registry;
 		}

--- a/libraries/joomla/table/update.php
+++ b/libraries/joomla/table/update.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Update table
  * Stores updates temporarily
@@ -67,14 +69,14 @@ class JTableUpdate extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}
 
 		if (isset($array['control']) && is_array($array['control']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['control']);
 			$array['control'] = (string) $registry;
 		}

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Users table
  *
@@ -126,7 +128,7 @@ class JTableUser extends JTable
 	{
 		if (array_key_exists('params', $array) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}

--- a/libraries/joomla/twitter/oauth.php
+++ b/libraries/joomla/twitter/oauth.php
@@ -9,35 +9,36 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for generating Twitter API access token.
  *
  * @package     Joomla.Platform
  * @subpackage  Twitter
- *
  * @since       12.3
  */
 class JTwitterOAuth extends JOAuth1Client
 {
 	/**
-	* @var JRegistry Options for the JTwitterOauth object.
-	* @since 12.3
+	* @var    Registry  Options for the JTwitterOauth object.
+	* @since  12.3
 	*/
 	protected $options;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry        $options      JTwitterOauth options object.
+	 * @param   Registry         $options      JTwitterOauth options object.
 	 * @param   JHttp            $client       The HTTP client object.
 	 * @param   JInput           $input        The input object.
 	 * @param   JApplicationWeb  $application  The application object.
 	 *
-	 * @since 12.3
+	 * @since   12.3
 	 */
-	public function __construct(JRegistry $options = null, JHttp $client = null, JInput $input = null, JApplicationWeb $application = null)
+	public function __construct(Registry $options = null, JHttp $client = null, JInput $input = null, JApplicationWeb $application = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 
 		$this->options->def('accessTokenURL', 'https://api.twitter.com/oauth/access_token');
 		$this->options->def('authenticateURL', 'https://api.twitter.com/oauth/authenticate');

--- a/libraries/joomla/twitter/object.php
+++ b/libraries/joomla/twitter/object.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Twitter API object class for the Joomla Platform.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 abstract class JTwitterObject
 {
 	/**
-	 * @var    JRegistry  Options for the Twitter object.
+	 * @var    Registry  Options for the Twitter object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -39,15 +41,15 @@ abstract class JTwitterObject
 	/**
 	 * Constructor.
 	 *
-	 * @param   JRegistry      &$options  Twitter options object.
+	 * @param   Registry       &$options  Twitter options object.
 	 * @param   JHttp          $client    The HTTP client object.
 	 * @param   JTwitterOAuth  $oauth     The OAuth client.
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JRegistry &$options = null, JHttp $client = null, JTwitterOAuth $oauth = null)
+	public function __construct(Registry &$options = null, JHttp $client = null, JTwitterOAuth $oauth = null)
 	{
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client = isset($client) ? $client : new JHttp($this->options);
 		$this->oauth = $oauth;
 	}

--- a/libraries/joomla/twitter/twitter.php
+++ b/libraries/joomla/twitter/twitter.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die();
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Platform class for interacting with a Twitter API instance.
  *
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die();
 class JTwitter
 {
 	/**
-	 * @var    JRegistry  Options for the GitHub object.
+	 * @var    Registry  Options for the JTwitter object.
 	 * @since  12.3
 	 */
 	protected $options;
@@ -31,8 +33,8 @@ class JTwitter
 	protected $client;
 
 	/**
-	 * @var JTwitterOAuth The OAuth client.
-	 * @since 12.3
+	 * @var    JTwitterOAuth The OAuth client.
+	 * @since  12.3
 	 */
 	protected $oauth;
 
@@ -112,15 +114,15 @@ class JTwitter
 	 * Constructor.
 	 *
 	 * @param   JTwitterOauth  $oauth    The oauth client.
-	 * @param   JRegistry      $options  Twitter options object.
+	 * @param   Registry       $options  Twitter options object.
 	 * @param   JHttp          $client   The HTTP client object.
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(JTwitterOAuth $oauth = null, JRegistry $options = null, JHttp $client = null)
+	public function __construct(JTwitterOAuth $oauth = null, Registry $options = null, JHttp $client = null)
 	{
 		$this->oauth = $oauth;
-		$this->options = isset($options) ? $options : new JRegistry;
+		$this->options = isset($options) ? $options : new Registry;
 		$this->client  = isset($client) ? $client : new JHttp($this->options);
 
 		// Setup the default API url if not already set.

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * User class.  Handles all application interaction with a user
  *
@@ -117,7 +119,7 @@ class JUser extends JObject
 	/**
 	 * User parameters
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  11.1
 	 */
 	public $params = null;
@@ -165,7 +167,7 @@ class JUser extends JObject
 	/**
 	 * User parameters
 	 *
-	 * @var    JRegistry
+	 * @var    Registry
 	 * @since  11.1
 	 */
 	protected $_params = null;
@@ -218,7 +220,7 @@ class JUser extends JObject
 	public function __construct($identifier = 0)
 	{
 		// Create the user parameters object
-		$this->_params = new JRegistry;
+		$this->_params = new Registry;
 
 		// Load the user if it exists
 		if (!empty($identifier))
@@ -756,7 +758,7 @@ class JUser extends JObject
 
 			if ($my->id == $table->id)
 			{
-				$registry = new JRegistry;
+				$registry = new Registry;
 				$registry->loadString($table->params);
 				$my->setParameters($registry);
 			}

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 JLog::add('JApplication is deprecated.', JLog::WARNING, 'deprecated');
 
 /**
@@ -786,7 +788,7 @@ class JApplication extends JApplicationBase
 		$template = new stdClass;
 
 		$template->template = 'system';
-		$template->params   = new JRegistry;
+		$template->params   = new Registry;
 
 		if ($params)
 		{
@@ -1097,7 +1099,7 @@ class JApplication extends JApplicationBase
 
 		if ($session->isNew())
 		{
-			$session->set('registry', new JRegistry('session'));
+			$session->set('registry', new Registry('session'));
 			$session->set('user', new JUser);
 		}
 	}

--- a/libraries/legacy/application/cli.php
+++ b/libraries/legacy/application/cli.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Deprecated class placeholder. You should use JApplicationCli instead.
  *
@@ -23,22 +25,22 @@ class JCli extends JApplicationCli
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
-	 *                              input object.  If the argument is a JInputCli object that object will become
-	 *                              the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
-	 *                              the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become
-	 *                              the application's event dispatcher, if it is null then the default event dispatcher
-	 *                              will be created based on the application's loadDispatcher() method.
+	 * @param   JInputCli  $input              An optional argument to provide dependency injection for the application's
+	 *                                         input object.  If the argument is a JInputCli object that object will become
+	 *                                         the application's input object, otherwise a default input object is created.
+	 * @param   Registry  $config              An optional argument to provide dependency injection for the application's
+	 *                                         config object.  If the argument is a Registry object that object will become
+	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JEventDispatcher  $dispatcher  An optional argument to provide dependency injection for the application's
+	 *                                         event dispatcher.  If the argument is a JEventDispatcher object that object will become
+	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                         will be created based on the application's loadDispatcher() method.
 	 *
 	 * @see     JApplicationBase::loadDispatcher()
 	 * @since   11.1
 	 * @deprecated  12.3 (Platform) & 4.0 (CMS) - Use JApplicationCli instead.
 	 */
-	public function __construct(JInputCli $input = null, JRegistry $config = null, JEventDispatcher $dispatcher = null)
+	public function __construct(JInputCli $input = null, Registry $config = null, JEventDispatcher $dispatcher = null)
 	{
 		JLog::add('JCli is deprecated. Use JApplicationCli instead.', JLog::WARNING, 'deprecated');
 		parent::__construct($input, $config, $dispatcher);

--- a/libraries/legacy/application/daemon.php
+++ b/libraries/legacy/application/daemon.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 JLog::add('JDaemon has been renamed to JApplicationDaemon.', JLog::WARNING, 'deprecated');
 
 /**
@@ -25,22 +27,22 @@ class JDaemon extends JApplicationDaemon
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
-	 *                              input object.  If the argument is a JInputCli object that object will become
-	 *                              the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config      An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a JRegistry object that object will become
-	 *                              the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                              event dispatcher.  If the argument is a JEventDispatcher object that object will become
-	 *                              the application's event dispatcher, if it is null then the default event dispatcher
-	 *                              will be created based on the application's loadDispatcher() method.
+	 * @param   JInputCli  $input              An optional argument to provide dependency injection for the application's
+	 *                                         input object.  If the argument is a JInputCli object that object will become
+	 *                                         the application's input object, otherwise a default input object is created.
+	 * @param   Registry  $config              An optional argument to provide dependency injection for the application's
+	 *                                         config object.  If the argument is a Registry object that object will become
+	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JEventDispatcher  $dispatcher  An optional argument to provide dependency injection for the application's
+	 *                                         event dispatcher.  If the argument is a JEventDispatcher object that object will become
+	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                         will be created based on the application's loadDispatcher() method.
 	 *
 	 * @since   11.1
 	 * @deprecated  12.3 Use JApplicationDaemon instead.
 	 * @throws  RuntimeException
 	 */
-	public function __construct(JInputCli $input = null, JRegistry $config = null, JEventDispatcher $dispatcher = null)
+	public function __construct(JInputCli $input = null, Registry $config = null, JEventDispatcher $dispatcher = null)
 	{
 		JLog::add('JDaemon is deprecated. Use JApplicationDaemon instead.', JLog::WARNING, 'deprecated');
 		parent::__construct($input, $config, $dispatcher);

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * JCategories Class.
  *
@@ -884,15 +886,15 @@ class JCategoryNode extends JObject
 	/**
 	 * Returns the category parameters
 	 *
-	 * @return  JRegistry
+	 * @return  Registry
 	 *
 	 * @since   11.1
 	 */
 	public function getParams()
 	{
-		if (!($this->params instanceof JRegistry))
+		if (!($this->params instanceof Registry))
 		{
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString($this->params);
 			$this->params = $temp;
 		}
@@ -903,15 +905,15 @@ class JCategoryNode extends JObject
 	/**
 	 * Returns the category metadata
 	 *
-	 * @return  JRegistry  A JRegistry object containing the metadata
+	 * @return  Registry  A Registry object containing the metadata
 	 *
 	 * @since   11.1
 	 */
 	public function getMetadata()
 	{
-		if (!($this->metadata instanceof JRegistry))
+		if (!($this->metadata instanceof Registry))
 		{
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString($this->metadata);
 			$this->metadata = $temp;
 		}

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Prototype admin model.
  *
@@ -850,7 +852,7 @@ abstract class JModelAdmin extends JModelForm
 
 		if (property_exists($item, 'params'))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadString($item->params);
 			$item->params = $registry->toArray();
 		}

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Category table
  *
@@ -174,14 +176,14 @@ class JTableCategory extends JTableNested
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}
 
 		if (isset($array['metadata']) && is_array($array['metadata']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['metadata']);
 			$array['metadata'] = (string) $registry;
 		}

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Content table
  *
@@ -138,14 +140,14 @@ class JTableContent extends JTable
 
 		if (isset($array['attribs']) && is_array($array['attribs']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['attribs']);
 			$array['attribs'] = (string) $registry;
 		}
 
 		if (isset($array['metadata']) && is_array($array['metadata']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['metadata']);
 			$array['metadata'] = (string) $registry;
 		}

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Menu table
  *
@@ -72,7 +74,7 @@ class JTableMenu extends JTableNested
 
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Module table
  *
@@ -148,7 +150,7 @@ class JTableModule extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new JRegistry;
+			$registry = new Registry;
 			$registry->loadArray($array['params']);
 			$array['params'] = (string) $registry;
 		}

--- a/libraries/legacy/view/categories.php
+++ b/libraries/legacy/view/categories.php
@@ -21,7 +21,7 @@ class JViewCategories extends JViewLegacy
 	/**
 	 * State data
 	 *
-	 * @var    JRegistry
+	 * @var    \Joomla\Registry\Registry
 	 * @since  3.2
 	 */
 	protected $state;

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -21,7 +21,7 @@ class JViewCategory extends JViewLegacy
 	/**
 	 * State data
 	 *
-	 * @var    JRegistry
+	 * @var    \Joomla\Registry\Registry
 	 * @since  3.2
 	 */
 	protected $state;

--- a/libraries/legacy/web/web.php
+++ b/libraries/legacy/web/web.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Deprecated class placeholder.  You should use JApplicationWeb instead.
  *
@@ -23,20 +25,20 @@ class JWeb extends JApplicationWeb
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
-	 *                          input object.  If the argument is a JInput object that object will become
-	 *                          the application's input object, otherwise a default input object is created.
-	 * @param   mixed  $config  An optional argument to provide dependency injection for the application's
-	 *                          config object.  If the argument is a JRegistry object that object will become
-	 *                          the application's config object, otherwise a default config object is created.
-	 * @param   mixed  $client  An optional argument to provide dependency injection for the application's
-	 *                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
+	 *                                          input object.  If the argument is a JInput object that object will become
+	 *                                          the application's input object, otherwise a default input object is created.
+	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
+	 *                                          config object.  If the argument is a Registry object that object will become
+	 *                                          the application's config object, otherwise a default config object is created.
+	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
+	 *                                          the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   11.3
 	 * @deprecated  12.3 (Platform) & 4.0 (CMS) Use JApplicationWeb instead.
 	 */
-	public function __construct(JInput $input = null, JRegistry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
 	{
 		JLog::add('JWeb is deprecated. Use JApplicationWeb instead.', JLog::WARNING, 'deprecated');
 		parent::__construct($input, $config, $client);

--- a/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JApplicationAdministrator.
  *
@@ -81,7 +83,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 		// Set the config for the app
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('session', false);
 
 		// Get a new JApplicationAdministrator instance.
@@ -224,9 +226,9 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 
 		$template = $this->class->getTemplate(true);
 
-		$this->assertThat(
-			$template->params,
-			$this->isInstanceOf('JRegistry')
+		$this->assertInstanceOf(
+			'\\Joomla\\Registry\\Registry',
+			$template->params
 		);
 
 		$this->assertThat(

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 include_once __DIR__ . '/stubs/JApplicationCmsInspector.php';
 
 /**
@@ -83,7 +85,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 		// Set the config for the app
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('session', false);
 
 		// Get a new JApplicationCmsInspector instance.
@@ -152,7 +154,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		$this->assertInstanceOf(
-			'JRegistry',
+			'\\Joomla\\Registry\\Registry',
 			TestReflection::getValue($this->class, 'config'),
 			'Config property wrong type'
 		);
@@ -192,7 +194,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 			$this->returnValue('ok')
 		);
 
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('session', false);
 
 		$mockClient = $this->getMock('JApplicationWebClient', array('test'), array(), '', false);
@@ -320,7 +322,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 */
 	public function testGetCfg()
 	{
-		$config = new JRegistry(array('foo' => 'bar'));
+		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::setValue($this->class, 'config', $config);
 
@@ -419,9 +421,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 	{
 		$template = $this->class->getTemplate(true);
 
-		$this->assertThat(
-			$template->params,
-			$this->isInstanceOf('JRegistry')
+		$this->assertInstanceOf(
+			'\\Joomla\\Registry\\Registry',
+			$template->params
 		);
 
 		$this->assertThat(
@@ -483,7 +485,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
@@ -524,7 +526,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
@@ -574,7 +576,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		JApplicationCmsInspector::$headersSent = true;
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
@@ -687,7 +689,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 		$config->set('uri.request', $request);
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JApplicationSite.
  *
@@ -81,7 +83,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 		// Set the config for the app
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('session', false);
 
 		// Get a new JApplicationSite instance.
@@ -242,9 +244,9 @@ class JApplicationSiteTest extends TestCaseDatabase
 	{
 		$template = $this->class->getTemplate(true);
 
-		$this->assertThat(
-			$template->params,
-			$this->isInstanceOf('JRegistry')
+		$this->assertInstanceOf(
+			'\\Joomla\\Registry\\Registry',
+			$template->params
 		);
 
 		$this->assertThat(
@@ -366,9 +368,9 @@ class JApplicationSiteTest extends TestCaseDatabase
 
 		$template = $this->class->getTemplate(true);
 
-		$this->assertThat(
-			$template->params,
-			$this->isInstanceOf('JRegistry')
+		$this->assertInstanceOf(
+			'\\Joomla\\Registry\\Registry',
+			$template->params
 		);
 
 		$this->assertThat(

--- a/tests/unit/suites/libraries/cms/help/JHelpTest.php
+++ b/tests/unit/suites/libraries/cms/help/JHelpTest.php
@@ -19,7 +19,7 @@ class JHelpTest extends TestCase
 	/**
 	 * The mock config object
 	 *
-	 * @var    JRegistry
+	 * @var    \Joomla\Registry\Registry
 	 * @since  3.0
 	 */
 	protected $config;

--- a/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemBase.php
+++ b/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemBase.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Stub plugin class for unit testing
  *
@@ -29,7 +31,7 @@ class PlgSystemBase extends JPlugin
 		$config = array();
 		$config['name']   = 'Base';
 		$config['type']   = 'System';
-		$config['params'] = new JRegistry;
+		$config['params'] = new Registry;
 
 		$dispatcher = JEventDispatcher::getInstance();
 

--- a/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemJoomla.php
+++ b/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemJoomla.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Stub plugin class for unit testing
  *
@@ -45,7 +47,7 @@ class PlgSystemJoomla extends JPlugin
 		$config = array();
 		$config['name']   = 'Joomla';
 		$config['type']   = 'System';
-		$config['params'] = new JRegistry;
+		$config['params'] = new Registry;
 
 		$dispatcher = JEventDispatcher::getInstance();
 

--- a/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemPrivate.php
+++ b/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemPrivate.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Stub plugin class for unit testing
  *
@@ -45,7 +47,7 @@ class PlgSystemPrivate extends JPlugin
 		$config = array();
 		$config['name']   = 'Private';
 		$config['type']   = 'System';
-		$config['params'] = new JRegistry;
+		$config['params'] = new Registry;
 
 		$dispatcher = JEventDispatcher::getInstance();
 

--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -79,7 +79,7 @@ class JFactoryTest extends TestCase
 		JFactory::$config = null;
 
 		$this->assertInstanceOf(
-			'JRegistry',
+			'\\Joomla\\Registry\\Registry',
 			JFactory::getConfig(JPATH_TESTS . '/config.php'),
 			'Line: ' . __LINE__
 		);

--- a/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 include_once __DIR__ . '/stubs/JApplicationCliInspector.php';
 
 /**
@@ -68,7 +70,7 @@ class JApplicationCliTest extends TestCase
 	{
 		$this->assertInstanceOf('JInput', $this->class->input, 'Input property wrong type');
 
-		$this->assertAttributeInstanceOf('JRegistry', 'config', $this->class, 'Checks config property');
+		$this->assertAttributeInstanceOf('\\Joomla\\Registry\\Registry', 'config', $this->class, 'Checks config property');
 
 		$this->assertAttributeInstanceOf('JEventDispatcher', 'dispatcher', $this->class, 'Checks dispatcher property');
 
@@ -100,7 +102,7 @@ class JApplicationCliTest extends TestCase
 			$this->returnValue('ok')
 		);
 
-		$mockConfig = $this->getMock('JRegistry', array('test'), array(null), '', true);
+		$mockConfig = $this->getMock('\\Joomla\\Registry\\Registry', array('test'), array(null), '', true);
 		$mockConfig
 			->expects($this->any())
 			->method('test')
@@ -262,7 +264,7 @@ class JApplicationCliTest extends TestCase
 	 */
 	public function testGet()
 	{
-		$config = new JRegistry(array('foo' => 'bar'));
+		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::getValue($this->class, 'config', $config);
 
@@ -338,7 +340,7 @@ class JApplicationCliTest extends TestCase
 	 */
 	public function testSet()
 	{
-		$config = new JRegistry(array('foo' => 'bar'));
+		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::setValue($this->class, 'config', $config);
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 include_once __DIR__ . '/stubs/JApplicationWebInspector.php';
 
 /**
@@ -148,7 +150,7 @@ class JApplicationWebTest extends TestCase
 		);
 
 		$this->assertInstanceOf(
-			'JRegistry',
+			'\\Joomla\\Registry\\Registry',
 			TestReflection::getValue($this->class, 'config'),
 			'Config property wrong type'
 		);
@@ -202,7 +204,7 @@ class JApplicationWebTest extends TestCase
 			$this->returnValue('ok')
 		);
 
-		$mockConfig = $this->getMock('JRegistry', array('test'), array(null), '', true);
+		$mockConfig = $this->getMock('\\Joomla\\Registry\\Registry', array('test'), array(null), '', true);
 		$mockConfig
 			->expects($this->any())
 			->method('test')
@@ -847,7 +849,7 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testGet()
 	{
-		$config = new JRegistry(array('foo' => 'bar'));
+		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::setValue($this->class, 'config', $config);
 
@@ -1203,7 +1205,7 @@ class JApplicationWebTest extends TestCase
 	public function testLoadSystemUrisWithSiteUriSet()
 	{
 		// Set the site_uri value in the configuration.
-		$config = new JRegistry(array('site_uri' => 'http://test.joomla.org/path/'));
+		$config = new Registry(array('site_uri' => 'http://test.joomla.org/path/'));
 		TestReflection::setValue($this->class, 'config', $config);
 
 		TestReflection::invoke($this->class, 'loadSystemUris');
@@ -1291,7 +1293,7 @@ class JApplicationWebTest extends TestCase
 	public function testLoadSystemUrisWithoutSiteUriWithMediaUriSet()
 	{
 		// Set the media_uri value in the configuration.
-		$config = new JRegistry(array('media_uri' => 'http://cdn.joomla.org/media/'));
+		$config = new Registry(array('media_uri' => 'http://cdn.joomla.org/media/'));
 		TestReflection::setValue($this->class, 'config', $config);
 
 		TestReflection::invoke($this->class, 'loadSystemUris', 'http://joom.la/application');
@@ -1338,7 +1340,7 @@ class JApplicationWebTest extends TestCase
 	public function testLoadSystemUrisWithoutSiteUriWithRelativeMediaUriSet()
 	{
 		// Set the media_uri value in the configuration.
-		$config = new JRegistry(array('media_uri' => '/media/'));
+		$config = new Registry(array('media_uri' => '/media/'));
 		TestReflection::setValue($this->class, 'config', $config);
 
 		TestReflection::invoke($this->class, 'loadSystemUris', 'http://joom.la/application');
@@ -1430,7 +1432,7 @@ class JApplicationWebTest extends TestCase
 		);
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
@@ -1465,7 +1467,7 @@ class JApplicationWebTest extends TestCase
 		JApplicationWebInspector::$headersSent = true;
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
@@ -1578,7 +1580,7 @@ class JApplicationWebTest extends TestCase
 		);
 
 		// Inject the internal configuration.
-		$config = new JRegistry;
+		$config = new Registry;
 		$config->set('uri.base.full', $base);
 		$config->set('uri.request', $request);
 
@@ -1695,7 +1697,7 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testSet()
 	{
-		$config = new JRegistry(array('foo' => 'bar'));
+		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::setValue($this->class, 'config', $config);
 

--- a/tests/unit/suites/libraries/joomla/data/JDataTest.php
+++ b/tests/unit/suites/libraries/joomla/data/JDataTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 JLoader::register('JDataBuran', __DIR__ . '/stubs/buran.php');
 JLoader::register('JDataCapitaliser', __DIR__ . '/stubs/capitaliser.php');
 
@@ -268,7 +270,7 @@ class JDataTest extends TestCase
 		$properties = array(
 			'scalar' => 'value_1',
 			'date' => new JDate('2012-01-01'),
-			'registry' => new JRegistry(array('key' => 'value')),
+			'registry' => new Registry(array('key' => 'value')),
 			'JData' => new JData(
 				array(
 					'level2' => new JData(
@@ -303,7 +305,7 @@ class JDataTest extends TestCase
 
 		$dump = $this->_instance->dump(0);
 		$this->assertInstanceOf('JDate', $dump->date);
-		$this->assertInstanceOf('JRegistry', $dump->registry);
+		$this->assertInstanceOf('\\Joomla\\Registry\\Registry', $dump->registry);
 		$this->assertInstanceOf('JData', $dump->JData);
 
 		$dump = $this->_instance->dump(1);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookAlbumTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookAlbumTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookAlbum.
  *
@@ -17,7 +19,7 @@
 class JFacebookAlbumTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -76,7 +78,7 @@ class JFacebookAlbumTest extends TestCase
 			'created' => '2443672521'
 		);
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookCheckinTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookCheckinTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookCheckin.
  *
@@ -17,7 +19,7 @@
 class JFacebookCheckinTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -76,7 +78,7 @@ class JFacebookCheckinTest extends TestCase
 			'created' => '2443672521'
 		);
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookCommentTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookCommentTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookComment.
  *
@@ -17,7 +19,7 @@
 class JFacebookCommentTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -76,7 +78,7 @@ class JFacebookCommentTest extends TestCase
 			'created' => '2443672521'
 		);
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookEventTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookEventTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookEvent.
  *
@@ -17,7 +19,7 @@
 class JFacebookEventTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -82,7 +84,7 @@ class JFacebookEventTest extends TestCase
 			'created' => '2443672521'
 		);
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookGroupTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookGroupTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookGroup.
  *
@@ -17,7 +19,7 @@
 class JFacebookGroupTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -80,7 +82,7 @@ class JFacebookGroupTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookLinkTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookLinkTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookLink.
  *
@@ -17,7 +19,7 @@
 class JFacebookLinkTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -80,7 +82,7 @@ class JFacebookLinkTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookNoteTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookNoteTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookNote.
  *
@@ -17,7 +19,7 @@
 class JFacebookNoteTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -74,7 +76,7 @@ class JFacebookNoteTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookOauthTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookOauthTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookOauth.
  *
@@ -17,7 +19,7 @@
 class JFacebookOauthTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -55,7 +57,7 @@ class JFacebookOauthTest extends TestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookObjectTest.php
@@ -9,6 +9,8 @@
 
 require_once __DIR__ . '/stubs/JFacebookObjectMock.php';
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookObject.
  *
@@ -19,7 +21,7 @@ require_once __DIR__ . '/stubs/JFacebookObjectMock.php';
 class JFacebookObjectTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -63,7 +65,7 @@ class JFacebookObjectTest extends TestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 
 		$this->object = new JFacebookObjectMock($this->options, $this->client);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookPhotoTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookPhotoTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookPhoto.
  *
@@ -17,7 +19,7 @@
 class JFacebookPhotoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -74,7 +76,7 @@ class JFacebookPhotoTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookPostTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookPostTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookPost.
  *
@@ -17,7 +19,7 @@
 class JFacebookPostTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -74,7 +76,7 @@ class JFacebookPostTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookStatusTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookStatusTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookStatus.
  *
@@ -17,7 +19,7 @@
 class JFacebookStatusTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -74,7 +76,7 @@ class JFacebookStatusTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebook.
  *
@@ -17,7 +19,7 @@
 class JFacebookTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -55,7 +57,7 @@ class JFacebookTest extends TestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 
 		$this->object = new JFacebook($this->oauth, $this->options, $this->client);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookUserTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookUserTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookUser.
  *
@@ -17,7 +19,7 @@
 class JFacebookUserTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -86,7 +88,7 @@ class JFacebookUserTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/facebook/JFacebookVideoTest.php
+++ b/tests/unit/suites/libraries/joomla/facebook/JFacebookVideoTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JFacebookVideo.
  *
@@ -17,7 +19,7 @@
 class JFacebookVideoTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the Facebook object.
+	 * @var    Registry  Options for the Facebook object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -74,7 +76,7 @@ class JFacebookVideoTest extends TestCase
 			'access_token' => 'token',
 			'expires' => '51837673', 'created' => '2443672521');
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput;
 		$this->oauth = new JFacebookOauth($this->options, $this->client, $this->input);

--- a/tests/unit/suites/libraries/joomla/model/JModelBaseTest.php
+++ b/tests/unit/suites/libraries/joomla/model/JModelBaseTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 JLoader::register('BaseModel', __DIR__ . '/stubs/tbase.php');
 
 /**
@@ -36,10 +38,10 @@ class JModelBaseTest extends TestCase
 	{
 		// @codingStandardsIgnoreStart
 		// @todo check the instanciating new classes without brackets sniff
-		$this->assertEquals(new JRegistry, $this->_instance->getState(), 'Checks default state.');
+		$this->assertEquals(new Registry, $this->_instance->getState(), 'Checks default state.');
 		// @codingStandardsIgnoreEnd
 
-		$state = new JRegistry(array('foo' => 'bar'));
+		$state = new Registry(array('foo' => 'bar'));
 		$class = new BaseModel($state);
 		$this->assertEquals($state, $class->getState(), 'Checks state injection.');
 	}
@@ -70,7 +72,7 @@ class JModelBaseTest extends TestCase
 	 */
 	public function testSetState()
 	{
-		$state = new JRegistry(array('foo' => 'bar'));
+		$state = new Registry(array('foo' => 'bar'));
 		$this->_instance->setState($state);
 		$this->assertSame($state, $this->_instance->getState());
 	}
@@ -85,7 +87,7 @@ class JModelBaseTest extends TestCase
 	 */
 	public function testLoadState()
 	{
-		$this->assertInstanceOf('JRegistry', TestReflection::invoke($this->_instance, 'loadState'));
+		$this->assertInstanceOf('\\Joomla\\Registry\\Registry', TestReflection::invoke($this->_instance, 'loadState'));
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
+++ b/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 include_once __DIR__ . '/stubs/JOAuth1ClientInspector.php';
 include_once __DIR__ . '/../application/stubs/JApplicationWebInspector.php';
 
@@ -26,7 +28,7 @@ class JOAuth1ClientTest extends TestCase
 	protected $input;
 
 	/**
-	 * @var    JRegistry  Options for the OAuth object.
+	 * @var    Registry  Options for the OAuth object.
 	 * @since  13.1
 	 */
 	protected $options;
@@ -80,7 +82,7 @@ class JOAuth1ClientTest extends TestCase
 		$secret = "TEST_SECRET";
 		$my_url = "TEST_URL";
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->client = $this->getMock('JHttp', array('get', 'post', 'delete', 'put'));
 		$this->input = new JInput(array());
 		$this->application = new JApplicationWebInspector;

--- a/tests/unit/suites/libraries/joomla/oauth2/JOauth2ClientTest.php
+++ b/tests/unit/suites/libraries/joomla/oauth2/JOauth2ClientTest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Test class for JOAuth2Client.
  *
@@ -17,7 +19,7 @@
 class JOAuth2ClientTest extends TestCase
 {
 	/**
-	 * @var    JRegistry  Options for the JOAuth2Client object.
+	 * @var    Registry  Options for the JOAuth2Client object.
 	 */
 	protected $options;
 
@@ -57,7 +59,7 @@ class JOAuth2ClientTest extends TestCase
 		$_SERVER['REQUEST_URI'] = '/index.php';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		$this->options = new JRegistry;
+		$this->options = new Registry;
 		$this->http = $this->getMock('JHttp', array('head', 'get', 'delete', 'trace', 'post', 'put', 'patch'), array($this->options));
 		$array = array();
 		$this->input = new JInput($array);


### PR DESCRIPTION
Updates references to no longer present `JRegistry` to the namespaced `\Joomla\Registry\Registry`
