### PR TITLE
Fix warning in installer.php when tmp dir deleted

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1870,7 +1870,7 @@ class JInstaller extends JAdapter
 		$allXmlFiles    = JFolder::files($this->getPath('source'), '.xml$', 1, true);
 
 		// Create an unique array of files ordered by priority
-		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
+		$xmlfiles = array_unique(array_merge($parentXmlfiles ? $parentXmlfiles : array(), $allXmlFiles ? $allXmlFiles : array()));
 
 		// If at least one XML file exists
 		if (!empty($xmlfiles))


### PR DESCRIPTION
If the expected manifest XML files/dirs are missing, the findManifest() method fails with:

```
[ErrorException] array_merge(): Argument #1 is not an array
```

because `$parentXmlfiles` and/or `$allXmlFiles` are false, rather than an array.

Caveat - although this fixed the problem for me, I don't fully understand the context of this code so perhaps there is a deeper problem? I was using the [Joomlatools Composer Installer](https://github.com/joomlatools/joomla-composer) to install a module and had deleted the contents of the tmp directory before this happened. Not sure why the tmp dir would be referenced to see if a module/component/plugin is installed, obviously the tmp dir will get cleared out periodically.
