### PR TITLE
Fix: & in url of newsfeed not escaped Ref: #4862

### DIFF
--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -63,8 +63,7 @@ else
 		{
 			?>
 					<h2 class="<?php echo $direction; ?>">
-						<?php preg_replace('/&(?!amp;)/', '&amp;', $rssurl); ?>
-						<a href="<?php echo $rssurl; ?>" target="_blank">
+						<a href="<?php echo htmlspecialchars($rssurl); ?>" target="_blank">
 						<?php echo $feed->title; ?></a>
 					</h2>
 			<?php
@@ -102,9 +101,8 @@ else
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<h5 class="feed-link">
-						<?php preg_replace('/&(?!amp;)/', '&amp;', $uri); ?>
-						<a href="<?php echo $uri; ?>" target="_blank">
-						<?php  echo $feed[$i]->title; ?></a></h5>
+						<a href="<?php echo htmlspecialchars($uri); ?>" target="_blank">
+						<?php echo $feed[$i]->title; ?></a></h5>
 					<?php else : ?>
 						<h5 class="feed-link"><?php  echo $feed[$i]->title; ?></h5>
 					<?php  endif; ?>

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -53,7 +53,7 @@ else
 	if ($feed != false)
 	{
 		// Image handling
-		$iUrl	= isset($feed->image)	? $feed->image	: null;
+		$iUrl	= isset($feed->image) ? $feed->image : null;
 		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
 		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> ! important"  class="feed<?php echo $moduleclass_sfx; ?>">
@@ -63,7 +63,8 @@ else
 		{
 			?>
 					<h2 class="<?php echo $direction; ?>">
-						<a href="<?php echo str_replace('&', '&amp;', $rssurl); ?>" target="_blank">
+						<?php preg_replace('/&(?!amp;)/', '&amp;', $rssurl); ?>
+						<a href="<?php echo $rssurl; ?>" target="_blank">
 						<?php echo $feed->title; ?></a>
 					</h2>
 			<?php
@@ -94,13 +95,14 @@ else
 			}
 			?>
 			<?php
-				$uri = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? $feed[$i]->uri : $feed[$i]->guid;
-				$uri = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;
+				$uri  = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? $feed[$i]->uri : $feed[$i]->guid;
+				$uri  = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;
 				$text = !empty($feed[$i]->content) ||  !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
 			?>
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<h5 class="feed-link">
+						<?php preg_replace('/&(?!amp;)/', '&amp;', $uri); ?>
 						<a href="<?php echo $uri; ?>" target="_blank">
 						<?php  echo $feed[$i]->title; ?></a></h5>
 					<?php else : ?>


### PR DESCRIPTION
#### Steps to reproduce the issue

Make a module "Feed display" and take for eg. this as feed Url: http://www.zdnet.de/feed/
#### Expected result

The above feed gives URLs like

http://www.zdnet.de/88208524/fitbit-plant-fitness-smartwatch-mit-gps/?utm_source=rss&utm_medium=rss&utm_campaign=rss

In line 104 of /modules/mod_feed/tmpl/default

``` php
<?php echo $uri; ?>
```

should be replaced with

``` php
<?php preg_replace('/&(?!amp;)/', '&amp;', $uri); ?>
<?php echo $uri; ?>
```

also in line 66 of the same file.
#### Actual result

& don't get replaced.
#### System information (as much as possible)

Joomla! 3.3.6
#### Additional comments

See: https://github.com/joomla/joomla-cms/issues/4862 by @dirk-graetz
