### PR TITLE
[3.4] Fix a non bootstrap dropdown

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -13,6 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidation');
 JHtml::_('behavior.keepalive');
+JHtml::_('formbehavior.chosen', 'select');
 $user = JFactory::getUser();
 ?>
 <script type="text/javascript">


### PR DESCRIPTION
bevor patch
![bevor_dropdown_issue](https://cloud.githubusercontent.com/assets/2596554/4431641/530c493c-4671-11e4-8a25-04707308db2f.JPG)

after patch
![after_patch](https://cloud.githubusercontent.com/assets/2596554/4431643/5a66419c-4671-11e4-9c75-eda09b901ad3.JPG)

See here: BE --> Extensions --> Template Manager --> Isis --> Advanced
