### PR TITLE
Fix ACL in quickicon plugin for Joomla Update

### DIFF
--- a/plugins/quickicon/joomlaupdate/joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.php
@@ -38,7 +38,7 @@ class PlgQuickiconJoomlaupdate extends JPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		if ($context != $this->params->get('context', 'mod_quickicon') || !JFactory::getUser()->authorise('core.manage', 'com_installer'))
+		if ($context != $this->params->get('context', 'mod_quickicon') || !JFactory::getUser()->authorise('core.manage', 'com_joomlaupdate'))
 		{
 			return;
 		}


### PR DESCRIPTION
### Issue

As written in https://github.com/joomla/joomla-cms/issues/4982, the quickicon notification for the Joomla Update component doesn't show for administrators.
The reason is that the plugin checks if the user is authorised to access the extension manager, but it should check if the user is authorised to access the Joomla Update component.
### Solution

This PR changes the ACL check so it checks the proper permissions.
