### PR TITLE
[#4505] Wrong datetime NOW for JForm field calendar

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -167,7 +167,7 @@ class JFormFieldCalendar extends JFormField
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')
 		{
-			$this->value = strftime($format);
+			$this->value = JFactory::getDate()->toSql();
 		}
 
 		// Get some system objects.


### PR DESCRIPTION
#### Steps to reproduce the issue

For a calendar form field you set the default value to "NOW" and add a new item.
To  test you can edit any form with a calendar field.
#### Expected result
1. The actual user date and time shown
   or
2. The actual server date and time shown
   depending on the filter used
#### Actual result

The date and time is wrongly calculated with the actual server date and time as basis.
Must use UTC+0 as basis.
#### System information (as much as possible)

J 3.3.6
#### Additional comments

PR on GitHub
calendar.php
        // Handle the special case for "now".
        if (strtoupper($this->value) == 'NOW')
        {
            //$this->value = strftime($format);
            $this->value = JFactory::getDate()->toSql();
        }
