### PR TITLE
Makes a list of tags into… a list!

### DIFF
--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -13,17 +13,17 @@ JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/
 
 ?>
 <?php if (!empty($displayData)) : ?>
-	<div class="tags">
+	<ul class="tags inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id')))) : ?>
 				<?php $tagParams = new JRegistry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
-				<span class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">
+				<li class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">
 					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . '-' . $tag->alias)) ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
-				</span>
+				</li>
 			<?php endif; ?>
 		<?php endforeach; ?>
-	</div>
+	</ul>
 <?php endif; ?>


### PR DESCRIPTION
# Tag, you're it!

A list of tags is logically just that, a list, making a list element is the correct semantic choice for a containing element. Span makes no sense in this context and appears to have been used simply to render the tags inline. 

Using the wrong element to achieve a certain visual appearance is **bad**.
## Get a free froghurt

This PR implements the correct html tag for the job at hand and throws list items inline using Bootstrap's purpose-made .inline class, saving on additional css.
### The frogurt is also cursed

Bootstrap's padding on inline-list elements is slightly greater than one letterspace (the whitespace that exists naturally between span elements), so tags will be spaced slightly further apart after this change.
#### But you get a free topping

This is actually beneficial because natural whitespace can be affected in unpredictable ways by, for example, extensions that minify the html. That would remove natural whitespace causing tags to smash into each other, something which would be prevented by this change.
