### PR TITLE
[fix] Multilanguage: Checking proper default menu item in mod_menu

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -194,7 +194,18 @@ class ModMenuHelper
 	public static function getActive(&$params)
 	{
 		$menu = JFactory::getApplication()->getMenu();
+		$lang = JFactory::getLanguage();
 
-		return $menu->getActive() ? $menu->getActive() : $menu->getDefault();
+		// Look for the home menu
+		if (JLanguageMultilang::isEnabled())
+		{
+			$home = $menu->getDefault($lang->getTag());
+		}
+		else
+		{
+			$home  = $menu->getDefault();
+		}
+
+		return $menu->getActive() ? $menu->getActive() : $home;
 	}
 }


### PR DESCRIPTION
Same issue as in https://github.com/joomla/joomla-cms/pull/4994 which was merged and solved the pathway if in the _menu table the row mainmenu with Home set to Language All, i.e. *, is deleted.

See specifically the comment https://github.com/joomla/joomla-cms/pull/4994#issuecomment-61855825
To test use a multilang site, delete the said menu item.
Create a tag and apply to some articles. Display these articles once at least in frontend.
Create a Popular Tags module and display in frontend.
As $menu->getDefault() does not exist, you will get many notices including
Notice: Trying to get property of non-object in ROOT\modules\mod_menu\helper.php on line 40

Patch and retest
