### PR TITLE
Fix #4662 - Cancel button doesn't work in com_config if form validation fails

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -20,7 +20,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <script type="text/javascript">
 	Joomla.submitbutton = function(task)
 	{
-		if (document.formvalidator.isValid(document.id('component-form')))
+		if (task == 'config.cancel.component' || document.formvalidator.isValid(document.id('component-form')))
 		{
 			Joomla.submitform(task, document.getElementById('component-form'));
 		}


### PR DESCRIPTION
Fix for https://github.com/joomla/joomla-cms/issues/4662
