### PR TITLE
Change the way JTableUser::store saves groups

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -333,7 +333,7 @@ class JTableUser extends JTable
 			// Loop through them and check if database contains something $this->groups does not
 			if (count($result))
 			{
-				foreach($result as $map)
+				foreach ($result as $map)
 				{
 					if (array_key_exists($map->group_id, $this->groups))
 					{

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -321,56 +321,56 @@ class JTableUser extends JTable
 		// Store the group data if the user data was saved.
 		if (is_array($this->groups) && count($this->groups))
 		{
-            // Grab all usergroup entries for the user
-            $query -> clear()
-                -> select('*')
-                -> from($this->_db->quoteName('#__user_usergroup_map'))
-                -> where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id);
+			// Grab all usergroup entries for the user
+			$query -> clear()
+				-> select('*')
+				-> from($this->_db->quoteName('#__user_usergroup_map'))
+				-> where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id);
 
-            $this->_db->setQuery($query);
-            $result = $this->_db->loadObjectList();
+			$this->_db->setQuery($query);
+			$result = $this->_db->loadObjectList();
 
-            // Loop through them and check if database contains something $this->groups does not
-            if(sizeof($result))
-            {
-                foreach($result as $map)
-                {
-                    if(array_key_exists($map->group_id, $this->groups))
-                    {
-                        // it already exists, no action required
-                        unset($this->groups[$map->group_id]);
-                    }
-                    else
-                    {
-                        // it should be removed
-                        $query -> clear()
-                            -> delete($this->_db->quoteName('#__user_usergroup_map'))
-                            -> where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id)
-                            -> where($this->_db->quoteName('group_id') . ' = ' . (int) $map->group_id);
+			// Loop through them and check if database contains something $this->groups does not
+			if(count($result))
+			{
+				foreach($result as $map)
+				{
+					if(array_key_exists($map->group_id, $this->groups))
+					{
+						// it already exists, no action required
+						unset($this->groups[$map->group_id]);
+					}
+					else
+					{
+						// it should be removed
+						$query -> clear()
+							-> delete($this->_db->quoteName('#__user_usergroup_map'))
+							-> where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id)
+							-> where($this->_db->quoteName('group_id') . ' = ' . (int) $map->group_id);
 
-                        $this->_db->setQuery($query);
-                        $this->_db->execute();
-                    }
-                }
-            }
+						$this->_db->setQuery($query);
+						$this->_db->execute();
+					}
+				}
+			}
 
-            // If there is anything left in this->groups it needs to be inserted
-            if(sizeof($this->groups))
-            {
-			    // Set the new user group maps.
-			    $query->clear()
-				    ->insert($this->_db->quoteName('#__user_usergroup_map'))
-				    ->columns(array($this->_db->quoteName('user_id'), $this->_db->quoteName('group_id')));
+			// If there is anything left in this->groups it needs to be inserted
+			if(count($this->groups))
+			{
+				// Set the new user group maps.
+				$query->clear()
+					->insert($this->_db->quoteName('#__user_usergroup_map'))
+					->columns(array($this->_db->quoteName('user_id'), $this->_db->quoteName('group_id')));
 
-			    // Have to break this up into individual queries for cross-database support.
-			    foreach ($this->groups as $group)
-			    {
-				    $query->clear('values')
-					    ->values($this->id . ', ' . $group);
-				    $this->_db->setQuery($query);
-				    $this->_db->execute();
-			    }
-            }
+				// Have to break this up into individual queries for cross-database support.
+				foreach ($this->groups as $group)
+				{
+					$query->clear('values')
+						->values($this->id . ', ' . $group);
+					$this->_db->setQuery($query);
+					$this->_db->execute();
+				}
+			}
 		}
 
 		// If a user is blocked, delete the cookie login rows

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -331,18 +331,18 @@ class JTableUser extends JTable
 			$result = $this->_db->loadObjectList();
 
 			// Loop through them and check if database contains something $this->groups does not
-			if(count($result))
+			if (count($result))
 			{
 				foreach($result as $map)
 				{
-					if(array_key_exists($map->group_id, $this->groups))
+					if (array_key_exists($map->group_id, $this->groups))
 					{
-						// it already exists, no action required
+						// It already exists, no action required
 						unset($this->groups[$map->group_id]);
 					}
 					else
 					{
-						// it should be removed
+						// It should be removed
 						$query -> clear()
 							-> delete($this->_db->quoteName('#__user_usergroup_map'))
 							-> where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id)
@@ -355,7 +355,7 @@ class JTableUser extends JTable
 			}
 
 			// If there is anything left in this->groups it needs to be inserted
-			if(count($this->groups))
+			if (count($this->groups))
 			{
 				// Set the new user group maps.
 				$query->clear()


### PR DESCRIPTION
See http://issues.joomla.org/tracker/joomla-cms/5138

If JTable::store() happens on the same user concurrently, it will eventually lead to loss of #__user_usergroup_map rows for that user. Because JTable::store() deletes everything from #__user_usergroup_map and then re-adds one by one, if that process happens multiple times in parallel for the same user, the inserts and deletes get mixed up.

This is a fix for this, that instead of performing "delete and re-insert one by one", grabs the records from the database, loops through them, decides which should stay and which should go based on $this->groups and then adds new ones (if any) from $this->groups
