### PR TITLE
Error in com_newsfeeds in multilang and postgres

### DIFF
--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -180,7 +180,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_newsfeeds.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id');
+				->group('a.id, l.title, uc.name, ag.title, c.title');
 		}
 
 		// Filter by access level.


### PR DESCRIPTION
## Executive Summary

The group by clause when in multilingual mode in postgres breaks the query
## Testing instructions

In mysql and postgres check the newsfeeds list view continues to work as expected in the backend.

N.B. In order to get multilang working on postgres you'll need to either install the languages in the backend or  apply this patch (https://github.com/joomla/joomla-cms/pull/4969) to use the multilang installer during Joomla installation
