### PR TITLE
Fake password autofill

### DIFF
--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -47,6 +47,12 @@ $fieldsets = $this->form->getFieldsets();
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" class="form-validate form-horizontal" enctype="multipart/form-data">
 
+	<!-- fake password autofill -->
+	<div class="hidden">
+		<input name="fake-username" type="text">
+		<input name="fake-password" type="password">
+	</div>
+	
 	<?php echo JLayoutHelper::render('joomla.edit.item_title', $this); ?>
 
 	<fieldset>


### PR DESCRIPTION
Stop administrator user password to be filled when editing a user.

Prevent browsers autofill username and password where they should not, just by adding a "fake" fields in the beginning of the form as discussed here:

https://groups.google.com/forum/#!topic/joomla-dev-cms/yGIHq7g__uU

This PR is related with this other that I have also submitted:

https://github.com/joomla/joomla-cms/pull/4952

All forms with password fields should be faked like this as modern browsers are not going to provide a different way to prevent autofill as discussed.

Regards
