### PR TITLE
Remove the 2.5 EOS plugin if present

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -92,7 +92,7 @@ class JoomlaInstallerScript
 				$db->getQuery(true)
 					->update('#__extensions')
 					->set('protected = 0')
-					->where($db->quoteName('name') . ' = ' . $db->quote('plg_quickicon_eosnotify'))
+					->where($db->quoteName('extension_id') . ' = ' . $id)
 			)->execute();
 
 			$installer = new JInstaller;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -87,6 +87,14 @@ class JoomlaInstallerScript
 
 		if ($id)
 		{
+			// We need to unprotect the plugin so we can uninstall it
+			$db->setQuery(
+				$db->getQuery(true)
+					->update('#__extensions')
+					->set('protected = 0')
+					->where($db->quoteName('name') . ' = ' . $db->quote('plg_quickicon_eosnotify'))
+			)->execute();
+
 			$installer = new JInstaller;
 			$installer->uninstall('plugin', $id);
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -76,6 +76,20 @@ class JoomlaInstallerScript
 				}
 			}
 		}
+
+		// Check if the 2.5 EOS plugin is present and uninstall it if so
+		$id = $db->setQuery(
+			$db->getQuery(true)
+				->select('extension_id')
+				->from('#__extensions')
+				->where('name = ' . $db->quote('PLG_EOSNOTIFY'))
+		)->loadResult();
+
+		if ($id)
+		{
+			$installer = new JInstaller;
+			$installer->uninstall('plugin', $id);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR is in conjunction with #5063 and will remove the 2.5 End of Support plugin for users who have it installed and upgrade a 2.5 site to 3.x.
