### PR TITLE
Removed redundant code after ternary conditional

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -61,7 +61,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			if ($app->isSite())
 			{
 				// Setup language data.
-				self::$mode_sef 	= ($router->getMode() == JROUTER_MODE_SEF) ? true : false;
+				self::$mode_sef 	= $router->getMode() == JROUTER_MODE_SEF;
 				self::$sefs 		= JLanguageHelper::getLanguages('sef');
 				self::$lang_codes 	= JLanguageHelper::getLanguages('lang_code');
 				self::$default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');


### PR DESCRIPTION
Simple code clean-up. This shouldn't impact Joomla's behaviour in any way.

Code removed was redundant, as the operator already returns either `true` or `false`.
