### PR TITLE
Add support for socket based connections in PostgreSQL

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -116,7 +116,14 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		}
 
 		// Build the DSN for the connection.
-		$dsn = "host={$this->options['host']} dbname={$this->options['database']} user={$this->options['user']} password={$this->options['password']}";
+		$dsn = '';
+
+		if (!empty($this->options['host']))
+		{
+			$dsn .= "host={$this->options['host']} ";
+		}
+
+		$dsn .= "dbname={$this->options['database']} user={$this->options['user']} password={$this->options['password']}";
 
 		// Attempt to connect to the server.
 		if (!($this->connection = @pg_connect($dsn)))

--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -131,7 +131,19 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 	protected function getConnection()
 	{
 		// Compile the connection DSN.
-		$dsn = 'pgsql:host=' . self::$_options['host'] . ';port=' . self::$_options['port'] . ';dbname=' . self::$_options['database'];
+		$dsn = 'pgsql:';
+
+		if (!empty(self::$_options['host']))
+		{
+		        $dsn .= 'host=' . self::$_options['host'] . ' ';
+		}
+
+		if (!empty(self::$_options['port']))
+		{
+		        $dsn .= 'port=' . self::$_options['port'] . ' ';
+		}
+
+		$dsn .= 'dbname=' . self::$_options['database'];
 
 		// Create the PDO object from the DSN and options.
 		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);


### PR DESCRIPTION
While configuring our new Jenkins instance, the current setup is not allowing host based connections but rather requires socket based connections.  Our code does not allow for this type of connection as written.  This PR modifies the connection processing code for PostgreSQL to enable socket based connections.
### Testing

Being honest, I'm not so certain how this could be tested aside from having an environment where you can run the unit tests on a PostgreSQL database.  But, essentially, you have to have an empty host string when the connection is built.
