### PR TITLE
Add a class_exists check in JHttpFactory::getAvailableDriver()

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -89,7 +89,7 @@ class JHttpFactory
 		{
 			$class = 'JHttpTransport' . ucfirst($adapter);
 
-			if ($class::isSupported())
+			if (class_exists($class) && $class::isSupported())
 			{
 				return new $class($options);
 			}

--- a/tests/unit/suites/libraries/joomla/http/JHttpFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/http/JHttpFactoryTest.php
@@ -41,8 +41,6 @@ class JHttpFactoryTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetHttpException()
 	{
-		$this->markTestSkipped('Cannot test correctly because a class_exists check is not performed.');
-
 		JHttpFactory::getHttp(new \Joomla\Registry\Registry, array('fopen'));
 	}
 
@@ -59,8 +57,6 @@ class JHttpFactoryTest extends PHPUnit_Framework_TestCase
 			JHttpFactory::getAvailableDriver(new \Joomla\Registry\Registry, array()),
 			'Passing an empty array should return false due to there being no adapters to test'
 		);
-
-		$this->markTestIncomplete('Cannot test next assertion correctly because a class_exists check is not performed.');
 
 		$this->assertFalse(
 			JHttpFactory::getAvailableDriver(new \Joomla\Registry\Registry, array('fopen')),


### PR DESCRIPTION
This PR adds a class_exists() sanity check to `JHttpFactory::getAvailableDriver()` before trying to blindly call a class that may not be present in the filesystem in order to prevent a PHP Fatal Error.
