### PR TITLE
Handle accepted encoding in curl correct

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -112,7 +112,7 @@ class JHttpTransportCurl implements JHttpTransport
 			// Add the headers string into the stream context options array.
 			$options[CURLOPT_HTTPHEADER] = $headerArray;
 		}
-		
+
 		// Curl needs the accepted encoding header as option
 		if (isset($headers['Accept-Encoding']))
 		{

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -112,6 +112,12 @@ class JHttpTransportCurl implements JHttpTransport
 			// Add the headers string into the stream context options array.
 			$options[CURLOPT_HTTPHEADER] = $headerArray;
 		}
+		
+		// Curl needs the accepted encoding header as option
+		if (isset($headers['Accept-Encoding']))
+		{
+			$options[CURLOPT_ENCODING] = $headers['Accept-Encoding'];
+		}
 
 		// If an explicit timeout is given user it.
 		if (isset($timeout))


### PR DESCRIPTION
Curl needs the accepted encoding header set as curl option and not only as header.
## Test instructions

Add the following code to the file administrator/components/com_content/content.php after line 17

``` php
$options = new JRegistry();
$http = new JHttp($options, new JHttpTransportCurl($options));
$content = $http->get(
        'https://p20-calendars.icloud.com/published/2/L-7oRelmRSvcRxR8H-6Ni8btBd-dfx0NEh2GgZVeW1PZC1w1qHaA6-IKpUwsQ85mERNvoVjhUIgdyNwSvLelkS9DCTLKr_nLY0ZrMRD3mt4', array('Accept-Encoding'=>'deflate'))->body;
echo $content;die;
```

When you have applied the patch then you will see some ics content. If not then you will see some gzip compressed headers.
