### PR TITLE
JPagination fix: Wrong pagination when used a multiple instances

### DIFF
--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -82,6 +82,13 @@ class JPagination
 	protected $additionalUrlParams = array();
 
 	/**
+	 * Pagination data object
+	 *
+	 * @var object
+	 */
+	protected $data;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   integer  $total       The total number of items.
@@ -229,14 +236,12 @@ class JPagination
 	 */
 	public function getData()
 	{
-		static $data;
-
-		if (!is_object($data))
+		if (!$this->data)
 		{
-			$data = $this->_buildDataObject();
+			$this->data = $this->_buildDataObject();
 		}
 
-		return $data;
+		return $this->data;
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -366,6 +366,25 @@ class JPaginationTest extends TestCase
 	}
 
 	/**
+	 * Tests the getData method with multiple JPagination instances
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 * @link    https://github.com/joomla/joomla-cms/pull/4521
+	 */
+	public function testGetDataWithMultipleInstances()
+	{
+		$p1 = new JPagination(10, 0, 5, 'pref1');
+		$data1 = $p1->getData();
+		$p2 = new JPagination(20, 0, 10, 'pref2');
+		$data2 = $p2->getData();
+
+		$this->assertEquals(5, $data1->next->base, 'Assert the base value for the next page for object 1 is correct.');
+		$this->assertEquals(10, $data2->next->base, 'Assert the base value for the next page for object 2 is correct.');
+	}
+
+	/**
 	 * Provides the data to test the getPagesCounter() method.
 	 *
 	 * @return  array


### PR DESCRIPTION
This pull fix the issue when a couple JPagination instances used.

**Test**
Run next code:

``` php
$p1 = new JPagination(10, 0, 5, 'pref1');
$data1 = $p1->getData();
$p2 = new JPagination(20, 0, 10, 'pref2');
$data2 = $p2->getData();
echo '<pre>';
print_r($data1->next);
print_r($data2->next);
echo '</pre>';
```

Result (before patch):

```
JPaginationObject Object
(
    [text] => Next
    [base] => 5
    [link] => /jdev/?pref1limitstart=5
    [prefix] => pref1
    [active] => 
)
JPaginationObject Object
(
    [text] => Next
    [base] => 5
    [link] => /jdev/?pref1limitstart=5
    [prefix] => pref1
    [active] => 
)
```

**Expected result:**

```
JPaginationObject Object
(
    [text] => Next
    [base] => 5
    [link] => /jdev/?pref1limitstart=5
    [prefix] => pref1
    [active] => 
)
JPaginationObject Object
(
    [text] => Next
    [base] => 10
    [link] => /jdev/?pref2limitstart=10
    [prefix] => pref2
    [active] => 
)
```
