### PR TITLE
addAttachment() causing Strict-standard error

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -308,11 +308,11 @@ class JMail extends PHPMailer
 	/**
 	 * Add file attachments to the email
 	 *
-	 * @param   mixed   $attachment  Either a string or array of strings [filenames]
-	 * @param   mixed   $name        Either a string or array of strings [names]
-	 * @param   string  $encoding    The encoding of the attachment
-	 * @param   string  $type        The mime type
-	 * @param   string  $disposition The content disposition to use
+	 * @param   mixed   $attachment   Either a string or array of strings [filenames]
+	 * @param   mixed   $name         Either a string or array of strings [names]
+	 * @param   string  $encoding     The encoding of the attachment
+	 * @param   string  $type         The mime type
+	 * @param   string  $disposition  The content disposition to use
 	 *
 	 * @return  JMail  Returns this object for chaining.
 	 *

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -308,17 +308,18 @@ class JMail extends PHPMailer
 	/**
 	 * Add file attachments to the email
 	 *
-	 * @param   mixed  $attachment  Either a string or array of strings [filenames]
-	 * @param   mixed  $name        Either a string or array of strings [names]
-	 * @param   mixed  $encoding    The encoding of the attachment
-	 * @param   mixed  $type        The mime type
+	 * @param   mixed   $attachment  Either a string or array of strings [filenames]
+	 * @param   mixed   $name        Either a string or array of strings [names]
+	 * @param   string  $encoding    The encoding of the attachment
+	 * @param   string  $type        The mime type
+	 * @param   string  $disposition The content disposition to use
 	 *
 	 * @return  JMail  Returns this object for chaining.
 	 *
 	 * @since   12.2
 	 * @throws  InvalidArgumentException
 	 */
-	public function addAttachment($attachment, $name = '', $encoding = 'base64', $type = 'application/octet-stream')
+	public function addAttachment($attachment, $name = '', $encoding = 'base64', $type = 'application/octet-stream', $disposition = 'attachment')
 	{
 		// If the file attachments is an array, add each file... otherwise just add the one
 		if (isset($attachment))


### PR DESCRIPTION
Change 1: Function signature - added 5th parameter for content `disposition` because its absense is causing the Strict-Standard error _Strict Standards: Declaration of JMail::addAttachment() should be compatible with PHPMailer::addAttachment($path, $name = '', $encoding = 'base64', $type = '', $disposition = 'attachment') in /libraries/joomla/mail/mail.php on line 22_

Change 2: The function parameters `encoding, type, disposition` are always of type `string`. I changed the type note to reflect this.
