### PR TITLE
Fix Sorting Joomla! available languages issue

### DIFF
--- a/libraries/joomla/form/fields/language.php
+++ b/libraries/joomla/form/fields/language.php
@@ -45,10 +45,23 @@ class JFormFieldLanguage extends JFormFieldList
 			$client = 'site';
 		}
 
+		// Make sure the languages are sorted base on locale instead of random sorting
+		$languages = JLanguageHelper::createLanguageList($this->value, constant('JPATH_' . strtoupper($client)), true, true);
+		if (count($languages) > 1)
+		{
+			usort(
+				$languages,
+				function ($a, $b)
+				{
+					return strcmp($a["value"], $b["value"]);
+				}
+			);
+		}
+
 		// Merge any additional options in the XML definition.
 		$options = array_merge(
 			parent::getOptions(),
-			JLanguageHelper::createLanguageList($this->value, constant('JPATH_' . strtoupper($client)), true, true)
+			$languages
 		);
 
 		// Set the default value active language


### PR DESCRIPTION
## PR summary

This PR fixes the issue #4907 reported by @brianteeman. Please see https://github.com/joomla/joomla-cms/issues/4907 for details description of the issue, he explained it very well.
## How to test:
1. Make sure your site has more than one language available.
2. Apply this PR
3. Login to back-end of your website, then go to Users -> Users Manager, click on an existing users to edit. Look at Basic Settings tab, there are two params "Backend language" and "Frontend language", please check and make sure the languages displayed in these languages dropdown are sorted by locale.
