### PR TITLE
Searchtools dowsn't allow to pass two options with same value

### DIFF
--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -22,7 +22,7 @@ $customOptions = array(
 	'orderFieldSelector'  => '#list_fullordering'
 );
 
-$data['options'] = array_unique(array_merge($customOptions, $data['options']));
+$data['options'] = array_merge($customOptions, $data['options']);
 
 $formSelector = !empty($data['options']['formSelector']) ? $data['options']['formSelector'] : '#adminForm';
 


### PR DESCRIPTION
### Fun Fact

The searchtools JLayout allows to pass some options into it. But the options need to be of different values to stick. If two are passed of same value then only the first one sticks and the second gets deleted.
### Issue

The JLayout uses `array_unique()` after it merged some default options with the passed options. I have no clue what the author wanted to achieve, but it's certainly wrong. `array_unqiue` will make sure that the **values** of the array are unique.
### Solution

Removing `array_unique()`
### Testing

Edit the call to the JLayout and pass some additional options to it.
Example:
In https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/views/articles/tmpl/default.php#L65 change `echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));` to `echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false, 'searchButton' => false)));`
Supported options would be
- filterButton
- searchButton
- filtersHidden
- defaultLimit
- searchFieldSelector
- orderFieldSelector
  The first three are good candidates to play with as they all expect boolean parameter.

Either check by testing if the output reflects the parameters or dump the `$data['options']` in the JLayout file (/layouts/joomla/searchtools/default.php).
