### PR TITLE
[fix] error when adding tags with keyboard. Fixes #4394

### DIFF
--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -163,10 +163,9 @@ abstract class JHtmlTag
 	 */
 	public static function ajaxfield($selector='#jform_tags', $allowCustom = true)
 	{
-
 		// Get the component parameters
 		$params = JComponentHelper::getParams("com_tags");
-		$minTermLength = (int) $params->get("min_term_length");
+		$minTermLength = (int) $params->get("min_term_length", 3);
 
 		// Tags field ajax
 		$chosenAjaxSettings = new JRegistry(
@@ -193,8 +192,8 @@ abstract class JHtmlTag
 						// Method to add tags pressing enter
 						$('" . $selector . "_chzn input').keyup(function(event) {
 
-							// Tag is greater than 3 chars and enter pressed
-							if (this.value.length >= " . $minTermLength . " && (event.which === 13 || event.which === 188)) {
+							// Tag is greater than the minimum required chars and enter pressed
+							if (this.value && this.value.length >= " . $minTermLength . " && (event.which === 13 || event.which === 188)) {
 
 								// Search an highlighted result
 								var highlighted = $('" . $selector . "_chzn').find('li.active-result.highlighted').first();


### PR DESCRIPTION
This fixes the issue described in:
https://github.com/joomla/joomla-cms/issues/4394

This was introduced in: https://github.com/joomla/joomla-cms/commit/88ed53e960c70830d6cce2a16add1dec2a79808e#diff-0fe9e3814af6ea886d29a21726738a2aR166

Apparently minTermLength fix from @davidhurley's didn't include a default value for the setting. So it was using 0 as minimum length (until you save the `com_params` config). I added an extra `this.value` check to be sure that an empty tag is never going to be added even if someone manages to use 0 as `minTermLength` (which should not be possible because the minimum in config is 1).
