### PR TITLE
Copy Template uses wrong name to replace in the manifest file.

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -187,7 +187,7 @@ class TemplatesModelTemplate extends JModelForm
 
 			// Get the template information.
 			$query = $db->getQuery(true)
-				->select('extension_id, client_id, element, name')
+				->select('extension_id, client_id, element, name, manifest_cache')
 				->from('#__extensions')
 				->where($db->quoteName('extension_id') . ' = ' . (int) $pk)
 				->where($db->quoteName('type') . ' = ' . $db->quote('template'));
@@ -325,10 +325,12 @@ class TemplatesModelTemplate extends JModelForm
 	{
 		// Rename Language files
 		// Get list of language files
-		$result = true;
-		$files = JFolder::files($this->getState('to_path'), '.ini', true, true);
-		$newName = strtolower($this->getState('new_name'));
-		$oldName = $this->getTemplate()->element;
+		$result   = true;
+		$files    = JFolder::files($this->getState('to_path'), '.ini', true, true);
+		$newName  = strtolower($this->getState('new_name'));
+		$template = $this->getTemplate();
+		$oldName  = $template->element;
+		$manifest = json_decode($template->manifest_cache);
 
 		jimport('joomla.filesystem.file');
 
@@ -344,7 +346,7 @@ class TemplatesModelTemplate extends JModelForm
 		if (JFile::exists($xmlFile))
 		{
 			$contents = file_get_contents($xmlFile);
-			$pattern[] = '#<name>\s*' . $oldName . '\s*</name>#i';
+			$pattern[] = '#<name>\s*' . $manifest->name . '\s*</name>#i';
 			$replace[] = '<name>' . $newName . '</name>';
 			$pattern[] = '#<language(.*)' . $oldName . '(.*)</language>#';
 			$replace[] = '<language${1}' . $newName . '${2}</language>';


### PR DESCRIPTION
### Issue

The copy template feature in our template manager fails when the template has a name with spaces or special characters defined in the XML.
The reason is that the method uses the name from the database, which is a sanitised version of the XML name. The real name is saved in the manifest_cache.
### Solution

Get and use the name from the manifest_cache instead for the search/replace function.
### Testing

Try to copy a template with a space or special character in the name.
You can use my template `{LESS} Allrounder` (http://www.bakual.net/download/less-allrounder/less-allrounder-2-0-1/tpl_lessallrounder-zip-5.raw) to do that.
Without patch it will tell you that it worked, but when you're going to check, it didn't copy the template (instead it "updated" the existing one).
With patch it will still tell you that it worked, but now when you're going to check there now is a second template with the new name.

Make also sure that other templates like Protostar still work to copy.
