### PR TITLE
JHtmlBootstrap::tooltip() hide vs. hideme

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -471,7 +471,6 @@ abstract class JHtmlBootstrap
 			$onShow = isset($params['onShow']) ? (string) $params['onShow'] : null;
 			$onShown = isset($params['onShown']) ? (string) $params['onShown'] : null;
 			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
-			$onHideMe = isset($params['onHideMe']) ? (string) $params['onHideMe'] : null;
 			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
 			$options = JHtml::getJSObject($opt);
@@ -493,12 +492,7 @@ abstract class JHtmlBootstrap
 
 			if ($onHide)
 			{
-				$script[] = "\tjQuery('" . $selector . "').on('hide.bs.tooltip', " . $onHide . ");";
-			}
-
-			if ($onHideMe)
-			{
-				$script[] = "\tjQuery('" . $selector . "').on('hideme.bs.tooltip', " . $onHideMe . ");";
+				$script[] = "\tjQuery('" . $selector . "').on('hideme.bs.tooltip', " . $onHide . ");";
 			}
 
 			if ($onHidden)

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -471,6 +471,7 @@ abstract class JHtmlBootstrap
 			$onShow = isset($params['onShow']) ? (string) $params['onShow'] : null;
 			$onShown = isset($params['onShown']) ? (string) $params['onShown'] : null;
 			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
+			$onHideMe = isset($params['onHideMe']) ? (string) $params['onHideMe'] : null;
 			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
 			$options = JHtml::getJSObject($opt);

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -497,7 +497,7 @@ abstract class JHtmlBootstrap
 
 			if ($onHideMe)
 			{
-				$script[] = "\tjQuery('" . $selector . "').on('hideme.bs.tooltip', " . $onHideMe . ");";	// Added
+				$script[] = "\tjQuery('" . $selector . "').on('hideme.bs.tooltip', " . $onHideMe . ");";
 			}
 
 			if ($onHidden)

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -495,6 +495,11 @@ abstract class JHtmlBootstrap
 				$script[] = "\tjQuery('" . $selector . "').on('hide.bs.tooltip', " . $onHide . ");";
 			}
 
+			if ($onHideMe)
+			{
+				$script[] = "\tjQuery('" . $selector . "').on('hideme.bs.tooltip', " . $onHideMe . ");";	// Added
+			}
+
 			if ($onHidden)
 			{
 				$script[] = "\tjQuery('" . $selector . "').on('hidden.bs.tooltip', " . $onHidden . ");";


### PR DESCRIPTION
It appears the `hide` event is not fired when triggering an element to show the tooltip. However, the `hideme` event is fired. This can easily be tested with the following code:

```
JHtml::_('bootstrap.tooltip', '.hasStickyTooltip', array(
    'onShow'   => 'function ( e ) {'
        .'alert("onShow executed")'.
    '}',
    'onShown'  => 'function ( e ) {'
        .'alert("onShown executed")'.
    '}',
    'onHide'   => 'function ( e ) {'
        .'alert("onHide executed")'.
    '}',
    'onHideMe' => 'function ( e ) {'
        .'alert("onHideMe executed")'.
    '}',
    'onHidden' => 'function ( e ) {'
        .'alert("onHidden executed")'.
    '}'
));
```

This proves the message `onHide executed` never appears. To get hands on the event fired before the widget is getting hidden i added the corresponding listener `onHideMe` to the configuration array. With this listener in place the message `onHideMe executed` is shown and the corresponding event is handled by the plugin.
