### PR TITLE
#4215 Multilingual: Remove language code in alternate link 

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -633,7 +633,17 @@ class PlgSystemLanguageFilter extends JPlugin
 					if (isset($cassociations[$language->lang_code]))
 					{
 						$link = JRoute::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
-						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+
+						// Check if language is the default site language and remove url language code is on
+						if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
+						{
+							$relLink = str_replace('/' . $language->sef, '', $link);
+							$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+						}
+						else
+						{
+							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+						}
 					}
 					elseif (isset($associations[$language->lang_code]))
 					{
@@ -650,7 +660,16 @@ class PlgSystemLanguageFilter extends JPlugin
 								$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 							}
 
-							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+							// Check if language is the default site language and remove url language code is on
+							if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
+							{
+								$relLink = str_replace('/' . $language->sef, '', $link);
+								$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+							}
+							else
+							{
+								$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+							}
 						}
 					}
 				}
@@ -678,7 +697,16 @@ class PlgSystemLanguageFilter extends JPlugin
 							$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 						}
 
-						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+						// Check if language is the default site language and remove url language code is on
+						if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
+						{
+							$relLink = str_replace('/' . $language->sef, '', $link);
+							$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+						}
+						else
+						{
+							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This PR to solve the issue described in https://github.com/joomla/joomla-cms/issues/4215 when language is the default site language and remove url language code is on.
after patch, the alternate link for the default site language will not contain the code anymore:
instead of
mysite.com/en/whatever
one will get
mysite.com/whatever

Example of result (en-GB is default site and url language code is on):
Home page before patch:

```
  <link href="http://localhost:8888/testwindows/trunkgitnew/en" rel="alternate" hreflang="en-GB" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/de/" rel="alternate" hreflang="de-DE" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/it/" rel="alternate" hreflang="it-IT" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/es/" rel="alternate" hreflang="es-ES" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/mk/" rel="alternate" hreflang="mk-MK" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/ta/" rel="alternate" hreflang="ta-IN" />
```

Home page after:

```
  <link href="http://localhost:8888/testwindows/trunkgitnew/" rel="alternate" hreflang="en-GB" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/de/" rel="alternate" hreflang="de-DE" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/it/" rel="alternate" hreflang="it-IT" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/es/" rel="alternate" hreflang="es-ES" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/mk/" rel="alternate" hreflang="mk-MK" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/ta/" rel="alternate" hreflang="ta-IN" />
```

Another associated item after patch:

```
 <link href="/testwindows/trunkgitnew/fr/instructions-multilangue.html" rel="canonical" />
  <link href="/testwindows/trunkgitnew/fr/instructions-multilangue.feed?type=rss" rel="alternate" type="application/rss+xml" title="RSS 2.0" />
  <link href="/testwindows/trunkgitnew/fr/instructions-multilangue.feed?type=atom" rel="alternate" type="application/atom+xml" title="Atom 1.0" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/multi-lingual-steps-by-steps.html" rel="alternate" hreflang="en-GB" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/de/schritt-für-schritt-zur-mehrsprachigkeit.html" rel="alternate" hreflang="de-DE" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/it/multilingua-passo-dopo-passo.html" rel="alternate" hreflang="it-IT" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/es/multiidioma-paso-a-paso.html" rel="alternate" hreflang="es-ES" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/mk/повеќејазичност-чекор-по-чекор.html" rel="alternate" hreflang="mk-MK" />
  <link href="http://localhost:8888/testwindows/trunkgitnew/ta/பன்-மொழி-படிப்படியாக.html" rel="alternate" hreflang="ta-IN" />
```
