### PR TITLE
Removed extra wrapping array on model configuration array

### DIFF
--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -51,13 +51,11 @@ class TemplatesModelStyle extends JModelAdmin
 	{
 		$config = array_merge(
 			array(
-				array(
-					'event_before_delete' => 'onExtensionBeforeDelete',
-					'event_after_delete'  => 'onExtensionAfterDelete',
-					'event_before_save'   => 'onExtensionBeforeSave',
-					'event_after_save'    => 'onExtensionAfterSave',
-					'events_map'          => array('delete' => 'extension', 'save' => 'extension')
-				)
+				'event_before_delete' => 'onExtensionBeforeDelete',
+				'event_after_delete'  => 'onExtensionAfterDelete',
+				'event_before_save'   => 'onExtensionBeforeSave',
+				'event_after_save'    => 'onExtensionAfterSave',
+				'events_map'          => array('delete' => 'extension', 'save' => 'extension')
 			), $config
 		);
 


### PR DESCRIPTION
## Problem:

There's an extra wrapping array inside the configuration array.
## Consequences:

Wrong events are being triggered on the wrong plugins for this model.

The fix is related to the work done in PR #4308.

Sorry again for the trouble guys
