### PR TITLE
[fix] Broken groups management by #4308

### DIFF
--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -16,6 +16,11 @@ defined('_JEXEC') or die;
  */
 class UsersModelGroup extends JModelAdmin
 {
+	/**
+	 * Constructor
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 */
 	public function __construct($config = array())
 	{
 		$config = array_merge(
@@ -268,14 +273,11 @@ class UsersModelGroup extends JModelAdmin
 						$this->setError($table->getError());
 
 						return false;
-					} else {
-						// Trigger the after delete event.
-						$dispatcher->trigger($this->event_after_delete, array($table->getProperties(), true, $this->getError()));
 					}
 					else
 					{
-						// Trigger the onUserAfterDeleteGroup event.
-						$dispatcher->trigger('onUserAfterDeleteGroup', array($table->getProperties(), true, $this->getError()));
+						// Trigger the after delete event.
+						$dispatcher->trigger($this->event_after_delete, array($table->getProperties(), true, $this->getError()));
 					}
 				}
 				else


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/4308 added an addittional else statement to the user group model that avoids you to edit groups. 

This should be an high priority PR. 
### Steps to reproduce the issue

Go to user groups management and try to edit a group. You get an error. 
### How to test

Check that after applying the patch you can create / edit user groups correctly
