### PR TITLE
Category Manager: Articles > Moved "Trash" button to the right

### DIFF
--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -151,15 +151,6 @@ class CategoriesViewCategories extends JViewLegacy
 			JToolbarHelper::checkin('categories.checkin');
 		}
 
-		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete', $component))
-		{
-			JToolbarHelper::deleteList('', 'categories.delete', 'JTOOLBAR_EMPTY_TRASH');
-		}
-		elseif ($canDo->get('core.edit.state'))
-		{
-			JToolbarHelper::trash('categories.trash');
-		}
-
 		// Add a batch button
 		if ($user->authorise('core.create', $extension) & $user->authorise('core.edit', $extension) && $user->authorise('core.edit.state', $extension))
 		{
@@ -177,6 +168,15 @@ class CategoriesViewCategories extends JViewLegacy
 		{
 			JToolbarHelper::custom('categories.rebuild', 'refresh.png', 'refresh_f2.png', 'JTOOLBAR_REBUILD', false);
 			JToolbarHelper::preferences($component);
+		}
+
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete', $component))
+		{
+			JToolbarHelper::deleteList('', 'categories.delete', 'JTOOLBAR_EMPTY_TRASH');
+		}
+		elseif ($canDo->get('core.edit.state'))
+		{
+			JToolbarHelper::trash('categories.trash');
 		}
 
 		// Compute the ref_key if it does exist in the component


### PR DESCRIPTION
See overall issue Inconsistency in order of admin "edit" etc buttons #4963

This patch is a replacement patch for patch http://issues.joomla.org/tracker/joomla-cms/4965
