### PR TITLE
Link should not be styled as button

### DIFF
--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -10,7 +10,9 @@
 defined('_JEXEC') or die;
 ?>
 <a rel="{handler: 'iframe', size: {x: <?php echo $displayData['height']; ?>, y: <?php echo $displayData['width']; ?>}}"
-	href="index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id=<?php echo (int) $displayData['itemId']; ?>&amp;type_id=<?php echo $displayData['typeId']; ?>&amp;type_alias=<?php echo $displayData['typeAlias']; ?>&amp;<?php echo JSession::getFormToken(); ?>=1"
-	title="<?php echo $displayData['title']; ?>" class="btn btn-small modal_jform_contenthistory">
-	<i class="icon-archive"></i> <?php echo $displayData['title']; ?>
+	href="index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id=<?php echo (int) $displayData['itemId']; ?>&amp;type_id=<?php echo $displayData['typeId']; ?>&amp;type_alias=<?php echo $displayData['typeAlias']; ?>&amp;<?php echo JSession::getFormToken(); ?>=1" 
+	title="<?php echo $displayData['title']; ?>" class="modal_jform_contenthistory">
+	<button class="btn btn-small">
+		<i class="icon-archive"></i> <?php echo $displayData['title']; ?>
+	</button>
 </a>


### PR DESCRIPTION
Minor styling change on the versions button so all the toolbar button are treated equal. 
Link should wrap the button+icon and not have a class btn
