### PR TITLE
Introduce jquery  formvalidator for com_admin

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -12,24 +12,24 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
+	Joomla.submitbutton = function(task)
+	{
+		if (task == "profile.cancel" || document.formvalidator.isValid(document.id("profile-form")))
+		{
+			Joomla.submitform(task, document.getElementById("profile-form"));
+		}
+	}
+});');
 // Load chosen.css
 JHtml::_('formbehavior.chosen', 'select');
 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();
 ?>
-
-<script type="text/javascript">
-	Joomla.submitbutton = function(task)
-	{
-		if (task == 'profile.cancel' || document.formvalidator.isValid(document.id('profile-form')))
-		{
-			Joomla.submitform(task, document.getElementById('profile-form'));
-		}
-	}
-</script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_admin&view=profile&layout=edit&id=' . $this->item->id); ?>" method="post" name="adminForm" id="profile-form" class="form-validate form-horizontal" enctype="multipart/form-data">
 	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'account')); ?>


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_users to use plain jquery (no mootools call on every form ).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area go to com_users and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
http://localhost/administrator/index.php?option=com_admin&view=sysinfo should demonstrate highlighter.js without mt
Logout and log in to demonstrate the use of noframes without mt.
