### PR TITLE
SQLite timestamp fix.

### DIFF
--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -260,4 +260,9 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 			return "datetime('" . $date . "', '" . $interval . " " . $datePart . "')";
 		}
 	}
+	
+	public function currentTimestamp()
+	{
+		return 'CURRENT_TIMESTAMP';
+	}
 }


### PR DESCRIPTION
SQLite is throwing an error because of brackets in the currently returned CURRENT_TIMESTAMP sql command. These have been removed by overriding currentTimestamp method in the SQLite query class.
