### PR TITLE
Allow JURI to be injected nice, but...

### DIFF
--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -42,7 +42,7 @@ abstract class JGoogleEmbed
 	public function __construct(JRegistry $options = null, JUri $uri = null)
 	{
 		$this->options = $options ? $options : new JRegistry;
-		$this->uri = $uri ? $uri : new JUri;
+		$this->uri = $uri ? $uri : JUri::getInstance();
 	}
 
 	/**


### PR DESCRIPTION
I'm not to sure about this as when DI is implemented all injected JUri instances would be a shared instance of the current request (Currently JFactory::getUri();). But for the time being doing new JUri isn't making it possible for my https site to load Google maps as the scheme on an empty JUri instance is null.

There is another way of doing this which would be modifying JUri setting the construct to accept 'SERVER' and then $this->populateFromServer();
