### PR TITLE
Force loading MooTools in backend for B/C

### DIFF
--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -15,6 +15,9 @@ $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
 
+// Force loading MooTools for B/C
+JHtml::_('behavior.framework', true);
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -21,6 +21,9 @@ $user            = JFactory::getUser();
 JHtml::_('bootstrap.framework');
 $doc->addScriptVersion('templates/' . $this->template . '/js/template.js');
 
+// Force loading MooTools for B/C
+JHtml::_('behavior.framework', true);
+
 // Add Stylesheets
 $doc->addStyleSheetVersion('templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 


### PR DESCRIPTION
As we often do not load MooTools for our own needs, here we force the loading of it for B/C with 3rd party extensions back-end
