### PR TITLE
Wrapper class for JArchive to get rid of static methods

### DIFF
--- a/libraries/joomla/archive/wrapper.php
+++ b/libraries/joomla/archive/wrapper.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Archive
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JArchive
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Archive
+ * @since       3.4
+ */
+class JArchiveWrapper
+{
+	/**
+	 * Helper wrapper method for extract
+	 *
+	 * @param   string  $archivename  The name of the archive file
+	 * @param   string  $extractdir   Directory to unpack into
+	 *
+	 * @return  boolean  True for success
+	 *
+	 * @see     JArchive::extract()
+	 * @since   3.4
+	 * @throws InvalidArgumentException
+	 */
+	public function extract($archivename, $extractdir)
+	{
+		return JArchive::extract($archivename, $extractdir);
+	}
+
+	/**
+	 * Helper wrapper method for getAdapter
+	 *
+	 * @param   string  $type  The type of adapter (bzip2|gzip|tar|zip).
+	 *
+	 * @return  JArchiveExtractable  Adapter for the requested type
+	 *
+	 * @see     JUserHelper::getAdapter()
+	 * @since   3.4
+	 */
+	public function getAdapter($type)
+	{
+		return JArchive::getAdapter($type);
+	}
+}


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for the JArchive class to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
