### PR TITLE
Don't access application class var directly

### DIFF
--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -68,7 +68,7 @@ class JResponseJson
 		$this->message = $message;
 
 		// Get the message queue if requested and available
-		$app = JFactory::$application;
+		$app = JFactory::getApplication();
 
 		if (!$ignoreMessages && !is_null($app) && is_callable(array($app, 'getMessageQueue')))
 		{


### PR DESCRIPTION
In JResponseJson (the thing that loads the error page when an exception in a component or similar) we can choose to render the messages stored in the application. Currently we get the application object with `JFactory::$application` instead of `JFactory::getApplication()` - which is really bad practice
## Testing Instructions

Test rendering this error page (throw a random exception in a component high level file (for example the entry point file)) and check everything continues to work as expected
