### PR TITLE
Who's online module shows multiple entries for a user name in release 3

### DIFF
--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -77,11 +77,11 @@ class ModWhosonlineHelper
 	{
 		$db		= JFactory::getDbo();
 		$query	= $db->getQuery(true)
-			->select($db->quoteName(array('a.username', 'a.time', 'a.userid', 'a.client_id')))
+			->select($db->quoteName(array('a.username',  'a.userid', 'a.client_id')))
 			->from('#__session AS a')
 			->where($db->quoteName('a.userid') . ' != 0')
 			->where($db->quoteName('a.client_id') . ' = 0')
-			->group($db->quoteName(array('a.username', 'a.time', 'a.userid', 'a.client_id')));
+			->group($db->quoteName(array('a.username',  'a.userid', 'a.client_id')));
 		$user = JFactory::getUser();
 
 		if (!$user->authorise('core.admin') && $params->get('filter_groups', 0) == 1)


### PR DESCRIPTION
This is a proposed change for tracker issue #5083

The list of users online is currently based on sessions resulting in names being duplicated. This change removes the time field from the sql select statement field list and also group by list.
