### PR TITLE
Remove close tag for an unopened span element.

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -144,7 +144,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						<?php endif; ?>
 					</td>
 					<td class="center hidden-phone">
-						<?php echo (int) $item->id; ?></span>
+						<?php echo (int) $item->id; ?>
 					</td>
 				</tr>
 			<?php endforeach; ?>


### PR DESCRIPTION
This is probably a close tag from the default.php list view where the id is enclosed in a span element with a title set to the lft and rgt of the item. The starting tag was removed but the closing tag was still there. Removing the close tag results in a cleaner and valid html code.
