### PR TITLE
Set proper autoincrement values for PostgreSQL

### DIFF
--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -83,6 +83,8 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (52, 18, 66, 67, 2, 'com_modules.module.79', 'Multilanguage status', '{"core.delete":[],"core.edit":[],"core.edit.state":[]}'),
 (53, 18, 68, 69, 2, 'com_modules.module.86', 'Joomla Version', '{"core.delete":[],"core.edit":[],"core.edit.state":[]}');
 
+SELECT setval('#__assets_id_seq', 54, false);
+
 --
 -- Table: #__associations
 --
@@ -238,6 +240,8 @@ INSERT INTO "#__categories" ("id", "asset_id", "parent_id", "lft", "rgt", "level
 (5, 30, 1, 7, 8, 1, 'uncategorised', 'com_newsfeeds', 'Uncategorised', 'uncategorised', '', '', 1, 0, '1970-01-01 00:00:00', 1, '{"category_layout":"","image":""}', '', '', '{"author":"","robots":""}', 42, '2011-01-01 00:00:01', 0, '1970-01-01 00:00:00', 0, '*', 1),
 (6, 31, 1, 9, 10, 1, 'uncategorised', 'com_weblinks', 'Uncategorised', 'uncategorised', '', '', 1, 0, '1970-01-01 00:00:00', 1, '{"category_layout":"","image":""}', '', '', '{"author":"","robots":""}', 42, '2011-01-01 00:00:01', 0, '1970-01-01 00:00:00', 0, '*', 1),
 (7, 32, 1, 11, 12, 1, 'uncategorised', 'com_users', 'Uncategorised', 'uncategorised', '', '', 1, 0, '1970-01-01 00:00:00', 1, '{"category_layout":"","image":""}', '', '', '{"author":"","robots":""}', 42, '2011-01-01 00:00:01', 0, '1970-01-01 00:00:00', 0, '*', 1);
+
+SELECT setval('#__categories_id_seq', 8, false);
 
 --
 -- Table: #__contact_details
@@ -408,7 +412,6 @@ INSERT INTO "#__content_types" ("type_id", "type_title", "type_alias", "table", 
 (14, 'User Notes', 'com_users.note', '{"special":{"dbtable":"#__user_notes","key":"id","type":"Note","prefix":"UsersTable"}}', '', '', '', '{"formFile":"administrator\\/components\\/com_users\\/models\\/forms\\/note.xml", "hideFields":["checked_out","checked_out_time", "publish_up", "publish_down"],"ignoreChanges":["modified_user_id", "modified_time", "checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"],"displayLookup":[{"sourceColumn":"catid","targetTable":"#__categories","targetColumn":"id","displayColumn":"title"}, {"sourceColumn":"created_user_id","targetTable":"#__users","targetColumn":"id","displayColumn":"name"}, {"sourceColumn":"user_id","targetTable":"#__users","targetColumn":"id","displayColumn":"name"}, {"sourceColumn":"modified_user_id","targetTable":"#__users","targetColumn":"id","displayColumn":"name"}]}'),
 (15, 'User Notes Category', 'com_users.category', '{"special":{"dbtable":"#__categories","key":"id","type":"Category","prefix":"JTable","config":"array()"},"common":{"dbtable":"#__ucm_content","key":"ucm_id","type":"Corecontent","prefix":"JTable","config":"array()"}}', '', '{"common":{"core_content_item_id":"id","core_title":"title","core_state":"published","core_alias":"alias","core_created_time":"created_time","core_modified_time":"modified_time","core_body":"description", "core_hits":"hits","core_publish_up":"null","core_publish_down":"null","core_access":"access", "core_params":"params", "core_featured":"null", "core_metadata":"metadata", "core_language":"language", "core_images":"null", "core_urls":"null", "core_version":"version", "core_ordering":"null", "core_metakey":"metakey", "core_metadesc":"metadesc", "core_catid":"parent_id", "core_xreference":"null", "asset_id":"asset_id"}, "special":{"parent_id":"parent_id","lft":"lft","rgt":"rgt","level":"level","path":"path","extension":"extension","note":"note"}}', '', '{"formFile":"administrator\\/components\\/com_categories\\/models\\/forms\\/category.xml", "hideFields":["checked_out","checked_out_time","version","lft","rgt","level","path","extension"], "ignoreChanges":["modified_user_id", "modified_time", "checked_out", "checked_out_time", "version", "hits", "path"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"created_user_id","targetTable":"#__users","targetColumn":"id","displayColumn":"name"}, {"sourceColumn":"access","targetTable":"#__viewlevels","targetColumn":"id","displayColumn":"title"},{"sourceColumn":"modified_user_id","targetTable":"#__users","targetColumn":"id","displayColumn":"name"},{"sourceColumn":"parent_id","targetTable":"#__categories","targetColumn":"id","displayColumn":"title"}]}');
 
-SELECT nextval('#__content_types_type_id_seq');
 SELECT setval('#__content_types_type_id_seq', 10000, false);
 
 --
@@ -634,7 +637,6 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
-SELECT nextval('#__extensions_extension_id_seq');
 SELECT setval('#__extensions_extension_id_seq', 10000, false);
 
 --
@@ -906,6 +908,8 @@ CREATE INDEX "#__finder_taxonomy_idx_parent_published" on "#__finder_taxonomy" (
 INSERT INTO "#__finder_taxonomy" ("id", "parent_id", "title", "state", "access", "ordering") VALUES
 (1, 0, 'ROOT', 0, 0, 0);
 
+SELECT setval('#__finder_taxonomy_id_seq', 2, false);
+
 --
 -- Table: #__finder_taxonomy_map
 --
@@ -1144,6 +1148,8 @@ CREATE INDEX "#__languages_idx_access" ON "#__languages" ("access");
 INSERT INTO "#__languages" ("lang_id", "lang_code", "title", "title_native", "sef", "image", "description", "metakey", "metadesc", "sitename", "published", "access", "ordering") VALUES
 (1, 'en-GB', 'English (UK)', 'English (UK)', 'en', 'en', '', '', '', '', 1, 1, 1);
 
+SELECT setval('#__languages_lang_id_seq', 2, false);
+
 --
 -- Table: #__menu
 --
@@ -1232,7 +1238,6 @@ INSERT INTO "#__menu" ("id", "menutype", "title", "alias", "note", "path", "link
 (24, 'main', 'com_postinstall', 'Post-installation messages', '', 'Post-installation messages', 'index.php?option=com_postinstall', 'component', 0, 1, 1, 32, 0, '1970-01-01 00:00:00', 0, 1, 'class:postinstall', 0, '', 45, 46, 0, '*', 1),
 (101, 'mainmenu', 'Home', 'home', '', 'home', 'index.php?option=com_content&view=featured', 'component', 1, 1, 1, 22, 0, '1970-01-01 00:00:00', 0, 1, '', 0, '{"featured_categories":[""],"layout_type":"blog","num_leading_articles":"1","num_intro_articles":"3","num_columns":"3","num_links":"0","multi_column_order":"1","orderby_pri":"","orderby_sec":"front","order_date":"","show_pagination":"2","show_pagination_results":"1","show_title":"","link_titles":"","show_intro":"","info_block_position":"","show_category":"","link_category":"","show_parent_category":"","link_parent_category":"","show_author":"","link_author":"","show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","show_noauth":"","show_feed_link":"1","feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_text":1,"page_title":"","show_page_heading":1,"page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}', 47, 48, 1, '*', 0);
 
-SELECT nextval('#__menu_id_seq');
 SELECT setval('#__menu_id_seq', 102, false);
 
 --
@@ -1252,6 +1257,8 @@ CREATE TABLE "#__menu_types" (
 --
 INSERT INTO "#__menu_types" ("id", "menutype", "title", "description") VALUES
 (1, 'mainmenu', 'Main Menu', 'The main menu for the site');
+
+SELECT setval('#__menu_types_id_seq', 2, false);
 
 --
 -- Table: #__messages
@@ -1328,7 +1335,6 @@ INSERT INTO "#__modules" ("id", "asset_id", "title", "note", "content", "orderin
 (79, 52, 'Multilanguage status', '', '', 1, 'status', 0, '1970-01-01 00:00:00', '1970-01-01 00:00:00', '1970-01-01 00:00:00', 0, 'mod_multilangstatus', 3, 1, '{"layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*'),
 (86, 53, 'Joomla Version', '', '', 1, 'footer', 0, '1970-01-01 00:00:00', '1970-01-01 00:00:00', '1970-01-01 00:00:00', 1, 'mod_version', 3, 1, '{"format":"short","product":"1","layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*');
 
-SELECT nextval('#__modules_id_seq');
 SELECT setval('#__modules_id_seq', 87, false);
 
 --
@@ -1553,6 +1559,8 @@ CREATE INDEX "#__tags_idx_language" ON "#__tags" ("language");
 INSERT INTO "#__tags" ("id", "parent_id", "lft", "rgt", "level", "path", "title", "alias", "note", "description", "published", "checked_out", "checked_out_time", "access", "params", "metadesc", "metakey", "metadata", "created_user_id", "created_time", "created_by_alias", "modified_user_id", "modified_time", "images", "urls", "hits", "language", "version") VALUES
 (1, 0, 0, 1, 0, '', 'ROOT', 'root', '', '', 1, 0, '1970-01-01 00:00:00', 1, '', '', '', '', 42, '2011-01-01 00:00:01', '', 0, '1970-01-01 00:00:00', '', '',  0, '*', 1);
 
+SELECT setval('#__tags_id_seq', 2, false);
+
 --
 -- Table: #__template_styles
 --
@@ -1578,7 +1586,6 @@ INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title"
 (7, 'protostar', 0, '1', 'protostar - Default', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}'),
 (8, 'isis', 1, '1', 'isis - Default', '{"templateColor":"","logoFile":""}');
 
-SELECT nextval('#__template_styles_id_seq');
 SELECT setval('#__template_styles_id_seq', 9, false);
 
 --
@@ -1720,6 +1727,8 @@ INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "en
 (3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
 (4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
+SELECT setval('#__update_sites_update_site_id_seq', 5, false);
+
 --
 -- Table: #__update_sites_extensions
 --
@@ -1739,13 +1748,6 @@ INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALU
 (2, 700),
 (3, 600),
 (4, 28);
-
---
--- Postgressql use the sequence instead of autoincrement,
--- So, need to tell what is the last value of the sequnce after the 4
---
-SELECT nextval('#__update_sites_update_site_id_seq');
-SELECT setval('#__update_sites_update_site_id_seq', 5, false);
 
 --
 -- Table: #__usergroups
@@ -1781,6 +1783,8 @@ INSERT INTO "#__usergroups" ("id", "parent_id", "lft", "rgt", "title") VALUES
 (7, 6, 5, 6, 'Administrator'),
 (8, 1, 16, 17, 'Super Users'),
 (9, 1, 2, 3, 'Guest');
+
+SELECT setval('#__usergroups_id_seq', 10, false);
 
 --
 -- Table: #__user_usergroup_map
@@ -1905,7 +1909,6 @@ INSERT INTO "#__viewlevels" ("id", "title", "ordering", "rules") VALUES
 (5, 'Guest', 0, '[9]'),
 (6, 'Super Users', 0, '[8]');
 
-SELECT nextval('#__viewlevels_id_seq');
 SELECT setval('#__viewlevels_id_seq', 7, false);
 
 --


### PR DESCRIPTION
### Issue

Install Joomla (current staging) on PostgreSQL without Sample Data.
Try to create a module. It will fail with an error message related to the assets id.
### Reason

During installation, we insert data together with a fixed ID into various tables. In PostgreSQL you need to adjust the sequence number (= autoincrement value) after you manually inserted an ID.
We did that for some tables but not for all. The #__assets one was missing for example.
### Solution

This PR adds the queries to set the next sequence value for those tables that have a serial ID and after we manually inserted IDs.
It also removes some unneeded `nextval` (which only increments the sequence number) and one `setval` (because there is no serial ID in that table).
#### Testing

Make sure you can create modules, categories and the like.
