### PR TITLE
Fix postgres when installing language content in the installer

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -599,7 +599,8 @@ class InstallationModelLanguages extends JModelBase
 				. '"module_tag":"div","bootstrap_size":"0","header_tag":"h3","header_class":"","style":"0"}',
 			'client_id' => 0,
 			'language'  => '*',
-			'published' => 1
+			'published' => 1,
+			'rules'     => array()
 		);
 
 		// Bind the data.


### PR DESCRIPTION
Download staging and install no sample data and navigate through the install an extra language section. Choose to install some sample data.

In postgres you will not be able to proceed beyond this step. Apply the patch. You can check that this bug is fixed by looking at the DB errors in `pg_log` (postgres error log file) and seeing that the old error was related to a missing rules field and now the error is that there is a duplicate primary key. Note I'm still experiencing other bugs at this stage which still stops you from proceeding at this stage because something weird is happening in the serial fields. I will provide a separate PR for that issue when I can work out what's going on there.

In mysql the procedure should work before and after you apply the patch. 
