### PR TITLE
Button logic

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -167,7 +167,7 @@ abstract class JHtmlJGrid
 		$states = array(1 => array('unpublish', 'JPUBLISHED', 'JLIB_HTML_UNPUBLISH_ITEM', 'JPUBLISHED', true, 'publish', 'publish'),
 			0 => array('publish', 'JUNPUBLISHED', 'JLIB_HTML_PUBLISH_ITEM', 'JUNPUBLISHED', true, 'unpublish', 'unpublish'),
 			2 => array('unpublish', 'JARCHIVED', 'JLIB_HTML_UNPUBLISH_ITEM', 'JARCHIVED', true, 'archive', 'archive'),
-			-2 => array('publish', 'JTRASHED', 'JLIB_HTML_PUBLISH_ITEM', 'JTRASHED', true, 'trash', 'trash'));
+			-2 => array('publish', 'JTRASHED', 'JLIB_HTML_PUBLISH_ITEM', 'JTRASHED', true, 'undo', 'undo'));
 
 		// Special state for dates
 		if ($publish_up || $publish_down)


### PR DESCRIPTION
When trashing an item in Joomla, the publish icon is a trash can (see the screenshot). In my opinion this doesn't make sense UX wise, since the button actually publishes the item again. 

I would like to suggest to change the icon from icon-trash to icon-undo. 

![screen](https://cloud.githubusercontent.com/assets/1738811/5059224/40ec2a74-6d13-11e4-9c45-2ca15b28e859.jpg)

![screen2](https://cloud.githubusercontent.com/assets/1738811/5059230/a7c71df8-6d13-11e4-9faa-9cc0f8d88689.jpg)
