### PR TITLE
com_tags : router error

### DIFF
--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -86,7 +86,7 @@ class TagsRouter extends JComponentRouterBase
 					}
 					else
 					{
-						$id = $query['id'];
+						$id = (int) $query['id'];
 					}
 
 					$segments[] = $id;


### PR DESCRIPTION
#### Steps to reproduce the issue

Install Joomla (Test English (GB) Sample Data), for example
From the backend set the configuration ‘Search Engine Friendly URLs’ = ‘YES’
Use the url: index.php?option=com_tags&view=tag&layout=list&id[0]=3 (not sef url into a sef one. The id can have another value and NO Itemid has to be set)

You will have 3 times the error:
Notice: Array to string conversion in /libraries/cms/router/site.php on line 465

The proposal to fix is to replace
 $id = $query['id'];
 with
 $id = (int) $query['id'];
 which seems coherent with the test line 80
#### Expected result

No error
#### Actual result

Notice: Array to string conversion in /libraries/cms/router/site.php on line 465
#### System information (as much as possible)

Joomla 3.3.6
