### PR TITLE
Don't reveal the real path on error msg

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -280,6 +280,8 @@ abstract class JLoader
 		// Verify the library path exists.
 		if (!file_exists($path))
 		{
+			$path = (str_replace(JPATH_ROOT, '', $path) == $path) ? basename($path) : str_replace(JPATH_ROOT, '', $path);
+
 			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
 		}
 
@@ -344,6 +346,8 @@ abstract class JLoader
 		// Verify the library path exists.
 		if (!file_exists($path))
 		{
+			$path = (str_replace(JPATH_ROOT, '', $path) == $path) ? basename($path) : str_replace(JPATH_ROOT, '', $path);
+
 			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
 		}
 


### PR DESCRIPTION
This is a recommit of #4317 which was meshed up!
#### Scope

Reaveal a trimmed path on an error message produced in /libraries/loader.php instead of the actual real path
#### B/C

None
#### Tests

Try renaming a library, so its unavailable. Loader will come up with an error 500 and the message 
`Library path /Applications/Mamp…. cannot be found.` which is too liberal.
Apply the patch and re run
message should be `Library path /libraries/... cannot be found.`
