### PR TITLE
Backport: email cloaking does not work with & in text to 2.5.x

### DIFF
--- a/libraries/joomla/html/html/email.php
+++ b/libraries/joomla/html/html/email.php
@@ -111,7 +111,7 @@ abstract class JHtmlEmail
 		$text = str_replace('o', '&#111;', $text);
 		$text = str_replace('u', '&#117;', $text);
 
-		$text = htmlentities($text,ENT_QUOTES,'UTF-8',false);
+		$text = htmlentities($text, ENT_QUOTES, 'UTF-8', false);
 
 		return $text;
 	}

--- a/libraries/joomla/html/html/email.php
+++ b/libraries/joomla/html/html/email.php
@@ -102,12 +102,16 @@ abstract class JHtmlEmail
 	 */
 	protected static function _convertEncoding($text)
 	{
+		$text = html_entity_decode($text);
+
 		// Replace vowels with character encoding
 		$text = str_replace('a', '&#97;', $text);
 		$text = str_replace('e', '&#101;', $text);
 		$text = str_replace('i', '&#105;', $text);
 		$text = str_replace('o', '&#111;', $text);
 		$text = str_replace('u', '&#117;', $text);
+
+		$text = htmlentities($text,ENT_QUOTES,'UTF-8',false);
 
 		return $text;
 	}


### PR DESCRIPTION
Please see the orginal issue for 3.x (https://github.com/joomla/joomla-cms/issues/4263) and the PR against staging (https://github.com/joomla/joomla-cms/pull/4273)

The same issue is in 2.5.x and the same fix work good for me.

As the code is by @heleneross i mark my test as the first successful test. The PR against staging was by @n9iels Thank you guys.
