### PR TITLE
Fix undefined variable in Article Model

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -519,7 +519,7 @@ class ContentModelArticle extends JModelAdmin
 
 				if (isset($msg))
 				{
-					$app->enqueueMessage($msg, 'warning');
+					JFactory::getApplication()->enqueueMessage($msg, 'warning');
 				}
 			}
 		}


### PR DESCRIPTION
Fixing fatal error during article saving as reported by Brian in #5159

```
Notice: Undefined variable: app in administrator/components/com_content/models/article.php on line 522

Fatal error: Call to a member function enqueueMessage() on a non-object in administrator/components/com_content/models/article.php on line 522
```

To reproduce you likely need to save an article without specifying an alias. If the generated alias already exists, Joomla tries to issue a warning, which triggers that error.
At least that's what I would expect from looking at the code.
