### PR TITLE
Status of modules : missing pending and expired

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -159,7 +159,7 @@ $sortFields = $this->getSortFields();
 					</td>
 					<td class="center">
 						<div class="btn-group">
-							<?php echo JHtml::_('modules.state', $item->published, $i, $canChange, 'cb'); ?>
+							<?php echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 							<?php
 								// Create dropdown items
 								JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');


### PR DESCRIPTION
Fix to Brian request : https://github.com/joomla/joomla-cms/issues/4414

<pre>
Create a module with an end publishing date in the PAST. In the module list there is no visible change to its publishing status. It is still green. If you check an expired article you will see that the icon in the article list is orange not green to indicate it has expired.
</pre>
