### PR TITLE
Change order Buttons in Menu Manager: Menu Items

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -247,11 +247,6 @@ class MenusViewItems extends JViewLegacy
 			JToolbarHelper::unpublish('items.unpublish', 'JTOOLBAR_UNPUBLISH', true);
 		}
 
-		if (JFactory::getUser()->authorise('core.admin'))
-		{
-			JToolbarHelper::checkin('items.checkin', 'JTOOLBAR_CHECKIN', true);
-		}
-
 		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			JToolbarHelper::deleteList('', 'items.delete', 'JTOOLBAR_EMPTY_TRASH');
@@ -259,6 +254,11 @@ class MenusViewItems extends JViewLegacy
 		elseif ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::trash('items.trash');
+		}
+
+		if (JFactory::getUser()->authorise('core.admin'))
+		{
+			JToolbarHelper::checkin('items.checkin', 'JTOOLBAR_CHECKIN', true);
 		}
 
 		if ($canDo->get('core.edit.state'))


### PR DESCRIPTION
Patch 4 to solve inconsistency in order of admin "edit" etc buttons issue #4963

Change order from
Menu Manager: Menu Items
New Edit Publish Unpublish Check In Trash Home Rebuild Batch

to
Menu Manager: Menu Items
New Edit Publish Unpublish Trash Check In Home Rebuild Batch
