### PR TITLE
If the field is hidden, just display the input

### DIFF
--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -52,11 +52,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 			<?php endif;?>
 			<?php foreach ($fields as $field):// Iterate through the fields in the set and display them.?>
 				<?php if ($field->hidden):// If the field is hidden, just display the input.?>
-					<div class="control-group">
-						<div class="controls">
-							<?php echo $field->input;?>
-						</div>
-					</div>
+					<?php echo $field->input;?>
 				<?php else:?>
 					<div class="control-group">
 						<div class="control-label">


### PR DESCRIPTION
The comment above is right but it was not applied

It is just to have a design easier and it is damage to overwrite the template just for that
