### PR TITLE
[fix] Save and copy modules does not add (copy)

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -930,12 +930,13 @@ class ModulesModelModule extends JModelAdmin
 		// Alter the title and published state for Save as Copy
 		if ($input->get('task') == 'save2copy')
 		{
-			$orig_data  = $input->post->get('jform', array(), 'array');
+			$orig_table = clone $this->getTable();
+			$orig_table->load((int) $input->getInt('id'));
+			$data['published'] = 0;
 
-			if ($data['title'] == $orig_data['title'])
+			if ($data['title'] == $orig_table->title)
 			{
 				$data['title'] .= ' ' . JText::_('JGLOBAL_COPY');
-				$data['published'] = 0;
 			}
 		}
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -931,10 +931,8 @@ class ModulesModelModule extends JModelAdmin
 		if ($input->get('task') == 'save2copy')
 		{
 			$orig_data  = $input->post->get('jform', array(), 'array');
-			$orig_table = clone $this->getTable();
-			$orig_table->load((int) $orig_data['id']);
 
-			if ($data['title'] == $orig_table->title)
+			if ($data['title'] == $orig_data['title'])
 			{
 				$data['title'] .= ' ' . JText::_('JGLOBAL_COPY');
 				$data['published'] = 0;


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/4702
When trying to Save and Copy a module, the new module does not get (copy) appended to the title (regression vs 2.5)
The issue comes from the change from var to input.
Here is a tentative patch, restoring the former behaviour.
