### PR TITLE
Update repeatable-uncompressed.js

### DIFF
--- a/media/system/js/repeatable-uncompressed.js
+++ b/media/system/js/repeatable-uncompressed.js
@@ -28,7 +28,7 @@
             mask.show();
 
             // Set original content for cancel
-            origContent = getTrs().clone();
+            origContent = getTrs();
         };
 
         /**


### PR DESCRIPTION
This fix will solve the problem of duplicate data when the modal of the repeatable element is closed. Currently when you press cancel and reopen the modal view of the repeatble element, the data that was already present is now duplicated. The probblem was found and fixed by JohhnyPixel: http://joomla.stackexchange.com/users/427/jonnypixel
The problem was reported and fixed here: http://joomla.stackexchange.com/a/903
