### PR TITLE
Introduce jquery formvalidator for com_config ::frontend

### DIFF
--- a/components/com_config/view/config/tmpl/default.php
+++ b/components/com_config/view/config/tmpl/default.php
@@ -15,14 +15,13 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('application-form'))) {
 			Joomla.submitform(task, document.getElementById('application-form'));
 		}
 	}
-});");
+");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config');?>" id="application-form" method="post" name="adminForm" class="form-validate">

--- a/components/com_config/view/config/tmpl/default.php
+++ b/components/com_config/view/config/tmpl/default.php
@@ -10,18 +10,20 @@
 defined('_JEXEC') or die;
 
 // Load tooltips behavior
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'config.cancel' || document.formvalidator.isValid(document.id('application-form'))) {
+		if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('application-form'))) {
 			Joomla.submitform(task, document.getElementById('application-form'));
 		}
 	}
-</script>
+});");
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config');?>" id="application-form" method="post" name="adminForm" class="form-validate">
 	<div class="row-fluid">

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.tooltip');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.framework', true);
 JHtml::_('behavior.combobox');
@@ -23,17 +23,18 @@ if (JLanguageMultilang::isEnabled())
 {
 	$this->form->setFieldAttribute('language', 'readonly', 'true');
 }
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'config.cancel.modules' || document.formvalidator.isValid(document.id('modules-form')))
+		if (task == 'config.cancel.modules' || document.formvalidator.isValid(document.getElementById('modules-form')))
 		{
 			Joomla.submitform(task, document.getElementById('modules-form'));
 		}
 	}
-</script>
+});");
+?>
 
 <form
 	action="<?php echo JRoute::_('index.php?option=com_config'); ?>"

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -25,7 +25,6 @@ if (JLanguageMultilang::isEnabled())
 }
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'config.cancel.modules' || document.formvalidator.isValid(document.getElementById('modules-form')))
@@ -33,7 +32,7 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task, document.getElementById('modules-form'));
 		}
 	}
-});");
+");
 ?>
 
 <form

--- a/components/com_config/view/templates/tmpl/default.php
+++ b/components/com_config/view/templates/tmpl/default.php
@@ -14,7 +14,6 @@ JHtml::_('behavior.keepalive');
 $user = JFactory::getUser();
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('templates-form')))
@@ -22,7 +21,7 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task, document.getElementById('templates-form'));
 		}
 	}
-});");
+");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">

--- a/components/com_config/view/templates/tmpl/default.php
+++ b/components/com_config/view/templates/tmpl/default.php
@@ -9,20 +9,21 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 $user = JFactory::getUser();
 
-?>
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'config.cancel' || document.formvalidator.isValid(document.id('templates-form')))
+		if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('templates-form')))
 		{
 			Joomla.submitform(task, document.getElementById('templates-form'));
 		}
 	}
-</script>
+});");
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_config to use plain jquery (no mootools call on every form 
