### PR TITLE
Unify the handeling of the login and logout redirect Ref #4142

### DIFF
--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -37,7 +37,7 @@ class UsersHelperLogin
 
 		if (is_numeric($itemid))
 		{
-			$db	   = JFactory::getDbo();
+			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('link'))
 				->from($db->quoteName('#__menu'))

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -59,7 +59,6 @@ class UsersHelperLogin
 			}
 		}
 
-
 		// B/C checks
 		// @deprecated with 4.0
 		// @note if we can break B/C You can remove $typeBC & $urlBc and the following if statement

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -35,6 +35,18 @@ class UsersHelperLogin
 		$url    = null;
 		$itemid = $params->get($type);
 
+		// B/C checks
+		// @deprecated with 4.0
+		// @note if we can break B/C You can remove $typeBC & $urlBc and the following if statement
+		$typeBc = $type . '_redirect_url';
+		$urlBc  = $params->get($typeBC);
+
+		// If we have a old URL use it.
+		if ($urlBc != '')
+		{
+			$itemid = $urlBc;
+		}		
+
 		if (is_numeric($itemid))
 		{
 			$db    = JFactory::getDbo();
@@ -59,11 +71,13 @@ class UsersHelperLogin
 			}
 		}
 
+		// For B/C reasons
+		// The value in the param is not a number and not null
+		// so the param store a old value like a URL and it will used.
+		// @deprecated with 4.0
+		// @note if we can break B/C You can remove this if statement
 		if ($itemid != '')
 		{
-			// For B/C reasons
-			// The value in the param is not a number and not null
-			// so the param store a old value like a URL and it will used.
 			$url = $itemid;
 		}
 
@@ -103,6 +117,11 @@ class UsersHelperLogin
 			}
 		}
 
+		// Set the current url to the B/C hidden field.
+		// @deprecated with 4.0
+		// @note if we can break B/C You can remove the next line.
+		$params->set($typeBc, $url);
+
 		return base64_encode($url);
 	}
 
@@ -117,7 +136,7 @@ class UsersHelperLogin
 	{
 		$user = JFactory::getUser();
 
-		return (!$user->get('guest')) ? 'logout_redirect_url' : 'login_redirect_url';
+		return (!$user->get('guest')) ? 'logout' : 'login';
 	}
 
 	/**

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -59,10 +59,11 @@ class UsersHelperLogin
 			}
 		}
 
-		if ($itemid)
+		if ($itemid != '')
 		{
 			// For B/C reasons
-			// If the param store a old value like a URL it will used
+			// The value in the param is not a number and not null
+			// so the param store a old value like a URL and it will used.
 			$url = $itemid;
 		}
 

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -66,8 +66,8 @@ class UsersHelperLogin
 		$typeBc = $type . '_redirect_url';
 		$urlBc  = $params->get($typeBC);
 
-		// If we have a old URL use it.
-		if ($urlBc != '')
+		// If we have a old URL but no new one use it.
+		if ($urlBc != '' && !$url)
 		{
 			$url = $urlBc;
 		}

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -35,18 +35,6 @@ class UsersHelperLogin
 		$url    = null;
 		$itemid = $params->get($type);
 
-		// B/C checks
-		// @deprecated with 4.0
-		// @note if we can break B/C You can remove $typeBC & $urlBc and the following if statement
-		$typeBc = $type . '_redirect_url';
-		$urlBc  = $params->get($typeBC);
-
-		// If we have a old URL use it.
-		if ($urlBc != '')
-		{
-			$itemid = $urlBc;
-		}		
-
 		if (is_numeric($itemid))
 		{
 			$db    = JFactory::getDbo();
@@ -71,14 +59,17 @@ class UsersHelperLogin
 			}
 		}
 
-		// For B/C reasons
-		// The value in the param is not a number and not null
-		// so the param store a old value like a URL and it will used.
+
+		// B/C checks
 		// @deprecated with 4.0
-		// @note if we can break B/C You can remove this if statement
-		if ($itemid != '')
+		// @note if we can break B/C You can remove $typeBC & $urlBc and the following if statement
+		$typeBc = $type . '_redirect_url';
+		$urlBc  = $params->get($typeBC);
+
+		// If we have a old URL use it.
+		if ($urlBc != '')
 		{
-			$url = $itemid;
+			$url = $urlBc;
 		}
 
 		if (!$url)

--- a/components/com_users/helpers/login.php
+++ b/components/com_users/helpers/login.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Users Login Helper
+ *
+ * @package     Joomla.Site
+ * @subpackage  com_users
+ * @since       3.4
+ */
+class UsersHelperLogin
+{
+	/**
+	 * Retrieve the url where the user should be returned after logging in
+	 *
+	 * @param   JRegistry  $params  view parameters
+	 * @param   string     $type    return type
+	 *
+	 * @return string 
+	 *
+	 * @since  3.4
+	 */
+	public static function getReturnURL($params, $type)
+	{
+		$app	= JFactory::getApplication();
+		$router = $app::getRouter();
+		$url    = null;
+		$itemid = $params->get($type);
+
+		if (is_numeric($itemid))
+		{
+			$db	   = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName('link'))
+				->from($db->quoteName('#__menu'))
+				->where($db->quoteName('published') . '=1')
+				->where($db->quoteName('id') . '=' . $db->quote($itemid));
+
+			$db->setQuery($query);
+
+			if ($link = $db->loadResult())
+			{
+				if ($router->getMode() == JROUTER_MODE_SEF)
+				{
+					$url = 'index.php?Itemid=' . $itemid;
+				}
+				else
+				{
+					$url = $link . '&Itemid=' . $itemid;
+				}
+			}
+		}
+
+		if ($itemid)
+		{
+			// For B/C reasons
+			// If the param store a old value like a URL it will used
+			$url = $itemid;
+		}
+
+		if (!$url)
+		{
+			// Stay on the same page
+			$uri  = clone JUri::getInstance();
+			$vars = $router->parse($uri);
+			unset($vars['lang']);
+
+			if ($router->getMode() == JROUTER_MODE_SEF)
+			{
+				if (isset($vars['Itemid']))
+				{
+					$itemid = $vars['Itemid'];
+					$menu   = $app->getMenu();
+					$item   = $menu->getItem($itemid);
+					unset($vars['Itemid']);
+
+					if (isset($item) && $vars == $item->query)
+					{
+						$url = 'index.php?Itemid=' . $itemid;
+					}
+					else
+					{
+						$url = 'index.php?' . JUri::buildQuery($vars) . '&Itemid=' . $itemid;
+					}
+				}
+				else
+				{
+					$url = 'index.php?' . JUri::buildQuery($vars);
+				}
+			}
+			else
+			{
+				$url = 'index.php?' . JUri::buildQuery($vars);
+			}
+		}
+
+		return base64_encode($url);
+	}
+
+	/**
+	 * Returns the current users type
+	 *
+	 * @return string
+	 *
+	 * @since  3.4
+	 */
+	public static function getType()
+	{
+		$user = JFactory::getUser();
+
+		return (!$user->get('guest')) ? 'logout_redirect_url' : 'login_redirect_url';
+	}
+
+	/**
+	 * Get list of available two factor methods
+	 *
+	 * @return array
+	 *
+	 * @since  3.4
+	 */
+	public static function getTwoFactorMethods()
+	{
+		require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
+
+		return UsersHelper::getTwoFactorMethods();
+	}
+}

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -15,14 +15,17 @@
 		<!-- Basic options. -->
 		<fieldset name="basic" label="COM_MENUS_BASIC_FIELDSET_LABEL">
 
+		<!-- For BC reasons please remove this with 4.0 -->
+		<field name="login_redirect_url" type="hidden" default="" />
+
 		<field
-			name="login_redirect_url"
+			name="login"
 			type="menuitem"
 			disable="separator"
 			label="JFIELD_LOGIN_REDIRECT_URL_LABEL"
 			description="JFIELD_LOGIN_REDIRECT_URL_DESC">
 			<option value="">JDEFAULT</option>
-			</field>
+		</field>
 
 		 <field
 			name="logindescription_show"
@@ -56,8 +59,11 @@
 			hr="true"
 		/>
 
+		<!-- For BC reasons please remove this with 4.0 -->
+		<field name="logout_redirect_url" type="hidden" default="" />
+
 		<field
-			name="logout_redirect_url"
+			name="logout"
 			type="menuitem"
 			disable="separator"
 			label="JFIELD_LOGOUT_REDIRECT_URL_LABEL"
@@ -65,7 +71,7 @@
 			<option value="">JDEFAULT</option>
 		</field>
 
-         	<field
+         <field
 			name="logoutdescription_show"
 			type="list"
 			label="JFIELD_BASIS_LOGOUT_DESCRIPTION_SHOW_LABEL"

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -3,7 +3,8 @@
 	<layout title="com_user_login_view_default_title" option="com_user_login_view_default_option">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_USER_LOGIN"
-		/>		<message>
+		/>
+		<message>
 			<![CDATA[COM_USER_LOGIN_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
@@ -15,11 +16,13 @@
 		<fieldset name="basic" label="COM_MENUS_BASIC_FIELDSET_LABEL">
 
 		<field
-		name="login_redirect_url"
-		type="text"
-		label="JFIELD_LOGIN_REDIRECT_URL_LABEL"
-		description="JFIELD_LOGIN_REDIRECT_URL_DESC"
-		class="inputbox"/>
+			name="login_redirect_url"
+			type="menuitem"
+			disable="separator"
+			label="JFIELD_LOGIN_REDIRECT_URL_LABEL"
+			description="JFIELD_LOGIN_REDIRECT_URL_DESC">
+			<option value="">JDEFAULT</option>
+			</field>
 
 		 <field
 			name="logindescription_show"
@@ -27,60 +30,66 @@
 			label="JFIELD_BASIS_LOGIN_DESCRIPTION_SHOW_LABEL"
 			description="JFIELD_BASIS_LOGIN_DESCRIPTION_SHOW_DESC"
 			default="1">
-			<option
-				value="0">JHIDE</option>
-			<option
-				value="1">JSHOW</option>
-				</field>
-		<field
-		name="login_description"
-		type="textarea"
-		label="JFIELD_BASIS_LOGIN_DESCRIPTION_LABEL"
-		description="JFIELD_BASIS_LOGIN_DESCRIPTION_DESC"
-		rows="3"
-		cols="40"/>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
+		</field>
 
 		<field
-		name="login_image"
-		type="media"
-		label="JFIELD_LOGIN_IMAGE_LABEL"
-		description="JFIELD_LOGIN_IMAGE_DESC"/>
+			name="login_description"
+			type="textarea"
+			label="JFIELD_BASIS_LOGIN_DESCRIPTION_LABEL"
+			description="JFIELD_BASIS_LOGIN_DESCRIPTION_DESC"
+			rows="3"
+			cols="40"
+		/>
 
-		<field name="spacer1" type="spacer"
-				hr="true"
-			/>
 		<field
-		name="logout_redirect_url"
-		type="text"
-		label="JFIELD_LOGOUT_REDIRECT_URL_LABEL"
-		description="JFIELD_LOGOUT_REDIRECT_URL_DESC"
-		class="inputbox"/>
-         <field
+			name="login_image"
+			type="media"
+			label="JFIELD_LOGIN_IMAGE_LABEL"
+			description="JFIELD_LOGIN_IMAGE_DESC"
+		/>
+
+		<field
+			name="spacer1"
+			type="spacer"
+			hr="true"
+		/>
+
+		<field
+			name="logout_redirect_url"
+			type="menuitem"
+			disable="separator"
+			label="JFIELD_LOGOUT_REDIRECT_URL_LABEL"
+			description="JFIELD_LOGOUT_REDIRECT_URL_DESC">
+			<option value="">JDEFAULT</option>
+		</field>
+
+         	<field
 			name="logoutdescription_show"
 			type="list"
 			label="JFIELD_BASIS_LOGOUT_DESCRIPTION_SHOW_LABEL"
 			description="JFIELD_BASIS_LOGOUT_DESCRIPTION_SHOW_DESC"
 			default="1">
-			<option
-				value="0">JHIDE</option>
-			<option
-				value="1">JSHOW</option>
-				</field>
-		<field
-		name="logout_description"
-		type="textarea"
-		label="JFIELD_BASIS_LOGOUT_DESCRIPTION_LABEL"
-		description="JFIELD_BASIS_LOGOUT_DESCRIPTION_DESC"
-		rows="3"
-		cols="40"/>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
+		</field>
 
 		<field
-		name="logout_image"
-		type="media"
-		label="JFIELD_LOGOUT_IMAGE_LABEL"
-		description="JFIELD_LOGOUT_IMAGE_DESC"/>
+			name="logout_description"
+			type="textarea"
+			label="JFIELD_BASIS_LOGOUT_DESCRIPTION_LABEL"
+			description="JFIELD_BASIS_LOGOUT_DESCRIPTION_DESC"
+			rows="3"
+			cols="40"
+		/>
 
-
+		<field
+			name="logout_image"
+			type="media"
+			label="JFIELD_LOGOUT_IMAGE_LABEL"
+			description="JFIELD_LOGOUT_IMAGE_DESC"
+		/>
 
 		</fieldset>
 	</fields>

--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -78,7 +78,7 @@ JHtml::_('behavior.keepalive');
 				</div>
 			</div>
 
-			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('login_redirect_url', $this->form->getValue('return'))); ?>" />
+			<input type="hidden" name="return" value="<?php echo $this->redirect; ?>" />
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 	</form>

--- a/components/com_users/views/login/tmpl/default_logout.php
+++ b/components/com_users/views/login/tmpl/default_logout.php
@@ -40,7 +40,7 @@ defined('_JEXEC') or die;
 				<button type="submit" class="btn btn-primary"><span class="icon-arrow-left icon-white"></span> <?php echo JText::_('JLOGOUT'); ?></button>
 			</div>
 		</div>
-		<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return'))); ?>" />
+		<input type="hidden" name="return" value="<?php echo $this->redirect; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 </div>

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -25,7 +25,7 @@ class UsersViewLogin extends JViewLegacy
 	protected $state;
 
 	protected $user;
-	
+
 	protected $redirect;
 
 	/**

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -25,20 +25,30 @@ class UsersViewLogin extends JViewLegacy
 	protected $state;
 
 	protected $user;
+	
+	protected $redirect;
 
 	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  The template file to include
+	 *
 	 * @since   1.5
 	 */
 	public function display($tpl = null)
 	{
 		// Get the view data.
-		$this->user		= JFactory::getUser();
-		$this->form		= $this->get('Form');
-		$this->state	= $this->get('State');
-		$this->params	= $this->state->get('params');
+		$this->user   = JFactory::getUser();
+		$this->form   = $this->get('Form');
+		$this->state  = $this->get('State');
+		$this->params = $this->state->get('params');
+
+		// Include the Login Helper (UsersHelperLogin)
+		require_once JPATH_SITE . '/components/com_users/helpers/login.php';
+
+		// Build the return url
+		$type           = UsersHelperLogin::getType();
+		$this->redirect = UsersHelperLogin::getReturnURL($this->params, $type);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -49,13 +59,13 @@ class UsersViewLogin extends JViewLegacy
 
 		// Check for layout override
 		$active = JFactory::getApplication()->getMenu()->getActive();
+
 		if (isset($active->query['layout']))
 		{
 			$this->setLayout($active->query['layout']);
 		}
 
-		require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
-		$tfa = UsersHelper::getTwoFactorMethods();
+		$tfa       = UsersHelperLogin::getTwoFactorMethods();
 		$this->tfa = is_array($tfa) && count($tfa) > 1;
 
 		//Escape strings for HTML output
@@ -68,19 +78,21 @@ class UsersViewLogin extends JViewLegacy
 
 	/**
 	 * Prepares the document
+	 *
 	 * @since   1.6
 	 */
 	protected function prepareDocument()
 	{
-		$app		= JFactory::getApplication();
-		$menus		= $app->getMenu();
-		$user		= JFactory::getUser();
-		$login		= $user->get('guest') ? true : false;
-		$title 		= null;
+		$app   = JFactory::getApplication();
+		$menus = $app->getMenu();
+		$user  = JFactory::getUser();
+		$login = $user->get('guest') ? true : false;
+		$title = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
+
 		if ($menu)
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));


### PR DESCRIPTION
### Issue

JTracker: http://issues.joomla.org/tracker/joomla-cms/4142
Gh: https://github.com/joomla/joomla-cms/issues/4142

Login redirect don't work for external URLs and currently we use a simple text field to store the value.
I would vote for changing the behavior on the com_users login form to the behavior that we have on mod_login that only internal urls are allow and use a dropdown to select it.
This is a workable solution 
### How to test
1. apply patch
2. create a new menu itm with the com_users login view. (not mod_login ;))
3. choose a login redirect page with the dropdown
4. choose a logout redirect page with the dropdown
5. save
6. login by using this menu itm
7. make sure the redirect is correct
8. logout by using the menu itm
9. make sure the redirect is correct
### This is B/C save

The old way is that we use a string containing the redirect url that stored in the params the new way is to store the ID.
This part of code will handel it:

``` php
$itemid = $params->get($type);

if (is_numeric($itemid))
{
[...]
}
if ($itemid != '')
{
        // For B/C reasons
        // The value in the param is not a number and not null
        // so the param store a old value like a URL and it will used.
        $url = $itemid;
}
```

https://github.com/zero-24/joomla-cms/blob/patch-10/components/com_users/helpers/login.php#L62-68

If the params stores a old value like a url it will be used. If it store the id it also works.
### Possible B/C break

if someone override one of these files (the views):
https://github.com/zero-24/joomla-cms/blob/patch-10/components/com_users/views/login/tmpl/default_logout.php
https://github.com/zero-24/joomla-cms/blob/patch-10/components/com_users/views/login/tmpl/default_login.php

They need to change the line

``` php
<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return'))); ?>" />
```

to

``` php
<input type="hidden" name="return" value="<?php echo $this->redirect; ?>" />
```
##### Question

Is this a B/C Issue so this need to wait for 4.0 or can we add this to 3.3/3.4?
If it is a B/C Issue can we handel this any how?
### Other mirror changes
- Some mirror CS issues specifically on the default.xml file.
- Move the TFA function (getTwoFactorMethods()) to UsersHelperLogin
