### PR TITLE
Add note about changing static method

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -526,6 +526,7 @@ class JUser extends JObject
 	 *
 	 * @return  object  The user table object
 	 *
+	 * @note    At 4.0 this method will no longer be static
 	 * @since   11.1
 	 */
 	public static function getTable($type = null, $prefix = 'JTable')


### PR DESCRIPTION
Internal to the class, the `getTable` method is not used in a static context.  In an effort to improve code structure, this method should no longer be declared static.  Since it is possible the method could be called by an external source statically, we can't make the change now as doing so would throw a warning about calling a non-static method in a static manner.  Therefore, for awareness purposes, I've added a note which indicates this change should occur in 4.0.

Note there isn't anything testable about this PR but it does serve as a documentation reference.
