### PR TITLE
Change order Buttons in Article Manager: Articles

### DIFF
--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -107,9 +107,6 @@ class ContentViewArticles extends JViewLegacy
 		{
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('articles.unpublish', 'JTOOLBAR_UNPUBLISH', true);
-			JToolbarHelper::custom('articles.featured', 'featured.png', 'featured_f2.png', 'JFEATURED', true);
-			JToolbarHelper::archiveList('articles.archive');
-			JToolbarHelper::checkin('articles.checkin');
 		}
 
 		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
@@ -119,6 +116,13 @@ class ContentViewArticles extends JViewLegacy
 		elseif ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::trash('articles.trash');
+		}
+
+		if ($canDo->get('core.edit.state'))
+		{
+			JToolbarHelper::checkin('articles.checkin');
+			JToolbarHelper::archiveList('articles.archive');
+			JToolbarHelper::custom('articles.featured', 'featured.png', 'featured_f2.png', 'JFEATURED', true);
 		}
 
 		// Add a batch button


### PR DESCRIPTION
Patch 1 to solve inconsistency in order of admin "edit" etc buttons issue #4963

Change order from
Article Manager: Articles
New Edit Publish Unpublish Featured Archive Check In Trash Batch

to
Article Manager: Articles
New Edit Publish Unpublish Trash Check In Archive Featured Batch
