### PR TITLE
Wrapper class to remove static methods

### DIFF
--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -31,9 +31,11 @@ abstract class ModLoginHelper
 		{
 			return '';
 		}
-		
-		// Make sure the languages are sorted based on locale code instead of random sorting
-		ksort($languages);
+
+		usort($languages, function ($a, $b)
+		{
+			return strcmp($a["value"], $b["value"]);
+		});
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -31,6 +31,9 @@ abstract class ModLoginHelper
 		{
 			return '';
 		}
+		
+		// Make sure the languages are sorted based on locale code instead of random sorting
+		ksort($languages);
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -32,10 +32,13 @@ abstract class ModLoginHelper
 			return '';
 		}
 
-		usort($languages, function ($a, $b)
-		{
-			return strcmp($a["value"], $b["value"]);
-		});
+		usort(
+			$languages,
+			function ($a, $b)
+			{
+				return strcmp($a["value"], $b["value"]);
+			}
+		);
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 

--- a/libraries/joomla/user/helperWrapper.php
+++ b/libraries/joomla/user/helperWrapper.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  User
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JUserHelper
+ *
+ * @see    JUserHelper
+ * @since  3.4
+ */
+class JUserHelperWrapper
+{
+	/**
+	 * Helper wrapper method for addUserToGroup
+	 *
+	 * @param   integer  $userId   The id of the user.
+	 * @param   integer  $groupId  The id of the group.
+	 *
+	 * @return boolean  True on success
+	 *
+	 * @throws RuntimeException
+	 * @see     JUserHelper::addUserToGroup
+	 *
+	 * @since   3.4
+	 */
+	public function addUserToGroup($userId, $groupId)
+	{
+		return JUserHelper::addUserToGroup($userId, $groupId);
+	}
+
+	/**
+	 * Helper wrapper method for getUserGroups
+	 *
+	 * @param   integer  $userId  The id of the user.
+	 *
+	 * @return array    List of groups
+	 *
+	 * @see     JUserHelper::getUserGroups
+	 *
+	 * @since   3.4
+	 */
+	public function getUserGroups($userId)
+	{
+		return JUserHelper::getUserGroups($userId);
+	}
+
+	/**
+	 * Helper wrapper method for removeUserFromGroup
+	 *
+	 * @param   integer  $userId   The id of the user.
+	 * @param   integer  $groupId  The id of the group.
+	 *
+	 * @return boolean  True on success
+	 *
+	 * @see     JUserHelper::removeUserFromGroup
+	 *
+	 * @since   3.4
+	 */
+	public function removeUserFromGroup($userId, $groupId)
+	{
+		return JUserHelper::removeUserFromGroup($userId, $groupId);
+	}
+
+	/**
+	 * Helper wrapper method for setUserGroups
+	 *
+	 * @param   integer  $userId  The id of the user.
+	 * @param   array    $groups  An array of group ids to put the user in.
+	 *
+	 * @return boolean  True on success
+	 *
+	 * @see     JUserHelper::setUserGroups
+	 *
+	 * @since   3.4
+	 */
+	public function setUserGroups($userId, $groups)
+	{
+		return JUserHelper::setUserGroups($userId, $groups);
+	}
+
+	/**
+	 * Helper wrapper method for getProfile
+	 *
+	 * @param   integer  $userId  The id of the user.
+	 *
+	 * @return object
+	 *
+	 * @see     JUserHelper::getProfile
+	 *
+	 * @since   3.4
+	 */
+	public function getProfile($userId = 0)
+	{
+		return JUserHelper::getProfile($userId);
+	}
+
+	/**
+	 * Helper wrapper method for activateUser
+	 *
+	 * @param   string  $activation  Activation string
+	 *
+	 * @return boolean  True on success
+	 *
+	 * @see     JUserHelper::activateUser
+	 *
+	 * @since   3.4
+	 */
+	public function activateUser($activation)
+	{
+		return JUserHelper::activateUser($activation);
+	}
+
+	/**
+	 * Helper wrapper method for getUserId
+	 *
+	 * @param   string  $username  The username to search on.
+	 *
+	 * @return integer  The user id or 0 if not found.
+	 *
+	 * @see     JUserHelper::getUserId
+	 *
+	 * @since   3.4
+	 */
+	public function getUserId($username)
+	{
+		return JUserHelper::getUserId($username);
+	}
+
+	/**
+	 * Helper wrapper method for hashPassword
+	 *
+	 * @param   string  $password  The plaintext password to encrypt.
+	 *
+	 * @return string  The encrypted password.
+	 *
+	 * @see     JUserHelper::hashPassword
+	 *
+	 * @since   3.4
+	 */
+	public function hashPassword($password)
+	{
+		return JUserHelper::hashPassword($password);
+	}
+
+	/**
+	 * Helper wrapper method for verifyPassword
+	 *
+	 * @param   string   $password  The plaintext password to check.
+	 * @param   string   $hash      The hash to verify against.
+	 * @param   integer  $user_id   ID of the user if the password hash should be updated
+	 *
+	 * @return boolean  True if the password and hash match, false otherwise
+	 *
+	 * @see     JUserHelper::verifyPassword
+	 *
+	 * @since   3.4
+	 */
+	public function verifyPassword($password, $hash, $user_id = 0)
+	{
+		return JUserHelper::verifyPassword($password, $hash, $user_id);
+	}
+
+	/**
+	 * Helper wrapper method for getCryptedPassword
+	 *
+	 * @param   string   $plaintext     The plaintext password to encrypt.
+	 * @param   string   $salt          The salt to use to encrypt the password. []
+	 * @param   string   $encryption    The kind of password encryption to use.
+	 * @param   boolean  $show_encrypt  Some password systems prepend the kind of
+	 *
+	 * @return string  The encrypted password.
+	 *
+	 * @see     JUserHelper::getCryptedPassword
+	 *
+	 * @since   3.4
+	 */
+	public function getCryptedPassword($plaintext, $salt = '', $encryption = 'md5-hex', $show_encrypt = false)
+	{
+		return JUserHelper::getCryptedPassword($plaintext, $salt, $encryption, $show_encrypt);
+	}
+
+	/**
+	 * Helper wrapper method for getSalt
+	 *
+	 * @param   string  $encryption  The kind of password encryption to use.
+	 * @param   string  $seed        The seed to get the salt from (probably a
+	 * @param   string  $plaintext   The plaintext password that we're generating
+	 *
+	 * @return string  The generated or extracted salt.
+	 *
+	 * @see     JUserHelper::getSalt
+	 *
+	 * @since   3.4
+	 */
+	public function getSalt($encryption = 'md5-hex', $seed = '', $plaintext = '')
+	{
+		return JUserHelper::getSalt($encryption, $seed, $plaintext);
+	}
+
+	/**
+	 * Helper wrapper method for genRandomPassword
+	 *
+	 * @param   integer  $length  Length of the password to generate
+	 *
+	 * @return string  Random Password
+	 *
+	 * @see     JUserHelper::genRandomPassword
+	 *
+	 * @since   3.4
+	 */
+	public function genRandomPassword($length = 8)
+	{
+		return JUserHelper::genRandomPassword($length);
+	}
+
+	/**
+	 * Helper wrapper method for invalidateCookie
+	 *
+	 * @param   string  $userId      User ID for this user
+	 * @param   string  $cookieName  Series id (cookie name decoded)
+	 *
+	 * @return boolean  True on success
+	 *
+	 * @see JUserHelper::invalidateCookie
+	 */
+	public function invalidateCookie($userId, $cookieName)
+	{
+		return JUserHelper::invalidateCookie($userId, $cookieName);
+	}
+
+	/**
+	 * Helper wrapper method for clearExpiredTokens
+	 *
+	 * @return mixed  Database query result
+	 *
+	 * @see     JUserHelper::clearExpiredTokens
+	 *
+	 * @since   3.4
+	 */
+	public function clearExpiredTokens()
+	{
+		return JUserHelper::clearExpiredTokens();
+	}
+
+	/**
+	 * Helper wrapper method for getRememberCookieData
+	 *
+	 * @return mixed  An array of information from an authentication cookie or false if there is no cookie
+	 *
+	 * @see     JUserHelper::getRememberCookieData
+	 *
+	 * @since   3.4
+	 */
+	public function getRememberCookieData()
+	{
+		return JUserHelper::getRememberCookieData();
+	}
+
+	/**
+	 * Helper wrapper method for getShortHashedUserAgent
+	 *
+	 * @return string  A hashed user agent string with version replaced by 'abcd'
+	 *
+	 * @see     JUserHelper::getShortHashedUserAgent
+	 *
+	 * @since   3.4
+	 */
+	public function getShortHashedUserAgent()
+	{
+		return JUserHelper::getShortHashedUserAgent();
+	}
+}

--- a/tests/unit/core/case/case.php
+++ b/tests/unit/core/case/case.php
@@ -199,16 +199,21 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 	/**
 	 * Gets a mock database object.
 	 *
+	 * @param   string  $driver        Optional driver to create a sub-class of JDatabaseDriver
+	 * @param   array   $extraMethods  An array of additional methods to add to the mock
+	 * @param   string  $nullDate      A null date string for the driver.
+	 * @param   string  $dateFormat    A date format for the driver.
+	 *
 	 * @return  JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	public function getMockDatabase()
+	public function getMockDatabase($driver = '', array $extraMethods = array(), $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
 	{
 		// Attempt to load the real class first.
 		class_exists('JDatabaseDriver');
 
-		return TestMockDatabaseDriver::create($this);
+		return TestMockDatabaseDriver::create($this, $driver, $extraMethods, $nullDate, $dateFormat);
 	}
 
 	/**

--- a/tests/unit/core/case/database.php
+++ b/tests/unit/core/case/database.php
@@ -227,16 +227,21 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	/**
 	 * Gets a mock database object.
 	 *
+	 * @param   string  $driver        Optional driver to create a sub-class of JDatabaseDriver
+	 * @param   array   $extraMethods  An array of additional methods to add to the mock
+	 * @param   string  $nullDate      A null date string for the driver.
+	 * @param   string  $dateFormat    A date format for the driver.
+	 *
 	 * @return  JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	public function getMockDatabase()
+	public function getMockDatabase($driver = '', array $extraMethods = array(), $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
 	{
 		// Attempt to load the real class first.
 		class_exists('JDatabaseDriver');
 
-		return TestMockDatabaseDriver::create($this);
+		return TestMockDatabaseDriver::create($this, $driver, $extraMethods, $nullDate, $dateFormat);
 	}
 
 	/**

--- a/tests/unit/core/mock/database/driver.php
+++ b/tests/unit/core/mock/database/driver.php
@@ -26,8 +26,8 @@ class TestMockDatabaseDriver
 	 * Creates and instance of the mock JDatabaseDriver object.
 	 *
 	 * @param   PHPUnit_Framework_TestCase  $test          A test object.
-	 * @param   string                      $driver        The database driver object to mock.
-	 * @param   array                       $extraMethods  An array of additional methods to add to the mock
+	 * @param   string                      $driver        Optional driver to create a sub-class of JDatabaseDriver.
+	 * @param   array                       $extraMethods  An array of additional methods to add to the mock.
 	 * @param   string                      $nullDate      A null date string for the driver.
 	 * @param   string                      $dateFormat    A date format for the driver.
 	 *

--- a/tests/unit/suites/administrator/includes/JAdministratorHelperTest.php
+++ b/tests/unit/suites/administrator/includes/JAdministratorHelperTest.php
@@ -14,9 +14,14 @@ require_once JPATH_ADMINISTRATOR . '/includes/helper.php';
 class JAdministratorHelperTest extends TestCase
 {
 	/**
-	 * @var JAdministratorHelper
+	 * @var  JAdministratorHelper
 	 */
 	protected $object;
+
+	/**
+	 * @var  PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $user;
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -28,8 +33,8 @@ class JAdministratorHelperTest extends TestCase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
-		JFactory::$application->input = new JInput(array());
-		$this->user = $this->getMock('Observer', array('get', 'authorise'));
+		JFactory::$application->input = $this->getMockInput();
+		$this->user = $this->getMock('JUser', array('get', 'authorise'));
 
 		JFactory::$application->expects($this->once())
 			->method('getIdentity')
@@ -53,7 +58,8 @@ class JAdministratorHelperTest extends TestCase
 		$this->user->expects($this->once())
 			->method('get')
 			->with($this->equalTo('guest'))
-			->will($this->returnValue(true));
+			->willReturn(true);
+
 		$this->user->expects($this->never())
 			->method('authorise');
 
@@ -76,11 +82,12 @@ class JAdministratorHelperTest extends TestCase
 		$this->user->expects($this->once())
 			->method('get')
 			->with($this->equalTo('guest'))
-			->will($this->returnValue(false));
+			->willReturn(false);
+
 		$this->user->expects($this->once())
 			->method('authorise')
 			->with($this->equalTo('core.login.admin'))
-			->will($this->returnValue(false));
+			->willReturn(false);
 
 		$this->assertEquals(
 			'com_login',
@@ -101,11 +108,12 @@ class JAdministratorHelperTest extends TestCase
 		$this->user->expects($this->once())
 			->method('get')
 			->with($this->equalTo('guest'))
-			->will($this->returnValue(false));
+			->willReturn(false);
+
 		$this->user->expects($this->once())
 			->method('authorise')
 			->with($this->equalTo('core.login.admin'))
-			->will($this->returnValue(true));
+			->willReturn(true);
 
 		$this->assertEquals(
 			'com_cpanel',
@@ -126,11 +134,12 @@ class JAdministratorHelperTest extends TestCase
 		$this->user->expects($this->once())
 			->method('get')
 			->with($this->equalTo('guest'))
-			->will($this->returnValue(false));
+			->willReturn(false);
+
 		$this->user->expects($this->once())
 			->method('authorise')
 			->with($this->equalTo('core.login.admin'))
-			->will($this->returnValue(true));
+			->willReturn(false);
 
 		JFactory::$application->input->set('option', 'foo');
 

--- a/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
@@ -34,7 +34,7 @@ class JDatabaseExporterMysqlTest extends TestCase
 		parent::setUp();
 
 		// Set up the database object mock.
-		$this->dbo = TestMockDatabaseDriver::create($this, 'Mysql');
+		$this->dbo = $this->getMockDatabase('Mysql');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
@@ -34,7 +34,7 @@ class JDatabaseExporterMysqliTest extends TestCase
 		parent::setUp();
 
 		// Set up the database object mock.
-		$this->dbo = TestMockDatabaseDriver::create($this, 'Mysqli');
+		$this->dbo = $this->getMockDatabase('Mysqli');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -46,7 +46,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		parent::setUp();
 
 		// Set up the database object mock.
-		$this->dbo = TestMockDatabaseDriver::create($this, 'Postgresql', array('getTableSequences'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -128,7 +128,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	{
 		parent::setUp();
 
-		$this->dbo = TestMockDatabaseDriver::create($this, 'Postgresql', array(), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', array(), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->_instance = new JDatabaseQueryPostgresql($this->dbo);
 	}

--- a/tests/unit/suites/finderIndexer/FinderIndexerHelperTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerHelperTest.php
@@ -42,9 +42,9 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 */
 	public function testParse()
 	{
-		$this->assertThat(
+		$this->assertEquals(
+			'Test string to parse with the txt parser',
 			FinderIndexerHelper::parse('Test string to parse with the txt parser', 'txt'),
-			$this->stringContains('Test string to parse with the txt parser'),
 			'Tests that FinderIndexerHelper::parse() returns the string given with the txt parser.'
 		);
 	}
@@ -66,9 +66,9 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 */
 	public function testAddContentType()
 	{
-		$this->assertThat(
+		$this->assertEquals(
+			4,
 			FinderIndexerHelper::addContentType('Article'),
-			$this->equalTo('4'),
 			'Tests that addContentType returns the ID for an already existing type.'
 		);
 
@@ -110,9 +110,9 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 */
 	public function testGetDefaultLanguage()
 	{
-		$this->assertThat(
+		$this->assertEquals(
+			'en-GB',
 			FinderIndexerHelper::getDefaultLanguage(),
-			$this->StringContains('en-GB'),
 			'The default language is en-GB'
 		);
 	}
@@ -126,9 +126,9 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 */
 	public function testGetPrimaryLanguage()
 	{
-		$this->assertThat(
+		$this->assertEquals(
+			'en',
 			FinderIndexerHelper::getPrimaryLanguage('en-GB'),
-			$this->StringContains('en'),
 			'The primary language is en'
 		);
 	}

--- a/tests/unit/suites/finderIndexer/FinderIndexerParserTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerParserTest.php
@@ -16,22 +16,6 @@ require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/parse
 class FinderIndexerParserTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * Sets up the fixture, for example, opens a network connection.
-	 * This method is called before a test is executed.
-	 */
-	protected function setUp()
-	{
-	}
-
-	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 */
-	protected function tearDown()
-	{
-	}
-
-	/**
 	 * Tests the getInstance method
 	 *
 	 * @return  void
@@ -40,9 +24,9 @@ class FinderIndexerParserTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetInstance()
 	{
-		$this->assertThat(
+		$this->assertInstanceOf(
+			'FinderIndexerParserHtml',
 			FinderIndexerParser::getInstance('html'),
-			$this->isInstanceOf('FinderIndexerParserHtml'),
 			'getInstance with param "html" returns an instance of FinderIndexerParserHtml.'
 		);
 	}

--- a/tests/unit/suites/finderIndexer/FinderIndexerResultTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerResultTest.php
@@ -180,9 +180,9 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 */
 	public function testGetTaxonomy()
 	{
-		$this->assertThat(
-			$this->object->getTaxonomy(),
-			$this->isType('array')
+		$this->assertInternalType(
+			'array',
+			$this->object->getTaxonomy()
 		);
 	}
 
@@ -202,9 +202,9 @@ class FinderIndexerResultTest extends TestCaseDatabase
 		$taxonomy = $this->object->getTaxonomy('testing');
 
 		// Verify our test item is an instance of JObject
-		$this->assertThat(
-			$taxonomy['Test Item'],
-			$this->isInstanceOf('JObject')
+		$this->assertInstanceOf(
+			'JObject',
+			$taxonomy['Test Item']
 		);
 	}
 

--- a/tests/unit/suites/finderIndexer/FinderIndexerStemmerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerStemmerTest.php
@@ -24,9 +24,9 @@ class FinderIndexerStemmerTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetInstance()
 	{
-		$this->assertThat(
+		$this->assertInstanceOf(
+			'FinderIndexerStemmerPorter_en',
 			FinderIndexerStemmer::getInstance('porter_en'),
-			$this->isInstanceOf('FinderIndexerStemmerPorter_en'),
 			'getInstance with param "porter_en" returns an instance of FinderIndexerStemmerPorter_en.'
 		);
 	}

--- a/tests/unit/suites/finderIndexer/FinderIndexerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTest.php
@@ -32,7 +32,7 @@ class FinderIndexerTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
-		JFactory::$database    = TestMockDatabaseDriver::create($this, 'Mysqli');
+		JFactory::$database    = $this->getMockDatabase('Mysqli');
 		JFactory::$session     = $this->getMockSession();
 
 		// Register the object

--- a/tests/unit/suites/finderIndexer/FinderIndexerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTest.php
@@ -16,20 +16,6 @@ require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/index
 class FinderIndexerTest extends TestCaseDatabase
 {
 	/**
-	 * The mock database object
-	 *
-	 * @var  JDatabaseDriver
-	 */
-	protected $db;
-
-	/**
-	 * The factory database object
-	 *
-	 * @var  JDatabaseDriver
-	 */
-	protected $factoryDb;
-
-	/**
 	 * @var FinderIndexer
 	 */
 	protected $object;
@@ -40,15 +26,14 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	protected function setUp()
 	{
+		parent::setUp();
+
 		// Store the factory state so we can mock the necessary objects
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$database    = TestMockDatabaseDriver::create($this, 'Mysqli');
 		JFactory::$session     = $this->getMockSession();
-
-		// Set up our mock database
-		$this->db = JFactory::getDbo();
-		$this->db->name = 'mysqli';
 
 		// Register the object
 		$this->object = FinderIndexer::getInstance();
@@ -62,6 +47,8 @@ class FinderIndexerTest extends TestCaseDatabase
 	{
 		// Restore the factory state
 		$this->restoreFactoryState();
+
+		parent::tearDown();
 	}
 
 	/**
@@ -81,31 +68,6 @@ class FinderIndexerTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Method to override the factory database instance
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	protected function saveFactoryDatabase()
-	{
-		$this->factoryDb = JFactory::$database;
-		JFactory::$database = $this->db;
-	}
-
-	/**
-	 * Method to restore the factory database instance
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	protected function restoreFactoryDatabase()
-	{
-		JFactory::$database = $this->factoryDb;
-	}
-
-	/**
 	 * Tests the getInstance method
 	 *
 	 * @return  void
@@ -114,16 +76,10 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testGetInstance()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
-		$this->assertThat(
-			FinderIndexer::getInstance(),
-			$this->isInstanceOf('FinderIndexerDriverMysql')
+		$this->assertInstanceOf(
+			'FinderIndexerDriverMysql',
+			FinderIndexer::getInstance()
 		);
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 
 	/**
@@ -135,18 +91,12 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testGetInstanceSqlazure()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
 		JFactory::$database->name = 'sqlazure';
 
-		$this->assertThat(
-			FinderIndexer::getInstance(),
-			$this->isInstanceOf('FinderIndexerDriverSqlsrv')
+		$this->assertInstanceOf(
+			'FinderIndexerDriverSqlsrv',
+			FinderIndexer::getInstance()
 		);
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 
 	/**
@@ -155,20 +105,13 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @expectedException  RuntimeException
 	 */
 	public function testGetInstanceException()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
 		JFactory::$database->name = 'nosql';
 
-		$this->setExpectedException('RuntimeException');
-
 		FinderIndexer::getInstance();
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 
 	/**
@@ -180,9 +123,9 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testGetState()
 	{
-		$this->assertThat(
-			FinderIndexer::getState(),
-			$this->isInstanceOf('JObject')
+		$this->assertInstanceOf(
+			'JObject',
+			FinderIndexer::getState()
 		);
 	}
 
@@ -195,30 +138,23 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testSetState()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
 		// Set up our test object
 		$test = new JObject;
 		$test->string = 'Testing FinderIndexer::setState()';
 
 		// First, assert we can successfully set the state
-		$this->assertThat(
-			FinderIndexer::setState($test),
-			$this->isTrue()
+		$this->assertTrue(
+			FinderIndexer::setState($test)
 		);
 
 		// Set the session data to test retrieval
 		FinderIndexer::setState($test);
 
 		// Now assert we can successfully get the state data we just stored
-		$this->assertThat(
-			FinderIndexer::getState(),
-			$this->isInstanceOf('JObject')
+		$this->assertInstanceOf(
+			'JObject',
+			FinderIndexer::getState()
 		);
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 
 	/**
@@ -230,22 +166,15 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testSetStateBadData()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
 		// Set up our test object
 		$test = new JRegistry;
 		$test->set('string', 'Testing FinderIndexer::setState()');
 
 		// Attempt to set the state
-		$this->assertThat(
+		$this->assertFalse(
 			FinderIndexer::setState($test),
-			$this->isFalse(),
 			'setState method is not compatible with JRegistry'
 		);
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 
 	/**
@@ -257,19 +186,12 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testResetState()
 	{
-		// Override the database in this method
-		$this->saveFactoryDatabase();
-
 		// Reset the state
 		FinderIndexer::resetState();
 
 		// Test we get a null object
-		$this->assertThat(
-			JFactory::getSession()->get('_finder.state', null),
-			$this->isNull()
+		$this->assertNull(
+			JFactory::getSession()->get('_finder.state', null)
 		);
-
-		// Restore the database
-		$this->restoreFactoryDatabase();
 	}
 }

--- a/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
@@ -33,7 +33,7 @@ class FinderIndexerTokenTest extends TestCase
 		$this->saveFactoryState();
 
 		// Set up our mock database
-		JFactory::$database = TestMockDatabaseDriver::create($this, 'Mysqli');
+		JFactory::$database = $this->getMockDatabase('Mysqli');
 
 		FinderIndexerHelper::$stemmer = FinderIndexerStemmer::getInstance('porter_en');
 	}

--- a/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
@@ -27,14 +27,13 @@ class FinderIndexerTokenTest extends TestCase
 	 */
 	protected function setUp()
 	{
+		parent::setUp();
+
 		// Store the factory state so we can mock the necessary objects
 		$this->saveFactoryState();
 
 		// Set up our mock database
-		$db = JFactory::getDbo();
-		$db->name = 'mysqli';
-
-		JFactory::$database = $db;
+		JFactory::$database = TestMockDatabaseDriver::create($this, 'Mysqli');
 
 		FinderIndexerHelper::$stemmer = FinderIndexerStemmer::getInstance('porter_en');
 	}
@@ -51,6 +50,8 @@ class FinderIndexerTokenTest extends TestCase
 	{
 		// Restore the factory state
 		$this->restoreFactoryState();
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/suites/finderIndexer/parser/FinderIndexerParserHtmlTest.php
+++ b/tests/unit/suites/finderIndexer/parser/FinderIndexerParserHtmlTest.php
@@ -38,11 +38,9 @@ class FinderIndexerParserHtmlTest extends PHPUnit_Framework_TestCase
 
 		$input = file_get_contents(dirname(__DIR__) . '/data/parseHtml.txt');
 
-		$parsed = $this->object->parse($input);
-
 		$this->assertContains(
 			$testResult,
-			$parsed
+			$this->object->parse($input)
 		);
 	}
 }

--- a/tests/unit/suites/finderIndexer/parser/FinderIndexerParserRtfTest.php
+++ b/tests/unit/suites/finderIndexer/parser/FinderIndexerParserRtfTest.php
@@ -38,11 +38,9 @@ class FinderIndexerParserRtfTest extends PHPUnit_Framework_TestCase
 
 		$input = file_get_contents(dirname(__DIR__) . '/data/parseHtml.txt');
 
-		$parsed = $this->object->parse($input);
-
 		$this->assertContains(
 			$testResult,
-			$parsed
+			$this->object->parse($input)
 		);
 	}
 }

--- a/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerFrTest.php
+++ b/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerFrTest.php
@@ -29,14 +29,6 @@ class FinderIndexerStemmerFrTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 */
-	protected function tearDown()
-	{
-	}
-
-	/**
 	 * Tests the stem method of the French language stemmer
 	 *
 	 * @return  void

--- a/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerPorter_EnTest.php
+++ b/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerPorter_EnTest.php
@@ -30,14 +30,6 @@ class FinderIndexerStemmerPorter_EnTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 */
-	protected function tearDown()
-	{
-	}
-
-	/**
 	 * Tests the stem method of the porter_en stemmer
 	 *
 	 * @return  void

--- a/tests/unit/suites/libraries/joomla/model/JModelDatabaseTest.php
+++ b/tests/unit/suites/libraries/joomla/model/JModelDatabaseTest.php
@@ -37,7 +37,7 @@ class JModelDatabaseTest extends TestCase
 		$this->assertSame(JFactory::getDbo(), $this->_instance->getDb(), 'Checks default database driver.');
 
 		// Create a new datbase mock for injection.
-		$db = TestMockDatabaseDriver::create($this);
+		$db = $this->getMockDatabase();
 		$class = new DatabaseModel(null, $db);
 		$this->assertSame($db, $class->getDb(), 'Checks injected database driver.');
 	}
@@ -101,7 +101,7 @@ class JModelDatabaseTest extends TestCase
 
 		$this->saveFactoryState();
 
-		JFactory::$database = TestMockDatabaseDriver::create($this);
+		JFactory::$database = $this->getMockDatabase();
 
 		$this->_instance = new DatabaseModel;
 	}


### PR DESCRIPTION
This first PR introduces a wrapper class for the JUserHelper class to get rid of the static methods to improve the testing basis of the code.

It should be used as a template for other classes which also have to be considered.
