### PR TITLE
Use new JTable features for WeblinksTableWeblink

### DIFF
--- a/administrator/components/com_weblinks/tables/weblink.php
+++ b/administrator/components/com_weblinks/tables/weblink.php
@@ -26,7 +26,7 @@ class WeblinksTableWeblink extends JTable
 	 * @var    array
 	 * @since  3.4
 	 */
-	protected $jsonEncode = array('params', 'metadata', 'images');
+	protected $_jsonEncode = array('params', 'metadata', 'images');
 
 	/**
 	 * Constructor


### PR DESCRIPTION
This method removes the overridden method for the publish method in favour of the table column alias introduced in https://github.com/joomla/joomla-cms/pull/3416

It also removes the override for the bind method in favour of the quicker method introduced in https://github.com/joomla/joomla-cms/pull/3423
## Testing

Test publishing a weblink in the list view works as expected (single and multiple items) and that saving an item works correctly (with things like associated images, params and metadata)
