### PR TITLE
B/C issue on $app->redirect($url, $msg)

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -546,13 +546,18 @@ class JApplicationWeb extends JApplicationBase
 					$status = $status ? 301 : 303;
 				}
 
-				if (!is_int($status) && !isset($this->responseMap[$status]))
+				// Handle B/C by checking if a message was passed to the method, will be removed at 4.0
+				if (!count($this->_messageQueue))
 				{
-					throw new \InvalidArgumentException('You have not supplied a valid HTTP 1.1 status code');
+					if (!is_int($status) && !isset($this->responseMap[$status]))
+					{
+						throw new \InvalidArgumentException('You have not supplied a valid HTTP 1.1 status code');
+					}
+
+					// All other cases use the more efficient HTTP header for redirection.
+					$this->header($this->responseMap[$status]);
 				}
 
-				// All other cases use the more efficient HTTP header for redirection.
-				$this->header($this->responseMap[$status]);
 				$this->header('Location: ' . $url);
 				$this->header('Content-Type: text/html; charset=' . $this->charSet);
 			}


### PR DESCRIPTION
I've found a B/C issue in 3.4.0-alpha related to a change done in /libraries/joomla/application/web.php, line 549 https://github.com/joomla/joomla-cms/pull/4292

If a third-party extension uses the deprecated $app->redirect($url, $msg), as $msg ($status) is not numeric, it will return an error <b>0 You have not supplied a valid HTTP 1.1 status code</b>
