### PR TITLE
Implementing popup warning if no items are selected

### DIFF
--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -66,8 +66,8 @@ class MessagesViewMessages extends JViewLegacy
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ',true);
-			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD',true);
+			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ', true);
+			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD', true);
 		}
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -66,8 +66,8 @@ class MessagesViewMessages extends JViewLegacy
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ');
-			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD');
+			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ',true);
+			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD',true);
 		}
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -66,8 +66,8 @@ class MessagesViewMessages extends JViewLegacy
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ',true);
-			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD',true);
+			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ' ,true);
+			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD' ,true);
 		}
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -66,8 +66,8 @@ class MessagesViewMessages extends JViewLegacy
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ' ,true);
-			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD' ,true);
+			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ', true);
+			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD', true);
 		}
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -66,8 +66,8 @@ class MessagesViewMessages extends JViewLegacy
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ', true);
-			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD', true);
+			JToolbarHelper::publish('messages.publish', 'COM_MESSAGES_TOOLBAR_MARK_AS_READ' ,true);
+			JToolbarHelper::unpublish('messages.unpublish', 'COM_MESSAGES_TOOLBAR_MARK_AS_UNREAD' ,true);
 		}
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))


### PR DESCRIPTION
This fixes issue #4767 by implementing a popup to warn if no items have been selected.

The alert box should be displayed for Mark as Read & Mark as Unread on Messaging page.
