### PR TITLE
Removed additional filters from modules view. Fixes issue #3369

### DIFF
--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -132,18 +132,6 @@ class ModulesViewModules extends JViewLegacy
 
 		JToolbarHelper::help('JHELP_EXTENSIONS_MODULE_MANAGER');
 
-		JHtmlSidebar::addEntry(
-			JText::_('JSITE'),
-			'index.php?option=com_modules&filter_client_id=0',
-			$this->state->get('filter.client_id') == 0
-		);
-
-		JHtmlSidebar::addEntry(
-			JText::_('JADMINISTRATOR'),
-			'index.php?option=com_modules&filter_client_id=1',
-			$this->state->get('filter.client_id') == 1
-		);
-
 		JHtmlSidebar::setAction('index.php?option=com_modules');
 
 		JHtmlSidebar::addFilter(


### PR DESCRIPTION
#### Steps to reproduce the issue

Go to:
- Extensions -> Module Manager

You will notice that there are two filters for filtering between "Site and Administrator". And both do the same task.

![filters](https://f.cloud.github.com/assets/1375475/2512543/79017414-b427-11e3-87d1-55cd6d52ce1b.png)
