### PR TITLE
Add update channel for the update component

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.3.6-2014-09-30.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.3.6-2014-09-30.sql
@@ -1,0 +1,5 @@
+INSERT INTO `#__update_sites` (`name`, `type`, `location`, `enabled`) VALUES
+('Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1);
+
+INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
+((SELECT `update_site_id` FROM `#__update_sites` WHERE `name` = 'Joomla! Update Component Update Site'), (SELECT `extension_id` FROM `#__extensions` WHERE `name` = 'com_joomlaupdate'));

--- a/administrator/components/com_admin/sql/updates/postgresql/3.3.6-2014-09-30.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.3.6-2014-09-30.sql
@@ -1,0 +1,5 @@
+INSERT INTO "#__update_sites" ("name", "type", "location", "enabled") VALUES
+('Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1);
+
+INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
+((SELECT "update_site_id" FROM "#__update_sites" WHERE "name" = 'Joomla! Update Component Update Site'), (SELECT "extension_id" FROM "#__extensions" WHERE "name" = 'com_joomlaupdate'));

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.3.6-2014-09-30.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.3.6-2014-09-30.sql
@@ -1,0 +1,5 @@
+INSERT INTO [#__update_sites] ([name], [type], [location], [enabled])
+SELECT 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1;
+
+INSERT INTO [#__update_sites_extensions] ([update_site_id], [extension_id])
+SELECT (SELECT [update_site_id] FROM [#__update_sites] WHERE [name] = 'Joomla! Update Component Update Site'), (SELECT [extension_id] FROM [#__extensions] WHERE [name] = 'com_joomlaupdate');

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -26,5 +26,8 @@
 			<language tag="en-GB">language/en-GB.com_joomlaupdate.sys.ini</language>
 		</languages>
 	</administration>
+	<updateservers>
+		<server type="extension" name="Joomla! Update Component Update Site">http://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
+	</updateservers>
 </extension>
 

--- a/build.xml
+++ b/build.xml
@@ -130,6 +130,21 @@
 		</apply>
 	</target>
 
+	<target name="make-updatecomponent" description="Create an installable package from the com_joomlaupdate component" >
+		<delete dir="${basedir}/build/com_joomlaupdate-pkg" includeemptydirs="true" failonerror="false" />
+		<mkdir dir="${basedir}/build/com_joomlaupdate-pkg" />
+		<echo message="Create com_joomlaupdate package" />
+		<mkdir dir="${basedir}/build/com_joomlaupdate-pkg/staging" />
+		<mkdir dir="${basedir}/build/com_joomlaupdate-pkg/staging/admin" />
+		<copy todir="${basedir}/build/com_joomlaupdate-pkg/staging/admin">
+			<fileset dir="${basedir}/administrator/components/com_joomlaupdate" />
+		</copy>
+		<move file="${basedir}/build/com_joomlaupdate-pkg/staging/admin/joomlaupdate.xml" todir="${basedir}/build/com_joomlaupdate-pkg/staging" />
+
+		<echo message="Archiving package" />
+		<mkdir dir="${basedir}/build/com_joomlaupdate-pkg/packages" />
+		<zip destfile="${basedir}/build/com_joomlaupdate-pkg/packages/com_joomlaupdate.zip" basedir="${basedir}/build/com_joomlaupdate-pkg/staging" />
+	</target>
 
 	<target name="build" depends="clean,phpunit,parallelTasks" />
 </project>

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -6,3 +6,4 @@
 
 # Ignore the folder the build script creates for packages
 /tmp
+/com_joomlaupdate-pkg

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1795,7 +1795,8 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
 (1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
 (2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0);
+(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 -- --------------------------------------------------------
 
@@ -1816,7 +1817,8 @@ CREATE TABLE IF NOT EXISTS `#__update_sites_extensions` (
 INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
 (1, 700),
 (2, 700),
-(3, 600);
+(3, 600),
+(4, 28);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1716,7 +1716,8 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
 (1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
 (2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0);
+(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 --
 -- Table: #__update_sites_extensions
@@ -1735,7 +1736,8 @@ COMMENT ON TABLE "#__update_sites_extensions" IS 'Links extensions to update sit
 INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
 (1, 700),
 (2, 700),
-(3, 600);
+(3, 600),
+(4, 28);
 
 --
 -- Table: #__usergroups

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2753,7 +2753,9 @@ SELECT 1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml'
 UNION ALL
 SELECT 2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0
 UNION ALL
-SELECT 3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0;
+SELECT 3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0
+UNION ALL
+SELECT 4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0;
 
 SET IDENTITY_INSERT [#__update_sites] OFF;
 
@@ -2775,7 +2777,9 @@ SELECT 1, 700
 UNION ALL
 SELECT 2, 700
 UNION ALL
-SELECT 3, 600;
+SELECT 3, 600
+UNION ALL
+SELECT 4, 28;
 
 /****** Object:  Table [#__updates] ******/
 SET QUOTED_IDENTIFIER ON;


### PR DESCRIPTION
This PR will add an update channel for our update component which will allow for updates to the component to be distributed separate from a CMS release.
### Why?

If we were to ever have a repeat of what happened with 3.1.1 through 3.1.4 or in a rare instance where an update to the component was required in order to update the CMS, the update component would potentially fail when trying to update its own files.  Adding this update channel allows the update component to be updated with Joomla's integrated extension update mechanisms, which would not use the code in the update component, and provides a fallback in case of such an emergency.
### Testing Instructions

A new installation should have new database entries in the `#__update_sites` and `#__update_sites_extensions` table for this stream.  Upgraded installations should also get the channel but without known ID values (hence the subqueries in the update SQL files).  Updates on this channel will not work at this time, an XML file has not been provisioned at the coded location.
