### PR TITLE
Removed unreachable code

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -36,7 +36,6 @@ class JErrorPage
 			{
 				// We're probably in an CLI environment
 				exit($error->getMessage());
-				$app->close(0);
 			}
 
 			$config = JFactory::getConfig();


### PR DESCRIPTION
exit() terminates execution of the script.
Shutdown functions and object destructors will always be executed, but there is no chance to execute $app->close(0);
