### PR TITLE
[fix] Mail helper is not synced with email validation

### DIFF
--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -127,7 +127,7 @@ abstract class JMailHelper
 		 * The first and last character in local cannot be a period ('.')
 		 * Also, period should not appear 2 or more times consecutively
 		 */
-		$allowed = 'a-zA-Z0-9.!#$%&‚Äô*+\/=?^_`{|}~-';
+		$allowed = 'a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-';
 		$regex = "/^[$allowed][\.$allowed]{0,63}$/";
 
 		if (!preg_match($regex, $local) || substr($local, -1) == '.' || $local[0] == '.' || preg_match('/\.\./', $local))

--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -123,7 +123,7 @@ abstract class JMailHelper
 
 		/*
 		 * Check the local address
-		 * We're a bit more conservative about what constitutes a "legal" address, that is, A-Za-z0-9!#$%&\‚Äô*+/=?^_`{|}~-
+		 * We're a bit more conservative about what constitutes a "legal" address, that is, a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-
 		 * The first and last character in local cannot be a period ('.')
 		 * Also, period should not appear 2 or more times consecutively
 		 */

--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -123,13 +123,14 @@ abstract class JMailHelper
 
 		/*
 		 * Check the local address
-		 * We're a bit more conservative about what constitutes a "legal" address, that is, A-Za-z0-9!#$%&\'*+/=?^_`{|}~-
-		 * Also, the last character in local cannot be a period ('.')
+		 * We're a bit more conservative about what constitutes a "legal" address, that is, A-Za-z0-9!#$%&\‚Äô*+/=?^_`{|}~-
+		 * The first and last character in local cannot be a period ('.')
+		 * Also, period should not appear 2 or more times consecutively
 		 */
-		$allowed = 'A-Za-z0-9!#&*+=?_-';
+		$allowed = 'a-zA-Z0-9.!#$%&‚Äô*+\/=?^_`{|}~-';
 		$regex = "/^[$allowed][\.$allowed]{0,63}$/";
 
-		if (!preg_match($regex, $local) || substr($local, -1) == '.')
+		if (!preg_match($regex, $local) || substr($local, -1) == '.' || $local[0] == '.' || preg_match('/\.\./', $local))
 		{
 			return false;
 		}

--- a/tests/unit/suites/libraries/joomla/mail/JMailHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/mail/JMailHelperTest.php
@@ -271,10 +271,12 @@ class JMailHelperTest extends TestCase
 			array(".joe@bob.com", false),
 			array("joe<>bob@bob.come", false),
 			array("joe&bob@bob.com", true),
-			array("~joe@bob.com", false),
-			array("joe$@bob.com", false),
+			array("~joe@bob.com", true),
+			array("joe..bob@bob.com", false),
+			array("joe$@bob.com", true),
 			array("joe+bob@bob.com", true),
-			array("o'reilly@there.com", false)
+			array("o'reilly@there.com", false),
+			array("o’reilly@there.com", true)
 		);
 	}
 


### PR DESCRIPTION
The local part of an email (text before the "@") may include any of the following characters
( http://www.w3.org/TR/html-markup/input.email.html )
Uppercase and lowercase English letters (a–z, A–Z)
Digits 0 to 9 
These special characters: ! # $ % & ’ \* + - / = ? ^ _ ` { | } ~
Character . (dot, period, full stop) (ASCII: 46) provided that it is not the first or last character, and provided also that it does not appear consecutively (e.g. John..Doe@example.com is not allowed).

After correcting the validation (See https://github.com/joomla/joomla-cms/pull/4894 and https://github.com/joomla/joomla-cms/commit/6ba7987c142e5e859da52a33c5b7f7c62f1d1e64 ), we still could not save an email containing for example any of these in the local part.
`/{|}~-^`
This patch will allow using them. It will also take care of the double dot and dot as first character.
