### PR TITLE
Fixed JLog class to accept event handler callables objects with closures

### DIFF
--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -183,10 +183,18 @@ class JLog
 
 		// Special case - if a Closure object is sent as the callback (in case of JLogLoggerCallback)
 		// Closure objects are not serializable so swap it out for a unique id first then back again later
-		if (isset($options['callback']) && is_a($options['callback'], 'closure'))
+		if (isset($options['callback']))
 		{
-			$callback = $options['callback'];
-			$options['callback'] = spl_object_hash($options['callback']);
+			if (is_a($options['callback'], 'closure'))
+			{
+				$callback = $options['callback'];
+				$options['callback'] = spl_object_hash($options['callback']);
+			}
+			elseif (is_array($options['callback']) && count($options['callback']) == 2 && is_object($options['callback'][0]))
+			{
+				$callback = $options['callback'];
+				$options['callback'] = spl_object_hash($options['callback'][0]) . '::' . $options['callback'][1];
+			}
 		}
 
 		// Generate a unique signature for the JLog instance based on its options.


### PR DESCRIPTION
This PR fixes JLog class as used in the Joomla Debug plugin, to accept callables of type array(object, method) where object has closures.

serialize() of object with closures generates a fatal error in php.

Thus for closures as handlers, this has been fixed already by using spl_object_hash() for the closure. But in case of a handler that is array(object, method) where object might have variables containing closures (or objects containing variables with closures), it is still generating a fatal error.

This PR is obvious with a source-code review. Tests should check that plugins continue to work fine (e.g. remember-me and sef). If desired, a valid test-code that generates a fatal with master, but works fine with PR can be provided.
