### PR TITLE
Review the installation/configuration.php-dist

### DIFF
--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -26,7 +26,6 @@ class JConfig {
 	public $editor = 'tinymce';
 	public $captcha = '0';
 	public $list_limit = '20';
-	/* public $root_user = '42'; */          // The User whose ID is here is SuperUser (Whatever is set at the database). This sholud only use if it is realy needed
 	public $access = '1';
 
 	/* Database Settings */

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -48,8 +48,8 @@ class JConfig {
 	public $ftp_pass = '';
 	public $ftp_root = '';
 	public $ftp_enable = '';
-	public $tmp_path = '/tmp';                // Please make sure that this is correct temp path and check it with your host. This path needs to be writable by Joomla!
-	public $log_path = '/var/logs';           // Please make sure that this is correct log path and check it with your host. This path needs to be writable by Joomla!
+	public $tmp_path = '/tmp';                // Please check with your host that this is the correct path to the temp directory. This path needs to be writable by Joomla!
+	public $log_path = '/var/logs';           // Please check with your host that this is the correct path to the logs directory. This path needs to be writable by Joomla!
 	public $live_site = '';                   // Optional, full url to Joomla install.
 	public $force_ssl = 0;                    // Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
 

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -1,8 +1,8 @@
 <?php
 /**
- * @package		Joomla
- * @copyright	Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @package     Joomla
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  *
  * -------------------------------------------------------------------------
  * THIS SHOULD ONLY BE USED AS A LAST RESORT WHEN THE WEB INSTALLER FAILS
@@ -22,23 +22,23 @@ class JConfig {
 	public $offline_message = 'This site is down for maintenance.<br /> Please check back again soon.';
 	public $display_offline_message = '1';
 	public $offline_image = '';
-	public $sitename = 'Joomla!';				// Name of Joomla site
+	public $sitename = 'Joomla!';            // Name of Joomla site
 	public $editor = 'tinymce';
 	public $captcha = '0';
 	public $list_limit = '20';
-	public $root_user = '42';
+	/* public $root_user = '42'; */          // The User whose ID is here is SuperUser (Whatever is set at the database). This sholud only use if it is realy needed
 	public $access = '1';
 
 	/* Database Settings */
-	public $dbtype = 'mysql';					// Normally mysql
-	public $host = 'localhost';					// This is normally set to localhost
-	public $user = '';							// DB username
-	public $password = '';						// DB password
-	public $db = '';							// DB database name
-	public $dbprefix = 'jos_';					// Do not change unless you need to!
+	public $dbtype = 'mysqli';               // Normally mysqli
+	public $host = 'localhost';              // This is normally set to localhost
+	public $user = '';                       // DB username
+	public $password = '';                   // DB password
+	public $db = '';                         // DB database name
+	public $dbprefix = 'jos_';               // Do not change unless you need to!
 
 	/* Server Settings */
-	public $secret = 'FBVtggIk5lAzEU9H'; 		// Change this to something more secure
+	public $secret = 'FBVtggIk5lAzEU9H';     // Change this to something more secure
 	public $gzip = '0';
 	public $error_reporting = 'default';
 	public $helpurl = 'http://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}';
@@ -48,16 +48,16 @@ class JConfig {
 	public $ftp_pass = '';
 	public $ftp_root = '';
 	public $ftp_enable = '';
-	public $tmp_path = '/tmp';
-	public $log_path = '/var/logs';
-	public $live_site = ''; 					// Optional, Full url to Joomla install.
-	public $force_ssl = 0;						// Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
+	public $tmp_path = '/tmp';                // Please make sure that this is correct temp path and check it with your host. This path needs to be writable by Joomla!
+	public $log_path = '/var/logs';           // Please make sure that this is correct log path and check it with your host. This path needs to be writable by Joomla!
+	public $live_site = '';                   // Optional, full url to Joomla install.
+	public $force_ssl = 0;                    // Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
 
 	/* Locale Settings */
 	public $offset = 'UTC';
 
 	/* Session settings */
-	public $lifetime = '15';					// Session time
+	public $lifetime = '15';                  // Session time
 	public $session_handler = 'database';
 
 	/* Mail Settings */


### PR DESCRIPTION
See: https://github.com/joomla/joomla-cms/issues/4498

This is a review of the installation/configuration.php-dist file. I have add some comments move the default dbtype to mysqli and outcommend the root_user (<-- or is this realy needed?)

I don't know if this need any testing but it can be tested is the following:
1. download a clean staging
2. extract
3. move this file to the joomla root
4. change the needed settings
5. install the database manualy
6. make sure all works as if you use the installer.

Thanks @robations for pointing it out.
