### PR TITLE
[fix] unable to save assets when updateNulls = true

### DIFF
--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -123,4 +123,28 @@ class JTableAsset extends JTableNested
 
 		return true;
 	}
+
+	/**
+	 * Method to store a node in the database table.
+	 *
+	 * @param   boolean  $updateNulls  True to update null values as well.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   3.3.4
+	 */
+	public function store($updateNulls = false)
+	{
+		/**
+		 * Void errors on save with $updateNulls = true
+		 * JTableNested has a public alias property but assets DB table does not
+		 * This check allows that any table extending JTableAsset with alias still works
+		 */
+		if (property_exists($this, 'alias') && empty($this->alias))
+		{
+			unset ($this->alias);
+		}
+
+		return parent::store($updateNulls);
+	}
 }


### PR DESCRIPTION
#### Steps to reproduce the issue

We need a table with `$updateNulls` set to true on `store()` method. Let's for example use content articles. Edit file:

`libraries/legacy/table/content.php`

and modify the `store` method declaration from:

``` php
public function store($updateNulls = false)
```

to: 

``` php
public function store($updateNulls = true)
```

That will try to update null fields on save. Someone decided that the asset table should inherit it.

Now in backend open any article and click `Save`.
#### Expected result

Article & the corresponding asset are saved correctly.
#### Actual result

Page is reloaded without saving message. What happened internally is that the article was saved but the asset was not.
#### Pull request testing

After applying the patch on this PR try to save the article again. All should be saved correctly.
#### Backward compatibility

There is no B/C issue as it ensures that any table extending `JTableAsset` with an `alias` field still works.
#### System information (as much as possible)

Joomla: Latest staging 3.3.x version.
#### Additional comments

Remember to edit back `libraries/legacy/table/content.php` !! :dash: 
