### PR TITLE
Fix tags not saving in postgres

### DIFF
--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fields name="urls">
-		<field
-			name="urla"
-			type="hidden"
-		/>
+		<!-- This fieldset is needed to stop the URLs column being null which throws errors in postgres -->
+		<fieldset name="urls">
+			<field
+				name="urla"
+				type="hidden"
+			/>
+		</fieldset>
 	</fields>
 
 	<field
@@ -209,12 +212,12 @@
 	>
 		<option value="*">JALL</option>
 	</field>
-	
-	<field name="version_note" 
-		type="text" 
+
+	<field name="version_note"
+		type="text"
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
-		description="JGLOBAL_FIELD_VERSION_NOTE_DESC" 
-		class="span12" size="45" 
+		description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+		class="span12" size="45"
 		labelclass="control-label"
 	/>
 
@@ -246,7 +249,9 @@
 			/>
 
 		</fieldset>
+	</fields>
 
+	<fields name="images">
 		<fieldset name="images" label="JGLOBAL_FIELDSET_IMAGE_OPTIONS">
 			<field
 				name="image_intro"

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -64,6 +64,10 @@ $params = $params->toArray();
 
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS', true)); ?>
+		<?php echo $this->form->renderFieldset('images'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
+		<?php echo $this->form->renderFieldset('urls'); ?>
 	</div>
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>


### PR DESCRIPTION
Also fixes bug where images can't be viewed in tags.

N.B. The version note field is untouched (even though it shows in the diff - my ide really didn't like this file for some reason and was intent on autoformatting it!!)
## Executive summary

You can't save tags in postgres because of an SQL error. For a related reason in all database formats the images attached to a tag could not be viewed in the frontend
## Detailed description

In the code sprint the images fieldset was moved inside the params `<field>` attribute. This meant the name of the images fields changed from `jform[images][image_intro]` to `jform[params][image_intro]`. This meant all images got stored in the params column in the database column leaving the images column blank. As a result no images showed in the frontend on all databases and additionally in postgres the 
## Backwards Compatibility

Any images created on a tag since 3.2 will now not show and will be wiped on next saving the tag (as they are stored in the params column and not the images column as they are supposed to). However offsetting this any images stored between tags introduction in 3.1 and 3.2 WILL now show. 
## Testing Instructions

Test saving a tag in postgres on version 3.3.6 (note NOT current staging because of a regression that was introduced by https://github.com/joomla/joomla-cms/pull/4114)

You can test this on mysql by checking that images now function in the frontend correctly (note in postgres looks like more sql errors mean you can't open a tag yet - that is for a future PR)
## Is Brian Happy yet

You'll have to ask @brianteeman whether this is detailed enough :P 
