### PR TITLE
batch exec queries instead as each as single query

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -12,8 +12,10 @@ defined('JPATH_PLATFORM') or die;
 /**
  * MySQLi database driver
  *
- * @see    http://php.net/manual/en/book.mysqli.php
- * @since  12.1
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @see         http://php.net/manual/en/book.mysqli.php
+ * @since       12.1
  */
 class JDatabaseDriverMysqli extends JDatabaseDriver
 {
@@ -505,20 +507,14 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Execute the SQL statement.
 	 *
-	 * @return  mixed  A database cursor resource on success, boolean false on failure.
+	 * @return  mixed  A database cursor resource on success.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
 	public function execute()
 	{
-		$this->connect();
-
-		if (!is_object($this->connection))
-		{
-			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
-		}
+		$this->checkConnection();
 
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$query = $this->replacePrefix((string) $this->sql);
@@ -534,25 +530,11 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Reset the error values.
 		$this->errorNum = 0;
 		$this->errorMsg = '';
-		$memoryBefore   = null;
 
 		// If debugging is enabled then let's log the query.
 		if ($this->debug)
 		{
-			// Add the query to the object queue.
-			$this->log[] = $query;
-
-			JLog::add($query, JLog::DEBUG, 'databasequery');
-
-			$this->timings[] = microtime(true);
-
-			if (is_object($this->cursor))
-			{
-				// Avoid warning if result already freed by third-party library
-				@$this->freeResult();
-			}
-
-			$memoryBefore = memory_get_usage();
+			$this->debugQuery($query, 'before');
 		}
 
 		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
@@ -560,22 +542,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 
 		if ($this->debug)
 		{
-			$this->timings[] = microtime(true);
-
-			if (defined('DEBUG_BACKTRACE_IGNORE_ARGS'))
-			{
-				$this->callStacks[] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-			}
-			else
-			{
-				$this->callStacks[] = debug_backtrace();
-			}
-
-			$this->callStacks[count($this->callStacks) - 1][0]['memory'] = array(
-				$memoryBefore,
-				memory_get_usage(),
-				is_object($this->cursor) ? $this->getNumRows() : null
-			);
+			$this->debugQuery($query, 'after');
 		}
 
 		// If an error occurred handle it.
@@ -587,18 +554,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
-				try
-				{
-					// Attempt to reconnect.
-					$this->connection = null;
-					$this->connect();
-				}
-				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
-				{
-					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
-				}
+				$this->reConnect();
 
 				// Since we were able to reconnect, run the query again.
 				return $this->execute();
@@ -609,6 +565,78 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
+		}
+
+		return $this->cursor;
+	}
+
+	/**
+	 * Execute an array of SQL Statements in one go
+	 *
+	 * @param   array  $queries
+	 * @param   bool   $transactionSave
+	 *
+	 * @return  mixed  A database cursor resource on success.
+	 *
+	 * @throws  RuntimeException
+	 */
+	public function executeBatch($queries, $transactionSave = false)
+	{
+		$this->checkConnection();
+
+		$query = $this->replacePrefix((string) implode(';', $queries));
+
+		// Increment the query counter.
+		$this->count++;
+
+		// Reset the error values.
+		$this->errorNum = 0;
+		$this->errorMsg = '';
+
+		// If debugging is enabled then let's log the query.
+		if ($this->debug)
+		{
+			$this->debugQuery($query, 'before');
+		}
+
+		if ($transactionSave)
+		{
+			$this->transactionStart();
+		}
+
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
+		$this->cursor = @mysqli_multi_query($this->connection, $query);
+
+		// If an error occurred handle it.
+		if (!$this->cursor)
+		{
+			$this->errorNum = (int) mysqli_errno($this->connection);
+			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $query;
+
+			// Check if the server was disconnected.
+			if (!$this->connected())
+			{
+				$this->reConnect();
+
+				// Since we were able to reconnect, run the query again.
+				return $this->executeBatch($queries, $transactionSave);
+			}
+			// The server was not disconnected.
+			else
+			{
+				if ($transactionSave)
+				{
+					$this->transactionRollback();
+				}
+
+				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+				throw new RuntimeException($this->errorMsg, $this->errorNum);
+			}
+		}
+
+		if ($transactionSave)
+		{
+			$this->transactionCommit();
 		}
 
 		return $this->cursor;
@@ -864,6 +892,97 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		catch (Exception $e)
 		{
 			return false;
+		}
+	}
+
+	/**
+	 * Check is we have a connection
+	 *
+	 * @return  void
+	 *
+	 * @throws  RuntimeException
+	 */
+	protected function checkConnection()
+	{
+		$this->connect();
+
+		if (!is_object($this->connection))
+		{
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
+		}
+	}
+
+	/**
+	 * Debug a query
+	 *
+	 * @param   string  $query
+	 * @param   string  $when
+	 *
+	 * @return  void
+	 */
+	protected function debugQuery($query, $when='before')
+	{
+		static $memoryBefore = null;
+
+		if ($when == 'before')
+		{
+			// Add the query to the object queue.
+			$this->log[] = $query;
+
+			JLog::add($query, JLog::DEBUG, 'databasequery');
+
+			$this->timings[] = microtime(true);
+
+			if (is_object($this->cursor))
+			{
+				// Avoid warning if result already freed by third-party library
+				@$this->freeResult();
+			}
+
+			$memoryBefore = memory_get_usage();
+		}
+		else
+		{
+			$this->timings[] = microtime(true);
+
+			if (defined('DEBUG_BACKTRACE_IGNORE_ARGS'))
+			{
+				$this->callStacks[] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+			}
+			else
+			{
+				$this->callStacks[] = debug_backtrace();
+			}
+
+			$this->callStacks[count($this->callStacks) - 1][0]['memory'] = array(
+				$memoryBefore,
+				memory_get_usage(),
+				is_object($this->cursor) ? $this->getNumRows() : null
+			);
+		}
+	}
+
+	/**
+	 * Try to reConnect to the database server
+	 *
+	 * @return  void
+	 *
+	 * @throws  RuntimeException
+	 */
+	protected function reConnect()
+	{
+		try
+		{
+			// Attempt to reconnect.
+			$this->connection = null;
+			$this->connect();
+		}
+			// If connect fails, ignore that exception and throw the normal exception.
+		catch (RuntimeException $e)
+		{
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
 		}
 	}
 }

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -12,8 +12,10 @@ defined('JPATH_PLATFORM') or die;
 /**
  * MySQLi database driver
  *
- * @see    http://php.net/manual/en/book.mysqli.php
- * @since  12.1
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @see         http://php.net/manual/en/book.mysqli.php
+ * @since       12.1
  */
 class JDatabaseDriverMysqli extends JDatabaseDriver
 {
@@ -505,20 +507,14 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Execute the SQL statement.
 	 *
-	 * @return  mixed  A database cursor resource on success, boolean false on failure.
+	 * @return  mixed  A database cursor resource on success.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
 	public function execute()
 	{
-		$this->connect();
-
-		if (!is_object($this->connection))
-		{
-			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
-		}
+		$this->checkConnection();
 
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$query = $this->replacePrefix((string) $this->sql);
@@ -534,25 +530,11 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Reset the error values.
 		$this->errorNum = 0;
 		$this->errorMsg = '';
-		$memoryBefore   = null;
 
 		// If debugging is enabled then let's log the query.
 		if ($this->debug)
 		{
-			// Add the query to the object queue.
-			$this->log[] = $query;
-
-			JLog::add($query, JLog::DEBUG, 'databasequery');
-
-			$this->timings[] = microtime(true);
-
-			if (is_object($this->cursor))
-			{
-				// Avoid warning if result already freed by third-party library
-				@$this->freeResult();
-			}
-
-			$memoryBefore = memory_get_usage();
+			$this->debugQuery($query, 'before');
 		}
 
 		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
@@ -560,22 +542,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 
 		if ($this->debug)
 		{
-			$this->timings[] = microtime(true);
-
-			if (defined('DEBUG_BACKTRACE_IGNORE_ARGS'))
-			{
-				$this->callStacks[] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-			}
-			else
-			{
-				$this->callStacks[] = debug_backtrace();
-			}
-
-			$this->callStacks[count($this->callStacks) - 1][0]['memory'] = array(
-				$memoryBefore,
-				memory_get_usage(),
-				is_object($this->cursor) ? $this->getNumRows() : null
-			);
+			$this->debugQuery($query, 'after');
 		}
 
 		// If an error occurred handle it.
@@ -587,18 +554,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
-				try
-				{
-					// Attempt to reconnect.
-					$this->connection = null;
-					$this->connect();
-				}
-				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
-				{
-					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
-				}
+				$this->reConnect();
 
 				// Since we were able to reconnect, run the query again.
 				return $this->execute();
@@ -609,6 +565,77 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
+		}
+
+		return $this->cursor;
+	}
+
+	/**
+	 * Execute an array of SQL Statements in one go
+	 *
+	 * @param      $queries
+	 * @param bool $transactionSave
+	 *
+	 * @return  mixed  A database cursor resource on success.
+	 * @throws  RuntimeException
+	 */
+	public function executeBatch($queries, $transactionSave = false)
+	{
+		$this->checkConnection();
+
+		$query = $this->replacePrefix((string) implode(';', $queries));
+
+		// Increment the query counter.
+		$this->count++;
+
+		// Reset the error values.
+		$this->errorNum = 0;
+		$this->errorMsg = '';
+
+		// If debugging is enabled then let's log the query.
+		if ($this->debug)
+		{
+			$this->debugQuery($query, 'before');
+		}
+
+		if ($transactionSave)
+		{
+			$this->transactionStart();
+		}
+
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
+		$this->cursor = @mysqli_multi_query($this->connection, $query);
+
+		// If an error occurred handle it.
+		if (!$this->cursor)
+		{
+			$this->errorNum = (int) mysqli_errno($this->connection);
+			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $query;
+
+			// Check if the server was disconnected.
+			if (!$this->connected())
+			{
+				$this->reConnect();
+
+				// Since we were able to reconnect, run the query again.
+				return $this->executeBatch($queries, $transactionSave);
+			}
+			// The server was not disconnected.
+			else
+			{
+				if ($transactionSave)
+				{
+					$this->transactionRollback();
+				}
+
+				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+				throw new RuntimeException($this->errorMsg, $this->errorNum);
+			}
+		}
+
+		if ($transactionSave)
+		{
+			$this->transactionCommit();
 		}
 
 		return $this->cursor;
@@ -864,6 +891,94 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		catch (Exception $e)
 		{
 			return false;
+		}
+	}
+
+	/**
+	 * Check is we have a connection
+	 *
+	 * @return  void
+	 * @throws  RuntimeException
+	 */
+	protected function checkConnection()
+	{
+		$this->connect();
+
+		if (!is_object($this->connection))
+		{
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
+		}
+	}
+
+	/**
+	 * Debug a query
+	 *
+	 * @param        $query
+	 * @param string $when
+	 *
+	 * @return  void
+	 */
+	protected function debugQuery($query, $when='before')
+	{
+		static $memoryBefore = null;
+
+		if ($when == 'before')
+		{
+			// Add the query to the object queue.
+			$this->log[] = $query;
+
+			JLog::add($query, JLog::DEBUG, 'databasequery');
+
+			$this->timings[] = microtime(true);
+
+			if (is_object($this->cursor)) {
+				// Avoid warning if result already freed by third-party library
+				@$this->freeResult();
+			}
+
+			$memoryBefore = memory_get_usage();
+		}
+		else
+		{
+			$this->timings[] = microtime(true);
+
+			if (defined('DEBUG_BACKTRACE_IGNORE_ARGS'))
+			{
+				$this->callStacks[] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+			}
+			else
+			{
+				$this->callStacks[] = debug_backtrace();
+			}
+
+			$this->callStacks[count($this->callStacks) - 1][0]['memory'] = array(
+				$memoryBefore,
+				memory_get_usage(),
+				is_object($this->cursor) ? $this->getNumRows() : null
+			);
+		}
+	}
+
+	/**
+	 * Try to reConnect to the database server
+	 *
+	 * @return  void
+	 * @throws  RuntimeException
+	 */
+	protected function reConnect()
+	{
+		try
+		{
+			// Attempt to reconnect.
+			$this->connection = null;
+			$this->connect();
+		}
+			// If connect fails, ignore that exception and throw the normal exception.
+		catch (RuntimeException $e)
+		{
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
 		}
 	}
 }

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -573,8 +573,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Execute an array of SQL Statements in one go
 	 *
-	 * @param   array  $queries
-	 * @param   bool   $transactionSave
+	 * @param   array  $queries          an array of queries
+	 * @param   bool   $transactionSave  if true lets run the queries in a transaction if possible
 	 *
 	 * @return  mixed  A database cursor resource on success.
 	 *
@@ -916,8 +916,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Debug a query
 	 *
-	 * @param   string  $query
-	 * @param   string  $when
+	 * @param   string  $query  the query string
+	 * @param   string  $when   are we before or after we have executed the query
 	 *
 	 * @return  void
 	 */

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -16,9 +16,11 @@ jimport('joomla.filesystem.path');
  *
  * Parent class to all tables.
  *
- * @link   http://docs.joomla.org/JTable
- * @since  11.1
- * @tutorial  Joomla.Platform/jtable.cls
+ * @package     Joomla.Platform
+ * @subpackage  Table
+ * @link        http://docs.joomla.org/JTable
+ * @since       11.1
+ * @tutorial	Joomla.Platform/jtable.cls
  */
 abstract class JTable extends JObject implements JObservableInterface, JTableInterface
 {
@@ -1378,6 +1380,10 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
+		$queries = [];
+
+		// check if we can execute the query as batch
+		$batchExecute = method_exists($this->_db, 'executeBatch');
 
 		// Compact the ordering values.
 		foreach ($rows as $i => $row)
@@ -1393,10 +1399,25 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 						->update($this->_tbl)
 						->set('ordering = ' . ($i + 1));
 					$this->appendPrimaryKeys($query, $row);
-					$this->_db->setQuery($query);
-					$this->_db->execute();
+					if ($batchExecute)
+					{
+						// put the query into an array to execute it later in one transaction
+						$queries[] = $query;
+					}
+					else
+					{
+						// execute the query now, bad performance if we need to reorder a lot of items
+						$this->_db->setQuery($query);
+						$this->_db->execute();
+					}
 				}
 			}
+		}
+
+		// if we have a not empty array we can execute it in a batch
+		if (!empty($queries))
+		{
+			$this->_db->executeBatch($queries);
 		}
 
 		return true;


### PR DESCRIPTION
The reodering in the JTable executes any reordering statement as a single query. If you have a lot of articles in one category it can easily add hunderts of query this results in a large response time and can be result in timeouts.

This is hard to find out, because of the redirect after a save the debug shows only the executed queries from the last request and not from the save request.

This patch implements for the mysqli DB driver a executeBatch command that can handle an array of queries, concats the queries and execute it with the  mysqli_multi_query function. This is significant faster, I had on my local env. 1:15 before and 0:02 after the patch. (just watch the videos)

I also did some refactoring because if I did not I had to duplicate code. I don't think there are BC issues because I implemented a new function instead of extending the execute function. I think that is more save because in this area the test coverage is not so good.
# How to test this:

I have made a database backup, because you need a DB with 3000 Articles in one single category to see an effect in a local env. If you are on a shared hosting env. you can run into troubles with much less articles. I have seen that in a database von 300 articles in one category. So you can use my DB backup and them simply try to save an article in the category "Overload 1", it might be take some time, so if you timeouts on a low lover you will probably not seeing the result page, try to set "max_execution_time = 240" or zero and make sure you memory_limit is high enough. If you have done that just wait, grab a coffee or watch a star trek episode. 

Then add the patch and do it again you should see that there is a significant difference.

Here are the link to the files you might need to test or view what happened.

https://dl.dropboxusercontent.com/u/959364/dbExecuteBatch.sql.zip
https://dl.dropboxusercontent.com/u/959364/beforepatch.mp4
https://dl.dropboxusercontent.com/u/959364/afterpatch.mp4
