### PR TITLE
Use GMT localtime only if localzone is not set

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -286,7 +286,7 @@ class JDate extends DateTime
 		}
 
 		// If the returned time should not be local use GMT.
-		if ($local == false)
+		if ($local == false && !isset($this->tz))
 		{
 			parent::setTimezone(self::$gmt);
 		}


### PR DESCRIPTION
If we try to get the current date using JDate, for example:

```
$date = new JDate();
$date->format('H:i:s')
```

This example return the current time but using the GMT timezone and not using the saved into the Joomla! configuration (in my case 'America/Argentina/Buenos_Aires' GMT-3).

With the current patch, this bug is fixed.
