### PR TITLE
Bug in Content-Disposition - wrong filename

### DIFF
--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -67,8 +67,8 @@ abstract class JInstallerHelper
 		if (isset($response->headers['Content-Disposition'])
 			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'], $parts))
 		{
-			$flds = explode( ';', $parts[1]);
-			$target = trim( $flds[0], '"');
+			$flds = explode(';', $parts[1]);
+			$target = trim($flds[0], '"');
 		}
 
 		// Set the target path if not given

--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -67,7 +67,8 @@ abstract class JInstallerHelper
 		if (isset($response->headers['Content-Disposition'])
 			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'], $parts))
 		{
-			$target = trim(rtrim($parts[1], ";"), '"');
+			$flds = explode( ';', $parts[1]);
+			$target = trim( $flds[0], '"');
 		}
 
 		// Set the target path if not given


### PR DESCRIPTION
The filename field present in the Content-Disposition can be followed by other fields.
In this case, the target is wrong.

Here it is an example of Content-Disposition value.
attachment; filename="jms2win_checkupdates_1336.zip"; modification-date="Fri, 28 Nov 2014 13:57:42 +0100"; size=675299;

The bug is that the target value with the previous implementation were
jms2win_checkupdates_1336.zip"; modification-date="Fri, 28 Nov 2014 13:57:42 +0100"; size=675299
instead of return
jms2win_checkupdates_1336.zip

This fix should be also applied in J2.5 that were modified recently with the code that introduced this bug
