### PR TITLE
Pagination with Postgres Database doesn't work

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -271,6 +271,7 @@ class JModelList extends JModelLegacy
 
 		try
 		{
+			$query->clear('offset');
 			$total = (int) $this->_getListCount($query);
 		}
 		catch (RuntimeException $e)


### PR DESCRIPTION
Hello,

in regard to the issues found in #4330 and #4485 the problem still persists in a setup with 3.3.6 and Postgresql 9.0 Database.

One issue is the query resulting from #4330 leaving the databse with an empty result, the other one is that the total number of items for pagination is calculated wrong on the following pages.

Therefore I have attached adaptions to the files legacy.php with _getListCount that solves to problem for Postges, as well in list.php to fix the total results.
