### PR TITLE
Disable menu when editing a message

### DIFF
--- a/administrator/components/com_messages/views/message/view.html.php
+++ b/administrator/components/com_messages/views/message/view.html.php
@@ -48,6 +48,7 @@ class MessagesViewMessage extends JViewLegacy
 	{
 		if ($this->getLayout() == 'edit')
 		{
+			JFactory::getApplication()->input->set('hidemainmenu', true);
 			JToolbarHelper::title(JText::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-opened new-privatemessage');
 			JToolbarHelper::save('message.save', 'COM_MESSAGES_TOOLBAR_SEND');
 			JToolbarHelper::cancel('message.cancel');


### PR DESCRIPTION
#### Consistency

As stated here https://github.com/joomla/joomla-cms/pull/4694#issuecomment-59464421 when editing a message the main menu is still available. This differs from the rest of the admin area behavior. This PR unifies it.
#### test

Apply patch
go to /index.php?option=com_messages&view=message&layout=edit
Main menu should be disabled.
