### PR TITLE
Improvement - Get the maximum upload file size

### DIFF
--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -297,27 +297,35 @@ class JFilesystemHelper
 	}
 
 	/**
-	 * Calculates the maximum file upload size
+	 * Calculates the maximum upload file size and return string with unit or the size in Bytes
 	 *
 	 * Call it with JFilesystemHelper::fileUploadMaxSize();
 	 *
-	 * @return string The maximum upload size of files with the appropriate unit
+	 * @param   bool  $unit_output  This parameter determines whether the return value should be a string with a unit
+	 *
+	 * @return float|string The maximum upload size of files with the appropriate unit or in Bytes
 	 */
-	public static function fileUploadMaxSize()
+	public static function fileUploadMaxSize($unit_output = true)
 	{
 		static $max_size = false;
+		static $output_type = true;
 
-		if ($max_size === false)
+		if ($max_size === false || $output_type != $unit_output)
 		{
-			$max_size   = JFilesystemHelper::parseSize(ini_get('post_max_size'));
-			$upload_max = JFilesystemHelper::parseSize(ini_get('upload_max_filesize'));
+			$max_size   = self::parseSize(ini_get('post_max_size'));
+			$upload_max = self::parseSize(ini_get('upload_max_filesize'));
 
 			if ($upload_max > 0 && ($upload_max < $max_size || $max_size == 0))
 			{
 				$max_size = $upload_max;
 			}
 
-			$max_size = JFilesystemHelper::parseSizeUnit($max_size);
+			if ($unit_output == true)
+			{
+				$max_size = self::parseSizeUnit($max_size);
+			}
+
+			$output_type = $unit_output;
 		}
 
 		return $max_size;
@@ -326,7 +334,7 @@ class JFilesystemHelper
 	/**
 	 * Returns the size in bytes without the unit for the comparison
 	 *
-	 * @param $size The size which is received from the PHP settings
+	 * @param   string  $size  The size which is received from the PHP settings
 	 *
 	 * @return float The size in Bytes without the unit
 	 */
@@ -335,20 +343,20 @@ class JFilesystemHelper
 		$unit = preg_replace('/[^bkmgtpezy]/i', '', $size);
 		$size = preg_replace('/[^0-9\.]/', '', $size);
 
+		$return = round($size);
+
 		if ($unit)
 		{
-			return round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
+			$return = round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
 		}
-		else
-		{
-			return round($size);
-		}
+
+		return $return;
 	}
 
 	/**
 	 * Creates the rounded size of the size with the appropriate unit
 	 *
-	 * @param $max_size The maximum size which is allowed for the uploads
+	 * @param   float  $max_size  The maximum size which is allowed for the uploads
 	 *
 	 * @return string String with the size and the appropriate unit
 	 */

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -297,13 +297,15 @@ class JFilesystemHelper
 	}
 
 	/**
-	 * Calculates the maximum upload file size and return string with unit or the size in Bytes
+	 * Calculates the maximum upload file size and returns string with unit or the size in bytes
 	 *
 	 * Call it with JFilesystemHelper::fileUploadMaxSize();
 	 *
 	 * @param   bool  $unit_output  This parameter determines whether the return value should be a string with a unit
 	 *
-	 * @return float|string The maximum upload size of files with the appropriate unit or in Bytes
+	 * @return  float|string The maximum upload size of files with the appropriate unit or in bytes
+	 *
+	 * @since   13.1
 	 */
 	public static function fileUploadMaxSize($unit_output = true)
 	{
@@ -336,7 +338,9 @@ class JFilesystemHelper
 	 *
 	 * @param   string  $size  The size which is received from the PHP settings
 	 *
-	 * @return float The size in Bytes without the unit
+	 * @return  float The size in bytes without the unit
+	 *
+	 * @since   13.1
 	 */
 	private static function parseSize($size)
 	{
@@ -359,6 +363,8 @@ class JFilesystemHelper
 	 * @param   float  $max_size  The maximum size which is allowed for the uploads
 	 *
 	 * @return string String with the size and the appropriate unit
+	 *
+	 * @since   13.1
 	 */
 	private static function parseSizeUnit($max_size)
 	{

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -295,4 +295,68 @@ class JFilesystemHelper
 	{
 		return in_array($streamname, self::getJStreams());
 	}
+
+	/**
+	 * Calculates the maximum file upload size
+	 *
+	 * Call it with JFilesystemHelper::fileUploadMaxSize();
+	 *
+	 * @return string The maximum upload size of files with the appropriate unit
+	 */
+	public static function fileUploadMaxSize()
+	{
+		static $max_size = false;
+
+		if ($max_size === false)
+		{
+			$max_size   = JFilesystemHelper::parseSize(ini_get('post_max_size'));
+			$upload_max = JFilesystemHelper::parseSize(ini_get('upload_max_filesize'));
+
+			if ($upload_max > 0 && ($upload_max < $max_size || $max_size == 0))
+			{
+				$max_size = $upload_max;
+			}
+
+			$max_size = JFilesystemHelper::parseSizeUnit($max_size);
+		}
+
+		return $max_size;
+	}
+
+	/**
+	 * Returns the size in bytes without the unit for the comparison
+	 *
+	 * @param $size The size which is received from the PHP settings
+	 *
+	 * @return float The size in Bytes without the unit
+	 */
+	private static function parseSize($size)
+	{
+		$unit = preg_replace('/[^bkmgtpezy]/i', '', $size);
+		$size = preg_replace('/[^0-9\.]/', '', $size);
+
+		if ($unit)
+		{
+			return round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
+		}
+		else
+		{
+			return round($size);
+		}
+	}
+
+	/**
+	 * Creates the rounded size of the size with the appropriate unit
+	 *
+	 * @param $max_size The maximum size which is allowed for the uploads
+	 *
+	 * @return string String with the size and the appropriate unit
+	 */
+	private static function parseSizeUnit($max_size)
+	{
+		$base     = log($max_size) / log(1024);
+		$suffixes = array('', 'k', 'M', 'G', 'T');
+
+		return round(pow(1024, $base - floor($base)), 0) . $suffixes[floor($base)];
+	}
 }

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -305,7 +305,7 @@ class JFilesystemHelper
 	 *
 	 * @return  float|string The maximum upload size of files with the appropriate unit or in bytes
 	 *
-	 * @since   13.1
+	 * @since   3.4
 	 */
 	public static function fileUploadMaxSize($unit_output = true)
 	{
@@ -340,7 +340,7 @@ class JFilesystemHelper
 	 *
 	 * @return  float The size in bytes without the unit
 	 *
-	 * @since   13.1
+	 * @since   3.4
 	 */
 	private static function parseSize($size)
 	{
@@ -364,7 +364,7 @@ class JFilesystemHelper
 	 *
 	 * @return  string String with the size and the appropriate unit
 	 *
-	 * @since   13.1
+	 * @since   3.4
 	 */
 	private static function parseSizeUnit($max_size)
 	{

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -362,7 +362,7 @@ class JFilesystemHelper
 	 *
 	 * @param   float  $max_size  The maximum size which is allowed for the uploads
 	 *
-	 * @return string String with the size and the appropriate unit
+	 * @return  string String with the size and the appropriate unit
 	 *
 	 * @since   13.1
 	 */


### PR DESCRIPTION
Reference and discussion: Template upload size #4337

Call it with JFilesystemHelper::fileUploadMaxSize(); from anywhere you need to get the maximum upload file size!

**How to test?**

Change the 'post_max_size' and 'upload_max_filesize' (in the php.ini) and check whether you get the correct maximum size with the call mentioned above!
