### PR TITLE
Introduce jquery formvalidator for com_tags ::frontend

### DIFF
--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers');
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 
 // Get the user object.

--- a/components/com_tags/views/tag/tmpl/list_items.php
+++ b/components/com_tags/views/tag/tmpl/list_items.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 
 $n			= count($this->items);

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 
 // Get the user object.


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_tags to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing

**Make sure you have some tags**
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area create new menu items for tags (all three options) 
4. go to the new menus and test that everything is still OK

If no javascript errors are logged in your browser’s console and the functionality remains the same, your test is passing in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
Logout and log in to demonstrate the use of noframes without mt.
