### PR TITLE
Removing unnecessary run of JRouter::parse()

### DIFF
--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -60,8 +60,7 @@ class ModLoginHelper
 		if (!$url)
 		{
 			// Stay on the same page
-			$uri = clone JUri::getInstance();
-			$vars = $router->parse($uri);
+			$vars = $router->getVars();
 			unset($vars['lang']);
 
 			if ($router->getMode() == JROUTER_MODE_SEF)


### PR DESCRIPTION
$router->getVars() is a simple lookup of the parsed variables of the current URI and saves A LOT of memory and run time. See #4612 for a similar issue.
