### PR TITLE
Fix: Empty Sessions / Logged-in in other accounts Ref #5214

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -518,6 +518,7 @@ class JSession extends JObject
 		else
 		{
 			$session_name = session_name();
+
 			if (!JRequest::getVar($session_name, false, 'COOKIE'))
 			{
 				if (JRequest::getVar($session_name))
@@ -525,6 +526,10 @@ class JSession extends JObject
 					session_id(JRequest::getVar($session_name));
 					setcookie($session_name, '', time() - 3600);
 				}
+				elseif (JRequest::getVar($session_name) == '')
+				{
+        				session_id($this->_createId());
+        			}
 			}
 		}
 

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -526,7 +526,7 @@ class JSession extends JObject
 					session_id(JRequest::getVar($session_name));
 					setcookie($session_name, '', time() - 3600);
 				}
-				elseif (JRequest::getVar($session_name) == '')
+				else
 				{
         				session_id($this->_createId());
         			}


### PR DESCRIPTION
code by @enesbil

See: https://github.com/joomla/joomla-cms/issues/5214
#### Orginal report

My community has over 300.000 registered Members and est. 200.000 users daily. When entering joomla, a lot of users get empty sessions. That means, the Session-ID is just "".
If one of these users log in with the empty session, some of the others are also logged in with the same account. They can edit the profile, read/write personal messages etc. That's a huge problem, because no one wants others to enter the profile.
#### Steps to reproduce the issue

Delete all the cookies, and enter Joomla website.
#### Expected result

User gets an unique Session-ID.
#### Actual result

You are logged in as another user and/or share the empty Session-ID with other people. This happens with low likelihood. But if you have lots of users, it happens a lot.
#### System information (as much as possible)

Joomla:  Joomla! 2.5.27 Stable [ Ember ] 30-September-2014 14:00 GMT 
Webserver:  nginx/1.2.1 
Database-version:  5.5.40-0+wheezy1-log 
PHP:  fpm-fcgi 
#### Additional comments

You can also reproduce this issue, if you change your session-id cookie within browser developer tools.

I have solved this issue, with the following edits:

Open: /libraries/joomla/session/session.php
Function to edit: _start()

Before:

``` php
            if (!JRequest::getVar($session_name, false, 'COOKIE'))
            {
                if (JRequest::getVar($session_name))
                {
                    session_id(JRequest::getVar($session_name));
                    setcookie($session_name, '', time() - 3600);
                }
            }
```

After:

``` php
            if (!JRequest::getVar($session_name, false, 'COOKIE'))
            {
                if (JRequest::getVar($session_name))
                {
                    session_id(JRequest::getVar($session_name));
                    setcookie($session_name, '', time() - 3600);
                }elseif(JRequest::getVar($session_name) == ''){
                    session_id($this->_createId());
                }
            }
```

This solved the problem, of getting empty sessions. It's just a little hack, to avoid users getting logged-in in other accounts.

Kind regards
