### PR TITLE
Fixes Issues in "Smart Search" [#5204]

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -36,7 +36,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
 
 		// Strip the tags from the input
-		$input = strip_tags(str_replace('>', '> ', $input)); 
+		$input = strip_tags(str_replace('>', '> ', $input));
 
 		// Deal with spacing issues in the input
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -36,7 +36,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
 
 		// Strip the tags from the input
-		$input = preg_replace ('/<[^>]*>/', ' ', $input); 
+		$input = strip_tags(str_replace('>','> ',$input)); 
 
 		// Deal with spacing issues in the input
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -36,7 +36,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
 
 		// Strip the tags from the input
-		$input = strip_tags(str_replace('>','> ',$input)); 
+		$input = strip_tags(str_replace('>', '> ', $input)); 
 
 		// Deal with spacing issues in the input
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -36,7 +36,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
 
 		// Strip the tags from the input
-		$input = strip_tags($input);
+		$input = preg_replace ('/<[^>]*>/', ' ', $input); 
 
 		// Deal with spacing issues in the input
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);


### PR DESCRIPTION
This fixes the second of the issues I exposed in #5204

The problem was with the use of PHP strip_tags()

Using it a string of the kind &lt;h1&gt;Title&lt;/h1&gt;&lt;p&gt;This is the paragraph&lt;/p&gt; is translated to:
TitleThis is the paragraph

Adding a space after each &gt; does the trick...
