### PR TITLE
Fix behavior keepalive

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -599,7 +599,7 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		$url = JUri::base(true) . 'index.php?option=com_ajax&format=json';
+		$url = JUri::base(true) . '/index.php?option=com_ajax&format=json';
 
 		$script = 'window.setInterval(function(){';
 		$script .= 'var r;';

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -599,30 +599,18 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		$config = JFactory::getConfig();
-		$lifetime = ($config->get('lifetime') * 60000);
-		$refreshTime = ($lifetime <= 60000) ? 30000 : $lifetime - 60000;
+		$url = JUri::base(true) . 'index.php?option=com_ajax&format=json';
 
-		// Refresh time is 1 minute less than the lifetime assigned in the configuration.php file.
-
-		// The longest refresh period is one hour to prevent integer overflow.
-		if ($refreshTime > 3600000 || $refreshTime <= 0)
-		{
-			$refreshTime = 3600000;
-		}
-
-		$url = JRoute::_("index.php?option=com_ajax&format=json", false);
-
-		$document = JFactory::getDocument();
 		$script = 'window.setInterval(function(){';
 		$script .= 'var r;';
 		$script .= 'try{';
 		$script .= 'r=window.XMLHttpRequest?new XMLHttpRequest():new ActiveXObject("Microsoft.XMLHTTP")';
 		$script .= '}catch(e){}';
 		$script .= 'if(r){r.open("GET","' . $url . '",true);r.send(null)}';
-		$script .= '},' . $refreshTime . ');';
+		$script .= '},60000);';
 
-		$document->addScriptDeclaration($script);
+		JFactory::getDocument()->addScriptDeclaration($script);
+
 		static::$loaded[__METHOD__] = true;
 
 		return;

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -607,7 +607,7 @@ abstract class JHtmlBehavior
 		$script .= 'r=window.XMLHttpRequest?new XMLHttpRequest():new ActiveXObject("Microsoft.XMLHTTP")';
 		$script .= '}catch(e){}';
 		$script .= 'if(r){r.open("GET","' . $url . '",true);r.send(null)}';
-		$script .= '},60000);';
+		$script .= '},45000);';
 
 		JFactory::getDocument()->addScriptDeclaration($script);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -611,13 +611,15 @@ abstract class JHtmlBehavior
 			$refreshTime = 3600000;
 		}
 
+		$url = JRoute::_("index.php?option=com_ajax&format=json", false);
+
 		$document = JFactory::getDocument();
 		$script = 'window.setInterval(function(){';
 		$script .= 'var r;';
 		$script .= 'try{';
 		$script .= 'r=window.XMLHttpRequest?new XMLHttpRequest():new ActiveXObject("Microsoft.XMLHTTP")';
 		$script .= '}catch(e){}';
-		$script .= 'if(r){r.open("GET","./",true);r.send(null)}';
+		$script .= 'if(r){r.open("GET","' . $url . '",true);r.send(null)}';
 		$script .= '},' . $refreshTime . ');';
 
 		$document->addScriptDeclaration($script);

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -633,14 +633,11 @@ class JHtmlBehaviorTest extends TestCase
 		$template = 'mytemplate' . rand(1, 10000);
 
 		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate and getRouter
-		$mock = eval(
-			'class JJApplication_JHtmlBehavior_Keepalive_Stub {' .
-			'public function getTemplate() { return \'' . $template . '\'; }' .
-			'public static function getRouter() { return new JRouter; }' .
-			'}' .
-			'return new JJApplication_JHtmlBehavior_Keepalive_Stub;'
-		);
+		// to return a value from getTemplate
+		$mock = $this->getMock('myMockObject', array('getTemplate'));
+		$mock->expects($this->any())
+			->method('getTemplate')
+			->will($this->returnValue($template));
 
 		// @todo We need to mock this.
 		$mock->input = new JInput;

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -634,13 +634,13 @@ class JHtmlBehaviorTest extends TestCase
 
 		// We create a stub (not a mock because we don't enforce whether it is called or not)
 		// to return a value from getTemplate and getRouter
-		$mock = $this->getMock('myMockObject', array('getTemplate', 'getRouter'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-		$mock->expects($this->any())
-			->method('getRouter')
-			->will($this->returnValue(new JRouter));
+		$mock = eval(
+			'class JJApplication_JHtmlBehavior_Keepalive_Stub {' .
+			'public function getTemplate() { return \'' . $template . '\'; }' .
+			'public static function getRouter() { return new JRouter; }' .
+			'}' .
+			'return new JJApplication_JHtmlBehavior_Keepalive_Stub;'
+		);
 
 		// @todo We need to mock this.
 		$mock->input = new JInput;

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -633,11 +633,14 @@ class JHtmlBehaviorTest extends TestCase
 		$template = 'mytemplate' . rand(1, 10000);
 
 		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
+		// to return a value from getTemplate and getRouter
+		$mock = $this->getMock('myMockObject', array('getTemplate', 'getRouter'));
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+		$mock->expects($this->any())
+			->method('getRouter')
+			->will($this->returnValue(new JRouter));
 
 		// @todo We need to mock this.
 		$mock->input = new JInput;


### PR DESCRIPTION
### I found three issues:

1: In some cases, call an invalid URL, resulting in a response with code 404. (still refresh the session)
2: Update the article hits counter.
3: Work in different ways with "Search Engine Friendly URLs" enabled or disabled.
### How to reproduce number 1
- Enable "Search Engine Friendly URLs"
- Set "Session Lifetime" to 1 (not required but useful to test faster!)
- Create a menu of type "Menu Heading" and call it "heading"
- Create a menu that point to an article and add it as child of "heading"
- Create a Login module and put it some where in the page (add the "behavior.keepalive")
- Use the article menu (you will be redirected to a page with an URL like "www.host.net/index.php/heading/article")
- Wait some "Session Lifetime" minutes and an ajax call to the URL "www.host.net/index.php/heading/" will be executed but ends with a 404 error

The session is refreshed but it isn't nice to generate a 404 error that, for example, ends up in the apache logs.
### How to reproduce number 2
- Set "Session Lifetime" to 1 (not required but useful to test faster!)
- Create a menu that point to an article and set it as default
- Create a Login module and put it some where in the page (add the "behavior.keepalive")
- Go to the homepage of the site, the article will be displayed with a counter hits = C
- Wait some "Session Lifetime" minutes and an ajax call to the homepage will be executed (increasing the hits counter)
- Refresh the page

The counter was increased by 1+X where X is the number of ajax calls.
### How to reproduce number 3
- Disable "Search Engine Friendly URLs"
- Set "Session Lifetime" to 1 (not required but useful to test faster!)
- Create a menu of type "Menu Heading" and call it "heading"
- Create a menu that point to an article and add it as child of "heading"
- Create a Login module and put it some where in the page (add the "behavior.keepalive")
- Use the article menu (you will be redirected to a page with an URL like "www.host.net/index.php?option=com_content&view=article&id=12&Itemid=160")
- Wait some "Session Lifetime" minutes and an ajax call to the URL "www.host.net/" will be executed.

This is the same procedure to reproduce number 1 but ends with a different behavior that, if the homepage display an article, generate the same issue of number 2.
(This because the homepage of the site has been called.)
### Proposed solution

I modified the URL of the ajax call from "./" to:

``` php
JRoute::_("index.php?option=com_ajax&format=json", false)
```

This call refresh the session without generate any html and/or call model methods that can lead to unexpected/unwanted behaviors (for example in an increased article hits counter).
This call is available on both site and administrator applications.

To test it in the administrator application (for example) go to the edit category page that include the "behavior.keepalive" and wait for the ajax call.
