### PR TITLE
URL checking improved

### DIFF
--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -84,7 +84,7 @@ class WrapperViewWrapper extends JViewLegacy
 			if (substr($url, 0, 2) == '//')
 			{
 				// Url without scheme in component. Prepend current scheme.
-				 $wrapper->url = JUri::getInstance()->toString(array('scheme')) . substr($url, 2);
+				$wrapper->url = JUri::getInstance()->toString(array('scheme')) . substr($url, 2);
 			}
 			elseif (substr($url, 0, 1) == '/')
 			{

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -81,15 +81,20 @@ class WrapperViewWrapper extends JViewLegacy
 		if ($params->def('add_scheme', 1))
 		{
 			// Adds 'http://' or 'https://' if none is set
-			if (substr($url, 0, 1) == '/')
+			if (substr($url, 0, 2) == '//')
+			{
+				// Url without scheme in component. Prepend current scheme.
+				 $wrapper->url = JUri::getInstance()->toString(array('scheme')) . substr($url, 2);
+			}
+			elseif (substr($url, 0, 1) == '/')
 			{
 				// Relative url in component. Use scheme + host + port.
 				$wrapper->url = JUri::getInstance()->toString(array('scheme', 'host', 'port')) . $url;
 			}
 			elseif (strpos($url, 'http://') !== 0 && strpos($url, 'https://') !== 0)
 			{
-				// Url doesn't start with either 'http://' or 'https://'. Add 'http://'.
-				$wrapper->url = 'http://' . $url;
+				// Url doesn't start with either 'http://' or 'https://'. Add current scheme.
+				$wrapper->url = JUri::getInstance()->toString(array('scheme')) . $url;
 			}
 			else
 			{

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -80,18 +80,20 @@ class WrapperViewWrapper extends JViewLegacy
 
 		if ($params->def('add_scheme', 1))
 		{
-			// Adds 'http://' if none is set
+			// Adds 'http://' or 'https://' if none is set
 			if (substr($url, 0, 1) == '/')
 			{
-				// Relative url in component. Use server http_host.
-				$wrapper->url = 'http://' . $_SERVER['HTTP_HOST'] . $url;
+				// Relative url in component. Use scheme + host + port.
+				$wrapper->url = JUri::getInstance()->toString(array('scheme', 'host', 'port')) . $url;
 			}
-			elseif (!strstr($url, 'http') && !strstr($url, 'https'))
+			elseif (strpos($url, 'http://') !== 0 && strpos($url, 'https://') !== 0)
 			{
+				// Url doesn't start with either 'http://' or 'https://'. Add 'http://'.
 				$wrapper->url = 'http://' . $url;
 			}
 			else
 			{
+				// Url starts with either 'http://' or 'https://'. Do not change it.
 				$wrapper->url = $url;
 			}
 		}


### PR DESCRIPTION
When adding the scheme to an URL use correct scheme (http or https) and port.
Checking for "http" or "https" via strstr() in the URL matched also these strings embedded in the URL (e.g. in /static/http/index.html), due to that checks changed to strpos().
