### PR TITLE
Introduce jquery formvalidator for com_banners

### DIFF
--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -10,35 +10,32 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app = JFactory::getApplication();
-
-$script = "
-	jQuery(document).ready(function ($){
-		$('#jform_type').change(function(){
-			if($(this).val() == 1) {
-				$('#image').css('display', 'none');
-				$('#custom').css('display', 'block');
-			} else {
-				$('#image').css('display', 'block');
-				$('#custom').css('display', 'none');
-			}
-		}).trigger('change');
-	});";
-// Add the script to the document head.
-JFactory::getDocument()->addScriptDeclaration($script);
-?>
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'banner.cancel' || document.formvalidator.isValid(document.id('banner-form')))
+		if (task == "banner.cancel" || document.formvalidator.isValid(document.getElementById("banner-form")))
 		{
-			Joomla.submitform(task, document.getElementById('banner-form'));
+			Joomla.submitform(task, document.getElementById("banner-form"));
 		}
-	}
-</script>
+	};
+});
+jQuery(document).ready(function ($){
+	$("#jform_type").change(function(){
+		if($(this).val() == 1) {
+			$("#image").css("display", "none");
+			$("#custom").css("display", "block");
+		} else {
+			$("#image").css("display", "block");
+			$("#custom").css("display", "none");
+		}
+	}).trigger("change");
+});');
+
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_banners&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="banner-form" class="form-validate">
 

--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -39,7 +39,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -32,24 +32,27 @@ if ($saveOrder)
 }
 
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});
+');
+?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -10,17 +10,22 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'client.cancel' || document.formvalidator.isValid(document.id('client-form')))
+		if (task == "client.cancel" || document.formvalidator.isValid(document.getElementById("client-form")))
 		{
-			Joomla.submitform(task, document.getElementById('client-form'));
+			Joomla.submitform(task, document.getElementById("client-form"));
 		}
 	}
+});');
+?>
+<script type="text/javascript">
+
 </script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_banners&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="client-form" class="form-validate">

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -23,24 +23,27 @@ $params     = (isset($this->state->params)) ? $this->state->params : new JObject
 $archived   = $this->state->get('filter.state') == 2 ? true : false;
 $trashed    = $this->state->get('filter.state') == -2 ? true : false;
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=clients'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -31,7 +31,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -19,28 +19,33 @@ $userId     = $user->get('id');
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+		dirn = "asc";
 		}
 		else
 		{
-			dirn = direction.options[direction.selectedIndex].value;
+		dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
 
-	Joomla.closeModalDialog = function()
-	{
-		window.jQuery('#modal-download').modal('hide');
-	}
+Joomla.closeModalDialog = function()
+{
+	window.jQuery("#modal-download").modal("hide");
+}
+});');
+?>
+<script type="text/javascript">
+
 </script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=tracks'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -27,7 +27,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 		dirn = "asc";
 		}

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -32,24 +32,28 @@ if ($saveOrder)
 }
 
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+
+?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -40,7 +40,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
@@ -20,18 +20,20 @@ $app = JFactory::getApplication();
 $input = $app->input;
 
 $assoc = JLanguageAssociations::isEnabled();
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'category.cancel' || document.formvalidator.isValid(document.id('item-form')))
+		if (task == "category.cancel" || document.formvalidator.isValid(document.getElementById("item-form")))
 		{
-			<?php echo $this->form->getField('description')->save(); ?>
-			Joomla.submitform(task, document.getElementById('item-form'));
+			'. $this->form->getField("description")->save() .'
+			Joomla.submitform(task, document.getElementById("item-form"));
 		}
 	}
-</script>
+});');
+
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_banners to use plain jquery (no mootools call on every form).
This also covers com_categories
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area go to com_banners and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
http://localhost/administrator/index.php?option=com_admin&view=sysinfo should demonstrate highlighter.js without mt
Logout and log in to demonstrate the use of noframes without mt.
