### PR TITLE
Remove an iframe on Post-installation Messages

### DIFF
--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -9,8 +9,20 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('formbehavior.chosen', 'select');
+$renderer       = JFactory::getDocument()->loadRenderer('module');
+$options        = array('style' => 'raw');
+$mod            = JModuleHelper::getModule('mod_feed');
+$param          = array("rssurl" => "http://www.joomla.org/announcements/release-news.feed?type=rss",
+						"rsstitle" => 0,
+						"rssdesc" => 0,
+						"rssimage" => 1,
+						"rssitems" => 5,
+						"rssitemdesc" => 1,
+						"word_count" => 200,
+						"cache" => 0);
+$params         = array('params' => json_encode($param));
 
+JHtml::_('formbehavior.chosen', 'select');
 ?>
 
 <form action="index.php" method="post" name="adminForm" class="form-inline">
@@ -58,7 +70,7 @@ JHtml::_('formbehavior.chosen', 'select');
 	</div>
 	<div class="span4">
 		<h2><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS'); ?></h2>
-		<iframe width="100%" height="1000" src="http://www.joomla.org/announcements/release-news"></iframe>
+		<?php echo $renderer->render($mod, $params, $options); ?>
 	</div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
This is a response to #5217
#### What’s changed?

in `/administrator/index.php?option=com_postinstall&eid=700` there was an iframe for fetching release informations from Joomla.org. This PR replaces the iframe with a module feed
#### Testing

go to `/administrator/index.php?option=com_postinstall&eid=700` and observe that on the right side there is an iframe
Apply this and go to `/administrator/index.php?option=com_postinstall&eid=700` 
No iframe should be there but instead this:

![screen shot 2014-11-27 at 3 15 53](https://cloud.githubusercontent.com/assets/3889375/5217398/554dc714-7648-11e4-85d1-12ccf98a8da5.png)
