### PR TITLE
[fix] Correcting span6 columns in batch modal

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8728,3 +8728,6 @@ div#j-sidebar-container.j-toggle-visible #j-toggle-sidebar-button {
 		margin-right: 0;
 	}
 }
+.row-fluid .modal-batch [class*="span"] {
+	margin-right: 0;
+}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7429,6 +7429,9 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
+	.row-fluid .modal-batch [class*="span"] {
+		margin-left: 0;
+	}
 }
 @media (max-width: 767px) {
 	.navbar-search.pull-right {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8719,3 +8719,12 @@ div#j-sidebar-container.j-toggle-visible #j-toggle-sidebar-button {
 #j-main-container.expanded {
 	margin-right: 0;
 }
+@media (min-width: 768px) {
+	.row-fluid [class*="span"] {
+		margin-right: 15px;
+		margin-left: 0;
+	}
+	.row-fluid .modal-batch [class*="span"] {
+		margin-right: 0;
+	}
+}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7429,6 +7429,9 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
+	.row-fluid .modal-batch [class*="span"] {
+		margin-left: 0;
+	}
 }
 @media (max-width: 767px) {
 	.navbar-search.pull-right {

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -133,3 +133,6 @@ div#j-sidebar-container.j-toggle-visible #j-toggle-sidebar-button {
 		margin-right: 0;
 	}
 }
+.row-fluid .modal-batch [class*="span"] {
+	margin-right: 0;
+}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -122,3 +122,14 @@ div#j-sidebar-container.j-toggle-visible #j-toggle-sidebar-button {
 #j-main-container.expanded {
 	margin-right: 0;
 }
+
+/* Modal batch */
+@media (min-width: 768px) {
+	.row-fluid [class*="span"]{
+		margin-right: 15px;
+		margin-left: 0;
+	}
+	.row-fluid .modal-batch [class*="span"] {
+		margin-right: 0;
+	}
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -550,6 +550,9 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 	.row-fluid [class*="span"]{
 		margin-left: 15px;
 	}
+	.row-fluid .modal-batch [class*="span"] {
+		margin-left: 0;
+	}
 }
 @media (max-width: 767px) {
 	.navbar-search.pull-right{


### PR DESCRIPTION
batch modals do not display the span6 columns i.e. display the parameters as a single column.

before patch:
![wrong batch](https://cloud.githubusercontent.com/assets/869724/4964024/94579d0e-6743-11e4-86f0-fad67f590725.png)

after patch
![screen shot 2014-11-08 at 11 21 56](https://cloud.githubusercontent.com/assets/869724/4964025/9a48574e-6743-11e4-89f6-b9acc9da0989.png)

this has to be corrected before testing the bunch of PRs to display the parameters consistently
