### PR TITLE
using catslug for article links in content modules

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,7 +227,7 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid ? $item->catid . ':' . $item->category_alias : $item->catid;
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -90,7 +90,7 @@ abstract class ModArticlesNewsHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link     = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
+				$item->link     = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
 				$item->linkText = JText::_('MOD_ARTICLES_NEWS_READMORE');
 			}
 			else

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -65,7 +65,7 @@ abstract class ModArticlesPopularHelper
 
 		foreach ($items as &$item)
 		{
-			$item->slug = $item->id . ':' . $item->alias;
+			$item->slug    = $item->id . ':' . $item->alias;
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))


### PR DESCRIPTION
The request is to use the same principle for creating link to articles in content modules. 
Since catslug is used in some modules and is not used in other module, this potentially leads to double article URLs (when SEF is disabled). 
E.g. mod_news uses only catid instead of catslug when creating links to articles.

**Steps to reproduce the issue**
- disable SEF (SEO Settings - set all fields: No)
- publish thee content modules Articles Category Module, Latest News Module, Articles Newsflash Module in the same page for comparison.
- In the module settings select the same one category as source (the same for three modules).
- Compare URLs to the same article in different modules.

**The results I got:**
Articles Category Module and Latest News Module
`http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12:category-alias&Itemid=101`

Articles Newsflash Module
`http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12&Itemid=101`

**Expected result**
All the links to the same article must be identical in all modules. Otherwise, it's a serious SEO mistake.
