### PR TITLE
In User Notes if we try to add the note using toggle editor then data is not saved.

### DIFF
--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -16,7 +16,7 @@ JHtml::_('formbehavior.chosen', 'select');
 Joomla.submitbutton = function(task)
 {
 	if (task == 'note.cancel' || document.formvalidator.isValid(document.id('note-form')))
-	{
+	{         <?php echo $this->form->getField('body')->save(); ?>
 		Joomla.submitform(task, document.getElementById('note-form'));
 	}
 }


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Go to the User User Notes module and create new record.
2. Save the Note using toggle editor.
3. Record is not saved.
   Or
4. Create User notes by filling all the fields.
5. Edit the user not and add the record.
6. Click on save button.![screen shot 2014-10-17 at 02 18 50](http://issues.joomla.org/uploads/1/c4a03ec15a57c18a9d972a6b5e47e6ca.jpg)
#### Expected result

Data should be save using toggle editor.
#### Actual result

Data is not saved using toggle editor.
#### Additional comments

I put <?php echo $this->form->getField('body')->save(); ?> in line number 19 within the javascript function at administrator\components\com_users\views\note\tmpl\edit.php
