### PR TITLE
Error on linking a category of another language

### DIFF
--- a/libraries/framework/Joomla/Registry/Registry.php
+++ b/libraries/framework/Joomla/Registry/Registry.php
@@ -425,7 +425,10 @@ class Registry implements \JsonSerializable, \ArrayAccess
 			}
 
 			// Get the old value if exists so we can return it
-			$result = $node->$nodes[$i] = $value;
+			if (is_object($node))
+			{
+				$result = $node->$nodes[$i] = $value;
+			}
 		}
 
 		return $result;


### PR DESCRIPTION
This PR for fix issue #4467 
## Original Report
#### Steps to reproduce the issue

create a content category for a language.
create another content category for the second langauge.
link the two categories with each other.
#### Expected result

linked categories
#### Actual result

errors in linking popup:
Warning: Attempt to assign property of non-object in /srv/www/vhosts/kubler.ch/httpdocs/libraries/framework/Joomla/Registry/Registry.php on line 428

Warning: Attempt to assign property of non-object in /srv/www/vhosts/kubler.ch/httpdocs/libraries/framework/Joomla/Registry/Registry.php on line 428

Warning: Attempt to assign property of non-object in /srv/www/vhosts/kubler.ch/httpdocs/libraries/framework/Joomla/Registry/Registry.php on line 428
#### System information (as much as possible)

joomla 3.3.6
#### Additional comments

sometimes the linking works, but on some parcticular categories i get the errors above.
