### PR TITLE
Update registration.php Fixes https://github.com/joomla/joomla-cms/issues/4841

### DIFF
--- a/components/com_users/controllers/registration.php
+++ b/components/com_users/controllers/registration.php
@@ -30,12 +30,6 @@ class UsersControllerRegistration extends UsersController
 		$user		= JFactory::getUser();
 		$uParams	= JComponentHelper::getParams('com_users');
 
-		// If the user is logged in, return them back to the homepage.
-		if ($user->get('id')) {
-			$this->setRedirect('index.php');
-			return true;
-		}
-
 		// If user registration or account activation is disabled, throw a 403.
 		if ($uParams->get('useractivation') == 0 || $uParams->get('allowUserRegistration') == 0) {
 			JError::raiseError(403, JText::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'));


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/4841

User registration from frontend should work, whether you are logged in or not. Both user email and admin verification should be allowed when logged in. Both as user and admin.

Testing scenario's:
1. Backend adding user
2. Frontend registration with verification none
3. Frontend registration with verification self, verification while not logged in
4. Frontend registration with verification self, verification while logged in as different user
5. Frontend registration with verification admin, verification while not logged in
6. Frontend registration with verification admin, verification while logged in as different user
7. Frontend registration with verification admin, verification while logged in as admin

All scenarios passed with PR applied to J2520 updated to J2527 via J2525 on MySQL, Apache on W8.1
