### PR TITLE
Wrapper classes to get rid of static methods - Refactoring

### DIFF
--- a/libraries/joomla/access/wrapper/access.php
+++ b/libraries/joomla/access/wrapper/access.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  User
  * @since       3.4
  */
-class JAccessWrapper
+class JAccessWrapperAccess
 {
 	/**
 	 * Helper wrapper method for addUserToGroup

--- a/libraries/joomla/archive/wrapper/archive.php
+++ b/libraries/joomla/archive/wrapper/archive.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Archive
  * @since       3.4
  */
-class JArchiveWrapper
+class JArchiveWrapperArchive
 {
 	/**
 	 * Helper wrapper method for extract

--- a/libraries/joomla/route/wrapper/route.php
+++ b/libraries/joomla/route/wrapper/route.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Application
  * @since       3.4
  */
-class JRouteWrapper
+class JRouteWrapperRoute
 {
 	/**
 	 * Helper wrapper method for _


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper classes to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
