### PR TITLE
Wrapper class for JClientHelper to get rid of static methods

### DIFF
--- a/libraries/joomla/client/helper/wrapper.php
+++ b/libraries/joomla/client/helper/wrapper.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Client
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JClientHelper
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Client
+ * @since       3.4
+ */
+class JClientHelperWrapper
+{
+	/**
+	 * Helper wrapper method for getCredentials
+	 *
+	 * @param   string   $client  Client name, currently only 'ftp' is supported
+	 * @param   boolean  $force   Forces re-creation of the login credentials. Set this to
+	 *
+	 * @return  array    Client layer configuration options, consisting of at least
+	 *
+	 * @see     JClientHelper::getCredentials()
+	 * @since   3.4
+	 */
+	public function getCredentials($client, $force = false)
+	{
+		return JClientHelper::getCredentials($client, $force);
+	}
+
+	/**
+	 * Helper wrapper method for setCredentials
+	 *
+	 * @param   string  $client  Client name, currently only 'ftp' is supported
+	 * @param   string  $user    Username
+	 * @param   string  $pass    Password
+	 *
+	 * @return boolean  True if the given login credentials have been set and are valid
+	 *
+	 * @see     JClientHelper::setCredentials()
+	 * @since   3.4
+	 */
+	public function setCredentials($client, $user, $pass)
+	{
+		return JClientHelper::setCredentials($client, $user, $pass);
+	}
+
+	/**
+	 * Helper wrapper method for hasCredentials
+	 *
+	 * @param   string  $client  Client name, currently only 'ftp' is supported
+	 *
+	 * @return boolean  True if login credentials are available
+	 *
+	 * @see     JClientHelper::hasCredentials()
+	 * @since   3.4
+	 */
+	public function hasCredentials($client)
+	{
+		return JClientHelper::hasCredentials($client);
+	}
+
+	/**
+	 * Helper wrapper method for setCredentialsFromRequest
+	 *
+	 * @param   string  $client  The name of the client.
+	 *
+	 * @return  mixed  True, if FTP settings; JError if using legacy tree
+	 *
+	 * @see     JUserHelper::setCredentialsFromRequest()
+	 * @since   3.4
+	 * @throws  InvalidArgumentException if credentials invalid
+	 */
+	public function setCredentialsFromRequest($client)
+	{
+		return JClientHelper::setCredentialsFromRequest($client);
+	}
+}

--- a/libraries/joomla/client/wrapper/helper.php
+++ b/libraries/joomla/client/wrapper/helper.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Client
  * @since       3.4
  */
-class JClientHelperWrapper
+class JClientWrapperHelper
 {
 	/**
 	 * Helper wrapper method for getCredentials


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for the JClientHelper class to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
