### PR TITLE
Fixed "TypeError: $(...).ready is not a function" when loading a Google Map with jQuery

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -614,7 +614,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 			break;
 
 			case 'jquery':
-			$output .= "$(document).ready({$onload});";
+			$output .= "jQuery(document).ready({$onload});";
 			break;
 
 			case 'mootools':

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -616,7 +616,7 @@ class JGoogleEmbedMapsTest extends TestCase
 
 		$this->object->setAutoload('jquery');
 		$header = $this->object->getHeader();
-		$this->assertContains('$(document).ready(', $header);
+		$this->assertContains('jQuery(document).ready(', $header);
 
 		$this->object->setAutoload('mootools');
 		$header = $this->object->getHeader();


### PR DESCRIPTION
Fixed "TypeError: $(...).ready is not a function" when loading a Google Map with jQuery

To test:

``` php
jimport('jquery.framework');
$options = new JRegistry;
$options->set('autoload', 'jquery');

$google = new JGoogle($options);
$map = $google->embed('Maps');

$map->setCenter(array(48.1415102, 11.548463), 'Test');

$map->echoHeader();
$map->echoBody();
```

Before patch: you get the javascript error in the Console
After: map should be shown
