### PR TITLE
Introduce jquery formvalidator for com_contact ::frontend

### DIFF
--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));

--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 
 if (isset($this->error)) : ?>
 	<div class="contact-error">

--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_config to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area create new menu items for contact (categories, category, etc) 
4. go to the new menus and test that everything is still OK

If no javascript errors are logged in your browser’s console and the functionality remains the same, your test is passing in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
Logout and log in to demonstrate the use of noframes without mt.
