### PR TITLE
Groups user lost after saving

### DIFF
--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -393,16 +393,19 @@ class UsersModelProfile extends JModelForm
 		JPluginHelper::importPlugin('user');
 
 		// Null the user groups so they don't get overwritten
+		$groups = $user->groups;
 		$user->groups = null;
 
 		// Store the data.
 		if (!$user->save())
 		{
+			$user->groups = $groups;
 			$this->setError($user->getError());
 
 			return false;
 		}
 
+		$user->groups = $groups;
 		$user->tags = new JHelperTags;
 		$user->tags->getTagIds($user->id, 'com_users.user');
 


### PR DESCRIPTION
When a user changes his profile, the groups data is lost because before saving the new data, the groups property is set to null.

I propose to save the groups property before saving and restore it after.
