### PR TITLE
[J25] Fix: Installation error: Deprecated: iconv_set_encoding(): Use of iconv.output_encoding is deprecated

### DIFF
--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -21,16 +21,16 @@ if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN
 	@ini_set('mbstring.http_output', 'UTF-8');
 }
 
-if (version_compare(PHP_VERSION, '5.6', '>='))
+// Same for iconv
+if (function_exists('iconv'))
 {
-	@ini_set('default_charset', 'UTF-8');
-}
-else
-{
-	// Same for iconv
-	if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('iconv.so'))))
+	// These are settings that can be set inside code
+	if (version_compare(PHP_VERSION, '5.6', '>='))
 	{
-		// These are settings that can be set inside code
+		@ini_set('default_charset', 'UTF-8');
+	}
+	else
+	{
 		iconv_set_encoding("internal_encoding", "UTF-8");
 		iconv_set_encoding("input_encoding", "UTF-8");
 		iconv_set_encoding("output_encoding", "UTF-8");

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -21,13 +21,20 @@ if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN
 	@ini_set('mbstring.http_output', 'UTF-8');
 }
 
-// Same for iconv
-if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('iconv.so'))))
+if (version_compare(PHP_VERSION, '5.6', '>='))
 {
-	// These are settings that can be set inside code
-	iconv_set_encoding("internal_encoding", "UTF-8");
-	iconv_set_encoding("input_encoding", "UTF-8");
-	iconv_set_encoding("output_encoding", "UTF-8");
+	@ini_set('default_charset', 'UTF-8');
+}
+else
+{
+	// Same for iconv
+	if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('iconv.so'))))
+	{
+		// These are settings that can be set inside code
+		iconv_set_encoding("internal_encoding", "UTF-8");
+		iconv_set_encoding("input_encoding", "UTF-8");
+		iconv_set_encoding("output_encoding", "UTF-8");
+	}
 }
 
 /**

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -22,7 +22,7 @@ if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN
 }
 
 // Same for iconv
-if (function_exists('iconv'))
+if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('iconv.so'))))
 {
 	// These are settings that can be set inside code
 	if (version_compare(PHP_VERSION, '5.6', '>='))


### PR DESCRIPTION
This fixes: https://github.com/joomla/joomla-cms/issues/5192

See https://github.com/joomla/joomla-cms/commit/82d8459268177b3299c0505ddbb48ecb2269c6b2 for the fix against staging.
#### Steps to reproduce the issue

Download and extract xampp 5.6.3 (they change the versioning to reflect the PHP Version)
Download and extract joomla 2.5.x (github branche or stable)
try to install
#### Expected result

Install works (after fixing this it still don't work but i will open a new issue for that; see: #5193 )
#### Actual result

Deprecated: iconv_set_encoding(): Use of iconv.internal_encoding is deprecated in JRoot\libraries\joomla\string\string.php on line 28
Deprecated: iconv_set_encoding(): Use of iconv.input_encoding is deprecated in JRoot\libraries\joomla\string\string.php on line 29
Deprecated: iconv_set_encoding(): Use of iconv.output_encoding is deprecated in JRoot\libraries\joomla\string\string.php on line 30

![screen shot 2014-11-25 at 01 20 50](http://issues.joomla.org/uploads/1/9dc4f533402530aebb44271a72f1581f.jpg)
#### System information (as much as possible)

Default xampp Konfiguration with:

Apache 2.4.10, MySQL 5.6.21, PHP 5.6.3, phpMyAdmin 4.2.11, OpenSSL 1.0.1, XAMPP Control Panel 3.2.1, Webalizer 2.23-04, Mercury Mail Transport System 4.63, FileZilla FTP Server 0.9.41, Tomcat 7.0.56 (with mod_proxy_ajp as connector), Strawberry Perl 7.0.56 Portable
#### Additional comments

I think the Joomla Core should work with the default xampp config as it is often used for "testing" and planing joomla if can't be done on the production site not only by experts mostly by end users to pre-test Joomla.
