### PR TITLE
Discover plugin: skipping XML which are not manifest

### DIFF
--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -770,17 +770,19 @@ class JInstallerAdapterPlugin extends JAdapterInstance
 				$file = JFile::stripExt($file);
 
 				// Ignore example plugins
-				if ($file == 'example')
+				if ($file == 'example' || $manifest_details === false)
 				{
 					continue;
 				}
+				
+				$element = empty($manifest_details['filename']) ? $file : $manifest_details['filename'];
 
 				$extension = JTable::getInstance('extension');
 				$extension->set('type', 'plugin');
 				$extension->set('client_id', 0);
-				$extension->set('element', $file);
+				$extension->set('element', $element);
 				$extension->set('folder', $folder);
-				$extension->set('name', $file);
+				$extension->set('name', $manifest_details['name']);
 				$extension->set('state', -1);
 				$extension->set('manifest_cache', json_encode($manifest_details));
 				$extension->set('params', '{}');
@@ -800,18 +802,20 @@ class JInstallerAdapterPlugin extends JAdapterInstance
 					);
 					$file = JFile::stripExt($file);
 
-					if ($file == 'example')
+					if ($file == 'example' || $manifest_details === false)
 					{
 						continue;
 					}
+					
+					$element = empty($manifest_details['filename']) ? $file : $manifest_details['filename'];
 
 					// Ignore example plugins
 					$extension = JTable::getInstance('extension');
 					$extension->set('type', 'plugin');
 					$extension->set('client_id', 0);
-					$extension->set('element', $file);
+					$extension->set('element', $element);
 					$extension->set('folder', $folder);
-					$extension->set('name', $file);
+					$extension->set('name', $manifest_details['name']);
 					$extension->set('state', -1);
 					$extension->set('manifest_cache', json_encode($manifest_details));
 					$extension->set('params', '{}');

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -2180,6 +2180,21 @@ class JInstaller extends JAdapter
 		$data['description'] = (string) $xml->description;
 		$data['group'] = (string) $xml->group;
 
+		if ($xml->files && count($xml->files->children()))
+		{
+			$filename = JFile::getName($path);
+			$data['filename'] = JFile::stripExt($filename);
+
+			foreach ($xml->files->children() as $oneFile)
+			{
+				if ((string) $oneFile->attributes()->plugin)
+				{
+					$data['filename'] = (string) $oneFile->attributes()->plugin;
+					break;
+				}
+			}
+		}
+
 		return $data;
 	}
 }


### PR DESCRIPTION
# Install - Discover

The Joomla "plugin discover" did not skip the XML which are not manifest.
The patch also improve the displayed information.
# To reproduce

Having a plugin which have a non manifest XML file.
- helloword.xml
- helloworld.php
- data.xml
