### PR TITLE
Introduce jquery formvalidator for com_mailto ::frontend

### DIFF
--- a/components/com_mailto/views/mailto/tmpl/default.php
+++ b/components/com_mailto/views/mailto/tmpl/default.php
@@ -8,24 +8,25 @@
  */
 
 defined('_JEXEC') or die;
+JHtml::_('behavior.core');
 JHtml::_('behavior.keepalive');
-?>
-<script type="text/javascript">
+
+$data	= $this->get('data');
+
+JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(pressbutton)
 	{
 		var form = document.getElementById('mailtoForm');
 
 		// do field validation
-		if (form.mailto.value == "" || form.from.value == "")
+		if (form.mailto.value == '' || form.from.value == '')
 		{
-			alert('<?php echo JText::_('COM_MAILTO_EMAIL_ERR_NOINFO'); ?>');
+			alert('" . JText::_('COM_MAILTO_EMAIL_ERR_NOINFO') . "');
 			return false;
 		}
 		form.submit();
 	}
-</script>
-<?php
-$data	= $this->get('data');
+");
 ?>
 
 <div id="mailto-window">


### PR DESCRIPTION
#### Executive summary

This PR converts the form on com_mailto to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. go to front end on an article view and test that you can send mails

If no javascript errors are logged in your browser’s console and the functionality remains the same, your test is passing in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
Logout and log in to demonstrate the use of noframes without mt.
