### PR TITLE
[Code Test] Implement tests for JLayout base

### DIFF
--- a/tests/unit/suites/libraries/cms/layout/JLayoutBaseTest.php
+++ b/tests/unit/suites/libraries/cms/layout/JLayoutBaseTest.php
@@ -18,10 +18,7 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	protected $layoutBase;
 
 	/**
-	 * Sets up the fixture, for example, opens a network connection.
-	 * This method is called before a test is executed.
-	 *
-	 * @return  void.
+	 * Sets up the test by instantiating JLayoutBase
 	 */
 	protected function setUp()
 	{
@@ -29,11 +26,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * JLayoutbase set options returns a JLayoutbase instance with empty parameter.
-	 *
 	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with empty parameter.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithEmptyParameter()
 	{
@@ -41,11 +36,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * JLayoutbase set options returns a JLayoutbase instance with JRegistry parameter.
-	 *
 	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with JRegistry parameter.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithJregistryParameter()
 	{
@@ -53,11 +46,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * JLayoutbase set options returns a JLayoutbase instance with an array parameter.
-	 *
 	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with an array parameter.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithAnArrayParameter()
 	{
@@ -65,11 +56,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Options can be configured empty.
-	 *
 	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is empty.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParamaterIsEmpty()
 	{
@@ -80,11 +69,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Options can be configured as an array and is converted to a JRegistry object.
-	 *
 	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is an array.
 	 *
-	 * @return void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParamaterIsAnArray()
 	{
@@ -96,11 +83,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Get options can be configured as JRegistry object.
-	 *
 	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is a JRegistry object.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParameterIsAJregistryObject()
 	{
@@ -112,11 +97,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Options can be configured as an array and is converted to a JRegistry object.
-	 *
 	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object value using an array.
 	 *
-	 * @return void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectValueUsingAnArray()
 	{
@@ -127,11 +110,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Options can be configured as an array and is converted to a JRegistry object.
-	 *
 	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object value using JRegistry.
 	 *
-	 * @return void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectValueUsingJregistry()
 	{
@@ -143,11 +124,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Options can be configured as an array and is converted to a JRegistry object.
-	 *
 	 * @testdox  JLayoutbase->resetOptions() and check options is empty.
 	 *
-	 * @return void.
+	 * @since   3.3.7
 	 */
 	public function testJlayoutbaseResetOptionsAndCheckOptionsIsEmpty()
 	{
@@ -161,9 +140,7 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Tests the escape method.
 	 *
-	 * @return  void
-	 *
-	 * @since   3.0
+	 * @since   3.3.7
 	 */
 	public function testEscapingSpecialCharactersIntoHtmlEntities()
 	{
@@ -195,7 +172,7 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Test the adding of debug messages.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testAddOneDebugMessageToTheQueue()
 	{
@@ -205,11 +182,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test retrieving the debug messages.
-	 *
 	 * @testdox  JLayoutBase->getDebugMessages() retrieves a list of debug messages in an array.
 	 *
-	 * @return  void.
+	 * @since   3.3.7
 	 */
 	public function testRetrievingTheListOfDebugMessagesIsAnArray()
 	{
@@ -217,11 +192,9 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test rendering the debug messages
-	 *
 	 * @testdox  JLayoutBase->renderDebugMessages() returns string of messages separated by newline character.
 	 *
-	 * @return void.
+	 * @since   3.3.7
 	 */
 	public function testRenderDebugMessageReturnsStringOfMessagesSeparatedByNewlineCharacter()
 	{
@@ -232,20 +205,12 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the render method
-	 *
 	 * @testdox  JLayoutBase->render() returns an empty string.
 	 *
-	 * @return  void
-	 *
-	 * @since   3.0
+	 * @since   3.3.7
 	 */
 	public function testRenderReturnsAnEmptyString()
 	{
-		$this->assertThat(
-			$this->layoutBase->render('Data'),
-			$this->equalTo(''),
-			'JLayoutBase::render does not render an output'
-		);
+		$this->assertEquals('', $this->layoutBase->render('Data'), 'JLayoutBase::render does not render an output');
 	}
 }

--- a/tests/unit/suites/libraries/cms/layout/JLayoutBaseTest.php
+++ b/tests/unit/suites/libraries/cms/layout/JLayoutBaseTest.php
@@ -15,43 +15,235 @@ class JLayoutBaseTest extends PHPUnit_Framework_TestCase
 	/**
 	 * @var JLayoutBase
 	 */
-	protected $object;
+	protected $layoutBase;
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
+	 *
+	 * @return  void.
 	 */
 	protected function setUp()
 	{
-		$this->object = new JLayoutBase;
+		$this->layoutBase = new JLayoutBase;
 	}
 
 	/**
-	 * Tests the escape method
+	 * JLayoutbase set options returns a JLayoutbase instance with empty parameter.
+	 *
+	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with empty parameter.
+	 *
+	 * @return  void.
+	 */
+	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithEmptyParameter()
+	{
+		$this->assertInstanceOf('JLayoutBase', $this->layoutBase->setOptions());
+	}
+
+	/**
+	 * JLayoutbase set options returns a JLayoutbase instance with JRegistry parameter.
+	 *
+	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with JRegistry parameter.
+	 *
+	 * @return  void.
+	 */
+	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithJregistryParameter()
+	{
+		$this->assertInstanceOf('JLayoutBase', $this->layoutBase->setOptions(new JRegistry));
+	}
+
+	/**
+	 * JLayoutbase set options returns a JLayoutbase instance with an array parameter.
+	 *
+	 * @testdox  JLayoutbase->setOptions() returns a JLayoutbase instance with an array parameter.
+	 *
+	 * @return  void.
+	 */
+	public function testJlayoutbaseSetOptionsReturnsAJlayoutbaseInstanceWithAnArrayParameter()
+	{
+		$this->assertInstanceOf('JLayoutBase', $this->layoutBase->setOptions(array()));
+	}
+
+	/**
+	 * Options can be configured empty.
+	 *
+	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is empty.
+	 *
+	 * @return  void.
+	 */
+	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParamaterIsEmpty()
+	{
+		$this->layoutBase->setOptions();
+
+		$this->assertInstanceOf('JRegistry', $this->layoutBase->getOptions());
+		$this->assertEmpty($this->layoutBase->getOptions()->toArray());
+	}
+
+	/**
+	 * Options can be configured as an array and is converted to a JRegistry object.
+	 *
+	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is an array.
+	 *
+	 * @return void.
+	 */
+	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParamaterIsAnArray()
+	{
+		$options = array();
+		$this->layoutBase->setOptions($options);
+
+		$this->assertInstanceOf('JRegistry', $this->layoutBase->getOptions());
+		$this->assertEmpty($this->layoutBase->getOptions()->toArray());
+	}
+
+	/**
+	 * Get options can be configured as JRegistry object.
+	 *
+	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object when options parameter is a JRegistry object.
+	 *
+	 * @return  void.
+	 */
+	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectWhenOptionsParameterIsAJregistryObject()
+	{
+		$options = new JRegistry;
+		$this->layoutBase->setOptions($options);
+
+		$this->assertInstanceOf('JRegistry', $this->layoutBase->getOptions());
+		$this->assertEmpty($this->layoutBase->getOptions()->toArray());
+	}
+
+	/**
+	 * Options can be configured as an array and is converted to a JRegistry object.
+	 *
+	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object value using an array.
+	 *
+	 * @return void.
+	 */
+	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectValueUsingAnArray()
+	{
+		$options = array('option' => 'value');
+		$this->layoutBase->setOptions($options);
+
+		$this->assertEquals('value', $this->layoutBase->getOptions()->get('option'));
+	}
+
+	/**
+	 * Options can be configured as an array and is converted to a JRegistry object.
+	 *
+	 * @testdox  JLayoutbase->getOptions() returns a JRegistry object value using JRegistry.
+	 *
+	 * @return void.
+	 */
+	public function testJlayoutbaseGetOptionsReturnsAJregistryObjectValueUsingJregistry()
+	{
+		$options = new JRegistry;
+		$options->set('option', 'value');
+		$this->layoutBase->setOptions($options);
+
+		$this->assertEquals('value', $this->layoutBase->getOptions()->get('option'));
+	}
+
+	/**
+	 * Options can be configured as an array and is converted to a JRegistry object.
+	 *
+	 * @testdox  JLayoutbase->resetOptions() and check options is empty.
+	 *
+	 * @return void.
+	 */
+	public function testJlayoutbaseResetOptionsAndCheckOptionsIsEmpty()
+	{
+		$options = new JRegistry;
+		$options->set('option', 'value');
+		$this->layoutBase->setOptions($options);
+
+		$this->assertEmpty($this->layoutBase->resetOptions()->getOptions()->toArray());
+	}
+
+	/**
+	 * Tests the escape method.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public function testEscape()
+	public function testEscapingSpecialCharactersIntoHtmlEntities()
 	{
 		$this->assertThat(
-			$this->object->escape('This is cool & fun to use!'),
-			$this->equalTo('This is cool &amp; fun to use!')
+			$this->layoutBase->escape('&'),
+			$this->equalTo('&amp;'),
+			'Test the ampersand is converted to HTML code'
 		);
+
+		$this->assertThat(
+			$this->layoutBase->escape('"'),
+			$this->equalTo('&quot;'),
+			'Test the double quote is converted to HTML code'
+		);
+
+		$this->assertThat(
+			$this->layoutBase->escape("'"),
+			$this->equalTo("'"),
+			'Test the single quote is not converted'
+		);
+
+		$this->assertThat(
+			$this->layoutBase->escape("<a href='test'>Test</a>"),
+			$this->equalTo("&lt;a href='test'&gt;Test&lt;/a&gt;"),
+			'Test the characters <> are not converted'
+		);
+	}
+
+	/**
+	 * Test the adding of debug messages.
+	 *
+	 * @return  void.
+	 */
+	public function testAddOneDebugMessageToTheQueue()
+	{
+		$messages = count($this->layoutBase->getDebugMessages());
+		$this->layoutBase->addDebugMessage('Unit test');
+		$this->assertCount($messages + 1, $this->layoutBase->getDebugMessages());
+	}
+
+	/**
+	 * Test retrieving the debug messages.
+	 *
+	 * @testdox  JLayoutBase->getDebugMessages() retrieves a list of debug messages in an array.
+	 *
+	 * @return  void.
+	 */
+	public function testRetrievingTheListOfDebugMessagesIsAnArray()
+	{
+		$this->assertInternalType('array', $this->layoutBase->getDebugMessages());
+	}
+
+	/**
+	 * Test rendering the debug messages
+	 *
+	 * @testdox  JLayoutBase->renderDebugMessages() returns string of messages separated by newline character.
+	 *
+	 * @return void.
+	 */
+	public function testRenderDebugMessageReturnsStringOfMessagesSeparatedByNewlineCharacter()
+	{
+		$this->layoutBase->addDebugMessage('Debug message 1');
+		$this->assertEquals("Debug message 1", $this->layoutBase->renderDebugMessages());
+		$this->layoutBase->addDebugMessage('Debug message 2');
+		$this->assertEquals("Debug message 1\nDebug message 2", $this->layoutBase->renderDebugMessages());
 	}
 
 	/**
 	 * Tests the render method
 	 *
+	 * @testdox  JLayoutBase->render() returns an empty string.
+	 *
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public function testRender()
+	public function testRenderReturnsAnEmptyString()
 	{
 		$this->assertThat(
-			$this->object->render('Data'),
+			$this->layoutBase->render('Data'),
 			$this->equalTo(''),
 			'JLayoutBase::render does not render an output'
 		);


### PR DESCRIPTION
- [x] JLayoutbase->setOptions() returns a JLayoutbase instance with empty parameter.
- [x] JLayoutbase->setOptions() returns a JLayoutbase instance with JRegistry parameter.
- [x] JLayoutbase->setOptions() returns a JLayoutbase instance with an array parameter.
- [x] JLayoutbase->getOptions() returns a JRegistry object when options parameter is empty.
- [x] JLayoutbase->getOptions() returns a JRegistry object when options parameter is an array.
- [x] JLayoutbase->getOptions() returns a JRegistry object when options parameter is a JRegistry object.
- [x] JLayoutbase->getOptions() returns a JRegistry object value using an array.
- [x] JLayoutbase->getOptions() returns a JRegistry object value using JRegistry.
- [x] JLayoutbase->resetOptions() and check options is empty.
- [x] Escaping special characters into html entities
- [x] Add one debug message to the queue
- [x] JLayoutBase->getDebugMessages() retrieves a list of debug messages in an array.
- [x] JLayoutBase->renderDebugMessages() returns string of messages separated by newline character.
- [x] JLayoutBase->render() returns an empty string.
