### PR TITLE
Making sure Components menu is not case sensitive

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -133,7 +133,7 @@ abstract class ModMenuHelper
 			}
 		}
 
-		$result = JArrayHelper::sortObjects($result, 'text', 1, true, true);
+		$result = JArrayHelper::sortObjects($result, 'text', 1, false, true);
 
 		return $result;
 	}


### PR DESCRIPTION
In one of the previous Joomla! 3 major versions, 3.0, 3.1 or 3.2, I can't remember which, the default ordering for the Components menu was changed to be case sensitive. From that moment, extensions that started with a lowercase letter in their name would be listed at the bottom of the Components menu. This pull request reverts that change back, so the Components menu is truly in alphabetical order again.

The situation currently in Joomla! 3.3.x:
![joomla - administration - control panel 2014-10-21 19-17-44](https://cloud.githubusercontent.com/assets/524491/4723366/2175e8ea-5947-11e4-9f6d-73538a6515ae.jpg)

Corrected:
![joomla - administration - control panel 2014-10-21 19-18-17](https://cloud.githubusercontent.com/assets/524491/4723375/2f63bb44-5947-11e4-9dd3-0e01dee599b3.jpg)
