### PR TITLE
Fix Fatal error when create external url menu item has &table= in the url

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -649,7 +649,8 @@ class MenusModelItem extends JModelAdmin
 			case 'url':
 				$table->component_id = 0;
 
-				parse_str(parse_url($table->link, PHP_URL_QUERY));
+				$args = array();
+				parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
 				break;
 
 			case 'component':
@@ -666,7 +667,7 @@ class MenusModelItem extends JModelAdmin
 					// Load the language file for the component.
 					$lang = JFactory::getLanguage();
 					$lang->load($args['option'], JPATH_ADMINISTRATOR, null, false, true)
-						|| $lang->load($args['option'], JPATH_ADMINISTRATOR . '/components/' . $args['option'], null, false, true);
+					|| $lang->load($args['option'], JPATH_ADMINISTRATOR . '/components/' . $args['option'], null, false, true);
 
 					// Determine the component id.
 					$component = JComponentHelper::getComponent($args['option']);
@@ -702,21 +703,16 @@ class MenusModelItem extends JModelAdmin
 		if ($table->type == 'alias')
 		{
 			// Note that all request arguments become reserved parameter names.
-			$args = array();
-			parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
 			$result->params = array_merge($result->params, $args);
 		}
 
 		if ($table->type == 'url')
 		{
 			// Note that all request arguments become reserved parameter names.
-			$args = array();
-			parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
 			$result->params = array_merge($result->params, $args);
 		}
 
 		// Load associated menu items
-		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 		if ($assoc)
 		{
@@ -905,8 +901,8 @@ class MenusModelItem extends JModelAdmin
 
 				// Check for the layout XML file. Use standard xml file if it exists.
 				$tplFolders = array(
-						$base . '/views/' . $view . '/tmpl',
-						$base . '/view/' . $view . '/tmpl'
+					$base . '/views/' . $view . '/tmpl',
+					$base . '/view/' . $view . '/tmpl'
 				);
 				$path = JPath::find($tplFolders, $layout . '.xml');
 
@@ -934,8 +930,8 @@ class MenusModelItem extends JModelAdmin
 				if (isset($view))
 				{
 					$metadataFolders = array(
-							$base . '/view/' . $view,
-							$base . '/views/' . $view
+						$base . '/view/' . $view,
+						$base . '/views/' . $view
 					);
 					$metaPath = JPath::find($metadataFolders, 'metadata.xml');
 


### PR DESCRIPTION
This pull request fixes the Fatal error issue which is reported at https://groups.google.com/forum/#!topic/joomla-dev-general/vNaXN3RGmb8

The reason of the error is because the link has table variable in query string and after the command in line 652 parse_str(parse_url($table->link, PHP_URL_QUERY)); , the table object (which is a local variable in the method) is replaced by the value of table variable in the link (which is an integer value in the sample link) and causes the fatal error when the method $table->getProperties(1); is called (because $table is not an object anymore).

How to test :
1. Create an menu item, type external url, type the sample link http://sbkost.sm-u.de/index.php?seite=spielplan&table=993 (or any url which has table variable in query string)
2. Save it and you will see the fatal error
3. Apply this patch
4. Check it again and make sure the URL is saved.

I also made some small changes the code of getItem method:
1. Remove the line of code parse_str(parse_url($table->link, PHP_URL_QUERY), $args); because it is written in switch block already.
2. Remove the command $app = JFactory::getApplication(); because the $app variable is not used in that method at all.
