### PR TITLE
Optimizing JComponentHelper::getComponent

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -54,6 +54,13 @@ class JComponentHelper
 			$result = static::$components[$option];
 		}
 
+		if (is_string($result->params))
+		{
+			$temp = new JRegistry;
+			$temp->loadString(static::$components[$option]->params);
+			static::$components[$option]->params = $temp;
+		}
+
 		return $result;
 	}
 
@@ -383,15 +390,14 @@ class JComponentHelper
 		$query = $db->getQuery(true)
 			->select('extension_id AS id, element AS "option", params, enabled')
 			->from('#__extensions')
-			->where($db->quoteName('type') . ' = ' . $db->quote('component'))
-			->where($db->quoteName('element') . ' = ' . $db->quote($option));
+			->where($db->quoteName('type') . ' = ' . $db->quote('component'));
 		$db->setQuery($query);
 
 		$cache = JFactory::getCache('_system', 'callback');
 
 		try
 		{
-			static::$components[$option] = $cache->get(array($db, 'loadObject'), null, $option, false);
+			static::$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);
 		}
 		catch (RuntimeException $e)
 		{
@@ -408,14 +414,6 @@ class JComponentHelper
 			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $error), JLog::WARNING, 'jerror');
 
 			return false;
-		}
-
-		// Convert the params to an object.
-		if (is_string(static::$components[$option]->params))
-		{
-			$temp = new JRegistry;
-			$temp->loadString(static::$components[$option]->params);
-			static::$components[$option]->params = $temp;
 		}
 
 		return true;


### PR DESCRIPTION
Joomla currently loads each and every component seperately when it tries to retrieve the parameters of a component for example. On a vanilla Joomla, that means at least an additional 7 queries per pageload. This PR combines those into one query against the extension table and caching all results of that. This means less load for the database, less (albeit neglectable) memory consumption for Joomla and slightly less execution time for the overall system. The effects on a test-system might not be big, but it will be an optimization for larger systems.

This PR has one downside: So far the protected methode load() retrieved the data and then created the params object of each component. With the change I could either generate the params object for all components up front, or delegate that step to the getComponent() method and do it on demand. I choose the later option. This means that the load() method has a slightly changed behavior, which could be called a break in backwards compatibility. Since load() would only be accessible from inside the JComponentHelper class or a class inheriting from it and I simply can't think of a reason to create such an inheriting class, this change seems acceptable. However, I'd like to hear other opinions on this.
### Test instructions:
1. Enable debug mode, notice the number of queries on a page, its execution time and memory consumption.
2. Apply the change.
3. Reload the page and see a reduced number of queries and slightly reduced numbers for execution time and memory consumption.
