### PR TITLE
Remove redundant calls for mootools

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -24,7 +24,7 @@ $fieldsets = $this->form->getFieldsets();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'profile.cancel' || document.formvalidator.isValid(document.id('profile-form')))
+		if (task == 'profile.cancel' || document.formvalidator.isValid(document.getElementById('profile-form')))
 		{
 			Joomla.submitform(task, document.getElementById('profile-form'));
 		}

--- a/administrator/components/com_banners/models/fields/clicks.php
+++ b/administrator/components/com_banners/models/fields/clicks.php
@@ -35,7 +35,7 @@ class JFormFieldClicks extends JFormField
 	 */
 	protected function getInput()
 	{
-		$onclick = ' onclick="document.id(\'' . $this->id . '\').value=\'0\';"';
+		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
 
 		return
 			'<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'

--- a/administrator/components/com_banners/models/fields/impmade.php
+++ b/administrator/components/com_banners/models/fields/impmade.php
@@ -35,7 +35,7 @@ class JFormFieldImpMade extends JFormField
 	 */
 	protected function getInput()
 	{
-		$onclick = ' onclick="document.id(\'' . $this->id . '\').value=\'0\';"';
+		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
 
 		return
 			'<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'

--- a/administrator/components/com_banners/models/fields/imptotal.php
+++ b/administrator/components/com_banners/models/fields/imptotal.php
@@ -36,8 +36,8 @@ class JFormFieldImpTotal extends JFormField
 	protected function getInput()
 	{
 		$class		= ' class="validate-numeric text_area"';
-		$onchange	= ' onchange="document.id(\'' . $this->id . '_unlimited\').checked=document.id(\'' . $this->id . '\').value==\'\';"';
-		$onclick	= ' onclick="if (document.id(\'' . $this->id . '_unlimited\').checked) document.id(\'' . $this->id . '\').value=\'\';"';
+		$onchange	= ' onchange="document.getElementById(\'' . $this->id . '_unlimited\').checked=document.getElementById(\'' . $this->id . '\').value==\'\';"';
+		$onclick	= ' onclick="if (document.getElementById(\'' . $this->id . '_unlimited\').checked) document.getElementById(\'' . $this->id . '\').value=\'\';"';
 		$value		= empty($this->value) ? '' : $this->value;
 		$checked	= empty($this->value) ? ' checked="checked"' : '';
 

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -33,7 +33,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'banner.cancel' || document.formvalidator.isValid(document.id('banner-form')))
+		if (task == 'banner.cancel' || document.formvalidator.isValid(document.getElementById('banner-form')))
 		{
 			Joomla.submitform(task, document.getElementById('banner-form'));
 		}

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -33,7 +33,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'banner.cancel' || document.formvalidator.isValid(document.id('banner-form')))
+		if (task == 'banner.cancel' || document.formvalidator.isValid(document.getElementById('filter_search')))
 		{
 			Joomla.submitform(task, document.getElementById('banner-form'));
 		}

--- a/administrator/components/com_banners/views/banners/tmpl/default_batch.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default_batch.php
@@ -41,7 +41,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-client-id').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-client-id').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('banner.batch');">

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -16,7 +16,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'client.cancel' || document.formvalidator.isValid(document.id('client-form')))
+		if (task == 'client.cancel' || document.formvalidator.isValid(document.getElementById('client-form')))
 		{
 			Joomla.submitform(task, document.getElementById('client-form'));
 		}

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch.php
@@ -64,7 +64,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('category.batch');">

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -43,7 +43,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">
 					<span class="icon-search"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
-				<button type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();">
+				<button type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<span class="icon-remove"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 			</div>
 			<div class="clearfix"></div>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -25,7 +25,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'category.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == 'category.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
 			<?php echo $this->form->getField('description')->save(); ?>
 			Joomla.submitform(task, document.getElementById('item-form'));

--- a/administrator/components/com_categories/views/category/tmpl/modal.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal.php
@@ -26,7 +26,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'category.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == 'category.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
 			<?php echo $this->form->getField('description')->save(); ?>
 

--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -26,7 +26,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>">
 					<i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();">
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<i class="icon-remove"></i></button>
 			</div>
 		</div>

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -17,7 +17,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'application.cancel' || document.formvalidator.isValid(document.id('application-form')))
+		if (task == 'application.cancel' || document.formvalidator.isValid(document.getElementById('application-form')))
 		{
 			Joomla.submitform(task, document.getElementById('application-form'));
 		}

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -20,7 +20,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (document.formvalidator.isValid(document.id('component-form')))
+		if (document.formvalidator.isValid(document.getElementById('component-form')))
 		{
 			Joomla.submitform(task, document.getElementById('component-form'));
 		}

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -51,8 +51,8 @@ class JFormFieldModal_Contact extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectContact_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.id("' . $this->id . '_id").value = id;';
-		$script[] = '		document.id("' . $this->id . '_name").value = name;';
+		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
 
 		if ($allowEdit)
 		{

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -21,7 +21,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'contact.cancel' || document.formvalidator.isValid(document.id('contact-form')))
+		if (task == 'contact.cancel' || document.formvalidator.isValid(document.getElementById('contact-form')))
 		{
 			<?php echo $this->form->getField('misc')->save(); ?>
 			Joomla.submitform(task, document.getElementById('contact-form'));

--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -23,7 +23,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'contact.cancel' || document.formvalidator.isValid(document.id('contact-form')))
+		if (task == 'contact.cancel' || document.formvalidator.isValid(document.getElementById('contact-form')))
 		{
 			<?php echo $this->form->getField('misc')->save(); ?>
 

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -68,7 +68,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch.php
@@ -53,7 +53,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value='';document.id('batch-user-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('contact.batch');">

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -34,7 +34,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
 					<i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.id('filter_search').value='';this.form.submit();">
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<i class="icon-remove"></i></button>
 			</div>
 			<div class="clearfix"></div>

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -66,7 +66,7 @@ if (isset($this->item->attribs['show_urls_images_backend']) && $this->item->attr
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'article.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == 'article.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
 			<?php echo $this->form->getField('articletext')->save(); ?>
 			Joomla.submitform(task, document.getElementById('item-form'));

--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -68,7 +68,7 @@ if (isset($this->item->attribs['show_urls_images_backend']) && $this->item->attr
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'article.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == 'article.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
 			<?php echo $this->form->getField('articletext')->save(); ?>
 

--- a/administrator/components/com_content/views/articles/tmpl/default_batch.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch.php
@@ -46,7 +46,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-iddocument.getElementById;document.id('document.getElementByIds').value='';documedocument.getElementByIdh-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('article.batch');">

--- a/administrator/components/com_content/views/articles/tmpl/default_batch.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch.php
@@ -46,7 +46,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementByI(('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('article.batch');">

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -41,7 +41,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
 					<span class="icon-search"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.id('filter_search').value='';this.form.submit();">
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<span class="icon-remove"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 			</div>
 			<div class="clearfix"></div>

--- a/administrator/components/com_finder/views/filters/tmpl/default.php
+++ b/administrator/components/com_finder/views/filters/tmpl/default.php
@@ -52,7 +52,7 @@ Joomla.submitbutton = function(pressbutton)
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -66,7 +66,7 @@ Joomla.submitbutton = function(pressbutton)
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -99,7 +99,7 @@ Joomla.submitbutton = function(pressbutton)
 							$title = $lang->hasKey($key) ? JText::_($key) : $item->title;
 						?>
 						<?php if ($this->state->get('filter.branch') == 1 && $item->num_children) : ?>
-							<a href="document.getElementById"document.id('filter_branch').value='<?php echo (int) $item->id;?>';document.adminForm.submit();" title="<?php echo JText::_('COM_FINDER_MAPS_BRANCH_LINK'); ?>">
+							<a href="#" onclick="document.getElementById('filter_branch').value='<?php echo (int) $item->id;?>';document.adminForm.submit();" title="<?php echo JText::_('COM_FINDER_MAPS_BRANCH_LINK'); ?>">
 								<?php echo $this->escape($title); ?></a>
 						<?php else: ?>
 							<?php echo $this->escape(($title == '*') ? JText::_('JALL_LANGUAGE') : $title); ?>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -51,7 +51,7 @@ Joomla.submitbutton = function(pressbutton)
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>
@@ -80,7 +80,7 @@ Joomla.submitbutton = function(pressbutton)
 				<?php if ($this->state->get('filter.branch') != 1) : ?>
 				<tr class="row1">
 					<td colspan="5" class="center">
-						<a href="#" onclick="document.id('filter_branch').value='1';document.adminForm.submit();">
+						<a href="#" onclick="document.getElementById('filter_branch').value='1';document.adminForm.submit();">
 							<?php echo JText::_('COM_FINDER_MAPS_RETURN_TO_BRANCHES'); ?></a>
 					</td>
 				</tr>
@@ -99,7 +99,7 @@ Joomla.submitbutton = function(pressbutton)
 							$title = $lang->hasKey($key) ? JText::_($key) : $item->title;
 						?>
 						<?php if ($this->state->get('filter.branch') == 1 && $item->num_children) : ?>
-							<a href="#" onclick="document.id('filter_branch').value='<?php echo (int) $item->id;?>';document.adminForm.submit();" title="<?php echo JText::_('COM_FINDER_MAPS_BRANCH_LINK'); ?>">
+							<a href="document.getElementById"document.id('filter_branch').value='<?php echo (int) $item->id;?>';document.adminForm.submit();" title="<?php echo JText::_('COM_FINDER_MAPS_BRANCH_LINK'); ?>">
 								<?php echo $this->escape($title); ?></a>
 						<?php else: ?>
 							<?php echo $this->escape(($title == '*') ? JText::_('JALL_LANGUAGE') : $title); ?>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -46,7 +46,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
       </div>
       <div class="btn-group pull-left">
         <button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-        <button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+        <button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
       </div>
     </div>
     <div class="clearfix"> </div>

--- a/administrator/components/com_installer/views/languages/tmpl/default_filter.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default_filter.php
@@ -21,7 +21,7 @@ JHtml::_('bootstrap.tooltip');
 	</div>
 	<div class="btn-group pull-left hidden-phone">
 		<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-		<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+		<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 	</div>
 </div>
 <div class="clearfix"> </div>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -44,7 +44,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -40,7 +40,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</div>
 		<div class="btn-group pull-left">
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 		</div>
 	</div>
 	<div class="clearfix"> </div>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -17,7 +17,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'language.cancel' || document.formvalidator.isValid(document.id('language-form')))
+		if (task == 'language.cancel' || document.formvalidator.isValid(document.getElementById('language-form')))
 		{
 			Joomla.submitform(task, document.getElementById('language-form'));
 		}

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -63,7 +63,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_languages/views/override/tmpl/edit.php
+++ b/administrator/components/com_languages/views/override/tmpl/edit.php
@@ -18,7 +18,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 		window.addEvent('domready', function()
 		{
-			document.id('jform_searchstring').addEvent('focus', function()
+			document.getElementById('jform_searchstring').addEvent('focus', function()
 			{
 				if (!Joomla.overrider.states.refreshed)
 				{
@@ -32,7 +32,7 @@ JHtml::_('formbehavior.chosen', 'select');
 		});
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'override.cancel' || document.formvalidator.isValid(document.id('override-form')))
+		if (task == 'override.cancel' || document.formvalidator.isValid(document.getElementById('override-form')))
 		{
 			Joomla.submitform(task, document.getElementById('override-form'));
 		}

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -32,7 +32,7 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -36,7 +36,7 @@ echo $params->get('image_path', 'images'); ?>/';
 				</div>
 			</div>
 			<div class="pull-right">
-				<button class="btn btn-primary" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.id('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.SqueezeBox.close();"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+				<button class="btn btn-primary" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.SqueezeBox.close();"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 				<button class="btn" type="button" onclick="window.parent.SqueezeBox.close();"><?php echo JText::_('JCANCEL') ?></button>
 			</div>
 		</div>

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -59,13 +59,11 @@ JFactory::getDocument()->addScriptDeclaration($script);
 		{
 			if (task == 'item.setType')
 			{
-				document.id('item-form').elements['jform[type]'].value = type;
-				document.id('fieldtype').value = 'type';
-			} else {
+				document.getElementById('item-form').elements['jform[type]'].value document.getElementById	document.id('fieldtype').value = document.getElementById} else {
 				document.id('item-form').elements['jform[menutype]'].value = type;
 			}
-			Joomla.submitform('item.setType', document.id('item-form'));
-		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.id('item-form')))
+	document.getElementByIdbmitform('item.setType', document.id('item-form'));
+		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementByIdocument.getElementByIdm')))
 		{
 			Joomla.submitform(task, document.id('item-form'));
 		}
@@ -76,7 +74,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 			{
 				var idReversed = field.id.split("").reverse().join("");
 				var separatorLocation = idReversed.indexOf('_');
-				var name = idReversed.substr(separatorLocation).split("").reverse().join("") + 'name';
+				var name = idReversed.substr(sedocument.getElementByIdtion).split("").reverse().join("") + 'name';
 				document.id(name).addClass('invalid');
 			});
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -59,13 +59,16 @@ JFactory::getDocument()->addScriptDeclaration($script);
 		{
 			if (task == 'item.setType')
 			{
-				document.getElementById('item-form').elements['jform[type]'].value document.getElementById	document.id('fieldtype').value = document.getElementById} else {
-				document.id('item-form').elements['jform[menutype]'].value = type;
+				document.getElementById('item-form').elements['jform[type]'].value = type;
+				document.getElementById('fieldtype').value = 'type';
+			} else {
+				document.getElementById('item-form').elements['jform[menutype]'].value = type;
 			}
-	document.getElementByIdbmitform('item.setType', document.id('item-form'));
-		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementByIdocument.getElementByIdm')))
+			Joomla.submitform('item.setType', document.getElementById('item-form'));
+		}
+		else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
-			Joomla.submitform(task, document.id('item-form'));
+			Joomla.submitform(task, document.getElementById('item-form'));
 		}
 		else
 		{
@@ -74,7 +77,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 			{
 				var idReversed = field.id.split("").reverse().join("");
 				var separatorLocation = idReversed.indexOf('_');
-				var name = idReversed.substr(sedocument.getElementByIdtion).split("").reverse().join("") + 'name';
+				var name = idReversed.substr(separatorLocation).split("").reverse().join("") + 'name';
 				document.id(name).addClass('invalid');
 			});
 

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -13,8 +13,8 @@ JHtml::_('behavior.framework', true);
 
 $script = array();
 $script[] = "	window.addEvent('domready', function() {";
-$script[] = "		document.id('showmods').addEvent('click', function(e) {";
-$script[] = "			document.id('showmods').setStyle('display', 'block');";
+$script[] = "		document.getElementById('showmods').addEvent('click', function(e) {";
+$scrdocument.getElementById	document.id('showmods').setStyle('display', 'block');";
 $script[] = "		jQuery('.table tr.no').toggle();";
 $script[] = "		});";
 $script[] = "	})";

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -14,7 +14,7 @@ JHtml::_('behavior.framework', true);
 $script = array();
 $script[] = "	window.addEvent('domready', function() {";
 $script[] = "		document.getElementById('showmods').addEvent('click', function(e) {";
-$scrdocument.getElementById	document.id('showmods').setStyle('display', 'block');";
+$script[] = "		document.getElementById('showmods').setStyle('display', 'block');";
 $script[] = "		jQuery('.table tr.no').toggle();";
 $script[] = "		});";
 $script[] = "	})";

--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -54,7 +54,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.getElementById('batch-menu-iddocument.getElementById;document.id('document.getElementByIds').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('item.batch');">

--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -54,7 +54,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-menu-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-menu-iddocument.getElementById;document.id('document.getElementByIds').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('item.batch');">

--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -19,7 +19,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'menu.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == 'menu.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
 		{
 			Joomla.submitform(task, document.getElementById('item-form'));
 		}

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -50,7 +50,7 @@ $modMenuId = (int) $this->get('ModMenuId');
 			</div>
 			<div class="btn-group pull-left hidden-phone">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -19,7 +19,7 @@ JHtml::_('behavior.modal');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'config.cancel' || document.formvalidator.isValid(document.id('config-form')))
+		if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('config-form')))
 		{
 			Joomla.submitform(task, document.getElementById('config-form'));
 		}

--- a/administrator/components/com_messages/views/message/tmpl/edit.php
+++ b/administrator/components/com_messages/views/message/tmpl/edit.php
@@ -18,7 +18,7 @@ JHtml::_('behavior.keepalive');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'message.cancel' || document.formvalidator.isValid(document.id('message-form')))
+		if (task == 'message.cancel' || document.formvalidator.isValid(document.getElementById('message-form')))
 		{
 			Joomla.submitform(task, document.getElementById('message-form'));
 		}

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -36,7 +36,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-left">
 				<select name="filter_state" onchange="this.form.submit()">

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -29,7 +29,7 @@ $this->fieldsets = $this->form->getFieldsets('params');
 
 $script = "Joomla.submitbutton = function(task)
 	{
-			if (task == 'module.cancel' || document.formvalidator.isValid(document.id('module-form'))) {";
+			if (task == 'module.cancel' || document.formvalidator.isValid(document.getElementById('module-form'))) {";
 if ($hasContent)
 {
 	$script .= $this->form->getField($hasContentFieldName)->save();

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -61,7 +61,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group pull-left hidden-phone">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -66,7 +66,7 @@ $attr = array(
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.getElementById('batch-position-iddocument.getElementById;document.id('document.getElementByIds').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('module.batch');">

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -66,7 +66,7 @@ $attr = array(
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-position-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-position-iddocument.getElementById;document.id('document.getElementByIds').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('module.batch');">

--- a/administrator/components/com_modules/views/positions/tmpl/modal.php
+++ b/administrator/components/com_modules/views/positions/tmpl/modal.php
@@ -32,7 +32,7 @@ $type      = $this->state->get('filter.type');
 
 			<button type="submit">
 				<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
-			<button type="button" onclick="document.id('filter_search').value='';this.form.submit();">
+			<button type="button" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 				<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 		</div>
 

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -51,7 +51,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Select button script
 		$script[] = '	function jSelectNewsfeed_'.$this->id.'(id, name, object) {';
 		$script[] = '		document.getElementById("'.$this->id.'_id").value = id;';
-		$scdocument.getElementById	document.id("'.$this->id.'_name").value = name;';
+		$script[] = '		document.getElementById("'.$this->id.'_name").value = name;';
 
 		if ($allowEdit)
 		{

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -50,8 +50,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectNewsfeed_'.$this->id.'(id, name, object) {';
-		$script[] = '		document.id("'.$this->id.'_id").value = id;';
-		$script[] = '		document.id("'.$this->id.'_name").value = name;';
+		$script[] = '		document.getElementById("'.$this->id.'_id").value = id;';
+		$scdocument.getElementById	document.id("'.$this->id.'_name").value = name;';
 
 		if ($allowEdit)
 		{

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -23,7 +23,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.id('newsfeed-form'))) {
+		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.getElementById('newsfeed-form'))) {
 			Joomla.submitform(task, document.getElementById('newsfeed-form'));
 		}
 	}

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -23,7 +23,7 @@ $assoc = JLanguageAssociations::isEnabled();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.id('newsfeed-form')))
+		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.getElementById('newsfeed-form')))
 		{
 			if (window.opener && (task == 'newsfeed.save' || task == 'newsfeed.cancel'))
 			{

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -66,7 +66,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 			</div>
 			<div class="btn-group pull-left hidden-phone">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
@@ -46,7 +46,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.getElementById('batch-category-iddocument.getElementById;document.id('document.getElementByIds').value='';documedocument.getElementByIdh-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('newsfeed.batch');">

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
@@ -46,7 +46,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-iddocument.getElementById;document.id('document.getElementByIds').value='';documedocument.getElementByIdh-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('newsfeed.batch');">

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -33,7 +33,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
 					<i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.id('filter_search').value='';this.form.submit();">
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<i class="icon-remove"></i></button>
 			</div>
 			<div class="clearfix"></div>

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -18,7 +18,7 @@ $this->fieldsets = $this->form->getFieldsets('params');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'plugin.cancel' || document.formvalidator.isValid(document.id('style-form'))) {
+		if (task == 'plugin.cancel' || document.formvalidator.isValid(document.getElementById('style-form'))) {
 			Joomla.submitform(task, document.getElementById('style-form'));
 		}
 	}

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -61,7 +61,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -19,7 +19,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'link.cancel' || document.formvalidator.isValid(document.id('link-form')))
+		if (task == 'link.cancel' || document.formvalidator.isValid(document.getElementById('link-form')))
 		{
 			Joomla.submitform(task, document.getElementById('link-form'));
 		}

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -36,7 +36,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -26,7 +26,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</div>
 		<div class="filter-search btn-group pull-left">
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 		</div>
 		<div class="btn-group pull-right hidden-phone">
 			<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -24,7 +24,7 @@ $params = $params->toArray();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'tag.cancel' || document.formvalidator.isValid(document.id('item-form'))) {
+		if (task == 'tag.cancel' || document.formvalidator.isValid(document.getElementById('item-form'))) {
 			<?php echo $this->form->getField('description')->save(); ?>
 			Joomla.submitform(task, document.getElementById('item-form'));
 		}

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -61,7 +61,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group hidden-phone">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch.php
@@ -32,7 +32,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-				<button class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('tag.batch');">

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch.php
@@ -32,7 +32,7 @@ $published = $this->state->get('filter.published');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-tag-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value=''" data-dismiss="modal">
+				<button class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('tag.batch');">

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -18,7 +18,7 @@ $user = JFactory::getUser();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'style.cancel' || document.formvalidator.isValid(document.id('style-form'))) {
+		if (task == 'style.cancel' || document.formvalidator.isValid(document.getElementById('style-form'))) {
 			Joomla.submitform(task, document.getElementById('style-form'));
 		}
 	}

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -36,7 +36,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		</div>
 		<div class="btn-group pull-left">
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 		</div>
 		<div class="btn-group pull-right hidden-phone">
 			<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -34,7 +34,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</div>
 		<div class="btn-group pull-left">
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 		</div>
 	</div>
 	<div class="clearfix"> </div>

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -33,7 +33,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -32,7 +32,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -19,7 +19,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'group.cancel' || document.formvalidator.isValid(document.id('group-form')))
+		if (task == 'group.cancel' || document.formvalidator.isValid(document.getElementById('group-form')))
 		{
 			Joomla.submitform(task, document.getElementById('group-form'));
 		}

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -79,7 +79,7 @@ JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -27,7 +27,7 @@ Joomla.submitbutton = function(task)
 window.addEvent('domready', fdocument.getElementById	document.id('user-groups').getElements('input').each(function(i){
 		// Event to check all child groups.
 		i.addEvent('check', function(e){
-			// Chedocument.getElementByIdd groups.
+			// Check the child groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (this.getProperty('rel') == c.id)
 				{
@@ -40,7 +40,7 @@ window.addEvent('domready', fdocument.getElementById	document.id('user-groups').
 
 		// Event to uncheck all the parent groups.
 		i.addEvent('uncheck', function(e){
-document.getElementByIdck the parent groups.
+		// Uncheck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (c.getProperty('rel') == this.id)
 				{
@@ -52,7 +52,7 @@ document.getElementByIdck the parent groups.
 		}.bind(i));
 
 		// Bind to the click event to check/uncheck child/parent groups.
-		i.addEvent('click'document.getElementByIde){
+		i.addEvent('click', function(e){
 			// Check the child groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (this.getProperty('rel') == c.id)
@@ -65,7 +65,8 @@ document.getElementByIdck the parent groups.
 						c.setProperty('disabled', false);
 					}
 					c.fireEvent('check');
-	document.getElementByIdind(this));
+				}
+            }.bind(this));
 
 			// Uncheck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -24,7 +24,8 @@ Joomla.submitbutton = function(task)
 	}
 }
 /*
-window.addEvent('domready', fdocument.getElementById	document.id('user-groups').getElements('input').each(function(i){
+window.addEvent('domready', function(){
+	document.getElementById('user-groups').getElements('input').each(function(i){
 		// Event to check all child groups.
 		i.addEvent('check', function(e){
 			// Check the child groups.
@@ -40,7 +41,7 @@ window.addEvent('domready', fdocument.getElementById	document.id('user-groups').
 
 		// Event to uncheck all the parent groups.
 		i.addEvent('uncheck', function(e){
-		// Uncheck the parent groups.
+			// Uncheck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (c.getProperty('rel') == this.id)
 				{
@@ -66,7 +67,7 @@ window.addEvent('domready', fdocument.getElementById	document.id('user-groups').
 					}
 					c.fireEvent('check');
 				}
-            }.bind(this));
+			}.bind(this));
 
 			// Uncheck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -18,17 +18,16 @@ JHtml::_('behavior.formvalidation');
 <script type="text/javascript">
 Joomla.submitbutton = function(task)
 {
-	if (task == 'level.cancel' || document.formvalidator.isValid(document.id('level-form')))
+	if (task == 'level.cancel' || document.formvalidator.isValid(document.getElementById('level-form')))
 	{
-		Joomla.submitform(task, document.id('level-form'));
+		Joomla.submitform(task, document.getElementById('level-form'));
 	}
 }
 /*
-window.addEvent('domready', function(){
-	document.id('user-groups').getElements('input').each(function(i){
+window.addEvent('domready', fdocument.getElementById	document.id('user-groups').getElements('input').each(function(i){
 		// Event to check all child groups.
 		i.addEvent('check', function(e){
-			// Check the child groups.
+			// Chedocument.getElementByIdd groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (this.getProperty('rel') == c.id)
 				{
@@ -41,7 +40,7 @@ window.addEvent('domready', function(){
 
 		// Event to uncheck all the parent groups.
 		i.addEvent('uncheck', function(e){
-			// Uncheck the parent groups.
+document.getElementByIdck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (c.getProperty('rel') == this.id)
 				{
@@ -53,7 +52,7 @@ window.addEvent('domready', function(){
 		}.bind(i));
 
 		// Bind to the click event to check/uncheck child/parent groups.
-		i.addEvent('click', function(e){
+		i.addEvent('click'document.getElementByIde){
 			// Check the child groups.
 			document.id('user-groups').getElements('input').each(function(c){
 				if (this.getProperty('rel') == c.id)
@@ -66,8 +65,7 @@ window.addEvent('domready', function(){
 						c.setProperty('disabled', false);
 					}
 					c.fireEvent('check');
-				}
-			}.bind(this));
+	document.getElementByIdind(this));
 
 			// Uncheck the parent groups.
 			document.id('user-groups').getElements('input').each(function(c){

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -61,7 +61,7 @@ if ($saveOrder)
 			</div>
 			<div class="filter-search btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_RESET'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_users/views/mail/tmpl/default.php
+++ b/administrator/components/com_users/views/mail/tmpl/default.php
@@ -27,8 +27,8 @@ $script .= "\t\t\t".'Joomla.submitform(pressbutton);'."\n";
 $script .= "\t\t".'}'."\n";
 $script .= "\t\t".'}'."\n";
 
-JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.core');
+JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>

--- a/administrator/components/com_users/views/mail/tmpl/default.php
+++ b/administrator/components/com_users/views/mail/tmpl/default.php
@@ -28,6 +28,7 @@ $script .= "\t\t".'}'."\n";
 $script .= "\t\t".'}'."\n";
 
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.core');
 
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script language="javascript" type="text/javascript">
 Joomla.submitbutton = function(task)
 {
-	if (task == 'note.cancel' || document.formvalidator.isValid(document.id('note-form')))
+	if (task == 'note.cancel' || document.formvalidator.isValid(document.getElementById('note-form')))
 	{
 		Joomla.submitform(task, document.getElementById('note-form'));
 	}

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -51,7 +51,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -22,7 +22,7 @@ $fieldsets = $this->form->getFieldsets();
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'user.cancel' || document.formvalidator.isValid(document.id('user-form')))
+		if (task == 'user.cancel' || document.formvalidator.isValid(document.getElementById('user-form')))
 		{
 			Joomla.submitform(task, document.getElementById('user-form'));
 		}

--- a/administrator/components/com_users/views/users/tmpl/default_batch.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch.php
@@ -54,7 +54,7 @@ JHtml::_('formbehavior.chosen', 'select');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-group-id').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-group-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('user.batch');">

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -30,7 +30,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 				<button type="button" class="btn" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('', '<?php echo JText::_('JLIB_FORM_SELECT_USER'); ?>');"><?php echo JText::_('JOPTION_NO_USER'); ?></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">

--- a/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -18,7 +18,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'weblink.cancel' || document.formvalidator.isValid(document.id('weblink-form'))) {
+		if (task == 'weblink.cancel' || document.formvalidator.isValid(document.getElementById('weblink-form'))) {
 			<?php echo $this->form->getField('description')->save(); ?>
 			Joomla.submitform(task, document.getElementById('weblink-form'));
 		}

--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -61,7 +61,7 @@ $sortFields = $this->getSortFields();
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>

--- a/administrator/components/com_weblinks/views/weblinks/tmpl/default_batch.php
+++ b/administrator/components/com_weblinks/views/weblinks/tmpl/default_batch.php
@@ -46,7 +46,7 @@ $published = $this->state->get('filter.state');
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch-category-id').value='';document.id('batch-access').value='';document.id('batch-language-id').value='';document.id('batch-tag-id)').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id)').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('weblink.batch');">

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -8,8 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-
-JHtml::_('behavior.framework');
 ?>
 <div class="btn-wrapper" <?php echo $displayData['id']; ?>>
 	<?php echo $displayData['action']; ?>

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -8,6 +8,8 @@
  */
 
 defined('_JEXEC') or die;
+
+JHtml::_('behavior.framework');
 ?>
 <div class="btn-wrapper" <?php echo $displayData['id']; ?>>
 	<?php echo $displayData['action']; ?>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 
 $title = $displayData['title'];
 

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.framework');
+
 $title = $displayData['title'];
 
 ?>

--- a/layouts/joomla/toolbar/confirm.php
+++ b/layouts/joomla/toolbar/confirm.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.framework');
+
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.core');
+
 $doTask = $displayData['doTask'];
 $text   = $displayData['text'];
 

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.framework');
+
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.core');
+
 $doTask  = $displayData['doTask'];
 $class   = $displayData['class'];
 $text    = $displayData['text'];

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('behavior.framework');
+
 $doTask   = $displayData['doTask'];
 $class    = $displayData['class'];
 $text     = $displayData['text'];

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+JHtml::_('behavior.framework');
+
 ?>
 <a rel="{handler: 'iframe', size: {x: <?php echo $displayData['height']; ?>, y: <?php echo $displayData['width']; ?>}}"
 	href="index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id=<?php echo (int) $displayData['itemId']; ?>&amp;type_id=<?php echo $displayData['typeId']; ?>&amp;type_alias=<?php echo $displayData['typeAlias']; ?>&amp;<?php echo JSession::getFormToken(); ?>=1"

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -251,6 +251,9 @@ abstract class JHtmlBehavior
 			return;
 		}
 
+		// Include MooTools framework
+		static::framework(true);
+
 		// Setup options object
 		$opt['maxTitleChars'] = (isset($params['maxTitleChars']) && ($params['maxTitleChars'])) ? (int) $params['maxTitleChars'] : 50;
 
@@ -279,10 +282,6 @@ abstract class JHtmlBehavior
 					$(this).data('tip:text', parts[1]);
 				}
 			});
-
-			if (typeof Tips == 'function') {
-				JTooltips = new Tips($('$selector').get(), $options);
-				}
 		});"
 		);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -176,7 +176,7 @@ abstract class JHtmlBehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 
-		JHtml::_('script', 'system/switcher.js', true, true);
+		JHtml::_('script', 'system/switcher.js', false, true);
 
 		$script = "
 			document.switcher = null;
@@ -317,11 +317,10 @@ abstract class JHtmlBehavior
 		// Load the necessary files if they haven't yet been loaded
 		if (!isset(static::$loaded[__METHOD__]))
 		{
-			// Include MooTools framework
-			static::framework(true);
+			// Include core
+			static::core();
 
-			// Load the JavaScript and css
-			JHtml::_('script', 'system/modal.js', true, true);
+			JHtml::_('script', 'system/modal.js', false, true);
 			JHtml::_('stylesheet', 'system/modal.css', array(), true);
 		}
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -176,7 +176,7 @@ abstract class JHtmlBehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 
-		JHtml::_('script', 'system/switcher.js', false, true);
+		JHtml::_('script', 'system/switcher.js', true, true);
 
 		$script = "
 			document.switcher = null;
@@ -317,10 +317,10 @@ abstract class JHtmlBehavior
 		// Load the necessary files if they haven't yet been loaded
 		if (!isset(static::$loaded[__METHOD__]))
 		{
-			// Include core
-			static::core();
+			// Include MooTools framework
+			static::framework(true);
 
-			JHtml::_('script', 'system/modal.js', false, true);
+			JHtml::_('script', 'system/modal.js', true, true);
 			JHtml::_('stylesheet', 'system/modal.css', array(), true);
 		}
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -212,7 +212,7 @@ abstract class JHtmlBehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 
-		JHtml::_('script', 'system/combobox.js', true, true);
+		JHtml::_('script', 'system/combobox.js', false, true);
 		static::$loaded[__METHOD__] = true;
 	}
 
@@ -399,12 +399,12 @@ abstract class JHtmlBehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 
-		JHtml::_('script', 'system/multiselect.js', true, true);
+		JHtml::_('script', 'system/multiselect.js', false, true);
 
 		// Attach multiselect to document
 		JFactory::getDocument()->addScriptDeclaration(
-			"window.addEvent('domready', function() {
-				new Joomla.JMultiSelect('" . $id . "');
+			"jQuery(document).ready(function() {
+				Joomla.JMultiSelect('" . $id . "');
 			});"
 		);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -147,9 +147,6 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include MooTools framework
-		static::framework();
-
 		// Include jQuery Framework
 		JHtml::_('jquery.framework');
 
@@ -211,8 +208,6 @@ abstract class JHtmlBehavior
 		{
 			return;
 		}
-		// Include MooTools framework
-		static::framework();
 
 		JHtml::_('script', 'system/combobox.js', true, true);
 		static::$loaded[__METHOD__] = true;
@@ -252,9 +247,6 @@ abstract class JHtmlBehavior
 		{
 			return;
 		}
-
-		// Include MooTools framework
-		static::framework(true);
 
 		// Setup options object
 		$opt['maxTitleChars'] = (isset($params['maxTitleChars']) && ($params['maxTitleChars'])) ? (int) $params['maxTitleChars'] : 50;
@@ -322,8 +314,6 @@ abstract class JHtmlBehavior
 		// Load the necessary files if they haven't yet been loaded
 		if (!isset(static::$loaded[__METHOD__]))
 		{
-			// Include MooTools framework
-			static::framework(true);
 
 			// Load the JavaScript and css
 			JHtml::_('script', 'system/modal.js', true, true);
@@ -696,9 +686,6 @@ abstract class JHtmlBehavior
 		{
 			return;
 		}
-
-		// Include MooTools framework
-		static::framework();
 
 		// Include jQuery
 		JHtml::_('jquery.framework');

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -147,7 +147,7 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include core and jQuery framework
+		// Include core
 		static::core();
 
 		// Add validate.js language strings
@@ -209,8 +209,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include core and jQuery framework
-		static::core();
+		// Include jQuery
+		JHtml::_('jquery.framework');
 
 		JHtml::_('script', 'system/combobox.js', true, true);
 		static::$loaded[__METHOD__] = true;
@@ -317,6 +317,8 @@ abstract class JHtmlBehavior
 		// Load the necessary files if they haven't yet been loaded
 		if (!isset(static::$loaded[__METHOD__]))
 		{
+			// Include MooTools framework
+			static::framework(true);
 
 			// Load the JavaScript and css
 			JHtml::_('script', 'system/modal.js', true, true);

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -147,8 +147,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include jQuery Framework
-		JHtml::_('jquery.framework');
+		// Include core and jQuery framework
+		static::core();
 
 		// Add validate.js language strings
 		JText::script('JLIB_FORM_FIELD_INVALID');
@@ -208,6 +208,9 @@ abstract class JHtmlBehavior
 		{
 			return;
 		}
+
+		// Include core and jQuery framework
+		static::core();
 
 		JHtml::_('script', 'system/combobox.js', true, true);
 		static::$loaded[__METHOD__] = true;

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -279,7 +279,10 @@ abstract class JHtmlBehavior
 					$(this).data('tip:text', parts[1]);
 				}
 			});
-			var JTooltips = new Tips($('$selector').get(), $options);
+
+			if (typeof Tips == 'function') {
+				JTooltips = new Tips($('$selector').get(), $options);
+				}
 		});"
 		);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -209,8 +209,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include jQuery
-		JHtml::_('jquery.framework');
+		// Include core
+		static::core();
 
 		JHtml::_('script', 'system/combobox.js', false, true);
 		static::$loaded[__METHOD__] = true;
@@ -281,8 +281,8 @@ abstract class JHtmlBehavior
 					$(this).data('tip:title', parts[0]);
 					$(this).data('tip:text', parts[1]);
 				}
-				JTooltips = new Tips($('$selector').get(), $options);
 			});
+			var JTooltips = new Tips($('$selector').get(), $options);
 		});"
 		);
 
@@ -398,8 +398,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include jQuery
-		JHtml::_('jquery.framework');
+		// Include core
+		static::core();
 
 		JHtml::_('script', 'system/multiselect.js', false, true);
 
@@ -647,8 +647,8 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include jQuery
-		JHtml::_('jquery.framework');
+		// Include core
+		static::core();
 
 		JHtml::_('script', 'system/highlighter.js', true, true);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -281,6 +281,7 @@ abstract class JHtmlBehavior
 					$(this).data('tip:title', parts[0]);
 					$(this).data('tip:text', parts[1]);
 				}
+				JTooltips = new Tips($('$selector').get(), $options);
 			});
 		});"
 		);

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -89,13 +89,13 @@ class JToolbarButtonConfirm extends JToolbarButton
 	 */
 	protected function _getCommand($msg, $name, $task, $list)
 	{
-		JHtml::_('behavior.framework');
+
 		$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 		$message = addslashes($message);
 
 		if ($list)
 		{
-			$cmd = "if (document.adminForm.boxchecked.value==0){alert('$message');}else{if (confirm('$msg')){Joomla.submitbutton('$task');}}";
+			$cmd = "if (document.adminForm.boxchecked.value==0){alert('$message');}else{ Joomla.submitbutton('$task')}";
 		}
 		else
 		{

--- a/libraries/cms/toolbar/button/help.php
+++ b/libraries/cms/toolbar/button/help.php
@@ -77,7 +77,6 @@ class JToolbarButtonHelp extends JToolbarButton
 	 */
 	protected function _getCommand($ref, $com, $override, $component)
 	{
-		JHtml::_('behavior.framework');
 
 		// Get Help URL
 		$url = JHelp::createURL($ref, $com, $override, $component);

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -94,7 +94,6 @@ class JToolbarButtonStandard extends JToolbarButton
 	 */
 	protected function _getCommand($name, $task, $list)
 	{
-		JHtml::_('behavior.framework');
 		$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 		$message = addslashes($message);
 

--- a/media/system/js/multiselect-uncompressed.js
+++ b/media/system/js/multiselect-uncompressed.js
@@ -8,7 +8,7 @@
  */
 (function($) {
     
-    Joomla = Joomla || {};
+    Joomla = window.Joomla || {};
     var $boxes;
     Joomla.JMultiSelect = function(table) {
         var $last,

--- a/media/system/js/multiselect.js
+++ b/media/system/js/multiselect.js
@@ -1,4 +1,4 @@
 /*
         GNU General Public License version 2 or later; see LICENSE.txt
 */
-(function(b){Joomla=Joomla||{};var a;Joomla.JMultiSelect=function(f){var e,c=function(g){a=b("#"+g).find("input[type=checkbox]");a.on("click",function(h){d(h)})},d=function(j){var h=b(j.target),l,k,g,i;if(j.shiftKey&&e.length){l=h.is(":checked");k=a.index(e);g=a.index(h);if(g<k){i=k;k=g;g=i}a.slice(k,g+1).attr("checked",l)}e=h};c(f)}})(jQuery);
+(function(e){Joomla=window.Joomla||{};var t;Joomla.JMultiSelect=function(n){var r,i=function(n){t=e("#"+n).find("input[type=checkbox]");t.on("click",function(e){s(e)})},s=function(n){var i=e(n.target),s,o,u,a;if(n.shiftKey&&r.length){s=i.is(":checked");o=t.index(r);u=t.index(i);if(u<o){a=o;o=u;u=a}t.slice(o,u+1).attr("checked",s)}r=i};i(n)}})(jQuery)

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -204,7 +204,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::formvalidation();
 		$this->assertEquals(
-			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::formvalidation' => true),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::formvalidation' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -284,7 +284,6 @@ class JHtmlBehaviorTest extends TestCase
 			array(
 				array(
 					'JHtmlBehavior::core' => true,
-					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip', array()))) => true
 					),
@@ -293,7 +292,6 @@ class JHtmlBehaviorTest extends TestCase
 			array(
 				array(
 					'JHtmlBehavior::core' => true,
-					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array()))) => true
 					),
@@ -303,7 +301,6 @@ class JHtmlBehaviorTest extends TestCase
 			array(
 				array(
 					'JHtmlBehavior::core' => true,
-					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array('showDelay' => 1000)))) => true
 					),
@@ -677,7 +674,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::noframes();
 		$this->assertEquals(
-			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::noframes' => true, 'JHtmlBehavior::framework' => array('core' => true)),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::noframes' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -283,6 +283,8 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip', array()))) => true
 					),
@@ -290,6 +292,8 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array()))) => true
 					),
@@ -298,6 +302,8 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
+					'JHtmlBehavior::core' => true,
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array('showDelay' => 1000)))) => true
 					),

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -283,7 +283,6 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
-					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip', array()))) => true
 					),
@@ -291,7 +290,6 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
-					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array()))) => true
 					),
@@ -300,7 +298,6 @@ class JHtmlBehaviorTest extends TestCase
 			),
 			array(
 				array(
-					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::tooltip' => array(
 						md5(serialize(array('.hasTooltip2', array('showDelay' => 1000)))) => true
 					),
@@ -674,7 +671,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::noframes();
 		$this->assertEquals(
-			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::noframes' => true),
+			array('JHtmlBehavior::noframes' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -266,7 +266,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::combobox();
 		$this->assertEquals(
-			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::combobox' => true),
+			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::combobox' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -440,14 +440,12 @@ class JHtmlBehaviorTest extends TestCase
 			array(
 				array(
 					'JHtmlBehavior::core' => true,
-					'JHtmlBehavior::framework' => array('core' => true),
 					'JHtmlBehavior::multiselect' => array('adminForm' => true),
 				)
 			),
 			array(
 				array(
 					'JHtmlBehavior::core' => true,
-					'JHtmlBehavior::framework' => array('core' => true),
 					'JHtmlBehavior::multiselect' => array('adminForm2' => true),
 				),
 				'adminForm2'

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -266,7 +266,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JHtmlBehaviorInspector::combobox();
 		$this->assertEquals(
-			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::combobox' => true),
+			array('JHtmlBehavior::combobox' => true),
 			JHtmlBehaviorInspector::getLoaded()
 		);
 	}
@@ -439,13 +439,11 @@ class JHtmlBehaviorTest extends TestCase
 		$data = array(
 			array(
 				array(
-					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::multiselect' => array('adminForm' => true),
 				)
 			),
 			array(
 				array(
-					'JHtmlBehavior::core' => true,
 					'JHtmlBehavior::multiselect' => array('adminForm2' => true),
 				),
 				'adminForm2'


### PR DESCRIPTION
As most of the javascripts are now based on jQuery some calls to load mootools framework are redundant.
This is a response to #4473
This PR removes it from 

> formvalidate  https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/behavior.php#L151
> combobox https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/behavior.php#L215
> tooltip https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/behavior.php#L257
> modal https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/behavior.php#L326
> noframes https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/behavior.php#L701

The only case I left the moo tools framework is for tree.

B/C
Shouldn’t break something, as the scripts are NOT moo tools dependent. 

Test
Try different navigation on a site (admin will be easier) and check that form validate, compobox, tooltip, modal and noframes still function as usual. Please check 3PD code with this, let’s NOT break things here!!!

EDIT
Except libraries/joomla/cms/html/behavior.php 

I found out that toolbar is always loading mootools, for no particular reason so removed it from the files confirm, standard, help in libraries/joomla/cms/toolbar/button

Also almost all backend views have a basic check for the form where the code expects mootools 

```
document.id('banner-form’)
```

This can be done also with vanilla `document.getElementById('banner-form’)`
So most of the changes are document.id -> document.getElementById

Thanks @fedik for the heads up!!!
