### PR TITLE
swap two options for better UI

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -198,11 +198,6 @@
 					hr="true" />
 
 				<field
-					name="filteringspacer6"
-					type="spacer"
-					hr="true" />
-
-				<field
 					name="date_filtering"
 					type="list"
 					default="off"

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -58,6 +58,13 @@
 				label="MOD_ARTICLES_CATEGORY_FIELD_GROUP_FILTERING_LABEL"
 			>
 				<field
+					name="count"
+					type="text"
+					default="0"
+					label="MOD_ARTICLES_CATEGORY_FIELD_COUNT_LABEL"
+					description="MOD_ARTICLES_CATEGORY_FIELD_COUNT_DESC" />
+
+				<field
 					name="show_front"
 					type="list"
 					default="show"
@@ -68,18 +75,6 @@
 					<option value="hide">JHIDE</option>
 					<option value="only">MOD_ARTICLES_CATEGORY_OPTION_ONLYFEATURED_VALUE</option>
 				</field>
-
-				<field
-					name="filteringspacer0"
-					type="spacer"
-					hr="true" />
-
-				<field
-					name="count"
-					type="text"
-					default="0"
-					label="MOD_ARTICLES_CATEGORY_FIELD_COUNT_LABEL"
-					description="MOD_ARTICLES_CATEGORY_FIELD_COUNT_DESC" />
 
 				<field
 					name="filteringspacer1"

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -70,6 +70,11 @@
 				</field>
 
 				<field
+					name="filteringspacer0"
+					type="spacer"
+					hr="true" />
+
+				<field
 					name="count"
 					type="text"
 					default="0"


### PR DESCRIPTION
there is no line between the option to show/hide featured articles and the amount of articles to show in this module.
Without the line people (read: me) can read it as: How many featured articles can be shown. Therefor I was looking for the field to set the amount of other articles I can show. 

With the line between the option show/hide featured articles and the field amount people (read: me) have better understanding of the meaning of amount.
