### PR TITLE
Sidebar Toggle doesn't load core.js

### DIFF
--- a/layouts/joomla/sidebars/submenu.php
+++ b/layouts/joomla/sidebars/submenu.php
@@ -8,6 +8,8 @@
  */
 
 defined('JPATH_BASE') or die;
+
+JHtmlBehavior::core();
 ?>
 
 	<script type="text/javascript">


### PR DESCRIPTION
### Issue

In current staging there is a new feature which allows to hide the sidebar.
For that it uses a new JS function in /media/system/core.js`named`Joomla.toggleSidebar()`.
However the JLayouts don't load`core.js`. This works currently for most views because there are other places where it is loaded. But if your extension has a pure informational page like mine has, then it breaks the whole thing.
### Solution

Make sure core.js is loaded by calling `JHtmlBehavior::core()` in the JLayout.
### Testing

In Core this doesn't happen (afaik). So the easiest way would be to install an extension with the issue. You can use my extension "SermonSpeaker" (use Webinstaller or http://www.sermonspeaker.net/download/sermonspeaker-component/sermonspeaker-component-5-2-3/pkg_sermonspeaker-zip-3.html) and navigate to the "Help" view.
