### PR TITLE
don't quote the segment twice. Do it only once.

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -423,7 +423,7 @@ class ContentRouter extends JComponentRouterBase
 						->select($db->quoteName('id'))
 						->from('#__content')
 						->where($db->quoteName('catid') . ' = ' . (int) $vars['catid'])
-						->where($db->quoteName('alias') . ' = ' . $db->quote($db->quote($segment)));
+						->where($db->quoteName('alias') . ' = ' . $db->quote($segment));
 					$db->setQuery($query);
 					$cid = $db->loadResult();
 				}


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Turn on SEF Advanced Routing in the content component settings. This is not currently possible, it's a hidden feature. Do it anyway.
2. Go to a category page, you'll notice that now your article links are just the article's alias, not the ugly old id-alias combo. 
3. Click on one of those fancy new links. You'll get an error as if the article was not found (because the article was not found).
#### Expected result

We should expect the article to be found and an article page rendered. Alas...
#### Actual result

The article will not be found so you get 404.
#### Additional comments

The fix is pretty obvious. This thing was getting quoted twice. Obviously that query isn't going to work. Now it works. We can start using SEF Advanced Routing. Welcome to the future.
