### PR TITLE
Wrapper classes for JLanguage to get rid of static methods

### DIFF
--- a/libraries/joomla/language/wrapper/helper.php
+++ b/libraries/joomla/language/wrapper/helper.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JLanguageHelper
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ * @since       3.4
+ */
+class JLanguageWrapperHelper
+{
+	/**
+	 * Helper wrapper method for createLanguageList
+	 *
+	 * @param   string   $actualLanguage  Client key for the area.
+	 * @param   string   $basePath        Base path to use.
+	 * @param   boolean  $caching         True if caching is used.
+	 * @param   boolean  $installed       Get only installed languages.
+	 *
+	 * @return  array  List of system languages.
+	 *
+	 * @see     JLanguageHelper::createLanguageList
+	 * @since   3.4
+	 */
+	public function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false)
+	{
+		return JLanguageHelper::createLanguageList($actualLanguage, $basePath, $caching, $installed);
+	}
+
+	/**
+	 * Helper wrapper method for detectLanguage
+	 *
+	 * @return  string  locale or null if not found.
+	 *
+	 * @see     JLanguageHelper::detectLanguage
+	 * @since   3.4
+	 */
+	public function detectLanguage()
+	{
+		return JLanguageHelper::detectLanguage();
+	}
+
+	/**
+	 * Helper wrapper method for getLanguages
+	 *
+	 * @param   string  $key  Array key
+	 *
+	 * @return  array  An array of published languages.
+	 *
+	 * @see     JLanguageHelper::getLanguages
+	 * @since   3.4
+	 */
+	public function getLanguages($key = 'default')
+	{
+		return JLanguageHelper::getLanguages($key);
+	}
+}

--- a/libraries/joomla/language/wrapper/text.php
+++ b/libraries/joomla/language/wrapper/text.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JText
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ * @since       3.4
+ */
+class JLanguageWrapperText
+{
+	/**
+	 * Helper wrapper method for _
+	 *
+	 * @param   string   $string                The string to translate.
+	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
+	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation).
+	 * @param   boolean  $script                To indicate that the string will be push in the javascript language store.
+	 *
+	 * @return  string  The translated string or the key is $script is true.
+	 *
+	 * @see     JText::_
+	 * @since   3.4
+	 */
+	public function _($string, $jsSafe = false, $interpretBackSlashes = true, $script = false)
+	{
+		return JText::_($string, $jsSafe, $interpretBackSlashes, $script);
+	}
+
+	/**
+	 * Helper wrapper method for alt
+	 *
+	 * @param   string   $string                The string to translate.
+	 * @param   string   $alt                   The alternate option for global string.
+	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
+	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation).
+	 * @param   boolean  $script                To indicate that the string will be pushed in the javascript language store.
+	 *
+	 * @return  string  The translated string or the key if $script is true.
+	 *
+	 * @see     JText::alt
+	 * @since   3.4
+	 */
+	public function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true, $script = false)
+	{
+		return JText::alt($string, $alt, $jsSafe, $interpretBackSlashes, $script);
+	}
+
+	/**
+	 * Helper wrapper method for plural
+	 *
+	 * @param   string   $string  The format string.
+	 * @param   integer  $n       The number of items.
+	 *
+	 * @return  string  The translated strings or the key if 'script' is true in the array of options.
+	 *
+	 * @see     JText::plural
+	 * @since   3.4
+	 */
+	public function plural($string, $n)
+	{
+		return JText::plural($string, $n);
+	}
+
+	/**
+	 * Helper wrapper method for sprintf
+	 *
+	 * @param   string  $string  The format string.
+	 *
+	 * @return  string  The translated strings or the key if 'script' is true in the array of options.
+	 *
+	 * @see     JText::sprintf
+	 * @since   3.4
+	 */
+	public function sprintf($string)
+	{
+		return JText::sprintf($string);
+	}
+
+	/**
+	 * Helper wrapper method for printf
+	 *
+	 * @param   format  $string  The format string.
+	 *
+	 * @return  mixed
+	 *
+	 * @see     JText::printf
+	 * @since   3.4
+	 */
+	public function printf($string)
+	{
+		return JText::printf($string);
+	}
+
+	/**
+	 * Helper wrapper method for script
+	 *
+	 * @param   string   $string                The JText key.
+	 * @param   boolean  $jsSafe                Ensure the output is JavaScript safe.
+	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n.
+	 *
+	 * @return  string
+	 *
+	 * @see     JText::script
+	 * @since   3.4
+	 */
+	public function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
+	{
+		return JText::script($string, $jsSafe, $interpretBackSlashes);
+	}
+}

--- a/libraries/joomla/language/wrapper/transliterate.php
+++ b/libraries/joomla/language/wrapper/transliterate.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JLanguageTransliterate
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Language
+ * @since       3.4
+ */
+class JLanguageWrapperTransliterate
+{
+	/**
+	 * Helper wrapper method for utf8_latin_to_ascii
+	 *
+	 * @param   string  $string String to transliterate.
+	 * @param   integer $case   Optionally specify upper or lower case. Default to null.
+	 *
+	 * @return  string  Transliterated string.
+	 *
+	 * @see     JLanguageTransliterate::utf8_latin_to_ascii()
+	 * @since   3.4
+	 */
+	public function utf8_latin_to_ascii($string, $case = 0)
+	{
+		return JLanguageTransliterate::utf8_latin_to_ascii($string, $case);
+	}
+}


### PR DESCRIPTION
Reference: #4717

This PR introduces wrapper classes for the JLanguage class (+JText) to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
