### PR TITLE
Bug fixes in content router for enabling Advanced option

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -319,7 +319,7 @@ class ContentRouter extends JComponentRouterBase
 				{
 					$vars['view'] = 'article';
 					$vars['id'] = (int) $segments[0];
-	
+
 					return $vars;
 				}
 			}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -312,13 +312,16 @@ class ContentRouter extends JComponentRouterBase
 		 */
 		if ($count == 1)
 		{
-			// We check to see if an alias is given.  If not, we assume it is an article
-			if (strpos($segments[0], ':') === false)
+			if (!$advanced)
 			{
-				$vars['view'] = 'article';
-				$vars['id'] = (int) $segments[0];
-
-				return $vars;
+				// We check to see if an alias is given.  If not, we assume it is an article
+				if (strpos($segments[0], ':') === false)
+				{
+					$vars['view'] = 'article';
+					$vars['id'] = (int) $segments[0];
+	
+					return $vars;
+				}
 			}
 
 			list($id, $alias) = explode(':', $segments[0], 2);
@@ -383,7 +386,11 @@ class ContentRouter extends JComponentRouterBase
 		}
 
 		// We get the category id from the menu item and search from there
-		$id = $item->query['id'];
+		if (!$advanced)
+		{
+			$id = $item->query['id'];
+		}
+
 		$category = JCategories::getInstance('Content')->get($id);
 
 		if (!$category)


### PR DESCRIPTION
## This fixes two bugs that exist when enabling Advanced SEF in content router and is complimentary to #4246

How to test:
## Faulty assumption that an alias will be article

Create a new category
Create a new article in that category
Create a menu pointing in that article
navigate to that article
click on the category link
get a nice 404 error 
## The duplicate alias name on different languages. Kudos to @infograf768 for mentioning the duplication of alias in menus

Create a multilingual env
Create a category menu in english with alias faulty
Create in the second language a category menu with alias test
Create another category menu with alias faulty and with parent the menu with alias test
try to access faulty in english and in the other language 
get a nice 404 error on the other language

Apply the patch and try to access the broken links!
