### PR TITLE
SimpleXMLElement::addChild() [simplexmlelement.addchild]: unterminated entity reference

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -2116,7 +2116,7 @@ class JForm
 	protected static function addNode(SimpleXMLElement $source, SimpleXMLElement $new)
 	{
 		// Add the new child node.
-		$node = $source->addChild($new->getName(), trim($new));
+		$node = $source->addChild($new->getName(), htmlspecialchars(trim($new)));
 
 		// Add the attributes of the child node.
 		foreach ($new->attributes() as $name => $value)


### PR DESCRIPTION
#### Steps to reproduce the issue

Create a user custom profile with a country list and a properly escaped ampersand (Issue tracker may replace my escaped ampersand as non-escaped):
<field
        name="country"
        type="list"
        default=""
        label="PLG_USER_PROFILE_FIELD_COUNTRY_LABEL"
        description="PLG_USER_PROFILE_FIELD_COUNTRY_DESC">
        <option value="US">United States</option>
        <option value="AG">Antigua &amp; Barbuda</option>
        ...
        <option value="BA">Bosnia &amp; Herzegovina</option>
        ...
        <option value="TT">Trinidad &amp; Tobago</option>
</field>
#### Expected result

Simple list of countries in the profile
#### Actual result

Warning: SimpleXMLElement::addChild() [simplexmlelement.addchild]: unterminated entity reference Barbuda in /home/website/public_html/joomla/libraries/joomla/form/form.php on line 2119
Warning: SimpleXMLElement::addChild() [simplexmlelement.addchild]: unterminated entity reference Herzegovina in /home/website/public_html/joomla/libraries/joomla/form/form.php on line 2119
Warning: SimpleXMLElement::addChild() [simplexmlelement.addchild]: unterminated entity reference Tobago in /home/website/public_html/joomla/libraries/joomla/form/form.php on line 2119
#### System information (as much as possible)

PHP Version: 5.4.24
Web Server: Apache Phusion_Passenger/4.0.10 mod_bwlimited/1.4 mod_fcgid/2.3.9
WebServer to PHP Interface: cgi-fcgi
Joomla! Version: Joomla! 3.3.4 Stable [ Ember ] 23-September-2014 14:00 GMT
Joomla! Platform Version: Joomla Platform 13.1.0 Stable [ Curiosity ] 24-Apr-2013 00:00 GMT
User Agent: Mozilla/5.0 (Windows NT 6.1; rv:32.0) Gecko/20100101 Firefox/32.0 
#### Additional comments

Solving the problem is simply updating form.php at line 2119:

//$node = $source->addChild($new->getName(), trim($new));
$node = $source->addChild($new->getName(), htmlspecialchars(trim($new)));

Using language files for all of the countries with ampersands also works to solve the issue, however I do not believe this should be the preferred method to fix it.
