### PR TITLE
Introduce jquery formvalidator for mod_finder ::frontend

### DIFF
--- a/components/com_finder/views/search/tmpl/default.php
+++ b/components/com_finder/views/search/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::stylesheet('com_finder/finder.css', false, true, false);
 ?>

--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -8,62 +8,61 @@
  */
 
 defined('_JEXEC') or die;
-?>
 
-<script type="text/javascript">
-	jQuery(function($) {
-<?php if ($this->params->get('show_advanced', 1)) : ?>
-		/*
-		 * This segment of code adds the slide effect to the advanced search box.
-		 */
-		var $searchSlider = $('#advanced-search');
-		if ($searchSlider.length)
+$script = "jQuery(function() {";
+if ($this->params->get('show_advanced', 1))
+{
+	/*
+	 * This segment of code adds the slide effect to the advanced search box.
+	 */
+	$script .= "		var searchSlider = jQuery('#advanced-search');
+		if (searchSlider.length)
 		{
-			<?php if (!$this->params->get('expand_advanced', 0)) : ?>
-			$searchSlider.hide();
-			<?php endif; ?>
+		";
+	if (!$this->params->get('expand_advanced', 0))
+	{
+		$script .= "searchSlider.hide();";
+	}
 
-			$('#advanced-search-toggle').on('click', function(e)
-			{
+	$script .= "jQuery('#advanced-search-toggle').on('click', function(e) {
 				e.stopPropagation();
 				e.preventDefault();
-				$searchSlider.slideToggle();
+				searchSlider.slideToggle();
 			});
-		}
-
-		/*
-		 * This segment of code disables select boxes that have no value when the
-		 * form is submitted so that the URL doesn't get blown up with null values.
-		 */
-		if ($('#finder-search').length)
-		{
-			$('#finder-search').on('submit', function(e){
+		}";
+	/*
+	 * This segment of code disables select boxes that have no value when the
+	 * form is submitted so that the URL doesn't get blown up with null values.
+	 */
+	$script .= "		if (jQuery('#finder-search').length) {
+			jQuery('#finder-search').on('submit', function(e){
 				e.stopPropagation();
-
-				if ($searchSlider.length)
+				if (searchSlider.length)
 				{
 					// Disable select boxes with no value selected.
-					$searchSlider.find('select').each(function(index, el) {
-						var $el = $(el);
-			        	if(!$el.val()){
-			        		$el.attr('disabled', 'disabled');
-			        	}
-        			});
+					searchSlider.find('select').each(function(index, el) {
+						var el = jQuery(el);
+						if(!el.val()){
+							el.attr('disabled', 'disabled');
+						}
+					});
 				}
-
 			});
-		}
-<?php endif; ?>
-		/*
-		 * This segment of code sets up the autocompleter.
-		 */
-<?php if ($this->params->get('show_autosuggest', 1)) : ?>
-	<?php JHtml::_('script', 'com_finder/autocompleter.js', false, true); ?>
-	var url = '<?php echo JRoute::_('index.php?option=com_finder&task=suggestions.display&format=json&tmpl=component', false); ?>';
-	var completer = new Autocompleter.Request.JSON(document.getElementById("q"), url, {'postVar': 'q'});
-<?php endif; ?>
-	});
-</script>
+		}";
+}
+/*
+ * This segment of code sets up the autocompleter.
+ */
+if ($this->params->get('show_autosuggest', 1))
+{
+	JHtml::_('script', 'com_finder/autocompleter.js', true, true);
+	$script .= "var url = '" . JRoute::_('index.php?option=com_finder&task=suggestions.display&format=json&tmpl=component', false) . "', ";
+	$script .= "completer = new Autocompleter.Request.JSON(document.getElementById('q'), url, {'postVar': 'q'});";
+}
+$script .= "});";
+
+JFactory::getDocument()->addScriptDeclaration($script);
+?>
 
 <form id="finder-search" action="<?php echo JRoute::_($this->query->toURI()); ?>" method="get" class="form-inline">
 	<?php echo $this->getFields(); ?>

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -71,68 +71,65 @@ if ($params->get('show_button'))
 }
 
 JHtml::stylesheet('com_finder/finder.css', false, true, false);
-?>
 
-<script type="text/javascript">
-//<![CDATA[
-	jQuery(function($)
-	{
-		var value, $searchword = $('#mod-finder-searchword');
+$script = "
+jQuery(document).ready(function() {
+	var value, searchword = jQuery('#mod-finder-searchword');
 
 		// Set the input value if not already set.
-		if (!$searchword.val())
+		if (!searchword.val())
 		{
-			$searchword.val('<?php echo JText::_('MOD_FINDER_SEARCH_VALUE', true); ?>');
+			searchword.val('" . JText::_('MOD_FINDER_SEARCH_VALUE', true) . "');
 		}
 
 		// Get the current value.
-		value = $searchword.val();
+		value = searchword.val();
 
 		// If the current value equals the default value, clear it.
-		$searchword.on('focus', function()
-		{	var $el = $(this);
-			if ($el.val() === '<?php echo JText::_('MOD_FINDER_SEARCH_VALUE', true); ?>')
+		searchword.on('focus', function()
+		{	var el = jQuery(this);
+			if (el.val() === '" . JText::_('MOD_FINDER_SEARCH_VALUE', true) . "')
 			{
-				$el.val('');
+				el.val('');
 			}
 		});
 
 		// If the current value is empty, set the previous value.
-		$searchword.on('blur', function()
-		{	var $el = $(this);
-			if (!$el.val())
+		searchword.on('blur', function()
+		{	var el = jQuery(this);
+			if (!el.val())
 			{
-				$el.val(value);
+				el.val(value);
 			}
 		});
 
-		$('#mod-finder-searchform').on('submit', function(e){
+		jQuery('#mod-finder-searchform').on('submit', function(e){
 			e.stopPropagation();
-			var $advanced = $('#mod-finder-advanced');
+			var advanced = jQuery('#mod-finder-advanced');
 			// Disable select boxes with no value selected.
-			if ( $advanced.length)
+			if ( advanced.length)
 			{
-				 $advanced.find('select').each(function(index, el) {
-					var $el = $(el);
-					if(!$el.val()){
-						$el.attr('disabled', 'disabled');
+				advanced.find('select').each(function(index, el) {
+					var el = jQuery(el);
+					if(!el.val()){
+						el.attr('disabled', 'disabled');
 					}
 				});
 			}
 		});
+		";
 
-		/*
-		 * This segment of code sets up the autocompleter.
-		 */
-		<?php if ($params->get('show_autosuggest', 1)) : ?>
-			<?php JHtml::_('behavior.framework'); ?>
-			<?php JHtml::_('script', 'com_finder/autocompleter.js', false, true); ?>
-			var url = '<?php echo JRoute::_('index.php?option=com_finder&task=suggestions.display&format=json&tmpl=component', false); ?>';
-			var ModCompleter = new Autocompleter.Request.JSON(document.getElementById('mod-finder-searchword'), url, {'postVar': 'q'});
-		<?php endif; ?>
-	});
-//]]>
-</script>
+if ($params->get('show_autosuggest', 1))
+{
+	JHtml::_('script', 'com_finder/autocompleter.js', true, true);
+	$script .= "var url = '" . JRoute::_('index.php?option=com_finder&task=suggestions.display&format=json&tmpl=component', false) . "'; ";
+	$script .= "var ModCompleter = new Autocompleter.Request.JSON(document.getElementById('mod-finder-searchword'), url, {'postVar': 'q'});
+	";
+}
+$script .= "});";
+
+JFactory::getDocument()->addScriptDeclaration($script);
+?>
 
 <form id="mod-finder-searchform" action="<?php echo JRoute::_($route); ?>" method="get" class="form-search">
 	<div class="finder<?php echo $suffix; ?>">


### PR DESCRIPTION
#### Smart search spoils every page that has it!

Inline scripts are bad.
This PR removes the inline script for module and component finder (front end ONLY).
#### Test

*\* Make sure you have some data and you have indexed stuff in finder **
1. Got to admin -> System -> Global configuration and click on the left panel at Smart Search
2. Disable everything
3. Apply this with Patchtester
4. Go to front end at the page you have mod_finder published and make a search
5. Got to admin -> System -> Global configuration and click on the left panel at Smart Search and start enabling options
For each one you enabling go to front end make a search

Please also watch your browser console log for script errors

The script should be on the page’s `<head>` like this:
![screen shot 2014-11-14 at 11 05 47](https://cloud.githubusercontent.com/assets/3889375/5053572/8cd7cf5c-6c54-11e4-8f36-a2067f2ea761.png)
