### PR TITLE
Removing conditional if statement for hiding alias on external URL menu items

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -88,12 +88,6 @@ JFactory::getDocument()->addScriptDeclaration($script);
 
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
-	<?php
-	if ($this->item->type == 'url')
-	{
-		$this->form->setFieldAttribute('alias', 'type', 'hidden');
-	}
-	?>
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div class="form-horizontal">


### PR DESCRIPTION
#### Steps to reproduce the issue

Create a menu structure as below:
Menu item 1 (featured article) with alias of 12345
- Menu item 2 (article) with alias of menu-item-1

Enable SEF URL's using htaccess to rewrite.

Check the structure of the main menu item and the menu item beneath - Menu item 2 will have a SEF path of /12345/menu-item-1.

Now change Menu item 1 to be an external URL with the link field containing #, as an example.  The path should remain the same (don't change the alias field).

An SEO person tells you that 12345 isn't a great alias to use in your menu structure, and suggests that it be changed (and of course that the URLs redirected!), but when you try to edit the menu item (which is now an external URL) there is no alias field present to be edited.
#### Expected result

It would be expected that, as this field is being used in SEF URL generation, that it could be edited.  I think perhaps the logic was that if you're using an external URL then you wouldn't need an alias, but when it's used in a menu system, it needs to be configurable - especially as historically many folk used an external URL pointing at # to be a top-level non-clickable item.
#### Actual result

The alias field is not visible, and can't be edited unless you change the item type, edit the alias, then change it back.
#### System information (as much as possible)

Joomla 3
#### Additional comments

While it's not generally a sensible thing to do changing aliases of menu items due to the fact that it impacts on all URLs beneath, and I appreciate the logic that most folk using an external URL won't need to have an alias, there are occasions where this needs to be edited.  Often these will have randomly generated aliases which need to be optimised and it's a real pain to have to change the item type just to edit the alias.
