### PR TITLE
Added verification to hide/show intro text in blogs

### DIFF
--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -40,11 +40,13 @@ $info    = $params->get('info_block_position', 0);
 
 <?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
 
-
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 <?php endif; ?>
+
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->event->beforeDisplayContent; ?> <?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'below')); ?>
@@ -72,4 +74,6 @@ $info    = $params->get('info_block_position', 0);
 </div>
 <?php endif; ?>
 
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->event->afterDisplayContent; ?>
+<?php endif; ?>

--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -130,7 +130,10 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 	</div>
 <?php endif; ?>
+
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->introtext; ?>
+<?php endif; ?>
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
@@ -169,4 +172,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php endif; ?>
 
 <div class="item-separator"></div>
+<?php if ($params->get('show_intro')) : ?>
 <?php echo $this->item->event->afterDisplayContent; ?>
+<?php endif; ?>


### PR DESCRIPTION
Test steps:
1. Create an "Articles" > "Category Blog" menu item.
2. In "Options" set "Show Intro Text" to Hide

Before this proposed fix, this option won't hide the intro text of the articles.

Fixed when using Joomla default content (with Protostar template for example) and also when using Beez3
