### PR TITLE
Disable the max_execution_time for the installation Ref: #5193

### DIFF
--- a/installation/application/framework.php
+++ b/installation/application/framework.php
@@ -15,6 +15,7 @@ defined('_JEXEC') or die;
 
 const JDEBUG = false;
 @ini_set('magic_quotes_runtime', 0);
+
 // Disable the max_execution_time for the installation
 // see: https://github.com/joomla/joomla-cms/issues/5193
 @set_time_limit(0);

--- a/installation/application/framework.php
+++ b/installation/application/framework.php
@@ -15,6 +15,9 @@ defined('_JEXEC') or die;
 
 const JDEBUG = false;
 @ini_set('magic_quotes_runtime', 0);
+// Disable the max_execution_time for the installation
+// see: https://github.com/joomla/joomla-cms/issues/5193
+@set_time_limit(0);
 
 /*
  * Check if a configuration file already exists.

--- a/installation/application/framework.php
+++ b/installation/application/framework.php
@@ -16,10 +16,6 @@ defined('_JEXEC') or die;
 const JDEBUG = false;
 @ini_set('magic_quotes_runtime', 0);
 
-// Disable the max_execution_time for the installation
-// see: https://github.com/joomla/joomla-cms/issues/5193
-@set_time_limit(0);
-
 /*
  * Check if a configuration file already exists.
  */

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -892,7 +892,7 @@ class InstallationModelDatabase extends JModelBase
 		 * Reset the time limit so it run also on very low level HW (e.g. with XAMPP)
 		 * see: https://github.com/joomla/joomla-cms/issues/5193
 		 * see: https://github.com/joomla/joomla-cms/pull/5256 
-		*/
+		 */
 		@set_time_limit();
 
 		foreach ($queries as $query)

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -888,6 +888,11 @@ class InstallationModelDatabase extends JModelBase
 		// Get an array of queries from the schema and process them.
 		$queries = $this->_splitQueries($buffer);
 
+		// Reset the time limit so it run also on very low level HW (e.g. with XAMPP)
+		// see: https://github.com/joomla/joomla-cms/issues/5193
+		// see: https://github.com/joomla/joomla-cms/pull/5256
+		@set_time_limit();
+
 		foreach ($queries as $query)
 		{
 			// Trim any whitespace.

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -888,9 +888,11 @@ class InstallationModelDatabase extends JModelBase
 		// Get an array of queries from the schema and process them.
 		$queries = $this->_splitQueries($buffer);
 
-		// Reset the time limit so it run also on very low level HW (e.g. with XAMPP)
-		// see: https://github.com/joomla/joomla-cms/issues/5193
-		// see: https://github.com/joomla/joomla-cms/pull/5256
+		/**
+		 * Reset the time limit so it run also on very low level HW (e.g. with XAMPP)
+		 * see: https://github.com/joomla/joomla-cms/issues/5193
+		 * see: https://github.com/joomla/joomla-cms/pull/5256 
+		*/
 		@set_time_limit();
 
 		foreach ($queries as $query)


### PR DESCRIPTION
Disable the max_execution_time for the installation see: https://github.com/joomla/joomla-cms/issues/5193

kudos goes to @sovainfo
## Orginal Issue
#### Steps to reproduce the issue

Download and extract xampp 5.6.3 (they change the versioning to reflect the PHP Version)
Download and extract joomla 2.5.x / 3.x (staging) (github branche or stable)
try to install
#### Expected result

Installation works
#### Actual result

Installation hangs by creating the database
#### System information (as much as possible)

Default xampp Konfiguration with:

Apache 2.4.10, MySQL 5.6.21, PHP 5.6.3, phpMyAdmin 4.2.11, OpenSSL 1.0.1, XAMPP Control Panel 3.2.1, Webalizer 2.23-04, Mercury Mail Transport System 4.63, FileZilla FTP Server 0.9.41, Tomcat 7.0.56 (with mod_proxy_ajp as connector), Strawberry Perl 7.0.56 Portable
#### Additional comments

I think the Joomla Core should work with the default xampp config as it is often used for "testing" and planing joomla if can't be done on the production site not only by experts mostly by end users to pre-test Joomla.
