### PR TITLE
Fix for #4314 Wrong URL when search sub-category by tag if SEF is on

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -171,7 +171,7 @@ class ContentRouter extends JComponentRouterBase
 
 			if (!$advanced && count($array))
 			{
-				$array[0] = (int) $catid . ':' . $array[0];
+				$array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
 			}
 
 			$segments = array_merge($segments, $array);

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -171,7 +171,10 @@ class ContentRouter extends JComponentRouterBase
 
 			if (!$advanced && count($array))
 			{
-				$array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
+				$array[0] = (int) $catid . ':' . $array[0];
+                                if (count($array) > 1) {
+                                        $array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
+                                }
 			}
 
 			$segments = array_merge($segments, $array);

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -317,8 +317,10 @@ class ContentRouter extends JComponentRouterBase
 			{
 				$vars['view'] = 'article';
 				
-				foreach(array_reverse($segments) as $seg) {
-					if (preg_match('/^\d+\:/', $seg)) {
+				foreach(array_reverse($segments) as $seg)
+				{
+					if (preg_match('/^\d+\:/', $seg))
+					{
 						$vars['id'] = $seg;
 						break;
 					}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -172,9 +172,9 @@ class ContentRouter extends JComponentRouterBase
 			if (!$advanced && count($array))
 			{
 				$array[0] = (int) $catid . ':' . $array[0];
-                                if (count($array) > 1) {
-                                        $array[count($array)-1] = (int) $catid . ':' . $array[count($array)-1];
-                                }
+				if (count($array) > 1) {
+					$array[count($array) - 1] = (int) $catid . ':' . $array[count($array) - 1];
+				}
 			}
 
 			$segments = array_merge($segments, $array);

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -316,8 +316,8 @@ class ContentRouter extends JComponentRouterBase
 			if (strpos($segments[0], ':') === false)
 			{
 				$vars['view'] = 'article';
-				
-				foreach(array_reverse($segments) as $seg)
+
+				foreach (array_reverse($segments) as $seg)
 				{
 					if (preg_match('/^\d+\:/', $seg))
 					{

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -172,9 +172,6 @@ class ContentRouter extends JComponentRouterBase
 			if (!$advanced && count($array))
 			{
 				$array[0] = (int) $catid . ':' . $array[0];
-				if (count($array) > 1) {
-					$array[count($array) - 1] = (int) $catid . ':' . $array[count($array) - 1];
-				}
 			}
 
 			$segments = array_merge($segments, $array);
@@ -319,7 +316,13 @@ class ContentRouter extends JComponentRouterBase
 			if (strpos($segments[0], ':') === false)
 			{
 				$vars['view'] = 'article';
-				$vars['id'] = (int) $segments[0];
+				
+				foreach(array_reverse($segments) as $seg) {
+					if (preg_match('/^\d+\:/', $seg)) {
+						$vars['id'] = $seg;
+						break;
+					}
+				}
 
 				return $vars;
 			}


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Enable SEF.
2. Create "category1" with ID 1 and alias "alias1"
3. For "category1" create child "category2" with ID 2 and alias "alias2"
4. Create "tag1" and assign it to "category2"
5. Try to search by "tag1"
#### Expected result

In search result there will be right URL to "category2" like:
/index.php/component/content/category/1-alias1/2-alias2
or
/index.php/component/content/category/2-alias2
or
/index.php/component/content/category/alias1/2-alias2
or
/index.php/component/content/category/2-alias1/2-alias2
#### Actual result

In search result category2 has a wrong URL which gives 404 error
/index.php/component/content/category/2-alias1/alias2
#### System information (as much as possible)

Joomla 3.3.3
PHP 5.4
#### Additional comments

only if SEF is On
only if search by tag
