### PR TITLE
Handle URLs starting with index.php correctly

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1268,14 +1268,17 @@ class JForm
 				{
 					$protocol = 'http';
 					// If it looks like an internal link, then add the root.
-					if (substr($value, 0) == 'index.php')
+					if (substr($value, 0, 9) == 'index.php')
 					{
 						$value = JURI::root() . $value;
 					}
 
-					// Otherwise we treat it is an external link.
-					// Put the url back together.
-					$value = $protocol . '://' . $value;
+					// Otherwise we treat it as an external link.
+					else
+					{
+						// Put the url back together.
+						$value = $protocol . '://' . $value;
+					}
 				}
 
 				// If relative URLS are allowed we assume that URLs without protocols are internal.


### PR DESCRIPTION
If the URL "index.php" was given, it was converted into "http://http://&lt;servername&gt;/index.php", and an URL starting with "index.php" (e.g. "index.php/sample-sites") was converted into (in this example) "http://index.php/sample-sites". Now "index.php" and e.g. "index.php/sample-sites" are treated identically, they are converted into "http://&lt;servername&gt;/index.php" resp. "http://&lt;servername&gt;/index.php/sample-sites".
