### PR TITLE
Don't change the default session_handler if it is allready set Ref: #5127

### DIFF
--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -29,7 +29,7 @@ class JSessionStorageNone extends JSessionStorage
 		$handler = ini_get('session.save_handler');
 
 		// Set session.save_handler to files only if nothing else is set
-		if ($handler = '')
+		ifv(!$handler)
 		{
 			ini_set('session.save_handler', 'files');
 		}

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -26,12 +26,6 @@ class JSessionStorageNone extends JSessionStorage
 	 */
 	public function register()
 	{
-		$handler = ini_get('session.save_handler');
-
-		// Set session.save_handler to files only if nothing else is set
-		ifv(!$handler)
-		{
-			ini_set('session.save_handler', 'files');
-		}
+		// Default session handler is `files`
 	}
 }

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -26,7 +26,7 @@ class JSessionStorageNone extends JSessionStorage
 	 */
 	public function register()
 	{
-		// Set session.handler to file if nothing else is set
+		// Set session.handler to files only if nothing else is set
 		if (empty(ini_get('session.save_handler')))
 		{
 			ini_set('session.save_handler', 'files');

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -26,6 +26,10 @@ class JSessionStorageNone extends JSessionStorage
 	 */
 	public function register()
 	{
-		ini_set('session.save_handler', 'files');
+		// Set session.handler to file if nothing else is set
+		if (empty(ini_get('session.save_handler')))
+		{
+			ini_set('session.save_handler', 'files');
+		}
 	}
 }

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -26,8 +26,10 @@ class JSessionStorageNone extends JSessionStorage
 	 */
 	public function register()
 	{
-		// Set session.handler to files only if nothing else is set
-		if (empty(ini_get('session.save_handler')))
+		$handler = ini_get('session.save_handler');
+
+		// Set session.save_handler to files only if nothing else is set
+		if ($handler = '')
 		{
 			ini_set('session.save_handler', 'files');
 		}


### PR DESCRIPTION
#### Steps to reproduce the issue

We are using memcache as default session handler and this set up is in php.ini.
#### Expected result

Joomla to use default session handler is not set in configuration.
#### Actual result

PHP Warning:  session_start(): open(tcp://127.0.0.1:11211/sess_r5c5940ecaru55pr69bssctmu2, O_RDWR) failed: No such file or directory
#### System information (as much as possible)

php.ini: session.save_handler = memcache
#### Additional comments

Change libraries/joomla/session/storage/none.php to use default php session handler.

See: #5127 by @Olvikolvi
