### PR TITLE
prevent stupid Joomla URL

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -93,6 +93,13 @@ class ContentRouter extends JComponentRouterBase
 				$segments[] = $view;
 			}
 
+			// If I view a category within a category... I'm on a forbidden URI
+			if ($view == 'category')
+			{
+				JError::raiseError(404, JText::_('COM_CONTENT_ERROR_PARENT_CATEGORY_NOT_FOUND'));
+				return $segments;
+			}
+			
 			unset($query['view']);
 
 			if ($view == 'article')


### PR DESCRIPTION
Use this pull request / core hack as a temporary fix until Hannes Papenberg (@Hackwar) publishes his new URL router. 

With the current Joomla implementation it's possible to generate very stupid URLs from a category blog view. 
When you create a menu item for a category blog view you can call another catogory with it's alias. 
example
menu item for category blog view
https://www.byte.nl/nieuws/
an article in this view will be
https://www.byte.nl/nieuws/2799-lek-bash-shell-gedicht

another category might be Products
it's category ID is 78
thus the alias will be 78-products
therefor you can call the url
https://www.byte.nl/nieuws/78-products
and it will display all items from category Products as a category blog view in menu item Nieuws

I don't want Joomla to render such a stupid link.
Instead of waiting for @Hackwar I implemented this temporary solution.

It will raise an error 302 to /nieuws instead of a /404
For me that's okay since people and search engines cannot render the other page anymore.
