### PR TITLE
Introduce jquery formvalidator for com_users

### DIFF
--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -16,7 +16,6 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'group.cancel' || document.formvalidator.isValid(document.getElementById('group-form')))
@@ -24,7 +23,7 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task, document.getElementById('group-form'));
 		}
 	}
-});");
+");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="group-form" class="form-validate form-horizontal">

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -22,7 +22,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		{
 			Joomla.submitform(task, document.getElementById('group-form'));
 		}
-	}
+	};
 ");
 ?>
 

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -12,19 +12,20 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'group.cancel' || document.formvalidator.isValid(document.id('group-form')))
+		if (task == 'group.cancel' || document.formvalidator.isValid(document.getElementById('group-form')))
 		{
 			Joomla.submitform(task, document.getElementById('group-form'));
 		}
 	}
-</script>
+});");
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="group-form" class="form-validate form-horizontal">
 	<fieldset>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -24,7 +24,6 @@ $sortFields = $this->getSortFields();
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
 $script = '
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task) {
 		if (task == "groups.delete")
 		{
@@ -48,12 +47,11 @@ $script .= '
 		}
 	Joomla.submitform(task);
 	}
-});';
+';
 
 
 JFactory::getDocument()->addScriptDeclaration($script);
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -69,7 +67,7 @@ jQuery(document).ready(function() {
 		}
 		Joomla.tableOrdering(order, dirn, "");
 	}
-});');
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=groups');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -23,34 +23,38 @@ $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
-$script = '
-	Joomla.submitbutton = function(task) {
-		if (task == "groups.delete")
-		{
-			var f = document.adminForm;
-			var cb="";';
+$groupsWithUsers = array();
+
 foreach ($this->items as $i => $item)
 {
 	if ($item->user_count > 0)
 	{
-		$script .= '
-			cb = f["cb"+' . $i . '];
-			if (cb && cb.checked) {
-				if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) {
-					Joomla.submitform(task);
-				}
-				return;
-			}';
+		array_push($groupsWithUsers, $i);
 	}
 }
-$script .= '
-		}
-	Joomla.submitform(task);
-	}
-';
 
+JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
-JFactory::getDocument()->addScriptDeclaration($script);
+JFactory::getDocument()->addScriptDeclaration('
+		Joomla.submitbutton = function(task) {
+			if (task == "groups.delete") {
+				var f = document.adminForm;
+				var cb = "";
+				var groupsWithUsers = [' . implode(',', $groupsWithUsers) . '];
+				for (index = 0; index < groupsWithUsers.length; ++index) {
+					cb = f["cb" + groupsWithUsers[index]];
+					if (cb && cb.checked) {
+						if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) {
+							Joomla.submitform(task);
+						}
+						return;
+					}
+				}
+			}
+			Joomla.submitform(task);
+		};
+');
+
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()
 	{
@@ -66,7 +70,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=groups');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -23,29 +23,29 @@ $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
-$script = 'jQuery(document).ready(function() {';
-$script .= '	Joomla.submitbutton = function(task) {';
-$script .= '		if (task == "groups.delete")';
-$script .= '		{';
-$script .= '			var f = document.adminForm;';
-$script .= '			var cb="";';
+$script = 'jQuery(document).ready(function() {' . PHP_EOL;
+$script .= '	Joomla.submitbutton = function(task) {' . PHP_EOL;
+$script .= '		if (task == "groups.delete")' . PHP_EOL;
+$script .= '		{' . PHP_EOL;
+$script .= '			var f = document.adminForm;' . PHP_EOL;
+$script .= '			var cb="";' . PHP_EOL;
 foreach ($this->items as $i => $item)
 {
 	if ($item->user_count > 0)
 	{
-		$script .= '	cb = f["cb"+' . $i . '];';
-		$script .= '	if (cb && cb.checked) { ';
-		$script .= '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ';
-		$script .= '			Joomla.submitform(task);';
-		$script .= '		}';
-		$script .= '		return;';
-		$script .= '	}';
+		$script .= '	cb = f["cb"+' . $i . '];' . PHP_EOL;
+		$script .= '	if (cb && cb.checked) { ' . PHP_EOL;
+		$script .= '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ' . PHP_EOL;
+		$script .= '			Joomla.submitform(task);' . PHP_EOL;
+		$script .= '		}' . PHP_EOL;
+		$script .= '		return;' . PHP_EOL;
+		$script .= '	}' . PHP_EOL;
 	}
 }
-$script .= '		}';
-$script .= '	Joomla.submitform(task);';
-$script .= '	}';
-$script .= '});';
+$script .= '		}' . PHP_EOL;
+$script .= '	Joomla.submitform(task);' . PHP_EOL;
+$script .= '	}' . PHP_EOL;
+$script .= '});' . PHP_EOL;
 
 JFactory::getDocument()->addScriptDeclaration($script);
 JFactory::getDocument()->addScriptDeclaration('

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -47,7 +47,7 @@ $script[] = '	Joomla.submitform(task);';
 $script[] = '	}';
 $script[] = '});';
 
-JFactory::getDocument()->addScriptDeclaration($script);
+JFactory::getDocument()->addScriptDeclaration(implode($script, ''));
 JFactory::getDocument()->addScriptDeclaration('
 jQuery(document).ready(function() {
 	Joomla.orderTable = function()

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -22,48 +22,51 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
-?>
-<script type="text/javascript">
-	Joomla.submitbutton = function(task)
+
+$script[] = 'jQuery(document).ready(function() {';
+$script[] = '	Joomla.submitbutton = function(task) {';
+$script[] = '		if (task == "groups.delete")';
+$script[] = '		{';
+$script[] = '			var f = document.adminForm;';
+$script[] = '			var cb="";';
+foreach ($this->items as $i => $item)
+{
+	if ($item->user_count > 0)
 	{
-		if (task == 'groups.delete')
-		{
-			var f = document.adminForm;
-			var cb='';
-<?php foreach ($this->items as $i => $item):?>
-<?php if ($item->user_count > 0):?>
-			cb = f['cb'+<?php echo $i;?>];
-			if (cb && cb.checked)
-			{
-				if (confirm(Joomla.JText._('COM_USERS_GROUPS_CONFIRM_DELETE')))
-				{
-					Joomla.submitform(task);
-				}
-				return;
-			}
-<?php endif;?>
-<?php endforeach;?>
-		}
-		Joomla.submitform(task);
+		$script[] = '	cb = f["cb"+' . $i . '];';
+		$script[] = '	if (cb && cb.checked) { ';
+		$script[] = '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ';
+		$script[] = '			Joomla.submitform(task);';
+		$script[] = '		}';
+		$script[] = '		return;';
+		$script[] = '	}';
 	}
-</script>
-<script type="text/javascript">
+}
+$script[] = '		}';
+$script[] = '	Joomla.submitform(task);';
+$script[] = '	}';
+$script[] = '});';
+
+JFactory::getDocument()->addScriptDeclaration($script);
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=groups');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -23,29 +23,33 @@ $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
-$script = 'jQuery(document).ready(function() {' . PHP_EOL;
-$script .= '	Joomla.submitbutton = function(task) {' . PHP_EOL;
-$script .= '		if (task == "groups.delete")' . PHP_EOL;
-$script .= '		{' . PHP_EOL;
-$script .= '			var f = document.adminForm;' . PHP_EOL;
-$script .= '			var cb="";' . PHP_EOL;
+$script = '
+jQuery(document).ready(function() {
+	Joomla.submitbutton = function(task) {
+		if (task == "groups.delete")
+		{
+			var f = document.adminForm;
+			var cb="";';
 foreach ($this->items as $i => $item)
 {
 	if ($item->user_count > 0)
 	{
-		$script .= '	cb = f["cb"+' . $i . '];' . PHP_EOL;
-		$script .= '	if (cb && cb.checked) { ' . PHP_EOL;
-		$script .= '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ' . PHP_EOL;
-		$script .= '			Joomla.submitform(task);' . PHP_EOL;
-		$script .= '		}' . PHP_EOL;
-		$script .= '		return;' . PHP_EOL;
-		$script .= '	}' . PHP_EOL;
+		$script .= '
+			cb = f["cb"+' . $i . '];
+			if (cb && cb.checked) {
+				if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) {
+					Joomla.submitform(task);
+				}
+				return;
+			}';
 	}
 }
-$script .= '		}' . PHP_EOL;
-$script .= '	Joomla.submitform(task);' . PHP_EOL;
-$script .= '	}' . PHP_EOL;
-$script .= '});' . PHP_EOL;
+$script .= '
+		}
+	Joomla.submitform(task);
+	}
+});';
+
 
 JFactory::getDocument()->addScriptDeclaration($script);
 JFactory::getDocument()->addScriptDeclaration('

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -55,7 +55,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -47,7 +47,7 @@ $script[] = '	Joomla.submitform(task);';
 $script[] = '	}';
 $script[] = '});';
 
-JFactory::getDocument()->addScriptDeclaration(implode($script, ''));
+JFactory::getDocument()->addScriptDeclaration(implode('\n', $script));
 JFactory::getDocument()->addScriptDeclaration('
 jQuery(document).ready(function() {
 	Joomla.orderTable = function()

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -23,31 +23,31 @@ $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
-$script[] = 'jQuery(document).ready(function() {';
-$script[] = '	Joomla.submitbutton = function(task) {';
-$script[] = '		if (task == "groups.delete")';
-$script[] = '		{';
-$script[] = '			var f = document.adminForm;';
-$script[] = '			var cb="";';
+$script = 'jQuery(document).ready(function() {';
+$script .= '	Joomla.submitbutton = function(task) {';
+$script .= '		if (task == "groups.delete")';
+$script .= '		{';
+$script .= '			var f = document.adminForm;';
+$script .= '			var cb="";';
 foreach ($this->items as $i => $item)
 {
 	if ($item->user_count > 0)
 	{
-		$script[] = '	cb = f["cb"+' . $i . '];';
-		$script[] = '	if (cb && cb.checked) { ';
-		$script[] = '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ';
-		$script[] = '			Joomla.submitform(task);';
-		$script[] = '		}';
-		$script[] = '		return;';
-		$script[] = '	}';
+		$script .= '	cb = f["cb"+' . $i . '];';
+		$script .= '	if (cb && cb.checked) { ';
+		$script .= '		if (confirm(Joomla.JText._("COM_USERS_GROUPS_CONFIRM_DELETE"))) { ';
+		$script .= '			Joomla.submitform(task);';
+		$script .= '		}';
+		$script .= '		return;';
+		$script .= '	}';
 	}
 }
-$script[] = '		}';
-$script[] = '	Joomla.submitform(task);';
-$script[] = '	}';
-$script[] = '});';
+$script .= '		}';
+$script .= '	Joomla.submitform(task);';
+$script .= '	}';
+$script .= '});';
 
-JFactory::getDocument()->addScriptDeclaration(implode('\n', $script));
+JFactory::getDocument()->addScriptDeclaration($script);
 JFactory::getDocument()->addScriptDeclaration('
 jQuery(document).ready(function() {
 	Joomla.orderTable = function()

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -15,7 +15,6 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.formvalidator');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'level.cancel' || document.formvalidator.isValid(document.getElementById('level-form')))
@@ -23,7 +22,7 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task, document.getElementById('level-form'));
 		}
 	}
-});");
+");
 /*
 window.addEvent('domready', function(){
 	document.id('user-groups').getElements('input').each(function(i){

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -12,17 +12,18 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
-JHtml::_('behavior.formvalidation');
-?>
+JHtml::_('behavior.formvalidator');
 
-<script type="text/javascript">
-Joomla.submitbutton = function(task)
-{
-	if (task == 'level.cancel' || document.formvalidator.isValid(document.id('level-form')))
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
+	Joomla.submitbutton = function(task)
 	{
-		Joomla.submitform(task, document.id('level-form'));
+		if (task == 'level.cancel' || document.formvalidator.isValid(document.getElementById('level-form')))
+		{
+			Joomla.submitform(task, document.getElementById('level-form'));
+		}
 	}
-}
+});");
 /*
 window.addEvent('domready', function(){
 	document.id('user-groups').getElements('input').each(function(i){
@@ -88,8 +89,7 @@ window.addEvent('domready', function(){
 	});
 });
 */
-</script>
-
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="level-form" class="form-validate form-horizontal">
 	<fieldset>

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		{
 			Joomla.submitform(task, document.getElementById('level-form'));
 		}
-	}
+	};
 ");
 /*
 window.addEvent('domready', function(){

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -28,24 +28,26 @@ if ($saveOrder)
 	$saveOrderingUrl = 'index.php?option=com_users&task=levels.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'levelList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -44,7 +44,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -30,7 +30,6 @@ if ($saveOrder)
 }
 
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -46,7 +45,7 @@ jQuery(document).ready(function() {
 		}
 		Joomla.tableOrdering(order, dirn, "");
 	}
-});');
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -36,7 +36,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -19,7 +19,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		{
 			Joomla.submitform(task, document.getElementById('note-form'));
 		}
-	}
+	};
 ");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id='.(int) $this->item->id);?>" method="post" name="adminForm" id="note-form" class="form-validate form-horizontal">

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -9,18 +9,20 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-?>
-<script language="javascript" type="text/javascript">
-Joomla.submitbutton = function(task)
-{
-	if (task == 'note.cancel' || document.formvalidator.isValid(document.id('note-form')))
+
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
+	Joomla.submitbutton = function(task)
 	{
-		Joomla.submitform(task, document.getElementById('note-form'));
+		if (task == 'note.cancel' || document.formvalidator.isValid(document.getElementById('note-form')))
+		{
+			Joomla.submitform(task, document.getElementById('note-form'));
+		}
 	}
-}
-</script>
+});");
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id='.(int) $this->item->id);?>" method="post" name="adminForm" id="note-form" class="form-validate form-horizontal">
 		<fieldset class="adminform">
 			<div class="control-group">

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -13,7 +13,6 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'note.cancel' || document.formvalidator.isValid(document.getElementById('note-form')))
@@ -21,7 +20,7 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task, document.getElementById('note-form'));
 		}
 	}
-});");
+");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id='.(int) $this->item->id);?>" method="post" name="adminForm" id="note-form" class="form-validate form-horizontal">
 		<fieldset class="adminform">

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -34,7 +34,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=notes');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -26,7 +26,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -20,7 +20,6 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -36,7 +35,7 @@ jQuery(document).ready(function() {
 		}
 		Joomla.tableOrdering(order, dirn, "");
 	}
-});');
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=notes');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -18,24 +18,26 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn = $this->escape($this->state->get('list.direction'));
 $canEdit = $user->authorise('core.edit', 'com_users');
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=notes');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -22,7 +22,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		{
 			Joomla.submitform(task, document.getElementById('user-form'));
 		}
-	}
+	};
 
 	jQuery(document).ready(function() {
 		Joomla.twoFactorMethodChange = function(e)

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -24,23 +24,21 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 
-	jQuery(document).ready(function() {
-		Joomla.twoFactorMethodChange = function(e)
-		{
-			var selectedPane = 'com_users_twofactor_' + jQuery('#jform_twofactor_method').val();
+	Joomla.twoFactorMethodChange = function(e)
+	{
+		var selectedPane = 'com_users_twofactor_' + jQuery('#jform_twofactor_method').val();
 
-			jQuery.each(jQuery('#com_users_twofactor_forms_container>div'), function(i, el) {
-				if (el.id != selectedPane)
-				{
-					jQuery('#' + el.id).hide(0);
-				}
-				else
-				{
-					jQuery('#' + el.id).show(0);
-				}
-			});
-		}
-	});
+		jQuery.each(jQuery('#com_users_twofactor_forms_container>div'), function(i, el) {
+			if (el.id != selectedPane)
+			{
+				jQuery('#' + el.id).hide(0);
+			}
+			else
+			{
+				jQuery('#' + el.id).show(0);
+			}
+		});
+	};
 ");
 
 // Get the form fieldsets.

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -16,7 +16,6 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'user.cancel' || document.formvalidator.isValid(document.getElementById('user-form')))
@@ -25,22 +24,24 @@ jQuery(document).ready(function() {
 		}
 	}
 
-	Joomla.twoFactorMethodChange = function(e)
-	{
-		var selectedPane = 'com_users_twofactor_' + jQuery('#jform_twofactor_method').val();
+	jQuery(document).ready(function() {
+		Joomla.twoFactorMethodChange = function(e)
+		{
+			var selectedPane = 'com_users_twofactor_' + jQuery('#jform_twofactor_method').val();
 
-		jQuery.each(jQuery('#com_users_twofactor_forms_container>div'), function(i, el) {
-			if (el.id != selectedPane)
-			{
-				jQuery('#' + el.id).hide(0);
-			}
-			else
-			{
-				jQuery('#' + el.id).show(0);
-			}
-		});
-	}
-});");
+			jQuery.each(jQuery('#com_users_twofactor_forms_container>div'), function(i, el) {
+				if (el.id != selectedPane)
+				{
+					jQuery('#' + el.id).hide(0);
+				}
+				else
+				{
+					jQuery('#' + el.id).show(0);
+				}
+			});
+		}
+	});
+");
 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -12,17 +12,14 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-// Get the form fieldsets.
-$fieldsets = $this->form->getFieldsets();
-?>
-
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'user.cancel' || document.formvalidator.isValid(document.id('user-form')))
+		if (task == 'user.cancel' || document.formvalidator.isValid(document.getElementById('user-form')))
 		{
 			Joomla.submitform(task, document.getElementById('user-form'));
 		}
@@ -43,7 +40,11 @@ $fieldsets = $this->form->getFieldsets();
 			}
 		});
 	}
-</script>
+});");
+
+// Get the form fieldsets.
+$fieldsets = $this->form->getFieldsets();
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" class="form-validate form-horizontal" enctype="multipart/form-data">
 

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -26,7 +26,7 @@ jQuery(document).ready(function() {
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != ' . $listOrder . ')
+		if (order != "' . $listOrder . '")
 		{
 			dirn = "asc";
 		}

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -18,24 +18,26 @@ $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $loggeduser = JFactory::getUser();
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != ' . $listOrder . ')
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+});');
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=users');?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -20,7 +20,6 @@ $loggeduser = JFactory::getUser();
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -36,7 +35,7 @@ jQuery(document).ready(function() {
 		}
 		Joomla.tableOrdering(order, dirn, "");
 	}
-});');
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=users');?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -34,7 +34,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=users');?>" method="post" name="adminForm" id="adminForm">


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_users to use plain jquery (no mootools call on every form ).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area go to com_users and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here
