### PR TITLE
Fix for: Banners matched only by tags results in SQL error

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -83,8 +83,7 @@ class BannersModelBanners extends JModelList
 
 		if ($cid)
 		{
-			$query->join('LEFT', '#__categories as cat ON a.catid = cat.id')
-				->where('a.cid = ' . (int) $cid)
+			$query->where('a.cid = ' . (int) $cid)
 				->where('cl.state = 1');
 		}
 
@@ -140,6 +139,11 @@ class BannersModelBanners extends JModelList
 				$temp = array();
 				$config = JComponentHelper::getParams('com_banners');
 				$prefix = $config->get('metakey_prefix');
+
+				if ($categoryId)
+				{
+					$query->join('LEFT', '#__categories as cat ON a.catid = cat.id');
+				}
 
 				foreach ($keywords as $keyword)
 				{


### PR DESCRIPTION
The category table is falsely included/not included. Long story short, this fixes #5000 and is a better fix than #5098 See there for testing instructions.
