### PR TITLE
Fix missing title and alias for com_contact modal Ref #5065

### DIFF
--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -48,7 +48,10 @@ $assoc = JLanguageAssociations::isEnabled();
 <div class="clearfix"> </div>
 <hr class="hr-condensed" />
 
-<form action="<?php echo JRoute::_('index.php?option=com_contact&layout=modal&tmpl=component&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="contact-form" class="form-validate form-horizontal">
+<form action="<?php echo JRoute::_('index.php?option=com_contact&layout=modal&tmpl=component&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="contact-form" class="form-validate">
+
+	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
+
 	<div class="form-horizontal">
 		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 


### PR DESCRIPTION
Joomla 3.3.6

Having a menu item type: Contacts > Single contact
Edit this menu item from Menus > your-menu >  your-menu-item > Select Contact > Edit. 
This will open the contact to edit, don't change nothing and press "Save" button, you will get a warning: "Field required: Name" due actuallt the name field is not being there in first place.

ref: #5065

Can you have a look into it @htmgarcia If you need help by testing see here: http://docs.joomla.org/Component_Patchtester_for_Testers
