### PR TITLE
Wrapper class for JUser to get rid of static methods - Refactoring

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -205,9 +205,9 @@ class JUser extends JObject
 	protected $_errorMsg = null;
 
 	/**
-	 * JUserHelperWrapper object
+	 * JUserWrapperHelper object
 	 *
-	 * @var    JUserHelperWrapper
+	 * @var    JUserWrapperHelper
 	 * @since  3.4
 	 */
 	protected $userHelper = null;
@@ -222,15 +222,15 @@ class JUser extends JObject
 	 * Constructor activating the default information of the language
 	 *
 	 * @param   integer             $identifier  The primary key of the user to load (optional).
-	 * @param   JUserHelperWrapper  $userHelper  The JUserHelperWrapper for the static methods.
+	 * @param   JUserWrapperHelper  $userHelper  The JUserWrapperHelper for the static methods.
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($identifier = 0, JUserHelperWrapper $userHelper = null)
+	public function __construct($identifier = 0, JUserWrapperHelper $userHelper = null)
 	{
 		if (null === $userHelper)
 		{
-			$userHelper = new JUserHelperWrapper;
+			$userHelper = new JUserWrapperHelper;
 		}
 
 		$this->userHelper = $userHelper;
@@ -257,17 +257,17 @@ class JUser extends JObject
 	 * Returns the global User object, only creating it if it doesn't already exist.
 	 *
 	 * @param   integer             $identifier  The primary key of the user to load (optional).
-	 * @param   JUserHelperWrapper  $userHelper  The JUserHelperWrapper for the static methods.
+	 * @param   JUserWrapperHelper  $userHelper  The JUserWrapperHelper for the static methods.
 	 *
 	 * @return  JUser  The User object.
 	 *
 	 * @since   11.1
 	 */
-	public static function getInstance($identifier = 0, JUserHelperWrapper $userHelper = null)
+	public static function getInstance($identifier = 0, JUserWrapperHelper $userHelper = null)
 	{
 		if (null === $userHelper)
 		{
-			$userHelper = new JUserHelperWrapper;
+			$userHelper = new JUserWrapperHelper;
 		}
 
 		// Find the user id

--- a/libraries/joomla/user/wrapper/helper.php
+++ b/libraries/joomla/user/wrapper/helper.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  User
  * @since       3.4
  */
-class JUserHelperWrapper
+class JUserWrapperHelper
 {
 	/**
 	 * Helper wrapper method for addUserToGroup


### PR DESCRIPTION
Reference: #4717

This PR introduces a wrapper class for JUser to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
