### PR TITLE
Batch process pop-up gets open even without selection

### DIFF
--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -10,9 +10,11 @@
 defined('_JEXEC') or die;
 
 $title = $displayData['title'];
-
+$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 ?>
-<button data-toggle="modal" data-target="#collapseModal" class="btn btn-small">
+<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $message; ?>');  }else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
 	<i class="icon-checkbox-partial" title="<?php echo $title; ?>"></i>
 	<?php echo $title; ?>
 </button>
+
+


### PR DESCRIPTION
. We can apply validation, to make selection first 

![1](https://cloud.githubusercontent.com/assets/8975463/4677705/86ac3b92-55eb-11e4-8f57-c6fca8674808.png)
![2](https://cloud.githubusercontent.com/assets/8975463/4677712/99837b4a-55eb-11e4-9852-61472ef033ff.png)
