### PR TITLE
Add missing log categories

### DIFF
--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -45,7 +45,7 @@ class FinderControllerIndexer extends JControllerLegacy
 		}
 
 		// Log the start
-		JLog::add('Starting the indexer', JLog::INFO);
+		JLog::add('Starting the indexer', JLog::INFO, 'com_finder');
 
 		// We don't want this form to be cached.
 		header('Pragma: no-cache');
@@ -112,7 +112,7 @@ class FinderControllerIndexer extends JControllerLegacy
 		}
 
 		// Log the start
-		JLog::add('Starting the indexer batch process', JLog::INFO);
+		JLog::add('Starting the indexer batch process', JLog::INFO, 'com_finder');
 
 		// We don't want this form to be cached.
 		header('Pragma: no-cache');
@@ -284,7 +284,7 @@ class FinderControllerIndexer extends JControllerLegacy
 		// Send the assigned error code if we are catching an exception.
 		if ($data instanceof Exception)
 		{
-			JLog::add($data->getMessage(), JLog::ERROR);
+			JLog::add($data->getMessage(), JLog::ERROR, 'com_finder');
 			JResponse::setHeader('status', $data->getCode());
 			JResponse::sendHeaders();
 		}
@@ -342,7 +342,7 @@ class FinderIndexerResponse
 		if ($state instanceof Exception)
 		{
 			// Log the error
-			JLog::add($state->getMessage(), JLog::ERROR);
+			JLog::add($state->getMessage(), JLog::ERROR, 'com_finder');
 
 			// Prepare the error response.
 			$this->error = true;

--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -157,7 +157,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	public function onStartIndex()
 	{
-		JLog::add('FinderIndexerAdapter::onStartIndex', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::onStartIndex', JLog::DEBUG, 'com_finder');
 
 		// Get the indexer state.
 		$iState = FinderIndexer::getState();
@@ -187,7 +187,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	public function onBeforeIndex()
 	{
-		JLog::add('FinderIndexerAdapter::onBeforeIndex', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::onBeforeIndex', JLog::DEBUG, 'com_finder');
 
 		// Get the indexer and adapter state.
 		$iState = FinderIndexer::getState();
@@ -216,7 +216,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	public function onBuildIndex()
 	{
-		JLog::add('FinderIndexerAdapter::onBuildIndex', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::onBuildIndex', JLog::DEBUG, 'com_finder');
 
 		// Get the indexer and adapter state.
 		$iState = FinderIndexer::getState();
@@ -271,7 +271,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function change($id, $property, $value)
 	{
-		JLog::add('FinderIndexerAdapter::change', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::change', JLog::DEBUG, 'com_finder');
 
 		// Check for a property we know how to handle.
 		if ($property !== 'state' && $property !== 'access')
@@ -349,7 +349,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function remove($id)
 	{
-		JLog::add('FinderIndexerAdapter::remove', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::remove', JLog::DEBUG, 'com_finder');
 
 		// Get the item's URL
 		$url = $this->db->quote($this->getUrl($id, $this->extension, $this->layout));
@@ -517,7 +517,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getContentCount()
 	{
-		JLog::add('FinderIndexerAdapter::getContentCount', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getContentCount', JLog::DEBUG, 'com_finder');
 
 		$return = 0;
 
@@ -565,7 +565,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getItem($id)
 	{
-		JLog::add('FinderIndexerAdapter::getItem', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getItem', JLog::DEBUG, 'com_finder');
 
 		// Get the list query and add the extra WHERE clause.
 		$sql = $this->getListQuery();
@@ -608,7 +608,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getItems($offset, $limit, $sql = null)
 	{
-		JLog::add('FinderIndexerAdapter::getItems', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getItems', JLog::DEBUG, 'com_finder');
 
 		$items = array();
 
@@ -662,7 +662,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getListQuery($sql = null)
 	{
-		JLog::add('FinderIndexerAdapter::getListQuery', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getListQuery', JLog::DEBUG, 'com_finder');
 
 		// Check if we can use the supplied SQL query.
 		$sql = $sql instanceof JDatabaseQuery ? $sql : $this->db->getQuery(true);
@@ -726,7 +726,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getUpdateQueryByTime($time)
 	{
-		JLog::add('FinderIndexerAdapter::getUpdateQueryByTime', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getUpdateQueryByTime', JLog::DEBUG, 'com_finder');
 
 		// Build an SQL query based on the modified time.
 		$sql = $this->db->getQuery(true);
@@ -746,7 +746,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getUpdateQueryByIds($ids)
 	{
-		JLog::add('FinderIndexerAdapter::getUpdateQueryByIds', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getUpdateQueryByIds', JLog::DEBUG, 'com_finder');
 
 		// Build an SQL query based on the item ids.
 		$sql = $this->db->getQuery(true);
@@ -765,7 +765,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getTypeId()
 	{
-		JLog::add('FinderIndexerAdapter::getTypeId', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getTypeId', JLog::DEBUG, 'com_finder');
 
 		// Get the type id from the database.
 		$query = $this->db->getQuery(true);
@@ -815,7 +815,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 */
 	protected function getItemMenuTitle($url)
 	{
-		JLog::add('FinderIndexerAdapter::getItemMenuTitle', JLog::INFO);
+		JLog::add('FinderIndexerAdapter::getItemMenuTitle', JLog::DEBUG, 'com_finder');
 
 		$return = null;
 

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -107,14 +107,14 @@ class JApplicationDaemon extends JApplicationCli
 		// @codeCoverageIgnoreStart
 		if (!defined('SIGHUP'))
 		{
-			JLog::add('The PCNTL extension for PHP is not available.', JLog::ERROR);
+			JLog::add('The PCNTL extension for PHP is not available.', JLog::ERROR, 'daemon');
 			throw new RuntimeException('The PCNTL extension for PHP is not available.');
 		}
 
 		// Verify that POSIX support for PHP is available.
 		if (!function_exists('posix_getpid'))
 		{
-			JLog::add('The POSIX extension for PHP is not available.', JLog::ERROR);
+			JLog::add('The POSIX extension for PHP is not available.', JLog::ERROR, 'daemon');
 			throw new RuntimeException('The POSIX extension for PHP is not available.');
 		}
 		// @codeCoverageIgnoreEnd
@@ -147,12 +147,12 @@ class JApplicationDaemon extends JApplicationCli
 	public static function signal($signal)
 	{
 		// Log all signals sent to the daemon.
-		JLog::add('Received signal: ' . $signal, JLog::DEBUG);
+		JLog::add('Received signal: ' . $signal, JLog::DEBUG, 'daemon');
 
 		// Let's make sure we have an application instance.
 		if (!is_subclass_of(self::$instance, 'JApplicationDaemon'))
 		{
-			JLog::add('Cannot find the application instance.', JLog::EMERGENCY);
+			JLog::add('Cannot find the application instance.', JLog::EMERGENCY, 'daemon');
 			throw new RuntimeException('Cannot find the application instance.');
 		}
 
@@ -237,7 +237,7 @@ class JApplicationDaemon extends JApplicationCli
 		{
 			// No response so remove the process id file and log the situation.
 			@ unlink($pidFile);
-			JLog::add('The process found based on PID file was unresponsive.', JLog::WARNING);
+			JLog::add('The process found based on PID file was unresponsive.', JLog::WARNING, 'daemon');
 
 			return false;
 		}
@@ -353,7 +353,7 @@ class JApplicationDaemon extends JApplicationCli
 	 */
 	public function restart()
 	{
-		JLog::add('Stopping ' . $this->name, JLog::INFO);
+		JLog::add('Stopping ' . $this->name, JLog::INFO, 'daemon');
 		$this->shutdown(true);
 	}
 
@@ -372,7 +372,7 @@ class JApplicationDaemon extends JApplicationCli
 			gc_enable();
 		}
 
-		JLog::add('Starting ' . $this->name, JLog::INFO);
+		JLog::add('Starting ' . $this->name, JLog::INFO, 'daemon');
 
 		// Set off the process for becoming a daemon.
 		if ($this->daemonize())
@@ -397,7 +397,7 @@ class JApplicationDaemon extends JApplicationCli
 		// We were not able to daemonize the application so log the failure and die gracefully.
 		else
 		{
-			JLog::add('Starting ' . $this->name . ' failed', JLog::INFO);
+			JLog::add('Starting ' . $this->name . ' failed', JLog::INFO, 'daemon');
 		}
 	}
 
@@ -411,7 +411,7 @@ class JApplicationDaemon extends JApplicationCli
 	 */
 	public function stop()
 	{
-		JLog::add('Stopping ' . $this->name, JLog::INFO);
+		JLog::add('Stopping ' . $this->name, JLog::INFO, 'daemon');
 		$this->shutdown();
 	}
 
@@ -435,14 +435,14 @@ class JApplicationDaemon extends JApplicationCli
 		// Change the user id for the process id file if necessary.
 		if ($uid && (fileowner($file) != $uid) && (!@ chown($file, $uid)))
 		{
-			JLog::add('Unable to change user ownership of the process id file.', JLog::ERROR);
+			JLog::add('Unable to change user ownership of the process id file.', JLog::ERROR, 'daemon');
 			return false;
 		}
 
 		// Change the group id for the process id file if necessary.
 		if ($gid && (filegroup($file) != $gid) && (!@ chgrp($file, $gid)))
 		{
-			JLog::add('Unable to change group ownership of the process id file.', JLog::ERROR);
+			JLog::add('Unable to change group ownership of the process id file.', JLog::ERROR, 'daemon');
 			return false;
 		}
 
@@ -455,14 +455,14 @@ class JApplicationDaemon extends JApplicationCli
 		// Change the user id for the process necessary.
 		if ($uid && (posix_getuid($file) != $uid) && (!@ posix_setuid($uid)))
 		{
-			JLog::add('Unable to change user ownership of the proccess.', JLog::ERROR);
+			JLog::add('Unable to change user ownership of the proccess.', JLog::ERROR, 'daemon');
 			return false;
 		}
 
 		// Change the group id for the process necessary.
 		if ($gid && (posix_getgid($file) != $gid) && (!@ posix_setgid($gid)))
 		{
-			JLog::add('Unable to change group ownership of the proccess.', JLog::ERROR);
+			JLog::add('Unable to change group ownership of the proccess.', JLog::ERROR, 'daemon');
 			return false;
 		}
 
@@ -470,7 +470,7 @@ class JApplicationDaemon extends JApplicationCli
 		$user = posix_getpwuid($uid);
 		$group = posix_getgrgid($gid);
 
-		JLog::add('Changed daemon identity to ' . $user['name'] . ':' . $group['name'], JLog::INFO);
+		JLog::add('Changed daemon identity to ' . $user['name'] . ':' . $group['name'], JLog::INFO, 'daemon');
 
 		return true;
 	}
@@ -488,7 +488,7 @@ class JApplicationDaemon extends JApplicationCli
 		// Is there already an active daemon running?
 		if ($this->isActive())
 		{
-			JLog::add($this->name . ' daemon is still running. Exiting the application.', JLog::EMERGENCY);
+			JLog::add($this->name . ' daemon is still running. Exiting the application.', JLog::EMERGENCY, 'daemon');
 			return false;
 		}
 
@@ -504,14 +504,14 @@ class JApplicationDaemon extends JApplicationCli
 		}
 		catch (RuntimeException $e)
 		{
-			JLog::add('Unable to fork.', JLog::EMERGENCY);
+			JLog::add('Unable to fork.', JLog::EMERGENCY, 'daemon');
 			return false;
 		}
 
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			JLog::add('The process id is invalid; the fork failed.', JLog::EMERGENCY);
+			JLog::add('The process id is invalid; the fork failed.', JLog::EMERGENCY, 'daemon');
 			return false;
 		}
 
@@ -521,7 +521,7 @@ class JApplicationDaemon extends JApplicationCli
 		// Write out the process id file for concurrency management.
 		if (!$this->writeProcessIdFile())
 		{
-			JLog::add('Unable to write the pid file at: ' . $this->config->get('application_pid_file'), JLog::EMERGENCY);
+			JLog::add('Unable to write the pid file at: ' . $this->config->get('application_pid_file'), JLog::EMERGENCY, 'daemon');
 			return false;
 		}
 
@@ -532,12 +532,12 @@ class JApplicationDaemon extends JApplicationCli
 			// If the identity change was required then we need to return false.
 			if ($this->config->get('application_require_identity'))
 			{
-				JLog::add('Unable to change process owner.', JLog::CRITICAL);
+				JLog::add('Unable to change process owner.', JLog::CRITICAL, 'daemon');
 				return false;
 			}
 			else
 			{
-				JLog::add('Unable to change process owner.', JLog::WARNING);
+				JLog::add('Unable to change process owner.', JLog::WARNING, 'daemon');
 			}
 		}
 
@@ -564,7 +564,7 @@ class JApplicationDaemon extends JApplicationCli
 	 */
 	protected function detach()
 	{
-		JLog::add('Detaching the ' . $this->name . ' daemon.', JLog::DEBUG);
+		JLog::add('Detaching the ' . $this->name . ' daemon.', JLog::DEBUG, 'daemon');
 
 		// Attempt to fork the process.
 		$pid = $this->fork();
@@ -573,7 +573,7 @@ class JApplicationDaemon extends JApplicationCli
 		if ($pid)
 		{
 			// Add the log entry for debugging purposes and exit gracefully.
-			JLog::add('Ending ' . $this->name . ' parent process', JLog::DEBUG);
+			JLog::add('Ending ' . $this->name . ' parent process', JLog::DEBUG, 'daemon');
 			$this->close();
 		}
 		// We are in the forked child process.
@@ -612,7 +612,7 @@ class JApplicationDaemon extends JApplicationCli
 		else
 		{
 			// Log the fork.
-			JLog::add('Process forked ' . $pid, JLog::DEBUG);
+			JLog::add('Process forked ' . $pid, JLog::DEBUG, 'daemon');
 		}
 
 		// Trigger the onFork event.
@@ -666,7 +666,7 @@ class JApplicationDaemon extends JApplicationCli
 			// Attach the signal handler for the signal.
 			if (!$this->pcntlSignal(constant($signal), array('JApplicationDaemon', 'signal')))
 			{
-				JLog::add(sprintf('Unable to reroute signal handler: %s', $signal), JLog::EMERGENCY);
+				JLog::add(sprintf('Unable to reroute signal handler: %s', $signal), JLog::EMERGENCY, 'daemon');
 				return false;
 			}
 		}
@@ -699,7 +699,7 @@ class JApplicationDaemon extends JApplicationCli
 		// If we aren't already daemonized then just kill the application.
 		if (!$this->running && !$this->isActive())
 		{
-			JLog::add('Process was not daemonized yet, just halting current process', JLog::INFO);
+			JLog::add('Process was not daemonized yet, just halting current process', JLog::INFO, 'daemon');
 			$this->close();
 		}
 
@@ -737,7 +737,7 @@ class JApplicationDaemon extends JApplicationCli
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			JLog::add('The process id is invalid.', JLog::EMERGENCY);
+			JLog::add('The process id is invalid.', JLog::EMERGENCY, 'daemon');
 			return false;
 		}
 
@@ -745,7 +745,7 @@ class JApplicationDaemon extends JApplicationCli
 		$file = $this->config->get('application_pid_file');
 		if (empty($file))
 		{
-			JLog::add('The process id file path is empty.', JLog::ERROR);
+			JLog::add('The process id file path is empty.', JLog::ERROR, 'daemon');
 			return false;
 		}
 
@@ -753,21 +753,21 @@ class JApplicationDaemon extends JApplicationCli
 		$folder = dirname($file);
 		if (!is_dir($folder) && !JFolder::create($folder))
 		{
-			JLog::add('Unable to create directory: ' . $folder, JLog::ERROR);
+			JLog::add('Unable to create directory: ' . $folder, JLog::ERROR, 'daemon');
 			return false;
 		}
 
 		// Write the process id file out to disk.
 		if (!file_put_contents($file, $this->processId))
 		{
-			JLog::add('Unable to write proccess id file: ' . $file, JLog::ERROR);
+			JLog::add('Unable to write proccess id file: ' . $file, JLog::ERROR, 'daemon');
 			return false;
 		}
 
 		// Make sure the permissions for the proccess id file are accurate.
 		if (!chmod($file, 0644))
 		{
-			JLog::add('Unable to adjust permissions for the proccess id file: ' . $file, JLog::ERROR);
+			JLog::add('Unable to adjust permissions for the proccess id file: ' . $file, JLog::ERROR, 'daemon');
 			return false;
 		}
 

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -790,7 +790,7 @@ class JBrowser extends JObject
 		// Can't identify browser version
 		$this->_majorVersion = 0;
 		$this->_minorVersion = 0;
-		JLog::add("Can't identify browser version. Agent: " . $this->_agent, JLog::NOTICE);
+		JLog::add("Can't identify browser version. Agent: " . $this->_agent, JLog::NOTICE, 'browser');
 	}
 
 	/**

--- a/libraries/joomla/image/filter.php
+++ b/libraries/joomla/image/filter.php
@@ -37,7 +37,7 @@ abstract class JImageFilter
 		// Make sure the file handle is valid.
 		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
 		{
-			JLog::add('The image handle is invalid for the image filter.', JLog::ERROR);
+			JLog::add('The image handle is invalid for the image filter.', JLog::ERROR, 'image');
 			throw new InvalidArgumentException('The image handle is invalid for the image filter.');
 		}
 

--- a/libraries/joomla/image/filters/brightness.php
+++ b/libraries/joomla/image/filters/brightness.php
@@ -35,7 +35,7 @@ class JImageFilterBrightness extends JImageFilter
 		if (!function_exists('imagefilter'))
 		{
 			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 
 			// @codeCoverageIgnoreEnd

--- a/libraries/joomla/image/filters/contrast.php
+++ b/libraries/joomla/image/filters/contrast.php
@@ -35,7 +35,7 @@ class JImageFilterContrast extends JImageFilter
 		if (!function_exists('imagefilter'))
 		{
 			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 
 			// @codeCoverageIgnoreEnd

--- a/libraries/joomla/image/filters/edgedetect.php
+++ b/libraries/joomla/image/filters/edgedetect.php
@@ -34,7 +34,7 @@ class JImageFilterEdgedetect extends JImageFilter
 		if (!function_exists('imagefilter'))
 		{
 			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 
 			// @codeCoverageIgnoreEnd

--- a/libraries/joomla/image/filters/emboss.php
+++ b/libraries/joomla/image/filters/emboss.php
@@ -33,7 +33,7 @@ class JImageFilterEmboss extends JImageFilter
 		// Verify that image filter support for PHP is available.
 		if (!function_exists('imagefilter'))
 		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 		}
 

--- a/libraries/joomla/image/filters/grayscale.php
+++ b/libraries/joomla/image/filters/grayscale.php
@@ -34,7 +34,7 @@ class JImageFilterGrayScale extends JImageFilter
 		// Verify that image filter support for PHP is available.
 		if (!function_exists('imagefilter'))
 		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 		}
 

--- a/libraries/joomla/image/filters/negate.php
+++ b/libraries/joomla/image/filters/negate.php
@@ -33,7 +33,7 @@ class JImageFilterNegate extends JImageFilter
 		// Verify that image filter support for PHP is available.
 		if (!function_exists('imagefilter'))
 		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 		}
 

--- a/libraries/joomla/image/filters/sketchy.php
+++ b/libraries/joomla/image/filters/sketchy.php
@@ -33,7 +33,7 @@ class JImageFilterSketchy extends JImageFilter
 		// Verify that image filter support for PHP is available.
 		if (!function_exists('imagefilter'))
 		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 		}
 

--- a/libraries/joomla/image/filters/smooth.php
+++ b/libraries/joomla/image/filters/smooth.php
@@ -34,7 +34,7 @@ class JImageFilterSmooth extends JImageFilter
 		// Verify that image filter support for PHP is available.
 		if (!function_exists('imagefilter'))
 		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The imagefilter function for PHP is not available.');
 		}
 

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -68,7 +68,7 @@ class JImage
 		if (!extension_loaded('gd'))
 		{
 			// @codeCoverageIgnoreStart
-			JLog::add('The GD extension for PHP is not available.', JLog::ERROR);
+			JLog::add('The GD extension for PHP is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The GD extension for PHP is not available.');
 
 			// @codeCoverageIgnoreEnd
@@ -365,7 +365,7 @@ class JImage
 				if (empty(self::$formats[IMAGETYPE_GIF]))
 				{
 					// @codeCoverageIgnoreStart
-					JLog::add('Attempting to load an image of unsupported type GIF.', JLog::ERROR);
+					JLog::add('Attempting to load an image of unsupported type GIF.', JLog::ERROR, 'image');
 					throw new RuntimeException('Attempting to load an image of unsupported type GIF.');
 
 					// @codeCoverageIgnoreEnd
@@ -388,7 +388,7 @@ class JImage
 				if (empty(self::$formats[IMAGETYPE_JPEG]))
 				{
 					// @codeCoverageIgnoreStart
-					JLog::add('Attempting to load an image of unsupported type JPG.', JLog::ERROR);
+					JLog::add('Attempting to load an image of unsupported type JPG.', JLog::ERROR, 'image');
 					throw new RuntimeException('Attempting to load an image of unsupported type JPG.');
 
 					// @codeCoverageIgnoreEnd
@@ -411,7 +411,7 @@ class JImage
 				if (empty(self::$formats[IMAGETYPE_PNG]))
 				{
 					// @codeCoverageIgnoreStart
-					JLog::add('Attempting to load an image of unsupported type PNG.', JLog::ERROR);
+					JLog::add('Attempting to load an image of unsupported type PNG.', JLog::ERROR, 'image');
 					throw new RuntimeException('Attempting to load an image of unsupported type PNG.');
 
 					// @codeCoverageIgnoreEnd
@@ -430,7 +430,7 @@ class JImage
 				break;
 
 			default:
-				JLog::add('Attempting to load an image of unsupported type: ' . $properties->mime, JLog::ERROR);
+				JLog::add('Attempting to load an image of unsupported type: ' . $properties->mime, JLog::ERROR, 'image');
 				throw new InvalidArgumentException('Attempting to load an image of unsupported type: ' . $properties->mime);
 				break;
 		}
@@ -625,7 +625,7 @@ class JImage
 		$className = 'JImageFilter' . ucfirst($type);
 		if (!class_exists($className))
 		{
-			JLog::add('The ' . ucfirst($type) . ' image filter is not available.', JLog::ERROR);
+			JLog::add('The ' . ucfirst($type) . ' image filter is not available.', JLog::ERROR, 'image');
 			throw new RuntimeException('The ' . ucfirst($type) . ' image filter is not available.');
 		}
 
@@ -636,7 +636,7 @@ class JImage
 		if (!($instance instanceof JImageFilter))
 		{
 			// @codeCoverageIgnoreStart
-			JLog::add('The ' . ucfirst($type) . ' image filter is not valid.', JLog::ERROR);
+			JLog::add('The ' . ucfirst($type) . ' image filter is not valid.', JLog::ERROR, 'image');
 			throw new RuntimeException('The ' . ucfirst($type) . ' image filter is not valid.');
 
 			// @codeCoverageIgnoreEnd


### PR DESCRIPTION
This is to fix superfluous log messages in custom logs. It adds categories to those JLog::add calls where there was no category specified yet.

Short history (tl;dr: skip this paragraph): For my own extension, I wanted to create a separate logfile.
For that reason, I called the addLogger function just as described here: http://docs.joomla.org/Using_JLog. I noticed however that some unrelated messages were cropping up from time to time in the extension's log files ("FinderIndexerAdapter::getTypeId", "Can't identify browser version. [..]"); that was even though I had specified my extension's name as category. Looking through the core code, I realized this was due to those error messages not having assigned a category. That's why I've prepared this pull request for Joomla.

This is my first pull request for Joomla, so please point me in the right direction if there's anything amiss; I've already signed the contributor's agreement (my name is Bernhard Fröhler).

I hope I have chosen the correct branch to base this on - not sure about the branching strategy of Joomla? Are such fixes supposed to go into staging/master first maybe? Problem is some things ("Can't identify browser") were already removed there. And which branches would this need to be merged in addition? I suppose 3.4-dev? Thanks in advance for your patience with a newbie...
