### PR TITLE
Add div to headertag

### DIFF
--- a/libraries/cms/form/field/headertag.php
+++ b/libraries/cms/form/field/headertag.php
@@ -38,7 +38,7 @@ class JFormFieldHeadertag extends JFormFieldList
 	protected function getOptions()
 	{
 		$options = array();
-		$tags = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p');
+		$tags = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div');
 
 		// Create one new option object for each tag
 		foreach ($tags as $tag)


### PR DESCRIPTION
Often it's quite nice to have the possibility to add a div to the module headertag instead to H-tags or paragraphs.

![headertag](https://cloud.githubusercontent.com/assets/1738811/4348542/e693eaa2-418f-11e4-8b98-ebb38dd294c2.jpg)
