### PR TITLE
Fixed event dispatching inconsistencies leading to incomplete API

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -448,18 +448,19 @@ class CategoriesModelCategory extends JModelAdmin
 	public function save($data)
 	{
 		$dispatcher = JEventDispatcher::getInstance();
-		$table = $this->getTable();
-		$input = JFactory::getApplication()->input;
-		$pk = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
-		$isNew = true;
+		$table      = $this->getTable();
+		$input      = JFactory::getApplication()->input;
+		$pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
+		$isNew      = true;
+		$context    = $this->option . '.' . $this->name;
 
 		if ((!empty($data['tags']) && $data['tags'][0] != ''))
 		{
 			$table->newTags = $data['tags'];
 		}
 
-		// Include the content plugins for the on save events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the save events.
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Load the row if saving an existing category.
 		if ($pk > 0)
@@ -506,8 +507,8 @@ class CategoriesModelCategory extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onContentBeforeSave event.
-		$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 
 		if (in_array(false, $result, true))
 		{
@@ -589,8 +590,8 @@ class CategoriesModelCategory extends JModelAdmin
 			}
 		}
 
-		// Trigger the onContentAfterSave event.
-		$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Rebuild the path for the category:
 		if (!$table->rebuildPath($table->id))

--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -121,7 +121,10 @@ class ConfigModelComponent extends ConfigModelForm
 	 */
 	public function save($data)
 	{
-		$table	= JTable::getInstance('extension');
+		$table      = JTable::getInstance('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$context    = $this->option . '.' . $this->name;
+		JPluginHelper::importPlugin('extension');
 
 		// Save the rules.
 		if (isset($data['params']) && isset($data['params']['rules']))
@@ -170,11 +173,16 @@ class ConfigModelComponent extends ConfigModelForm
 			throw new RuntimeException($table->getError());
 		}
 
-		// Store the data.
-		if (!$table->store())
+		$result = $dispatcher->trigger('onExtensionBeforeSave', array($context, &$table, false));
+
+			// Store the data.
+		if (in_array(false, $result, true) || !$table->store())
 		{
 			throw new RuntimeException($table->getError());
 		}
+
+		// Trigger the after save event.
+		$dispatcher->trigger('onExtensionAfterSave', array($context, &$table, false));
 
 		// Clean the component cache.
 		$this->cleanCache('_system', 0);

--- a/administrator/components/com_languages/models/language.php
+++ b/administrator/components/com_languages/models/language.php
@@ -17,6 +17,26 @@ defined('_JEXEC') or die;
 class LanguagesModelLanguage extends JModelAdmin
 {
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 */
+	public function __construct($config = array())
+	{
+		$config = array_merge(
+			array(
+				'event_after_save'  => 'onExtensionAfterSave',
+				'event_before_save' => 'onExtensionBeforeSave',
+				'events_map'        => array(
+					'save' => 'extension'
+				)
+			), $config
+		);
+
+		parent::__construct($config);
+	}
+
+	/**
 	 * Override to get the table.
 	 *
 	 * @param   string  $name     Name of the table.
@@ -150,13 +170,14 @@ class LanguagesModelLanguage extends JModelAdmin
 	 */
 	public function save($data)
 	{
-		$langId	= (int) $this->getState('language.id');
+		$langId = (!empty($data['lang_id'])) ? $data['lang_id'] : (int) $this->getState('language.id');
 		$isNew	= true;
 
 		$dispatcher = JEventDispatcher::getInstance();
-		JPluginHelper::importPlugin('extension');
+		JPluginHelper::importPlugin($this->events_map['save']);
 
-		$table = $this->getTable();
+		$table   = $this->getTable();
+		$context = $this->option . '.' . $this->name;
 
 		// Load the row if saving an existing item.
 		if ($langId > 0)
@@ -187,8 +208,8 @@ class LanguagesModelLanguage extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onExtensionBeforeSave event.
-		$result = $dispatcher->trigger('onExtensionBeforeSave', array('com_languages.language', &$table, $isNew));
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 
 		// Check the event responses.
 		if (in_array(false, $result, true))
@@ -206,8 +227,8 @@ class LanguagesModelLanguage extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onExtensionAfterSave event.
-		$dispatcher->trigger('onExtensionAfterSave', array('com_languages.language', &$table, $isNew));
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		$this->setState('language.id', $table->lang_id);
 

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -171,14 +171,20 @@ class MenusModelMenu extends JModelForm
 	 */
 	public function save($data)
 	{
-		$id = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('menu.id');
+		$dispatcher = JEventDispatcher::getInstance();
+		$id         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('menu.id');
+		$isNew      = true;
 
 		// Get a row instance.
 		$table = $this->getTable();
 
+		// Include the plugins for the save events.
+		JPluginHelper::importPlugin('content');
+
 		// Load the row if saving an existing item.
 		if ($id > 0)
 		{
+			$isNew = false;
 			$table->load($id);
 		}
 
@@ -196,12 +202,18 @@ class MenusModelMenu extends JModelForm
 			return false;
 		}
 
+		// Trigger the before event.
+		$result = $dispatcher->trigger('onContentBeforeSave', array($this->_context, &$table, $isNew));
+
 		// Store the data.
-		if (!$table->store())
+		if (in_array(false, $result, true) || !$table->store())
 		{
 			$this->setError($table->getError());
 			return false;
 		}
+
+		// Trigger the after save event.
+		$dispatcher->trigger('onContentAfterSave', array($this->_context, &$table, $isNew));
 
 		$this->setState('menu.id', $table->id);
 
@@ -219,6 +231,8 @@ class MenusModelMenu extends JModelForm
 	 */
 	public function delete($itemIds)
 	{
+		$dispatcher = JEventDispatcher::getInstance();
+
 		// Sanitize the ids.
 		$itemIds = (array) $itemIds;
 		JArrayHelper::toInteger($itemIds);
@@ -226,16 +240,25 @@ class MenusModelMenu extends JModelForm
 		// Get a group row instance.
 		$table = $this->getTable();
 
+		// Include the plugins for the delete events.
+		JPluginHelper::importPlugin('content');
+
 		// Iterate the items to delete each one.
 		foreach ($itemIds as $itemId)
 		{
-			// TODO: Delete the menu associations - Menu items and Modules
+			// Trigger the before delete event.
+			$result = $dispatcher->trigger('onContentBeforeDelete', array($this->_context, $table));
 
-			if (!$table->delete($itemId))
+			if (in_array(false, $result, true) || !$table->delete($itemId))
 			{
 				$this->setError($table->getError());
 				return false;
 			}
+
+			// Trigger the after delete event.
+			$dispatcher->trigger('onContentAfterDelete', array($this->_context, $table));
+
+			// TODO: Delete the menu associations - Menu items and Modules
 		}
 
 		// Clean the cache

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -35,6 +35,29 @@ class ModulesModelModule extends JModelAdmin
 	protected $helpURL;
 
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 */
+	public function __construct($config = array())
+	{
+		$config = array_merge(
+			array(
+				'event_after_delete'  => 'onExtensionAfterDelete',
+				'event_after_save'    => 'onExtensionAfterSave',
+				'event_before_delete' => 'onExtensionBeforeDelete',
+				'event_before_save'   => 'onExtensionBeforeSave',
+				'events_map'          => array(
+					'save'   => 'extension',
+					'delete' => 'extension'
+				)
+			), $config
+		);
+
+		parent::__construct($config);
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.
@@ -363,9 +386,14 @@ class ModulesModelModule extends JModelAdmin
 	 */
 	public function delete(&$pks)
 	{
-		$pks	= (array) $pks;
-		$user	= JFactory::getUser();
-		$table	= $this->getTable();
+		$dispatcher = JEventDispatcher::getInstance();
+		$pks        = (array) $pks;
+		$user       = JFactory::getUser();
+		$table      = $this->getTable();
+		$context    = $this->option . '.' . $this->name;
+
+		// Include the plugins for the on delete events.
+		JPluginHelper::importPlugin($this->events_map['delete']);
 
 		// Iterate the items to delete each one.
 		foreach ($pks as $pk)
@@ -380,7 +408,10 @@ class ModulesModelModule extends JModelAdmin
 					return;
 				}
 
-				if (!$table->delete($pk))
+				// Trigger the before delete event.
+				$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
+
+				if (in_array(false, $result, true) || !$table->delete($pk))
 				{
 					throw new Exception($table->getError());
 				}
@@ -393,6 +424,9 @@ class ModulesModelModule extends JModelAdmin
 						->where('moduleid=' . (int) $pk);
 					$db->setQuery($query);
 					$db->execute();
+
+					// Trigger the after delete event.
+					$dispatcher->trigger($this->event_after_delete, array($context, $table));
 				}
 
 				// Clear module cache
@@ -916,9 +950,10 @@ class ModulesModelModule extends JModelAdmin
 		$table      = $this->getTable();
 		$pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('module.id');
 		$isNew      = true;
+		$context    = $this->option . '.' . $this->name;
 
-		// Include the content modules for the onSave events.
-		JPluginHelper::importPlugin('extension');
+		// Include the plugins for the save event.
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Load the row if saving an existing record.
 		if ($pk > 0)
@@ -959,8 +994,8 @@ class ModulesModelModule extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onExtensionBeforeSave event.
-		$result = $dispatcher->trigger('onExtensionBeforeSave', array('com_modules.module', &$table, $isNew));
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 
 		if (in_array(false, $result, true))
 		{
@@ -1063,8 +1098,8 @@ class ModulesModelModule extends JModelAdmin
 			}
 		}
 
-		// Trigger the onExtensionAfterSave event.
-		$dispatcher->trigger('onExtensionAfterSave', array('com_modules.module', &$table, $isNew));
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Compute the extension id of this module in case the controller wants it.
 		$query	= $db->getQuery(true)

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -35,16 +35,24 @@ class PluginsModelPlugin extends JModelAdmin
 	protected $_cache;
 
 	/**
-	 * @var     string  The event to trigger after saving the data.
-	 * @since   1.6
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
 	 */
-	protected $event_after_save = 'onExtensionAfterSave';
+	public function __construct($config = array())
+	{
+		$config = array_merge(
+			array(
+				'event_after_save'  => 'onExtensionAfterSave',
+				'event_before_save' => 'onExtensionBeforeSave',
+				'events_map'        => array(
+					'save' => 'extension'
+				)
+			), $config
+		);
 
-	/**
-	 * @var     string  The event to trigger after before the data.
-	 * @since   1.6
-	 */
-	protected $event_before_save = 'onExtensionBeforeSave';
+		parent::__construct($config);
+	}
 
 	/**
 	 * Method to get the record form.
@@ -323,9 +331,6 @@ class PluginsModelPlugin extends JModelAdmin
 	 */
 	public function save($data)
 	{
-		// Load the extension plugin group.
-		JPluginHelper::importPlugin('extension');
-
 		// Setup type.
 		$data['type'] = 'plugin';
 

--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -262,9 +262,10 @@ class TagsModelTag extends JModelAdmin
 		$input      = JFactory::getApplication()->input;
 		$pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
 		$isNew      = true;
+		$context    = $this->option . '.' . $this->name;
 
-		// Include the content plugins for the on save events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the save events.
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Load the row if saving an existing tag.
 		if ($pk > 0)
@@ -322,8 +323,8 @@ class TagsModelTag extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onContentBeforeSave event.
-		$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
 		if (in_array(false, $result, true))
 		{
 			$this->setError($table->getError());
@@ -337,8 +338,8 @@ class TagsModelTag extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onContentAfterSave event.
-		$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, &$table, $isNew));
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Rebuild the path for the tag:
 		if (!$table->rebuildPath($table->id))

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -34,6 +34,28 @@ class TemplatesModelStyle extends JModelAdmin
 	private $_cache = array();
 
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 */
+	public function __construct($config = array())
+	{
+		$config = array_merge(
+			array(
+				array(
+					'event_before_delete' => 'onExtensionBeforeDelete',
+					'event_after_delete'  => 'onExtensionAfterDelete',
+					'event_before_save'   => 'onExtensionBeforeSave',
+					'event_after_save'    => 'onExtensionAfterSave',
+					'events_map'          => array('delete' => 'extension', 'save' => 'extension')
+				)
+			), $config
+		);
+
+		parent::__construct($config);
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * @note    Calling getState in this method will result in recursion.
@@ -64,9 +86,13 @@ class TemplatesModelStyle extends JModelAdmin
 	 */
 	public function delete(&$pks)
 	{
-		$pks	= (array) $pks;
-		$user	= JFactory::getUser();
-		$table	= $this->getTable();
+		$pks        = (array) $pks;
+		$user       = JFactory::getUser();
+		$table      = $this->getTable();
+		$dispatcher = JEventDispatcher::getInstance();
+		$context    = $this->option . '.' . $this->name;
+
+		JPluginHelper::importPlugin($this->events_map['delete']);
 
 		// Iterate the items to delete each one.
 		foreach ($pks as $pk)
@@ -87,12 +113,18 @@ class TemplatesModelStyle extends JModelAdmin
 					return false;
 				}
 
-				if (!$table->delete($pk))
+				// Trigger the before delete event.
+				$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
+
+				if (in_array(false, $result, true) || !$table->delete($pk))
 				{
 					$this->setError($table->getError());
 
 					return false;
 				}
+
+				// Trigger the after delete event.
+				$dispatcher->trigger($this->event_after_delete, array($context, $table));
 			}
 			else
 			{
@@ -127,6 +159,12 @@ class TemplatesModelStyle extends JModelAdmin
 			throw new Exception(JText::_('JERROR_CORE_CREATE_NOT_PERMITTED'));
 		}
 
+		$dispatcher = JEventDispatcher::getInstance();
+		$context    = $this->option . '.' . $this->name;
+
+		// Include the plugins for the save events.
+		JPluginHelper::importPlugin($this->events_map['save']);
+
 		$table = $this->getTable();
 
 		foreach ($pks as $pk)
@@ -143,10 +181,21 @@ class TemplatesModelStyle extends JModelAdmin
 				$m = null;
 				$table->title = $this->generateNewTitle(null, null, $table->title);
 
-				if (!$table->check() || !$table->store())
+				if (!$table->check())
 				{
 					throw new Exception($table->getError());
 				}
+
+				// Trigger the before save event.
+				$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, true));
+
+				if (in_array(false, $result, true) || !$table->store())
+				{
+					throw new Exception($table->getError());
+				}
+
+				// Trigger the after save event.
+				$dispatcher->trigger($this->event_after_save, array($context, &$table, true));
 			}
 			else
 			{
@@ -423,7 +472,7 @@ class TemplatesModelStyle extends JModelAdmin
 		$isNew      = true;
 
 		// Include the extension plugins for the save events.
-		JPluginHelper::importPlugin('extension');
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Load the row if saving an existing record.
 		if ($pk > 0)
@@ -458,18 +507,11 @@ class TemplatesModelStyle extends JModelAdmin
 			return false;
 		}
 
-		// Trigger the onExtensionBeforeSave event.
-		$result = $dispatcher->trigger('onExtensionBeforeSave', array('com_templates.style', &$table, $isNew));
-
-		if (in_array(false, $result, true))
-		{
-			$this->setError($table->getError());
-
-			return false;
-		}
+		// Trigger the before save event.
+		$result = $dispatcher->trigger($this->event_before_save, array('com_templates.style', &$table, $isNew));
 
 		// Store the data.
-		if (!$table->store())
+		if (in_array(false, $result, true) || !$table->store())
 		{
 			$this->setError($table->getError());
 
@@ -527,8 +569,8 @@ class TemplatesModelStyle extends JModelAdmin
 		// Clean the cache.
 		$this->cleanCache();
 
-		// Trigger the onExtensionAfterSave event.
-		$dispatcher->trigger('onExtensionAfterSave', array('com_templates.style', &$table, $isNew));
+		// Trigger the after save event.
+		$dispatcher->trigger($this->event_after_save, array('com_templates.style', &$table, $isNew));
 
 		$this->setState('style.id', $table->id);
 

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -16,17 +16,20 @@ defined('_JEXEC') or die;
  */
 class UsersModelGroup extends JModelAdmin
 {
-	/**
-	 * @var		string	The event to trigger after saving the data.
-	 * @since   1.6
-	 */
-	protected $event_after_save = 'onUserAfterSaveGroup';
+	public function __construct($config = array())
+	{
+		$config = array_merge(
+			array(
+				'event_after_delete'  => 'onUserAfterDeleteGroup',
+				'event_after_save'    => 'onUserAfterSaveGroup',
+				'event_before_delete' => 'onUserBeforeDeleteGroup',
+				'event_before_save'   => 'onUserBeforeSaveGroup',
+				'events_map'          => array('delete' => 'user', 'save' => 'user')
+			), $config
+		);
 
-	/**
-	 * @var		string	The event to trigger after before the data.
-	 * @since   1.6
-	 */
-	protected $event_before_save = 'onUserBeforeSaveGroup';
+		parent::__construct($config);
+	}
 
 	/**
 	 * Returns a reference to the a Table object, always creating it.
@@ -128,7 +131,7 @@ class UsersModelGroup extends JModelAdmin
 	public function save($data)
 	{
 		// Include the content plugins for events.
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		/**
 		 * Check the super admin permissions for group
@@ -237,7 +240,7 @@ class UsersModelGroup extends JModelAdmin
 		$table = $this->getTable();
 
 		// Load plugins.
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->events_map['delete']);
 		$dispatcher = JEventDispatcher::getInstance();
 
 		// Check if I am a Super Admin
@@ -266,14 +269,17 @@ class UsersModelGroup extends JModelAdmin
 
 				if ($allow)
 				{
-					// Fire the onUserBeforeDeleteGroup event.
-					$dispatcher->trigger('onUserBeforeDeleteGroup', array($table->getProperties()));
+					// Fire the before delete event.
+					$dispatcher->trigger($this->event_before_delete, array($table->getProperties()));
 
 					if (!$table->delete($pk))
 					{
 						$this->setError($table->getError());
 
 						return false;
+					} else {
+						// Trigger the after delete event.
+						$dispatcher->trigger($this->event_after_delete, array($table->getProperties(), true, $this->getError()));
 					}
 					else
 					{

--- a/administrator/components/com_users/models/note.php
+++ b/administrator/components/com_users/models/note.php
@@ -60,8 +60,11 @@ class UsersModelNote extends JModelAdmin
 	{
 		$result = parent::getItem($pk);
 
-		// Get the dispatcher and load the users plugins.
+		// Get the dispatcher and load the content plugins.
 		$dispatcher	= JEventDispatcher::getInstance();
+		JPluginHelper::importPlugin('content');
+
+		// Load the user plugins for backward compatibility (v3.3.3 and earlier).
 		JPluginHelper::importPlugin('user');
 
 		// Trigger the data preparation event.

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -25,6 +25,16 @@ class UsersModelUser extends JModelAdmin
 	 */
 	public function __construct($config = array())
 	{
+		$config = array_merge(
+			array(
+				'event_after_delete'  => 'onUserAfterDelete',
+				'event_after_save'    => 'onUserAfterSave',
+				'event_before_delete' => 'onUserBeforeDelete',
+				'event_before_save'   => 'onUserBeforeSave',
+				'events_map'          => array('save' => 'user', 'delete' => 'user')
+			), $config
+		);
+
 		parent::__construct($config);
 
 		// Load the Joomla! RAD layer
@@ -65,15 +75,20 @@ class UsersModelUser extends JModelAdmin
 	{
 		$result = parent::getItem($pk);
 
-		$result->tags = new JHelperTags;
-		$result->tags->getTagIds($result->id, 'com_users.user');
+		$context = 'com_users.user';
 
-		// Get the dispatcher and load the users plugins.
+		$result->tags = new JHelperTags;
+		$result->tags->getTagIds($result->id, $context);
+
+		// Get the dispatcher and load the content plugins.
 		$dispatcher	= JEventDispatcher::getInstance();
+		JPluginHelper::importPlugin('content');
+
+		// Load the user plugins for backward compatibility (v3.3.3 and earlier).
 		JPluginHelper::importPlugin('user');
 
 		// Trigger the data preparation event.
-		$dispatcher->trigger('onContentPrepareData', array('com_users.user', $result));
+		$dispatcher->trigger('onContentPrepareData', array($context, $result));
 
 		return $result;
 	}
@@ -302,8 +317,7 @@ class UsersModelUser extends JModelAdmin
 		// Check if I am a Super Admin
 		$iAmSuperAdmin = $user->authorise('core.admin');
 
-		// Trigger the onUserBeforeSave event.
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->events_map['delete']);
 		$dispatcher = JEventDispatcher::getInstance();
 
 		if (in_array($user->id, $pks))
@@ -329,8 +343,8 @@ class UsersModelUser extends JModelAdmin
 					// Get users data for the users to delete.
 					$user_to_delete = JFactory::getUser($pk);
 
-					// Fire the onUserBeforeDelete event.
-					$dispatcher->trigger('onUserBeforeDelete', array($table->getProperties()));
+					// Fire the before delete event.
+					$dispatcher->trigger($this->event_before_delete, array($table->getProperties()));
 
 					if (!$table->delete($pk))
 					{
@@ -340,8 +354,8 @@ class UsersModelUser extends JModelAdmin
 					}
 					else
 					{
-						// Trigger the onUserAfterDelete event.
-						$dispatcher->trigger('onUserAfterDelete', array($user_to_delete->getProperties(), true, $this->getError()));
+						// Trigger the after delete event.
+						$dispatcher->trigger($this->event_after_delete, array($user_to_delete->getProperties(), true, $this->getError()));
 					}
 				}
 				else
@@ -383,7 +397,7 @@ class UsersModelUser extends JModelAdmin
 		$table         = $this->getTable();
 		$pks           = (array) $pks;
 
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -434,8 +448,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onUserBeforeSave event.
-						$result = $dispatcher->trigger('onUserBeforeSave', array($old, false, $table->getProperties()));
+						// Trigger the before save event.
+						$result = $dispatcher->trigger($this->event_before_save, array($old, false, $table->getProperties()));
 
 						if (in_array(false, $result, true))
 						{
@@ -451,8 +465,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onAftereStoreUser event
-						$dispatcher->trigger('onUserAfterSave', array($table->getProperties(), false, true, null));
+						// Trigger the after save event
+						$dispatcher->trigger($this->event_after_save, array($table->getProperties(), false, true, null));
 					}
 					catch (Exception $e)
 					{
@@ -498,7 +512,7 @@ class UsersModelUser extends JModelAdmin
 		$table         = $this->getTable();
 		$pks           = (array) $pks;
 
-		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -531,8 +545,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Trigger the onUserBeforeSave event.
-						$result = $dispatcher->trigger('onUserBeforeSave', array($old, false, $table->getProperties()));
+						// Trigger the before save event.
+						$result = $dispatcher->trigger($this->event_before_save, array($old, false, $table->getProperties()));
 
 						if (in_array(false, $result, true))
 						{
@@ -548,8 +562,8 @@ class UsersModelUser extends JModelAdmin
 							return false;
 						}
 
-						// Fire the onAftereStoreUser event
-						$dispatcher->trigger('onUserAfterSave', array($table->getProperties(), false, true, null));
+						// Fire the after save event
+						$dispatcher->trigger($this->event_after_save, array($table->getProperties(), false, true, null));
 					}
 					catch (Exception $e)
 					{

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -619,6 +619,8 @@ class JApplication extends JApplicationBase
 		// Get the global JAuthentication object.
 		jimport('joomla.user.authentication');
 
+		JPluginHelper::importPlugin('user');
+
 		$authenticate = JAuthentication::getInstance();
 		$response = $authenticate->authenticate($credentials, $options);
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -67,6 +67,13 @@ abstract class JModelAdmin extends JModelForm
 	protected $event_change_state = null;
 
 	/**
+	 * Maps events to plugin groups.
+	 *
+	 * @var array
+	 */
+	protected $events_map = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -122,6 +129,16 @@ abstract class JModelAdmin extends JModelForm
 		{
 			$this->event_change_state = 'onContentChangeState';
 		}
+
+		$config['events_map'] = isset($config['events_map']) ? $config['events_map'] : array();
+
+		$this->events_map = array_merge(
+			array(
+				'delete'       => 'content',
+				'save'         => 'content',
+				'change_state' => 'content'
+			), $config['events_map']
+		);
 
 		// Guess the JText message prefix. Defaults to the option.
 		if (isset($config['text_prefix']))
@@ -729,8 +746,8 @@ abstract class JModelAdmin extends JModelForm
 		$pks = (array) $pks;
 		$table = $this->getTable();
 
-		// Include the content plugins for the on delete events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the delete events.
+		JPluginHelper::importPlugin($this->events_map['delete']);
 
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
@@ -741,7 +758,7 @@ abstract class JModelAdmin extends JModelForm
 				{
 					$context = $this->option . '.' . $this->name;
 
-					// Trigger the onContentBeforeDelete event.
+					// Trigger the before delete event.
 					$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
 
 					if (in_array(false, $result, true))
@@ -758,7 +775,7 @@ abstract class JModelAdmin extends JModelForm
 						return false;
 					}
 
-					// Trigger the onContentAfterDelete event.
+					// Trigger the after event.
 					$dispatcher->trigger($this->event_after_delete, array($context, $table));
 				}
 				else
@@ -928,8 +945,8 @@ abstract class JModelAdmin extends JModelForm
 		$table = $this->getTable();
 		$pks = (array) $pks;
 
-		// Include the content plugins for the change of state event.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the change of state event.
+		JPluginHelper::importPlugin($this->events_map['change_state']);
 
 		// Access checks.
 		foreach ($pks as $i => $pk)
@@ -959,7 +976,7 @@ abstract class JModelAdmin extends JModelForm
 
 		$context = $this->option . '.' . $this->name;
 
-		// Trigger the onContentChangeState event.
+		// Trigger the change state event.
 		$result = $dispatcher->trigger($this->event_change_state, array($context, $pks, $value));
 
 		if (in_array(false, $result, true))
@@ -1058,7 +1075,8 @@ abstract class JModelAdmin extends JModelForm
 	public function save($data)
 	{
 		$dispatcher = JEventDispatcher::getInstance();
-		$table = $this->getTable();
+		$table      = $this->getTable();
+		$context    = $this->option . '_' . $this->name;
 
 		if ((!empty($data['tags']) && $data['tags'][0] != ''))
 		{
@@ -1069,8 +1087,8 @@ abstract class JModelAdmin extends JModelForm
 		$pk = (!empty($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
 		$isNew = true;
 
-		// Include the content plugins for the on save events.
-		JPluginHelper::importPlugin('content');
+		// Include the plugins for the save events.
+		JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Allow an exception to be thrown.
 		try
@@ -1101,8 +1119,8 @@ abstract class JModelAdmin extends JModelForm
 				return false;
 			}
 
-			// Trigger the onContentBeforeSave event.
-			$result = $dispatcher->trigger($this->event_before_save, array($this->option . '.' . $this->name, $table, $isNew));
+			// Trigger the before save event.
+			$result = $dispatcher->trigger($this->event_before_save, array($context, $table, $isNew));
 
 			if (in_array(false, $result, true))
 			{
@@ -1122,8 +1140,8 @@ abstract class JModelAdmin extends JModelForm
 			// Clean the cache.
 			$this->cleanCache();
 
-			// Trigger the onContentAfterSave event.
-			$dispatcher->trigger($this->event_after_save, array($this->option . '.' . $this->name, $table, $isNew));
+			// Trigger the after save event.
+			$dispatcher->trigger($this->event_after_save, array($context, $table, $isNew));
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
# Reason

Incomplete API. We spotted inconsistencies on some component models which are not properly triggering events as expected. This results in an incomplete and inconsistent API for developers. For example in our case we would like to be able to keep track of extension events, which is currently not possible.
# Problem

Some model’s methods are being overridden without calling their parent method. By not calling the parent the event dispatching process is being bypassed.
# Example

[MenusModelItem::save](https://github.com/joomla/joomla-cms/blob/3.3.3/administrator/components/com_menus/models/item.php#L1141) does not trigger the before/after save events because it does not call its parent.
# Patch

This patch includes the following fixes and enhancements:
- It aims to solve the issue by properly taking care of the dispatching process on model actions.
- It also improves JModelAdmin a bit by reducing the amount of required code in some cases, e.g. extending JModelAdmin and wanting to trigger events on plugins other than content.
- Additionally event support was also added to com_config component save actions.
# The API

Extreme care has been taken in order to provide full backwards compatibility, meaning that no API change has been introduced in this patch. However, we would like to report some anomalies that are a direct consequence of the previous inheritance approach being used.

Delete and state change actions from [PluginsModelPlugin](https://github.com/joomla/joomla-cms/blob/3.3.3/administrator/components/com_plugins/models/plugin.php) are inherited from [JModelAdmin](https://github.com/joomla/joomla-cms/blob/3.3.3/libraries/legacy/model/admin.php). This means that until now, the events being triggered for these actions are onContent(Before/After)Delete and onContentChangeState respectively.

On the other hand, onExtension(Before/After)Save events are triggered on [PluginsModelPlugin::save](https://github.com/joomla/joomla-cms/blob/3.3.3/administrator/components/com_plugins/models/plugin.php#L309) calls. This introduces inconsistencies in the API.

One possible approach to fix this would be to use extension events for the delete and change state actions, i.e. onExtension(Before/After)Delete and onExtensionChangeState respectively.

However, and in order to keep things clean while ensuring backward compatibility, we decided not to introduce these changes, but to report them.

This same behavior can be observed on [ModulesModelModule](https://github.com/joomla/joomla-cms/blob/3.3.3/administrator/components/com_modules/models/module.php) and [LanguagesLanguage](https://github.com/joomla/joomla-cms/blob/3.3.3/administrator/components/com_modules/models/module.php).

onExtension(After/Before)Delete events have been introduced on [ModulesModelModule::delete](https://github.com/nooku/joomla-cms/blob/staging/administrator/components/com_modules/models/module.php#L377) and [TemplatesModelStyle::delete](https://github.com/nooku/joomla-cms/blob/staging/administrator/components/com_templates/models/style.php#L87) calls. Since no events were previously triggered on these calls, triggering these new events does not introduce an API change which might lead to backward compatibility problems.
# Tests

In order to properly test this patch, we have developed a small package for catching events. We have called it Catcher. 

The package includes a library and set of configurable plugins. These plugins catch events and reports them (optionally with event data) to the UI using the Joomla! messaging queue.

The Catcher package may be found in the following repo: 

[https://github.com/nooku/joomla-catcher](https://github.com/nooku/joomla-catcher)

The package may be installed in using composer or by building a package.
## Composer install

This is the easiest way to install the Catcher. The first step is to [download composer](https://getcomposer.org/download/) on your Joomla! site root path. Then create a new composer.json file (also in the root directory of the site) with the following content:

```
{
    "require": {
        "nooku/pkg_catcher": "1.*"
    }
}
```

The next and last step is to run the following command from your terminal while located in the site root directory:

```
php composer.phar install
```
## Package install

For convenience, a [phing](http://www.phing.info/) script for building the package is also available under the [/scripts/build](https://github.com/amazeika/catcher/tree/master/scripts/build) folder of the repo.

After the package is installed, make sure to enable the plugins and configure them to catch and report events.

Thanks in advance for considering this patch.

The Timble team.
[http://www.timble.net](http://www.timble.net)
