### PR TITLE
[3.4] Fix CS and the bootstrap dropdown on com_postinstall

### DIFF
--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -8,54 +8,56 @@
  */
 
 defined('_JEXEC') or die;
+
+JHtml::_('formbehavior.chosen', 'select');
 ?>
 
 <form action="index.php" method="post" name="adminForm" class="form-inline">
 	<input type="hidden" name="option" value="com_postinstall">
-	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR') ?></label>
+	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
 	<?php echo JHTML::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
 </form>
 
-<?php if (empty($this->items)): ?>
+<?php if (empty($this->items)) : ?>
 <div class="hero-unit">
-	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE') ?></h2>
-	<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC') ?></p>
+	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
+	<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
 	<a href="index.php?option=com_postinstall&view=messages&task=reset&eid=<?php echo $this->eid; ?>&<?php echo $this->token ?>=1" class="btn btn-warning btn-large">
 		<span class="icon icon-eye-open"></span>
-		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET') ?>
+		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET'); ?>
 	</a>
 </div>
 <?php else: ?>
-<?php if ($this->eid == 700): ?>
+<?php if ($this->eid == 700) : ?>
 <div class="row-fluid">
 	<div class="span8">
 <?php endif; ?>
-	<?php foreach($this->items as $item): ?>
+	<?php foreach($this->items as $item) : ?>
 	<fieldset>
-		<legend><?php echo JText::_($item->title_key) ?></legend>
+		<legend><?php echo JText::_($item->title_key); ?></legend>
 		<p class="small">
-			<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced) ?>
+			<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced); ?>
 		</p>
-		<p><?php echo JText::_($item->description_key) ?></p>
+		<p><?php echo JText::_($item->description_key); ?></p>
 
 		<div>
-			<?php if ($item->type !== 'message'): ?>
+			<?php if ($item->type !== 'message') : ?>
 			<a href="index.php?option=com_postinstall&view=messages&task=action&id=<?php echo $item->postinstall_message_id ?>&<?php echo $this->token ?>=1" class="btn btn-primary">
-				<?php echo JText::_($item->action_key) ?>
+				<?php echo JText::_($item->action_key); ?>
 			</a>
 			<?php endif; ?>
 			<?php if (JFactory::getUser()->authorise('core.edit.state', 'com_postinstall')) : ?>
 			<a href="index.php?option=com_postinstall&view=message&task=unpublish&id=<?php echo $item->postinstall_message_id ?>&<?php echo $this->token ?>=1" class="btn btn-inverse btn-small">
-				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE') ?>
+				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE'); ?>
 			</a>
 			<?php endif; ?>
 		</div>
 	</fieldset>
 	<?php endforeach; ?>
-<?php if ($this->eid == 700): ?>
+<?php if ($this->eid == 700) : ?>
 	</div>
 	<div class="span4">
-		<h2><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS') ?></h2>
+		<h2><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS'); ?></h2>
 		<iframe width="100%" height="1000" src="http://www.joomla.org/announcements/release-news">
 		</iframe>
 	</div>

--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -13,6 +13,12 @@ JHtml::_('formbehavior.chosen', 'select');
 
 ?>
 
+<form action="index.php" method="post" name="adminForm" class="form-inline">
+	<input type="hidden" name="option" value="com_postinstall">
+	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR') ?></label>
+	<?php echo JHTML::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
+</form>
+
 <?php if (empty($this->items)): ?>
 <div class="hero-unit">
 	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE') ?></h2>
@@ -27,7 +33,6 @@ JHtml::_('formbehavior.chosen', 'select');
 <div class="row-fluid">
 	<div class="span8">
 <?php endif; ?>
-	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_MESSAGES') ?></h2>
 	<?php foreach($this->items as $item): ?>
 	<fieldset>
 		<legend><?php echo JText::_($item->title_key) ?></legend>

--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -10,54 +10,50 @@
 defined('_JEXEC') or die;
 
 JHtml::_('formbehavior.chosen', 'select');
+
 ?>
 
-<form action="index.php" method="post" name="adminForm" class="form-inline">
-	<input type="hidden" name="option" value="com_postinstall">
-	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
-	<?php echo JHTML::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
-</form>
-
-<?php if (empty($this->items)) : ?>
+<?php if (empty($this->items)): ?>
 <div class="hero-unit">
-	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
-	<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
+	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE') ?></h2>
+	<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC') ?></p>
 	<a href="index.php?option=com_postinstall&view=messages&task=reset&eid=<?php echo $this->eid; ?>&<?php echo $this->token ?>=1" class="btn btn-warning btn-large">
 		<span class="icon icon-eye-open"></span>
-		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET'); ?>
+		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET') ?>
 	</a>
 </div>
 <?php else: ?>
-<?php if ($this->eid == 700) : ?>
+<?php if ($this->eid == 700): ?>
 <div class="row-fluid">
 	<div class="span8">
 <?php endif; ?>
-	<?php foreach($this->items as $item) : ?>
+	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_MESSAGES') ?></h2>
+	<?php foreach($this->items as $item): ?>
 	<fieldset>
-		<legend><?php echo JText::_($item->title_key); ?></legend>
+		<legend><?php echo JText::_($item->title_key) ?></legend>
 		<p class="small">
-			<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced); ?>
+			<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced) ?>
 		</p>
-		<p><?php echo JText::_($item->description_key); ?></p>
+		<p><?php echo JText::_($item->description_key) ?></p>
 
 		<div>
-			<?php if ($item->type !== 'message') : ?>
+			<?php if ($item->type !== 'message'): ?>
 			<a href="index.php?option=com_postinstall&view=messages&task=action&id=<?php echo $item->postinstall_message_id ?>&<?php echo $this->token ?>=1" class="btn btn-primary">
-				<?php echo JText::_($item->action_key); ?>
+				<?php echo JText::_($item->action_key) ?>
 			</a>
 			<?php endif; ?>
 			<?php if (JFactory::getUser()->authorise('core.edit.state', 'com_postinstall')) : ?>
 			<a href="index.php?option=com_postinstall&view=message&task=unpublish&id=<?php echo $item->postinstall_message_id ?>&<?php echo $this->token ?>=1" class="btn btn-inverse btn-small">
-				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE'); ?>
+				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE') ?>
 			</a>
 			<?php endif; ?>
 		</div>
 	</fieldset>
 	<?php endforeach; ?>
-<?php if ($this->eid == 700) : ?>
+<?php if ($this->eid == 700): ?>
 	</div>
 	<div class="span4">
-		<h2><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS'); ?></h2>
+		<h2><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS') ?></h2>
 		<iframe width="100%" height="1000" src="http://www.joomla.org/announcements/release-news">
 		</iframe>
 	</div>


### PR DESCRIPTION
This fix CS and the bootstrap dropdown on com_postinstall
#### Bevor Patch

![current_com_postinstall](https://cloud.githubusercontent.com/assets/2596554/4434833/18e651a6-4727-11e4-8b2f-c4a1cd7dc556.JPG)
#### After Patch

![fixed_com_postinstall](https://cloud.githubusercontent.com/assets/2596554/4434837/2280b274-4727-11e4-83a8-9cc0e141bfba.JPG)
