### PR TITLE
Optimizing JComponentHelper::getComponent

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -48,7 +48,7 @@ class JComponentHelper
 			{
 				$result = new stdClass;
 				$result->enabled = $strict ? false : true;
-				$result->params = new JRegistry;
+				$result->params = new Registry;
 			}
 		}
 		else
@@ -58,7 +58,7 @@ class JComponentHelper
 
 		if (is_string($result->params))
 		{
-			$temp = new JRegistry;
+			$temp = new Registry;
 			$temp->loadString(static::$components[$option]->params);
 			static::$components[$option]->params = $temp;
 		}


### PR DESCRIPTION
Joomla currently loads each and every component seperately when it tries to retrieve the parameters of a component for example. On a vanilla Joomla, that means at least an additional 7 queries per pageload. This PR combines those into one query against the extension table and caching all results of that. This means less load for the database, less (albeit neglectable) memory consumption for Joomla and slightly less execution time for the overall system. The effects on a test-system might not be big, but it will be an optimization for larger systems.

This PR has one downside: So far the protected methode load() retrieved the data and then created the params object of each component. With the change I could either generate the params object for all components up front, or delegate that step to the getComponent() method and do it on demand. I choose the later option. This means that the load() method has a slightly changed behavior, which could be called a break in backwards compatibility. Since load() would only be accessible from inside the JComponentHelper class or a class inheriting from it and I simply can't think of a reason to create such an inheriting class, this change seems acceptable. However, I'd like to hear other opinions on this.
### Test instructions:
1. Enable debug mode, notice the number of queries on a page, its execution time and memory consumption.
2. Apply the change.
3. Reload the page and see a reduced number of queries and slightly reduced numbers for execution time and memory consumption.
