### PR TITLE
Add div and class for Bootstrap2 page-header.

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -26,13 +26,15 @@ function iFrameHeight()
 </script>
 <div class="contentpane<?php echo $this->pageclass_sfx; ?>">
 <?php if ($this->params->get('show_page_heading')) : ?>
-	<h1>
-		<?php if ($this->escape($this->params->get('page_heading'))) :?>
-			<?php echo $this->escape($this->params->get('page_heading')); ?>
-		<?php else : ?>
-			<?php echo $this->escape($this->params->get('page_title')); ?>
-		<?php endif; ?>
-	</h1>
+	<div class="page-header">
+		<h1>
+			<?php if ($this->escape($this->params->get('page_heading'))) :?>
+				<?php echo $this->escape($this->params->get('page_heading')); ?>
+			<?php else : ?>
+				<?php echo $this->escape($this->params->get('page_title')); ?>
+			<?php endif; ?>
+		</h1>
+	</div>
 <?php endif; ?>
 <iframe <?php echo $this->wrapper->load; ?>
 	id="blockrandom"


### PR DESCRIPTION
Bootstrap2 has a div containing class=page-header for page header. 
This tiny piece of html was missing from com_wrapper
