### PR TITLE
Routing: Implementing an interface for component router rules

### DIFF
--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * JComponentRouterRules interface for Joomla
+ *
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ * @since       3.4.0
+ */
+interface JComponentRouterRulesInterface
+{
+	/**
+	 * Prepares a query set to be handed over to the build() method.
+	 * This should complete a partial query set to work as a complete non-SEFed
+	 * URL and in general make sure that all information is present and properly
+	 * formatted. For example, the Itemid should be retrieved and set here.
+	 * 
+	 * @param   JComponentRouter  $router  The calling router object
+	 * @param   array             $query   The query array to process
+	 * 
+	 * @return  void
+	 * 
+	 * @since   3.4.0
+	 */
+	public function preprocess(JComponentRouter &$router, &$query);
+
+	/**
+	 * Parses an URI to retrieve informations for the right route through
+	 * the component.
+	 * This method should retrieve all its input from its method arguments.
+	 *
+	 * @param   JComponentRouter  $router    The calling router object
+	 * @param   array             $segments  The URL segments to parse
+	 * @param   array             $vars      The vars that result from the segments
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4.0
+	 */
+	public function parse(JComponentRouter &$router, &$segments, &$vars);
+
+	/**
+	 * Builds URI segments from a query to encode the necessary informations
+	 * for a route in a human-readable URL.
+	 * This method should retrieve all its input from its method arguments.
+	 *
+	 * @param   JComponentRouter  $router    The calling router object
+	 * @param   array             $query     The vars that should be converted
+	 * @param   array             $segments  The URL segments to create
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4.0
+	 */
+	public function build(JComponentRouter &$router, &$query, &$segments);
+}

--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -22,8 +22,8 @@ interface JComponentRouterRulesInterface
 	 * URL and in general make sure that all information is present and properly
 	 * formatted. For example, the Itemid should be retrieved and set here.
 	 * 
-	 * @param   JComponentRouter  $router  The calling router object
-	 * @param   array             $query   The query array to process
+	 * @param   JComponentRouter  &$router  The calling router object
+	 * @param   array             &$query   The query array to process
 	 * 
 	 * @return  void
 	 * 
@@ -36,9 +36,9 @@ interface JComponentRouterRulesInterface
 	 * the component.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   JComponentRouter  $router    The calling router object
-	 * @param   array             $segments  The URL segments to parse
-	 * @param   array             $vars      The vars that result from the segments
+	 * @param   JComponentRouter  &$router    The calling router object
+	 * @param   array             &$segments  The URL segments to parse
+	 * @param   array             &$vars      The vars that result from the segments
 	 *
 	 * @return  void
 	 *
@@ -51,9 +51,9 @@ interface JComponentRouterRulesInterface
 	 * for a route in a human-readable URL.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   JComponentRouter  $router    The calling router object
-	 * @param   array             $query     The vars that should be converted
-	 * @param   array             $segments  The URL segments to create
+	 * @param   JComponentRouter  &$router    The calling router object
+	 * @param   array             &$query     The vars that should be converted
+	 * @param   array             &$segments  The URL segments to create
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
This introduces an interface for component router rules. These are pretty similar to the application router rules. The idea is, that Joomla will provide both a traditional router class that people can use for very limited components and an extended, rules based component router, which is easily extendable on the fly and requires just a tiny amount of code from the component developers. For those last types of routers, the router rules are implemented and this is their interface.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
