### PR TITLE
Error in com_categories in multilang and postgres

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -183,7 +183,7 @@ class CategoriesModelCategories extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_categories.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id');
+				->group('a.id, l.title, uc.name, ag.title, ua.name');
 		}
 
 		// Filter by extension


### PR DESCRIPTION
## Executive Summary

The group by clause when in multilingual mode in postgres breaks the query
## Testing instructions

In mysql check the categories list view continues to work as expected.

N.B. In order to get multilang working on postgres you'll need to either install the languages in the backend or  apply this patch (https://github.com/joomla/joomla-cms/pull/4969) to use the multilang installer during Joomla installation
