### PR TITLE
Added SVG files to the image list

### DIFF
--- a/administrator/components/com_media/models/list.php
+++ b/administrator/components/com_media/models/list.php
@@ -134,6 +134,7 @@ class MediaModelList extends JModelLegacy
 						case 'bmp':
 						case 'jpeg':
 						case 'ico':
+						case 'svg':
 							$info = @getimagesize($tmp->path);
 							$tmp->width		= @$info[0];
 							$tmp->height	= @$info[1];


### PR DESCRIPTION
At the moment it's not possible (without hacking the path with Firebug/Inspector) to use SVG files for e.g. menu images or with the "image button" in the article edit form.

Apply path => SVG files can be chosen.
