### PR TITLE
Article Manager: Articles > Moved "Trash" button to the right

### DIFF
--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -112,15 +112,6 @@ class ContentViewArticles extends JViewLegacy
 			JToolbarHelper::checkin('articles.checkin');
 		}
 
-		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
-		{
-			JToolbarHelper::deleteList('', 'articles.delete', 'JTOOLBAR_EMPTY_TRASH');
-		}
-		elseif ($canDo->get('core.edit.state'))
-		{
-			JToolbarHelper::trash('articles.trash');
-		}
-
 		// Add a batch button
 		if ($user->authorise('core.create', 'com_content') && $user->authorise('core.edit', 'com_content') && $user->authorise('core.edit.state', 'com_content'))
 		{
@@ -132,6 +123,15 @@ class ContentViewArticles extends JViewLegacy
 
 			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');
+		}
+
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		{
+			JToolbarHelper::deleteList('', 'articles.delete', 'JTOOLBAR_EMPTY_TRASH');
+		}
+		elseif ($canDo->get('core.edit.state'))
+		{
+			JToolbarHelper::trash('articles.trash');
 		}
 
 		if ($user->authorise('core.admin', 'com_content'))


### PR DESCRIPTION
See overall issue Inconsistency in order of admin "edit" etc buttons
https://github.com/joomla/joomla-cms/issues/4963

This patch is a replacement patch for patch http://issues.joomla.org/tracker/joomla-cms/4964
