### PR TITLE
Add formbehavior chosen to selects

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -21,6 +21,7 @@ require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.framework', true);
+JHtml::_('formbehavior.chosen', 'select');
 
 $function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));


### PR DESCRIPTION
This adds the chosen form behavior to the selects in the article modal.
## Current behavior

![skaermbillede 2014-10-05 kl 19 40 36](https://cloud.githubusercontent.com/assets/1738811/4519334/dda7ef6a-4cb6-11e4-96a0-ed80c5d7318b.png)
## After patch

![skaermbillede 2014-10-05 kl 19 40 44](https://cloud.githubusercontent.com/assets/1738811/4519333/dd8dbc30-4cb6-11e4-8655-1be34c4f4477.png)
