### PR TITLE
Bootstrapization of pagebreak

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/pagebreak.php
+++ b/administrator/components/com_content/views/article/tmpl/pagebreak.php
@@ -29,28 +29,18 @@ $script .= '}'."\n";
 
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>
-	<form>
-		<table>
-			<tr>
-				<td class="key" align="right">
-					<label for="title">
-						<?php echo JText::_('COM_CONTENT_PAGEBREAK_TITLE'); ?>
-					</label>
-				</td>
-				<td>
-					<input type="text" id="title" name="title" />
-				</td>
-			</tr>
-			<tr>
-				<td class="key" align="right">
-					<label for="alias">
-						<?php echo JText::_('COM_CONTENT_PAGEBREAK_TOC'); ?>
-					</label>
-				</td>
-				<td>
-					<input type="text" id="alt" name="alt" />
-				</td>
-			</tr>
-		</table>
-	</form>
-	<button onclick="insertPagebreak();"><?php echo JText::_('COM_CONTENT_PAGEBREAK_INSERT_BUTTON'); ?></button>
+<form class="form-horizontal">
+	
+	<div class="control-group">
+		<label for="title" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TITLE'); ?></label>
+		<div class="controls"><input type="text" id="title" name="title" /></div>
+	</div>
+	
+	<div class="control-group">
+		<label for="alias" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TOC'); ?></label>
+		<div class="controls"><input type="text" id="alt" name="alt" /></div>		
+	</div>
+	
+	<button onclick="insertPagebreak();" class="btn btn-primary"><?php echo JText::_('COM_CONTENT_PAGEBREAK_INSERT_BUTTON'); ?></button>
+	
+</form>


### PR DESCRIPTION
At the moment the content of the pagebreak is lacking styling. This PR fixes this:
## Current behavior

![skaermbillede 2014-10-05 kl 19 29 47](https://cloud.githubusercontent.com/assets/1738811/4519263/5466734e-4cb5-11e4-974c-f436c7cd0521.png)
## After patch

![skaermbillede 2014-10-05 kl 19 29 57](https://cloud.githubusercontent.com/assets/1738811/4519264/546da0e2-4cb5-11e4-9c03-7eff7c5be211.png)
