### PR TITLE
Respect layout parameter in administrator custom module

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.php
+++ b/administrator/modules/mod_custom/mod_custom.php
@@ -18,4 +18,4 @@ if ($params->def('prepare_content', 1))
 // Replace 'images/' to '../images/' when using an image from /images in backend.
 $module->content = preg_replace('*src\=\"(?!administrator\/)images/*', 'src="../images/', $module->content);
 
-require JModuleHelper::getLayoutPath('mod_custom');
+require JModuleHelper::getLayoutPath('mod_custom', $params->get('layout', 'default'));


### PR DESCRIPTION
### Steps to reproduce the issue

Create custom layout in /administrator/templates/isis/html/mod_custom/
Create new Custom HTML module and select this layout
-> Alternative layout is ignored.
