### PR TITLE
Fix "Save as Copy" for article issue

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -147,7 +147,7 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Method to test whether a record can be deleted.
 	 *
-	 * @param   object    $record    A record object.
+	 * @param   object  $record  A record object.
 	 *
 	 * @return  boolean  True if allowed to delete the record. Defaults to the permission set in the component.
 	 *
@@ -205,6 +205,7 @@ class ContentModelArticle extends JModelAdmin
 	 * @param   JTable  $table  A JTable object.
 	 *
 	 * @return  void
+	 *
 	 * @since   1.6
 	 */
 	protected function prepareTable($table)
@@ -311,10 +312,11 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Method to get the record form.
 	 *
-	 * @param   array      $data        Data for the form.
-	 * @param   boolean    $loadData    True if the form is to load its own data (default case), false if not.
+	 * @param   array    $data      Data for the form.
+	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
 	 * @return  mixed  A JForm object on success, false on failure
+	 *
 	 * @since   1.6
 	 */
 	public function getForm($data = array(), $loadData = true)
@@ -341,8 +343,10 @@ class ContentModelArticle extends JModelAdmin
 		if ($this->getState('article.id'))
 		{
 			$id = $this->getState('article.id');
+
 			// Existing record. Can only edit in selected categories.
 			$form->setFieldAttribute('catid', 'action', 'core.edit');
+
 			// Existing record. Can only edit own articles in selected categories.
 			$form->setFieldAttribute('catid', 'action', 'core.edit.own');
 		}
@@ -440,7 +444,7 @@ class ContentModelArticle extends JModelAdmin
 	 */
 	public function save($data)
 	{
-		$app = JFactory::getApplication();
+		$input = JFactory::getApplication()->input;
 
 		if (isset($data['images']) && is_array($data['images']))
 		{
@@ -466,11 +470,23 @@ class ContentModelArticle extends JModelAdmin
 		}
 
 		// Alter the title for save as copy
-		if ($app->input->get('task') == 'save2copy')
+		if ($input->get('task') == 'save2copy')
 		{
-			list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
-			$data['title'] = $title;
-			$data['alias'] = $alias;
+			$origTable = clone $this->getTable();
+			$origTable->load((int) $input->getInt('id'));
+			if ($data['title'] == $origTable->title)
+			{
+				list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
+				$data['title'] = $title;
+				$data['alias'] = $alias;
+			}
+			else
+			{
+				if ($data['alias'] == $origTable->alias)
+				{
+					$data['alias'] = '';
+				}
+			}
 			$data['state'] = 0;
 		}
 
@@ -667,8 +683,8 @@ class ContentModelArticle extends JModelAdmin
 	 *
 	 * Note. Calling getState in this method will result in recursion.
 	 *
-	 * @param   JForm   $form  The form object
-	 * @param   array   $data  The data to be merged into the form object
+	 * @param   JForm   $form   The form object
+	 * @param   array   $data   The data to be merged into the form object
 	 * @param   string  $group  The plugin group to be executed
 	 *
 	 * @return  void


### PR DESCRIPTION
## PR summary

This PR fix the issue #4912 reported by @brianteeman. Basically, when you open an article, change it's title (and maybe alias), then press "Save as Copy" button, the system should create a new article with the new title (and alias) which you entered.

However, at the moment, Joomla simply ignore the change you made before pressing "Save as Copy", it simply append (2) to the title (and alias) of the original article and use it as Title (and alias) of the new article. This is unexpected behavior and this PR fix it.
## How to test
1. Open an existing article
2. Change it's title (and maybe alias)
3. Press "Save as Copy" button. Make sure the system generate new article with the entered title (and alias), instead of appending (2) to the title of the article and use it as title of the new article.
