### PR TITLE
hide menu when editing configuration

### DIFF
--- a/administrator/components/com_config/view/application/html.php
+++ b/administrator/components/com_config/view/application/html.php
@@ -74,6 +74,7 @@ class ConfigViewApplicationHtml extends ConfigViewCmsHtml
 		$this->userIsSuperAdmin = $user->authorise('core.admin');
 
 		$this->addToolbar();
+		JFactory::getApplication()->input->set('hidemainmenu', true);
 
 		return parent::render();
 	}


### PR DESCRIPTION
#### Administrator consistency

When editing the configuration options the main menu is still available. This differs from the rest of the admin area behavior. This PR unifies it.
#### Test

Apply this patch
go to /administrator/index.php?option=com_config
Main menu should be disabled.
