### PR TITLE
Language Filter Warning: issue #4079

### DIFF
--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -19,7 +19,7 @@ abstract class MultilangstatusHelper
 	/**
 	 * Method to get the number of published home pages.
 	 *
-	 * @return  integer 
+	 * @return  integer
 	 */
 	public static function getHomes()
 	{
@@ -105,6 +105,7 @@ abstract class MultilangstatusHelper
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select('language')
+			->select('id')
 			->from($db->quoteName('#__menu'))
 			->where('home = 1')
 			->where('published = 1')

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -30,6 +30,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 	protected static $homes;
 
+	protected static $homepages;
+
 	protected static $default_lang;
 
 	protected static $default_sef;
@@ -67,6 +69,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				self::$default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 				self::$default_sef 	= self::$lang_codes[self::$default_lang]->sef;
 				self::$homes		= MultilangstatusHelper::getHomes();
+				self::$homepages	= MultilangstatusHelper::getHomepages();
 
 				$user = JFactory::getUser();
 				$levels = $user->getAuthorisedViewLevels();
@@ -530,7 +533,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 				else
 				{
-					$itemid = isset(self::$homes[$lang_code]) ? self::$homes[$lang_code]->id : self::$homes['*']->id;
+					$itemid = isset(self::$homepages[$lang_code]) ? self::$homepages[$lang_code]->id : self::$homepages['*']->id;
 					$app->setUserState('users.login.form.return', 'index.php?&Itemid=' . $itemid);
 				}
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -30,8 +30,6 @@ class PlgSystemLanguageFilter extends JPlugin
 
 	protected static $homes;
 
-	protected static $homepages;
-
 	protected static $default_lang;
 
 	protected static $default_sef;
@@ -68,8 +66,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				self::$lang_codes 	= JLanguageHelper::getLanguages('lang_code');
 				self::$default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 				self::$default_sef 	= self::$lang_codes[self::$default_lang]->sef;
-				self::$homes		= MultilangstatusHelper::getHomes();
-				self::$homepages	= MultilangstatusHelper::getHomepages();
+				self::$homes		= MultilangstatusHelper::getHomepages();
 
 				$user = JFactory::getUser();
 				$levels = $user->getAuthorisedViewLevels();
@@ -533,7 +530,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 				else
 				{
-					$itemid = isset(self::$homepages[$lang_code]) ? self::$homepages[$lang_code]->id : self::$homepages['*']->id;
+					$itemid = isset(self::$homes[$lang_code]) ? self::$homes[$lang_code]->id : self::$homes['*']->id;
 					$app->setUserState('users.login.form.return', 'index.php?&Itemid=' . $itemid);
 				}
 			}


### PR DESCRIPTION
Create a multilanguage site.
Set the languagefilter to
1. Items Associations: No
2. Use Automatic Language Change: Yes
3. Set a frontend registered user to use a specific language in frontend
4. Display the site in another language
5. Login with the user

before patch you will get (see #4079 ) "PHP Warning: Illegal string offset '*' etc.)

Patch and test again
