### PR TITLE
Not generating URLs with "limitstart=0"

### DIFF
--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -781,7 +781,7 @@ class JPagination
 			// @todo remove code: $page = $page == 0 ? '' : $page;
 
 			$data->start->base = '0';
-			$data->start->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=0');
+			$data->start->link = JRoute::_($params);
 			$data->previous->base = $page;
 			$data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
 		}
@@ -813,7 +813,14 @@ class JPagination
 			if ($i != $this->pagesCurrent || $this->viewall)
 			{
 				$data->pages[$i]->base = $offset;
-				$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+				if ($offset == 0)
+				{
+					$data->pages[$i]->link = JRoute::_($params);
+				}
+				else
+				{
+					$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+				}
 			}
 			else
 			{

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -532,7 +532,8 @@ class JRouterSite extends JRouter
 		// Process the pagination support
 		if ($this->_mode == JROUTER_MODE_SEF)
 		{
-			if ($start = $uri->getVar('start'))
+			$start = (int) $uri->getVar('start', -1)
+			if ($start >= 0)
 			{
 				$uri->delVar('start');
 				$vars['limitstart'] = $start;
@@ -579,9 +580,9 @@ class JRouterSite extends JRouter
 
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
-			$limitstart = (int) $uri->getVar('limitstart');
+			$limitstart = (int) $uri->getVar('limitstart', -1);
 
-			if ($limitstart > 0)
+			if ($limitstart >= 0)
 			{
 				$uri->setVar('start', $limitstart);
 			}

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -532,7 +532,7 @@ class JRouterSite extends JRouter
 		// Process the pagination support
 		if ($this->_mode == JROUTER_MODE_SEF)
 		{
-			$start = (int) $uri->getVar('start', -1)
+			$start = (int) $uri->getVar('start', -1);
 			if ($start >= 0)
 			{
 				$uri->delVar('start');


### PR DESCRIPTION
Instead of removing the "limitstart" parameter in the router file (see https://github.com/joomla/joomla-cms/pull/3725 ), we do not generate URLs with "limitstart=0".
Kind of weird to add it there to be then removed in the router, isn't it?

So components will be able to use the parameter "limitstart=0" if they want to... and we still avoid the duplicate url issue we used to have.
Sounds like a win / win! :)
