### PR TITLE
Regression: Fixing tags on PostgreSQL

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -116,7 +116,7 @@ class JFormFieldTag extends JFormFieldList
 
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published')
+			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft')
 			->from('#__tags AS a')
 			->join('LEFT', $db->qn('#__tags') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 


### PR DESCRIPTION
### Issue

According to @wilsonge PR 4114 broke tags on PostgreSQL (see https://github.com/joomla/joomla-cms/pull/4114#issuecomment-59571233).
### Solution

This PR adds the column `a.lft` to the select as suggested by @alikon.
