### PR TITLE
Value should be a js string but was not being encoded as such.

### DIFF
--- a/administrator/components/com_media/models/manager.php
+++ b/administrator/components/com_media/models/manager.php
@@ -101,13 +101,13 @@ class MediaModelManager extends JModelLegacy
 		// so both string and integer are supported.
 		if ($asset == 0)
 		{
-			$asset = $input->get('asset', 0, 'cmd');
+			$asset = htmlspecialchars(json_encode(trim($input->get('asset', 0, 'cmd'))));
 		}
 
 		$author = $input->get('author', 0, 'integer');
 
 		// Create the drop-down folder select list
-		$attribs = 'size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, ' . json_encode($asset) . ', ' . $author . ')" ';
+		$attribs = 'size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, ' . $asset . ', ' . $author . ')" ';
 		$list = JHtml::_('select.genericlist', $options, 'folderlist', $attribs, 'value', 'text', $base);
 
 		return $list;

--- a/administrator/components/com_media/models/manager.php
+++ b/administrator/components/com_media/models/manager.php
@@ -107,7 +107,7 @@ class MediaModelManager extends JModelLegacy
 		$author = $input->get('author', 0, 'integer');
 
 		// Create the drop-down folder select list
-		$attribs = 'size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, ' . $asset . ', ' . $author . ')" ';
+		$attribs = 'size="1" onchange="ImageManager.setFolder(this.options[this.selectedIndex].value, ' . json_encode($asset) . ', ' . $author . ')" ';
 		$list = JHtml::_('select.genericlist', $options, 'folderlist', $attribs, 'value', 'text', $base);
 
 		return $list;


### PR DESCRIPTION
The editor button 'image' pops up a dialog that allows you to navigate the media manager's files. There's a `select` in this dialog full of directories that you might want to navigate to but it doesn't work. This is because of a php string being inserted into js code as-is. It needs to be json encoded (typically this just means putting it in quotes) first. 
