### PR TITLE
Missing return type in PHPDoc

### DIFF
--- a/libraries/joomla/methods.php
+++ b/libraries/joomla/methods.php
@@ -26,7 +26,7 @@ class JRoute
 	 *                             0: Leave URI in the same secure state as it was passed to the function.
 	 *                            -1: Make URI unsecure using the global unsecure site URI.
 	 *
-	 * @return  The translated humanly readible URL.
+	 * @return  string  The translated humanly readible URL.
 	 *
 	 * @since   11.1
 	 */


### PR DESCRIPTION
Missing return type in PHPDoc causing in error "Method _toString is not implemented for class \The" in PHPStorm. This as a result of "The" interpreted as the type name by the IDE parser.
