### PR TITLE
Parent RegExp selector fix for sortable list

### DIFF
--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -272,7 +272,7 @@
 		}
 		
 		this.getChildrenNodes = function (parentId) {
-			return $('tr[parents*=" '+parentId+' "]');
+			return $('tr[parents~="'+parentId+'"]');
 		}
 		
 		this.getSameLevelNodes = function (level) {

--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -272,7 +272,7 @@
 		}
 		
 		this.getChildrenNodes = function (parentId) {
-			return $('tr[parents*=" '+parentId+'"]');
+			return $('tr[parents*=" '+parentId+' "]');
 		}
 		
 		this.getSameLevelNodes = function (level) {


### PR DESCRIPTION
$('tr[parents*=" '+parentId+'"]'); - selects parent id 2, 2[0..9] etc. so when there are a lot of categories, sorting does not work properly.

'tr[parents~="'+parentId+'"]  - this select exact phrase selected by space or at the beggining or the end of attribute value.

http://api.jquery.com/category/selectors/attribute-selectors/
