### PR TITLE
Fix for #4314 Wrong URL when search sub-category by tag if SEF is on

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -171,7 +171,7 @@ class ContentRouter extends JComponentRouterBase
 
 			if (!$advanced && count($array))
 			{
-				$array[0] = (int) $catid . ':' . $array[0];
+				$array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
 			}
 
 			$segments = array_merge($segments, $array);

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -171,7 +171,10 @@ class ContentRouter extends JComponentRouterBase
 
 			if (!$advanced && count($array))
 			{
-				$array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
+				$array[0] = (int) $catid . ':' . $array[0];
+                                if (count($array) > 1) {
+                                        $array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
+                                }
 			}
 
 			$segments = array_merge($segments, $array);


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/issues/4314
