### PR TITLE
Introduce jquery formvalidator for com_content ::frontend

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.calendar');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.modal', 'a.modal_jform_contenthistory');
 
@@ -27,18 +27,20 @@ if (!$editoroptions)
 {
 	$params->show_urls_images_frontend = '0';
 }
-?>
 
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'article.cancel' || document.formvalidator.isValid(document.getElementById('adminForm')))
 		{
-			<?php echo $this->form->getField('articletext')->save(); ?>
+			" . $this->form->getField('articletext')->save() . "
 			Joomla.submitform(task);
 		}
 	}
-</script>
+});
+");
+?>
 <div class="edit item-page<?php echo $this->pageclass_sfx; ?>">
 	<?php if ($params->get('show_page_heading', 1)) : ?>
 	<div class="page-header">

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -29,7 +29,6 @@ if (!$editoroptions)
 }
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'article.cancel' || document.formvalidator.isValid(document.getElementById('adminForm')))
@@ -38,7 +37,6 @@ jQuery(document).ready(function() {
 			Joomla.submitform(task);
 		}
 	}
-});
 ");
 ?>
 <div class="edit item-page<?php echo $this->pageclass_sfx; ?>">


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_content to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area create new menu item for submitting new article
4. go to the new menu and test that article is saved correctly

If no javascript errors are logged in your browser’s console and the functionality remains the same, your test is passing in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
Logout and log in to demonstrate the use of noframes without mt.
