### PR TITLE
[fix #5173] JRouterInstallation::build() strict standards

### DIFF
--- a/installation/application/router.php
+++ b/installation/application/router.php
@@ -38,7 +38,7 @@ class JRouterInstallation extends JRouter
 	 *
 	 * @since   1.5
 	 */
-	public function build(&$url)
+	public function build($url)
 	{
 		$url = str_replace('&amp;', '&', $url);
 

--- a/installation/application/router.php
+++ b/installation/application/router.php
@@ -32,7 +32,7 @@ class JRouterInstallation extends JRouter
 	/**
 	 * Function to convert an internal URI to a route
 	 *
-	 * @param   string  &$url  The internal URL
+	 * @param   string  $url  The internal URL
 	 *
 	 * @return  string  The absolute search engine friendly URL
 	 *


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/5173 corrected parse() and broke build()

To test, install a new staging and make sure you do not get the error:
[25-Nov-2014 09:47:40 UTC] PHP Strict standards: Declaration of JRouterInstallation::build() should be compatible with JRouter::build($url) in ROOT/installation/application/router.php on line 47
