### PR TITLE
Backport of #3981: Plaintext mode of mailcloak

### DIFF
--- a/libraries/joomla/html/html/email.php
+++ b/libraries/joomla/html/html/email.php
@@ -82,7 +82,7 @@ abstract class JHtmlEmail
 		}
 		else
 		{
-			$replacement .= "\n document.getElementById('cloak$rand').innerHTML += 'addy" . $rand . "';";
+			$replacement .= "\n document.getElementById('cloak$rand').innerHTML += addy" . $rand . ";";
 		}
 
 		$replacement .= "\n //-->";


### PR DESCRIPTION
Hi folks!

PR #3981 fixed the plaintext functionality of the emailcloak plugin for 3.x. This PR fixes the same thing for 2.5.x. 
## Testing instructions
- Edit the plugin "Content - Email Cloaking".
  - Enabled: Yes
  - Mode: Non-linkable text

Use cases of this plugin (every of them with javascript enabled and disabled):
1. `<a href="mailto:email@example.org">email@example.org</a>`
2. `<a href="mailto:email@example.org">text</a>`
3. `<a href="mailto:email@example.org"><img src="..." /></a>`
4. `<a href="mailto:email@example.org?subject=Text">email@example.org</a>`
5. `<a href="mailto:email@example.org?subject=Text">text</a>`
6. `<a href="mailto:email@example.org?subject=Text"><img src="..." /></a>`
7. plain `email@example.org`
