### PR TITLE
fix the codemirror display bug

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -337,7 +337,7 @@ class PlgEditorCodemirror extends JPlugin
 		// Listen for Bootstrap's 'shown' event. If this editor was in a hidden element when created, it may need to be refreshed.
 		$html[] = '		!!jQuery && jQuery(function ($) {';
 		$html[] = '			$(document.body).on("shown shown.bs.tab shown.bs.modal", function () {';
-		$html[] = '				editor.refresh();';
+		$html[] = '				Joomla.editors.instances[id].refresh();';
 		$html[] = '			});';
 		$html[] = '		});';
 

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -333,6 +333,14 @@ class PlgEditorCodemirror extends JPlugin
 		$html[] = '        };';
 		$html[] = '        cm.setGutterMarker(n, "CodeMirror-markergutter", hasMarker ? null : makeMarker());';
 		$html[] = '    });';
+
+		// Listen for Bootstrap's 'shown' event. If this editor was in a hidden element when created, it may need to be refreshed.
+		$html[] = '		!!jQuery && jQuery(function ($) {';
+		$html[] = '			$(document.body).on("shown shown.bs.tab shown.bs.modal", function () {';
+		$html[] = '				editor.refresh();';
+		$html[] = '			});';
+		$html[] = '		});';
+
 		$html[] = '}(' . json_encode($id) . ', ' . json_encode($options) . '));';
 		$html[] = '</script>';
 


### PR DESCRIPTION
Oh, you didn't know there was one? Well there was. 
## Testing

1) Set CodeMirror as your editor (as if you haven't already, right?)
2) Go to some page on which the editor will be in a hidden element... like a hidden tab or something.
3) Display the hidden tab. 
## Before

CodeMirror will appear broken. It's not, if you try to use it, it will fix itself right away. But it looks really bad at first. 
## After

CodeMirror will not appear broken. It will look great all the time.
## How?

Well, CodeMirror has a refresh function for exactly this kind of situation but we need to call it when CM becomes visible. Bootstrap provides events for doing this kind of thing when a tab or modal or other kind of hidden content gets shown. This addition just places a listener for those events and refreshes CM when one of them happens. It only works if jQuery is on the page and it only listens for Bootstrap's events (although anything that fires a 'shown' event could theoretically trigger this). There shouldn't be any problem if there is no jQuery or Bootstrap, but the refresh event won't get fired. Which is no worse than the current situation.
## Can it be better?

Yes, this rendering code can go in a layout so that it can be overridden in case a different js library is being used or something like that. I wanted to keep this PR simple though. 
