### PR TITLE
Add appropriate error message if no primary key

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1544,6 +1544,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 				// We don't have a full primary key - return false
 				else
 				{
+					$this->setError(JText::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
+
 					return false;
 				}
 			}


### PR DESCRIPTION
Add an appropriate error message if there isn't a primary key. This is something we're doing in a small number of components (e.g. weblinks) but probably should do across the board
## Testing Instructions

Try and click the publish button with no rows expected. Before see nothing. After see appropriate error message
