### PR TITLE
Correctly translate name of library using Joomla! language sys file.

### DIFF
--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -169,7 +169,7 @@ class InstallerModel extends JModelList
 					||	$lang->load("$extension.sys", $source, null, false, true);
 				break;
 			}
-			if (!in_array($item->type, array('language', 'template', 'library')))
+			if (!in_array($item->type, array('language', 'template')))
 			{
 				$item->name = JText::_($item->name);
 			}

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -40,7 +40,7 @@ class JInstallerAdapterLibrary extends JAdapterInstance
 		}
 
 		$this->manifest = $this->parent->getManifest();
-		$extension = 'lib_' . strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
+		$extension = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
 		$name = strtolower((string) $this->manifest->libraryname);
 		$lang = JFactory::getLanguage();
 		$source = $path ? $path : JPATH_PLATFORM . "/$name";

--- a/tests/unit/suites/libraries/cms/installer/data/joomla.xml
+++ b/tests/unit/suites/libraries/cms/installer/data/joomla.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="library" version="2.5">
-    <name>Joomla! Platform</name>
+    <name>lib_joomla</name>
     <libraryname>joomla</libraryname>
     <version>11.4</version>
     <description>LIB_JOOMLA_XML_DESCRIPTION</description>

--- a/tests/unit/suites/libraries/cms/installer/manifest/JInstallerManifestLibraryTest.php
+++ b/tests/unit/suites/libraries/cms/installer/manifest/JInstallerManifestLibraryTest.php
@@ -35,7 +35,7 @@ class JInstallerManifestLibraryTest extends TestCase
 		$this->object = new JInstallerManifestLibrary(dirname(__DIR__) . '/data/joomla.xml');
 
 		$this->assertEquals(
-			'Joomla! Platform',
+			'lib_joomla',
 			$this->object->name
 		);
 


### PR DESCRIPTION
The library description is not being translated when installing a 3rd party library via the Extension Manager. Additionally the library name is hardcoded (i.e. cannot be translated). These problems are due to the incorrect naming of the language file when it is being loaded.

The pull request adds correct loading of the library language sys file during installation and when displaying the library name in the Manage page.
