### PR TITLE
Menus - Batch Options in consistent order

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -23,16 +23,16 @@ $published = $this->state->get('filter.published');
 	<div class="modal-body modal-batch">
 		<p><?php echo JText::_('COM_MENUS_BATCH_TIP'); ?></p>
 		<div class="row-fluid">
-            <div class="control-group span6">
-				<div class="controls">
-					<?php echo JHtml::_('batch.access'); ?>
-				</div>
-			</div>
-			<div class="control-group span6">
+                	<div class="control-group span6">
 				<div class="controls">
 					<?php echo JHtml::_('batch.language'); ?>
 				</div>
 			</div>
+                        <div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.access'); ?>
+				</div>
+			</div>			
 		</div>
 		<div class="row-fluid">
 			<?php if ($published >= 0) : ?>


### PR DESCRIPTION
Bug report for overall inconsistancy of order of options in Batch screens: 
http://issues.joomla.org/tracker/joomla-cms/5028
