### PR TITLE
Removes self-linking article title

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -45,11 +45,7 @@ if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->
 	<div class="page-header">
 		<h2 itemprop="name">
 			<?php if ($params->get('show_title')) : ?>
-				<?php if ($params->get('link_titles') && !empty($this->item->readmore_link)) : ?>
-					<a href="<?php echo $this->item->readmore_link; ?>" itemprop="url"> <?php echo $this->escape($this->item->title); ?></a>
-				<?php else : ?>
-					<?php echo $this->escape($this->item->title); ?>
-				<?php endif; ?>
+				<?php echo $this->escape($this->item->title); ?>
 			<?php endif; ?>
 		</h2>
 		<?php if ($this->item->state == 0) : ?>


### PR DESCRIPTION
# Link not unto thyself

When linked article titles are enabled titles are not only linked to from blog, featured and list pages, but also in the article view itself.  This is clearly nonsensical, as the linked title of /my-awesome-post links only to /my-awesome-post.

This PR removes title linking in the article view.
## Test

After applying this patch an article title will no longer pointlessly link to itself, saving link-juice, mobius-logic and link-colored pixels.
