### PR TITLE
Error in com_content in multilang and postgres

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -199,7 +199,7 @@ class ContentModelArticles extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_content.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id');
+				->group('a.id, l.title, uc.name, ag.title, c.title, ua.name');
 		}
 
 		// Filter by access level.


### PR DESCRIPTION
## Executive Summary

The group by clause when in multilingual mode in postgres breaks the query
## Testing instructions

In mysql check the articles list view continues to work as expected.

In postgres you'll see the popular and latest news modules will give php errors and sql errors. Also the articles list view itself will give SQL errors and not show. Apply the patch and the list view should work as expected.

N.B. In order to get multilang working on postgres you'll need to either install the languages in the backend or  apply this patch (https://github.com/joomla/joomla-cms/pull/4969) to use the multilang installer during Joomla installation
