### PR TITLE
Move plugins modals to Bootstrap

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/pagebreak.php
+++ b/administrator/components/com_content/views/article/tmpl/pagebreak.php
@@ -23,7 +23,7 @@ $script .= 'alt = "alt=\""+alt+"\" ";'."\n\t";
 $script .= '}'."\n\t";
 $script .= 'var tag = "<hr class=\"system-pagebreak\" "+title+" "+alt+"/>";'."\n\t";
 $script .= 'window.parent.jInsertEditorText(tag, \''.$this->eName.'\');'."\n\t";
-$script .= 'window.parent.SqueezeBox.close();'."\n\t";
+$script .= 'window.parent.jQuery("#pagebreakModal").modal("hide");'."\n\t";
 $script .= 'return false;'."\n";
 $script .= '}'."\n";
 

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -3906,13 +3906,15 @@ input[type="submit"].btn.btn-mini {
 	line-height: 30px;
 }
 .modal-body {
+	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: 400px;
-	padding: 15px;
+	max-height: none;
+	padding: 1%;
 }
 .modal-body iframe {
-	max-height: 390px;
+	width: 100%;
+	max-height: none;
 	border: 0 !important;
 }
 .modal-form {
@@ -6151,11 +6153,11 @@ th .tooltip-inner {
 }
 div.modal {
 	position: fixed;
-	top: 10%;
+	top: 5%;
 	left: 50%;
 	z-index: 1050;
-	width: 580px;
-	margin-left: -280px;
+	width: 80%;
+	margin-left: -40%;
 	background-color: #fff;
 	border: 1px solid #999;
 	border: 1px solid rgba(0,0,0,0.3);
@@ -6179,7 +6181,7 @@ div.modal.fade {
 	top: -25%;
 }
 div.modal.fade.in {
-	top: 10%;
+	top: 5%;
 }
 .modal-batch {
 	overflow-y: visible;
@@ -7196,6 +7198,7 @@ body .navbar-fixed-top {
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
 	margin-bottom: 10px;
+	min-height: 43px;
 }
 .subhead-collapse.collapse {
 	height: auto;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -3906,13 +3906,15 @@ input[type="submit"].btn.btn-mini {
 	line-height: 30px;
 }
 .modal-body {
+	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: 400px;
-	padding: 15px;
+	max-height: none;
+	padding: 1%;
 }
 .modal-body iframe {
-	max-height: 390px;
+	width: 100%;
+	max-height: none;
 	border: 0 !important;
 }
 .modal-form {
@@ -6151,11 +6153,11 @@ th .tooltip-inner {
 }
 div.modal {
 	position: fixed;
-	top: 10%;
+	top: 5%;
 	left: 50%;
 	z-index: 1050;
-	width: 580px;
-	margin-left: -280px;
+	width: 80%;
+	margin-left: -40%;
 	background-color: #fff;
 	border: 1px solid #999;
 	border: 1px solid rgba(0,0,0,0.3);
@@ -6179,7 +6181,7 @@ div.modal.fade {
 	top: -25%;
 }
 div.modal.fade.in {
-	top: 10%;
+	top: 5%;
 }
 .modal-batch {
 	overflow-y: visible;
@@ -7196,7 +7198,7 @@ body .navbar-fixed-top {
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
 	margin-bottom: 10px;
-	min-height:43px;
+	min-height: 43px;
 }
 .subhead-collapse.collapse {
 	height: auto;

--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $buttons = $displayData;
 
 // Load modal popup behavior
-JHtml::_('behavior.modal', 'a.modal-button');
+JHtml::_('bootstrap.modal');
 ?>
 <div id="editor-xtd-buttons" class="btn-toolbar pull-left">
 	<?php if ($buttons) : ?>

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -11,16 +11,27 @@ defined('_JEXEC') or die;
 
 $button = $displayData;
 
-?>
-<?php if ($button->get('name')) : ?>
-	<?php
-		$class    = ($button->get('class')) ? $button->get('class') : null;
-		$class	 .= ($button->get('modal')) ? ' modal-button' : null;
-		$href     = ($button->get('link')) ? ' href="' . JUri::base() . $button->get('link') . '"' : null;
-		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : ' onclick="IeCursorFix(); return false;"';
-		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
-	?>
-	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href . $onclick; ?> rel="<?php echo $button->get('options'); ?>">
-		<i class="icon-<?php echo $button->get('name'); ?>"></i> <?php echo $button->get('text'); ?>
+if ($button->get('name'))
+{
+	$class    = ($button->get('class')) ? $button->get('class') : null;
+	$class	 .= ($button->get('modal')) ? ' modal-button' : null;
+	$href     = ($button->get('link')) ? ' href="' . JUri::base() . $button->get('link') . '"' : null;
+	$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : ' onclick="IeCursorFix(); return false;"';
+	$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+
+	if ($button->get('modal'))
+	{
+		$tmptitle    = str_replace(' ', '', strtolower(htmlspecialchars($title)));
+		echo JHtmlBootstrap::renderModal($tmptitle . 'Modal', array( 'url' => JUri::base() . $button->get('link'), 'title' => $title,'height' => '600px', 'width' => '800px')); ?>
+
+		<a href="#<?php echo $tmptitle; ?>Modal" role="button" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $title; ?>">
+			<i class="icon-<?php echo $button->get('name'); ?>"></i> <?php echo $button->get('text'); ?>
 	</a>
-<?php endif;
+
+<?php } else { ?>
+		<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href . $onclick; ?> rel="<?php echo $button->get('options'); ?>">
+			<i class="icon-<?php echo $button->get('name'); ?>"></i> <?php echo $button->get('text'); ?>
+		</a>
+<?php	}
+}

--- a/media/jui/less/modals.joomla.less
+++ b/media/jui/less/modals.joomla.less
@@ -8,11 +8,11 @@
 // Base modal
 div.modal {
   position: fixed;
-  top: 10%;
+  top: 5%;
   left: 50%;
   z-index: @zindexModal;
-  width: 580px;
-  margin-left: -280px;
+  width: 80%;
+  margin-left: -40%;
   background-color: @white;
   border: 1px solid #999;
   border: 1px solid rgba(0,0,0,.3);
@@ -27,7 +27,7 @@ div.modal {
     .transition(e('opacity .3s linear, top .3s ease-out'));
     top: -25%;
   }
-  &.fade.in { top: 10%; }
+  &.fade.in { top: 5%; }
 }
 //Modal for Batch views
 .modal-batch {

--- a/media/jui/less/modals.less
+++ b/media/jui/less/modals.less
@@ -39,14 +39,16 @@
 
 // Body (where all modal content resides)
 .modal-body {
+  width: 98%;
   position: relative;
   overflow-y: auto;
-  max-height: 400px;
-  padding: 15px;
+  max-height: none;
+  padding: 1%;
 }
 // Remove border and scrollbar from iframe modal
 .modal-body iframe {
-  max-height: 390px;
+  width: 100%;
+  max-height: none;
   border: 0 !important;
 }
 // Remove bottom margin if need be

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -54,7 +54,7 @@ class PlgButtonImage extends JPlugin
 			||	(count($user->getAuthorisedCategories($extension, 'core.edit.own')) > 0 && $author == $user->id))
 		{
 			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset=' . $asset . '&amp;author=' . $author;
-			JHtml::_('behavior.modal');
+			JHtml::_('bootstrap.modal');
 			$button = new JObject;
 			$button->modal = true;
 			$button->class = 'btn';

--- a/plugins/editors-xtd/pagebreak/pagebreak.php
+++ b/plugins/editors-xtd/pagebreak/pagebreak.php
@@ -35,7 +35,7 @@ class PlgButtonPagebreak extends JPlugin
 	 */
 	public function onDisplay($name)
 	{
-		JHtml::_('behavior.modal');
+		JHtml::_('bootstrap.modal');
 
 		$link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
 

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3906,13 +3906,15 @@ input[type="submit"].btn.btn-mini {
 	line-height: 30px;
 }
 .modal-body {
+	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: 400px;
-	padding: 15px;
+	max-height: none;
+	padding: 1%;
 }
 .modal-body iframe {
-	max-height: 390px;
+	width: 100%;
+	max-height: none;
 	border: 0 !important;
 }
 .modal-form {
@@ -6151,11 +6153,11 @@ th .tooltip-inner {
 }
 div.modal {
 	position: fixed;
-	top: 10%;
+	top: 5%;
 	left: 50%;
 	z-index: 1050;
-	width: 580px;
-	margin-left: -280px;
+	width: 80%;
+	margin-left: -40%;
 	background-color: #fff;
 	border: 1px solid #999;
 	border: 1px solid rgba(0,0,0,0.3);
@@ -6179,7 +6181,7 @@ div.modal.fade {
 	top: -25%;
 }
 div.modal.fade.in {
-	top: 10%;
+	top: 5%;
 }
 .modal-batch {
 	overflow-y: visible;


### PR DESCRIPTION
##### Moving current code to bootstrap modal

Same as #4661 #4645 #4575 #4563 #4561 #4514 #4513 

Testing:
After Applying this patch 
Try editing an article and use the editor’s buttons

Preview:
![screenshot 2014-10-14 07 48 07](https://cloud.githubusercontent.com/assets/3889375/4624141/3753192e-535e-11e4-98f5-a7a0f278e031.png)
![screenshot 2014-10-14 07 48 24](https://cloud.githubusercontent.com/assets/3889375/4624142/390ad6da-535e-11e4-8359-b1f11ea354ed.png)
![screenshot 2014-10-14 07 48 39](https://cloud.githubusercontent.com/assets/3889375/4624143/3c31c86e-535e-11e4-8fb6-5297b3846a99.png)
