### PR TITLE
Fix Numeric usernames can start with a space issue

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -187,7 +187,7 @@ class JTableUser extends JTable
 		}
 
 		if (preg_match('#[<>"\'%;()&\\\\]|\\.\\./#', $this->username) || strlen(utf8_decode($this->username)) < 2
-			|| trim($this->username) != $this->username)
+			|| trim($this->username) !== $this->username)
 		{
 			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_VALID_AZ09', 2));
 

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -171,15 +171,17 @@ class JTableUser extends JTable
 			$this->id = null;
 		}
 
+		$filterInput = JFilterInput::getInstance();
+
 		// Validate user information
-		if (trim($this->name) == '')
+		if ($filterInput->clean($this->name, 'TRIM') == '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_PLEASE_ENTER_YOUR_NAME'));
 
 			return false;
 		}
 
-		if (trim($this->username) == '')
+		if ($filterInput->clean($this->username, 'TRIM') == '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_PLEASE_ENTER_A_USER_NAME'));
 
@@ -187,14 +189,14 @@ class JTableUser extends JTable
 		}
 
 		if (preg_match('#[<>"\'%;()&\\\\]|\\.\\./#', $this->username) || strlen(utf8_decode($this->username)) < 2
-			|| trim($this->username) !== $this->username)
+			|| $filterInput->clean($this->username, 'TRIM') !== $this->username)
 		{
 			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_VALID_AZ09', 2));
 
 			return false;
 		}
 
-		if ((trim($this->email) == "") || !JMailHelper::isEmailAddress($this->email))
+		if (($filterInput->clean($this->email, 'TRIM') == "") || !JMailHelper::isEmailAddress($this->email))
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_VALID_MAIL'));
 


### PR DESCRIPTION
This pull request fix the issue #4481 Numeric usernames can start with a space. Basically, the username is validated using this line of code below in JTableUser class:

https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/table/user.php#L189

In this if command, the code trim($this->username) != $this->username doesn't work as expected.

In this case, when username only contains space and numeric characters, trim($this->username) != $this->username still return false (it seems because PHP "thinks" that " 123" and "123" are both number, so it is the same and the command return false instead of true as expected).

To fix this issue, we simply change != operator to !== and It works well.

How to test:
1. Try to register for an account using "Numeric usernames start with a space", for example " 123" (space + 123). You will see that Joomla still allows you to register using that username (unexpected behavior)
2. Apply this pull request
3. Try to register again. You will see that the username like that will be rejected
