### PR TITLE
Allow server-relative URLs in redirection

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -73,6 +73,18 @@ class PlgSystemRedirect extends JPlugin
 			$db->setQuery($query, 0, 1);
 			$link = $db->loadObject();
 
+			// If no redirect was found try with the server-relative URL
+			if (!$link) {
+				$currRel = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
+				$query = $db->getQuery(true)
+					->select($db->quoteName('new_url'))
+					->select($db->quoteName('published'))
+					->from($db->quoteName('#__redirect_links'))
+					->where($db->quoteName('old_url') . ' = ' . $db->quote($currRel));
+				$db->setQuery($query, 0, 1);
+				$link = $db->loadObject();
+			}
+	
 			// If a redirect exists and is published, permanently redirect.
 			if ($link and ($link->published == 1))
 			{


### PR DESCRIPTION
Suppose you have a web server using Joomla where this web server is both reachable via http://www.example.org/ and http:/example.org/. With the current implementation of the redirection plugin you need to define two redirections within the redirect manager component for every page you want to automatically redirect from its old location to its new location:

old page: http://www.example.org/path/to/old/page.html
=> new page: http://www.example.org/path/to/new/page.html

old page: http://example.org/path/to/old/page.html
=> new page: http://example.org/path/to/new/page.html

With my proposed file change it would be sufficient to define only one redirection in this case:

old server-relative page: /path/to/old/page.html
=> new server-relative page: /path/to/new/page.html
