### PR TITLE
Missing space in Postgres Update 3.4.0-2014-09-16.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-09-16.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "#__redirect_links" ADD COLUMN "header"INTEGER DEFAULT 301 NOT NULL;
+ALTER TABLE "#__redirect_links" ADD COLUMN "header" INTEGER DEFAULT 301 NOT NULL;
 ALTER TABLE "#__redirect_links" ALTER COLUMN "new_url" DROP NOT NULL;


### PR DESCRIPTION
I added a missing space. Without it you get a sql error message in Extension manager -> Database:
Database query failed (error # %s): %s SQL=ALTER TABLE "n6pbh_redirect_links" ADD COLUMN "header"INTEGER DEFAULT 301 NOT NULL;
