### PR TITLE
Make site's "Brand" (Web title") larger and on the header bars

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7150,6 +7150,26 @@ body .navbar-fixed-top {
 	max-width: 143px;
 	height: auto;
 }
+.container-title {
+    overflow: hidden;
+}
+.container-title .brand {
+    float: left;
+    font-size: 20px;
+    font-weight: bold;
+    margin: 0 30px;
+    color: #fff;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.8);
+    line-height: 36px;
+}
+.container-title .brand span {
+    padding: 0 10px 10px 10px;
+}
+.container-title .brand:hover, .brand:focus {
+    text-shadow:none;
+    color:#fff;
+    text-decoration:underline;
+}
 .page-title {
 	color: white;
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.8);

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -169,8 +169,6 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 						</ul>
 					</li>
 				</ul>
-				<a class="brand visible-desktop visible-tablet" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('TPL_ISIS_PREVIEW', $sitename); ?>" target="_blank"><?php echo JHtml::_('string.truncate', $sitename, 14, false, false); ?>
-					<span class="icon-out-2 small"></span></a>
 			</div>
 			<!--/.nav-collapse -->
 		</div>
@@ -184,6 +182,8 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 		</div>
 		<div class="container-title">
 			<jdoc:include type="modules" name="title" />
+             <a class="brand visible-desktop visible-tablet" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('TPL_ISIS_PREVIEW', $sitename); ?>" target="_blank"><?php echo JHtml::_('string.truncate', $sitename, 14, false, false); ?>
+					<span class="icon-out-2 small"></span></a>
 		</div>
 	</header>
 <?php endif; ?>


### PR DESCRIPTION
Make site's "Brand" (Web title") larger and on the header bars #4959

---
#### Steps to reproduce the issue

I work on multiple joomla sites, and sometimes when switching from one site to another I find myself working in the back end of the wrong site.  For example I am updating 4 sites for a university.  There is a live site, a development site etc etc for each of the 4 schools.  They all have similar names and to a certain extent similar content.

Just this morning I started working in the wrong development site.  Fortunately before I did too much damage, I noticed the tiny extremely abbreviated name of the site in the upper right corner of the administrator panel.  The css class is called "brand", so I assume that's what it's called in the programming.

To prevent this common error from occurring I suggest there be a small adjustment in all of the Joomla administrator panels.  Instead of rendering of the site's name in small type, flush right, usually "abbreviated" to just a few letters, why not move it down to the main Header blue bar and use the same size type as the component.  There is plenty of real estate there and no need to have the site's name abbreviated so extremely.  Certainly the name of the site's "brand" deserves to be about the same size as the Joomla logo on the header bar.
#### Expected result

I am not a programmer, just an end user.  So I am asking that a programmer take on this tracker item.
#### Additional comments

Attached is a mock up of my suggestion.  I am sure thousands of weary Joomla webmasters working late hours would appreciate this simple but effective change.  It would still provide a link to the front end of the site.

...Rowby
![screen shot 2014-10-30 at 19 14 21](http://issues.joomla.org/uploads/1/098ef0f9140d80222e7ccc12d641d5b5.jpg)
