### PR TITLE
Fixes for a regression introduced by #4221

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -637,13 +637,10 @@ class PlgSystemLanguageFilter extends JPlugin
 						// Check if language is the default site language and remove url language code is on
 						if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
 						{
-							$relLink = str_replace('/' . $language->sef, '', $link);
-							$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+							$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
 						}
-						else
-						{
-							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
-						}
+
+						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
 					}
 					elseif (isset($associations[$language->lang_code]))
 					{
@@ -663,13 +660,10 @@ class PlgSystemLanguageFilter extends JPlugin
 							// Check if language is the default site language and remove url language code is on
 							if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
 							{
-								$relLink = str_replace('/' . $language->sef, '', $link);
-								$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+								$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
 							}
-							else
-							{
-								$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
-							}
+
+							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
 						}
 					}
 				}
@@ -700,13 +694,10 @@ class PlgSystemLanguageFilter extends JPlugin
 						// Check if language is the default site language and remove url language code is on
 						if ($language->sef == self::$default_sef && $this->params->get('remove_default_prefix') == '1')
 						{
-							$relLink = str_replace('/' . $language->sef, '', $link);
-							$doc->addHeadLink($server . $relLink, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+							$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
 						}
-						else
-						{
-							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
-						}
+
+						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
 					}
 				}
 			}


### PR DESCRIPTION
#4221 was incorrectly using str_replace() to remove the default language code when required. As str_replace() acts globally on the subject, the language code was removed also out of context (e.g. when part of an alias).

With this PR I use instead preg_replace() with the limit of one substitution. As the /language-code/ string to be replaced appears between two slashes and just after the host name (eg. http://example.com/en/) this should guarantee the correct replacements of the language code only.

I took the occasion to make a bit of clean-up by aggregating some redundantly duplicated code
