### PR TITLE
Cannot change read/unread status on messages or delete them

### DIFF
--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -64,7 +64,7 @@ class MessagesModelMessage extends JModelAdmin
 		{
 			if ($table->load($pk))
 			{
-				if ($table->user_id_to !== $user->id)
+				if ($table->user_id_to != $user->id)
 				{
 					// Prune items that you can't change.
 					unset($pks[$i]);
@@ -244,7 +244,7 @@ class MessagesModelMessage extends JModelAdmin
 
 			if ($table->load($pk))
 			{
-				if ($table->user_id_to !== $user->id)
+				if ($table->user_id_to != $user->id)
 				{
 					// Prune items that you can't change.
 					unset($pks[$i]);


### PR DESCRIPTION
This is a replacement PR for #4147 which has been removed in error by the submitter
## Original Report
### Cannot change read/unread status on messages or delete them

The read/unread status on messages (http://...website.../administrator/index.php?option=com_messages) cannot be changed after the user has updated his profile (http://...website.../administrator/index.php?option=com_admin&view=profile&layout=edit&id=#user_id#).
Also a message cannot be deleted after the user has updated his profile.

The warning "Edit state is not permitted" is shown if try to change the read/unread status.
The warning "Delete not permitted" is shown if try to delete a message.
### How to reproduce the bug

1: Login in the backend side, and go to the message list view using the menu "Componentes > Messaging", ensure that you have at least one message.

2: Now you can change the read/unread state of the message or delete them.
- try select a message and press the button "Mark As Read" or "Mark As Unread"
- try use the link in the column "read"
- try select a message and press the button "Empty trash" (must have the filter "Trashed").

3: Use the top-right menu and go to "Edit Account" (you don't need to change anything).

4: Press "Save & Close"

5: Return to the message list view using the menu "Componentes > Messaging".

6: Now you cannot change the read/unread state of the message or delete them (logout/login to make it work again).
- try select a message and press the button "Mark As Read" or "Mark As Unread"
- try use the link in the column "read"
- try select a message and press the button "Empty trash" (must have the filter "Trashed").

Note that the point "2" is not relevant on the result of point "6".
