### PR TITLE
Postgresql: Database schema not up to date after installation

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.2.2-2014-01-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.2.2-2014-01-18.sql
@@ -1,2 +1,2 @@
 /* Update updates version length */
-ALTER TABLE "#__updates" ALTER COLUMN "version" TYPE varchar(32);
+ALTER TABLE "#__updates" ALTER COLUMN "version" TYPE character varying(32);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.3.4-2014-08-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.3.4-2014-08-03.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "#__user_profiles" ALTER COLUMN "profile_value" TYPE TEXT;
+ALTER TABLE "#__user_profiles" ALTER COLUMN "profile_value" TYPE text;

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -89,7 +89,7 @@ SELECT setval('#__assets_id_seq', 54, false);
 -- Table: #__associations
 --
 CREATE TABLE "#__associations" (
-  "id" bigint NOT NULL,
+  "id" int NOT NULL,
   "context" varchar(50) NOT NULL,
   "key" char(32) NOT NULL,
   CONSTRAINT "#__associations_idx_context_id" PRIMARY KEY ("context", "id")
@@ -427,6 +427,7 @@ CREATE TABLE "#__contentitem_tag_map" (
  CONSTRAINT "#__uc_ItemnameTagid" UNIQUE ("type_alias", "content_item_id", "tag_id")
 );
 CREATE INDEX "#__contentitem_tag_map_idx_tag_type" ON "#__contentitem_tag_map" ("tag_id", "type_id");
+CREATE INDEX "#__contentitem_tag_map_idx_tag_name" ON "#__contentitem_tag_map" ("tag_id", "type_alias");
 CREATE INDEX "#__contentitem_tag_map_idx_date_id" ON "#__contentitem_tag_map" ("tag_date", "tag_id");
 CREATE INDEX "#__contentitem_tag_map_idx_tag" ON "#__contentitem_tag_map" ("tag_id");
 CREATE INDEX "#__contentitem_tag_map_idx_type" ON "#__contentitem_tag_map" ("type_id");


### PR DESCRIPTION
As described in #4922 and #5177 the posgresql database schema is not up to date after installation. Apply this patch before installing. Then install on a postgresql database with "Install Sample Data" set to None. Login in the backend and go to the "Extension Manager" -> "Database" and verify that the database schema is uptodate.
