### PR TITLE
[#29248] FrontEnd - Disabling Show Navigation setting does not affect article

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -53,7 +53,7 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		// Create a shortcut for $item.
-		$item            = this->item;
+		$item            = $this->item;
 		$item->tagLayout = new JLayoutFile('joomla.content.tags');
 
 		// Add router helpers.

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -35,14 +35,14 @@ class ContentViewArticle extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$app		= JFactory::getApplication();
-		$user		= JFactory::getUser();
-		$dispatcher	= JEventDispatcher::getInstance();
+		$app        = JFactory::getApplication();
+		$user       = JFactory::getUser();
+		$dispatcher = JEventDispatcher::getInstance();
 
-		$this->item		= $this->get('Item');
-		$this->print	= $app->input->getBool('print');
-		$this->state	= $this->get('State');
-		$this->user		= $user;
+		$this->item  = $this->get('Item');
+		$this->print = $app->input->getBool('print');
+		$this->state = $this->get('State');
+		$this->user  = $user;
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -53,13 +53,13 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		// Create a shortcut for $item.
-		$item = $this->item;
+		$item            = this->item;
 		$item->tagLayout = new JLayoutFile('joomla.content.tags');
 
 		// Add router helpers.
-		$item->slug			= $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-		$item->catslug		= $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-		$item->parent_slug	= $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+		$item->slug        = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+		$item->catslug     = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
+		$item->parent_slug = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
 
 		// No link for ROOT category
 		if ($item->parent_alias == 'root')
@@ -73,8 +73,8 @@ class ContentViewArticle extends JViewLegacy
 		// Merge article params. If this is single-article view, menu params override article params
 		// Otherwise, article params override menu item params
 		$this->params = $this->state->get('params');
-		$active = $app->getMenu()->getActive();
-		$temp = clone $this->params;
+		$active       = $app->getMenu()->getActive();
+		$temp         = clone $this->params;
 
 		// Check to see which parameters should take priority
 		if ($active)
@@ -157,16 +157,16 @@ class ContentViewArticle extends JViewLegacy
 		// Process the content plugins.
 
 		JPluginHelper::importPlugin('content');
-		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$this->params, $offset));
+		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
 		$item->event = new stdClass;
-		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$this->params, $offset));
+		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-		$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_content.article', &$item, &$this->params, $offset));
+		$results = $dispatcher->trigger('onContentBeforeDisplay', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-		$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$this->params, $offset));
+		$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->afterDisplayContent = trim(implode("\n", $results));
 
 		// Increment the hit counter of the article.
@@ -191,10 +191,10 @@ class ContentViewArticle extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app		= JFactory::getApplication();
-		$menus		= $app->getMenu();
-		$pathway	= $app->getPathway();
-		$title		= null;
+		$app     = JFactory::getApplication();
+		$menus   = $app->getMenu();
+		$pathway = $app->getPathway();
+		$title   = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
@@ -222,12 +222,12 @@ class ContentViewArticle extends JViewLegacy
 				$title = $this->item->title;
 			}
 
-			$path = array(array('title' => $this->item->title, 'link' => ''));
+			$path     = array(array('title' => $this->item->title, 'link' => ''));
 			$category = JCategories::getInstance('Content')->get($this->item->catid);
 
 			while ($category && ($menu->query['option'] != 'com_content' || $menu->query['view'] == 'article' || $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));
+				$path[]   = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));
 				$category = $category->getParent();
 			}
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -140,7 +140,7 @@ class PlgContentPagenavigation extends JPlugin
 			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id . ' END as catslug';
-			$query->select('a.id, a.title,' . $case_when . ',' . $case_when1)
+			$query->select('a.id, a.title, a.attribs,' . $case_when . ',' . $case_when1)
 				->from('#__content AS a')
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(
@@ -206,6 +206,14 @@ class PlgContentPagenavigation extends JPlugin
 				$row->next = '';
 			}
 
+			$objAttrib = json_decode($rows[$location]->attribs);
+			
+			if ($objAttrib->show_item_navigation != '' && intval($objAttrib->show_item_navigation) == 0)
+			{
+				$row->prev = '';
+				$row->next = '';
+			}
+
 			// Output.
 			if ($row->prev || $row->next)
 			{
@@ -221,6 +229,9 @@ class PlgContentPagenavigation extends JPlugin
 
 				// This will default to the 1.5 and 1.6-1.7 behavior.
 				$row->paginationrelative = $this->params->get('relative', 0);
+				
+
+
 			}
 		}
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -207,7 +207,7 @@ class PlgContentPagenavigation extends JPlugin
 			}
 
 			$objAttrib = json_decode($rows[$location]->attribs);
-			
+
 			if ($objAttrib->show_item_navigation != '' && intval($objAttrib->show_item_navigation) == 0)
 			{
 				$row->prev = '';
@@ -229,9 +229,6 @@ class PlgContentPagenavigation extends JPlugin
 
 				// This will default to the 1.5 and 1.6-1.7 behavior.
 				$row->paginationrelative = $this->params->get('relative', 0);
-				
-
-
 			}
 		}
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -140,7 +140,7 @@ class PlgContentPagenavigation extends JPlugin
 			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id . ' END as catslug';
-			$query->select('a.id, a.title, a.attribs,' . $case_when . ',' . $case_when1)
+			$query->select('a.id, a.title,' . $case_when . ',' . $case_when1)
 				->from('#__content AS a')
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(
@@ -203,14 +203,6 @@ class PlgContentPagenavigation extends JPlugin
 			else
 			{
 				$row->next_label = '';
-				$row->next = '';
-			}
-
-			$objAttrib = json_decode($rows[$location]->attribs);
-
-			if ($objAttrib->show_item_navigation != '' && intval($objAttrib->show_item_navigation) == 0)
-			{
-				$row->prev = '';
 				$row->next = '';
 			}
 


### PR DESCRIPTION
### Tracker

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29248

Code by Karthikeyan S @skarthik2020
### How to redpoduce

Log into your Joomla 3.0 admin dashboard In the top menu, click Content and then click Article Manager In the list of articles on the page, click the article title that you want to toggle the Show Navigation setting for You will see several tabs above the article, click the Article Options tab Find the setting labeled Show Navigation. Set it to "Hide", and then click "Save" in the top left

When I set the "Show Navigation" setting for a specific article to "Hide", I still see the navigational buttons on the page.
