### PR TITLE
Fix for menu item when install / update a component with same name as a plugin.

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1249,6 +1249,7 @@ class JInstallerAdapterComponent extends JAdapterInstance
 			$query->clear()
 				->select('e.extension_id')
 				->from('#__extensions AS e')
+				->where('e.type = ' . $db->quote('component'))
 				->where('e.element = ' . $db->quote($option));
 
 			$db->setQuery($query);


### PR DESCRIPTION
Menu Item can be assigned to the components only. If more extensions (component, plugin) with same name/element is installed then it's needed to load ID of the component. The same problem occurs in Joomla 2.5.x and 3.x.
