### PR TITLE
Align Version button with Save / Cancel on front-end edit.

### DIFF
--- a/libraries/cms/form/field/contenthistory.php
+++ b/libraries/cms/form/field/contenthistory.php
@@ -44,7 +44,7 @@ class JFormFieldContenthistory extends JFormField
 			. $this->element['data-typeAlias'] . '&amp;' . JSession::getFormToken() . '=1';
 
 		// Load the modal behavior script.
-		JHtml::_('behavior.modal', 'a.modal_' . $this->id);
+		JHtml::_('behavior.modal', 'button.modal_' . $this->id);
 
 		$html[] = '		<button class="btn modal_' . $this->id . '" title="' . $label . '" href="' . $link . '"'
 			. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';

--- a/libraries/cms/form/field/contenthistory.php
+++ b/libraries/cms/form/field/contenthistory.php
@@ -46,11 +46,11 @@ class JFormFieldContenthistory extends JFormField
 		// Load the modal behavior script.
 		JHtml::_('behavior.modal', 'a.modal_' . $this->id);
 
-		$html[] = '		<a class="btn modal_' . $this->id . '" title="' . $label . '" href="' . $link . '"'
+		$html[] = '		<button class="btn modal_' . $this->id . '" title="' . $label . '" href="' . $link . '"'
 			. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';
 		$html[] = '<i class="icon-archive"></i>';
 		$html[] = $label;
-		$html[] = '</a>';
+		$html[] = '</button>';
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
Fix for issue #4637

If you have versioning on, then a front end editing page has the version button misaligned with the Save and Cancel buttons.

This is due to the Save and Cancel buttons being rendered with the `<button>` tag whilst Version is rendered with the `<a>` tag - and different CSS is applied.

![image](https://cloud.githubusercontent.com/assets/3001893/4431400/ff5eb44c-4665-11e4-9168-5324af80b1e8.png)

The fix is to change the `<a>` tag for a `<button>` tag in `/libraries/cms/form/field/contenthistory.php`  at lines 49/53.
