### PR TITLE
Fix: Double Quotes in Site Name not escaped in admin section (isis templ...

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -38,7 +38,7 @@ $view     = $input->get('view', '');
 $layout   = $input->get('layout', '');
 $task     = $input->get('task', '');
 $itemid   = $input->get('Itemid', '');
-$sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES);
+$sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $cpanel   = ($option === 'com_cpanel');
 
 $showSubmenu          = false;

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -38,8 +38,7 @@ $view     = $input->get('view', '');
 $layout   = $input->get('layout', '');
 $task     = $input->get('task', '');
 $itemid   = $input->get('Itemid', '');
-$sitename = $app->get('sitename');
-
+$sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES);
 $cpanel   = ($option === 'com_cpanel');
 
 $showSubmenu          = false;
@@ -146,7 +145,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 								</span>
 							</li>
 							<li class="divider"></li>
-							<li class="">
+							<li>
 								<a href="index.php?option=com_admin&amp;task=profile.edit&amp;id=<?php echo $user->id; ?>"><?php echo JText::_('TPL_ISIS_EDIT_ACCOUNT'); ?></a>
 							</li>
 							<li class="divider"></li>


### PR DESCRIPTION
...ate)

kudos goes to @dgt41 see: https://github.com/joomla/joomla-cms/issues/4864#issuecomment-59771496
#### Steps to reproduce the issue

Site Name: **Site "One" foo**
Open admin section using isis template
#### Expected result

HTML for preview button in the upper right corner:
a class="brand hidden-desktop hidden-tablet" href="http://www.my-site.com/" title="Preview Site &_quot_;One&_quot_; foo" target="_blank">Site &_quot_;One...

(without underscores around quot word)
#### Actual result

HTML not valid:
a class="brand hidden-desktop hidden-tablet" href="http://www.my-site.com/" title="Preview Site "One" foo" target="_blank">Site "One...
#### System information (as much as possible)

isis template
#### Additional comments

see: http://issues.joomla.org/tracker/joomla-cms/4864 @pl71 's issue
