### PR TITLE
Introduce jquery formvalidator for com_contact

### DIFF
--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -12,22 +12,24 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 $app = JFactory::getApplication();
 $assoc = JLanguageAssociations::isEnabled();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'contact.cancel' || document.formvalidator.isValid(document.id('contact-form')))
+		if (task == "contact.cancel" || document.formvalidator.isValid(document.getElementById("contact-form")))
 		{
-			<?php echo $this->form->getField('misc')->save(); ?>
-			Joomla.submitform(task, document.getElementById('contact-form'));
+			' . $this->form->getField("misc")->save() . '
+			Joomla.submitform(task, document.("contact-form"));
 		}
 	}
-</script>
+});');
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_contact&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="contact-form" class="form-validate">
 

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -25,7 +25,7 @@ jQuery(document).ready(function() {
 		if (task == "contact.cancel" || document.formvalidator.isValid(document.getElementById("contact-form")))
 		{
 			' . $this->form->getField("misc")->save() . '
-			Joomla.submitform(task, document.("contact-form"));
+			Joomla.submitform(task, document.getElementById("contact-form"));
 		}
 	}
 });');

--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -19,24 +19,26 @@ $app = JFactory::getApplication();
 
 $input = $app->input;
 $assoc = JLanguageAssociations::isEnabled();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'contact.cancel' || document.formvalidator.isValid(document.id('contact-form')))
+		if (task == "contact.cancel" || document.formvalidator.isValid(document.getElementById("contact-form")))
 		{
-			<?php echo $this->form->getField('misc')->save(); ?>
+			' . $this->form->getField('misc')->save() . '
 
-			if (window.opener && (task == 'contact.save' || task == 'contact.cancel'))
+			if (window.opener && (task == "contact.save" || task == "contact.cancel"))
 			{
 				window.opener.document.closeEditWindow = self;
-				window.opener.setTimeout('window.document.closeEditWindow.close()', 1000);
+				window.opener.setTimeout("window.document.closeEditWindow.close()", 1000);
 			}
 
-			Joomla.submitform(task, document.getElementById('contact-form'));
+			Joomla.submitform(task, document.getElementById("contact-form"));
 		}
 	}
-</script>
+});');
+?>
 <div class="container-popup">
 
 <div class="pull-right">

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -41,7 +41,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -33,25 +33,27 @@ if ($saveOrder)
 
 $sortFields = $this->getSortFields();
 $assoc		= JLanguageAssociations::isEnabled();
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_contact'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_contact to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area go to com_contact and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
http://localhost/administrator/index.php?option=com_admin&view=sysinfo should demonstrate highlighter.js without mt
Logout and log in to demonstrate the use of noframes without mt.
