### PR TITLE
[fix] permissions not checked to change state of a redirect

### DIFF
--- a/administrator/components/com_redirect/helpers/html/redirect.php
+++ b/administrator/components/com_redirect/helpers/html/redirect.php
@@ -30,16 +30,43 @@ class JHtmlRedirect
 	 *
 	 * @since   1.6
 	 *
+	 * @deprecated  4.0
+	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public static function published($value = 0, $i = null, $canChange = true)
+	public static function published($value = 0, $i = 0, $canChange = true)
 	{
+		// Log deprecated message
+		JLog::add(
+			'JHtmlRedirect::published() is deprecated. Use JHtmlRedirect::status() instead.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		// Note: $i is required but has to be an optional argument in the function call due to argument order
 		if (null === $i)
 		{
 			throw new InvalidArgumentException('$i is a required argument in JHtmlRedirect::published');
 		}
 
+		return static::status($i, $value, $canChange);
+	}
+
+	/**
+	 * Display the published or unpublished state of an item.
+	 *
+	 * @param   int      $i          The ID of the item.
+	 * @param   int      $value      The state value.
+	 * @param   boolean  $canChange  An optional prefix for the task.
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4
+	 *
+	 * @throws  InvalidArgumentException
+	 */
+	public static function status($i, $value = 0, $canChange = false)
+	{
 		// Array of image, task, title, action
 		$states	= array(
 			1	=> array('tick.png',		'links.unpublish',	'JENABLED',	'COM_REDIRECT_DISABLE_LINK'),

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -66,6 +66,9 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						<th width="20">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
+						<th width="1%" style="min-width:55px" class="nowrap center">
+							<?php echo JHtml::_('grid.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
+						</th>
 						<th class="title">
 							<?php echo JHtml::_('grid.sort', 'COM_REDIRECT_HEADING_OLD_URL', 'a.old_url', $listDirn, $listOrder); ?>
 						</th>
@@ -103,8 +106,10 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 						</td>
+						<td class="center">
+							<?php echo JHtml::_('redirect.status', $i, $item->published, $canChange); ?>
+						</td>
 						<td>
-							<?php echo JHtml::_('redirect.published', $item->published, $i); ?>
 							<?php if ($canEdit) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_redirect&task=link.edit&id='.$item->id);?>" title="<?php echo $this->escape($item->old_url); ?>">
 									<?php echo $this->escape(str_replace(JUri::root(), '', rawurldecode($item->old_url))); ?></a>


### PR DESCRIPTION
This PRs tries to fix some issues found after merging https://github.com/joomla/joomla-cms/pull/4609#discussion_r18748245
- I'm deprecating `JHtmlRedirect::published()` as the fix we applied is a bit tricky
- I'm creating a new function `JHtmlRedirect::status()` as replacement of the previous method
- I'm replacing the only existing call to `JHtml::_('redirect.published'` to use now `JHtml::_('redirect.status'`
- When replacing the call I realised that the `$canChange` is not checked to display the icon. That + having a default value of true made it always clickable by the user.

cc / @roland-d
