### PR TITLE
Remove catslug in content modules

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,12 +227,11 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid ? $item->catid . ':' . $item->category_alias : $item->catid;
 
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
 			}
 			else
 			{

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,7 +227,7 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			
+
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,6 +227,8 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
+			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,6 +227,7 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
+			
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -114,6 +114,8 @@ abstract class ModArticlesLatestHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
+			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -114,12 +114,11 @@ abstract class ModArticlesLatestHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
 			}
 			else
 			{

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -114,6 +114,7 @@ abstract class ModArticlesLatestHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
+			
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -114,7 +114,7 @@ abstract class ModArticlesLatestHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			
+
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -85,7 +85,6 @@ abstract class ModArticlesNewsHelper
 		{
 			$item->readmore = strlen(trim($item->fulltext));
 			$item->slug     = $item->id . ':' . $item->alias;
-			$item->catslug  = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -86,7 +86,7 @@ abstract class ModArticlesNewsHelper
 			$item->readmore = strlen(trim($item->fulltext));
 			$item->slug     = $item->id . ':' . $item->alias;
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
-			$item->catslug = $item->catid . ':' . $item->category_alias;
+			$item->catslug  = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -85,7 +85,7 @@ abstract class ModArticlesNewsHelper
 		{
 			$item->readmore = strlen(trim($item->fulltext));
 			$item->slug     = $item->id . ':' . $item->alias;
-			
+
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug  = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -85,6 +85,8 @@ abstract class ModArticlesNewsHelper
 		{
 			$item->readmore = strlen(trim($item->fulltext));
 			$item->slug     = $item->id . ':' . $item->alias;
+			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -85,6 +85,7 @@ abstract class ModArticlesNewsHelper
 		{
 			$item->readmore = strlen(trim($item->fulltext));
 			$item->slug     = $item->id . ':' . $item->alias;
+			
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug  = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -66,6 +66,7 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
+			
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -66,12 +66,11 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
 			}
 			else
 			{

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -66,7 +66,7 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			
+
 			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -65,7 +65,9 @@ abstract class ModArticlesPopularHelper
 
 		foreach ($items as &$item)
 		{
-			$item->slug = $item->id . ':' . $item->alias;
+			$item->slug    = $item->id . ':' . $item->alias;
+			// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -94,15 +94,7 @@ abstract class ModRelatedItemsHelper
 					$case_when .= $a_id . ' END as slug';
 					$query->select($case_when);
 
-					$case_when = ' CASE WHEN ';
-					$case_when .= $query->charLength('cc.alias', '!=', '0');
-					$case_when .= ' THEN ';
-					$c_id = $query->castAsChar('cc.id');
-					$case_when .= $query->concatenate(array($c_id, 'cc.alias'), ':');
-					$case_when .= ' ELSE ';
-					$case_when .= $c_id . ' END as catslug';
-					$query->select($case_when)
-						->from('#__content AS a')
+					$query->from('#__content AS a')
 						->join('LEFT', '#__content_frontpage AS f ON f.content_id = a.id')
 						->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 						->where('a.id != ' . (int) $id)
@@ -130,7 +122,7 @@ abstract class ModRelatedItemsHelper
 						{
 							if ($row->cat_state == 1)
 							{
-								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catslug));
+								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid));
 								$related[] = $row;
 							}
 						}

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -92,6 +92,16 @@ abstract class ModRelatedItemsHelper
 					$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 					$case_when .= ' ELSE ';
 					$case_when .= $a_id . ' END as slug';
+					$query->select($case_when);
+
+					// TODO: To remove because catslug is not used in non-SEF article URLs in com_content.
+					$case_when = ' CASE WHEN ';
+					$case_when .= $query->charLength('cc.alias', '!=', '0');
+					$case_when .= ' THEN ';
+					$c_id = $query->castAsChar('cc.id');
+					$case_when .= $query->concatenate(array($c_id, 'cc.alias'), ':');
+					$case_when .= ' ELSE ';
+					$case_when .= $c_id . ' END as catslug';
 					$query->select($case_when)
 						->from('#__content AS a')
 						->join('LEFT', '#__content_frontpage AS f ON f.content_id = a.id')

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -92,9 +92,8 @@ abstract class ModRelatedItemsHelper
 					$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 					$case_when .= ' ELSE ';
 					$case_when .= $a_id . ' END as slug';
-					$query->select($case_when);
-
-					$query->from('#__content AS a')
+					$query->select($case_when)
+						->from('#__content AS a')
 						->join('LEFT', '#__content_frontpage AS f ON f.content_id = a.id')
 						->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 						->where('a.id != ' . (int) $id)


### PR DESCRIPTION
The request is to use the same principle for creating links to articles in content modules. Since catslug is used in some modules and is not used in other module, this potentially leads to double article URLs (when SEF is disabled). But there is no need to use catslug in Joomla 3.x because process link function - ContentHelperRoute::getArticleRoute - requires only catid (integer value).
`/components/com_content/helpers/route.php`
`public static function getArticleRoute($id, $catid = 0, $language = 0)`

After going deeper into the issue I came to conclusion that only catid must be used, and catslug must be removed. 

**Steps to reproduce the issue**
- disable SEF (SEO Settings - set all fields: No)
- publish thee content modules Articles Category Module, Latest News Module, Articles Newsflash Module in the same page for comparison.
- In the module settings select the same one category as source (the same for three modules).
- Compare URLs to the same article in different modules.

**The results I got:**
Articles Category Module
`http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12:category-alias&Itemid=101`

Articles Newsflash Module
`http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12&Itemid=101`

**Expected result**
`http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12&Itemid=101`
All the links to the same article must be identical in all modules. Otherwise, it's a serious SEO mistake.
