### PR TITLE
Introduce predefined path in plugins, modules, templates for custom fields in the manifest file

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -555,11 +555,12 @@ class ModulesModelModule extends JModelAdmin
 			$id			= JArrayHelper::getValue($data, 'id');
 		}
 
-		$folder = null;
+		$folder = $clientId == 1 ? '/administrator' : '';
 
-		if ($clientId == 1) $folder = '/administrator';
-
-		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
+		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) 
+		{
+			JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
+		}
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -555,7 +555,9 @@ class ModulesModelModule extends JModelAdmin
 			$id			= JArrayHelper::getValue($data, 'id');
 		}
 
-		JForm::addFieldPath(JPATH_BASE . '/modules' . '/' . $module . '/fields');
+		// Add the default fields directory
+		$baseFolder = ($clientId) ? JPATH_ADMINISTRATOR : JPATH_SITE;
+		JForm::addFieldPath($baseFolder . '/modules' . '/' . $module . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -557,7 +557,7 @@ class ModulesModelModule extends JModelAdmin
 
 		$folder = $clientId == 1 ? '/administrator' : '';
 
-		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) 
+		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields'))
 		{
 			JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
 		}

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -555,6 +555,13 @@ class ModulesModelModule extends JModelAdmin
 			$id			= JArrayHelper::getValue($data, 'id');
 		}
 
+		$folder = null;
+
+		if ($clientId == 1) $folder = '/administrator';
+
+		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) 
+		JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
+
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);
 		$this->setState('item.module', $module);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -555,10 +555,7 @@ class ModulesModelModule extends JModelAdmin
 			$id			= JArrayHelper::getValue($data, 'id');
 		}
 
-		if (is_dir(JPATH_BASE . '/modules' . '/' . $module . '/fields'))
-		{
-			JForm::addFieldPath(JPATH_BASE . '/modules' . '/' . $module . '/fields');
-		}
+		JForm::addFieldPath(JPATH_BASE . '/modules' . '/' . $module . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -559,8 +559,7 @@ class ModulesModelModule extends JModelAdmin
 
 		if ($clientId == 1) $folder = '/administrator';
 
-		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) 
-		JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
+		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields')) JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -555,11 +555,9 @@ class ModulesModelModule extends JModelAdmin
 			$id			= JArrayHelper::getValue($data, 'id');
 		}
 
-		$folder = $clientId == 1 ? '/administrator' : '';
-
-		if (is_dir(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields'))
+		if (is_dir(JPATH_BASE . '/modules' . '/' . $module . '/fields'))
 		{
-			JForm::addFieldPath(JPATH_ROOT . $folder . '/modules' . '/' . $module . '/fields');
+			JForm::addFieldPath(JPATH_BASE . '/modules' . '/' . $module . '/fields');
 		}
 
 		// These variables are used to add data from the plugin XML files.

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -72,7 +72,7 @@ class PluginsModelPlugin extends JModelAdmin
 			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
-		JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
+		if (is_dir(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields')) JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.folder',	$folder);

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -72,10 +72,7 @@ class PluginsModelPlugin extends JModelAdmin
 			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
-		if (is_dir(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields'))
-		{
-			JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
-		}
+		JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.folder',	$folder);

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -72,7 +72,10 @@ class PluginsModelPlugin extends JModelAdmin
 			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
-		if (is_dir(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields')) JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
+		if (is_dir(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields'))
+		{
+			JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
+		}
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.folder',	$folder);

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -72,6 +72,7 @@ class PluginsModelPlugin extends JModelAdmin
 			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
+		// Add the default fields directory
 		JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
 
 		// These variables are used to add data from the plugin XML files.

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -72,6 +72,8 @@ class PluginsModelPlugin extends JModelAdmin
 			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
+		JForm::addFieldPath(JPATH_PLUGINS . '/' . $folder . '/' . $element . '/fields');
+
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.folder',	$folder);
 		$this->setState('item.element',	$element);

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -211,11 +211,12 @@ class TemplatesModelStyle extends JModelAdmin
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
 
-		$folder = null;
+		$folder = $clientId == 1 ? '/administrator' : '';
 
-		if ($clientId == 1) $folder = '/administrator';
-
-		if (is_dir(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields')) JForm::addFieldPath(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields');
+		if (is_dir(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields'))
+		{
+			JForm::addFieldPath(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields');
+		}
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -210,8 +210,9 @@ class TemplatesModelStyle extends JModelAdmin
 			$clientId  = JArrayHelper::getValue($data, 'client_id');
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
-
-		JForm::addFieldPath(JPATH_THEMES . '/' . $template . '/fields');
+		// Add the default fields directory
+		$baseFolder = ($clientId) ? JPATH_ADMINISTRATOR : JPATH_SITE;
+		JForm::addFieldPath($baseFolder . '/templates/' . $template . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -211,6 +211,12 @@ class TemplatesModelStyle extends JModelAdmin
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
 
+		$folder = null;
+
+		if ($clientId == 1) $folder = '/administrator';
+
+		if (is_dir(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields')) JForm::addFieldPath(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields');
+
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);
 		$this->setState('item.template', $template);

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -210,6 +210,7 @@ class TemplatesModelStyle extends JModelAdmin
 			$clientId  = JArrayHelper::getValue($data, 'client_id');
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
+
 		// Add the default fields directory
 		$baseFolder = ($clientId) ? JPATH_ADMINISTRATOR : JPATH_SITE;
 		JForm::addFieldPath($baseFolder . '/templates/' . $template . '/fields');

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -211,11 +211,9 @@ class TemplatesModelStyle extends JModelAdmin
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
 
-		$folder = $clientId == 1 ? '/administrator' : '';
-
-		if (is_dir(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields'))
+		if (is_dir(JPATH_THEMES . '/' . $template . '/fields'))
 		{
-			JForm::addFieldPath(JPATH_ROOT . $folder . '/templates' . '/' . $template . '/fields');
+			JForm::addFieldPath(JPATH_THEMES . '/' . $template . '/fields');
 		}
 
 		// These variables are used to add data from the plugin XML files.

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -211,10 +211,7 @@ class TemplatesModelStyle extends JModelAdmin
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
 
-		if (is_dir(JPATH_THEMES . '/' . $template . '/fields'))
-		{
-			JForm::addFieldPath(JPATH_THEMES . '/' . $template . '/fields');
-		}
+		JForm::addFieldPath(JPATH_THEMES . '/' . $template . '/fields');
 
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -318,8 +318,11 @@ class JComponentHelper
 
 		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
 		{
+			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/' . '/fields'))
+			{
+				JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/fields');
+			}
 
-			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/' . '/fields')) JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/fields');
 		}
 
 		// If component is disabled throw error

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -322,8 +322,6 @@ class JComponentHelper
 			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
-		JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
-
 		// Load common and local language files.
 		$lang->load($option, JPATH_BASE, null, false, true) || $lang->load($option, JPATH_COMPONENT, null, false, true);
 

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -329,6 +329,13 @@ class JComponentHelper
 				JForm::addFieldPath(JPATH_COMPONENT_ADMINISTRATOR . '/models/fields');
 			}
 		}
+		else
+		{
+			if (is_dir(JPATH_COMPONENT_SITE . '/models/fields'))
+			{
+				JForm::addFieldPath(JPATH_COMPONENT_SITE . '/models/fields');
+			}
+		}
 
 		// Load common and local language files.
 		$lang->load($option, JPATH_BASE, null, false, true) || $lang->load($option, JPATH_COMPONENT, null, false, true);

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -318,6 +318,7 @@ class JComponentHelper
 
 		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
 		{
+
 			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/' . '/fields')) JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/fields');
 		}
 

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -322,19 +322,9 @@ class JComponentHelper
 			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
-		if (JPATH_COMPONENT == JPATH_COMPONENT_ADMINISTRATOR)
+		if (is_dir(JPATH_COMPONENT . '/models/fields'))
 		{
-			if (is_dir(JPATH_COMPONENT_ADMINISTRATOR . '/models/fields'))
-			{
-				JForm::addFieldPath(JPATH_COMPONENT_ADMINISTRATOR . '/models/fields');
-			}
-		}
-		else
-		{
-			if (is_dir(JPATH_COMPONENT_SITE . '/models/fields'))
-			{
-				JForm::addFieldPath(JPATH_COMPONENT_SITE . '/models/fields');
-			}
+			JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
 		}
 
 		// Load common and local language files.

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -316,15 +316,6 @@ class JComponentHelper
 
 		$path = JPATH_COMPONENT . '/' . $file . '.php';
 
-		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
-		{
-			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/' . '/fields'))
-			{
-				JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/fields');
-			}
-
-		}
-
 		// If component is disabled throw error
 		if (!static::isEnabled($option) || !file_exists($path))
 		{

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -316,6 +316,11 @@ class JComponentHelper
 
 		$path = JPATH_COMPONENT . '/' . $file . '.php';
 
+		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
+		{
+			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/' . '/fields')) JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/fields');
+		}
+
 		// If component is disabled throw error
 		if (!static::isEnabled($option) || !file_exists($path))
 		{

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -322,11 +322,11 @@ class JComponentHelper
 			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
-		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
+		if (JPATH_COMPONENT == JPATH_COMPONENT_ADMINISTRATOR)
 		{
-			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields'))
+			if (is_dir(JPATH_COMPONENT_ADMINISTRATOR . '/models/fields'))
 			{
-				JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields');
+				JForm::addFieldPath(JPATH_COMPONENT_ADMINISTRATOR . '/models/fields');
 			}
 		}
 

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -322,10 +322,7 @@ class JComponentHelper
 			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
-		if (is_dir(JPATH_COMPONENT . '/models/fields'))
-		{
-			JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
-		}
+		JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
 
 		// Load common and local language files.
 		$lang->load($option, JPATH_BASE, null, false, true) || $lang->load($option, JPATH_COMPONENT, null, false, true);

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -316,18 +316,18 @@ class JComponentHelper
 
 		$path = JPATH_COMPONENT . '/' . $file . '.php';
 
+		// If component is disabled throw error
+		if (!static::isEnabled($option) || !file_exists($path))
+		{
+			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
+		}
+
 		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
 		{
 			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields'))
 			{
 				JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields');
 			}
-		}
-
-		// If component is disabled throw error
-		if (!static::isEnabled($option) || !file_exists($path))
-		{
-			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
 		// Load common and local language files.

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -316,6 +316,14 @@ class JComponentHelper
 
 		$path = JPATH_COMPONENT . '/' . $file . '.php';
 
+		if (JPATH_COMPONENT == JPATH_ADMINISTRATOR . '/components/' . $option)
+		{
+			if (is_dir(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields'))
+			{
+				JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $option . '/models/fields');
+			}
+		}
+
 		// If component is disabled throw error
 		if (!static::isEnabled($option) || !file_exists($path))
 		{


### PR DESCRIPTION
### Simple addition to allow components, plugins, modules and templates to use custom fileds in a sub-directory named `fields`.

This is an alternative way to use custom fields in these areas besides the classic hardcoding `addfieldpath=“wherever"`. Should make things a bit easier for devs without introducing complicated and slow procedures (only one directory check is actually used).
#### Pros

Predefined workflow
Easier implementation
No need for hardcoded paths in xml
Unified method that works along the existing hand coded `addfieldpath=“wherever"`
#### Against

Adds one more directory with predefined name
Adds some more calls for every template, module, plugin in the pile of execution code.
#### There shouldn't be any B/C breaks here.
##### How to test

For plugins:
apply this patch
apply also patch #4240
open /plugins/editors/tinymce/tinymce.xml and remove:
`addfieldpath="/plugins/editors/tinymce/fields”`
from the line:
`<fieldset name="basic" addfieldpath="/plugins/editors/tinymce/fields”>`
Go to admin and observe that the fields site skins and administrator skins are still functional.

For templates check the instructions at #4295

For modules repeat the instructions of plugins but for any module you choose. For a custom field code just use the one from the tinymce and it should work (you only need to see it rendering the functionality is not essential here). So for mod_breadcrumbs:
open mod_breadcrumbs.xml and paste 
`<field name="skin_admin" type="skins"
                       description="PLG_TINY_FIELD_SKIN_ADMIN_DESC"
                       label="PLG_TINY_FIELD_SKIN_ADMIN_LABEL"
                        >
                </field>`
under the fieldset=“basic”
copy the folder `fields` from the plugin tinimce [the plugin test abobe]
check in the admin module breadcrumps for the new option

For components:
This is already the standard for components. Custom fields expected to be found at `com_name/models/fields`

Also try that 3PD plugins, modules and templates don't misbehave!
