### PR TITLE
Alternative menu item not loading the php files in the override dir

### DIFF
--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -672,7 +672,7 @@ class JController extends JObject
 		$document = JFactory::getDocument();
 		$viewType = $document->getType();
 		$viewName = JRequest::getCmd('view', $this->default_view);
-		$viewLayout = JRequest::getCmd('layout', 'default');
+		$viewLayout = JRequest::getString('layout', 'default');
 
 		$view = $this->getView($viewName, $viewType, '', array('base_path' => $this->basePath, 'layout' => $viewLayout));
 


### PR DESCRIPTION
changed JRequest::getCmd('layout', 'default') to JRequest::getString('layout', 'default') at JController.
getCmd removes colons(:) which are required for template overrides to work
### original report

What I did 
I created an alternative menu item for com_wrapper. The steps:
1) Copy from /components/com_wrapper/views/wrapper/tmpl the files default.php and default.xml. 
2) Paste them in /templates/[template_name]/html/com_wrapper/wrapper
3) Rename them to custom.php and custom.xml
4) Edit custom.xml, changing title="COM_WRAPPER_WRAPPER_VIEW_DEFAULT_TITLE" on line 3 with title="custom"
5) In Joomla's backend, create a new menu item and choose type Wrapper => custom. Publish the menu item.

What happened
Changes to the custom.xml file get applied to the backend page for the alternative menu. But changes in the custom.php file do not get applied to the frontend page for that menu. It appears that the PHP file is not parsed at all because even obvious syntax errors do not have any effect. (Just to note, when editing /components/com_wrapper/views/wrapper/tmpl/default.php, changes do get applied.)

What should have happened 
Changes in the custom.php file should be applied to the frontend page for the alternative menu item.

Other information 
I believe this is a common problem. See here ( http://joomla.stackexchange.com/questions/4388/list-all-categories-com-content-views-categories-alternative-layout-not-workin ) for a clear and concise example, and here ( http://forum.joomla.org/viewtopic.php?f=579&t=578662 ) for a longer thread with many people reporting issues along these lines.

My environment
Joomla 2.5.24. XAMPP 1.8.3 on Win7. PHP 5.5.6, MySQL 5.6.14, Apache 2.4.7

I'd be happy to provide any other info if needed. Alternative overrides are a really important functionality. :)
