### PR TITLE
JModelLegacy::addIncludePath is supposed to support arrays

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -103,14 +103,22 @@ abstract class JModelLegacy extends JObject
 		{
 			jimport('joomla.filesystem.path');
 
-			if (!in_array($path, $paths[$prefix]))
+			if (!is_array($path))
 			{
-				array_unshift($paths[$prefix], JPath::clean($path));
+				$path = array($path);
 			}
 
-			if (!in_array($path, $paths['']))
+			foreach ($path as $includePath)
 			{
-				array_unshift($paths[''], JPath::clean($path));
+				if (!in_array($includePath, $paths[$prefix]))
+				{
+					array_unshift($paths[$prefix], JPath::clean($includePath));
+				}
+
+				if (!in_array($includePath, $paths['']))
+				{
+					array_unshift($paths[''], JPath::clean($includePath));
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR is for issue #4140 
## Original Report

Function declaration states that you can pass an array of paths to the `addIncludePath`:

``` php
/**
* Add a directory where JModelLegacy should search for models. You may
* either pass a string or an array of directories.
*
* @param mixed $path A path or array[sting] of paths to search.
* @param string $prefix A prefix for models.
*
* @return array An array with directory elements. If prefix is equal to '', all directories are returned.
*
* @since 12.2
*/
```

https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/model/legacy.php#L76

But that's false. If you try to use it like:

``` php
JModelLegacy::addIncludePath(
    array(
        JPATH_ADMINISTRATOR . '/components/com_content/models',
        JPATH_SITE . '/components/com_content/models'
    )
);
```

You will get a nice error caused because JPath expects to receive a string:
https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/filesystem/path.php#L199

And we are passing it the array:
https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/model/legacy.php#L108

Not time to dig into it. I just wanted to report it before forgetting it
