### PR TITLE
Postgres multilang install fixes

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1034,7 +1034,7 @@ class InstallationModelLanguages extends JModelBase
 			'parent_id'    => 1
 		);
 
-		// Set the level of the category
+		// Set the location in the tree.
 		$category->setLocation(1, 'last-child');
 
 		// Bind the data to the table

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1030,13 +1030,12 @@ class InstallationModelLanguages extends JModelBase
 			'metadata'     => '{"page_title":"","author":"","robots":""}',
 			'created_time' => JFactory::getDate()->toSql(),
 			'language'     => $itemLanguage->language,
-			'rules'        => array()
+			'rules'        => array(),
+			'parent_id'    => 1
 		);
 
-		// Using $category->setLocation(1, 'last-child'); would be ideal here but doesn't seem to work in postgres
-		// as we're in install and 'know' the structure we'll just manually set it to be a child of the root category.
-		$data['parent_id'] = 1;
-		$data['level']     = 1;
+		// Set the level of the category
+		$category->setLocation(1, 'last-child');
 
 		// Bind the data to the table
 		if (!$category->bind($data))

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -733,7 +733,10 @@ class InstallationModelLanguages extends JModelBase
 			'sef'          => $sefLangString,
 			'image'        => $flag,
 			'published'    => 1,
-			'ordering'     => 0
+			'ordering'     => 0,
+			'description'  => '',
+			'metakey'      => '',
+			'metadesc'     => ''
 		);
 
 		// Bind the data.
@@ -910,7 +913,8 @@ class InstallationModelLanguages extends JModelBase
 				. '"layout":"","moduleclass_sfx":"_menu","cache":"1","cache_time":"900","cachemode":"itemid"}',
 			'client_id' => 0,
 			'language'  => $itemLanguage->language,
-			'published' => 1
+			'published' => 1,
+			'rules' => array()
 		);
 
 		// Bind the data.
@@ -1013,18 +1017,31 @@ class InstallationModelLanguages extends JModelBase
 
 		// Initialize a new category.
 		$category                  = JTable::getInstance('Category');
-		$category->extension       = 'com_content';
-		$category->title           = $title . ' (' . strtolower($itemLanguage->language) . ')';
-		$category->description     = '';
-		$category->published       = 1;
-		$category->access          = 1;
-		$category->params          = '{"target":"","image":""}';
-		$category->metadata        = '{"page_title":"","author":"","robots":""}';
-		$category->created_time    = JFactory::getDate()->toSql();
-		$category->language        = $itemLanguage->language;
 
-		// Set the location in the tree.
-		$category->setLocation(1, 'last-child');
+		$data = array(
+			'extension'    => 'com_content',
+			'title'        => $title . ' (' . strtolower($itemLanguage->language) . ')',
+			'description'  => '',
+			'published'    => 1,
+			'access'       => 1,
+			'params'       => '{"target":"","image":""}',
+			'metadesc'     => '',
+			'metakey'      => '',
+			'metadata'     => '{"page_title":"","author":"","robots":""}',
+			'created_time' => JFactory::getDate()->toSql(),
+			'language'     => $itemLanguage->language,
+			'rules'        => array()
+		);
+
+		// Using $category->setLocation(1, 'last-child'); would be ideal here but doesn't seem to work in postgres
+		// as we're in install and 'know' the structure we'll just manually set it to be a child of the root category.
+		$data['parent_id'] = 1;
+
+		// Bind the data to the table
+		if (!$category->bind($data))
+		{
+			return false;
+		}
 
 		// Check to make sure our data is valid.
 		if (!$category->check())
@@ -1063,26 +1080,41 @@ class InstallationModelLanguages extends JModelBase
 		$title = $newlanguage->_('PLG_ARTICLE_BUTTON_ARTICLE');
 
 		$article                   = JTable::getInstance('Content');
-		$article->title            = $title . ' (' . strtolower($itemLanguage->language) . ')';
-		$article->introtext        = '<p>Lorem ipsum ad his scripta blandit partiendo, eum fastidii accumsan euripidis'
+
+		$data = array(
+			'title'            => $title . ' (' . strtolower($itemLanguage->language) . ')',
+			'introtext'        => '<p>Lorem ipsum ad his scripta blandit partiendo, eum fastidii accumsan euripidis'
 										. ' in, eum liber hendrerit an. Qui ut wisi vocibus suscipiantur, quo dicit'
 										. ' ridens inciderint id. Quo mundi lobortis reformidans eu, legimus senserit'
 										. 'definiebas an eos. Eu sit tincidunt incorrupte definitionem, vis mutat'
 										. ' affert percipit cu, eirmod consectetuer signiferumque eu per. In usu latine'
 										. 'equidem dolores. Quo no falli viris intellegam, ut fugit veritus placerat'
 										. 'per. Ius id vidit volumus mandamus, vide veritus democritum te nec, ei eos'
-										. 'debet libris consulatu.</p>';
-		$article->state            = 1;
-		$article->created          = JFactory::getDate()->toSql();
-		$article->created_by       = $this->getAdminId();
-		$article->created_by_alias = 'Joomla';
-		$article->publish_up       = JFactory::getDate()->toSql();
-		$article->publish_down     = $db->getNullDate();
-		$article->version          = 1;
-		$article->catid            = $categoryId;
-		$article->metadata         = '{"robots":"","author":"","rights":"","xreference":"","tags":null}';
-		$article->language         = $itemLanguage->language;
-		$article->featured         = 1;
+										. 'debet libris consulatu.</p>',
+			'images'           => json_encode(array()),
+			'urls'             => json_encode(array()),
+			'state'            => 1,
+			'created'          => JFactory::getDate()->toSql(),
+			'created_by'       => $this->getAdminId(),
+			'created_by_alias' => 'Joomla',
+			'publish_up'       => JFactory::getDate()->toSql(),
+			'publish_down'     => $db->getNullDate(),
+			'version'          => 1,
+			'catid'            => $categoryId,
+			'metadata'         => '{"robots":"","author":"","rights":"","xreference":"","tags":null}',
+			'metakey'          => '',
+			'metadesc'         => '{"robots":"","author":"","rights":"","xreference":""}',
+			'language'         => $itemLanguage->language,
+			'featured'         => 1,
+			'attribs'          => array(),
+			'rules'            => array()
+		);
+
+		// Bind the data to the table
+		if (!$article->bind($data))
+		{
+			return false;
+		}
 
 		// Check to make sure our data is valid.
 		if (!$article->check())

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1036,6 +1036,7 @@ class InstallationModelLanguages extends JModelBase
 		// Using $category->setLocation(1, 'last-child'); would be ideal here but doesn't seem to work in postgres
 		// as we're in install and 'know' the structure we'll just manually set it to be a child of the root category.
 		$data['parent_id'] = 1;
+		$data['level']     = 1;
 
 		// Bind the data to the table
 		if (!$category->bind($data))


### PR DESCRIPTION
## Executive Summary

The multilingual installer will not install sample data in postgres. This fixes it.
## More detail

Various not null fields are not passed into the data being binded in the multilingual installer. To avoid this I've used the bind method to ensure the rules are created properly and added in the missing fields
## Testing instructions

In mysql ensure that the multilingual installer continues to work as expected when installing data (make sure you enable all 3 options for data to install to test all options)

In postgres you can try running the multilingual installer first to prove there are errors. Note the languages will install thanks to previous PR's however the data will not be added correctly. Note you MUST test this with the staging branch. Apply the patch and all the data should be created properly (make sure you enable all 3 options for data to install to test all options). This includes the language switcher module, content, category and menu items. 
