### PR TITLE
Prevent javascript errors due to forgotten semicolons

### DIFF
--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -23,7 +23,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			{
 				Joomla.submitform(task, document.getElementById('config-form'));
 			}
-		}
+		};
 ");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">

--- a/administrator/components/com_messages/views/message/tmpl/edit.php
+++ b/administrator/components/com_messages/views/message/tmpl/edit.php
@@ -22,7 +22,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			{
 				Joomla.submitform(task, document.getElementById('message-form'));
 			}
-		}
+		};
 ");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -42,7 +42,7 @@ JFactory::getDocument()->addScriptDeclaration('
 				dirn = direction.options[direction.selectedIndex].value;
 			}
 			Joomla.tableOrdering(order, dirn, "");
-		}
+		};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -26,7 +26,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.getElementById('newsfeed-form'))) {
 			Joomla.submitform(task, document.getElementById('newsfeed-form'));
 		}
-	}
+	};
 ");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="newsfeed-form" class="form-validate">

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -33,7 +33,7 @@ JFactory::getDocument()->addScriptDeclaration("
 
 			Joomla.submitform(task, document.getElementById('newsfeed-form'));
 		}
-	}
+	};
 ");
 ?>
 <div class="container-popup">

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -48,7 +48,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		if (task == 'plugin.cancel' || document.formvalidator.isValid(document.getElementById('style-form'))) {
 			Joomla.submitform(task, document.getElementById('style-form'));
 		}
-	}
+	};
 ");
 ?>
 

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -43,7 +43,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -27,7 +27,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			" . $this->form->getField('description')->save() . "
 			Joomla.submitform(task, document.getElementById('item-form'));
 		}
-	}
+	};
 ");
 ?>
 

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -46,7 +46,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
+	};
 ');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_tags&view=tags');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -22,7 +22,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		if (task == 'style.cancel' || document.formvalidator.isValid(document.getElementById('style-form'))) {
 			Joomla.submitform(task, document.getElementById('style-form'));
 		}
-	}
+	};
 ");
 ?>
 


### PR DESCRIPTION
#### I've done something bad and this corrects it!
##### First of all I have to apologize for my mistake!

On the last commits there is some javascript code that should end on semicolon but that was missing. The problem is not immediately observed if that portion of code is the last on the chain. In case that is not the last part then the error will occur. 

Please someone from the PLT review this and commit it. @infograf768 @Bakual @phproberto 

Again I’m sorry for this!
