### PR TITLE
JRouterInstallation::parse() made compatible with the interface

### DIFF
--- a/installation/application/router.php
+++ b/installation/application/router.php
@@ -25,7 +25,7 @@ class JRouterInstallation extends JRouter
 	 *
 	 * @since   1.5
 	 */
-	public function parse($url)
+	public function parse(&$url)
 	{
 		return true;
 	}
@@ -39,7 +39,7 @@ class JRouterInstallation extends JRouter
 	 *
 	 * @since   1.5
 	 */
-	public function build($url)
+	public function build(&$url)
 	{
 		$url = str_replace('&amp;', '&', $url);
 


### PR DESCRIPTION
This fixes #5172. Mea culpa. I missed that & in the Installation router. :smile: 

Testing instructions:
Set PHP error reporting to maximum, try to install Joomla. You will get an error in your Ajax response and the installation does not proceed.
Apply patch and see that this does not happen anymore.
