### PR TITLE
Add some error information when developer using UCM Content

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -824,12 +824,12 @@ class JHelperTags extends JHelper
 				$result = $result && $ucmContentTable->bind($ucmData['common']);
 				$result = $result && $ucmContentTable->check();
 				$result = $result && $ucmContentTable->store();
-				
+
 				if (!$result)
 				{
 					throw new Exception($ucmContentTable->getError());
 				}
-				
+
 				$ucmId = $ucmContentTable->core_content_id;
 
 				// Store the tag data if the article data was saved and run related methods.

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -824,6 +824,12 @@ class JHelperTags extends JHelper
 				$result = $result && $ucmContentTable->bind($ucmData['common']);
 				$result = $result && $ucmContentTable->check();
 				$result = $result && $ucmContentTable->store();
+				
+				if (!$result)
+				{
+					throw new Exception($ucmContentTable->getError());
+				}
+				
 				$ucmId = $ucmContentTable->core_content_id;
 
 				// Store the tag data if the article data was saved and run related methods.

--- a/libraries/cms/ucm/content.php
+++ b/libraries/cms/ucm/content.php
@@ -133,9 +133,19 @@ class JUcmContent extends JUcmBase
 	{
 		$contentType = isset($type) ? $type : $this->type;
 
+		if (!is_object($contentType->type))
+		{
+			throw new \LogicException('Please add a row to content_type');
+		}
+
 		$fields = json_decode($contentType->type->field_mappings);
 
 		$ucmData = array();
+
+		if (!$fields)
+		{
+			throw new \LogicException('Please add field_mappings for this content type: ' . $contentType->type->type_alias);
+		}
 
 		$common = (is_object($fields->common)) ? $fields->common : $fields->common[0];
 


### PR DESCRIPTION
Throw some exceptions if developer did not complete the contentType information.

Otherwise it is only return `get property from non object` and hard to debug.
