### PR TITLE
Fix issue #4679: Sorting Joomla! available languages 

### DIFF
--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -31,9 +31,11 @@ abstract class ModLoginHelper
 		{
 			return '';
 		}
-		
-		// Make sure the languages are sorted based on locale code instead of random sorting
-		ksort($languages);
+
+		usort($languages, function ($a, $b)
+		{
+			return strcmp($a["value"], $b["value"]);
+		});
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -31,6 +31,9 @@ abstract class ModLoginHelper
 		{
 			return '';
 		}
+		
+		// Make sure the languages are sorted based on locale code instead of random sorting
+		ksort($languages);
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -32,10 +32,13 @@ abstract class ModLoginHelper
 			return '';
 		}
 
-		usort($languages, function ($a, $b)
-		{
-			return strcmp($a["value"], $b["value"]);
-		});
+		usort(
+			$languages,
+			function ($a, $b)
+			{
+				return strcmp($a["value"], $b["value"]);
+			}
+		);
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 


### PR DESCRIPTION
This PR fix the issue #4679 reported by @dkanchev. Basically, if your site has multiple languages installed, when you are on login page to login to administrator area of your site, the languages in languages dropdown might be displayed in random order (see https://github.com/joomla/joomla-cms/issues/4679 for more detail).

I just added one line of code to make sure the languages are sorted based on locale code instead of random order before (although this is difficult to replicate this issue).
## How to test
1. Make sure your site has atleast two languages installed.
2. Access to administrator area of your site, makes sure the language dropdown is sorted based on locale code instead of in a random order as explained in the issue.
