### PR TITLE
Introduce jquery formvalidator for com_wrapper ::frontend

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -15,7 +15,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		var h = 0;
 		if (!document.all)
 		{
-			h = document.getElementById('blockrandom').contentDocument.height;
+			h = document.getElementById('blockrandom').height;
 			document.getElementById('blockrandom').style.height = h + 60 + 'px';
 		} else if (document.all)
 		{

--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -16,11 +16,11 @@ JFactory::getDocument()->addScriptDeclaration("
 		if (!document.all)
 		{
 			h = document.getElementById('blockrandom').height;
-			document.getElementById('blockrandom').style.height = h + 60 + 'px';
+			document.getElementById('blockrandom').style.height = parseInt(h) + 60 + 'px';
 		} else if (document.all)
 		{
 			h = document.frames('blockrandom').document.body.scrollHeight;
-			document.all.blockrandom.style.height = h + 20 + 'px';
+			document.all.blockrandom.style.height = parseInt(h) + 20 + 'px';
 		}
 	}
 ");

--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -8,22 +8,23 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<script type="text/javascript">
-function iFrameHeight()
-{
-	var h = 0;
-	if (!document.all)
+
+JFactory::getDocument()->addScriptDeclaration("
+	function iFrameHeight()
 	{
-		h = document.getElementById('blockrandom').contentDocument.height;
-		document.getElementById('blockrandom').style.height = h + 60 + 'px';
-	} else if (document.all)
-	{
-		h = document.frames('blockrandom').document.body.scrollHeight;
-		document.all.blockrandom.style.height = h + 20 + 'px';
+		var h = 0;
+		if (!document.all)
+		{
+			h = document.getElementById('blockrandom').contentDocument.height;
+			document.getElementById('blockrandom').style.height = h + 60 + 'px';
+		} else if (document.all)
+		{
+			h = document.frames('blockrandom').document.body.scrollHeight;
+			document.all.blockrandom.style.height = h + 20 + 'px';
+		}
 	}
-}
-</script>
+");
+?>
 <div class="contentpane<?php echo $this->pageclass_sfx; ?>">
 <?php if ($this->params->get('show_page_heading')) : ?>
 	<h1>

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -15,7 +15,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		var h = 0;
 		if (!document.all)
 		{
-			h = document.getElementById('blockrandom').contentDocument.height;
+			h = document.getElementById('blockrandom').height;
 			document.getElementById('blockrandom').style.height = h + 60 + 'px';
 		} else if (document.all)
 		{

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -8,8 +8,8 @@
  */
 
 defined('_JEXEC') or die;
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration("
 	function iFrameHeight()
 	{
 		var h = 0;
@@ -23,8 +23,8 @@ defined('_JEXEC') or die;
 			document.all.blockrandom.style.height = h + 20 + 'px';
 		}
 	}
-</script>
-
+");
+?>
 <iframe <?php echo $load; ?>
 	id="blockrandom"
 	name="<?php echo $target; ?>"

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -16,11 +16,11 @@ JFactory::getDocument()->addScriptDeclaration("
 		if (!document.all)
 		{
 			h = document.getElementById('blockrandom').height;
-			document.getElementById('blockrandom').style.height = h + 60 + 'px';
+			document.getElementById('blockrandom').style.height = parseInt(h) + 60 + 'px';
 		} else if (document.all)
 		{
 			h = document.frames('blockrandom').document.body.scrollHeight;
-			document.all.blockrandom.style.height = h + 20 + 'px';
+			document.all.blockrandom.style.height = parseInt(h) + 20 + 'px';
 		}
 	}
 ");


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_wrapper to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!
#### Testing
1. Apply first PR #4888 (!important)
2. Apply this PR
3. In the admin area create new menu items for wrapper
4. go to the new menu and test that everything is still OK
5. In Admin, Create a new module wrapper and publish it
6. Check in front end that the module displays correctly

If no javascript errors are logged in your browser’s console and the functionality remains the same, your test is passing in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
Logout and log in to demonstrate the use of noframes without mt.

**I think I’m done here Joomla is now a lot less dependent on mootools**
~there are still some mootools stuff in the core, I guess we will tap them later on~
