### PR TITLE
Wrapper class for JRoute to get rid of static methods

### DIFF
--- a/libraries/joomla/route/wrapper.php
+++ b/libraries/joomla/route/wrapper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JRoute
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ * @since       3.4
+ */
+class JRouteWrapper
+{
+	/**
+	 * Helper wrapper method for _
+	 *
+	 * @param   string   $url    Absolute or Relative URI to Joomla resource.
+	 * @param   boolean  $xhtml  Replace & by &amp; for XML compliance.
+	 * @param   integer  $ssl    Secure state for the resolved URI.
+	 *
+	 * @return  string The translated humanly readable URL.
+	 *
+	 * @see     JRoute::_()
+	 * @since   3.4
+	 */
+	public function _($url, $xhtml = true, $ssl = null)
+	{
+		return JRoute::_($url, $xhtml, $ssl);
+	}
+}


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for the JRoute class to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
