### PR TITLE
Fix wrong redirect after featured/unfeatured article

### DIFF
--- a/administrator/components/com_content/controllers/articles.php
+++ b/administrator/components/com_content/controllers/articles.php
@@ -19,9 +19,8 @@ class ContentControllerArticles extends JControllerAdmin
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  $config	An optional associative array of configuration settings.
-
-	 * @return  ContentControllerArticles
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *
 	 * @see     JController
 	 * @since   1.6
 	 */
@@ -43,6 +42,7 @@ class ContentControllerArticles extends JControllerAdmin
 	 * Method to toggle the featured setting of a list of articles.
 	 *
 	 * @return  void
+	 *
 	 * @since   1.6
 	 */
 	public function featured()
@@ -59,7 +59,7 @@ class ContentControllerArticles extends JControllerAdmin
 		// Access checks.
 		foreach ($ids as $i => $id)
 		{
-			if (!$user->authorise('core.edit.state', 'com_content.article.'.(int) $id))
+			if (!$user->authorise('core.edit.state', 'com_content.article.' . (int) $id))
 			{
 				// Prune items that you can't change.
 				unset($ids[$i]);
@@ -83,16 +83,27 @@ class ContentControllerArticles extends JControllerAdmin
 			}
 		}
 
-		$this->setRedirect('index.php?option=com_content&view=articles');
+		$view = $this->input->get('view', '');
+
+		if ($view == 'featured')
+		{
+			$this->setRedirect('index.php?option=com_content&view=featured');
+		}
+		else
+		{
+			$this->setRedirect('index.php?option=com_content&view=articles');
+		}
 	}
 
 	/**
 	 * Proxy for getModel.
 	 *
-	 * @param   string	$name	The name of the model.
-	 * @param   string	$prefix	The prefix for the PHP class name.
+	 * @param   string  $name    The model name. Optional.
+	 * @param   string  $prefix  The class prefix. Optional.
+	 * @param   array   $config  The array of possible config values. Optional.
 	 *
 	 * @return  JModel
+	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Article', $prefix = 'ContentModel', $config = array('ignore_request' => true))
@@ -116,5 +127,4 @@ class ContentControllerArticles extends JControllerAdmin
 	protected function postDeleteHook(JModelLegacy $model, $ids = null)
 	{
 	}
-
 }


### PR DESCRIPTION
## PR summary

This PR fix the small issue #4834 reported by @clausw. When you go to Content -> Featured articles, click on star icon next to each article to feature/unfeature it. After change is made, instead of going back to Featured articles page (which display list of featured article), you are redirected to standard articles page (which display all articles).

The reason of this error is because the redirected url is hardcoded in the code. I just change the code alitle to redirect users back to the correct view.

I also fixes some code styles of the file administrator/components/com_content/controllers/articles.php as well
## How to test
1. Go to Content -> Featured articles, change status of an article to make it featured/unfeatured. Make sure that you are redirected back to featured articles page after the change is made
2. Go to Content -> Articles Manager, change status of an article to make it featured/unfeatured. Make sure you are redirected back to  Articles Manager page after the change is made.
