### PR TITLE
rel nofollow to mailto icon

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -110,7 +110,7 @@ abstract class JHtmlIcon
 		$attribs['title']   = JText::_('JGLOBAL_EMAIL');
 		$attribs['onclick'] = "window.open(this.href,'win2','" . $status . "'); return false;";
 		$attribs['rel']     = 'nofollow';
-		
+
 		$output = JHtml::_('link', JRoute::_($url), $text, $attribs);
 
 		return $output;

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -109,7 +109,8 @@ abstract class JHtmlIcon
 
 		$attribs['title']   = JText::_('JGLOBAL_EMAIL');
 		$attribs['onclick'] = "window.open(this.href,'win2','" . $status . "'); return false;";
-
+		$attribs['rel']     = 'nofollow';
+		
 		$output = JHtml::_('link', JRoute::_($url), $text, $attribs);
 
 		return $output;


### PR DESCRIPTION
This PR adds rel="nofollow" to the mailto link in com_content. This is done in order to stop search engines from following the link.

![skaermbillede 2014-10-17 kl 17 17 00](https://cloud.githubusercontent.com/assets/1738811/4681148/af9a98da-5610-11e4-9f5c-3f98ed38874a.png)
