### PR TITLE
Fix articles being saved with a tag in postgres

### DIFF
--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -277,6 +277,7 @@ class JTableCorecontent extends JTable
 		$query = $db->getQuery(true);
 		$languageId = JHelperContent::getLanguageId($this->core_language);
 
+		// Selecting "all languages" doesn't give a language id - we can't store a blank string in non mysql databases, so save 0 (the default value)
 		if (!$languageId)
 		{
 			$languageId = '0';

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -277,6 +277,11 @@ class JTableCorecontent extends JTable
 		$query = $db->getQuery(true);
 		$languageId = JHelperContent::getLanguageId($this->core_language);
 
+		if (!$languageId)
+		{
+			$languageId = '0';
+		}
+
 		if ($isNew)
 		{
 			$query->insert($db->quoteName('#__ucm_base'))


### PR DESCRIPTION
## Testing

Save an article with a tag with a language of "All languages" before patch in postgres this will give an sql error. After patch will save successfully (note use a tag that already exists as there are other patches pending for saving new tags)
