### PR TITLE
Handle translation for custom installer adapter

### DIFF
--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -152,10 +152,6 @@ class InstallerModel extends JModelList
 						$lang->load("$extension.sys", $path, null, false, true)
 					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
-				case 'package':
-					$extension = $item->element;
-						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
-				break;
 				case 'plugin':
 					$extension = 'plg_' . $item->folder . '_' . $item->element;
 					$source = JPATH_PLUGINS . '/' . $item->folder . '/' . $item->element;
@@ -167,6 +163,11 @@ class InstallerModel extends JModelList
 					$source = $path . '/templates/' . $item->element;
 						$lang->load("$extension.sys", $path, null, false, true)
 					||	$lang->load("$extension.sys", $source, null, false, true);
+				break;
+				case 'package':
+				default:
+					$extension = $item->element;
+						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
 				break;
 			}
 			if (!in_array($item->type, array('language', 'template', 'library')))


### PR DESCRIPTION
If you have a custom installer adapter, the name and the description of the custom elements will not translated. After the patch there is a small "hook" which allows translations.
