### PR TITLE
Clear old maps to fix remory leak

### DIFF
--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -108,6 +108,9 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 	 */
 	public function addMaps($maps)
 	{
+		// Clear old maps
+		$this->maps = array();
+
 		foreach ($maps as $pattern => $controller)
 		{
 			$this->addMap($pattern, $controller);


### PR DESCRIPTION
If we made multiple request using websocket, the old maps are stacked creating a memory overflow.
