### PR TITLE
[#33041] JHtmlBootstrap::tooltip() delay

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -465,7 +465,7 @@ abstract class JHtmlBootstrap
 			$opt['selector']  = isset($params['selector']) ? (string) $params['selector'] : null;
 			$opt['title']     = isset($params['title']) ? (string) $params['title'] : null;
 			$opt['trigger']   = isset($params['trigger']) ? (string) $params['trigger'] : null;
-			$opt['delay']     = isset($params['delay']) ? (int) $params['delay'] : null;
+			$opt['delay']     = isset($params['delay']) ? (is_array($params['delay']) ? $params['delay'] : (int) $params['delay']) : null;
 			$opt['container'] = isset($params['container']) ? $params['container'] : 'body';
 			$opt['template']  = isset($params['template']) ? (string) $params['template'] : null;
 			$onShow = isset($params['onShow']) ? (string) $params['onShow'] : null;


### PR DESCRIPTION
The JHtmlBootstrap::tooltip() method allows for passing an array of configuration parameters. This configuration may contain a parameter for the show/hide-delay. The value of this parameter may be an integer or a string representing a Javascript object. However, the method doesn't consider the value to be anything else than a number. So, when passing in an array the delay will end up as integer `1` because its datatype is forced by explicit an cast. I extended the line where this parameter is evaluated to check for it being an array or a number. This fixes that issue and creates the script with the correct delay-value. For example:

_before_ applying the patch

```
1. someview.php

JHtml::_('bootstrap.tooltip', '.hasTooltip', array(
    'delay' => array('show' => 500, 'hide' => 1000)
);

2. in JHtmlBootstrap.tooltip()
. . .
$opt['delay'] = isset($params['delay']) ? (int) $params['delay'] : null;
. . .
```

will set `$opt['delay'] = 1;`

_after_ applying the patch

```
1. someview.php

JHtml::_('bootstrap.tooltip', '.hasTooltip', array(
    'delay' => array('show' => 500, 'hide' => 1000)
);

2. in JHtmlBootstrap.tooltip()
. . .
$opt['delay'] = isset($params['delay']) ? (is_array($params['delay']) ? $params['delay'] : (int) $params['delay']) : null;
. . .
```

will set `$opt['delay'] = array('show' => 500, 'hide' => 1000);` , which is wished behaviour. I reported this issue several months back at the [joomlacode tracker.](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=33041)
