### PR TITLE
Added @medium annotation to time consuming tests

### DIFF
--- a/tests/unit/suites/libraries/cms/schema/JSchemaChangesetTest.php
+++ b/tests/unit/suites/libraries/cms/schema/JSchemaChangesetTest.php
@@ -74,21 +74,6 @@ class JSchemaChangesetTest extends TestCase
 	}
 
 	/**
-	 * Tests the __construct method
-	 *
-	 * @return  void
-	 *
-	 * @since   3.0
-	 */
-	public function test__construct()
-	{
-		$this->assertThat(
-			new JSchemaChangeset($this->db, null),
-			$this->isInstanceOf('JSchemaChangeset')
-		);
-	}
-
-	/**
 	 * Tests the __construct method with the PostgreSQL driver
 	 *
 	 * @return  void


### PR DESCRIPTION
When using the strict mode of PHPUnit, tests taking longer than 1 second will fail, if they are not marked as being of medium or large size (they are small by default). So the medium annotation enables these tests to run in strict mode.
