### PR TITLE
Fix renderModules error when getTemplate called with true from included module templates

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -169,9 +169,6 @@ abstract class JModuleHelper
 		$params = new JRegistry;
 		$params->loadString($module->params);
 
-		// Get the template
-		$template = $app->getTemplate();
-
 		// Get module path
 		$module->module = preg_replace('/[^A-Z0-9_\.-]/i', '', $module->module);
 		$path = JPATH_BASE . '/modules/' . $module->module . '/' . $module->module . '.php';
@@ -199,7 +196,7 @@ abstract class JModuleHelper
 		}
 
 		include_once JPATH_THEMES . '/system/html/modules.php';
-		$chromePath = JPATH_THEMES . '/' . $template . '/html/modules.php';
+		$chromePath = JPATH_THEMES . '/' . $app->getTemplate() . '/html/modules.php';
 
 		if (!isset($chrome[$chromePath]))
 		{
@@ -216,7 +213,7 @@ abstract class JModuleHelper
 
 		if ($paramsChromeStyle)
 		{
-			$attribs['style'] = preg_replace('/^(system|' . $template . ')\-/i', '', $paramsChromeStyle);
+			$attribs['style'] = preg_replace('/^(system|' . $app->getTemplate() . ')\-/i', '', $paramsChromeStyle);
 		}
 
 		// Make sure a style is set


### PR DESCRIPTION
When getTemplate(true) is called from a module override (i.e. to retrieve template params), JModuleHelper renderModules method breaks because the $template variable's value has changed from a string (the name of the template) to an object (holding the template's params) between being assigned and when actually called. This is due to module overrides being called after the variable has been assigned a value but before it is used by the chrome and attribs vars.

Instead of assigning to a $template var, getTemplate is called directly to ensure the template name is available rather than the stdClass.
