### PR TITLE
Use hash_equals for constant-time string comparison

### DIFF
--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -258,7 +258,8 @@ class JCrypt
 	/**
 	 * A timing safe comparison method. This defeats hacking
 	 * attempts that use timing based attack vectors.
-	 *
+	 * Length will leak.
+         *
 	 * @param   string  $known    A known string to check against.
 	 * @param   string  $unknown  An unknown string to check.
 	 *
@@ -268,6 +269,10 @@ class JCrypt
 	 */
 	public static function timingSafeCompare($known, $unknown)
 	{
+		if (function_exists('hash_equals')) {
+			return hash_equals((string) $known, (string) $unknown);
+		}
+
 		// Prevent issues if string length is 0
 		$known .= chr(0);
 		$unknown .= chr(0);


### PR DESCRIPTION
Use the `hash_equals` function (introduced in PHP 5.6) for timing attack safe string comparison when available.
Add in the DocBlock that length will leak (see php/php-src#792).
