### PR TITLE
[#31493] JForm::setFieldAttribute() to merge rather than replace

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1023,13 +1023,14 @@ class JForm
 	 * @param   string  $attribute  The name of the attribute for which to set a value.
 	 * @param   mixed   $value      The value to set for the attribute.
 	 * @param   string  $group      The optional dot-separated form group path on which to find the field.
+	 * @param   boolean $replace    True to replace whole existing field attributes or false to append the new.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function setFieldAttribute($name, $attribute, $value, $group = null)
+	public function setFieldAttribute($name, $attribute, $value, $group = null, $replace = true)
 	{
 		// Make sure there is a valid JForm XML document.
 		if (!($this->xml instanceof SimpleXMLElement))
@@ -1049,7 +1050,28 @@ class JForm
 		// Otherwise set the attribute and return true.
 		else
 		{
-			$element[$attribute] = $value;
+			// If the attribute to be set must not merged with existing ones, simply set it.
+			if ($replace)
+			{
+				$element[$attribute] = $value;
+			}
+			// Otherwise merge it.
+			else
+			{
+				// Explode current attributes into array.
+				$attributes = explode(' ', (string) $element[$attribute]);
+
+				// Explode passed in values into array.
+				$value = explode(' ', trim($value));
+
+				// Merge both.
+				$attributes = array_unique(array_filter(array_merge($attributes, $value)));
+
+				sort($attributes);
+
+				// Set merged attributes back.
+				$element[$attribute] = trim(implode(' ', $attributes));
+			}
 
 			// Synchronize any paths found in the load.
 			$this->syncPaths();

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1019,11 +1019,11 @@ class JForm
 	/**
 	 * Method to set an attribute value for a field XML element.
 	 *
-	 * @param   string  $name       The name of the form field for which to set the attribute value.
-	 * @param   string  $attribute  The name of the attribute for which to set a value.
-	 * @param   mixed   $value      The value to set for the attribute.
-	 * @param   string  $group      The optional dot-separated form group path on which to find the field.
-	 * @param   boolean $replace    True to replace whole existing field attributes or false to append the new.
+	 * @param   string   $name       The name of the form field for which to set the attribute value.
+	 * @param   string   $attribute  The name of the attribute for which to set a value.
+	 * @param   mixed    $value      The value to set for the attribute.
+	 * @param   string   $group      The optional dot-separated form group path on which to find the field.
+	 * @param   boolean  $replace    True to replace whole existing field attributes or false to append the new.
 	 *
 	 * @return  boolean  True on success.
 	 *


### PR DESCRIPTION
i found JForm::setFieldAttribute method to not evaluate if passed in values for a specific attribute shall be merged into existing values or instead replace them, which forces one to write longer setFieldAttribute() statements just not to loose existing values. For example:

```
$form->setFieldAttribute(
    'description',
    'labelclass',
    $form->getFieldAttribute('description', 'labelclass', '', 'params') . '
    new1 new2 new3 ...',
    'params'
);
```

Note the 3rd param. This is pretty long, isn't it? And since it is not always only one single attribute that might be passed in, this param might become much longer. Wouldn't you agree that it is much easier to write:

```
$form->setFieldAttribute(
    'description',
    'labelclass',
    'new1 new2 new3 ...',
    'params'
);
```

We can easily shorten it by changing the related JForm method to evaluate this circumstance and either merge or replace the related attribute.

There already is an [entry at the joomlacode bug tracker](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=31493) along with detailed testing instructions.
