### PR TITLE
Backport: [#31036] Search is broken on Chrome #1312 Ref #3724

### DIFF
--- a/libraries/joomla/environment/uri.php
+++ b/libraries/joomla/environment/uri.php
@@ -188,11 +188,8 @@ class JURI extends JObject
 					}
 				}
 
-				// Check for quotes in the URL to prevent injections through the Host header
-				if ($theURI !== str_replace(array("'", '"', '<', '>'), '', $theURI))
-				{
-					throw new InvalidArgumentException('Invalid URI detected.');
-				}
+				// Extra cleanup to remove invalid chars in the URL to prevent injections through the Host header
+				$theURI = str_replace(array("'", '"', '<', '>'), array("%27", "%22", "%3C", "%3E"), $theURI);
 			}
 			else
 			{


### PR DESCRIPTION
This backports: https://github.com/joomla/joomla-cms/pull/1312 to 2.5.x as requested here: https://github.com/joomla/joomla-cms/issues/3724

Commit against staging/master was: https://github.com/joomla/joomla-cms/commit/7c608a35eb7c7addd3903bfb1c7775858e1161c7
