### PR TITLE
Updating JComponentRouterRulesInterface

### DIFF
--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -20,7 +20,7 @@ interface JComponentRouterRulesInterface
 	 * URL and in general make sure that all information is present and properly
 	 * formatted. For example, the Itemid should be retrieved and set here.
 	 * 
-	 * @param   array                      &$query   The query array to process
+	 * @param   array  &$query  The query array to process
 	 * 
 	 * @return  void
 	 * 
@@ -33,8 +33,8 @@ interface JComponentRouterRulesInterface
 	 * the component.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   array                      &$segments  The URL segments to parse
-	 * @param   array                      &$vars      The vars that result from the segments
+	 * @param   array  &$segments  The URL segments to parse
+	 * @param   array  &$vars      The vars that result from the segments
 	 *
 	 * @return  void
 	 *
@@ -47,8 +47,8 @@ interface JComponentRouterRulesInterface
 	 * for a route in a human-readable URL.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   array                      &$query     The vars that should be converted
-	 * @param   array                      &$segments  The URL segments to create
+	 * @param   array  &$query     The vars that should be converted
+	 * @param   array  &$segments  The URL segments to create
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -29,7 +29,6 @@ interface JComponentRouterRulesInterface
 	 * URL and in general make sure that all information is present and properly
 	 * formatted. For example, the Itemid should be retrieved and set here.
 	 * 
-	 * @param   JComponentRouterInterface  &$router  The calling router object
 	 * @param   array                      &$query   The query array to process
 	 * 
 	 * @return  void
@@ -43,7 +42,6 @@ interface JComponentRouterRulesInterface
 	 * the component.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   JComponentRouterInterface  &$router    The calling router object
 	 * @param   array                      &$segments  The URL segments to parse
 	 * @param   array                      &$vars      The vars that result from the segments
 	 *
@@ -58,7 +56,6 @@ interface JComponentRouterRulesInterface
 	 * for a route in a human-readable URL.
 	 * This method should retrieve all its input from its method arguments.
 	 *
-	 * @param   JComponentRouterInterface  &$router    The calling router object
 	 * @param   array                      &$query     The vars that should be converted
 	 * @param   array                      &$segments  The URL segments to create
 	 *

--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -15,6 +15,15 @@
 interface JComponentRouterRulesInterface
 {
 	/**
+	 * Constructor for the rule
+	 * 
+	 * @param   JComponentRouterInterface  $router  The component router
+	 * 
+	 * @since   3.4
+	 */
+	public function __construct(JComponentRouterInterface $router);
+
+	/**
 	 * Prepares a query set to be handed over to the build() method.
 	 * This should complete a partial query set to work as a complete non-SEFed
 	 * URL and in general make sure that all information is present and properly
@@ -27,7 +36,7 @@ interface JComponentRouterRulesInterface
 	 * 
 	 * @since   3.4
 	 */
-	public function preprocess(JComponentRouterInterface &$router, &$query);
+	public function preprocess(&$query);
 
 	/**
 	 * Parses an URI to retrieve informations for the right route through
@@ -42,7 +51,7 @@ interface JComponentRouterRulesInterface
 	 *
 	 * @since   3.4
 	 */
-	public function parse(JComponentRouterInterface &$router, &$segments, &$vars);
+	public function parse(&$segments, &$vars);
 
 	/**
 	 * Builds URI segments from a query to encode the necessary informations
@@ -57,5 +66,5 @@ interface JComponentRouterRulesInterface
 	 *
 	 * @since   3.4
 	 */
-	public function build(JComponentRouterInterface &$router, &$query, &$segments);
+	public function build(&$query, &$segments);
 }

--- a/libraries/cms/component/router/rules/interface.php
+++ b/libraries/cms/component/router/rules/interface.php
@@ -15,15 +15,6 @@
 interface JComponentRouterRulesInterface
 {
 	/**
-	 * Constructor for the rule
-	 * 
-	 * @param   JComponentRouterInterface  $router  The component router
-	 * 
-	 * @since   3.4
-	 */
-	public function __construct(JComponentRouterInterface $router);
-
-	/**
 	 * Prepares a query set to be handed over to the build() method.
 	 * This should complete a partial query set to work as a complete non-SEFed
 	 * URL and in general make sure that all information is present and properly


### PR DESCRIPTION
I have to excuse myself, but the original interface that I proposed was sub-optimal. I would like to propose this change. The initial idea was to send in the router object each time the method is called and that the rules might even be called statically, but that idea wasn't very good. Instead, the rules are created as objects now and tied to the respective router. The router itself is handed over to the rule when the rule object is instantiated and can then be stored in a member of the object. This allows things to be set up in the constructor, like the lookup table for the menu item when finding out the right Itemid in the preprocess method.

Please review this code and merge it for Joomla 3.4.0. Right now, the code could still be changed.
