### PR TITLE
Display of the ordering field when editing items

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -234,12 +234,6 @@ class ContentModelArticle extends JModelAdmin
 
 		// Increment the content version number.
 		$table->version++;
-
-		// Reorder the articles within the category so the new article is first
-		if (empty($table->id))
-		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
-		}
 	}
 
 	/**
@@ -556,6 +550,13 @@ class ContentModelArticle extends JModelAdmin
 			{
 				$this->featured($this->getState($this->getName() . '.id'), $data['featured']);
 			}
+
+			// Reorder the articles within the category so the new article is first
+			$table = $this->getTable();
+			$key = $table->getKeyName();
+			$pk = (!empty($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+			$table->load($pk);
+			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
 
 			return true;
 		}

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -102,9 +102,8 @@
 			label="COM_CONTENT_FIELD_VERSION_LABEL" size="6" description="COM_CONTENT_FIELD_VERSION_DESC"
 			readonly="true" filter="unset" />
 
-		<field name="ordering" type="text" label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC" size="6"
-			default="0" />
+		<field name="ordering" type="ordering" label="JFIELD_ORDERING_LABEL"
+			description="JFIELD_ORDERING_DESC" class="inputbox" size="6" />
 
 		<field name="metakey" type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL" description="JFIELD_META_KEYWORDS_DESC"

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -30,6 +30,7 @@ $fields = $displayData->get('fields') ?: array(
 	'featured',
 	'sticky',
 	'access',
+	'ordering',
 	'language',
 	'tags',
 	'note',

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -103,7 +103,6 @@ abstract class JHtmlList
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
-			$items[$i]->text = JText::_($items[$i]->text);
 
 			if (JString::strlen($items[$i]->text) > $chop)
 			{

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -77,22 +77,24 @@ abstract class JHtmlList
 	/**
 	 * Returns an array of options
 	 *
-	 * @param   string   $query  SQL with 'ordering' AS value and 'name field' AS text
-	 * @param   integer  $chop   The length of the truncated headline
+	 * @param   string   $query         SQL with 'ordering' AS value and 'name field' AS text
+	 * @param   integer  $chop          The length of the truncated headline
+	 * @param   integer  $currentOrder  Order of the item
 	 *
 	 * @return  array  An array of objects formatted for JHtml list processing
 	 *
 	 * @since   1.5
 	 */
-	public static function genericordering($query, $chop = 30, $selectOrder = 0)
+	public static function genericordering($query, $chop = 30, $currentOrder = 0)
 	{
 		$db = JFactory::getDbo();
 		$options = array();
 		$db->setQuery($query);
 
 		$items = $db->loadObjectList();
+		$totalItems = count($items);
 
-		if (empty($items))
+		if ($totalItems == 0)
 		{
 			$options[] = JHtml::_('select.option', 1, JText::_('JOPTION_ORDER_FIRST'));
 
@@ -100,10 +102,10 @@ abstract class JHtmlList
 		}
 
 		$options[] = JHtml::_('select.option', 0, JText::_('JOPTION_ORDER_FIRST'));
+		$options[] = JHtml::_('select.option', $items[$totalItems - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
-		for ($i = 0, $n = count($items); $i < $n; $i++)
+		for ($i = 0; $i < $totalItems; ++$i)
 		{
-
 			if (JString::strlen($items[$i]->text) > $chop)
 			{
 				$text = JString::substr($items[$i]->text, 0, $chop) . "...";
@@ -113,10 +115,8 @@ abstract class JHtmlList
 				$text = $items[$i]->text;
 			}
 
-			$options[] = JHtml::_('select.option', ($items[$i]->value == $selectOrder ? $selectOrder : $items[$i]->value + 1), ($items[$i]->value + 1) / 2 . '. ' . $text);
+			$options[] = JHtml::_('select.option', $items[$i]->value + ($items[$i]->value < $currentOrder ? -1 : ($items[$i]->value > $currentOrder ? 1 : 0)), ($items[$i]->value + 1) / 2 . '. ' . $text);
 		}
-
-		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
 		return $options;
 	}

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -115,7 +115,11 @@ abstract class JHtmlList
 				$text = $items[$i]->text;
 			}
 
-			$options[] = JHtml::_('select.option', $items[$i]->value + ($items[$i]->value < $currentOrder ? -1 : ($items[$i]->value > $currentOrder ? 1 : 0)), ($items[$i]->value + 1) / 2 . '. ' . $text);
+			$options[] = JHtml::_(
+				'select.option',
+				$items[$i]->value + ($items[$i]->value < $currentOrder ? -1 : ($items[$i]->value > $currentOrder ? 1 : 0)),
+				($items[$i]->value + 1) / 2 . '. ' . $text
+			);
 		}
 
 		return $options;

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -84,7 +84,7 @@ abstract class JHtmlList
 	 *
 	 * @since   1.5
 	 */
-	public static function genericordering($query, $chop = 30)
+	public static function genericordering($query, $chop = 30, $selectOrder = 0)
 	{
 		$db = JFactory::getDbo();
 		$options = array();
@@ -99,7 +99,7 @@ abstract class JHtmlList
 			return $options;
 		}
 
-		$options[] = JHtml::_('select.option', 0, '0 ' . JText::_('JOPTION_ORDER_FIRST'));
+		$options[] = JHtml::_('select.option', 0, JText::_('JOPTION_ORDER_FIRST'));
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
@@ -113,10 +113,10 @@ abstract class JHtmlList
 				$text = $items[$i]->text;
 			}
 
-			$options[] = JHtml::_('select.option', $items[$i]->value, $items[$i]->value . '. ' . $text);
+			$options[] = JHtml::_('select.option', ($items[$i]->value == $selectOrder ? $selectOrder : $items[$i]->value + 1), ($items[$i]->value + 1) / 2 . '. ' . $text);
 		}
 
-		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, ($items[$i - 1]->value + 1) . ' ' . JText::_('JOPTION_ORDER_LAST'));
+		$options[] = JHtml::_('select.option', $items[$i - 1]->value + 1, JText::_('JOPTION_ORDER_LAST'));
 
 		return $options;
 	}
@@ -143,7 +143,7 @@ abstract class JHtmlList
 
 		if (empty($neworder))
 		{
-			$orders = JHtml::_('list.genericordering', $query);
+			$orders = JHtml::_('list.genericordering', $query, 30, (int) $selected);
 			$html = JHtml::_('select.genericlist', $orders, $name, array('list.attr' => $attribs, 'list.select' => (int) $selected));
 		}
 		else

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1392,12 +1392,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			if ($row->ordering >= 0)
 			{
 				// Only update rows that are necessary.
-				if ($row->ordering != $i*2 + 1)
+				if ($row->ordering != $i * 2 + 1)
 				{
 					// Update the row ordering field.
 					$query->clear()
 						->update($this->_tbl)
-						->set('ordering = ' . ($i*2 + 1));
+						->set('ordering = ' . ($i * 2 + 1));
 					$this->appendPrimaryKeys($query, $row);
 					$this->_db->setQuery($query);
 					$this->_db->execute();

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1392,12 +1392,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			if ($row->ordering >= 0)
 			{
 				// Only update rows that are necessary.
-				if ($row->ordering != $i + 1)
+				if ($row->ordering != $i*2 + 1)
 				{
 					// Update the row ordering field.
 					$query->clear()
 						->update($this->_tbl)
-						->set('ordering = ' . ($i + 1));
+						->set('ordering = ' . ($i*2 + 1));
 					$this->appendPrimaryKeys($query, $row);
 					$this->_db->setQuery($query);
 					$this->_db->execute();

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -531,7 +531,6 @@ class JTableTest extends TestCaseDatabase
 		$object2->load(array('id1' => 25, 'id2' => 50));
 
 		$this->AssertEquals('5', $object2->checked_out);
-
 	}
 
 	/**
@@ -713,7 +712,8 @@ class JTableTest extends TestCaseDatabase
 
 		$object2->load(array('id1' => 25, 'id2' => 51));
 
-		$this->assertEquals(2, $object2->ordering, 'Elements did not get reordered');
+		// Now order is stored in the sequence 1,3,5,7,9...
+		$this->assertEquals(3, $object2->ordering, 'Elements did not get reordered');
 	}
 
 	/**


### PR DESCRIPTION
This patch reinstates the display of the ordering field for banners, contacts, newsfeeds, weblinks in the edit views.
It also adds it for articles and featured articles.

The reasoning is that it is impossible to order these items by drag and drop when the number of items is important or is displayed on multiple pages, and as well on mobile devices.

The patch includes a change to list.php as the items in the dropdown are shown untranslated (?? item ??) when debug is on.
That part of the patch could be taken off if it is thought that it could create B/C with 3pd extensions.

Note: As we do not have an ordering type for categories, ordering field display is not implemented here for categories.
