### PR TITLE
Fixed typo introduced on PR #4308

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1086,7 +1086,7 @@ abstract class JModelAdmin extends JModelForm
 	{
 		$dispatcher = JEventDispatcher::getInstance();
 		$table      = $this->getTable();
-		$context    = $this->option . '_' . $this->name;
+		$context    = $this->option . '.' . $this->name;
 
 		if ((!empty($data['tags']) && $data['tags'][0] != ''))
 		{


### PR DESCRIPTION
The context being generated for triggering save events is currently malformed due to a un-noticed typo introduced on our PR #4308.

The context is currently being generated using:

``` php
$context    = $this->option . '_' . $this->name;
```

instead of:

``` php
$context    = $this->option . '.' . $this->name;
```

This PR solves this problem.

I'm really sorry for the trouble.

Thank you for taking the time to consider this PR.
