### PR TITLE
Clear limit for all JDatabaseQuery objects

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -317,7 +317,7 @@ abstract class JModelLegacy extends JObject
 	 */
 	protected function _getListCount($query)
 	{
-		// Use fast COUNT(*) on JDatabaseQuery objects if there no GROUP BY or HAVING clause:
+		// Use fast COUNT(*) on JDatabaseQuery objects if there is no GROUP BY or HAVING clause:
 		if ($query instanceof JDatabaseQuery
 			&& $query->type == 'select'
 			&& $query->group === null
@@ -332,6 +332,14 @@ abstract class JModelLegacy extends JObject
 		}
 
 		// Otherwise fall back to inefficient way of counting all results.
+
+		// Remove the limit and offset part if it's a JDatabaseQuery object
+		if ($query instanceof JDatabaseQuery)
+		{
+			$query = clone $query;
+			$query->clear('limit')->clear('offset');
+		}
+
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 


### PR DESCRIPTION
Same fix as #4330 but for queries which containg GROUP BY and/or HAVING.
### Issue

Pagination doesn't show at all.
### Testing

Issue has been raised in #4472 with the component JDownloads (http://www.jdownloads.com/index.php?option=com_jdownloads&Itemid=133&view=viewdownload&catid=43&cid=337). The issue doesn't show itself in core to my knowledge. So to test, best is to use JDownloads or any other 3rd party extension which uses a query with GROUP BY or HAVING clauses.

When testing especially make sure nothing else breaks.
