### PR TITLE
Filter Article View by Extension.

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -84,6 +84,11 @@ class ContentModelArticles extends JModelList
 			$this->context .= '.' . $layout;
 		}
 
+		$extension = $app->getUserStateFromRequest('com_content.articles.filter.extension', 'extension', 'com_content', 'cmd');
+
+		$this->setState('filter.extension', $extension);
+		$parts = explode('.', $extension);
+
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
 		$this->setState('filter.search', $search);
 
@@ -138,6 +143,7 @@ class ContentModelArticles extends JModelList
 	{
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
+		$id .= ':' . $this->getState('filter.extension');
 		$id .= ':' . $this->getState('filter.access');
 		$id .= ':' . $this->getState('filter.published');
 		$id .= ':' . $this->getState('filter.category_id');
@@ -200,6 +206,12 @@ class ContentModelArticles extends JModelList
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_content.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
 				->group('a.id');
+		}
+
+		// Filter by extension
+		if( $extension = $this->getState('filter.extension') )
+		{
+			$query->where('c.extension = ' . $db->quote($extension));
 		}
 
 		// Filter by access level.
@@ -299,7 +311,7 @@ class ContentModelArticles extends JModelList
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
+					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote($extension . '.article')
 				);
 		}
 


### PR DESCRIPTION
The administrator category list view filters by extension, which allows 3rd party extensions to use the #__categories database table.

However the article list view does not filter by extension type. This means that 3rd party extensions using the #__content database table for their content items appear in Joomla's article list. The Front-End code does properly filter by extension which enforces why this is expected behaviour.

The fix I propose copies the exact filtering code used in the com_categories\models\categories.php model. Although I did notice that the categories model didn't filter the #__associations query in getListQuery(); by extension so I have also left this out when copying the logic across to the articles model.
