### PR TITLE
Routing: using the dependency injected $app and $menu in the core routers

### DIFF
--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -30,18 +30,16 @@ class ContactRouter extends JComponentRouterBase
 		$segments = array();
 
 		// Get a menu item based on Itemid or currently active
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu();
 		$params = JComponentHelper::getParams('com_contact');
 		$advanced = $params->get('sef_advanced_link', 0);
 
 		if (empty($query['Itemid']))
 		{
-			$menuItem = $menu->getActive();
+			$menuItem = $this->menu->getActive();
 		}
 		else
 		{
-			$menuItem = $menu->getItem($query['Itemid']);
+			$menuItem = $this->menu->getItem($query['Itemid']);
 		}
 
 		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
@@ -178,9 +176,7 @@ class ContactRouter extends JComponentRouterBase
 		}
 
 		// Get the active menu item.
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu();
-		$item = $menu->getActive();
+		$item = $this->menu->getActive();
 		$params = JComponentHelper::getParams('com_contact');
 		$advanced = $params->get('sef_advanced_link', 0);
 

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -30,20 +30,18 @@ class ContentRouter extends JComponentRouterBase
 		$segments = array();
 
 		// Get a menu item based on Itemid or currently active
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu();
 		$params = JComponentHelper::getParams('com_content');
 		$advanced = $params->get('sef_advanced_link', 0);
 
 		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid']))
 		{
-			$menuItem = $menu->getActive();
+			$menuItem = $this->menu->getActive();
 			$menuItemGiven = false;
 		}
 		else
 		{
-			$menuItem = $menu->getItem($query['Itemid']);
+			$menuItem = $this->menu->getItem($query['Itemid']);
 			$menuItemGiven = true;
 		}
 
@@ -284,9 +282,7 @@ class ContentRouter extends JComponentRouterBase
 		}
 
 		// Get the active menu item.
-		$app = JFactory::getApplication();
-		$menu = $app->getMenu();
-		$item = $menu->getActive();
+		$item = $this->menu->getActive();
 		$params = JComponentHelper::getParams('com_content');
 		$advanced = $params->get('sef_advanced_link', 0);
 		$db = JFactory::getDbo();

--- a/components/com_finder/router.php
+++ b/components/com_finder/router.php
@@ -27,15 +27,7 @@ class FinderRouter extends JComponentRouterBase
 	 */
 	public function build(&$query)
 	{
-		static $menu;
-
 		$segments = array();
-
-		// Load the menu if necessary.
-		if (!$menu)
-		{
-			$menu = JFactory::getApplication('site')->getMenu();
-		}
 
 		/*
 		 * First, handle menu item routes first. When the menu system builds a
@@ -57,7 +49,7 @@ class FinderRouter extends JComponentRouterBase
 		if (!empty($query['Itemid']))
 		{
 			// Get the menu item.
-			$item = $menu->getItem($query['Itemid']);
+			$item = $this->menu->getItem($query['Itemid']);
 
 			// Check if the view matches.
 			if ($item && @$item->query['view'] === @$query['view'])

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -30,18 +30,16 @@ class NewsfeedsRouter extends JComponentRouterBase
 		$segments = array();
 
 		// Get a menu item based on Itemid or currently active
-		$app	= JFactory::getApplication();
-		$menu	= $app->getMenu();
 		$params = JComponentHelper::getParams('com_newsfeeds');
 		$advanced = $params->get('sef_advanced_link', 0);
 
 		if (empty($query['Itemid']))
 		{
-			$menuItem = $menu->getActive();
+			$menuItem = $this->menu->getActive();
 		}
 		else
 		{
-			$menuItem = $menu->getItem($query['Itemid']);
+			$menuItem = $this->menu->getItem($query['Itemid']);
 		}
 
 		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
@@ -178,9 +176,7 @@ class NewsfeedsRouter extends JComponentRouterBase
 		}
 
 		// Get the active menu item.
-		$app	= JFactory::getApplication();
-		$menu	= $app->getMenu();
-		$item	= $menu->getActive();
+		$item	= $this->menu->getActive();
 		$params = JComponentHelper::getParams('com_newsfeeds');
 		$advanced = $params->get('sef_advanced_link', 0);
 

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -30,19 +30,17 @@ class TagsRouter extends JComponentRouterBase
 		$segments = array();
 
 		// Get a menu item based on Itemid or currently active
-		$app		= JFactory::getApplication();
-		$menu		= $app->getMenu();
 		$params		= JComponentHelper::getParams('com_tags');
 		$advanced	= $params->get('sef_advanced_link', 0);
 
 		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid']))
 		{
-			$menuItem = $menu->getActive();
+			$menuItem = $this->menu->getActive();
 		}
 		else
 		{
-			$menuItem = $menu->getItem($query['Itemid']);
+			$menuItem = $this->menu->getItem($query['Itemid']);
 		}
 
 		$mView = (empty($menuItem->query['view'])) ? null : $menuItem->query['view'];
@@ -144,9 +142,7 @@ class TagsRouter extends JComponentRouterBase
 		}
 
 		// Get the active menu item.
-		$app	= JFactory::getApplication();
-		$menu	= $app->getMenu();
-		$item	= $menu->getActive();
+		$item	= $this->menu->getActive();
 
 		// Count route segments
 		$count = count($segments);

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -43,9 +43,7 @@ class UsersRouter extends JComponentRouterBase
 		if (empty($items))
 		{
 			// Get all relevant menu items.
-			$app = JFactory::getApplication();
-			$menu = $app->getMenu();
-			$items = $menu->getItems('component', 'com_users');
+			$items = $this->menu->getItems('component', 'com_users');
 
 			// Build an array of serialized query strings to menu item id mappings.
 			for ($i = 0, $n = count($items); $i < $n; $i++)

--- a/libraries/cms/component/router/base.php
+++ b/libraries/cms/component/router/base.php
@@ -17,6 +17,51 @@ defined('JPATH_PLATFORM') or die;
 abstract class JComponentRouterBase implements JComponentRouterInterface
 {
 	/**
+	 * Application object to use in the router
+	 *
+	 * @var    JApplicationCms
+	 * @since  3.4
+	 */
+	public $app;
+
+	/**
+	 * Menu object to use in the router
+	 *
+	 * @var    JMenu
+	 * @since  3.4
+	 */
+	public $menu;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param   JApplicationCms  $app   Application-object that the router should use
+	 * @param   JMenu            $menu  Menu-object that the router should use
+	 *
+	 * @since   3.4
+	 */
+	public function __construct($app = false, $menu = false)
+	{
+		if ($app)
+		{
+			$this->app = $app;
+		}
+		else
+		{
+			$this->app = JFactory::getApplication();
+		}
+
+		if ($menu)
+		{
+			$this->menu = $menu;
+		}
+		else
+		{
+			$this->menu = $this->app->getMenu();
+		}
+	}
+
+	/**
 	 * Generic method to preprocess a URL
 	 *
 	 * @param   array  $query  An associative array of URL arguments

--- a/libraries/cms/component/router/base.php
+++ b/libraries/cms/component/router/base.php
@@ -40,7 +40,7 @@ abstract class JComponentRouterBase implements JComponentRouterInterface
 	 *
 	 * @since   3.4
 	 */
-	public function __construct($app = false, $menu = false)
+	public function __construct($app = null, $menu = null)
 	{
 		if ($app)
 		{


### PR DESCRIPTION
In one of the last routing PRs, the JApplicationCms and JMenu objects were handed over to the constructor of the component routers. This allows to have test-objects be injected into the routers or to change the original objects where necessary. 

This PR implements this change in the core routers by modifying the JComponentRouterBase class and subsequently changing the code in the core routers to use the new objects of the class.

I've been trying to decide if this is backwards compatible for a while longer. Not so much because the core routers are slightly changed, but because JComponentRouterBase is changed in that it gets a constructor and that this constructor accepts 2 parameters. If a developer wrote his own router class which extends from JComponentRouterBase and which has its own constructor, but does not call the parent constructor, $this->app and $this->menu would not be available to the router. But then again, those routers would not use $this->app and $this->menu in their code anyway. The only way this could go wrong, would be if a developer extends a core router and has his own constructor written for it, that does not call the parent constructor. This is a VERY unlikely construct and I would say that this is equally possible to winning the lottery and being struck by lightning at the same time. So I think we are safe here. (I'm just trying to cover all our bases here.)

Testing instructions: Apply the change and simply see that nothing is broken.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
