### PR TITLE
Clear offset

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -651,6 +651,10 @@ abstract class JDatabaseQuery
 				$this->limit = 0;
 				break;
 
+			case 'offset':
+				$this->offset = 0;
+				break;
+
 			case 'union':
 				$this->union = null;
 				break;

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -324,7 +324,7 @@ abstract class JModelLegacy extends JObject
 			&& $query->having === null)
 		{
 			$query = clone $query;
-			$query->clear('select')->clear('order')->clear('limit')->select('COUNT(*)');
+			$query->clear('select')->clear('order')->clear('limit')->clear('offset')->select('COUNT(*)');
 
 			$this->_db->setQuery($query);
 


### PR DESCRIPTION
Related to #5010
### Issue

PostgreSQL allows to have an OFFSET without a LIMIT in the database query. In MySQL the OFFSET has to follow a LIMIT.
Thus our `JDatabaseQueryPostgresql` class thus allows to clear the limit independant from the offset, while our other database classes clear both limit and offset together with one call to `$query->clear('limit')`.
So far so good.
If you now use `$query->clear( 'offset')` it works as expected in PostgreSQL. But if you do the same in any other databases it will actually clear the full query since this case isn't defined and thus it uses the default case.
### Solution

This PR adds the case  `offset` to the `JDatabaseQuery` class so all databases will support that case and allow to clear the offset.

This PR also adds a `->clear('offset')` to the `JModelLegacy->_getListCount()` method. For MySQL and other databases this will not change anything as the offset is already cleared with `->clear('limit')` anyway. But it will fix the query for PostgreSQL and properly clear the offset there as well
### Testing

Create a list/blog where you get pagination and make sure the total and pagination works as expected.
With MySql you should see no difference at all. With PostgreSQL it should work with the patch.
