### PR TITLE
Allow "external" JDocument classes

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -294,7 +294,7 @@ class JDocument
 				{
 					$ntype = $type;
 					$type = 'raw';
-					
+
 					$class = 'JDocument' . $type;
 
 					require_once $rawpath;

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -277,26 +277,27 @@ class JDocument
 		{
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = __DIR__ . '/' . $type . '/' . $type . '.php';
+			$rawpath = __DIR__ . '/raw/raw.php';
 			$ntype = null;
-
-			// Check if the document type exists
-			if (!file_exists($path))
-			{
-				// Default to the raw format
-				$ntype = $type;
-				$type = 'raw';
-			}
 
 			// Determine the path and class
 			$class = 'JDocument' . $type;
 
 			if (!class_exists($class))
 			{
-				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
-
 				if (file_exists($path))
 				{
 					require_once $path;
+				}
+				// Default to the raw format
+				elseif (file_exists($rawpath))
+				{
+					$ntype = $type;
+					$type = 'raw';
+					
+					$class = 'JDocument' . $type;
+
+					require_once $rawpath;
 				}
 				else
 				{


### PR DESCRIPTION
At the moment all JDocument render classes have to be placed into "libraries/joomla/document". You cannot load your own JDocument child class with e.g. a plugin, because if getInstance does not find the class file in the mentioned path, it fallbacks to JDocumentRaw.

With this patch the getInstance method checks first if the class exists (= e.g. loaded by plugin) and uses the JDocumentRaw class as fallback after the requested class does not exist and could not be loaded.

To test: create an own JDocument child class (like this PDF class: http://docs.joomla.org/J2.5:Creating_PDF_views), load it over a plugin and try to call it with "format=pdf" over the url.
Before the patch you should get the raw output, after you should get the PDF.
