### PR TITLE
Block party

### DIFF
--- a/layouts/joomla/content/info_block/author.php
+++ b/layouts/joomla/content/info_block/author.php
@@ -10,12 +10,11 @@
 defined('JPATH_BASE') or die;
 
 ?>
-<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
-	<?php $author = ($displayData['item']->created_by_alias ? $displayData['item']->created_by_alias : $displayData['item']->author); ?>
-	<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
-	<?php if (!empty($displayData['item']->contact_link ) && $displayData['params']->get('link_author') == true) : ?>
-		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author, array('itemprop' => 'url'))); ?>
-	<?php else :?>
-		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
-	<?php endif; ?>
-</dd>
+
+<?php $author = ($displayData['item']->created_by_alias ? $displayData['item']->created_by_alias : $displayData['item']->author); ?>
+<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
+<?php if (!empty($displayData['item']->contact_link ) && $displayData['params']->get('link_author') == true) : ?>
+	<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author, array('itemprop' => 'url'))); ?>
+<?php else :?>
+	<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
+<?php endif; ?>

--- a/layouts/joomla/content/info_block/block.php
+++ b/layouts/joomla/content/info_block/block.php
@@ -12,49 +12,65 @@ defined('JPATH_BASE') or die;
 $blockPosition = $displayData['params']->get('info_block_position', 0);
 
 ?>
-	<dl class="article-info  muted">
 
-		<?php if ($displayData['position'] == 'above' && ($blockPosition == 0 || $blockPosition == 2)
-				|| $displayData['position'] == 'below' && ($blockPosition == 1)
-				) : ?>
+<dl class="article-info muted">
 
-			<dt class="article-info-term">
-				<?php // TODO: implement info_block_show_title param to hide article info title ?>
-				<?php if ($displayData['params']->get('info_block_show_title', 1)) : ?>
-					<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
-				<?php endif; ?>
-			</dt>
+	<?php if ($displayData['position'] == 'above' && ($blockPosition == 0 || $blockPosition == 2)
+			|| $displayData['position'] == 'below' && ($blockPosition == 1)
+			) : ?>
 
-			<?php if ($displayData['params']->get('show_author') && !empty($displayData['item']->author )) : ?>
+		<dt class="article-info-term">
+			<?php // TODO: implement info_block_show_title param to hide article info title ?>
+			<?php if ($displayData['params']->get('info_block_show_title', 1)) : ?>
+				<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
+			<?php endif; ?>
+		</dt>
+
+		<?php if ($displayData['params']->get('show_author') && !empty($displayData['item']->author )) : ?>
+			<dd class="createdby" itemprop="author" itemscope itemtype="http://schema.org/Person">
 				<?php echo JLayoutHelper::render('joomla.content.info_block.author', $displayData); ?>
-			<?php endif; ?>
+			</dd>
+		<?php endif; ?>
 
-			<?php if ($displayData['params']->get('show_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
+		<?php if ($displayData['params']->get('show_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
+			<dd class="parent-category-name">
 				<?php echo JLayoutHelper::render('joomla.content.info_block.parent_category', $displayData); ?>
-			<?php endif; ?>
+			</dd>
+		<?php endif; ?>
 
-			<?php if ($displayData['params']->get('show_category')) : ?>
+		<?php if ($displayData['params']->get('show_category')) : ?>
+			<dd class="category-name">
 				<?php echo JLayoutHelper::render('joomla.content.info_block.category', $displayData); ?>
-			<?php endif; ?>
+			</dd>
+		<?php endif; ?>
 
-			<?php if ($displayData['params']->get('show_publish_date')) : ?>
+		<?php if ($displayData['params']->get('show_publish_date')) : ?>
+			<dd class="published">
 				<?php echo JLayoutHelper::render('joomla.content.info_block.publish_date', $displayData); ?>
-			<?php endif; ?>
+			</dd>
 		<?php endif; ?>
+	<?php endif; ?>
 
-		<?php if ($displayData['position'] == 'above' && ($blockPosition == 0)
-				|| $displayData['position'] == 'below' && ($blockPosition == 1 || $blockPosition == 2)
-				) : ?>
-			<?php if ($displayData['params']->get('show_create_date')) : ?>
+	<?php if ($displayData['position'] == 'above' && ($blockPosition == 0)
+			|| $displayData['position'] == 'below' && ($blockPosition == 1 || $blockPosition == 2)
+			) : ?>
+		<?php if ($displayData['params']->get('show_create_date')) : ?>
+			<dd class="create">
 				<?php echo JLayoutHelper::render('joomla.content.info_block.create_date', $displayData); ?>
-			<?php endif; ?>
-
-			<?php if ($displayData['params']->get('show_modify_date')) : ?>
-				<?php echo JLayoutHelper::render('joomla.content.info_block.modify_date', $displayData); ?>
-			<?php endif; ?>
-
-			<?php if ($displayData['params']->get('show_hits')) : ?>
-				<?php echo JLayoutHelper::render('joomla.content.info_block.hits', $displayData); ?>
-			<?php endif; ?>
+			</dd>
 		<?php endif; ?>
-	</dl>
+
+		<?php if ($displayData['params']->get('show_modify_date')) : ?>
+			<dd class="modified">
+				<?php echo JLayoutHelper::render('joomla.content.info_block.modify_date', $displayData); ?>
+			</dd>
+		<?php endif; ?>
+
+		<?php if ($displayData['params']->get('show_hits')) : ?>
+			<dd class="hits">
+				<?php echo JLayoutHelper::render('joomla.content.info_block.hits', $displayData); ?>
+			</dd>
+		<?php endif; ?>
+	<?php endif; ?>
+
+</dl>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -10,12 +10,11 @@
 defined('JPATH_BASE') or die;
 
 ?>
-			<dd class="category-name">
-				<?php $title = $this->escape($displayData['item']->category_title); ?>
-				<?php if ($displayData['params']->get('link_category') && $displayData['item']->catslug) : ?>
-					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
-					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
-				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
-				<?php endif; ?>
-			</dd>
+
+<?php $title = $this->escape($displayData['item']->category_title); ?>
+<?php if ($displayData['params']->get('link_category') && $displayData['item']->catslug) : ?>
+	<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+	<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
+<?php else : ?>
+	<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
+<?php endif; ?>			

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -17,4 +17,4 @@ defined('JPATH_BASE') or die;
 	<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 <?php else : ?>
 	<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
-<?php endif; ?>			
+<?php endif; ?>

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -10,9 +10,8 @@
 defined('JPATH_BASE') or die;
 
 ?>
-			<dd class="create">
-					<span class="icon-calendar"></span>
-					<time datetime="<?php echo JHtml::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
-						<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $displayData['item']->created, JText::_('DATE_FORMAT_LC3'))); ?>
-					</time>
-			</dd>
+
+<span class="icon-calendar"></span>
+<time datetime="<?php echo JHtml::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
+	<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $displayData['item']->created, JText::_('DATE_FORMAT_LC3'))); ?>
+</time>

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -10,8 +10,7 @@
 defined('JPATH_BASE') or die;
 
 ?>
-			<dd class="hits">
-					<span class="icon-eye-open"></span>
-					<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>" />
-					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
-			</dd>
+
+<span class="icon-eye-open"></span>
+<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>" />
+<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>

--- a/layouts/joomla/content/info_block/modify_date.php
+++ b/layouts/joomla/content/info_block/modify_date.php
@@ -10,9 +10,8 @@
 defined('JPATH_BASE') or die;
 
 ?>
-			<dd class="modified">
-				<span class="icon-calendar"></span>
-				<time datetime="<?php echo JHtml::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
-					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $displayData['item']->modified, JText::_('DATE_FORMAT_LC3'))); ?>
-				</time>
-			</dd>
+
+<span class="icon-calendar"></span>
+<time datetime="<?php echo JHtml::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
+	<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $displayData['item']->modified, JText::_('DATE_FORMAT_LC3'))); ?>
+</time>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -10,12 +10,11 @@
 defined('JPATH_BASE') or die;
 
 ?>
-			<dd class="parent-category-name">
-				<?php $title = $this->escape($displayData['item']->parent_title); ?>
-				<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
-					<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
-					<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
-				<?php else : ?>
-					<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
-				<?php endif; ?>
-			</dd>
+
+<?php $title = $this->escape($displayData['item']->parent_title); ?>
+<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
+	<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+	<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
+<?php else : ?>
+	<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
+<?php endif; ?>

--- a/layouts/joomla/content/info_block/publish_date.php
+++ b/layouts/joomla/content/info_block/publish_date.php
@@ -9,9 +9,8 @@
 
 defined('JPATH_BASE') or die;
 ?>
-			<dd class="published">
-				<span class="icon-calendar"></span>
-				<time datetime="<?php echo JHtml::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
-					<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $displayData['item']->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
-				</time>
-			</dd>
+
+<span class="icon-calendar"></span>
+<time datetime="<?php echo JHtml::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
+	<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $displayData['item']->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
+</time>


### PR DESCRIPTION
# A premise, I promise

I think in order to facilitate ease-of-use, readability and maintenance related, and dependant, html should be rendered in one place. This is why we have layouts, after all. 
## Paints go in a paintbox, pencils in a pencil tin.

Currently, the interdependent markup for the article infoblock is scattered across 8 files. The parent block.php defines the content as a document list and each child element contains the document definition. 

The problem? a `<dd>` can not live a life independent of a `<dl>`, so these structural markup elements should live together.
### Once upon a time…

A young prince (not me) decided that his document information would be better served as a list of items and set out upon a great and noble quest. However, upon reaching the hitherto little-trod realm of `/layouts/joomla/content/info-block` this young prince did discover he must slay(override) not 1, but 8 fearsome dragons(layout files). This brought great sadness upon our hero and he was avowed to forge, with great cunning, a plan such that none should have to endure these trials again.

:hocho: :dragon: 
## TL:DR;

This PR pulls related markup from the 8 infoblock overrides into the parent, infoblock.php. This means that any wishing to change the markup, to an unordered list or simple paragraph for example, can do so with just one override.
### Testing

Apply patch and check that neither appearance or markup of article info block is changed.
