### PR TITLE
Set fixed precision avoid rounding related issues while executing the unit tests

### DIFF
--- a/build/generatecss.php
+++ b/build/generatecss.php
@@ -9,6 +9,9 @@
 // Set flag that this is a parent file.
 const _JEXEC = 1;
 
+// Set fixed precision value to avoid round related issues
+ini_set('precision', 14);
+
 // Load system defines
 if (file_exists(dirname(__DIR__) . '/defines.php'))
 {

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -22,6 +22,9 @@ ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL & ~(E_STRICT|E_USER_DEPRECATED));
 ini_set('display_errors', 1);
 
+// Set fixed precision value to avoid round related issues
+ini_set('precision', 14);
+
 /*
  * Ensure that required path constants are defined.  These can be overridden within the phpunit.xml file
  * if you chose to create a custom version of that file.


### PR DESCRIPTION
Fixes issues like:

```
1) JHtmlNumberTest::testBytes with data set #10 ('1099511627776 kb', 1125899906842624, 'kb')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1099511627776 kb'
+'1.09951162778E+12 kb'

/Users/sniper/Zend/workspaces/DefaultWorkspace/joomla-cms/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php:136

2) JHtmlNumberTest::testBytes with data set #11 ('1.1258999068426E+15 b', 1125899906842624, 'b')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1.1258999068426E+15 b'
+'1.12589990684E+15 b'
```
