### PR TITLE
Better Checking undefined this way and a fix for a problem

### DIFF
--- a/media/system/js/html5fallback-uncompressed.js
+++ b/media/system/js/html5fallback-uncompressed.js
@@ -139,7 +139,7 @@
 
 		validateField : function(e) {
 			var elem = e.target || e;
-			if(elem.form === undefined){
+			if(typeof elem.form == 'undefined' || elem.form === null){
 				return null;
 			}
 			var	self = elem.form.H5Form,


### PR DESCRIPTION
I came to this because I intergrated the jquery-fileupload plugin and noticed that there is an error when uploading a file. The reason is the the plugin fires the change event and the check fails because elem.form is null instead of undefined. This brings an error

"TypeError: elem.form is null"

for the line:

"var    self = elem.form.H5Form"

not the end of the world but also not nice. There might be other ways to go around that but this is what I did and it worked.
