### PR TITLE
Pipe ('|') as OR in search filter in Extension Manager::Manage (Issue 4494)

### DIFF
--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -68,6 +68,7 @@ class InstallerModel extends JModelList
 			if (!empty($search))
 			{
 				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
+
 				foreach ($result as $i => $item)
 				{
 					if (!preg_match("/$escapedSearchString/i", $item->name))

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -67,11 +67,10 @@ class InstallerModel extends JModelList
 
 			if (!empty($search))
 			{
-				$search = str_replace(' ', '.*', preg_quote(trim($search), '/'));
-
+				$escapedSearchString = $this->refineSearchStringToRegex( $search, '/' );
 				foreach ($result as $i => $item)
 				{
-					if (!preg_match("/$search/i", $item->name))
+					if (!preg_match("/$escapedSearchString/i", $item->name))
 					{
 						unset($result[$i]);
 					}
@@ -99,6 +98,31 @@ class InstallerModel extends JModelList
 			return $result;
 		}
 	}
+
+	/**
+	 * Parse and transform the search string into a string fit for regex-ing extensions' names against
+	 *
+	 * @param string The search string
+	 * @param string The regex delimiter to use for the quoting 
+	 *
+	 * @return string Search string escaped for regex
+	 */
+	private function refineSearchStringToRegex($search, $regexDelimiter = '/')
+	{
+		$searchArr = explode('|', trim($search, ' |'));
+		foreach ($searchArr as $key => $searchString)
+		{
+			if (strlen(trim($searchString)) == 0)
+			{
+				unset($searchArr[$key]);
+				continue;
+			}
+			$searchArr[$key] = str_replace(' ', '.*', preg_quote(trim($searchString), $regexDelimiter));
+		}
+
+		return implode('|', $searchArr);
+	}
+
 
 	/**
 	 * Translate a list of objects

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -67,7 +67,7 @@ class InstallerModel extends JModelList
 
 			if (!empty($search))
 			{
-				$escapedSearchString = $this->refineSearchStringToRegex( $search, '/' );
+				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
 				foreach ($result as $i => $item)
 				{
 					if (!preg_match("/$escapedSearchString/i", $item->name))
@@ -98,31 +98,6 @@ class InstallerModel extends JModelList
 			return $result;
 		}
 	}
-
-	/**
-	 * Parse and transform the search string into a string fit for regex-ing extensions' names against
-	 *
-	 * @param string The search string
-	 * @param string The regex delimiter to use for the quoting 
-	 *
-	 * @return string Search string escaped for regex
-	 */
-	private function refineSearchStringToRegex($search, $regexDelimiter = '/')
-	{
-		$searchArr = explode('|', trim($search, ' |'));
-		foreach ($searchArr as $key => $searchString)
-		{
-			if (strlen(trim($searchString)) == 0)
-			{
-				unset($searchArr[$key]);
-				continue;
-			}
-			$searchArr[$key] = str_replace(' ', '.*', preg_quote(trim($searchString), $regexDelimiter));
-		}
-
-		return implode('|', $searchArr);
-	}
-
 
 	/**
 	 * Translate a list of objects

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -329,8 +329,9 @@ class ModulesModelModules extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-				$query->where('(' . 'a.title LIKE ' . $search . ' OR a.note LIKE ' . $search . ')');
+				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
+				$search = $db->quote($escapedSearchString);
+				$query->where('(' . 'a.title REGEXP ' . $search . ' OR a.note REGEXP ' . $search . ')');
 			}
 		}
 

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -130,6 +130,7 @@ class PluginsModelPlugins extends JModelList
 			if (!empty($search))
 			{
 				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
+				
 				foreach ($result as $i => $item)
 				{
 					if (!preg_match("/$escapedSearchString/i", $item->name))

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -129,11 +129,10 @@ class PluginsModelPlugins extends JModelList
 
 			if (!empty($search))
 			{
-				$search = str_replace(' ', '.*', preg_quote(trim($search), '/'));
-
+				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
 				foreach ($result as $i => $item)
 				{
-					if (!preg_match("/$search/i", $item->name))
+					if (!preg_match("/$escapedSearchString/i", $item->name))
 					{
 						unset($result[$i]);
 					}

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -130,7 +130,7 @@ class PluginsModelPlugins extends JModelList
 			if (!empty($search))
 			{
 				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
-				
+
 				foreach ($result as $i => $item)
 				{
 					if (!preg_match("/$escapedSearchString/i", $item->name))

--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -152,8 +152,9 @@ class TemplatesModelStyles extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-				$query->where('a.template LIKE ' . $search . ' OR a.title LIKE ' . $search);
+				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
+				$search = $db->quote($escapedSearchString);
+				$query->where('(' . 'a.template REGEXP ' . $search . ' OR a.title REGEXP ' . $search . ')');
 			}
 		}
 

--- a/administrator/components/com_templates/models/templates.php
+++ b/administrator/components/com_templates/models/templates.php
@@ -110,8 +110,9 @@ class TemplatesModelTemplates extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-				$query->where('(a.element LIKE ' . $search . ' OR a.name LIKE ' . $search . ')');
+				$escapedSearchString = $this->refineSearchStringToRegex($search, '/');
+				$search = $db->quote($escapedSearchString);
+				$query->where('(' . 'a.element REGEXP ' . $search . ' OR a.name REGEXP ' . $search . ')');
 			}
 		}
 

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -683,8 +683,8 @@ class JModelList extends JModelLegacy
 	/**
 	 * Parse and transform the search string into a string fit for regex-ing arbitrary strings against
 	 *
-	 * @param string The search string
-	 * @param string The regex delimiter to use for the quoting 
+	 * @param string $search The search string
+	 * @param string $regexDelimiter The regex delimiter to use for the quoting
 	 *
 	 * @return string Search string escaped for regex
 	 */

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -683,8 +683,8 @@ class JModelList extends JModelLegacy
 	/**
 	 * Parse and transform the search string into a string fit for regex-ing arbitrary strings against
 	 *
-	 * @param string $search The search string
-	 * @param string $regexDelimiter The regex delimiter to use for the quoting
+	 * @param   string  $search          The search string
+	 * @param   string  $regexDelimiter  The regex delimiter to use for the quoting
 	 *
 	 * @return string Search string escaped for regex
 	 */

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -679,4 +679,28 @@ class JModelList extends JModelLegacy
 
 		return $new_state;
 	}
+
+	/**
+	 * Parse and transform the search string into a string fit for regex-ing arbitrary strings against
+	 *
+	 * @param string The search string
+	 * @param string The regex delimiter to use for the quoting 
+	 *
+	 * @return string Search string escaped for regex
+	 */
+	protected function refineSearchStringToRegex($search, $regexDelimiter = '/')
+	{
+		$searchArr = explode('|', trim($search, ' |'));
+		foreach ($searchArr as $key => $searchString)
+		{
+			if (strlen(trim($searchString)) == 0)
+			{
+				unset($searchArr[$key]);
+				continue;
+			}
+			$searchArr[$key] = str_replace(' ', '.*', preg_quote(trim($searchString), $regexDelimiter));
+		}
+
+		return implode('|', $searchArr);
+	}
 }


### PR DESCRIPTION
Adding option to use pipe ('|') as OR in search filter in Extension Manager: Manage
## Original Report

![screen shot 2014-10-09 at 16 02 16](http://issues.joomla.org/uploads/1/426b6682482c4ca9e6207cf27df1e8b7.png)
#### Steps to reproduce the issue
- in admin, go to the menu "Extensions > Extensions Manager"
- select "Manage" submenu
- type "module|category|contact" in the search box and click on search
  since Joomla 3.3.6, no results will be found

you can check with the direct url :
/administrator/index.php?option=com_installer&view=manage&filter_search=module|category|contact
and get no results too !
#### Expected result

in Joomla 3.3.3 and before, the filter_search will parse the "|" char and displays results by the "or" operator (see the attached PNG screen below)
#### Actual result
#### System information (as much as possible)
- Joomla 3.3.3 : the 'OR' operator works
- Joomla 3.3.6 : the 'OR' operator doesn't work
#### Additional comments
