### PR TITLE
Fixing com_content ACL to restore "Save as Copy" and "Save & New" buttons

### DIFF
--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -116,12 +116,7 @@ class JHelperContent
 			$assetName = $component;
 		}
 
-		if (empty($section))
-		{
-			$section = 'component';
-		}
-
-		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='" . $section . "']/");
+		$actions = JAccess::getActionsFromFile($path, "/access/section[@name='component']/");
 
 		foreach ($actions as $action)
 		{


### PR DESCRIPTION
### Issue

See Issue #4328. "Save as Copy" and "Save & New" buttons are currently not available in the article edit form.
This is because PR #4198 broke the ACL for core.create.
### Solution

Reverting PR #4198 since it broke "Save as Copy" and "Save & New" buttons in com_content.
### Testing

Make sure ACL works in com_content and other extensions as expected.
