### PR TITLE
use the correct dbo

### DIFF
--- a/libraries/joomla/table/language.php
+++ b/libraries/joomla/table/language.php
@@ -59,7 +59,7 @@ class JTableLanguage extends JTable
 	public function store($updateNulls = false)
 	{
 		// Verify that the sef field is unique
-		$table = JTable::getInstance('Language', 'JTable');
+		$table = JTable::getInstance('Language', 'JTable', array('dbo', $this->getDbo()));
 
 		if ($table->load(array('sef' => $this->sef)) && ($table->lang_id != $this->lang_id || $this->lang_id == 0))
 		{

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -538,7 +538,7 @@ class JTableNested extends JTable
 		if ($this->_trackAssets)
 		{
 			$name = $this->_getAssetName();
-			$asset = JTable::getInstance('Asset');
+			$asset = JTable::getInstance('Asset', 'JTable', array('dbo', $this->getDbo()));
 
 			// Lock the table for writing.
 			if (!$asset->_lock())

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -272,7 +272,7 @@ class JTableContent extends JTable
 		}
 
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Content', 'JTable');
+		$table = JTable::getInstance('Content', 'JTable', array('dbo', $this->getDbo()));
 
 		if ($table->load(array('alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
 		{

--- a/libraries/legacy/table/menu/type.php
+++ b/libraries/legacy/table/menu/type.php
@@ -93,7 +93,7 @@ class JTableMenuType extends JTable
 			$userId = JFactory::getUser()->id;
 
 			// Get the old value of the table
-			$table = JTable::getInstance('Menutype', 'JTable');
+			$table = JTable::getInstance('Menutype', 'JTable', array('dbo', $this->getDbo()));
 			$table->load($this->id);
 
 			// Verify that no items are checked out
@@ -179,7 +179,7 @@ class JTableMenuType extends JTable
 			$userId = JFactory::getUser()->id;
 
 			// Get the old value of the table
-			$table = JTable::getInstance('Menutype', 'JTable');
+			$table = JTable::getInstance('Menutype', 'JTable', array('dbo', $this->getDbo()));
 			$table->load($pk);
 
 			// Verify that no items are checked out


### PR DESCRIPTION
There are several cases of table classes which internally use instances of themselves or other table classes but get these instances without specifying a dbo. In normal Joomla operation, this will never be a problem but, when you try to do something funny, like manipulate tables on some other db, you may have problems. 

FOFTable may have the same issue but I don't understand the purpose of that class well enough to touch it right now. 
