### PR TITLE
[Code Style] Execute Code Style Checks in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ Desktop.ini
 
 # Never ignore #
 !.gitignore
+
+# Composer files #
+/composer.phar
+/vendor/
+/composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 
 before_script:
   - composer self-update
-  - pyrus install -f pear/PHP_CodeSniffer-1.5.4
   - phpenv rehash
   - mysql -e 'create database joomla_ut;'
   - mysql joomla_ut < tests/unit/suites/database/stubs/mysql.sql
@@ -17,7 +16,7 @@ before_script:
 
 script:
   - phpunit --configuration travisci-phpunit.xml
-  - phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .
+  - php .travis/phpcs.php
 
 branches:
   except:

--- a/.travis/phpcs.php
+++ b/.travis/phpcs.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Command line script for executing PHPCS during a Travis build.
+ *
+ * @package    Joomla.Travis
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Only run on the CLI SAPI
+(php_sapi_name() == 'cli' ?: die('CLI only'));
+
+// Script defines
+define('REPO_BASE', dirname(__DIR__));
+
+// Require Composer autoloader
+if (!file_exists(REPO_BASE . '/vendor/autoload.php'))
+{
+	fwrite(STDOUT, "\033[37;41mThis script requires Composer to be set up, please run 'composer install' first.\033[0m\n");
+}
+
+require REPO_BASE . '/vendor/autoload.php';
+
+// Welcome message
+fwrite(STDOUT, "\033[32;1mInitializing PHP_CodeSniffer checks.\033[0m\n");
+
+// Build the options for the sniffer
+$options = array(
+	'files'        => array(
+		REPO_BASE . '/components',
+		REPO_BASE . '/administrator',
+		REPO_BASE . '/installation',
+		REPO_BASE . '/libraries',
+		REPO_BASE . '/modules',
+		REPO_BASE . '/plugins',
+	),
+	'standard'     => array(REPO_BASE . '/build/phpcs/Joomla'),
+	'ignored'      => array(
+		REPO_BASE . '/component/admin/views/*/tmpl/*',
+		REPO_BASE . '/layouts/*'
+	),
+	'showProgress' => true
+);
+
+// Instantiate the sniffer
+$phpcs = new PHP_CodeSniffer_CLI;
+
+// Ensure PHPCS can run, will exit if requirements aren't met
+$phpcs->checkRequirements();
+
+// Run the sniffs
+$numErrors = $phpcs->process($options);
+
+// If there were errors, output the number and exit the app with a fail code
+if ($numErrors)
+{
+	fwrite(STDOUT, sprintf("\033[37;41mThere were %d issues detected.\033[0m\n", $numErrors));
+	exit(1);
+}
+else
+{
+	fwrite(STDOUT, "\033[32;1mThere were no issues detected.\033[0m\n");
+	exit(0);
+}

--- a/.travis/phpcs.php
+++ b/.travis/phpcs.php
@@ -37,7 +37,8 @@ $options = array(
 	),
 	'standard'     => array(REPO_BASE . '/build/phpcs/Joomla'),
 	'ignored'      => array(
-		REPO_BASE . '/component/admin/views/*/tmpl/*',
+		REPO_BASE . '/administrator/components/*/views/*/tmpl/*',
+		REPO_BASE . '/components/*/views/*/tmpl/*',
 		REPO_BASE . '/layouts/*'
 	),
 	'showProgress' => true

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name"       : "joomla/joomla-cms",
+    "description": "Home of the Joomla! Content Management System",
+    "license"    : "GPL-2.0+",
+    "require"    : {
+        "php": ">=5.3.10"
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "1.*"
+    }
+}


### PR DESCRIPTION
# Do not merge, this is work in progress

This pull adds the PHP script that @mbabker  did for com_localise in Joomla repo. This script is run by travis and it will do:

```
# When issues are detected Travis will fail
exit(1); 
```

![screen shot 2014-10-11 at 18 27 11](https://cloud.githubusercontent.com/assets/1375475/4603286/2d54a6ba-5163-11e4-91ee-ab99cad9ac9a.png)

```
# When no issues Travis will succed
exit(0);
```

![screen shot 2014-10-11 at 18 22 33](https://cloud.githubusercontent.com/assets/1375475/4603283/26138d30-5163-11e4-80cf-7b8bce28c6d4.png)

If we are able to get rid of all the current code style issues in the CMS we will be able to merge this pull request and it will automatically check new Pull request failing when a code style issue is added.
