### PR TITLE
Fix downloads from HTTPS on servers without a global cacert.pem

### DIFF
--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -125,7 +125,14 @@ class JHttpTransportStream implements JHttpTransport
 		$options['follow_location'] = (int) $this->options->get('follow_location', 1);
 
 		// Create the stream context for the request.
-		$context = stream_context_create(array('http' => $options));
+		$context = stream_context_create(array(
+			'http' => $options,
+			'ssl' => array(
+				'verify_peer'   => true,
+				'cafile'        => __DIR__ . '/cacert.pem',
+				'verify_depth'  => 5,
+			)
+		));
 
 		// Capture PHP errors
 		$php_errormsg = '';


### PR DESCRIPTION
Closes gh-4218
## Executive summary

When you have a server where the PHP curl module is not enabled Joomla! resorts to using fopen(). If the server doesn't have a root certificate authority cache made available to PHP, retrieving an HTTPS URL fails. This is obvious with extension updates when the update XML or update package URL is on an SSL site.
## Backwards compatibility issues

None
## Translation impact

None
## Testing

On an affected server try installing an extension from an HTTPS URL. It will fail. After the patch it will succeeed.
## Special notes

This is a trivial patch with a successful test in gh-4218 As a result it can be set immediately RTC.
