### PR TITLE
Postgres: Install of an additional language fails

### DIFF
--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -263,7 +263,7 @@ class JInstallerAdapterLanguage extends JAdapterInstance
 
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
-		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'client_id' => '', 'folder' => ''));
+		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'folder' => ''));
 
 		if ($uid)
 		{


### PR DESCRIPTION
I installed the current staging branch using postgresql successfully. Afterwards I tried to install an additional language in the backend but it failed with the following message:

0 Database query failed (error # %s): %s SQL=SELECT "update_id" FROM "aehqu_updates" WHERE element = 'de-DE' AND type = 'language' AND client_id = '' AND folder = '' 

After applying this patch the installation went fine. I borrowed the idea from #1695.
