### PR TITLE
Fix tag's view meta description

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -238,7 +238,7 @@ class TagsViewTag extends JViewLegacy
 			{
 				$this->document->setDescription($itemElement->metadesc);
 			}
-			elseif ($itemElement->metadesc && $this->params->get('menu-meta_description'))
+			elseif (!$itemElement->metadesc && $this->params->get('menu-meta_description'))
 			{
 				$this->document->setDescription($this->params->get('menu-meta_description'));
 			}

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -202,7 +202,7 @@ class TagsViewTags extends JViewLegacy
 				{
 					$this->document->setDescription($this->item->metadesc);
 				}
-				elseif ($itemElement->metadesc && $this->params->get('menu-meta_description'))
+				elseif (!$itemElement->metadesc && $this->params->get('menu-meta_description'))
 				{
 					$this->document->setDescription($this->params->get('menu-meta_description'));
 				}

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -164,6 +164,22 @@ class TagsViewTags extends JViewLegacy
 			$this->params->set('page_subheading', $menu->title);
 		}
 
+		// Set metadata for all tags menu item
+		if ($this->params->get('menu-meta_description'))
+		{
+			$this->document->setDescription($this->params->get('menu-meta_description'));
+		}
+
+		if ($this->params->get('menu-meta_keywords'))
+		{
+			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
+		}
+
+		if ($this->params->get('robots'))
+		{
+			$this->document->setMetadata('robots', $this->params->get('robots'));
+		}
+
 		// If this is not a single tag menu item, set the page title to the tag titles
 		$title = '';
 
@@ -177,6 +193,7 @@ class TagsViewTags extends JViewLegacy
 					{
 						$title .= ', ';
 					}
+
 					$title .= $itemElement->title;
 				}
 			}


### PR DESCRIPTION
### How to test
1. Create menu item "Tagged items" choose any tag you want, but ensure that this tag has empty "Meta Description".
2. Fill in "Meta Description" in the menu item and save.
3. Create a "List of all tags" menu item and fill in the metadata.
4. Proceed to tagged items view and notice that the meta description is empty.
5. Proceed to list of all tags view and notice that the metadata is empty.
6. Apply the patch.
7. Proceed to tagged items view and notice that meta description is taken from the menu item.
8. Fill in "Meta Description" in the chosen tag and ensure that it overrides meta description from the menu item.
9. Proceed to list of all tags view and notice that metadata is taken from the menu item.
