### PR TITLE
Wrapper class for JHttpFactory to get rid of static methods

### DIFF
--- a/libraries/joomla/http/wrapper/factory.php
+++ b/libraries/joomla/http/wrapper/factory.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Http
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Wrapper class for JHttpWrapperFactory
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Http
+ * @since       3.4
+ */
+class JHttpWrapperFactory
+{
+	/**
+	 * Helper wrapper method for getHttp
+	 *
+	 * @param   Registry  $options   Client options object.
+	 * @param   mixed     $adapters  Adapter (string) or queue of adapters (array) to use for communication.
+	 *
+	 * @return JHttp      Joomla Http class
+	 *
+	 * @see     JHttpFactory::getHttp()
+	 * @since   3.4
+	 * @throws  RuntimeException
+	 */
+	public function getHttp(Registry $options = null, $adapters = null)
+	{
+		return JHttpFactory::getHttp($options, $adapters);
+	}
+
+	/**
+	 * Helper wrapper method for getAvailableDriver
+	 *
+	 * @param   Registry  $options  Option for creating http transport object.
+	 * @param   mixed     $default  Adapter (string) or queue of adapters (array) to use.
+	 *
+	 * @return JHttpTransport Interface sub-class
+	 *
+	 * @see     JHttpFactory::getAvailableDriver()
+	 * @since   3.4
+	 */
+	public function getAvailableDriver(Registry $options, $default = null)
+	{
+		return JHttpFactory::getAvailableDriver($options, $default);
+	}
+
+	/**
+	 * Helper wrapper method for getHttpTransports
+	 *
+	 * @return array  An array of available transport handlers
+	 *
+	 * @see     JHttpFactory::getHttpTransports()
+	 * @since   3.4
+	 */
+	public function getHttpTransports()
+	{
+		return JHttpFactory::getHttpTransports();
+	}
+}

--- a/libraries/joomla/http/wrapper/factory.php
+++ b/libraries/joomla/http/wrapper/factory.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Registry\Registry;
 
 /**
- * Wrapper class for JHttpWrapperFactory
+ * Wrapper class for JHttpFactory
  *
  * @package     Joomla.Platform
  * @subpackage  Http


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for the JHttpFactory class to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
