### PR TITLE
Ensure vars are always set if the default menu item is retrieved (Ref #4183)

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -255,6 +255,8 @@ class JRouterSite extends JRouter
 
 				// Set the active menu item
 				$menu->setActive($vars['Itemid']);
+
+				$this->setVars($vars);
 			}
 
 			return $vars;


### PR DESCRIPTION
This solves the edge case reported in #4183 where the redirect for a contact form being the site's homepage does not route as expected.  It was found that when the default menu item is being pulled, the vars from the query are not being set to the class object, which causes the redirect fail.
