### PR TITLE
Non-descriptive error messages when a package upload fails in com_installer

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -226,14 +226,14 @@ class InstallerModelInstall extends JModelLegacy
 		// Is the PHP tmp directory missing?
 		if ($userfile['error'] && ($userfile['error'] == UPLOAD_ERR_NO_TMP_DIR))
 		{
-			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . ' ' . JText::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSET'));
+			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . '<br/>' . JText::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSET'));
 			return false;
 		}
 
 		// Is the max upload size too small in php.ini?
 		if ($userfile['error'] && ($userfile['error'] == UPLOAD_ERR_INI_SIZE))
 		{
-			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . ' ' . JText::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'));
+			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . '<br/>' . JText::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'));
 			return false;
 		}
 

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -194,7 +194,7 @@ class InstallerModelInstall extends JModelLegacy
 	/**
 	 * Works out an installation package from a HTTP upload
 	 *
-	 * @return package definition or false on failure
+	 * @return array package definition or false on failure
 	 */
 	protected function _getPackageFromUpload()
 	{
@@ -223,7 +223,21 @@ class InstallerModelInstall extends JModelLegacy
 			return false;
 		}
 
-		// Check if there was a problem uploading the file.
+		// Is the PHP tmp directory missing?
+		if ($userfile['error'] && ($userfile['error'] == UPLOAD_ERR_NO_TMP_DIR))
+		{
+			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . ' ' . JText::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSET'));
+			return false;
+		}
+
+		// Is the max upload size too small in php.ini?
+		if ($userfile['error'] && ($userfile['error'] == UPLOAD_ERR_INI_SIZE))
+		{
+			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR') . ' ' . JText::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'));
+			return false;
+		}
+
+		// Check if there was a different problem uploading the file.
 		if ($userfile['error'] || $userfile['size'] < 1)
 		{
 			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'));


### PR DESCRIPTION
## Executive summary

When you try installing an extension package file with Manage Extensions but your PHP upload temporary directory (upload_tmp_dir) is not set in pph.ini or the package size is larger than the maximum upload size (max_upload_size) you get a generic error which doesn't let you understand why the upload failed. This PR adds descriptive error messages using the same language strings we are already using in the Warnings page.
## Backwards compatibility

No backwards compatibility issues are introduced.
## Translation impact

No translation strings are added, removed or modified.
## Testing instructions

Test 1: Make sure that your server's php.ini has a max_upload_size of 1M. Try installing an extension bigger than that, e.g. Admin Tools Core, K2, Community Builder etc. You get a generic upload error. Apply the PR and retry. You now get an error telling you that the upload failed and that your maximum upload limit is too small.

Test 2 (the problem may not appear on all servers): Make sure that your server's php.ini doesn't have an upload_tmp_dir set. Try installing any extension. You get a generic upload error. Apply the PR and retry. You now get an error telling you that the upload failed and the PHP temporary directory is not set.
