### PR TITLE
Update Manager: Manage Refresh Cache

### DIFF
--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -84,7 +84,7 @@ class InstallerViewManage extends InstallerViewDefault
 			JToolbarHelper::divider();
 		}
 
-		JToolbarHelper::custom('manage.refresh', 'refresh', 'refresh', 'JTOOLBAR_REFRESH_CACHE', true);
+		JToolbarHelper::custom('manage.refresh', 'refresh', 'refresh', 'JTOOLBAR_REFRESH_CACHE', false);
 		JToolbarHelper::divider();
 
 		if ($canDo->get('core.delete'))


### PR DESCRIPTION
### Summary

there is no reason to select anything in order to refresh the cache -( or am i missing something)
#### Steps to reproduce the issue

Go to Extension Manager : Manage and click on refresh cache
#### Expected result

Cache is refreshed
#### Actual result

popup dialog with please make a selection from the list
#### Apply Patch

The cache should now be refreshed with no popup warning
