### PR TITLE
Mootools: Move help to jquery

### DIFF
--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -9,11 +9,13 @@
 
 defined('_JEXEC') or die;
 
-$doTask = $displayData['doTask'];
-$text   = $displayData['text'];
+JHtml::_('script', 'jui/jquery-popupwindow-min.js', false, true);
+
+$url = $displayData['doTask'];
+$text = $displayData['text'];
 
 ?>
-<button onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-small">
+<button href="<?php echo $url; ?>" rel="help" class="btn btn-small popup">
 	<span class="icon-question-sign"></span>
 	<?php echo $text; ?>
 </button>

--- a/libraries/cms/toolbar/button/help.php
+++ b/libraries/cms/toolbar/button/help.php
@@ -77,13 +77,10 @@ class JToolbarButtonHelp extends JToolbarButton
 	 */
 	protected function _getCommand($ref, $com, $override, $component)
 	{
-		JHtml::_('behavior.framework');
-
 		// Get Help URL
 		$url = JHelp::createURL($ref, $com, $override, $component);
 		$url = htmlspecialchars($url, ENT_QUOTES);
-		$cmd = "Joomla.popupWindow('$url', '" . JText::_('JHELP', true) . "', 700, 500, 1)";
 
-		return $cmd;
+		return $url;
 	}
 }

--- a/media/jui/js/jquery-popupwindow-min.js
+++ b/media/jui/js/jquery-popupwindow-min.js
@@ -1,0 +1,6 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+jQuery(function(a){a(".popup").click(function(d){d.preventDefault();var c=700;var b=500;var e=(a(window).height()/2)-(b/2);var f=(a(window).width()/2)-(c/2);window.open(a(this).attr("href"),"popupWindow","width="+c+",height="+b+",scrollbars=yes,left="+f+"top="+e)})});

--- a/media/jui/js/jquery-popupwindow.js
+++ b/media/jui/js/jquery-popupwindow.js
@@ -1,0 +1,15 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+jQuery(function ($) {
+	$('.popup').click(function (event) {
+		event.preventDefault();
+		var width = 700;
+		var height = 500;
+		var toppx = ($(window).height() / 2) - (height / 2);
+		var leftpx = ($(window).width() / 2) - (width / 2);
+		window.open($(this).attr("href"), "popupWindow", "width=" + width + ",height=" + height + ",scrollbars=yes,left=" + leftpx + "top=" + toppx);
+	});
+});


### PR DESCRIPTION
Move help (mootools) to Jquery
## Issue

We need to move mootools to Jquery
## Solution

This PR just changed the popupwindow code to Jquery
## Testing

Go to backend and click on the help buttons.
