### PR TITLE
getTagItemsQuery documentation incorrect, arguments causes SQL error

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -595,7 +595,7 @@ class JHelperTags extends JHelper
 		}
 
 		// Get the type data, limited to types in the request if there are any specified.
-		$typesarray = self::getTypes('assocList', $typesr, false);
+		$typesarray = self::getTypes('assocList', $typesr, true);
 
 		$typeAliases = '';
 


### PR DESCRIPTION
Changed 3rd arg of getTypes call to 'true' to lookup types by alias rather than ID (as per docs) (issue #4655)
#### Steps to reproduce the issue

1 - Call JHelperTags getTagItemsQuery method with the 2nd argument containing an array of type aliases (as perhttp://api.joomla.org/cms-3/classes/JHelperTags.html#method_getTagItemsQuery
#### Expected result

A DB object with items matching those tags, filtered by content type
#### Actual result

Error 1064 (MySQl error)
#### System information (as much as possible)

Joomla 3.3.6
PHP 5.3
#### Additional comments

The fix is fairly simple. getTagItemsQuery documentation says it expects the 2nd argument to be an array of content type aliases, a single alias, or null. In fact, because line 560 of JHelperTags calls self::getTypes('assocList', $typesr, false); with the 3rd param as 'false' it actually expects content type IDs, not aliases. Thus, the query causes an error. Changing this to true, or supplying getTagItemsQuery with type IDs, does not cause the issue
