### PR TITLE
Multilanguage: Implementing a 301 when Removing URL Language Code

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -355,7 +355,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						else
 						{
 							$path = $uri->toString(array('path', 'query', 'fragment'));
-							$app->redirect($uri->base() . 'index.php' . ($path ? ('/' . $path) : ''));
+							$app->redirect($uri->base() . 'index.php' . ($path ? ('/' . $path) : ''), true);
 						}
 					}
 				}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -350,7 +350,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if ($app->get('sef_rewrite'))
 						{
-							$app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
+							$app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')), true);
 						}
 						else
 						{


### PR DESCRIPTION
See wrong PR here (because the true is not placed where it should) and discussion: https://github.com/joomla/joomla-cms/pull/5092

Test instructions, set a multilanguage site with en-GB as default site
1. Remove URL Language Code is set to YES in the language filter
2. Language to display will be the default site language. Note it.
3. Search Engine Friendly URLs is set to Yes in Global configuration

When hovering on the language switcher module to get to the default site language, copy the link
It will be of the type http://mysite.com/en/  (if en-GB is the default site language)

Open  this online checker: http://redirectdetective.com/
Enter the link you just copied. See results.
=>303 redirect
Apply patch, and test again the same link in http://redirectdetective.com/
=> 301 redirect

---

Here is a live example of a site where the patch has been applied:
Go to:
http://info-graf.fr/multi/fr/blog-fran%C3%A7ais-%C3%A5-tester/2-article-fr-fr.html

Hover the English flag of the language switcher. 
The link is http://info-graf.fr/multi/en/home-en-gb/8-category-en-gb/1-article-en-gb.html
Copy the link in http://redirectdetective.com/ and Trace url.
It will show that the redirect is a 301
