### PR TITLE
Stg plg system debug log category mode

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -901,9 +901,17 @@ class PlgSystemDebug extends JPlugin
 				// Compute the query time.
 				$queryTime = ($timings[$id * 2 + 1] - $timings[$id * 2]) * 1000;
 
-				// Timing.  Formats the output for the query time with EXPLAIN query results as tooltip.
-				$htmlTiming = '<div style="margin: 0px 0 5px;"><span class="dbg-query-time">'
-					. JText::sprintf('PLG_DEBUG_QUERY_TIME', sprintf('<span class="label ' . $info[$id]->class . '">%.2f&nbsp;ms</span>', $timing[$id]['0']));
+				// Timing
+				// Formats the output for the query time with EXPLAIN query results as tooltip:
+				$htmlTiming = '<div style="margin: 0px 0 5px;"><span class="dbg-query-time">';
+				$htmlTiming .= JText::sprintf(
+						'PLG_DEBUG_QUERY_TIME',
+						sprintf(
+							'<span class="label %s">%.2f&nbsp;ms</span>',
+							$info[$id]->class,
+							$timing[$id]['0']
+						)
+					);
 
 				if ($timing[$id]['1'])
 				{
@@ -960,8 +968,7 @@ class PlgSystemDebug extends JPlugin
 						}
 
 						$htmlResultsReturned = '<span class="label ' . $labelClass . '">' . (int) $resultsReturned . '</span>';
-						$htmlTiming .= ' ' . '<span class="dbg-query-rowsnumber">'
-							. JText::sprintf('PLG_DEBUG_ROWS_RETURNED_BY_QUERY', $htmlResultsReturned) . '</span>';
+						$htmlTiming .= ' <span class="dbg-query-rowsnumber">' . JText::sprintf('PLG_DEBUG_ROWS_RETURNED_BY_QUERY', $htmlResultsReturned) . '</span>';
 					}
 				}
 
@@ -1001,8 +1008,8 @@ class PlgSystemDebug extends JPlugin
 
 					if (!$this->linkFormat)
 					{
-						$htmlCallStack .= '<div>[<a href="http://xdebug.org/docs/all_settings#file_link_format" target="_blank">'
-							. JText::_('PLG_DEBUG_LINK_FORMAT') . '</a>]</div>';
+						$htmlCallStack .= '<div>[<a href="http://xdebug.org/docs/all_settings#file_link_format" target="_blank">';
+						$htmlCallStack .= JText::_('PLG_DEBUG_LINK_FORMAT') . '</a>]</div>';
 					}
 				}
 
@@ -1162,11 +1169,11 @@ class PlgSystemDebug extends JPlugin
 	}
 
 	/**
-	 * Render bars.
+	 * Render the bars.
 	 *
-	 * @param   array    &$bars  Array of bar data.
-	 * @param   string   $class  Optional class for items.
-	 * @param   integer  $id     Id of the bar to highlight.
+	 * @param   array    &$bars  Array of bar data
+	 * @param   string   $class  Optional class for items
+	 * @param   integer  $id     Id if the bar to highlight
 	 *
 	 * @return  string
 	 *
@@ -1198,18 +1205,18 @@ class PlgSystemDebug extends JPlugin
 				$tip = JHtml::tooltipText($bar->tip, '', 0);
 			}
 
-			$html[] = '<a class="bar dbg-bar ' . $barClass . '" title="' . $tip . '" style="width: '
-				. $bar->width . '%;" href="#dbg-' . $class . '-' . ($i + 1) . '"></a>';
+			$html[] = '<a class="bar dbg-bar ' . $barClass . '" title="' . $tip . '" style="width: ' .
+						$bar->width . '%;" href="#dbg-' . $class . '-' . ($i + 1) . '"></a>';
 		}
 
 		return '<div class="progress dbg-bars dbg-bars-' . $class . '">' . implode('', $html) . '</div>';
 	}
 
 	/**
-	 * Render array as HTML table.
+	 * Render an HTML table based on a multi-dimensional array.
 	 *
-	 * @param   array    $table         Array to be rendered.
-	 * @param   boolean  &$hasWarnings  Changes value to true if warnings are displayed, otherwise untouched.
+	 * @param   array    $table         An array of tabular data.
+	 * @param   boolean  &$hasWarnings  Changes value to true if warnings are displayed, otherwise untouched
 	 *
 	 * @return  string
 	 *
@@ -1284,9 +1291,10 @@ class PlgSystemDebug extends JPlugin
 				{
 					if ($td === 'NULL')
 					{
-						// Displays query parts which don't use a key with warning.
-						$html[] = '<td><strong>' . '<span class="dbg-warning hasTooltip" title="' . JHtml::tooltipText('PLG_DEBUG_WARNING_NO_INDEX_DESC') . '">'
-							. JText::_('PLG_DEBUG_WARNING_NO_INDEX') . '</span>' . '</strong>';
+						// Displays query parts which don't use a key with warning:
+						$html[] = '<td><strong>' . '<span class="dbg-warning hasTooltip" title="' .
+									JHtml::tooltipText('PLG_DEBUG_WARNING_NO_INDEX_DESC') . '">' .
+									JText::_('PLG_DEBUG_WARNING_NO_INDEX') . '</span>' . '</strong>';
 						$hasWarnings = true;
 					}
 					else
@@ -1301,10 +1309,14 @@ class PlgSystemDebug extends JPlugin
 					// Replace spaces with &nbsp; (non-breaking spaces) for less tall tables displayed.
 					$htmlTd = preg_replace('/([^;]) /', '\1&nbsp;', $htmlTd);
 
-					// Displays warnings for "Using filesort".
-					$htmlTdWithWarnings = str_replace('Using&nbsp;filesort', '<span class="dbg-warning hasTooltip" title="'
-						. JHtml::tooltipText('PLG_DEBUG_WARNING_USING_FILESORT_DESC') . '">' . JText::_('PLG_DEBUG_WARNING_USING_FILESORT') . '</span>', $htmlTd
-					);
+					// Displays warnings for "Using filesort":
+					$htmlTdWithWarnings = str_replace(
+											'Using&nbsp;filesort',
+											'<span class="dbg-warning hasTooltip" title="' .
+												JHtml::tooltipText('PLG_DEBUG_WARNING_USING_FILESORT_DESC') . '">' .
+												JText::_('PLG_DEBUG_WARNING_USING_FILESORT') . '</span>',
+											$htmlTd
+										);
 
 					if ($htmlTdWithWarnings !== $htmlTd)
 					{

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -98,7 +98,7 @@
 					description="PLG_DEBUG_FIELD_LOG_CATEGORIES_DESC"
 				/>
 
-				<field name="log_category_mode" type="hidden" default="0"
+				<field name="log_category_mode" type="radio" default="0" class="btn-group"
 					label="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_LABEL"
 					description="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_DESC"
 				>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -98,7 +98,7 @@
 					description="PLG_DEBUG_FIELD_LOG_CATEGORIES_DESC"
 				/>
 
-				<field name="log_category_mode" type="radio" default="0" class="btn-group"
+				<field name="log_category_mode" type="radio" default="0" class="btn-group btn-group-yesno"
 					label="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_LABEL"
 					description="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_DESC"
 				>


### PR DESCRIPTION
Like #2253 but for staging instead of master.

Basically, since `JLog` now supports category exclusion instead of just inclusion, the logging feature in this plugin should also give that option. Exclusion is much more useful than inclusion in this case anyway because you probably want to see most logs but you will never want to see `databasequery` logs and you might get tired of looking at `deprecated` logs.
