### PR TITLE
fix in table related to defining protected variable with underscore

### DIFF
--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -21,7 +21,7 @@ class ContactTableContact extends JTable
 	 * @var    array
 	 * @since  3.3
 	 */
-	protected $jsonEncode = array('params', 'metadata');
+	protected $_jsonEncode = array('params', 'metadata');
 
 	/**
 	 * Constructor

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -21,7 +21,7 @@ class NewsfeedsTableNewsfeed extends JTable
 	 * @var    array
 	 * @since  3.3
 	 */
-	protected $jsonEncode = array('params', 'metadata', 'images');
+	protected $_jsonEncode = array('params', 'metadata', 'images');
 
 	/**
 	 * Constructor

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -110,7 +110,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 * @var    array
 	 * @since  3.3
 	 */
-	protected $jsonEncode = array();
+	protected $_jsonEncode = array();
 
 	/**
 	 * Object constructor to set table and key fields.  In most cases this will
@@ -593,9 +593,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	public function bind($src, $ignore = array())
 	{
 		// JSON encode any fields required
-		if (!empty($this->jsonEncode))
+		if (!empty($this->_jsonEncode))
 		{
-			foreach ($this->jsonEncode as $field)
+			foreach ($this->_jsonEncode as $field)
 			{
 				if (isset($src[$field]) && is_array($src[$field]))
 				{

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -354,7 +354,7 @@ class JTableTest extends TestCaseDatabase
 	 */
 	public function testBind()
 	{
-		TestReflection::setValue($this->object, 'jsonEncode', array('params'));
+		TestReflection::setValue($this->object, '_jsonEncode', array('params'));
 		$this->object->bind(array('id1' => 25, 'id2' => 50, 'title' => 'My Title', 'params' => array('param1' => 'value1', 'param2' => 25)));
 
 		$this->assertEquals(


### PR DESCRIPTION
Protected variable is not defined with starting as '_'(underscore), so it is not filtering out afterwards in getPropeties function and creating fatal error issue that trying to access protected function.
For example. If we call getProperties function on Jtable and apply loop on that, then jsonEncode variable also comes in that. And thus causing fatal error

  $vars = $this->getTable()->getProperties(); // $this->getTable gives the instance of desired table which is extended with Jtable. $vars contain $jsonEncode variable also.
  $retObj = new stdClass();

  $table = $this->getTable();
  $table->load(null);

  foreach($vars as $key => $value) {

   $retObj->$key = $table->$key; 
  }
