### PR TITLE
Implementing a tree node interface

### DIFF
--- a/libraries/cms/node/interface.php
+++ b/libraries/cms/node/interface.php
@@ -34,7 +34,7 @@ interface JNodeInterface
 	 *
 	 * If the child already has a parent, the link is unset
 	 *
-	 * @param   JNodeInterface  $child   The child to be added.
+	 * @param   JNodeInterface  $child  The child to be added.
 	 *
 	 * @return  void
 	 * 

--- a/libraries/cms/node/interface.php
+++ b/libraries/cms/node/interface.php
@@ -21,9 +21,10 @@ interface JNodeInterface
 	 *
 	 * If the node already has a parent, the link is unset
 	 *
-	 * @param   mixed   $parent  JNodeInterface for the parent to be set or null
+	 * @param   mixed  $parent  JNodeInterface for the parent to be set or null
 	 *
 	 * @return  void
+	 * 
 	 * @since   3.4
 	 */
 	public function setParent($parent);
@@ -36,6 +37,7 @@ interface JNodeInterface
 	 * @param   JNodeInterface  $child   The child to be added.
 	 *
 	 * @return  void
+	 * 
 	 * @since   3.4
 	 */
 	public function addChild($child);
@@ -46,6 +48,7 @@ interface JNodeInterface
 	 * @param   mixed  $child  An identifier for the child node
 	 *
 	 * @return  void
+	 * 
 	 * @since   3.4
 	 */
 	public function removeChild($child);
@@ -53,9 +56,10 @@ interface JNodeInterface
 	/**
 	 * Get the children of this node
 	 *
-	 * @param   boolean  $recursive    False by default
+	 * @param   boolean  $recursive  False by default
 	 *
-	 * @return  array    The children
+	 * @return  JNodeInterface[]   The children
+	 * 
 	 * @since   3.4
 	 */
 	public function &getChildren($recursive = false);
@@ -63,7 +67,7 @@ interface JNodeInterface
 	/**
 	 * Get the parent of this node
 	 *
-	 * @return  mixed  JNodeInterface or null
+	 * @return  JNodeInterface   The parent of this node or null
 	 *
 	 * @since   3.4
 	 */
@@ -72,7 +76,7 @@ interface JNodeInterface
 	/**
 	 * Test if this node has children
 	 *
-	 * @return  boolean  True if there is a child
+	 * @return  boolean   True if there is a child
 	 *
 	 * @since   3.4
 	 */
@@ -81,7 +85,7 @@ interface JNodeInterface
 	/**
 	 * Test if this node has a parent
 	 *
-	 * @return  boolean    True if there is a parent
+	 * @return  boolean   True if there is a parent
 	 *
 	 * @since   3.4
 	 */

--- a/libraries/cms/node/interface.php
+++ b/libraries/cms/node/interface.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Node
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * A Node interface for Joomla
+ * If you are creating a system that might create something
+ * similar to a tree, implement this interface for its nodes.
+ *
+ * @since  3.4
+ */
+interface JNodeInterface
+{
+	/**
+	 * Set the parent of this node
+	 *
+	 * If the node already has a parent, the link is unset
+	 *
+	 * @param   mixed   $parent  JNodeInterface for the parent to be set or null
+	 *
+	 * @return  void
+	 * @since   3.4
+	 */
+	public function setParent($parent);
+
+	/**
+	 * Add child to this node
+	 *
+	 * If the child already has a parent, the link is unset
+	 *
+	 * @param   JNodeInterface  $child   The child to be added.
+	 *
+	 * @return  void
+	 * @since   3.4
+	 */
+	public function addChild($child);
+
+	/**
+	 * Remove a specific child
+	 *
+	 * @param   mixed  $child  An identifier for the child node
+	 *
+	 * @return  void
+	 * @since   3.4
+	 */
+	public function removeChild($child);
+
+	/**
+	 * Get the children of this node
+	 *
+	 * @param   boolean  $recursive    False by default
+	 *
+	 * @return  array    The children
+	 * @since   3.4
+	 */
+	public function &getChildren($recursive = false);
+
+	/**
+	 * Get the parent of this node
+	 *
+	 * @return  mixed  JNodeInterface or null
+	 *
+	 * @since   3.4
+	 */
+	public function getParent();
+
+	/**
+	 * Test if this node has children
+	 *
+	 * @return  boolean  True if there is a child
+	 *
+	 * @since   3.4
+	 */
+	public function hasChildren();
+
+	/**
+	 * Test if this node has a parent
+	 *
+	 * @return  boolean    True if there is a parent
+	 *
+	 * @since   3.4
+	 */
+	public function hasParent();
+}

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -370,7 +370,7 @@ class JCategories
  *
  * @since  11.1
  */
-class JCategoryNode extends JObject
+class JCategoryNode extends JObject implements JNodeInterface
 {
 	/**
 	 * Primary key


### PR DESCRIPTION
### Goal

Currently we have a few constructs in our system that build a tree, but no proper interface for that. For example all menu items are forming a tree with nodes having a parent and children. Likewise with the categories and usergroups.
In the future, this interface should be implemented in those cases in order to provide developers with something to build on. For the moment, this would only be implemented in JCategoriesNode, further implementations would have to wait until Joomla 4.0, since they would break B/C.
### History

This PR is a result of the router changes that are currently being implemented. The idea is, that a generic router rule can work with data obtained by a specific component from its router and with this interface know what to do with it.
### Problems

My main issue right now is, if I have all bases covered or if I am forcing already too much unto future developers. I took JCategoriesNode as an example and removed what was category specific. I also removed the getSibbling() method, since I fear it is too much for a generic node interface/class. In JCategoriesNode this method is meant to allow navigation between sibbling categories and having simple arrows left and right on a category page to navigate between them.
While this interface implements all necessary methods for navigating between nodes, it does not provide means to enforce specific members of the class. From my POV we would need at least the class members $id, $title and $alias, but I would hate to create getters and setters for those simply because PHP does not support members in interfaces. So should this maybe even be an abstract class? That again would make this whole thing more difficult to adapt for third parties... Thoughts?
### Current Status

This PR is NOT ready for merging. It is meant for a place to discuss this idea and improve it. Right now I would not feel comfortable with this going into the core without some more thoughts by others.
