### PR TITLE
Email cloak broken when link parameters are not parsed

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -54,8 +54,7 @@ class PlgContentEmailcloak extends JPlugin
 	 */
 	protected function _getPattern ($link, $text)
 	{
-		$pattern = '~(?:<a ([\w "\'=\@\.\-:;]*)href\s*=\s*"mailto:'
-			. $link . '"([\w "\'=\@\.\-:;]*))>' . $text . '</a>~i';
+		$pattern = '~(?:<a ([^>]*)href\s*=\s*"mailto:' . $link . '"([^>]*))>' . $text . '</a>~i';
 
 		return $pattern;
 	}


### PR DESCRIPTION
When an email link parameter contains values with characters such as #, ( or ), among others -
< a href="mailto:email @ ..." style="color: #00F">email @ ...< /a>

only the latter pattern in the _clock function is matched and thus the code becomes broken.
