### PR TITLE
Fixing aliasing namespaced classes

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -6,7 +6,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-JLoader::registerAlias('JRegistry',           '\\Joomla\\Registry\\Registry');
+class_alias('\\Joomla\\Registry\\Registry', 'JRegistry');
 JLoader::registerAlias('JRegistryFormat',     '\\Joomla\\Registry\\AbstractRegistryFormat');
 JLoader::registerAlias('JRegistryFormatINI',  '\\Joomla\\Registry\\Format\\Ini');
 JLoader::registerAlias('JRegistryFormatJSON', '\\Joomla\\Registry\\Format\\Json');

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -73,5 +73,5 @@ JLoader::register('JInstallerPackage',  JPATH_PLATFORM . '/cms/installer/adapter
 JLoader::register('JInstallerPlugin',  JPATH_PLATFORM . '/cms/installer/adapter/plugin.php');
 JLoader::register('JInstallerTemplate',  JPATH_PLATFORM . '/cms/installer/adapter/template.php');
 JLoader::register('JExtension',  JPATH_PLATFORM . '/cms/installer/extension.php');
-JLoader::registerAlias('JAdministrator',  'JApplicationAdministrator');
-JLoader::registerAlias('JSite',  'JApplicationSite');
+class_alias('JApplicationAdministrator', 'JAdministrator');
+class_alias('JApplicationSite', 'JSite');


### PR DESCRIPTION
This fixes #5179. We currently have 2 places where class aliases are registered, once in /libraries/classmap.php and once in /libraries/cms.php. I decided to only call class_alias() directly for JAdministrator, JSite and JRegistry, since those 3 classes are classes that are passed between extensions and objects. This always loads those 3 classes on every pageload, but I hope that downside is negligible. All other classes are extremely likely to be instantiated first and then checked against, which is why I doubt that we need to care for those separately. Basically, all JRegistry\* classes are only used internally of JRegistry and JStringInflector seems to be a class that most likely is not created by the CMS and then used by an extension. JStringNormalise is abstract anyway, so this should not be a problem either.
