### PR TITLE
Fixed broken CropResize method

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -744,16 +744,19 @@ class JImage
 		$width   = $this->sanitizeWidth($width, $height);
 		$height  = $this->sanitizeHeight($height, $width);
 
+		$resizewidth = $width;
+		$resizeheight = $height;
+
 		if (($this->getWidth() / $width) < ($this->getHeight() / $height))
 		{
-			$this->resize($width, 0, false);
+			$resizeheight = 0;
 		}
 		else
 		{
-			$this->resize(0, $height, false);
+			$resizewidth = 0;
 		}
 
-		return $this->crop($width, $height, null, null, $createNew);
+		return $this->resize($resizewidth, $resizeheight, $createNew)->crop($width, $height, null, null, false);
 	}
 
 	/**


### PR DESCRIPTION
If you crop-resize an image and choose set the $createNew Parameter to true, the original image will be resized nevertheless.

The patch fixes this error.

Test:
- Load an image with JImage
- cropResize the Image with "$createNew" to "true".
- Look at the old (orignal) JImage object with the orignal image. It should be resized to the new dimensions
- Apply patch
- Try again => The original image object should have preserved its dimensions
