### PR TITLE
Disable cpanel and user menu when editing

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -276,7 +276,7 @@ if ($stickyToolbar) : ?>
 			{
 				$('.icon-joomla').addClass('disabled');
 				$('.nav-user').addClass('disabled');
-				$(".admin-logo").attr("href", "#");
+				$(".admin-logo").removeAttr("href");
 				$('ul.nav-user > li > a').attr("data-toggle","");
 			}
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -259,7 +259,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <jdoc:include type="modules" name="debug" style="none" />
 <?php
 // Get the singular view
-$singular = preg_match('/&id=|&layout=edit/', JURI::getInstance()->toString());
+$singular = preg_match('/&id=|=com_config|&view=mail|&layout=edit/', JURI::getInstance()->toString());
 if ($stickyToolbar) : ?>
 	<script>
 		(function($)
@@ -288,7 +288,7 @@ if ($stickyToolbar) : ?>
 			if (edit)
 			{
 				$('.navbar-fixed-top').addClass('hidden');
-				$('body').animate({ paddingTop: 0 });
+				$('body').css("padding-top", "0");
 			}
 
 			$win.on('scroll', processScroll)

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -259,7 +259,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <jdoc:include type="modules" name="debug" style="none" />
 <?php
 // Get the singular view
-$singular = preg_match('/&id=/', JURI::getInstance()->toString());
+$singular = preg_match('/&id=|&layout=edit/', JURI::getInstance()->toString());
 if ($stickyToolbar) : ?>
 	<script>
 		(function($)

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -259,7 +259,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <jdoc:include type="modules" name="debug" style="none" />
 <?php
 // Get the singular view
-$singular = preg_match('/&id=|=com_config|&view=mail|&layout=edit/', JURI::getInstance()->toString());
+$singular = preg_match('/&id=|&view=mail|&layout=edit/', JURI::getInstance()->toString());
 if ($stickyToolbar) : ?>
 	<script>
 		(function($)
@@ -267,7 +267,7 @@ if ($stickyToolbar) : ?>
 			// fix sub nav on scroll
 			var $win = $(window)
 				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php if ($displayHeader || !$statusFixed) : ?>50<?php else:?>30<?php endif;?>
+				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php if ($displayHeader || !$statusFixed) : ?>40<?php else:?>20<?php endif;?>
 				, isFixed = 0
 				, edit = <?php echo $singular; ?>
 
@@ -284,11 +284,11 @@ if ($stickyToolbar) : ?>
 				}
 			})
 
-			// remove disabled nav
+			// Hide cpanel and user menu
 			if (edit)
 			{
-				$('.navbar-fixed-top').addClass('hidden');
-				$('body').css("padding-top", "0");
+				$('.icon-joomla').addClass('disabled');
+				$('.nav-user').addClass('disabled');
 			}
 
 			$win.on('scroll', processScroll)
@@ -299,10 +299,11 @@ if ($stickyToolbar) : ?>
 				if (scrollTop >= navTop && !isFixed) {
 					isFixed = 1
 					$nav.addClass('subhead-fixed')
-					// remove disabled nav
+					// Hide cpanel and user menu
 					if (edit)
 					{
-						$('.subhead-fixed').css("top", "0");
+						$('.icon-joomla').addClass('disabled');
+						$('.nav-user').addClass('disabled');
 					}
 				} else if (scrollTop <= navTop && isFixed) {
 					isFixed = 0

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -267,11 +267,11 @@ if ($stickyToolbar) : ?>
 			// fix sub nav on scroll
 			var $win = $(window)
 				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top -  <?php if ($displayHeader || !$statusFixed) : ?>50<?php else:?>30<?php endif;?>
+				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php if ($displayHeader || !$statusFixed) : ?>50<?php else:?>30<?php endif;?>
 				, isFixed = 0
 				, edit = <?php echo $singular; ?>
 
-					processScroll()
+			processScroll()
 
 			// hack sad times - holdover until rewrite for 2.1
 			$nav.on('click', function()

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -271,6 +271,15 @@ if ($stickyToolbar) : ?>
 				, isFixed = 0
 				, edit = <?php echo $singular; ?>
 
+			// Disable cpanel and user menu
+			if (edit)
+			{
+				$('.icon-joomla').addClass('disabled');
+				$('.nav-user').addClass('disabled');
+				$(".admin-logo").attr("href", "#");
+				$('ul.nav-user > li > a').attr("data-toggle","");
+			}
+
 			processScroll()
 
 			// hack sad times - holdover until rewrite for 2.1
@@ -284,15 +293,6 @@ if ($stickyToolbar) : ?>
 				}
 			})
 
-			// Hide cpanel and user menu
-			if (edit)
-			{
-				$('.icon-joomla').addClass('disabled');
-				$('.nav-user').addClass('disabled');
-				$(".admin-logo").attr("href", "#");
-				$('ul.nav-user > li > a').attr("data-toggle","");
-			}
-
 			$win.on('scroll', processScroll)
 
 			function processScroll()
@@ -301,14 +301,6 @@ if ($stickyToolbar) : ?>
 				if (scrollTop >= navTop && !isFixed) {
 					isFixed = 1
 					$nav.addClass('subhead-fixed')
-					// Hide cpanel and user menu
-					if (edit)
-					{
-						$('.icon-joomla').addClass('disabled');
-						$('.nav-user').addClass('disabled');
-						$(".admin-logo").attr("href", "#");
-						$('ul.nav-user > li > a').attr("data-toggle","");
-					}
 				} else if (scrollTop <= navTop && isFixed) {
 					isFixed = 0
 					$nav.removeClass('subhead-fixed')

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -277,7 +277,8 @@ if ($stickyToolbar) : ?>
 				$('.icon-joomla').addClass('disabled');
 				$('.nav-user').addClass('disabled');
 				$(".admin-logo").removeAttr("href");
-				$('ul.nav-user > li > a').attr("data-toggle","");
+				$('ul.nav-user > li > a').removeAttr("data-toggle").removeAttr("href");
+				$('ul.nav-user > li > .dropdown-menu').empty();
 			}
 
 			processScroll()

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -267,7 +267,7 @@ if ($stickyToolbar) : ?>
 			// fix sub nav on scroll
 			var $win = $(window)
 				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top -50
+				, navTop  = $('.subhead').length && $('.subhead').offset().top -  <?php if ($displayHeader || !$statusFixed) : ?>50<?php else:?>30<?php endif;?>
 				, isFixed = 0
 				, edit = <?php echo $singular; ?>
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -289,6 +289,8 @@ if ($stickyToolbar) : ?>
 			{
 				$('.icon-joomla').addClass('disabled');
 				$('.nav-user').addClass('disabled');
+				$(".admin-logo").attr("href", "#");
+				$('ul.nav-user > li > a').attr("data-toggle","");
 			}
 
 			$win.on('scroll', processScroll)
@@ -304,6 +306,8 @@ if ($stickyToolbar) : ?>
 					{
 						$('.icon-joomla').addClass('disabled');
 						$('.nav-user').addClass('disabled');
+						$(".admin-logo").attr("href", "#");
+						$('ul.nav-user > li > a').attr("data-toggle","");
 					}
 				} else if (scrollTop <= navTop && isFixed) {
 					isFixed = 0

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -257,17 +257,21 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
-<?php if ($stickyToolbar) : ?>
+<?php
+// Get the singular view
+$singular = preg_match('/&id=/', JURI::getInstance()->toString());
+if ($stickyToolbar) : ?>
 	<script>
 		(function($)
 		{
 			// fix sub nav on scroll
 			var $win = $(window)
 				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php if ($displayHeader || !$statusFixed) : ?>40<?php else:?>20<?php endif;?>
+				, navTop  = $('.subhead').length && $('.subhead').offset().top -50
 				, isFixed = 0
+				, edit = <?php echo $singular; ?>
 
-			processScroll()
+					processScroll()
 
 			// hack sad times - holdover until rewrite for 2.1
 			$nav.on('click', function()
@@ -280,6 +284,13 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 				}
 			})
 
+			// remove disabled nav
+			if (edit)
+			{
+				$('.navbar-fixed-top').addClass('hidden');
+				$('body').animate({ paddingTop: 0 });
+			}
+
 			$win.on('scroll', processScroll)
 
 			function processScroll()
@@ -288,6 +299,11 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 				if (scrollTop >= navTop && !isFixed) {
 					isFixed = 1
 					$nav.addClass('subhead-fixed')
+					// remove disabled nav
+					if (edit)
+					{
+						$('.subhead-fixed').css("top", "0");
+					}
 				} else if (scrollTop <= navTop && isFixed) {
 					isFixed = 0
 					$nav.removeClass('subhead-fixed')


### PR DESCRIPTION
#### Small UX improvement in ISIS template
##### What is it?

On ISIS when we are editing something (basically when we are in singular view) the main navigation becomes greyed out but cpanel and user menu are still visible. This PR hide them and removes their functionality. 
#### Tests

Apply the patch and move around in the admin area
##### In pictures:

Normal view
![screenshot 2014-10-16 13 34 35](https://cloud.githubusercontent.com/assets/3889375/4661252/56b0838c-5521-11e4-8ec0-545311a61367.png)

Enter editing mode
![screenshot 2014-10-16 16 59 22](https://cloud.githubusercontent.com/assets/3889375/4664168/c946ed9e-5541-11e4-847e-775189f13920.png)
