### PR TITLE
Fix undefined index for REQUEST_METHOD

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -300,7 +300,9 @@ class JInput implements Serializable, Countable
 	 */
 	public function getMethod()
 	{
-		$method = strtoupper($_SERVER['REQUEST_METHOD']);
+		// Get method if exist
+		$method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : '';
+		$method = strtoupper($method);
 
 		return $method;
 	}


### PR DESCRIPTION
If we try to catch the input for websocket protocol, $_SERVER['REQUEST_METHOD'] is not set and not needed, so this fix check if this variable is set, if not return ''.
