### PR TITLE
Add if-not-empty check before foreach to prevent PHP warning (#4427)

### DIFF
--- a/libraries/legacy/view/categoryfeed.php
+++ b/libraries/legacy/view/categoryfeed.php
@@ -69,59 +69,62 @@ class JViewCategoryfeed extends JViewLegacy
 		$items    = $this->get('Items');
 		$category = $this->get('Category');
 
-		foreach ($items as $item)
+		if (!empty($items))
 		{
-			$this->reconcileNames($item);
-
-			// Strip html from feed item title
-			if ($titleField)
+			foreach ($items as $item)
 			{
-				$title = $this->escape($item->$titleField);
-				$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
-			}
-			else
-			{
-				$title = '';
-			}
+				$this->reconcileNames($item);
 
-			// URL link to article
-			$router = new JHelperRoute;
-			$link   = JRoute::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
+				// Strip html from feed item title
+				if ($titleField)
+				{
+					$title = $this->escape($item->$titleField);
+					$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
+				}
+				else
+				{
+					$title = '';
+				}
 
-			// Strip HTML from feed item description text.
-			$description = $item->description;
-			$author      = $item->created_by_alias ? $item->created_by_alias : $item->author;
+				// URL link to article
+				$router = new JHelperRoute;
+				$link   = JRoute::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
 
-			if ($createdField)
-			{
-				$date = isset($item->$createdField) ? date('r', strtotime($item->$createdField)) : '';
+				// Strip HTML from feed item description text.
+				$description = $item->description;
+				$author      = $item->created_by_alias ? $item->created_by_alias : $item->author;
+
+				if ($createdField)
+				{
+					$date = isset($item->$createdField) ? date('r', strtotime($item->$createdField)) : '';
+				}
+				else
+				{
+					$date = '';
+				}
+
+				// Load individual item creator class.
+				$feeditem              = new JFeedItem;
+				$feeditem->title       = $title;
+				$feeditem->link        = $link;
+				$feeditem->description = $description;
+				$feeditem->date        = $date;
+				$feeditem->category    = $category->title;
+				$feeditem->author      = $author;
+
+				// We don't have the author email so we have to use site in both cases.
+				if ($feedEmail == 'site')
+				{
+					$feeditem->authorEmail = $siteEmail;
+				}
+				elseif ($feedEmail === 'author')
+				{
+					$feeditem->authorEmail = $item->author_email;
+				}
+
+				// Loads item information into RSS array
+				$document->addItem($feeditem);
 			}
-			else
-			{
-				$date = '';
-			}
-
-			// Load individual item creator class.
-			$feeditem              = new JFeedItem;
-			$feeditem->title       = $title;
-			$feeditem->link        = $link;
-			$feeditem->description = $description;
-			$feeditem->date        = $date;
-			$feeditem->category    = $category->title;
-			$feeditem->author      = $author;
-
-			// We don't have the author email so we have to use site in both cases.
-			if ($feedEmail == 'site')
-			{
-				$feeditem->authorEmail = $siteEmail;
-			}
-			elseif ($feedEmail === 'author')
-			{
-				$feeditem->authorEmail = $item->author_email;
-			}
-
-			// Loads item information into RSS array
-			$document->addItem($feeditem);
 		}
 	}
 


### PR DESCRIPTION
#### Steps to reproduce the issue
- Enable PHP error reporting in your webserver
- Create an empty Joomla category with no articles
- Access this Joomla category URL in your browser - it should display no articles
- Append ?format=feed&type=rss to this URL
#### Expected result

This should not generate any PHP warning.
#### Actual result

This should generate a PHP warning in either your browser or in your PHP error_log. The problem is that the PHP code loops through a $this->items array without checking whether this array is actually empty or not.
#### Additional comments

GitHub pull request will come right after submitting the issue. The pull request will simply add a if-check around the foreach-loop to prevent the PHP warning.
