### PR TITLE
[imp] Changing minimum upper limit search to 200 characters

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -587,10 +587,8 @@ class JLanguage
 		{
 			return call_user_func($this->upperLimitSearchWordCallback);
 		}
-		else
-		{
-			return 200;
-		}
+
+		return 200;
 	}
 
 	/**

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -577,19 +577,19 @@ class JLanguage
 	/**
 	 * Returns an upper limit integer for length of search words
 	 *
-	 * @return  integer  The upper limit integer for length of search words (20 if no value was set for a specific language).
+	 * @return  integer  The upper limit integer for length of search words (200 if no value was set or if default value is < 200).
 	 *
 	 * @since   11.1
 	 */
 	public function getUpperLimitSearchWord()
 	{
-		if ($this->upperLimitSearchWordCallback !== null)
+		if ($this->upperLimitSearchWordCallback !== null && call_user_func($this->upperLimitSearchWordCallback) > 200)
 		{
 			return call_user_func($this->upperLimitSearchWordCallback);
 		}
 		else
 		{
-			return 20;
+			return 200;
 		}
 	}
 

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -558,7 +558,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 		$lang = new JLanguage('');
 
 		$this->assertEquals(
-			20,
+			200,
 			$lang->getUpperLimitSearchWord(),
 			'Line: ' . __LINE__
 		);


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/5103
To test in en-GB, add `var_dump ($upper_limit);` after line 33 `$upper_limit = $lang->getUpperLimitSearchWord();` in 
ROOT/modules/mod_search/mod_search.php

You should get `int 200`
