### PR TITLE
Fix "Save as copy" button of User Group

### DIFF
--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -200,7 +200,7 @@ class UsersModelGroup extends JModelAdmin
 
 		if (JFactory::getApplication()->input->get('task') == 'save2copy')
 		{
-			$data['title'] = $this->generateNewTitle($data['parent_id'], $data['title']);
+			$data['title'] = $this->generateGroupTitle($data['parent_id'], $data['title']);
 		}
 
 		// Proceed with the save
@@ -291,7 +291,7 @@ class UsersModelGroup extends JModelAdmin
 	}
 
 	/**
-	 * Method to change the title of group
+	 * Method to generate the title of group on Save as Copy action
 	 *
 	 * @param   integer  $parentId  The id of the parent.
 	 * @param   string   $title     The title of group
@@ -300,7 +300,7 @@ class UsersModelGroup extends JModelAdmin
 	 *
 	 * @since   3.3.7
 	 */
-	protected function generateNewTitle($parentId, $title)
+	protected function generateGroupTitle($parentId, $title)
 	{
 		// Alter the title & alias
 		$table = $this->getTable();

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -160,16 +160,7 @@ class UsersModelGroup extends JModelAdmin
 
 		if ((!$iAmSuperAdmin) && ($groupSuperAdmin))
 		{
-			try
-			{
-				throw new Exception(JText::_('JLIB_USER_ERROR_NOT_SUPERADMIN'));
-			}
-			catch (Exception $e)
-			{
-				$this->setError($e->getMessage());
-
-				return false;
-			}
+			$this->setError(JText::_('JLIB_USER_ERROR_NOT_SUPERADMIN'));
 		}
 
 		/**
@@ -198,18 +189,14 @@ class UsersModelGroup extends JModelAdmin
 				 */
 				if ((!$otherSuperAdmin) && (!$groupSuperAdmin))
 				{
-					try
-					{
-						throw new Exception(JText::_('JLIB_USER_ERROR_CANNOT_DEMOTE_SELF'));
-					}
-					catch (Exception $e)
-					{
-						$this->setError($e->getMessage());
-
-						return false;
-					}
+					$this->setError(JText::_('JLIB_USER_ERROR_CANNOT_DEMOTE_SELF'));
 				}
 			}
+		}
+
+		if (JFactory::getApplication()->input->get('task') == 'save2copy')
+		{
+			$data['title'] = $this->generateNewTitle($data['parent_id'], $data['title']);
 		}
 
 		// Proceed with the save
@@ -297,5 +284,31 @@ class UsersModelGroup extends JModelAdmin
 		}
 
 		return true;
+	}
+
+	/**
+	 * Method to change the title of group
+	 *
+	 * @param   integer  $parentId  The id of the parent.
+	 * @param   string   $title     The title of group
+	 *
+	 * @return  string  Contains the modified title.
+	 *
+	 * @since   3.3.7
+	 */
+	protected function generateNewTitle($parentId, $title)
+	{
+		// Alter the title & alias
+		$table = $this->getTable();
+
+		while ($table->load(array('title' => $title, 'parent_id' => $parentId)))
+		{
+			if ($title == $table->title)
+			{
+				$title = JString::increment($title);
+			}
+		}
+
+		return $title;
 	}
 }

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -161,6 +161,8 @@ class UsersModelGroup extends JModelAdmin
 		if ((!$iAmSuperAdmin) && ($groupSuperAdmin))
 		{
 			$this->setError(JText::_('JLIB_USER_ERROR_NOT_SUPERADMIN'));
+
+			return false;
 		}
 
 		/**
@@ -190,6 +192,8 @@ class UsersModelGroup extends JModelAdmin
 				if ((!$otherSuperAdmin) && (!$groupSuperAdmin))
 				{
 					$this->setError(JText::_('JLIB_USER_ERROR_CANNOT_DEMOTE_SELF'));
+
+					return false;
 				}
 			}
 		}


### PR DESCRIPTION
## PR summary

This PR fixes the issue #4778 reported by @apurvaduduskar. Basically, when you are on Joomla group edit screen, if you press "Save as Copy" button to create a new group without changing title, the system will throws an error message and doesn't create a copy group as expected.

I also fixed two ridiculous blocks of code at https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_users/models/group.php#L163 and https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_users/models/group.php#L201
## How to test:

Testing this PR is simple. You just need to login to administrator area of your site, then go to Users -> Groups, click on a group to edit (don't change group title), then press "Save as Copy" button in the toolbar:
1. Before patch: The system doesn't create the new group and throw an error message
2. After patch: The new group is created without error message. The title of the new group is created based on title of the original group and append an increment number: Group (2), Group (3)... 
