### PR TITLE
[fix] Batch Copy should unpublish items to be consistent

### DIFF
--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -262,7 +262,7 @@ class BannersModelBanner extends JModelAdmin
 			$table->catid = $categoryId;
 
 			// Unpublish because we are making a copy
-			$this->table->state = 0;
+			$table->state = 0;
 
 			// TODO: Deal with ordering?
 			// $table->ordering	= 1;

--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -260,6 +260,9 @@ class BannersModelBanner extends JModelAdmin
 
 			// New category ID
 			$table->catid = $categoryId;
+	
+			// Unpublish because we are making a copy
+			$this->table->state = 0;
 
 			// TODO: Deal with ordering?
 			// $table->ordering	= 1;

--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -260,7 +260,7 @@ class BannersModelBanner extends JModelAdmin
 
 			// New category ID
 			$table->catid = $categoryId;
-	
+
 			// Unpublish because we are making a copy
 			$this->table->state = 0;
 

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -919,6 +919,9 @@ class CategoriesModelCategory extends JModelAdmin
 			$this->table->title = $title;
 			$this->table->alias = $alias;
 
+			// Unpublish because we are making a copy
+			$this->table->published = 0;
+
 			parent::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 			// Store the row.

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -217,6 +217,9 @@ class ContactModelContact extends JModelAdmin
 			// New category ID
 			$this->table->catid = $categoryId;
 
+			// Unpublish because we are making a copy
+			$this->table->published = 0;
+
 			// TODO: Deal with ordering?
 
 			// Check the row.

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -91,6 +91,9 @@ class ContentModelArticle extends JModelAdmin
 			// Reset hits because we are making a copy
 			$this->table->hits = 0;
 
+			// Unpublish because we are making a copy
+			$this->table->state = 0;
+
 			// New category ID
 			$this->table->catid = $categoryId;
 

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -89,6 +89,9 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 			// Reset the ID because we are making a copy
 			$this->table->id = 0;
 
+			// Unpublish because we are making a copy
+			$this->table->published = 0;
+
 			// New category ID
 			$this->table->catid = $categoryId;
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -379,6 +379,16 @@ abstract class JModelAdmin extends JModelForm
 			// Reset the ID because we are making a copy
 			$this->table->id = 0;
 
+			// Unpublish because we are making a copy
+			if (isset($this->table->published))
+			{
+				$this->table->published = 0;
+			}
+			elseif (isset($this->table->state))
+			{
+				$this->table->state = 0;
+			}
+
 			// New category ID
 			$this->table->catid = $categoryId;
 


### PR DESCRIPTION
We have to be consistent. Save as Copy unpublishes the items.
After patching, test batch Copy
1. a banner
2. a category
3. a contact
4. an article
5. a newsfeed
6. a weblink // here it is done via the default batchcopy in libraries/legacy/model/admin.php
