### PR TITLE
Remove Joomla namespace from sidebar script

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -57,7 +57,7 @@
 		/**
 		 * USED IN: All list views to hide/show the sidebar
 		 */
-		toggleSidebar = function(force)
+		window.toggleSidebar = function(force)
 		{
 			var context = 'jsidebar';
 

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -6,6 +6,9 @@
  * @since       3.0
  */
 
+// Only define the Joomla namespace if not defined.
+Joomla = window.Joomla || {};
+
 (function($)
 {
 	$(document).ready(function()

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -6,9 +6,6 @@
  * @since       3.0
  */
 
-// Only define the Joomla namespace if not defined.
-Joomla = window.Joomla || {};
-
 (function($)
 {
 	$(document).ready(function()
@@ -60,7 +57,7 @@ Joomla = window.Joomla || {};
 		/**
 		 * USED IN: All list views to hide/show the sidebar
 		 */
-		Joomla.toggleSidebar = function(force)
+		toggleSidebar = function(force)
 		{
 			var context = 'jsidebar';
 

--- a/layouts/joomla/sidebars/submenu.php
+++ b/layouts/joomla/sidebars/submenu.php
@@ -14,7 +14,7 @@ JHtmlBehavior::core();
 JFactory::getDocument()->addScriptDeclaration('
 	jQuery(document).ready(function($)
 	{
-		if (typeof(toggleSidebar) !== "undefined")
+		if (window.toggleSidebar)
 		{
 			toggleSidebar(true);
 		}

--- a/layouts/joomla/sidebars/submenu.php
+++ b/layouts/joomla/sidebars/submenu.php
@@ -14,9 +14,9 @@ JHtmlBehavior::core();
 JFactory::getDocument()->addScriptDeclaration('
 	jQuery(document).ready(function($)
 	{
-		if (typeof(Joomla.toggleSidebar) !== "undefined")
+		if (typeof(toggleSidebar) !== "undefined")
 		{
-			Joomla.toggleSidebar(true);
+			toggleSidebar(true);
 		}
 		else
 		{

--- a/layouts/joomla/sidebars/toggle.php
+++ b/layouts/joomla/sidebars/toggle.php
@@ -18,7 +18,7 @@ JText::script('JTOGGLE_SHOW_SIDEBAR');
 	class="j-toggle-sidebar-button hidden-phone hasTooltip"
 	title="<?php echo JHtml::tooltipText('JTOGGLE_HIDE_SIDEBAR'); ?>"
 	type="button"
-	onclick="Joomla.toggleSidebar(false); return false;"
+	onclick="toggleSidebar(false); return false;"
 	>
 	<span id="j-toggle-sidebar-icon" class="icon-cancel"></span>
 </div>


### PR DESCRIPTION
This prevents error if core.js is not loaded by defining the Joomla namespace

Solves #5258 
