### PR TITLE
Finder: Fallback for routing is called with wrong parameters

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -301,7 +301,7 @@ class PlgFinderCategories extends FinderIndexerAdapter
 		}
 		else
 		{
-			$item->route = ContentHelperRoute::getCategoryRoute($item->slug, $item->catid);
+			$item->route = ContentHelperRoute::getCategoryRoute($item->id, $item->language);
 		}
 
 		$item->path = FinderIndexerHelper::getContentPath($item->route);


### PR DESCRIPTION
The method ContentHelperRoute::getCategoryRoute() does not have this signature. Instead, it needs to be called the same as in line 300. This needs a maintainer to simply look over this and give this a code-review.
