### PR TITLE
Improving query to use indexes better. Fixes #5101

### DIFF
--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -301,9 +301,9 @@ abstract class JPluginHelper
 			$query = $db->getQuery(true)
 				->select('folder AS type, element AS name, params')
 				->from('#__extensions')
-				->where('enabled >= 1')
+				->where('enabled = 1')
 				->where('type =' . $db->quote('plugin'))
-				->where('state >= 0')
+				->where('state IN (0,1)')
 				->where('access IN (' . $levels . ')')
 				->order('ordering');
 


### PR DESCRIPTION
As hinted at in the table, this fixes #5101 
enabled seems to only be toggled between 0 and 1, so if we check for everything greater than 1, we only have one value and then we can simply do a comparison. State equally seems to toggle between 0 and 1, although we don't seem to use it at all... This should be investigated further.
