### PR TITLE
Remove dublicate article URLs

### DIFF
--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -20,7 +20,7 @@ $params = $this->params;
 			<div class="page-header">
 				<h2 itemprop="name">
 					<?php if ($params->get('link_titles')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>" itemprop="url">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>" itemprop="url">
 							<?php echo $this->escape($item->title); ?>
 						</a>
 					<?php else: ?>

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -69,7 +69,7 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		// TODO: Change based on shownoauth
-		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
 
 		// Merge article params. If this is single-article view, menu params override article params
 		// Otherwise, article params override menu item params

--- a/components/com_content/views/featured/tmpl/default_links.php
+++ b/components/com_content/views/featured/tmpl/default_links.php
@@ -12,8 +12,9 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
-			<?php echo $item->title; ?></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+			<?php echo $item->title; ?>
+		</a>
 	</li>
 <?php endforeach; ?>
 </ol>

--- a/layouts/joomla/content/blog_style_default_links.php
+++ b/layouts/joomla/content/blog_style_default_links.php
@@ -12,8 +12,9 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($displayData->get('link_items') as $item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
-			<?php echo $item->title; ?></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+			<?php echo $item->title; ?>
+		</a>
 	</li>
 <?php endforeach; ?>
 </ol>

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -135,14 +135,7 @@ class PlgContentPagenavigation extends JPlugin
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id . ' END as slug';
 
-			$case_when1 = ' CASE WHEN ';
-			$case_when1 .= $query->charLength('cc.alias', '!=', '0');
-			$case_when1 .= ' THEN ';
-			$c_id = $query->castAsChar('cc.id');
-			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
-			$case_when1 .= ' ELSE ';
-			$case_when1 .= $c_id . ' END as catslug';
-			$query->select('a.id,' . $case_when . ',' . $case_when1)
+			$query->select('a.id,' . $case_when . ', a.catid')
 				->from('#__content AS a')
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(
@@ -196,7 +189,7 @@ class PlgContentPagenavigation extends JPlugin
 
 			if ($row->prev)
 			{
-				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catslug));
+				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catid));
 			}
 			else
 			{
@@ -205,7 +198,7 @@ class PlgContentPagenavigation extends JPlugin
 
 			if ($row->next)
 			{
-				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catslug));
+				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catid));
 			}
 			else
 			{

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -267,7 +267,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language);
+		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		// Get the menu title if it exists.

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -162,17 +162,9 @@ class PlgSearchContent extends JPlugin
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id . ' END as slug';
 
-			$case_when1 = ' CASE WHEN ';
-			$case_when1 .= $query->charLength('c.alias', '!=', '0');
-			$case_when1 .= ' THEN ';
-			$c_id = $query->castAsChar('c.id');
-			$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
-			$case_when1 .= ' ELSE ';
-			$case_when1 .= $c_id . ' END as catslug';
-
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
-				->select('c.title AS section, ' . $case_when . ',' . $case_when1 . ', ' . '\'2\' AS browsernav')
+				->select('c.title AS section, ' . $case_when . ', a.catid, ' . '\'2\' AS browsernav')
 
 				->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid')
@@ -200,7 +192,7 @@ class PlgSearchContent extends JPlugin
 			{
 				foreach ($list as $key => $item)
 				{
-					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug);
+					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catid);
 				}
 			}
 
@@ -221,18 +213,10 @@ class PlgSearchContent extends JPlugin
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id . ' END as slug';
 
-			$case_when1 = ' CASE WHEN ';
-			$case_when1 .= $query->charLength('c.alias', '!=', '0');
-			$case_when1 .= ' THEN ';
-			$c_id = $query->castAsChar('c.id');
-			$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
-			$case_when1 .= ' ELSE ';
-			$case_when1 .= $c_id . ' END as catslug';
-
 			$query->select(
 				'a.title AS title, a.metadesc, a.metakey, a.created AS created, '
 					. $query->concatenate(array("a.introtext", "a.fulltext")) . ' AS text,'
-					. $case_when . ',' . $case_when1 . ', '
+					. $case_when . ', '
 					. 'c.title AS section, \'2\' AS browsernav'
 			);
 

--- a/templates/beez3/html/com_content/featured/default_links.php
+++ b/templates/beez3/html/com_content/featured/default_links.php
@@ -8,17 +8,15 @@
  */
 
 defined('_JEXEC') or die;
-
 ?>
 
 <h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
-
 <ol class="links">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
-			<?php echo $item->title; ?></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+			<?php echo $item->title; ?>
+		</a>
 	</li>
 <?php endforeach; ?>
 </ol>
-


### PR DESCRIPTION
I found out that com_content still generates double URLs to articles in some cases. It's an old issue, and it's mostly removed in Joomla 3.x, but in some places we still can find that. It happens because when creating article links catslug is used instead of catid.
### How to test
- SEF must be disabled;
- Open category blog page and we see how the links look like.
  Practically all article links in com_content have this view:
  `http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12&Itemid=101` 
- But the same articles have different URLs in other places:
  `http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12:category-alias&Itemid=101`
### Where you can find "incorrect" links:
- Featured articles page, when featured links are used (menu item settings - layout - features links);
- Archived articles page;
- Next and Prev button links on any article page;
- Title links on search results page;
- Title links on smart search results page;
### Expected results:

 `http://test.com/index.php?option=com_content&view=article&id=49:article-alias&catid=12&Itemid=101`
 All the links to the same article must be identical in everywhere in Joomla. Otherwise, it's a serious SEO mistake.
