### PR TITLE
Regression: We can't remove the URL-Parameter "limitstart"

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -581,14 +581,11 @@ class JRouterSite extends JRouter
 
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
-			$limitstart = (int) $uri->getVar('limitstart');
-
-			if ($limitstart > 0)
+			if ($limitstart = $uri->getVar('limitstart'))
 			{
-				$uri->setVar('start', $limitstart);
+				$uri->setVar('start', (int) $limitstart);
+				$uri->delVar('limitstart');
 			}
-
-			$uri->delVar('limitstart');
 		}
 
 		$uri->setPath($route);


### PR DESCRIPTION
### Issue

In some extensions the user can't get back to the first page once he navigated to a later page.
To my knowledge this doesn't happen in core extensions but other extensions have this reported.
It only happens when SEF URLs are enabled.
### Explanation

If an extension uses `JModelList::populateState()`, the start of the pagination (`limitstart`) is stored in the session (userstate). That means the value is only changed if the limitstart parameter is present in the request. Due to a recent change (#3725) the limitstart was removed from the request when it was equal to zero. While this works for some extensions that don't use the userstates (like the core extensions), it broke pagination for the extensions which use those session states.
### Solution

This PR just reverts the faulty PR and restores the limitstart parameter.
### Testing

As this doesn't happen with core extensions, you need to use a 3rd party extension which is affected. You can use my own "SermonSpeaker" to do that. Either install it using the webinstaller or get it from http://www.sermonspeaker.net/download/sermonspeaker-component/sermonspeaker-component-5-2-3.html.
Create multiple sermons (batch copy the existing example sermon) and a menu item and test the pagination.
Make sure you have SEF URLs turned on as non-SEF URLs are not affected.
