### PR TITLE
JModelLegacy: Don't try to use "fast" count method for queries with union

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -321,6 +321,8 @@ abstract class JModelLegacy extends JObject
 		if ($query instanceof JDatabaseQuery
 			&& $query->type == 'select'
 			&& $query->group === null
+			&& $query->union === null
+			&& $query->unionAll === null
 			&& $query->having === null)
 		{
 			$query = clone $query;


### PR DESCRIPTION
To calculate the total number of items that a query returns, we try to use a faster method by replacing the whole SELECT part with a COUNT(_). When we are using a UNION or UNIONALL in our query, this however fails, since the number of fields of the 2 different queries when using COUNT(_) might differ. This PR excludes such queries from being treated in that special way.

Again, not easily testable, needs a maintainer to do a code review.

I will provide another PR soon, that merges the update and discover view of com_installer and which uses this feature.
