### PR TITLE
Move com_menus modals to Bootstrap

### DIFF
--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -72,7 +72,6 @@ class JFormFieldMenutype extends JFormFieldList
 		}
 		// Include jQuery
 		JHtml::_('jquery.framework');
-		JHtml::_('bootstrap.modal');
 
 		// Add the script to the document head.
 		JFactory::getDocument()->addScriptDeclaration('

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -70,19 +70,23 @@ class JFormFieldMenutype extends JFormFieldList
 				$value	= JText::_(JArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
 				break;
 		}
-		// Load the javascript and css
-		JHtml::_('behavior.framework');
-		JHtml::_('behavior.modal');
+		// Include jQuery
+		JHtml::_('jquery.framework');
+		JHtml::_('bootstrap.modal');
 
-		$getMenuTypesUrl = 'index.php?option=com_menus&view=menutypes&tmpl=component&recordId=' . $recordId;
-		$html[] = '<span class="input-append">'
-			. '<input type="text" ' . $required . ' readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' />'
-			. '<a class="btn btn-primary" '
-				. 'onclick="SqueezeBox.fromElement(this, {handler:\'iframe\', size: {x: 600, y: 450}, url:\'' . JRoute::_($getMenuTypesUrl) . '\'})">'
-				. '<i class="icon-list icon-white"></i> ' . JText::_('JSELECT')
-			. '</a></span>';
-		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" '
-			. 'value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
+		// Add the script to the document head.
+		JFactory::getDocument()->addScriptDeclaration('
+			function jSelectPosition_' . $this->id . '(name) {
+				document.getElementById("' . $this->id . '").value = name;
+				jQuery("#menuTypeModal").modal("hide");
+			}
+		');
+
+		$link = JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId=' . $recordId);
+		$html[] = '<span class="input-append"><input type="text" ' . $required . ' disabled="disabled" readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' />';
+		$html[] = '<a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="' . JText::_('JSELECT') . '"><i class="icon-list icon-white"></i> ' . JText::_('JSELECT') . '</a></span>';
+		$html[] = JHtmlBootstrap::renderModal('menuTypeModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),'height' => '600px', 'width' => '800px'), '');
+		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -21,10 +21,10 @@ JFactory::getDocument()->addScriptDeclaration('
 
 	jQuery(document).ready(function() {
 		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules1\']", function (event) {
-		    jQuery(".table tr.no").hide();
+			jQuery(".table tr.no").hide();
 		});
 		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules0\']", function (event) {
-		    jQuery(".table tr.no").show();
+			jQuery(".table tr.no").show();
 		});
 	});
 ');
@@ -65,7 +65,7 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 			<?php endif; ?>
 				<td id="<?php echo $module->id; ?>">
 					<?php $link = 'index.php?option=com_modules&amp;client_id=0&amp;task=module.edit&amp;id=' . $module->id . '&amp;tmpl=component&amp;view=module&amp;layout=modal'; ?>
-					<a class="modal" href="<?php echo $link;?>" rel="{handler: 'iframe', size: {x: 900, y: 550}}" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>" id="title-<?php echo $module->id; ?>">
+					<a href="#module<?php echo $module->id; ?>Modal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>" id="title-<?php echo $module->id; ?>">
 						<?php echo $this->escape($module->title); ?></a>
 				</td>
 				<td id="access-<?php echo $module->id; ?>">
@@ -99,6 +99,7 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 						</span>
 					<?php endif; ?>
 				</td>
+			<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -14,7 +14,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-JHtml::_('behavior.modal');
 JHtml::_('formbehavior.chosen', 'select');
 
 $uri = JUri::getInstance();
@@ -37,23 +36,21 @@ JFactory::getDocument()->addScriptDeclaration("
 
 $script = array();
 $script[] = "jQuery(document).ready(function() {";
+
 foreach ($this->items as $item) :
 	if ($user->authorise('core.edit', 'com_menus')) :
 		$script[] = '	function jSelectPosition_' . $item->id . '(name) {';
 		$script[] = '		document.getElementById("' . $item->id . '").value = name;';
-		$script[] = '		jQuery("#menusModuleModal").modal("hide");';
+		$script[] = '		jQuery(".modal").modal("hide");';
 		$script[] = '	};';
 	endif;
 endforeach;
-foreach ($this->modules as $module => $type) :
-	foreach ($type as $mod => $tp) :
-		$script[] = '	jQuery("#module' . $tp->id . 'Modal").on("hidden", function () {';
-		$script[] = '		setTimeout(function(){';
-		$script[] = '			window.parent.location.reload();';
-		$script[] = '		},1000);';
-		$script[] = '	});';
-	endforeach;
-endforeach;
+
+$script[] = '	jQuery(".modal").on("hidden", function () {';
+$script[] = '		setTimeout(function(){';
+$script[] = '			window.parent.location.reload();';
+$script[] = '		},1000);';
+$script[] = '	});';
 $script[] = "});";
 
 JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -45,12 +45,14 @@ foreach ($this->items as $item) :
 		$script[] = '	};';
 	endif;
 endforeach;
-foreach ($this->modules[$item->menutype] as &$module) :
-	$script[] = '	jQuery("#module' . $module->id . 'Modal").on("hidden", function () {';
-	$script[] = '		setTimeout(function(){';
-	$script[] = '			window.parent.location.reload();';
-	$script[] = '		},1000);';
-	$script[] = '	});';
+foreach ($this->modules as $module => $type) :
+	foreach ($type as $mod => $tp) :
+		$script[] = '	jQuery("#module' . $tp->id . 'Modal").on("hidden", function () {';
+		$script[] = '		setTimeout(function(){';
+		$script[] = '			window.parent.location.reload();';
+		$script[] = '		},1000);';
+		$script[] = '	});';
+	endforeach;
 endforeach;
 $script[] = "});";
 

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -34,6 +34,27 @@ JFactory::getDocument()->addScriptDeclaration("
 			}
 		};
 ");
+
+$script = array();
+$script[] = "jQuery(document).ready(function() {";
+foreach ($this->items as $item) :
+	if ($user->authorise('core.edit', 'com_menus')) :
+		$script[] = '	function jSelectPosition_' . $item->id . '(name) {';
+		$script[] = '		document.getElementById("' . $item->id . '").value = name;';
+		$script[] = '		jQuery("#menusModuleModal").modal("hide");';
+		$script[] = '	};';
+	endif;
+endforeach;
+foreach ($this->modules[$item->menutype] as &$module) :
+	$script[] = '	jQuery("#module' . $module->id . 'Modal").on("hidden", function () {';
+	$script[] = '		setTimeout(function(){';
+	$script[] = '			window.parent.location.reload();';
+	$script[] = '		},1000);';
+	$script[] = '	});';
+endforeach;
+$script[] = "});";
+
+JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=menus');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
@@ -142,8 +163,9 @@ JFactory::getDocument()->addScriptDeclaration("
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
 												<?php if ($canEdit) : ?>
-													<a class="small modal" href="<?php echo JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal');?>" rel="{handler: 'iframe', size: {x: 1024, y: 450}, onClose: function() {window.location.reload()}}" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>">
-													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
+													<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
+													<a href="#module<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>">
+														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else :?>
 													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?>
 												<?php endif; ?>
@@ -151,9 +173,16 @@ JFactory::getDocument()->addScriptDeclaration("
 										<?php endforeach; ?>
 									</ul>
 								 </div>
+								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
+									<?php if ($canEdit) : ?>
+										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
+										<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+									<?php endif; ?>
+								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
 								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
+								<?php echo JHtmlBootstrap::renderModal('moduleModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
 							<?php endif; ?>
 						</td>
 						<td class="center">

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -14,6 +14,7 @@ $input = JFactory::getApplication()->input;
 // Checking if loaded via index.php or component.php
 $tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
 
+JHtml::_('behavior.core');
 JFactory::getDocument()->addScriptDeclaration('
 		setmenutype = function(type) {
 			var tmpl = ' . json_encode($tmpl) . ';

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -73,7 +73,7 @@ $script .= "
 						}
 						if (updMenus == '-') {
 							tmpMenu.html('<span class=\"label label-important\">" . JText::_("JNO") . "</span>');
-							if (!tmpRow.hasClass('no')) { tmpRow.addClass('no '); }
+							if (!tmpRow.hasClass('no') || tmpRow.hasClass('')) { tmpRow.addClass('no '); }
 						}
 						if (updMenus > 0) {
 							if (window.parent.inMenus.indexOf(parent.menuId) >= 0)
@@ -81,18 +81,18 @@ $script .= "
 								if (window.parent.numMenus == window.parent.inMenus.length)
 								{
 									tmpMenu.html('<span class=\"label label-info\">" . JText::_("JALL") . "</span>');
-									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no '); }
+									if (tmpRow.hasClass('no') || tmpRow.hasClass('')) { tmpRow.removeClass('no'); }
 								}
 								else
 								{
 									tmpMenu.html('<span class=\"label label-success\">" . JText::_("JYES") . "</span>');
-									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no '); }
+									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no'); }
 								}
 							}
 							if (window.parent.inMenus.indexOf(parent.menuId) < 0)
 							{
 								tmpMenu.html('<span class=\"label label-important\">" . JText::_("JNO") . "</span>');
-								if (!tmpRow.hasClass('no')) { tmpRow.addClass('no '); }
+								if (!tmpRow.hasClass('no')) { tmpRow.addClass('no'); }
 							}
 						}
 						if (updMenus < 0) {
@@ -101,18 +101,18 @@ $script .= "
 								if (window.parent.numMenus == window.parent.inMenus.length)
 								{
 									tmpMenu.html('<span class=\"label label-info\">" . JText::_("JALL") . "</span>');
-									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no '); }
+									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no'); }
 								}
 								else
 								{
 									tmpMenu.html('<span class=\"label label-success\">" . JText::_("JYES") . "</span>');
-									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no '); }
+									if (tmpRow.hasClass('no')) { tmpRow.removeClass('no'); }
 								}
 							}
 							if (window.parent.inMenus.indexOf(parent.menuId) < 0)
 							{
 								tmpMenu.html('<span class=\"label label-important\">" . JText::_("JNO") . "</span>');
-								if (!tmpRow.hasClass('no')) { tmpRow.addClass('no '); }
+								if (!tmpRow.hasClass('no') || tmpRow.hasClass('')) { tmpRow.addClass('no'); }
 							}
 						}
 
@@ -120,7 +120,7 @@ $script .= "
 							jQuery('#position-" . $this->item->id . "', parent.document).text(updPosition);
 							jQuery('#access-" . $this->item->id . "', parent.document).html(parent.viewLevels[updAccess]);
 					}
-					window.top.setTimeout('window.parent.jModalClose()', 1000);
+					window.parent.jQuery('.modal').modal('hide');
 				}
 			}
 	};";

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -8,6 +8,10 @@
  */
 
 defined('_JEXEC') or die;
+
+JFactory::getDocument()->addScriptDeclaration('
+	window.parent.jQuery(".modal").on("hidden", function () { Joomla.submitbutton("module.cancel"); });
+');
 ?>
 <div class="btn-toolbar">
 	<div class="btn-group">
@@ -15,7 +19,7 @@ defined('_JEXEC') or die;
 		<?php echo JText::_('JSAVE');?></button>
 	</div>
 	<div class="btn-group">
-		<button type="button" class="btn" onclick="window.parent.jModalClose();">
+		<button type="button" class="btn" onclick="Joomla.submitbutton('module.cancel'); window.parent.jQuery('.modal').modal('hide');">
 		<?php echo JText::_('JCANCEL');?></button>
 	</div>
 	<div class="clearfix"></div>

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -24,24 +24,24 @@ $modMenuId = (int) $this->get('ModMenuId');
 
 $script = array();
 $script[] = "jQuery(document).ready(function() {";
+
 foreach ($this->items as $item) :
-		if ($user->authorise('core.edit', 'com_menus')) :
-			$script[] = '	function jSelectPosition_' . $item->id . '(name) {';
-			$script[] = '		document.getElementById("' . $item->id . '").value = name;';
-			$script[] = '		jQuery("#menusModuleModal").modal("hide");';
-			$script[] = '	};';
-		endif;
+	if ($user->authorise('core.edit', 'com_menus')) :
+		$script[] = '	function jSelectPosition_' . $item->id . '(name) {';
+		$script[] = '		document.getElementById("' . $item->id . '").value = name;';
+		$script[] = '		jQuery(".modal").modal("hide");';
+		$script[] = '	};';
+	endif;
 endforeach;
-foreach ($this->modules[$item->menutype] as &$module) :
-		$script[] = '	jQuery("#module' . $module->id . 'Modal").on("hidden", function () {';
-		$script[] = '		setTimeout(function(){';
-		$script[] = '			window.parent.location.reload();';
-		$script[] = '		},1000);';
-		$script[] = '	});';
-	endforeach;
+
+$script[] = '	jQuery(".modal").on("hidden", function () {';
+$script[] = '		setTimeout(function(){';
+$script[] = '			window.parent.location.reload();';
+$script[] = '		},1000);';
+$script[] = '	});';
 $script[] = "});";
 
-JFactory::getDocument()->addScriptDeclaration(implode($script));
+JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 ?>
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.multiselect');
-JHtml::_('behavior.modal');
 
 $uri		= JUri::getInstance();
 $return		= base64_encode($uri);
@@ -21,6 +20,28 @@ $user		= JFactory::getUser();
 $userId		= $user->get('id');
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
+$modMenuId = (int) $this->get('ModMenuId');
+
+$script = array();
+$script[] = "jQuery(document).ready(function() {";
+foreach ($this->items as $item) :
+		if ($user->authorise('core.edit', 'com_menus')) :
+			$script[] = '	function jSelectPosition_' . $item->id . '(name) {';
+			$script[] = '		document.getElementById("' . $item->id . '").value = name;';
+			$script[] = '		jQuery("#menusModuleModal").modal("hide");';
+			$script[] = '	};';
+		endif;
+endforeach;
+foreach ($this->modules[$item->menutype] as &$module) :
+		$script[] = '	jQuery("#module' . $module->id . 'Modal").on("hidden", function () {';
+		$script[] = '		setTimeout(function(){';
+		$script[] = '			window.parent.location.reload();';
+		$script[] = '		},1000);';
+		$script[] = '	});';
+	endforeach;
+$script[] = "});";
+
+JFactory::getDocument()->addScriptDeclaration(implode($script));
 ?>
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
@@ -124,17 +145,26 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						?>
 						<li>
 							<?php if ($canEdit) : ?>
-								<a class="modal" href="<?php echo JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal');?>" rel="{handler: 'iframe', size: {x: 1024, y: 450}}"  title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>">
-								<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
-							<?php else :?>
+								<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
+								<a href="#module<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>">
+									<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
+							<?php else : ?>
 								<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?>
 							<?php endif; ?>
 						</li>
-						<?php
-						endforeach;
-					endif;
-					?>
+						<?php endforeach; ?>
 				</ul>
+					<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
+						<?php if ($canEdit) : ?>
+							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
+							<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+						<?php endif; ?>
+					<?php endforeach; ?>
+					<?php elseif ($modMenuId) : ?>
+					<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]='.$item->menutype); ?>">
+						<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
+					<?php echo JHtmlBootstrap::renderModal('moduleModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+					<?php endif; ?>
 				</td>
 				<td class="center">
 					<?php echo $item->id; ?>

--- a/administrator/templates/hathor/html/com_modules/module/edit.php
+++ b/administrator/templates/hathor/html/com_modules/module/edit.php
@@ -17,7 +17,7 @@ $hasContent = empty($this->item->module) || $this->item->module == 'custom' || $
 
 $script = "Joomla.submitbutton = function(task)
 	{
-			if (task == 'module.cancel' || document.formvalidator.isValid(document.id('module-form'))) {";
+			if (task == 'module.cancel' || document.formvalidator.isValid(document.getElementById('module-form'))) {";
 if ($hasContent)
 {
 	$script .= $this->form->getField('content')->save();
@@ -25,7 +25,7 @@ if ($hasContent)
 $script .= "	Joomla.submitform(task, document.getElementById('module-form'));
 				if (self != top)
 				{
-					window.top.setTimeout('window.parent.jModalClose()', 1000);
+					window.parent.jQuery('.modal').modal('hide');
 				}
 			}
 	}";


### PR DESCRIPTION
This is a repost of #4562 which was ruined in the rebase...
#### Move modals from mootools to Bootstrap

This is the last (I hope) PR to get all back end using bootstrap modals. The rest are: #4513 #4514 #4561.

Testing:
## Apply patch and follow the images below to see where you should focus:

administrator/index.php?option=com_menus&view=menus
![screenshot 2014-10-12 06 35 39](https://cloud.githubusercontent.com/assets/3889375/4604953/16944584-51c2-11e4-93a2-d6b851a7d117.png)
## ![screenshot 2014-10-12 06 35 53](https://cloud.githubusercontent.com/assets/3889375/4604954/1d578ac0-51c2-11e4-9552-4d3e1407e0e6.png)

administrator/index.php?option=com_menus&view=item&layout=edit&id=101
![screenshot 2014-10-12 06 36 12](https://cloud.githubusercontent.com/assets/3889375/4604956/393e0fb6-51c2-11e4-9c80-b481b2051609.png)
![screenshot 2014-10-12 06 36 24](https://cloud.githubusercontent.com/assets/3889375/4604959/4f4465b2-51c2-11e4-968c-0289526c970a.png)

![screenshot 2014-10-12 06 36 36](https://cloud.githubusercontent.com/assets/3889375/4604960/53ad4e48-51c2-11e4-8a97-dac4d0c04482.png)
![screenshot 2014-10-12 06 36 46](https://cloud.githubusercontent.com/assets/3889375/4604961/569be2ae-51c2-11e4-87a5-e4ac6bdf44cf.png)
———————
