### PR TITLE
Changes in Isis for making debug cooperate with sidebar

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -309,5 +309,18 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 		})(jQuery);
 	</script>
 <?php endif; ?>
+<?php if (JFactory::getApplication()->get('debug') || JFactory::getApplication()->get('debug_lang')) : ?>
+	<script>
+		jQuery(document).ready(function(){
+			var newParent = document.getElementById('j-main-container');
+
+			if (newParent)
+			{
+				var oldParent = document.getElementById('system-debug');
+				jQuery(newParent).append(oldParent);
+			}
+		});
+	</script>
+<?php endif; ?>
 </body>
 </html>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -312,12 +312,9 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <?php if (JFactory::getApplication()->get('debug') || JFactory::getApplication()->get('debug_lang')) : ?>
 	<script>
 		jQuery(document).ready(function(){
-			var newParent = document.getElementById('j-main-container');
-
-			if (newParent)
+			if (jQuery('#j-main-container'))
 			{
-				var oldParent = document.getElementById('system-debug');
-				jQuery(newParent).append(oldParent);
+				jQuery('#j-main-container').append(jQuery('#system-debug'));
 			}
 		});
 	</script>

--- a/media/cms/css/debug.css
+++ b/media/cms/css/debug.css
@@ -113,6 +113,8 @@ div#system-debug {
 	font-size: 13px;
 	text-align: left;
 	direction: ltr;
+	white-space: pre;
+	word-wrap: break-word;
 }
 
 #system-debug p {


### PR DESCRIPTION
#### This is a fix for #5141

What this does: it moves the debug div into main content.
Also a minor stylistic touch on `<code>`

It looks like this:
![screen shot 2014-11-23 at 3 30 33](https://cloud.githubusercontent.com/assets/3889375/5157725/40c9e60c-7327-11e4-8725-b2a37e6c38f2.png)
#### Testing

Apply #5141
Apply this
Enable debug
Navigate around 
Disable debug, enable debug language
Navigate around 
