### PR TITLE
Deprecate JObject

### DIFF
--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -15,7 +15,8 @@ defined('JPATH_PLATFORM') or die;
  * This class allows for simple but smart objects with get and set methods
  * and an internal error handler.
  *
- * @since  11.1
+ * @since       11.1
+ * @depreacted  4.0
  */
 class JObject
 {

--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * and an internal error handler.
  *
  * @since       11.1
- * @depreacted  4.0
+ * @deprecated  4.0
  */
 class JObject
 {


### PR DESCRIPTION
JObject is one of the last classes remaining from the PHP 4 era. It has two uses. JError setting (now deprecated) and setting and getting class vars. In the past this allowed us to create our own public and private variables. However now this is happily not the case as PHP5 meant we could set these in the class. For that reason I'd like to mark this class as deprecated.

Just like JError we can't feasibly remove all uses before Joomla 4 in a b/c way. But it points to developers to stop using this class where feasibly possible

Note this PR going through doesn't mean you shouldn't test https://github.com/joomla/joomla-cms/pull/4909 (it's really good to have full unit test coverage as this class is still going to be used in many places in the 3.x series)
