### PR TITLE
[imp] Multilanguage: Breadcrumbs does not display submenus if the default Home menu item set to All languages is deleted

### DIFF
--- a/libraries/cms/pathway/site.php
+++ b/libraries/cms/pathway/site.php
@@ -29,11 +29,21 @@ class JPathwaySite extends JPathway
 
 		$app  = JApplication::getInstance('site');
 		$menu = $app->getMenu();
+		$lang = JFactory::getLanguage();
 
 		if ($item = $menu->getActive())
 		{
 			$menus = $menu->getMenu();
-			$home  = $menu->getDefault();
+
+			// Look for the home menu
+			if (JLanguageMultilang::isEnabled())
+			{
+				$home = $menu->getDefault($lang->getTag());
+			}
+			else
+			{
+				$home  = $menu->getDefault();
+			}
 
 			if (is_object($home) && ($item->id != $home->id))
 			{

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -31,6 +31,18 @@ class ModBreadCrumbsHelper
 		$app		= JFactory::getApplication();
 		$pathway	= $app->getPathway();
 		$items		= $pathway->getPathWay();
+		$lang = JFactory::getLanguage();
+		$menu = $app->getMenu();
+
+		// Look for the home menu
+		if (JLanguageMultilang::isEnabled())
+		{
+			$home = $menu->getDefault($lang->getTag());
+		}
+		else
+		{
+			$home  = $menu->getDefault();
+		}
 
 		$count = count($items);
 
@@ -48,7 +60,7 @@ class ModBreadCrumbsHelper
 		{
 			$item = new stdClass;
 			$item->name = htmlspecialchars($params->get('homeText', JText::_('MOD_BREADCRUMBS_HOME')));
-			$item->link = JRoute::_('index.php?Itemid=' . $app->getMenu()->getDefault()->id);
+			$item->link = JRoute::_('index.php?Itemid=' . $home->id);
 			array_unshift($crumbs, $item);
 		}
 


### PR DESCRIPTION
Test:
Install a basic multilingual site from scratch.
 See: https://github.com/joomla/joomla-cms/issues/4988
Create a submenu in the mainmenu of one of the languages.

Using PhpMyadmin, delete in the _menu table the row mainmenu with Home set to Language All, i.e. *

Display the site and the submenu
The breadcrumbs will not show the right items
you will also get an error:
`PHP Notice:  Trying to get property of non-object in ROOT/modules/mod_breadcrumbs/helper.php on line 51`

Patch and test again. 

(Don't forget to kill that test site as it is not normal to delete the mainmenu home menu item set to All languages in a multilingual site
