### PR TITLE
Fixed#4652 Schema  updated

### DIFF
--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -150,9 +150,10 @@ class InstallerModelDatabase extends InstallerModel
 			// Add new row.
 			$query->clear()
 				->insert($db->quoteName('#__schemas'))
-				->set($db->quoteName('extension_id') . '= 700')
-				->set($db->quoteName('version_id') . '= ' . $db->quote($schema));
+				->column(array($db->quoteName('extension_id'),$db->quoteName('version_id')))	
+				->values($db->quote('700') . ', ' . $db->quote($schema));
 			$db->setQuery($query);
+
 
 			if ($db->execute())
 			{


### PR DESCRIPTION
[#4652] - Schema not up-to-date - Error in MSSQL syntax.

Changes applied, The SQL command did as per joomla standard.
## Original Report
#### Steps to reproduce the issue

Upon updating to Joomla! 3.3.6, visit the Extension Manager>Database page. See that the database schema is not up-to-date. Click "Fix." Page will break.
#### Expected result

It should say "Database table structure is up to date."
#### Actual result

Page breaks.
#### System information (as much as possible)

MS-SQL, Joomla 3.3.6, IIS server.
#### Additional comments

Proposed fix... The SQL command currently is "INSERT INTO [#__schemas] SET [extension_id]= 700, [version_id]= '3.3.6-2014-09-30', but "SET" is not correct syntax apparently. Below is the correct syntax for the statement (not sure where to put this file though).

INSERT INTO [#__schemas]([extension_id]
           ,[version_id])
     VALUES
           (700
           ,'3.3.6-2014-09-30')
GO
