### PR TITLE
Test annotations

### DIFF
--- a/tests/unit/suites/libraries/cms/schema/JSchemaChangesetTest.php
+++ b/tests/unit/suites/libraries/cms/schema/JSchemaChangesetTest.php
@@ -73,55 +73,34 @@ class JSchemaChangesetTest extends TestCase
 		parent::tearDown();
 	}
 
-	/**
-	 * Tests the __construct method
-	 *
-	 * @return  void
-	 *
-	 * @since   3.0
-	 */
-	public function test__construct()
+	public function dataDriver()
 	{
-		$this->assertThat(
-			new JSchemaChangeset($this->db, null),
-			$this->isInstanceOf('JSchemaChangeset')
+		return array(
+			array('mysqli'),
+			array('postgresql'),
+			array('sqlsrv'),
 		);
 	}
 
 	/**
-	 * Tests the __construct method with the PostgreSQL driver
+	 * Tests the __construct method with the given driver
 	 *
+	 * @medium
+	 *
+	 * @dataProvider dataDriver
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public function test__constructPostgresql()
+	public function test__construct($driver)
 	{
-		$this->db->name = 'postgresql';
-
-		$this->assertThat(
-			new JSchemaChangeset($this->db, null),
-			$this->isInstanceOf('JSchemaChangeset')
-		);
-	}
-
-	/**
-	 * Tests the __construct method with the SQL Server driver
-	 *
-	 * @return  void
-	 *
-	 * @since   3.0
-	 */
-	public function test__constructSqlsrv()
-	{
-		$this->db->name = 'sqlsrv';
+		$this->db->name = $driver;
 
 		$this->assertThat(
 			new JSchemaChangeset($this->db, null),
 			$this->isInstanceOf('JSchemaChangeset')
 		);
 	}
-
 
 	/**
 	 * Tests the getInstance method with the MySQL driver

--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -214,6 +214,8 @@ class JFactoryTest extends TestCase
 	/**
 	 * Tests the JFactory::getDate method.
 	 *
+	 * @medium
+	 *
 	 * @return  void
 	 *
 	 * @since   12.3

--- a/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
@@ -517,6 +517,8 @@ class JCacheTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Testing Gc().
 	 *
+	 * @medium
+	 *
 	 * @return void
 	 */
 	public function testGc()

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMainTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMainTest.php
@@ -138,11 +138,11 @@ class JCacheStorageTest_Main extends TestCase
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @param   string  $store  The store.
+	 * @medium
 	 *
 	 * @dataProvider provider
+	 *
+	 * @param   string  $store  The store.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
When using the strict mode of PHPUnit, tests taking longer than 1 second will fail, if they are not marked as being of medium or large size (they are small by default). So the medium annotation enables these tests to run in strict mode.
