### PR TITLE
Fix mod_tags_similar in postgres

### DIFF
--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -59,13 +59,10 @@ abstract class ModTagssimilarHelper
 		$query = $db->getQuery(true)
 			->select(
 			array(
-				$db->quoteName('m.tag_id'),
 				$db->quoteName('m.core_content_id'),
 				$db->quoteName('m.content_item_id'),
 				$db->quoteName('m.type_alias'),
 					'COUNT( ' . $db->quoteName('tag_id') . ') AS ' . $db->quoteName('count'),
-				$db->quoteName('t.access'),
-				$db->quoteName('t.id'),
 				$db->quoteName('ct.router'),
 				$db->quoteName('cc.core_title'),
 				$db->quoteName('cc.core_alias'),
@@ -107,7 +104,7 @@ abstract class ModTagssimilarHelper
 
 		$query->group(
 			$db->quoteName(
-				array('m.tag_id', 'm.core_content_id', 'm.content_item_id', 'm.type_alias', 't.access', 't.id', 'ct.router', 'cc.core_title',
+				array('m.core_content_id', 'm.content_item_id', 'm.type_alias', 'ct.router', 'cc.core_title',
 				'cc.core_alias', 'cc.core_catid', 'cc.core_language', 'cc.core_params')
 			)
 		);

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -105,7 +105,12 @@ abstract class ModTagssimilarHelper
 			$query->where($db->quoteName('cc.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');
 		}
 
-		$query->group($db->quoteName(array('m.core_content_id')));
+		$query->group(
+			$db->quoteName(
+				array('m.tag_id', 'm.core_content_id', 'm.content_item_id', 'm.type_alias', 't.access', 't.id', 'ct.router', 'cc.core_title',
+				'cc.core_alias', 'cc.core_catid', 'cc.core_language', 'cc.core_params')
+			)
+		);
 
 		if ($matchtype == 'all' && $tagCount > 0)
 		{


### PR DESCRIPTION
## Executive Summary

The similar tags module throws an uncaught SQL exception in postgres breaking any page it's loaded on
## Testing Instructions

Install the testing dataset on postgres. The main home page will throw an SQL error. Apply the patch. This error will disappear and the page will render normally.
## Things to note

There's an issue with the fact the same page is shown 3 times still in the module - but until I can work out errors  with saving articles with tags treat this as a known issue. The fact that mysql with the same articles and associated tags shows 0 articles is just as concerning :P So let's just allow people to navigate on their site first!
