### PR TITLE
Fake password autocomplete

### DIFF
--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -25,6 +25,13 @@ JHtml::_('formbehavior.chosen', 'select');
 </script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
+	
+	<!-- fake password autofill -->
+	<div class="hidden">
+		<input name="fake-username" type="text">
+		<input name="fake-password" type="password">
+	</div>	
+	
 	<div class="row-fluid">
 		<!-- Begin Sidebar -->
 		<div id="sidebar" class="span2">


### PR DESCRIPTION
Stop administrator user username and password to be stored in Joomla FTP or SMTP fields in global configuration.

Prevent browsers autofill username and password where they should not, just by adding a "fake" fields in the beginning of the form as discussed here:

https://groups.google.com/forum/#!topic/joomla-dev-cms/yGIHq7g__uU

Cheers
