### PR TITLE
Wrapper classes for JString classes to get rid of static methods

### DIFF
--- a/libraries/joomla/string/wrapper/normalise.php
+++ b/libraries/joomla/string/wrapper/normalise.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Wrapper class for JStringNormalise
+ *
+ * @package     Joomla.Platform
+ * @subpackage  String
+ * @since       3.4
+ */
+class JStringWrapperNormalise
+{
+	/**
+	 * Helper wrapper method for fromCamelCase
+	 *
+	 * @param   string   $input    The string input (ASCII only).
+	 * @param   boolean  $grouped  Optionally allows splitting on groups of uppercase characters.
+	 *
+	 * @return mixed  The space separated string or an array of substrings if grouped is true.
+	 *
+	 * @see     JUserHelper::fromCamelCase()
+	 * @since   3.4
+	 */
+	public function fromCamelCase($input, $grouped = false)
+	{
+		return JStringNormalise::fromCamelCase($input, $grouped);
+	}
+
+	/**
+	 * Helper wrapper method for toCamelCase
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The camel case string.
+	 *
+	 * @see     JUserHelper::toCamelCase()
+	 * @since   3.4
+	 */
+	public function toCamelCase($input)
+	{
+		return JStringNormalise::toCamelCase($input);
+	}
+
+	/**
+	 * Helper wrapper method for toDashSeparated
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The dash separated string.
+	 *
+	 * @see     JUserHelper::toDashSeparated()
+	 * @since   3.4
+	 */
+	public function toDashSeparated($input)
+	{
+		return JStringNormalise::toDashSeparated($input);
+	}
+
+	/**
+	 * Helper wrapper method for toSpaceSeparated
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The space separated string.
+	 *
+	 * @see     JUserHelper::toSpaceSeparated()
+	 * @since   3.4
+	 */
+	public function toSpaceSeparated($input)
+	{
+		return JStringNormalise::toSpaceSeparated($input);
+	}
+
+	/**
+	 * Helper wrapper method for toUnderscoreSeparated
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The underscore separated string.
+	 *
+	 * @see     JUserHelper::toUnderscoreSeparated()
+	 * @since   3.4
+	 */
+	public function toUnderscoreSeparated($input)
+	{
+		return JStringNormalise::toUnderscoreSeparated($input);
+	}
+
+	/**
+	 * Helper wrapper method for toVariable
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The variable string.
+	 *
+	 * @see     JUserHelper::toVariable()
+	 * @since   3.4
+	 */
+	public function toVariable($input)
+	{
+		return JStringNormalise::toVariable($input);
+	}
+
+	/**
+	 * Helper wrapper method for toKey
+	 *
+	 * @param   string  $input  The string input (ASCII only).
+	 *
+	 * @return string  The key string.
+	 *
+	 * @see     JUserHelper::toKey()
+	 * @since   3.4
+	 */
+	public function toKey($input)
+	{
+		return JStringNormalise::toKey($input);
+	}
+}

--- a/libraries/joomla/string/wrapper/punycode.php
+++ b/libraries/joomla/string/wrapper/punycode.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+JLoader::register('idna_convert', JPATH_ROOT . '/libraries/idna_convert/idna_convert.class.php');
+
+/**
+ * Wrapper class for JStringPunycode
+ *
+ * @package     Joomla.Platform
+ * @subpackage  String
+ * @since       3.4
+ */
+class JStringWrapperPunycode
+{
+	/**
+	 * Helper wrapper method for toPunycode
+	 *
+	 * @param   string  $utfString  The UTF-8 string to transform.
+	 *
+	 * @return string  The punycode string.
+	 *
+	 * @see     JUserHelper::toPunycode()
+	 * @since   3.4
+	 */
+	public function toPunycode($utfString)
+	{
+		return JStringPunycode::toPunycode($utfString);
+	}
+
+	/**
+	 * Helper wrapper method for fromPunycode
+	 *
+	 * @param   string  $punycodeString  The Punycode string to transform.
+	 *
+	 * @return string  The UF-8 URL.
+	 *
+	 * @see     JUserHelper::fromPunycode()
+	 * @since   3.4
+	 */
+	public function fromPunycode($punycodeString)
+	{
+		return JStringPunycode::fromPunycode($punycodeString);
+	}
+
+	/**
+	 * Helper wrapper method for urlToPunycode
+	 *
+	 * @param   string  $uri  The UTF-8 URL to transform.
+	 *
+	 * @return string  The punycode URL.
+	 *
+	 * @see     JUserHelper::urlToPunycode()
+	 * @since   3.4
+	 */
+	public function urlToPunycode($uri)
+	{
+		return JStringPunycode::urlToPunycode($uri);
+	}
+
+	/**
+	 * Helper wrapper method for urlToUTF8
+	 *
+	 * @param   string  $uri  The Punycode URL to transform.
+	 *
+	 * @return string  The UTF-8 URL.
+	 *
+	 * @see     JStringPunycode::urlToUTF8()
+	 * @since   3.4
+	 */
+	public function urlToUTF8($uri)
+	{
+		return JStringPunycode::urlToUTF8($uri);
+	}
+
+	/**
+	 * Helper wrapper method for emailToPunycode
+	 *
+	 * @param   string  $email  The UTF-8 e-mail to transform.
+	 *
+	 * @return string  The punycode e-mail.
+	 *
+	 * @see     JStringPunycode::emailToPunycode()
+	 * @since   3.4
+	 */
+	public function emailToPunycode($email)
+	{
+		return JStringPunycode::emailToPunycode($email);
+	}
+
+	/**
+	 * Helper wrapper method for emailToUTF8
+	 *
+	 * @param   string  $email  The punycode e-mail to transform.
+	 *
+	 * @return string  The punycode e-mail.
+	 *
+	 * @see     JStringPunycode::emailToUTF8()
+	 * @since   3.4
+	 */
+	public function emailToUTF8($email)
+	{
+		return JStringPunycode::emailToUTF8($email);
+	}
+}


### PR DESCRIPTION
Reference: #4717

This PR introduces wrapper classes for JString classes to get rid of the static methods to improve the testing basis of the code for our PHPUnit tests!

The static methods (and the wrappers) will be removed completely in Joomla! 4.x.
