### PR TITLE
Completing the JFormFieldUser filters options, as noted in #5004

### DIFF
--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -114,6 +114,10 @@ class JFormFieldUser extends JFormField
 	 */
 	protected function getGroups()
 	{
+		if (isset($this->element['groups'])) {
+			return explode(',', $this->element['groups']);
+		}
+
 		return null;
 	}
 
@@ -126,6 +130,10 @@ class JFormFieldUser extends JFormField
 	 */
 	protected function getExcluded()
 	{
+		if (isset($this->element['exclude'])) {
+			return explode(',', $this->element['exclude']);
+		}
+
 		return null;
 	}
 }

--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -114,7 +114,8 @@ class JFormFieldUser extends JFormField
 	 */
 	protected function getGroups()
 	{
-		if (isset($this->element['groups'])) {
+		if (isset($this->element['groups']))
+		{
 			return explode(',', $this->element['groups']);
 		}
 
@@ -130,7 +131,8 @@ class JFormFieldUser extends JFormField
 	 */
 	protected function getExcluded()
 	{
-		if (isset($this->element['exclude'])) {
+		if (isset($this->element['exclude']))
+		{
 			return explode(',', $this->element['exclude']);
 		}
 


### PR DESCRIPTION
As noticed in #5004 the JFormFieldUser field was ready to accept "groups" and "exclude" filters, but the code was actually never completed.

In JFormFieldUser class there are two functions: 
- `protected function getGroups() { return null; }`
- `protected function getExcluded() { return null; }`

Function _getInput()_ invoke both this methods which is totally pointless because it always assign null values to this variables: 

```
$groups = $this->getGroups();
$excluded = $this->getExcluded();
```

Then this always null parameters are passed to _com_users&view=users&ayout=modal_ view which is working pretty nice when you provide some values. For example when getGroups function is recoded to: 

``````
protected function getGroups()
    {
        if(isset($this->element['filter'])) {
            return explode(',', $this->element['filter']);
        } 
        return null;
    }
``` using filtering field in form file like: 

``````

<field name="modified_user_id" type="user" label="JGLOBAL_FIELD_MODIFIED_BY_LABEL" filter="10" />

```

allows to show only users from particular user groups in modal because this filtering option is already implemented in this view (without hiding filter field).

# Testing Instructions

1) Apply the patch
2) Add a new User in Joomla and place in in a group (like Authors)
3) Open the form file of an existing component (like /administrator/components/com_contact/models/form/contact.xml)
4) Find the field with "type=user" in that file
5) Add an attribute "groups" to that xml field and place a csv list of user groups ids
6) Add an attribute "exclude" to that xml field and fill it with a csv list of user ids you want to exclude
7) Try creating a new contact from com_contact and check if selecting the user you see only the users in the "groups" and that are not "excluded"

```
