### PR TITLE
Do not create the admin menu item if the component has no admin files

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -201,14 +201,6 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		// Make sure that we have an admin element
-		if (!$this->manifest->administration)
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_COMP_INSTALL_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
-
 		/*
 		 * ---------------------------------------------------------------------------------------------
 		 * Filesystem Processing Section
@@ -388,7 +380,10 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		$this->parent->parseLanguages($this->manifest->administration->languages, 1);
+		if($this->manifest->administration->languages)
+		{
+			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
+		}
 
 		// If there is a manifest script, let's copy it.
 		if ($this->get('manifest_script'))
@@ -657,14 +652,6 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		// Make sure that we have an admin element
-		if (!$this->manifest->administration)
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ABORT_COMP_UPDATE_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
-
 		/**
 		 * ---------------------------------------------------------------------------------------------
 		 * Installer Trigger Loading
@@ -801,7 +788,10 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		$this->parent->parseLanguages($this->manifest->administration->languages, 1);
+		if($this->manifest->administration->languages)
+		{
+			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
+		}
 
 		// If there is a manifest script, let's copy it.
 		if ($this->get('manifest_script'))
@@ -1339,7 +1329,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 			$this->parent->pushStep(array('type' => 'menu', 'id' => $component_id));
 		}
 		// No menu element was specified, Let's make a generic menu item
-		else
+		elseif($this->manifest->administration->files)
 		{
 			$data = array();
 			$data['menutype'] = 'main';
@@ -1681,14 +1671,6 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * Basic Checks Section
 		 * ---------------------------------------------------------------------------------------------
 		 */
-
-		// Make sure that we have an admin element
-		if (!$this->manifest->administration)
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_COMP_INSTALL_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
 
 		/**
 		 * ---------------------------------------------------------------------------------------------

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -380,7 +380,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		if($this->manifest->administration->languages)
+		if ($this->manifest->administration->languages)
 		{
 			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
 		}
@@ -788,7 +788,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		if($this->manifest->administration->languages)
+		if ($this->manifest->administration->languages)
 		{
 			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
 		}

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -201,6 +201,14 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
+		// Make sure that we have an admin element
+		if (!$this->manifest->administration)
+		{
+			JLog::add(JText::_('JLIB_INSTALLER_ERROR_COMP_INSTALL_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
+
+			return false;
+		}
+
 		/*
 		 * ---------------------------------------------------------------------------------------------
 		 * Filesystem Processing Section
@@ -380,10 +388,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		if ($this->manifest->administration->languages)
-		{
-			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
-		}
+		$this->parent->parseLanguages($this->manifest->administration->languages, 1);
 
 		// If there is a manifest script, let's copy it.
 		if ($this->get('manifest_script'))
@@ -652,6 +657,14 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
+		// Make sure that we have an admin element
+		if (!$this->manifest->administration)
+		{
+			JLog::add(JText::_('JLIB_INSTALLER_ABORT_COMP_UPDATE_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
+
+			return false;
+		}
+
 		/**
 		 * ---------------------------------------------------------------------------------------------
 		 * Installer Trigger Loading
@@ -788,10 +801,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseMedia($this->manifest->media);
 		$this->parent->parseLanguages($this->manifest->languages);
-		if ($this->manifest->administration->languages)
-		{
-			$this->parent->parseLanguages($this->manifest->administration->languages, 1);
-		}
+		$this->parent->parseLanguages($this->manifest->administration->languages, 1);
 
 		// If there is a manifest script, let's copy it.
 		if ($this->get('manifest_script'))
@@ -1250,7 +1260,12 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		// Ok, now its time to handle the menus.  Start with the component root menu, then handle submenus.
 		$menuElement = $this->manifest->administration->menu;
 
-		if ($menuElement)
+		// @TODO: Just do not create the menu if $menuElement not exist
+		if (in_array((string) $menuElement['hidden'], array('true', 'hidden')))
+		{
+			return true;
+		}
+		elseif ($menuElement)
 		{
 			$data = array();
 			$data['menutype'] = 'main';
@@ -1329,7 +1344,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 			$this->parent->pushStep(array('type' => 'menu', 'id' => $component_id));
 		}
 		// No menu element was specified, Let's make a generic menu item
-		elseif($this->manifest->administration->files)
+		else
 		{
 			$data = array();
 			$data['menutype'] = 'main';
@@ -1671,6 +1686,14 @@ class JInstallerAdapterComponent extends JAdapterInstance
 		 * Basic Checks Section
 		 * ---------------------------------------------------------------------------------------------
 		 */
+
+		// Make sure that we have an admin element
+		if (!$this->manifest->administration)
+		{
+			JLog::add(JText::_('JLIB_INSTALLER_ERROR_COMP_INSTALL_ADMIN_ELEMENT'), JLog::WARNING, 'jerror');
+
+			return false;
+		}
 
 		/**
 		 * ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Problem**
Joomla! create a useless menu item for backend, when I create a simple component (with only a site part) that have no backend.

**How to test this pull**
Make a simple component, and try install it. Create folder `com_hello`, and put there two files `hello.php` (empty) and `hello.xml`

`hello.xml` content for test the component without backed:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<extension type="component" version="3.3" method="upgrade">
   <name>com_hello</name>
   <author>Your Name</author>
   <authorEmail>your.email@example.com</authorEmail>
   <authorUrl>example.com</authorUrl>
   <creationDate>September 2014</creationDate>
   <license>GNU/GPL</license>
   <version>1.0.0</version>
   <description>Simple Hello component</description>

   <files folder="site">
      <file>hello.php</file>
   </files>

</extension>
```

`hello.xml` content for test the component with backed:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<extension type="component" version="3.3" method="upgrade">
   <name>com_hello</name>
   <author>Your Name</author>
   <authorEmail>your.email@example.com</authorEmail>
   <authorUrl>example.com</authorUrl>
   <creationDate>September 2014</creationDate>
   <license>GNU/GPL</license>
   <version>1.0.0</version>
   <description>Simple Hello component</description>

   <files folder="site">
      <file>hello.php</file>
   </files>

   <administration>
        <files />
    </administration>

</extension>
```

Pack this to archive and try install.
After installation, check the admin menu Components->com-hello. It should not exist when test with the first XML, and exist for a second.
