### PR TITLE
Wrapper classes for JFilesystem to get rid of static methods

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 if (!defined('JPATH_ROOT'))
 {
 	// Define a string constant for the root directory of the file system in native format
-	define('JPATH_ROOT', JPath::clean(JPATH_SITE));
+	$pathHelper = new JFilesystemWrapperPath;
+	define('JPATH_ROOT', $pathHelper->clean(JPATH_SITE));
 }
 
 /**

--- a/libraries/joomla/filesystem/wrapper/file.php
+++ b/libraries/joomla/filesystem/wrapper/file.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JFilesystemWrapperFile
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ * @since       3.4
+ */
+class JFilesystemWrapperFile
+{
+	/**
+	 * Helper wrapper method for getExt
+	 *
+	 * @param   string  $file  The file name.
+	 *
+	 * @return  string  The file extension.
+	 *
+	 * @see     JFile::getExt()
+	 * @since   3.4
+	 */
+	public function getExt($file)
+	{
+		return JFile::getExt($file);
+	}
+
+	/**
+	 * Helper wrapper method for stripExt
+	 *
+	 * @param   string  $file  The file name.
+	 *
+	 * @return  string  The file name without the extension.
+	 *
+	 * @see     JFile::stripExt()
+	 * @since   3.4
+	 */
+	public function stripExt($file)
+	{
+		return JFile::stripExt($file);
+	}
+
+	/**
+	 * Helper wrapper method for makeSafe
+	 *
+	 * @param   string  $file  The name of the file [not full path].
+	 *
+	 * @return  string  The sanitised string.
+	 *
+	 * @see     JFile::makeSafe()
+	 * @since   3.4
+	 */
+	public function makeSafe($file)
+	{
+		return JFile::makeSafe($file);
+	}
+
+	/**
+	 * Helper wrapper method for copy
+	 *
+	 * @param   string   $src          The path to the source file.
+	 * @param   string   $dest         The path to the destination file.
+	 * @param   string   $path         An optional base path to prefix to the file names.
+	 * @param   boolean  $use_streams  True to use streams.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFile::copy()
+	 * @since   3.4
+	 */
+	public function copy($src, $dest, $path = null, $use_streams = false)
+	{
+		return JFile::copy($src, $dest, $path, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for delete
+	 *
+	 * @param   mixed  $file  The file name or an array of file names
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFile::delete()
+	 * @since   3.4
+	 */
+	public function delete($file)
+	{
+		return JFile::delete($file);
+	}
+
+	/**
+	 * Helper wrapper method for move
+	 *
+	 * @param   string   $src          The path to the source file.
+	 * @param   string   $dest         The path to the destination file.
+	 * @param   string   $path         An optional base path to prefix to the file names.
+	 * @param   boolean  $use_streams  True to use streams.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFile::move()
+	 * @since   3.4
+	 */
+	public function move($src, $dest, $path = '', $use_streams = false)
+	{
+		return JFile::move($src, $dest, $path, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for read
+	 *
+	 * @param   string   $filename   The full file path.
+	 * @param   boolean  $incpath    Use include path.
+	 * @param   integer  $amount     Amount of file to read.
+	 * @param   integer  $chunksize  Size of chunks to read.
+	 * @param   integer  $offset     Offset of the file.
+	 *
+	 * @return mixed  Returns file contents or boolean False if failed.
+	 *
+	 * @see     JFile::read()
+	 * @since   3.4
+	 */
+	public function read($filename, $incpath = false, $amount = 0, $chunksize = 8192, $offset = 0)
+	{
+		return JFile::read($filename, $incpath, $amount, $chunksize, $offset);
+	}
+
+	/**
+	 * Helper wrapper method for write
+	 *
+	 * @param   string   $file         The full file path.
+	 * @param   string   &$buffer      The buffer to write.
+	 * @param   boolean  $use_streams  Use streams.
+	 *
+	 * @return boolean  True on success.
+	 *
+	 * @see     JFile::write()
+	 * @since   3.4
+	 */
+	public function write($file, &$buffer, $use_streams = false)
+	{
+		return JFile::write($file, $buffer, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for upload
+	 *
+	 * @param   string   $src          The name of the php (temporary) uploaded file.
+	 * @param   string   $dest         The path (including filename) to move the uploaded file to.
+	 * @param   boolean  $use_streams  True to use streams.
+	 *
+	 * @return boolean  True on success.
+	 *
+	 * @see     JFile::upload()
+	 * @since   3.4
+	 */
+	public function upload($src, $dest, $use_streams = false)
+	{
+		return JFile::upload($src, $dest, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for exists
+	 *
+	 * @param   string  $file  File path.
+	 *
+	 * @return boolean  True if path is a file.
+	 *
+	 * @see     JFile::exists()
+	 * @since   3.4
+	 */
+	public function exists($file)
+	{
+		return JFile::exists($file);
+	}
+
+	/**
+	 * Helper wrapper method for getName
+	 *
+	 * @param   string  $file  File path.
+	 *
+	 * @return string  filename.
+	 *
+	 * @see     JFile::getName()
+	 * @since   3.4
+	 */
+	public function getName($file)
+	{
+		return JFile::getName($file);
+	}
+}

--- a/libraries/joomla/filesystem/wrapper/file.php
+++ b/libraries/joomla/filesystem/wrapper/file.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Wrapper class for JFilesystemWrapperFile
+ * Wrapper class for JFilesystemFile
  *
  * @package     Joomla.Platform
  * @subpackage  Filesystem

--- a/libraries/joomla/filesystem/wrapper/folder.php
+++ b/libraries/joomla/filesystem/wrapper/folder.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JFilesystemWrapperFolder
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ * @since       3.4
+ */
+class JFilesystemWrapperFolder
+{
+	/**
+	 * Helper wrapper method for copy
+	 *
+	 * @param   string   $src          The path to the source folder.
+	 * @param   string   $dest         The path to the destination folder.
+	 * @param   string   $path         An optional base path to prefix to the file names.
+	 * @param   boolean  $force        Force copy.
+	 * @param   boolean  $use_streams  Optionally force folder/file overwrites.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFolder::copy()
+	 * @since   3.4
+	 * @throws  RuntimeException
+	 */
+	public function copy($src, $dest, $path = '', $force = false, $use_streams = false)
+	{
+		return JFolder::copy($src, $dest, $path, $force, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for create
+	 *
+	 * @param   string   $path  A path to create from the base path.
+	 * @param   integer  $mode  Directory permissions to set for folders created. 0755 by default.
+	 *
+	 * @return  boolean  True if successful.
+	 *
+	 * @see     JFolder::create()
+	 * @since   3.4
+	 */
+	public function create($path = '', $mode = 493)
+	{
+		return JFolder::create($path, $mode);
+	}
+
+	/**
+	 * Helper wrapper method for delete
+	 *
+	 * @param   string  $path  The path to the folder to delete.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFolder::delete()
+	 * @since   3.4
+	 * @throws  UnexpectedValueException
+	 */
+	public function delete($path)
+	{
+		return JFolder::delete($path);
+	}
+
+	/**
+	 * Helper wrapper method for move
+	 *
+	 * @param   string   $src          The path to the source folder.
+	 * @param   string   $dest         The path to the destination folder.
+	 * @param   string   $path         An optional base path to prefix to the file names.
+	 * @param   boolean  $use_streams  Optionally use streams.
+	 *
+	 * @return  mixed  Error message on false or boolean true on success.
+	 *
+	 * @see     JFolder::move()
+	 * @since   3.4
+	 */
+	public function move($src, $dest, $path = '', $use_streams = false)
+	{
+		return JFolder::move($src, $dest, $path, $use_streams);
+	}
+
+	/**
+	 * Helper wrapper method for exists
+	 *
+	 * @param   string  $path  Folder name relative to installation dir.
+	 *
+	 * @return  boolean  True if path is a folder.
+	 *
+	 * @see     JFolder::exists()
+	 * @since   3.4
+	 */
+	public function exists($path)
+	{
+		return JFolder::exists($path);
+	}
+
+	/**
+	 * Helper wrapper method for files
+	 *
+	 * @param   string   $path           The path of the folder to read.
+	 * @param   string   $filter         A filter for file names.
+	 * @param   mixed    $recurse        True to recursively search into sub-folders, or an integer to specify the maximum depth.
+	 * @param   boolean  $full           True to return the full path to the file.
+	 * @param   array    $exclude        Array with names of files which should not be shown in the result.
+	 * @param   array    $excludefilter  Array of filter to exclude.
+	 * @param   boolean  $naturalSort    False for asort, true for natsort.
+	 *
+	 * @return  array  Files in the given folder.
+	 *
+	 * @see     JFolder::files()
+	 * @since   3.4
+	 */
+	public function files($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
+		$excludefilter = array('^\..*', '.*~'), $naturalSort = false)
+	{
+		return JFolder::files($path, $filter, $recurse, $full, $exclude, $excludefilter, $naturalSort);
+	}
+
+	/**
+	 * Helper wrapper method for folders
+	 *
+	 * @param   string   $path           The path of the folder to read.
+	 * @param   string   $filter         A filter for folder names.
+	 * @param   mixed    $recurse        True to recursively search into sub-folders, or an integer to specify the maximum depth.
+	 * @param   boolean  $full           True to return the full path to the folders.
+	 * @param   array    $exclude        Array with names of folders which should not be shown in the result.
+	 * @param   array    $excludefilter  Array with regular expressions matching folders which should not be shown in the result.
+	 *
+	 * @return  array  Folders in the given folder.
+	 *
+	 * @see     JFolder::folders()
+	 * @since   3.4
+	 */
+	public function folders($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
+		$excludefilter = array('^\..*'))
+	{
+		return JFolder::folders($path, $filter, $recurse, $full, $exclude, $excludefilter);
+	}
+
+	/**
+	 * Helper wrapper method for listFolderTree
+	 *
+	 * @param   string   $path      The path of the folder to read.
+	 * @param   string   $filter    A filter for folder names.
+	 * @param   integer  $maxLevel  The maximum number of levels to recursively read, defaults to three.
+	 * @param   integer  $level     The current level, optional.
+	 * @param   integer  $parent    Unique identifier of the parent folder, if any.
+	 *
+	 * @return  array  Folders in the given folder.
+	 *
+	 * @see     JFolder::listFolderTree()
+	 * @since   3.4
+	 */
+	public function listFolderTree($path, $filter, $maxLevel = 3, $level = 0, $parent = 0)
+	{
+		return JFolder::listFolderTree($path, $filter, $maxLevel, $level, $parent);
+	}
+
+	/**
+	 * Helper wrapper method for makeSafe
+	 *
+	 * @param   string  $path  The full path to sanitise.
+	 *
+	 * @return  string  The sanitised string
+	 *
+	 * @see     JFolder::makeSafe()
+	 * @since   3.4
+	 */
+	public function makeSafe($path)
+	{
+		return JFolder::makeSafe($path);
+	}
+}

--- a/libraries/joomla/filesystem/wrapper/folder.php
+++ b/libraries/joomla/filesystem/wrapper/folder.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Wrapper class for JFilesystemWrapperFolder
+ * Wrapper class for JFilesystemFolder
  *
  * @package     Joomla.Platform
  * @subpackage  Filesystem

--- a/libraries/joomla/filesystem/wrapper/path.php
+++ b/libraries/joomla/filesystem/wrapper/path.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JFilesystemWrapperPath
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Filesystem
+ * @since       3.4
+ */
+class JFilesystemWrapperPath
+{
+	/**
+	 * Helper wrapper method for canChmod
+	 *
+	 * @param   string  $path  Path to check.
+	 *
+	 * @return  boolean  True if path can have mode changed.
+	 *
+	 * @see     JPath::canChmod()
+	 * @since   3.4
+	 */
+	public function canChmod($path)
+	{
+		return JPath::canChmod($path);
+	}
+
+	/**
+	 * Helper wrapper method for setPermissions
+	 *
+	 * @param   string  $path        Root path to begin changing mode [without trailing slash].
+	 * @param   string  $filemode    Octal representation of the value to change file mode to [null = no change].
+	 * @param   string  $foldermode  Octal representation of the value to change folder mode to [null = no change].
+	 *
+	 * @return  boolean  True if successful [one fail means the whole operation failed].
+	 *
+	 * @see     JPath::setPermissions()
+	 * @since   3.4
+	 */
+	public function setPermissions($path, $filemode = '0644', $foldermode = '0755')
+	{
+		return JPath::setPermissions($path, $filemode, $foldermode);
+	}
+
+	/**
+	 * Helper wrapper method for getPermissions
+	 *
+	 * @param   string  $path  The path of a file/folder.
+	 *
+	 * @return  string  Filesystem permissions.
+	 *
+	 * @see     JPath::getPermissions()
+	 * @since   3.4
+	 */
+	public function getPermissions($path)
+	{
+		return JPath::getPermissions($path);
+	}
+
+	/**
+	 * Helper wrapper method for check
+	 *
+	 * @param   string  $path  A file system path to check.
+	 *
+	 * @return  string  A cleaned version of the path or exit on error.
+	 *
+	 * @see     JPath::check()
+	 * @since   3.4
+	 * @throws  Exception
+	 */
+	public function check($path)
+	{
+		return JPath::check($path);
+	}
+
+	/**
+	 * Helper wrapper method for clean
+	 *
+	 * @param   string  $path  The path to clean.
+	 * @param   string  $ds    Directory separator (optional).
+	 *
+	 * @return  string  The cleaned path.
+	 *
+	 * @see     JPath::clean()
+	 * @since   3.4
+	 * @throws  UnexpectedValueException
+	 */
+	public function clean($path, $ds = '\\')
+	{
+		return JPath::clean($path, $ds);
+	}
+
+	/**
+	 * Helper wrapper method for isOwner
+	 *
+	 * @param   string  $path  Path to check ownership.
+	 *
+	 * @return  boolean  True if the php script owns the path passed.
+	 *
+	 * @see     JPath::isOwner()
+	 * @since   3.4
+	 */
+	public function isOwner($path)
+	{
+		return JPath::isOwner($path);
+	}
+
+	/**
+	 * Helper wrapper method for find
+	 *
+	 * @param   mixed   $paths  An path string or array of path strings to search in
+	 * @param   string  $file   The file name to look for.
+	 *
+	 * @return mixed   The full path and file name for the target file, or boolean false if the file is not found in any of the paths.
+	 *
+	 * @see     JPath::find()
+	 * @since   3.4
+	 */
+	public function find($paths, $file)
+	{
+		return JPath::find($paths, $file);
+	}
+}

--- a/libraries/joomla/filesystem/wrapper/path.php
+++ b/libraries/joomla/filesystem/wrapper/path.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Wrapper class for JFilesystemWrapperPath
+ * Wrapper class for JFilesystemPath
  *
  * @package     Joomla.Platform
  * @subpackage  Filesystem


### PR DESCRIPTION
Reference: #4717

This PR introduces wrapper classes for JFilesystem to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
