### PR TITLE
Fix - Finder: Indexer Parsers break search result descriptions #4327

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -41,7 +41,6 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = strip_tags($input);
 
 		// Deal with spacing issues in the input
-		$input = str_replace('>', '> ', $input);
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
 		$input = trim(preg_replace('#\s+#u', ' ', $input));
 
@@ -49,6 +48,11 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		if (strpos($input, '>') !== false)
 		{
 			$input = substr($input, strpos($input, '>') + 1);
+		}
+
+		if (strpos($input, '<') !== false)
+		{
+			$input = substr($input, 0, strpos($input, '<'));
 		}
 
 		// Decode entities and remove unneeded white spaces

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -37,13 +37,21 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		// Strip all script tags.
 		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
 
-		// Deal with spacing issues in the input.
+		// Strip the tags from the input
+		$input = strip_tags($input);
+
+		// Deal with spacing issues in the input
 		$input = str_replace('>', '> ', $input);
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
 		$input = trim(preg_replace('#\s+#u', ' ', $input));
 
-		// Strip the tags from the input and decode entities.
-		$input = strip_tags($input);
+		// Remove last parts of HTML code which may be caused by a cut of the string
+		if (strpos($input, '>') !== false)
+		{
+			$input = substr($input, strpos($input, '>') + 1);
+		}
+
+		// Decode entities and remove unneeded white spaces
 		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
 		$input = trim(preg_replace('#\s+#u', ' ', $input));
 


### PR DESCRIPTION
See discussion here: https://github.com/joomla/joomla-cms/issues/4327

_How to test?_

In the comments you can find a link to a page from where you can copy the article text (view source code and copy&paste). For the second issue just copy the example in the description of the linked entry.

Create two articles with the example content. Enter the content in an article and run the indexer of the smart search component. Then go to the frontend and search for the articles. After applying the patch you should not see parts of the HTML code in the first and no spaces in the second article!

Thank you for reporting @andykirk!
