### PR TITLE
[#33194] change language redirect with language code from 303 to 301

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ administrator/components/com_patchtester/
 administrator/templates/hathor/html/com_patchtester
 components/com_patchtester/
 
+# german language #
+administrator/language/de-DE/
+administrator/manifests/packages/pkg_de-DE.xml
+language/de-DE/
+
 # OSX #
 ._*
 .Spotlight-V100

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -312,7 +312,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if ($app->get('sef_rewrite'))
 						{
-							$app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
+							$app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')), true);
 						}
 						else
 						{


### PR DESCRIPTION
On a multilingual site urls called without the language code are redirected by a "303 see other" instead of "301 moved permanently".
The code used here is the "first half" of https://github.com/joomla/joomla-cms/pull/2845/files provided by infograf768 (thanks!).
**Edit:**
**Please note:** this PR is only applying if "Use URL rewriting" is set to **"Yes"** and **"Remove URL Language Code"** is set to ~~"Yes"~~ **"No"** !
#### Steps to reproduce the issue:
1. create a multilingual site with "Use URL rewriting" set to "Yes" in global configuration
2. in plugin "System - Language Filter" set  
   a. "Language Selection for new Visitors" to "Site Language"  
   b. "Automatic Language Change" to "Yes"  
   c. "Item associations" to "Yes"  
   d. **"Remove URL Language Code"** to ~~"Yes"~~ **"No"**  
3. go to homepage in firefox
4. start firebug and switch to to the "network" tab
5. in the addressbar remove the language code and hit F5
#### Expected result:

The first redirect shown in the network tab should be a 301 redirect as the url without the language code is no longer available, and so it should be redirected "permanently".
#### Actual result:

The redirect is a "303 see other".
#### System information:

PHP 5.5.9-1ubuntu4.5
MySQLi 5.5.40-0ubuntu0.14.04.1
Caching Disabled
GZip Disabled
#### Additional comments:

After applying the patch, the redirect is a "301 moved permanently".

This was addressed a while ago on the old tracker:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33194&start=8400
and there were some problems with cache enabled mentioned by Jean-Marie Simonet. 
So please test with and without cache enabled.

And sorry for adding the changed gitignore file here - i don't know how to remove it from the PR - still new to git.
