### PR TITLE
Clear limit for list count

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -321,7 +321,7 @@ abstract class JModelLegacy extends JObject
 			&& $query->having === null)
 		{
 			$query = clone $query;
-			$query->clear('select')->clear('order')->select('COUNT(*)');
+			$query->clear('select')->clear('order')->clear('limit')->select('COUNT(*)');
 
 			$this->_db->setQuery($query);
 			return (int) $this->_db->loadResult();


### PR DESCRIPTION
Unfortunately https://github.com/joomla/joomla-cms/pull/3945 introduced a bug with pagination in `com_content` category view (list and blog). As soon as you change the page, the pagination vanishes.

The reason is that we now also pass the `limit` and `offset` properties of the query object to the `_getListCount` method. For some reason I couldn't tackle down yet, those are set in `com_content` but not in other extensions like `com_contact` or `com_weblinks`.

However to get the count we should not use any limits anyway. It does make no sense to run a query `SELECT COUNT(*) LIMIT 10, 20`. Thus we should be able to safely clear the limit part since we want an unlimited total list anyway.

Please test with various lists if this doesn't introduce yet another unexpected side effect...
