### PR TITLE
Fix issue #4702

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -450,7 +450,7 @@ class ModulesModelModule extends JModelAdmin
 
 				$data = $this->generateNewTitle(0, $table->title, $table->position);
 				$table->title = $data[0];
-				
+
 				// Unpublish duplicate module
 				$table->published = 0;
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -447,10 +447,10 @@ class ModulesModelModule extends JModelAdmin
 				{
 					$table->title = preg_replace('#\(\d+\)$#', '(' . ($m[1] + 1) . ')', $table->title);
 				}
-				else
-				{
-					$table->title .= ' (2)';
-				}
+
+				$data = $this->generateNewTitle(0, $table->title, $table->position);
+				$table->title = $data[0];
+				
 				// Unpublish duplicate module
 				$table->published = 0;
 
@@ -845,7 +845,7 @@ class ModulesModelModule extends JModelAdmin
 
 		// Load the core and/or local language file(s).
 		$lang->load($module, $client->path, null, false, true)
-			||	$lang->load($module, $client->path . '/modules/' . $module, null, false, true);
+		||	$lang->load($module, $client->path . '/modules/' . $module, null, false, true);
 
 		if (file_exists($formFile))
 		{


### PR DESCRIPTION
This PR fix the issue #4702 reported by @dkanchev. Please see https://github.com/joomla/joomla-cms/issues/4702 to understand the actual issue (he explained it very well).
## How to test
1. Apply this PR .
2. Go to Extensions -> Module Manager, try to duplicate a module several times.
3. Makes sure the title of the module is generated properly as explained in the Expected result of issue report (at the moment, the title of the duplicated module is always appended by (2) and it causes the confusing when you duplicate the same module several times)

> My opinion is that every duplicated module should have a new unique name and not the same name as another module. This helps people to differentiate the modules - users do not care about unique IDs - they use module names.
