### PR TITLE
Don't change MSSQL query if no limit or offset is set

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -260,6 +260,11 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
+		if (!$limit && !$offset)
+		{
+			return $query;
+		}
+
 		$start = $offset + 1;
 		$end   = $offset + $limit;
 


### PR DESCRIPTION
### Issue

Currently, MSSQL creates an error for each database query where no limit is set. Like for inserts, updates and the like.
See #3602 and #4869 for the issue reports.
### Solution

Add a check to the sqlsrv query class in the `processLimit()` method. Similar to what we already do in MySQL and PostgreSQL.
### Testing

@sovainfo can you explain how to reproduce the issue? As far as I understood one sees that on first page after updating?
