### PR TITLE
[Fix #4732] Add required to menu item type

### DIFF
--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -38,6 +38,7 @@ class JFormFieldMenutype extends JFormFieldList
 		$recordId	= (int) $this->form->getValue('id');
 		$size		= ($v = $this->element['size']) ? ' size="' . $v . '"' : '';
 		$class		= ($v = $this->element['class']) ? ' class="' . $v . '"' : 'class="text_area"';
+		$required   = ($v = $this->element['required']) ? ' required="required"' : '';
 
 		// Get a reverse lookup of the base link URL to Title
 		$model 	= JModelLegacy::getInstance('menutypes', 'menusModel');
@@ -71,7 +72,7 @@ class JFormFieldMenutype extends JFormFieldList
 		JHtml::_('behavior.framework');
 		JHtml::_('behavior.modal');
 
-		$html[] = '<span class="input-append"><input type="text" disabled="disabled" readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' /><a class="btn btn-primary" onclick="SqueezeBox.fromElement(this, {handler:\'iframe\', size: {x: 600, y: 450}, url:\''.JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId='.$recordId).'\'})"><i class="icon-list icon-white"></i> '.JText::_('JSELECT').'</a></span>';
+		$html[] = '<span class="input-append"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' /><a class="btn btn-primary" onclick="SqueezeBox.fromElement(this, {handler:\'iframe\', size: {x: 600, y: 450}, url:\''.JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId='.$recordId).'\'})"><i class="icon-list icon-white"></i> '.JText::_('JSELECT').'</a></span>';
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 
 		return implode("\n", $html);


### PR DESCRIPTION
Fix for #4732 . Add required attribute
## Original Report
#### Steps to reproduce the issue
1. Go to Menu->Main Menu-> Add New Menu Item.
2. Open Add New Menu Item form.
3. Fill the data only in title field and save the record.
4. Record is saved successfully.
#### Expected result

If mandatory field(Menu Item Type) is kept blank then record should not save. Also it should give proper validation message.
#### Actual result

Record saved successfully without any validation message.![screen shot 2014-10-17 at 02 37 12](http://issues.joomla.org/uploads/1/9adc1d4e46a62edc0933ac6ed37e2cd8.jpg)
#### System information (as much as possible)
#### Additional comments
