### PR TITLE
Added date configuration and right grouping for archived articles module

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -197,28 +197,19 @@ class ContentRouter extends JComponentRouterBase
 
 		if ($view == 'archive')
 		{
-			if (!$menuItemGiven)
-			{
-				$segments[] = $view;
-				unset($query['view']);
-			}
+			$segments[] = $view;
+			unset($query['view']);
 
 			if (isset($query['year']))
 			{
-				if ($menuItemGiven)
-				{
-					$segments[] = $query['year'];
-					unset($query['year']);
-				}
+				$segments[] = $query['year'];
+				unset($query['year']);
 			}
 
-			if (isset($query['year']) && isset($query['month']))
+			if (isset($query['month']))
 			{
-				if ($menuItemGiven)
-				{
-					$segments[] = $query['month'];
-					unset($query['month']);
-				}
+				$segments[] = $query['month'];
+				unset($query['month']);
 			}
 		}
 
@@ -296,14 +287,24 @@ class ContentRouter extends JComponentRouterBase
 
 		/*
 		 * Standard routing for articles.  If we don't pick up an Itemid then we get the view from the segments
-		 * the first segment is the view and the last segment is the id of the article or category.
 		 */
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			$vars['id'] = $segments[$count - 1];
 
-			return $vars;
+			switch ($vars['view'])
+			{
+				case 'archive':
+					// Parse the archived articles view
+					return $this->parseArchiveArticlesRoute($segments);
+					break;
+
+				default;
+					// The first segment is the view and the last segment is the id of the article or category in the default behavior
+					$vars['id'] = $segments[$count - 1];
+
+					return $vars;
+			}
 		}
 
 		/*
@@ -361,26 +362,37 @@ class ContentRouter extends JComponentRouterBase
 		 * If there was more than one segment, then we can determine where the URL points to
 		 * because the first segment will have the target category id prepended to it.  If the
 		 * last segment has a number prepended, it is an article, otherwise, it is a category.
+		 * Special behavior is considered if the first segment points to the archived articles view
 		 */
 		if (!$advanced)
 		{
-			$cat_id = (int) $segments[0];
+			$view = $segments[0];
 
-			$article_id = (int) $segments[$count - 1];
-
-			if ($article_id > 0)
+			switch ($view)
 			{
-				$vars['view'] = 'article';
-				$vars['catid'] = $cat_id;
-				$vars['id'] = $article_id;
-			}
-			else
-			{
-				$vars['view'] = 'category';
-				$vars['id'] = $cat_id;
-			}
+				case 'archive':
+					return $this->parseArchiveArticlesRoute($segments);
+					break;
 
-			return $vars;
+				default:
+					$cat_id = (int) $segments[0];
+
+					$article_id = (int) $segments[$count - 1];
+
+					if ($article_id > 0)
+					{
+						$vars['view'] = 'article';
+						$vars['catid'] = $cat_id;
+						$vars['id'] = $article_id;
+					}
+					else
+					{
+						$vars['view'] = 'category';
+						$vars['id'] = $cat_id;
+					}
+
+					return $vars;
+			}
 		}
 
 		// We get the category id from the menu item and search from there
@@ -433,22 +445,36 @@ class ContentRouter extends JComponentRouterBase
 				{
 					$cid = $segment;
 				}
-
-				$vars['id'] = $cid;
-
-				if ($item->query['view'] == 'archive' && $count != 1)
-				{
-					$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
-					$vars['month'] = $segments[$count - 1];
-					$vars['view'] = 'archive';
-				}
-				else
-				{
-					$vars['view'] = 'article';
-				}
 			}
 
 			$found = 0;
+		}
+
+		return $vars;
+	}
+
+	/**
+	 * Build the route for the archived articles view
+	 *
+	 * @param   array  &$segments  The segments of the URL to parse ($segment[0] is the view)
+	 *
+	 * @return  array  The URL attributes to be used by the application.
+	 *
+	 * @since   3.3
+	 */
+	public function parseArchiveArticlesRoute(&$segments)
+	{
+		$vars = array();
+		$vars['view'] = $segments[0];
+
+		if (isset($segments[1]))
+		{
+			$vars['year'] = $segments[1];
+		}
+
+		if (isset($segments[2]))
+		{
+			$vars['month'] = $segments[2];
 		}
 
 		return $vars;

--- a/language/en-GB/en-GB.mod_articles_archive.ini
+++ b/language/en-GB/en-GB.mod_articles_archive.ini
@@ -8,4 +8,5 @@ MOD_ARTICLES_ARCHIVE_FIELD_COUNT_LABEL="# of Months"
 MOD_ARTICLES_ARCHIVE_FIELD_COUNT_DESC="The number of months to display (the default is 10)"
 MOD_ARTICLES_ARCHIVE_XML_DESCRIPTION="This module shows a list of the calendar months containing archived articles. After you have changed the status of an article to archived, this list will be automatically generated."
 MOD_ARTICLES_ARCHIVE_DATE="%1$s, %2$s"
-
+MOD_ARTICLES_ARCHIVE_FIELD_SHOW_DATE_LABEL="Date to show"
+MOD_ARTICLES_ARCHIVE_FIELD_SHOW_DATE_DESC="Select the date to show when displaying the month/year article selection in the module"

--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -31,14 +31,23 @@ class ModArchiveHelper
 	{
 		// Get database
 		$db    = JFactory::getDbo();
+
+		$orderDate = $params->get('list_show_date', 'publish_up');
+
 		$query = $db->getQuery(true);
-		$query->select($query->month($db->quoteName('created')) . ' AS created_month')
-			->select('created, id, title')
-			->select($query->year($db->quoteName('created')) . ' AS created_year')
+		$query->select(
+				array(
+					$db->qn($orderDate, 'order_date'),
+					$db->qn('id'),
+					$db->qn('title'),
+					$query->month($db->qn($orderDate)) . ' AS ' . $db->qn('order_month'),
+					$query->year($db->qn($orderDate)) . ' AS ' . $db->qn('order_year'),
+				)
+			)
 			->from('#__content')
 			->where('state = 2 AND checked_out = 0')
-			->group('created_year, created_month, created, id, title')
-			->order('created_year DESC, created_month DESC');
+			->group('order_year, order_month')
+			->order('order_year DESC, order_month DESC');
 
 		// Filter by language
 		if (JFactory::getApplication()->getLanguageFilter())
@@ -59,18 +68,18 @@ class ModArchiveHelper
 
 		foreach ($rows as $row)
 		{
-			$date = JFactory::getDate($row->created);
+			$date = JFactory::getDate($row->order_date);
 
-			$created_month = $date->format('n');
-			$created_year  = $date->format('Y');
+			$order_month = $date->format('n');
+			$order_year  = $date->format('Y');
 
-			$created_year_cal = JHTML::_('date', $row->created, 'Y');
-			$month_name_cal   = JHTML::_('date', $row->created, 'F');
+			$order_year_cal = JHTML::_('date', $row->order_date, 'Y');
+			$order_month_cal   = JHTML::_('date', $row->order_date, 'F');
 
 			$lists[$i] = new stdClass;
 
-			$lists[$i]->link = JRoute::_('index.php?option=com_content&view=archive&year=' . $created_year . '&month=' . $created_month . $itemid);
-			$lists[$i]->text = JText::sprintf('MOD_ARTICLES_ARCHIVE_DATE', $month_name_cal, $created_year_cal);
+			$lists[$i]->link = JRoute::_('index.php?option=com_content&view=archive&year=' . $order_year . '&month=' . $order_month . $itemid);
+			$lists[$i]->text = JText::sprintf('MOD_ARTICLES_ARCHIVE_DATE', $order_month_cal, $order_year_cal);
 
 			$i++;
 		}

--- a/modules/mod_articles_archive/mod_articles_archive.xml
+++ b/modules/mod_articles_archive/mod_articles_archive.xml
@@ -33,8 +33,8 @@
 				<field name="list_show_date"
 					type="list"
 					default="publish_up"
-					label="JGLOBAL_SHOW_DATE_LABEL"
-					description="JGLOBAL_SHOW_DATE_DESC">
+					label="MOD_ARTICLES_ARCHIVE_FIELD_SHOW_DATE_LABEL"
+					description="MOD_ARTICLES_ARCHIVE_FIELD_SHOW_DATE_DESC">
 						<option value="created">JGLOBAL_CREATED</option>
 						<option value="modified">JGLOBAL_MODIFIED</option>
 						<option value="publish_up">JPUBLISHED</option>

--- a/modules/mod_articles_archive/mod_articles_archive.xml
+++ b/modules/mod_articles_archive/mod_articles_archive.xml
@@ -30,6 +30,15 @@
 					default="10"
 					label="MOD_ARTICLES_ARCHIVE_FIELD_COUNT_LABEL"
 					description="MOD_ARTICLES_ARCHIVE_FIELD_COUNT_DESC" />
+				<field name="list_show_date"
+					type="list"
+					default="publish_up"
+					label="JGLOBAL_SHOW_DATE_LABEL"
+					description="JGLOBAL_SHOW_DATE_DESC">
+						<option value="created">JGLOBAL_CREATED</option>
+						<option value="modified">JGLOBAL_MODIFIED</option>
+						<option value="publish_up">JPUBLISHED</option>
+				</field>
 			</fieldset>
 
 			<fieldset name="advanced">


### PR DESCRIPTION
A date configuration option has been added to the archive articles module, so the user can manually adjust this module to match the archive articles view.

The default has been changed to published date.

Date grouping has been fixed also - it was displaying duplicate months before
