### PR TITLE
Site language now gets fetched on login

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -505,7 +505,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (empty($lang_code))
 			{
-				$lang_code = self::$default_lang;
+				$lang_tag  = $app->getLanguage()->getTag();
+				$lang_code = empty($lang_tag) ? self::$default_lang : $lang_tag;
 			}
 
 			if ($lang_code != self::$tag)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -505,8 +505,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (empty($lang_code))
 			{
-				$lang_tag  = $app->getLanguage()->getTag();
-				$lang_code = empty($lang_tag) ? self::$default_lang : $lang_tag;
+				$lang_code = self::$tag;
 			}
 
 			if ($lang_code != self::$tag)


### PR DESCRIPTION
This PR solves the issue at #4483 

It fetches the application language tag and ensures it's not empty or null before defaulting to the site's default language.
