### PR TITLE
Fix for 'Plugin Manager: Plugins' view showing white-space when sidebar is collapsed

### DIFF
--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -50,9 +50,9 @@ $sortFields = $this->getSortFields();
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
-	<div id="main-container" class="span10">
+	<div id="j-main-container" class="span10">
 <?php else : ?>
-	<div id="main-container">
+	<div id="j-main-container">
 <?php endif;?>
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">


### PR DESCRIPTION
Fix for 'Plugin Manager: Plugins' view showing white-space when sidebar is collapsed

Before -
![before](https://cloud.githubusercontent.com/assets/1375006/4689125/68f9feba-56a7-11e4-83c7-185b3f24c1da.png)

After patch -
![after](https://cloud.githubusercontent.com/assets/1375006/4689126/6d600ad0-56a7-11e4-9052-a4221166e99f.png)
