### PR TITLE
Error in com_menus in multilang and postgres

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -243,7 +243,7 @@ class MenusModelItems extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id');
+				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name');
 		}
 
 		// Join over the extensions


### PR DESCRIPTION
## Executive Summary

The group by clause when in multilingual mode in postgres breaks the query
## Testing instructions

In mysql and postgres check the list of menu items continues to work as expected in the backend. Check the list displays and if you want you can test filtering.

N.B. In order to get multilang working on postgres you'll need to either install the languages in the backend or  apply this patch (https://github.com/joomla/joomla-cms/pull/4969) to use the multilang installer during Joomla installation
