### PR TITLE
Fix :: Component view is not responsive in protostar #4764

### DIFF
--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -27,6 +27,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <jdoc:include type="head" />
 <!--[if lt IE 9]>
 	<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>


### PR DESCRIPTION
Viewport meta tag in <head> has been added in component view of template protostar.
### to see this you will need to add ?tmpl=component to the URL
