### PR TITLE
Method __toString not implemented for '\The'

### DIFF
--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -27,16 +27,16 @@ class JRoute
 	private static $_router = null;
 
 	/**
-	 * Translates an internal Joomla URL to a humanly readible URL.
+	 * Translates an internal Joomla URL to a humanly readable URL.
 	 *
 	 * @param   string   $url    Absolute or Relative URI to Joomla resource.
-	 * @param   boolean  $xhtml  Replace & by &amp; for XML compilance.
+	 * @param   boolean  $xhtml  Replace & by &amp; for XML compliance.
 	 * @param   integer  $ssl    Secure state for the resolved URI.
 	 *                             0: (default) No change, use the protocol currently used in the request
 	 *                             1: Make URI secure using global secure site URI.
 	 *                             2: Make URI unsecure using the global unsecure site URI.
 	 *
-	 * @return  The translated humanly readible URL.
+	 * @return string The translated humanly readable URL.
 	 *
 	 * @since   11.1
 	 */


### PR DESCRIPTION
Due to data type omission, when calling JRoute::_($url) I receive the noticed that: Method __toString not implemented for '\The'
- Specified the data type of the return value
- Fixed additional typos
