### PR TITLE
Routing: Adding application and menu objects to component routers

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -689,8 +689,7 @@ class JRouterSite extends JRouter
 
 				if (in_array('JComponentRouterInterface', $reflection->getInterfaceNames()))
 				{
-					$app = JFactory::getApplication();
-					$this->componentRouters[$component] = new $name($app, $app->getMenu());
+					$this->componentRouters[$component] = new $name($this->app, $this->menu);
 				}
 			}
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -689,7 +689,7 @@ class JRouterSite extends JRouter
 
 				if (in_array('JComponentRouterInterface', $reflection->getInterfaceNames()))
 				{
-					$this->componentRouters[$component] = new $name($this->app, $this->menu);
+					$this->componentRouters[$component] = new $class($this->app, $this->menu);
 				}
 			}
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -689,7 +689,8 @@ class JRouterSite extends JRouter
 
 				if (in_array('JComponentRouterInterface', $reflection->getInterfaceNames()))
 				{
-					$this->componentRouters[$component] = new $class;
+					$app = JFactory::getApplication();
+					$this->componentRouters[$component] = new $name($app, $app->getMenu());
 				}
 			}
 


### PR DESCRIPTION
Routers in Joomla should be testable in the future with unittests. Right now, they heavily depend on JFactory and some not-so-nice code constructs to work. In order to introduce dependency injection, this PR hands over the application and the menu to the component routers. This means that you can inject fake application objects and menus into the router during testing. At the same time, component routers can build lookup tables once when they are instantiated and can get their input through these 2 objects.

This is backwards compatible, since additional arguments for a method/constructor are simply ignored by PHP and since we didn't have any arguments up to this point for the constructor, this has no effect so far.

In the future, the application router should get something similar in order to make the whole process testable. For the moment, the Singletons are still used.

Testing instructions: Set the error_reporting in Joomlas global configuration to maximum, check any errors/notices/warnings that appear, apply the change and then see that no new errors/notices/warnings showed up.

This is a new, cleaned up PR that relates to #4714.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
