### PR TITLE
Protostar template doesn't work with component links in SEF 

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -37,10 +37,10 @@ else
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
-$doc->addScript('templates/' . $this->template . '/js/template.js');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);


### PR DESCRIPTION
Fix issue #5081 by making template script and css links absolute rather than relative.
