### PR TITLE
[fix] broken events before and after save on JModelAdmin. Related #4308

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -766,7 +766,7 @@ abstract class JModelAdmin extends JModelForm
 			{
 				if ($this->canDelete($table))
 				{
-					$context = $this->option . '.' . $this->name;
+					$context = $this->getContext();
 
 					// Trigger the before delete event.
 					$result = $dispatcher->trigger($this->event_before_delete, array($context, $table));
@@ -984,7 +984,7 @@ abstract class JModelAdmin extends JModelForm
 			return false;
 		}
 
-		$context = $this->option . '.' . $this->name;
+		$context = $this->getContext();
 
 		// Trigger the change state event.
 		$result = $dispatcher->trigger($this->event_change_state, array($context, $pks, $value));

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1086,7 +1086,7 @@ abstract class JModelAdmin extends JModelForm
 	{
 		$dispatcher = JEventDispatcher::getInstance();
 		$table      = $this->getTable();
-		$context    = $this->option . '_' . $this->name;
+		$context    = $this->option . '.' . $this->name;
 
 		if ((!empty($data['tags']) && $data['tags'][0] != ''))
 		{

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -20,6 +20,14 @@ defined('JPATH_PLATFORM') or die;
 abstract class JModelLegacy extends JObject
 {
 	/**
+	 * Context string for the model type.  This is used to handle uniqueness
+	 *
+	 * @var    string
+	 * @since  3.4
+	 */
+	protected $context = null;
+
+	/**
 	 * Indicates if the internal state has been set
 	 *
 	 * @var    boolean
@@ -284,6 +292,12 @@ abstract class JModelLegacy extends JObject
 		{
 			$this->event_clean_cache = 'onContentCleanCache';
 		}
+
+		// Initialize context. Only here for B/C
+		if (empty($this->context))
+		{
+			$this->context = $this->getContext();
+		}
 	}
 
 	/**
@@ -365,6 +379,25 @@ abstract class JModelLegacy extends JObject
 		}
 
 		return JTable::getInstance($name, $prefix, $config);
+	}
+
+
+	/**
+	 * Overridable method to the active context
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4
+	 */
+	public function getContext()
+	{
+		// Guess the context as Option.ModelName.
+		if (null === $this->context)
+		{
+			$this->context = strtolower($this->option . '.' . $this->getName());
+		}
+
+		return $this->context;
 	}
 
 	/**


### PR DESCRIPTION
This PR broke event B/C https://github.com/joomla/joomla-cms/pull/4308

The default context passed to plugins on  `JModelAdmin` save was:

``` php
$this->option . '.' . $this->name`
```

and it was replaced by:

``` php
$context = $this->option . '_' . $this->name;
```

That breaks all the existing plugins triggered before and after save events.

See: 
https://github.com/joomla/joomla-cms/pull/4308/files#diff-39b4bc5cb02bbace2ee4febe8f54583eR1079
