### PR TITLE
This fixes #4763 where adding space created duplicate viewlevels

### DIFF
--- a/administrator/components/com_users/models/level.php
+++ b/administrator/components/com_users/models/level.php
@@ -213,8 +213,8 @@ class UsersModelLevel extends JModelAdmin
 		{
 			$data['rules'] = array();
 		}
-		
-		$data['title'] = trim($data['title']);
+
+		$data['title'] = JFilterInput::getInstance()->clean($data['title'], 'TRIM');
 
 		return parent::save($data);
 	}

--- a/administrator/components/com_users/models/level.php
+++ b/administrator/components/com_users/models/level.php
@@ -213,6 +213,8 @@ class UsersModelLevel extends JModelAdmin
 		{
 			$data['rules'] = array();
 		}
+		
+		$data['title'] = trim($data['title']);
 
 		return parent::save($data);
 	}


### PR DESCRIPTION
.#### Steps to reproduce the issue
1. Go to Users->Access levels.
2. Click on add button to create new record.
3. Enter space as chacter and existing level name.
4. Save the record.
#### Expected result

Duplicate access levels should not be added.
#### Actual result

Duplicate access levels are added successfully.![screen shot 2014-10-17 at 06 33 26](http://issues.joomla.org/uploads/1/c5b9cdef733e5f850ffd5dc6f97b7c58.png)
#### System information (as much as possible)

PHP Built On Windows NT 6.2 build 9200
Database Version 5.6.12-log
Database Collation utf8_general_ci
PHP Version 5.4.12
Web Server Apache/2.4.4 (Win64) PHP/5.4.12
WebServer to PHP Interface apache2handler
Joomla! Version Joomla! 3.3.7-dev Development [ Ember ] 01-October-2014 02:00 GMT
Joomla! Platform Version Joomla Platform 13.1.0 Stable [ Curiosity ] 24-Apr-2013 00:00 GMT
User Agent Mozilla/5.0 (Windows NT 6.1; rv:32.0) Gecko/20100101 Firefox/32.0
#### Additional comments
