### PR TITLE
Wrapper class for JObserverMapper to get rid of static methods

### DIFF
--- a/libraries/joomla/observer/wrapper/mapper.php
+++ b/libraries/joomla/observer/wrapper/mapper.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Observer
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JObserverMapper
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Observer
+ * @since       3.4
+ */
+class JObserverWrapperMapper
+{
+	/**
+	 * Helper wrapper method for addObserverClassToClass
+	 *
+	 * @param   string         $observerClass    The name of the observer class (implementing JObserverInterface).
+	 * @param   string         $observableClass  The name of the observable class (implementing JObservableInterface).
+	 * @param   array|boolean  $params           The params to give to the JObserverInterface::createObserver() function, or false to remove mapping.
+	 *
+	 * @return void
+	 *
+	 * @see     JObserverMapper::addObserverClassToClass
+	 * @since   3.4
+	 */
+	public function addObserverClassToClass($observerClass, $observableClass, $params = array())
+	{
+		return JObserverMapper::addObserverClassToClass($observerClass, $observableClass, $params);
+	}
+
+	/**
+	 * Helper wrapper method for attachAllObservers
+	 *
+	 * @param   JObservableInterface  $observableObject  The observable subject object.
+	 *
+	 * @return void
+	 *
+	 * @see     JObserverMapper::attachAllObservers
+	 * @since   3.4
+	 */
+	public function attachAllObservers(JObservableInterface $observableObject)
+	{
+		return JObserverMapper::attachAllObservers($observableObject);
+	}
+}


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for the JObserverMapper class to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
