### PR TITLE
Can't save and show error message when without filling the mandatory field "Menu Item Type"

### DIFF
--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -71,7 +71,7 @@ class JFormFieldMenutype extends JFormFieldList
 		JHtml::_('behavior.framework');
 		JHtml::_('behavior.modal');
 
-		$html[] = '<span class="input-append"><input type="text" disabled="disabled" readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' /><a class="btn btn-primary" onclick="SqueezeBox.fromElement(this, {handler:\'iframe\', size: {x: 600, y: 450}, url:\''.JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId='.$recordId).'\'})"><i class="icon-list icon-white"></i> '.JText::_('JSELECT').'</a></span>';
+		$html[] = '<span class="input-append"><input type="text" required="required" readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' /><a class="btn btn-primary" onclick="SqueezeBox.fromElement(this, {handler:\'iframe\', size: {x: 600, y: 450}, url:\''.JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId='.$recordId).'\'})"><i class="icon-list icon-white"></i> '.JText::_('JSELECT').'</a></span>';
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 
 		return implode("\n", $html);


### PR DESCRIPTION
can't save and show error message when without filling the mandatory field "Menu Item Type"
## Original Report
#### Steps to reproduce the issue
1. Go to Menu->Main Menu-> Add New Menu Item.
2. Open Add New Menu Item form.
3. Do not Fill the data in title field and click on save button.
4. Incorrect validation message is displayed as follow:
   Error
   Invalid form
#### Expected result

Validation message should be user friendly like "invalid field: title"
#### Actual result

Incorrect validation message is displayed as follow:
Error
Invalid form
#### System information (as much as possible)

PHP Built On Windows NT 6.2 build 9200
Database Version 5.6.12-log
Database Collation utf8_general_ci
PHP Version 5.4.12
Web Server Apache/2.4.4 (Win64) PHP/5.4.12
WebServer to PHP Interface apache2handler
Joomla! Version Joomla! 3.3.7-dev Development [ Ember ] 01-October-2014 02:00 GMT
Joomla! Platform Version Joomla Platform 13.1.0 Stable [ Curiosity ] 24-Apr-2013 00:00 GMT
User Agent Mozilla/5.0 (Windows NT 6.1; rv:32.0) Gecko/20100101 Firefox/32.0![screen shot 2014-10-17 at 03 17 42](http://issues.joomla.org/uploads/1/c6d90a9ac018cfe529a9551e962721eb.jpg)
#### Additional comments

Validation message should be user friendly.
