### PR TITLE
Modules - Batch Options in consistent order

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -35,18 +35,18 @@ $attr = array(
 	</div>
 	<div class="modal-body modal-batch">
 		<p><?php echo JText::_('COM_MODULES_BATCH_TIP'); ?></p>
-		<div class="row-fluid">
-			<div class="control-group span6">
-				<div class="controls">
-					<?php echo JHtml::_('batch.access'); ?>
-				</div>
-			</div>
+		<div class="row-fluid">			
 			<div class="control-group span6">
 				<div class="controls">
 					<?php echo JHtml::_('batch.language'); ?>
 				</div>
 			</div>
-		</div>
+                        <div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.access'); ?>
+				</div>
+			</div>                    
+		</div>		
 		<div class="row-fluid">
 			<?php if ($published >= 0) : ?>
 				<div class="span6">


### PR DESCRIPTION
Bug report for overall inconsistancy of order of options in Batch screens: 
http://issues.joomla.org/tracker/joomla-cms/5028
