### PR TITLE
Introduce jquery formvalidator for com_menus

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JText::script('ERROR');
@@ -23,45 +23,39 @@ JText::script('JGLOBAL_VALIDATION_FORM_FAILED');
 $assoc = JLanguageAssociations::isEnabled();
 
 // Ajax for parent items
-$script = "jQuery(document).ready(function ($){
-				$('#jform_menutype').change(function(){
-					var menutype = $(this).val();
-					$.ajax({
-						url: 'index.php?option=com_menus&task=item.getParentItem&menutype=' + menutype,
-						dataType: 'json'
-					}).done(function(data) {
-						$('#jform_parent_id option').each(function() {
-							if ($(this).val() != '1') {
-								$(this).remove();
-							}
-						});
+$script = "
+jQuery(document).ready(function ($){
+	$('#jform_menutype').change(function(){
+		var menutype = $(this).val();
+		$.ajax({
+			url: 'index.php?option=com_menus&task=item.getParentItem&menutype=' + menutype,
+			dataType: 'json'
+		}).done(function(data) {
+			$('#jform_parent_id option').each(function() {
+				if ($(this).val() != '1') {
+					$(this).remove();
+				}
+			});
 
-						$.each(data, function (i, val) {
-							var option = $('<option>');
-							option.text(val.title).val(val.id);
-							$('#jform_parent_id').append(option);
-						});
-						$('#jform_parent_id').trigger('liszt:updated');
-					});
-				});
-			});";
-
-// Add the script to the document head.
-JFactory::getDocument()->addScriptDeclaration($script);
-
-?>
-
-<script type="text/javascript">
-	Joomla.submitbutton = function(task, type)
-	{
+			$.each(data, function (i, val) {
+				var option = $('<option>');
+				option.text(val.title).val(val.id);
+				$('#jform_parent_id').append(option);
+			});
+			$('#jform_parent_id').trigger('liszt:updated');
+		});
+	});
+});
+jQuery(document).ready(function (){
+	Joomla.submitbutton = function(task, type){
 		if (task == 'item.setType' || task == 'item.setMenuType')
 		{
 			if (task == 'item.setType')
 			{
-				jQuery('#item-form input[name="jform[type]"]').val(type);
+				jQuery('#item-form input[name=\"jform[type]\"]').val(type);
 				jQuery('#fieldtype').val('type');
 			} else {
-				jQuery('#item-form input[name="jform[menutype]"]').val(type);
+				jQuery('#item-form input[name=\"jform[menutype]\"]').val(type);
 			}
 			Joomla.submitform('item.setType', document.getElementById('item-form'));
 		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
@@ -72,15 +66,21 @@ JFactory::getDocument()->addScriptDeclaration($script);
 		{
 			// special case for modal popups validation response
 			jQuery('#item-form .modal-value.invalid').each(function(){
-				var $field = jQuery(this),
-					idReversed = $field.attr('id').split("").reverse().join(""),
+				var field = jQuery(this),
+					idReversed = field.attr('id').split('').reverse().join(''),
 					separatorLocation = idReversed.indexOf('_'),
-					nameId = '#' + idReversed.substr(separatorLocation).split("").reverse().join("") + 'name';
+					nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
 				jQuery(nameId).addClass('invalid');
 			});
-		}
+		};
 	}
-</script>
+});
+";
+
+// Add the script to the document head.
+JFactory::getDocument()->addScriptDeclaration($script);
+
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -72,13 +72,13 @@ jQuery(document).ready(function (){
 					nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
 				jQuery(nameId).addClass('invalid');
 			});
-		};
+		}
 	}
 });
 ";
 
 // Add the script to the document head.
-JFactory::getDocument()->addScriptDeclaration('\n', $script);
+JFactory::getDocument()->addScriptDeclaration($script);
 
 ?>
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -78,7 +78,7 @@ jQuery(document).ready(function (){
 ";
 
 // Add the script to the document head.
-JFactory::getDocument()->addScriptDeclaration($script);
+JFactory::getDocument()->addScriptDeclaration('\n', $script);
 
 ?>
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -46,35 +46,33 @@ jQuery(document).ready(function ($){
 		});
 	});
 });
-jQuery(document).ready(function (){
-	Joomla.submitbutton = function(task, type){
-		if (task == 'item.setType' || task == 'item.setMenuType')
+Joomla.submitbutton = function(task, type){
+	if (task == 'item.setType' || task == 'item.setMenuType')
+	{
+		if (task == 'item.setType')
 		{
-			if (task == 'item.setType')
-			{
-				jQuery('#item-form input[name=\"jform[type]\"]').val(type);
-				jQuery('#fieldtype').val('type');
-			} else {
-				jQuery('#item-form input[name=\"jform[menutype]\"]').val(type);
-			}
-			Joomla.submitform('item.setType', document.getElementById('item-form'));
-		} else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
-		{
-			Joomla.submitform(task, document.getElementById('item-form'));
+			jQuery('#item-form input[name=\"jform[type]\"]').val(type);
+			jQuery('#fieldtype').val('type');
+		} else {
+			jQuery('#item-form input[name=\"jform[menutype]\"]').val(type);
 		}
-		else
-		{
-			// special case for modal popups validation response
-			jQuery('#item-form .modal-value.invalid').each(function(){
-				var field = jQuery(this),
-					idReversed = field.attr('id').split('').reverse().join(''),
-					separatorLocation = idReversed.indexOf('_'),
-					nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
-				jQuery(nameId).addClass('invalid');
-			});
-		}
+		Joomla.submitform('item.setType', document.getElementById('item-form'));
+	} else if (task == 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
+	{
+		Joomla.submitform(task, document.getElementById('item-form'));
 	}
-});
+	else
+	{
+		// special case for modal popups validation response
+		jQuery('#item-form .modal-value.invalid').each(function(){
+			var field = jQuery(this),
+				idReversed = field.attr('id').split('').reverse().join(''),
+				separatorLocation = idReversed.indexOf('_'),
+				nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
+			jQuery(nameId).addClass('invalid');
+		});
+	}
+};
 ";
 
 // Add the script to the document head.

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -12,9 +12,11 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.core');
 
 JFactory::getDocument()->addScriptDeclaration("
+	jQuery(document).ready(function() {
 		jQuery('#showmods').on('click', function(e) {
 			jQuery('.table tr.no').toggle();
 		});
+	})
 ");
 ?>
 

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -11,15 +11,14 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
 
-JFactory::getDocument()->addScriptDeclaration("
-		jQuery(document).ready(function() {
-			jQuery('#showmods').on('click', function(e) {
-				jQuery('.table tr.no').toggle();
-			});
-		})
-");
+$script = "	jQuery(document).ready(function() {";
+$script .= "		jQuery('#showmods').on('click', function(e) {";
+$script .= "			jQuery('.table tr.no').toggle();";
+$script .= "		});";
+$script .= "	})";
 
-?>
+// Add the script to the document head.
+JFactory::getDocument()->addScriptDeclaration($script);?>
 
 <div class="control-group">
 	<div class="control-label">

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -11,11 +11,11 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
 
-$script = "	jQuery(document).ready(function() {";
-$script .= "		jQuery('#showmods').on('click', function(e) {";
-$script .= "			jQuery('.table tr.no').toggle();";
-$script .= "		});";
-$script .= "	})";
+$script = "	jQuery(document).ready(function() {" . PHP_EOL;
+$script .= "		jQuery('#showmods').on('click', function(e) {" . PHP_EOL;
+$script .= "			jQuery('.table tr.no').toggle();" . PHP_EOL;
+$script .= "		});" . PHP_EOL;
+$script .= "	})" . PHP_EOL;
 
 // Add the script to the document head.
 JFactory::getDocument()->addScriptDeclaration($script);?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -11,11 +11,12 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
 
-$script = "	jQuery(document).ready(function() {" . PHP_EOL;
-$script .= "		jQuery('#showmods').on('click', function(e) {" . PHP_EOL;
-$script .= "			jQuery('.table tr.no').toggle();" . PHP_EOL;
-$script .= "		});" . PHP_EOL;
-$script .= "	})" . PHP_EOL;
+$script = "
+jQuery(document).ready(function() {
+	jQuery('#showmods').on('click', function(e) {
+		jQuery('.table tr.no').toggle();
+	});
+})";
 
 // Add the script to the document head.
 JFactory::getDocument()->addScriptDeclaration($script);?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -12,11 +12,9 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.core');
 
 JFactory::getDocument()->addScriptDeclaration("
-	jQuery(document).ready(function() {
 		jQuery('#showmods').on('click', function(e) {
 			jQuery('.table tr.no').toggle();
 		});
-	})
 ");
 ?>
 

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -11,15 +11,14 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
 
-$script = "
-jQuery(document).ready(function() {
-	jQuery('#showmods').on('click', function(e) {
-		jQuery('.table tr.no').toggle();
-	});
-})";
-
-// Add the script to the document head.
-JFactory::getDocument()->addScriptDeclaration($script);?>
+JFactory::getDocument()->addScriptDeclaration("
+	jQuery(document).ready(function() {
+		jQuery('#showmods').on('click', function(e) {
+			jQuery('.table tr.no').toggle();
+		});
+	})
+");
+?>
 
 <div class="control-group">
 	<div class="control-label">

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -33,24 +33,26 @@ if ($saveOrder)
 
 $sortFields = $this->getSortFields();
 $assoc		= JLanguageAssociations::isEnabled();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
 <?php // Set up the filter bar. ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -35,23 +35,22 @@ $sortFields = $this->getSortFields();
 $assoc		= JLanguageAssociations::isEnabled();
 
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
-	Joomla.orderTable = function()
-	{
-		table = document.getElementById("sortTable");
-		direction = document.getElementById("directionTable");
-		order = table.options[table.selectedIndex].value;
-		if (order != "' . $listOrder . '")
+		Joomla.orderTable = function()
 		{
-			dirn = "asc";
-		}
-		else
-		{
-			dirn = direction.options[direction.selectedIndex].value;
-		}
-		Joomla.tableOrdering(order, dirn, "");
-	}
-});');
+			table = document.getElementById("sortTable");
+			direction = document.getElementById("directionTable");
+			order = table.options[table.selectedIndex].value;
+			if (order != "' . $listOrder . '")
+			{
+				dirn = "asc";
+			}
+			else
+			{
+				dirn = direction.options[direction.selectedIndex].value;
+			}
+			Joomla.tableOrdering(order, dirn, "");
+		};
+');
 ?>
 <?php // Set up the filter bar. ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -41,7 +41,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -13,13 +13,13 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JText::script('ERROR');
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		var form = document.getElementById('item-form');
@@ -28,8 +28,8 @@ JText::script('ERROR');
 			Joomla.submitform(task, form);
 		}
 	}
-</script>
-
+});");
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-horizontal">
 	<fieldset>
 		<legend><?php echo JText::_('COM_MENUS_MENU_DETAILS');?></legend>

--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -19,16 +19,15 @@ JHtml::_('formbehavior.chosen', 'select');
 JText::script('ERROR');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
-	Joomla.submitbutton = function(task)
-	{
-		var form = document.getElementById('item-form');
-		if (task == 'menu.cancel' || document.formvalidator.isValid(form))
+		Joomla.submitbutton = function(task)
 		{
-			Joomla.submitform(task, form);
-		}
-	}
-});");
+			var form = document.getElementById('item-form');
+			if (task == 'menu.cancel' || document.formvalidator.isValid(form))
+			{
+				Joomla.submitform(task, form);
+			}
+		};
+");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-horizontal">
 	<fieldset>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -24,8 +24,9 @@ $userId = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn = $this->escape($this->state->get('list.direction'));
 $modMenuId = (int) $this->get('ModMenuId');
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task != 'menus.delete' || confirm('<?php echo JText::_('COM_MENUS_MENU_CONFIRM_DELETE', true);?>'))
@@ -33,7 +34,8 @@ $modMenuId = (int) $this->get('ModMenuId');
 			Joomla.submitform(task);
 		}
 	}
-</script>
+});");
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=menus');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -29,7 +29,7 @@ JFactory::getDocument()->addScriptDeclaration("
 jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task != 'menus.delete' || confirm('<?php echo JText::_('COM_MENUS_MENU_CONFIRM_DELETE', true);?>'))
+		if (task != 'menus.delete' || confirm('" .  JText::_('COM_MENUS_MENU_CONFIRM_DELETE', true) . "'))
 		{
 			Joomla.submitform(task);
 		}

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -26,15 +26,14 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 $modMenuId = (int) $this->get('ModMenuId');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
-	Joomla.submitbutton = function(task)
-	{
-		if (task != 'menus.delete' || confirm('" .  JText::_('COM_MENUS_MENU_CONFIRM_DELETE', true) . "'))
+		Joomla.submitbutton = function(task)
 		{
-			Joomla.submitform(task);
-		}
-	}
-});");
+			if (task != 'menus.delete' || confirm('" .  JText::_('COM_MENUS_MENU_CONFIRM_DELETE', true) . "'))
+			{
+				Joomla.submitform(task);
+			}
+		};
+");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=menus');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -15,7 +15,6 @@ $input = JFactory::getApplication()->input;
 $tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
 
 JFactory::getDocument()->addScriptDeclaration('
-	jQuery(document).ready(function() {
 		setmenutype = function(type) {
 			var tmpl = "' . $tmpl . '";
 			if (tmpl)
@@ -27,8 +26,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			{
 				window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);
 			}
-		}
-	});
+		};
 ');
 ?>
 

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -10,29 +10,26 @@
 defined('_JEXEC') or die;
 
 $input = JFactory::getApplication()->input;
+
 // Checking if loaded via index.php or component.php
-$tmpl = $input->getCmd('tmpl', '');
-$document = JFactory::getDocument();
+$tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
 
-$script = '
-jQuery(document).ready(function() {
-	setmenutype = function(type) {';
-if ($tmpl)
-{
-	$script .= '
-		window.parent.Joomla.submitbutton(\'item.setType\', type);
-		window.parent.SqueezeBox.close();';
-}
-else
-{
-	$script .= '
-		window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
-}
-$script .= '
-	}
-});';
-
-JFactory::getDocument()->addScriptDeclaration($script);
+JFactory::getDocument()->addScriptDeclaration('
+	jQuery(document).ready(function() {
+		setmenutype = function(type) {
+			var tmpl = "' . $tmpl . '";
+			if (tmpl)
+			{
+				window.parent.Joomla.submitbutton(\'item.setType\', type);
+				window.parent.SqueezeBox.close();
+			}
+			else
+			{
+				window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);
+			}
+		}
+	});
+');
 ?>
 
 <?php echo JHtml::_('bootstrap.startAccordion', 'collapseTypes', array('active' => 'slide1')); ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -14,18 +14,18 @@ $input = JFactory::getApplication()->input;
 $tmpl = $input->getCmd('tmpl', '');
 $document = JFactory::getDocument();
 
-$script[] = 'jQuery(document).ready(function() {';
-$script[] = '	setmenutype = function(type)';
-$script[] = '	{';
+$script = 'jQuery(document).ready(function() {';
+$script .= '	setmenutype = function(type)';
+$script .= '	{';
 if ($tmpl) :
-	$script[] = '	window.parent.Joomla.submitbutton(\'item.setType\', type);';
-	$script[] = '	window.parent.SqueezeBox.close();';
+	$script .= '	window.parent.Joomla.submitbutton(\'item.setType\', type);';
+	$script .= '	window.parent.SqueezeBox.close();';
 else :
-	$script[] = '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
+	$script .= '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
 endif;
-$script[] = '	}';
-$script[] = '});';
-JFactory::getDocument()->addScriptDeclaration(implode('\n',  $script));
+$script .= '	}';
+$script .= '});';
+JFactory::getDocument()->addScriptDeclaration($script);
 ?>
 
 <?php echo JHtml::_('bootstrap.startAccordion', 'collapseTypes', array('active' => 'slide1')); ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -14,20 +14,23 @@ $input = JFactory::getApplication()->input;
 $tmpl = $input->getCmd('tmpl', '');
 $document = JFactory::getDocument();
 
-$script = 'jQuery(document).ready(function() {' . PHP_EOL;
-$script .= '	setmenutype = function(type)' . PHP_EOL;
-$script .= '	{' . PHP_EOL;
+$script = '
+jQuery(document).ready(function() {
+	setmenutype = function(type) {';
 if ($tmpl)
 {
-	$script .= '	window.parent.Joomla.submitbutton(\'item.setType\', type);' . PHP_EOL;
-	$script .= '	window.parent.SqueezeBox.close();' . PHP_EOL;
+	$script .= '
+		window.parent.Joomla.submitbutton(\'item.setType\', type);
+		window.parent.SqueezeBox.close();';
 }
 else
 {
-	$script .= '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);' . PHP_EOL;
+	$script .= '
+		window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
 }
-$script .= '	}' . PHP_EOL;
-$script .= '});' . PHP_EOL;
+$script .= '
+	}
+});';
 
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -14,17 +14,21 @@ $input = JFactory::getApplication()->input;
 $tmpl = $input->getCmd('tmpl', '');
 $document = JFactory::getDocument();
 
-$script = 'jQuery(document).ready(function() {';
-$script .= '	setmenutype = function(type)';
-$script .= '	{';
-if ($tmpl) :
-	$script .= '	window.parent.Joomla.submitbutton(\'item.setType\', type);';
-	$script .= '	window.parent.SqueezeBox.close();';
-else :
-	$script .= '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
-endif;
-$script .= '	}';
-$script .= '});';
+$script = 'jQuery(document).ready(function() {' . PHP_EOL;
+$script .= '	setmenutype = function(type)' . PHP_EOL;
+$script .= '	{' . PHP_EOL;
+if ($tmpl)
+{
+	$script .= '	window.parent.Joomla.submitbutton(\'item.setType\', type);' . PHP_EOL;
+	$script .= '	window.parent.SqueezeBox.close();' . PHP_EOL;
+}
+else
+{
+	$script .= '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);' . PHP_EOL;
+}
+$script .= '	}' . PHP_EOL;
+$script .= '});' . PHP_EOL;
+
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>
 

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -25,7 +25,7 @@ else :
 endif;
 $script[] = '	}';
 $script[] = '});';
-JFactory::getDocument()->addScriptDeclaration(implode($script, ''));
+JFactory::getDocument()->addScriptDeclaration(implode('\n',  $script));
 ?>
 
 <?php echo JHtml::_('bootstrap.startAccordion', 'collapseTypes', array('active' => 'slide1')); ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -13,19 +13,20 @@ $input = JFactory::getApplication()->input;
 // Checking if loaded via index.php or component.php
 $tmpl = $input->getCmd('tmpl', '');
 $document = JFactory::getDocument();
-?>
 
-<script type="text/javascript">
-	setmenutype = function(type)
-	{
-		<?php if ($tmpl) : ?>
-			window.parent.Joomla.submitbutton('item.setType', type);
-			window.parent.SqueezeBox.close();
-		<?php else : ?>
-			window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+('item.setType', type);
-		<?php endif; ?>
-	}
-</script>
+$script[] = 'jQuery(document).ready(function() {';
+$script[] = '	setmenutype = function(type)';
+$script[] = '	{';
+if ($tmpl) :
+	$script[] = '	window.parent.Joomla.submitbutton(\'item.setType\', type);';
+	$script[] = '	window.parent.SqueezeBox.close();';
+else :
+	$script[] = '	window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type="+(\'item.setType\', type);';
+endif;
+$script[] = '	}';
+$script[] = '});';
+JFactory::getDocument()->addScriptDeclaration(implode($script, ''));
+?>
 
 <?php echo JHtml::_('bootstrap.startAccordion', 'collapseTypes', array('active' => 'slide1')); ?>
 	<?php


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_menus to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area go to com_menus and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
http://localhost/administrator/index.php?option=com_admin&view=sysinfo should demonstrate highlighter.js without mt
Logout and log in to demonstrate the use of noframes without mt.
