### PR TITLE
Allow to get permitions for section != 'component'

### DIFF
--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -120,7 +120,7 @@ class JHelperContent
 		{
 			$section = 'component';
 		}
-		
+
 		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='" . $section . "']/");
 
 		foreach ($actions as $action)

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -116,12 +116,12 @@ class JHelperContent
 			$assetName = $component;
 		}
 
-		if(empty($section))
+		if (empty($section))
 		{
 			$section = 'component';
 		}
 		
-		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='".$section."']/");
+		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='" . $section . "']/");
 
 		foreach ($actions as $action)
 		{

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -116,7 +116,12 @@ class JHelperContent
 			$assetName = $component;
 		}
 
-		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='component']/");
+		if(empty($section))
+		{
+			$section = 'component';
+		}
+		
+		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='".$section."']/");
 
 		foreach ($actions as $action)
 		{


### PR DESCRIPTION
This will allow to set ACL different groups based on category permissions, for example:
access.xml
    &lt;section name="component"&gt;
        [...]
    &lt;/section&gt;
    &lt;section name="category"&gt;
        &lt;action name="roles.list" title="roles list" description="" /&gt;
        &lt;action name="roles.manage" title="roles manage" description="" /&gt;
    &lt;/section&gt;

view.html.php (view of a generic component)
[...]
$this->canDo = JHelperContent::getActions('com_componentname', 'category', $item->catid);
if (!$this->canDo->get('roles.manage')) {
            JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
            $app = JFactory::getApplication();
            $app->redirect('index.php');
}
[...]
