### PR TITLE
Fixing canonical in SEF plugin

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -36,7 +36,7 @@ class PlgSystemSef extends JPlugin
 
 		$router = $app::getRouter();
 
-		$uri     = clone JUri::getInstance();
+		$uri     = JUri::getInstance();
 		$domain  = $this->params->get('domain');
 
 		if ($domain === null || $domain === '')
@@ -44,11 +44,9 @@ class PlgSystemSef extends JPlugin
 			$domain = $uri->toString(array('scheme', 'host', 'port'));
 		}
 
-		$parsed = $router->parse($uri);
-		$fakelink = 'index.php?' . http_build_query($parsed);
-		$link = $domain . JRoute::_($fakelink, false);
+		$link = $domain . JRoute::_('index.php?' . http_build_query($router->getVars()), false);
 
-		if ($uri !== $link)
+		if ($uri->toString() !== $link)
 		{
 			$doc->addHeadLink(htmlspecialchars($link), 'canonical');
 		}


### PR DESCRIPTION
The SEF plugin right now ALWAYS adds the canonical tag to the header. At the same time it is written extremely inefficient. Going through this step by step:
1. In line 39, the JUri object is cloned, even though it is not necessary. We are doing nothing with this and we are not modifying it. This wastes memory. (Albeit its only a little bit.)
2. In line 47 to 49, we take the current URI from JUri, parse that one again to retrieve the current data. $router->getVars() does the same and is a simple lookup instead of a few dozen function calls, a few thousand lines of code and lots of wasted CPU. $router->getVars() is the result of the first run of parse() over the current URI.
3. Now that we've wasted lots of time and memory already, we then come to line 51, which compares an object ($uri) against a string ($link). Since we are using !==, the object also is not casted to string, so the result is always true and the canonical tag is always added, making this feature completely useless.

This PR fixes all these issues.
