### PR TITLE
Include category table when needed

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -83,13 +83,16 @@ class BannersModelBanners extends JModelList
 			->where('(' . $query->currentTimestamp() . ' <= a.publish_down OR a.publish_down = ' . $nullDate . ')')
 			->where('(a.imptotal = 0 OR a.impmade <= a.imptotal)');
 
-		if ($cid)
+		if ($cid OR $categoryId)
 		{
-			$query->join('LEFT', '#__categories as cat ON a.catid = cat.id')
-				->where('a.cid = ' . (int) $cid)
-				->where('cl.state = 1');
+			$query->join('LEFT', '#__categories as cat ON a.catid = cat.id');
 		}
 
+		if ($cid)
+		{
+    			$query->where('a.cid = ' . (int) $cid)
+           		      ->where('cl.state = 1');
+		}
 		// Filter by a single or group of categories
 		if (is_numeric($categoryId))
 		{


### PR DESCRIPTION
Intended to fix joomla/joomla-cms#5000 where banners with matched by tags don't display.

Someone that is more familiar with this code might have a more elegant way of doing this. It works for us on favoritehotelscollection.com: http://favoritehotelscollection.com/places/europe/france-paris.html
