### PR TITLE
Remove doubled full stop in system/error.php

### DIFF
--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -53,7 +53,7 @@ $this->direction = $doc->direction;
 			<ul>
 				<li><a href="<?php echo $this->baseurl; ?>/index.php" title="<?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?>"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
 			</ul>
-			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?>.</p>
+			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 			<div id="techinfo">
 			<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 			<p>


### PR DESCRIPTION
In system/error.php, we have a full stop (".") after the "contact the system admin" string. Because a full stop is already included in said language string (see [L116](https://github.com/joomla/joomla-cms/blob/staging/language/en-GB/en-GB.ini#L116)), there are two at the final output. 
In Beez and Protostar, this full stop is already eliminated.
