### PR TITLE
Fixes Author and Copyright info for Editor - None

### DIFF
--- a/plugins/editors/none/none.xml
+++ b/plugins/editors/none/none.xml
@@ -2,7 +2,7 @@
 <extension version="3.1" type="plugin" group="editors">
 	<name>plg_editors_none</name>
 	<version>3.0.0</version>
-	<creationDate>August 2004</creationDate>
+	<creationDate>September 2005</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/plugins/editors/none/none.xml
+++ b/plugins/editors/none/none.xml
@@ -3,10 +3,10 @@
 	<name>plg_editors_none</name>
 	<version>3.0.0</version>
 	<creationDate>August 2004</creationDate>
-	<author></author>
-	<authorEmail>N/A</authorEmail>
-	<authorUrl></authorUrl>
-	<copyright></copyright>
+	<author>Joomla! Project</author>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<copyright>Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>PLG_NONE_XML_DESCRIPTION</description>
 	<files>


### PR DESCRIPTION
Just a tiny cosmetic fix:

I do not know if this is wanted for political or legal reasons, but in Extensions Manager, Editor - None is listed as having an "Unknown" author.
I fixed this by adding the required info in none.xml
There is an inconsistency, anyway: the "Creation Date" is set as "August 2004", while the standard Copyright notice says "2005 -2014"
