### PR TITLE
Language Switcher: Remove the language code for the default language

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -248,7 +248,8 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  The ID selector for the modal.
 	 * @param   array   $params    An array of options for the modal.
 	 *                             Options for the modal can be:
-	 *                             - backdrop  boolean  Includes a modal-backdrop element.
+	 *                             - backdrop  mixed    If boolean select to include a modal-backdrop element.
+	 *                                                  Alternatively, the string 'static' for a backdrop which doesn't close the modal on click.
 	 *                             - keyboard  boolean  Closes the modal when escape key is pressed.
 	 *                             - show      boolean  Shows the modal when initialized.
 	 *                             - remote    string   An optional remote URL to load
@@ -267,7 +268,18 @@ abstract class JHtmlBootstrap
 			static::framework();
 
 			// Setup options object
-			$opt['backdrop'] = isset($params['backdrop']) ? (boolean) $params['backdrop'] : true;
+			$opt['backdrop'] = true;
+			if (isset($params['backdrop']))
+			{
+				if (strcmp($params['backdrop'],'static') === 0)
+				{
+					$opt['backdrop'] = 'static';
+				}
+				else
+				{
+					$opt['backdrop'] = (boolean) $params['backdrop'];
+				}
+			}
 			$opt['keyboard'] = isset($params['keyboard']) ? (boolean) $params['keyboard'] : true;
 			$opt['show']     = isset($params['show']) ? (boolean) $params['show'] : true;
 			$opt['remote']   = isset($params['remote']) ?  $params['remote'] : '';
@@ -294,19 +306,23 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  The ID selector for the modal.
 	 * @param   array   $params    An array of options for the modal.
 	 * @param   string  $footer    Optional markup for the modal footer
+	 * @param	boolean $closebtn  Optional display modal close button
 	 *
 	 * @return  string  HTML markup for a modal
 	 *
 	 * @since   3.0
 	 */
-	public static function renderModal($selector = 'modal', $params = array(), $footer = '')
+	public static function renderModal($selector = 'modal', $params = array(), $footer = '', $closebtn = true)
 	{
 		// Ensure the behavior is loaded
 		static::modal($selector, $params);
 
 		$html = "<div class=\"modal hide fade\" id=\"" . $selector . "\">\n";
 		$html .= "<div class=\"modal-header\">\n";
-		$html .= "<button type=\"button\" class=\"close\" data-dismiss=\"modal\">×</button>\n";
+		if ($closebtn)
+		{
+			$html .= "<button type=\"button\" class=\"close\" data-dismiss=\"modal\">×</button>\n";
+		}
 		$html .= "<h3>" . $params['title'] . "</h3>\n";
 		$html .= "</div>\n";
 		$html .= "<div id=\"" . $selector . "-container\">\n";

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -248,8 +248,7 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  The ID selector for the modal.
 	 * @param   array   $params    An array of options for the modal.
 	 *                             Options for the modal can be:
-	 *                             - backdrop  mixed    If boolean select to include a modal-backdrop element.
-	 *                                                  Alternatively, the string 'static' for a backdrop which doesn't close the modal on click.
+	 *                             - backdrop  boolean  Includes a modal-backdrop element.
 	 *                             - keyboard  boolean  Closes the modal when escape key is pressed.
 	 *                             - show      boolean  Shows the modal when initialized.
 	 *                             - remote    string   An optional remote URL to load
@@ -268,18 +267,7 @@ abstract class JHtmlBootstrap
 			static::framework();
 
 			// Setup options object
-			$opt['backdrop'] = true;
-			if (isset($params['backdrop']))
-			{
-				if (strcmp($params['backdrop'],'static') === 0)
-				{
-					$opt['backdrop'] = 'static';
-				}
-				else
-				{
-					$opt['backdrop'] = (boolean) $params['backdrop'];
-				}
-			}
+			$opt['backdrop'] = isset($params['backdrop']) ? (boolean) $params['backdrop'] : true;
 			$opt['keyboard'] = isset($params['keyboard']) ? (boolean) $params['keyboard'] : true;
 			$opt['show']     = isset($params['show']) ? (boolean) $params['show'] : true;
 			$opt['remote']   = isset($params['remote']) ?  $params['remote'] : '';
@@ -306,23 +294,19 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  The ID selector for the modal.
 	 * @param   array   $params    An array of options for the modal.
 	 * @param   string  $footer    Optional markup for the modal footer
-	 * @param	boolean $closebtn  Optional display modal close button
 	 *
 	 * @return  string  HTML markup for a modal
 	 *
 	 * @since   3.0
 	 */
-	public static function renderModal($selector = 'modal', $params = array(), $footer = '', $closebtn = true)
+	public static function renderModal($selector = 'modal', $params = array(), $footer = '')
 	{
 		// Ensure the behavior is loaded
 		static::modal($selector, $params);
 
 		$html = "<div class=\"modal hide fade\" id=\"" . $selector . "\">\n";
 		$html .= "<div class=\"modal-header\">\n";
-		if ($closebtn)
-		{
-			$html .= "<button type=\"button\" class=\"close\" data-dismiss=\"modal\">×</button>\n";
-		}
+		$html .= "<button type=\"button\" class=\"close\" data-dismiss=\"modal\">×</button>\n";
 		$html .= "<h3>" . $params['title'] . "</h3>\n";
 		$html .= "</div>\n";
 		$html .= "<div id=\"" . $selector . "-container\">\n";

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -45,9 +45,8 @@ abstract class ModLanguagesHelper
 		if (is_object($languagefilter))
 		{
 			$languagefilter_params = new JRegistry($languagefilter->params);
-			$remove_default_prefix = 
-				$languagefilter_params->get('enabled') == '1' && 
-				$languagefilter_params->get('remove_default_prefix') == '1' && 
+			$remove_default_prefix = $languagefilter_params->get('remove_default_prefix') == '1' &&
+				$languagefilter_params->get('enabled') == '1' &&
 				$active != $menu->getDefault($activeLanguage);
 		}
 		else

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -46,6 +46,7 @@ abstract class ModLanguagesHelper
 		{
 			$languagefilter_params = new JRegistry($languagefilter->params);
 			$remove_default_prefix = $languagefilter_params->get('remove_default_prefix') == '1' &&
+				$languagefilter_params->get('lang_cookie', 1) == 2 &&
 				$active != $menu->getDefault($activeLanguage);
 		}
 		else
@@ -146,17 +147,17 @@ abstract class ModLanguagesHelper
 							$language->link = 'index.php?lang=' . $language->sef;
 						}
 					}
+
+					// Remove the default language code from the SEF URL when needed
+					if ($remove_default_prefix && $language->sef == $default_sef)
+					{
+						$language->link = preg_replace('|/' . $language->sef . '/|', '/', $language->link, 1);
+					}
 				}
 				else
 				{
 					$language->link = JRoute::_('&Itemid=' . $homes['*']->id);
 				}
-			}
-
-			// Remove the default language code from the SEF URL when needed
-			if ($remove_default_prefix && $language->sef == $default_sef)
-			{
-				$language->link = preg_replace('|/' . $language->sef . '/|', '/', $language->link, 1);
 			}
 		}
 

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -34,15 +34,21 @@ abstract class ModLanguagesHelper
 		$lang 	= JFactory::getLanguage();
 		$app	= JFactory::getApplication();
 		$menu 	= $app->getMenu();
+		$active = $menu->getActive();
+		$levels	= $user->getAuthorisedViewLevels();
+		$languages = JLanguageHelper::getLanguages();
+		$activeLanguage = JFactory::getLanguage()->getTag();
+		$assoc = JLanguageAssociations::isEnabled();
 
 		// Get parameters from the Language Filter Plugin and check if "Remove URL Language Code" is set
 		$languagefilter = JPluginHelper::getPlugin('system', 'languagefilter');
-
-		// TODO: below, also check if the plugin is enabled. I have to find out how...
 		if (is_object($languagefilter))
 		{
 			$languagefilter_params = new JRegistry($languagefilter->params);
-			$remove_default_prefix = $languagefilter_params->get('remove_default_prefix') == '1';
+			$remove_default_prefix = 
+				$languagefilter_params->get('enabled') == '1' && 
+				$languagefilter_params->get('remove_default_prefix') == '1' && 
+				$active != $menu->getDefault($activeLanguage);
 		}
 		else
 		{
@@ -66,12 +72,8 @@ abstract class ModLanguagesHelper
 		}
 
 		// Load associations
-		$assoc = JLanguageAssociations::isEnabled();
-
 		if ($assoc)
 		{
-			$active = $menu->getActive();
-
 			if ($active)
 			{
 				$associations = MenusHelper::getAssociations($active->id);
@@ -88,10 +90,6 @@ abstract class ModLanguagesHelper
 				$cassociations = call_user_func(array($cName, 'getAssociations'));
 			}
 		}
-
-		$levels		= $user->getAuthorisedViewLevels();
-		$languages	= JLanguageHelper::getLanguages();
-		$activeLanguage = JFactory::getLanguage()->getTag();
 
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -46,7 +46,6 @@ abstract class ModLanguagesHelper
 		{
 			$languagefilter_params = new JRegistry($languagefilter->params);
 			$remove_default_prefix = $languagefilter_params->get('remove_default_prefix') == '1' &&
-				$languagefilter_params->get('enabled') == '1' &&
 				$active != $menu->getDefault($activeLanguage);
 		}
 		else

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -51,7 +51,7 @@ abstract class ModLanguagesHelper
 		$lang_codes		= JLanguageHelper::getLanguages('lang_code');
 		$default_lang 	= JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 		$default_sef 	= $lang_codes[$default_lang]->sef;
-		
+
 		// Get menu home items
 		$homes = array();
 

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -37,6 +37,7 @@ abstract class ModLanguagesHelper
 
 		// Get parameters from the Language Filter Plugin and check if "Remove URL Language Code" is set
 		$languagefilter = JPluginHelper::getPlugin('system', 'languagefilter');
+
 		// TODO: below, also check if the plugin is enabled. I have to find out how...
 		if (is_object($languagefilter))
 		{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -37,6 +37,7 @@ abstract class ModLanguagesHelper
 
 		// Get parameters from the Language Filter Plugin and check if "Remove URL Language Code" is set
 		$languagefilter = JPluginHelper::getPlugin('system', 'languagefilter');
+		// TODO: below, also check if the plugin is enabled. I have to find out how...
 		if (is_object($languagefilter))
 		{
 			$languagefilter_params = new JRegistry($languagefilter->params);

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -35,6 +35,23 @@ abstract class ModLanguagesHelper
 		$app	= JFactory::getApplication();
 		$menu 	= $app->getMenu();
 
+		// Get parameters from the Language Filter Plugin and check if "Remove URL Language Code" is set
+		$languagefilter = JPluginHelper::getPlugin('system', 'languagefilter');
+		if (is_object($languagefilter))
+		{
+			$languagefilter_params = new JRegistry($languagefilter->params);
+			$remove_default_prefix = $languagefilter_params->get('remove_default_prefix') == '1';
+		}
+		else
+		{
+			$remove_default_prefix = false;
+		}
+
+		// Get language codes, default language and default language code
+		$lang_codes		= JLanguageHelper::getLanguages('lang_code');
+		$default_lang 	= JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+		$default_sef 	= $lang_codes[$default_lang]->sef;
+		
 		// Get menu home items
 		$homes = array();
 
@@ -136,6 +153,12 @@ abstract class ModLanguagesHelper
 				{
 					$language->link = JRoute::_('&Itemid=' . $homes['*']->id);
 				}
+			}
+
+			// Remove the default language code from the SEF URL when needed
+			if ($remove_default_prefix && $language->sef == $default_sef)
+			{
+				$language->link = preg_replace('|/' . $language->sef . '/|', '/', $language->link, 1);
 			}
 		}
 


### PR DESCRIPTION
This will remove the language code for the default language when needed, i.e. when using sef URLs and when the _"Remove URL Language Code"_ option is set in the language filter
