### PR TITLE
ContentHelperRoute::getArticleRoute needs to be called with catid and language

### DIFF
--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -101,7 +101,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid)); ?>');">
+					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>');">
 						<?php echo $this->escape($item->title); ?></a>
 				</th>
 				<td class="center">

--- a/components/com_contact/helpers/icon.php
+++ b/components/com_contact/helpers/icon.php
@@ -46,9 +46,9 @@ class JHtmlIcon
 		return $output;
 	}
 
-	public static function print_popup($article, $params, $attribs = array())
+	public static function print_popup($contact, $params, $attribs = array())
 	{
-		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language);
+		$url  = ContactHelperRoute::getContactRoute($contact->slug, $contact->catid, $contact->language);
 		$url .= '&tmpl=component&print=1&layout=default&page=' . @ $request->limitstart;
 
 		$status = 'status=no,toolbar=no,scrollbars=yes,titlebar=no,menubar=no,resizable=yes,width=640,height=480,directories=no,location=no';

--- a/components/com_contact/helpers/icon.php
+++ b/components/com_contact/helpers/icon.php
@@ -19,12 +19,12 @@ defined('_JEXEC') or die;
  */
 class JHtmlIcon
 {
-	public static function email($article, $params, $attribs = array())
+	public static function email($contact, $params, $attribs = array())
 	{
 		require_once JPATH_SITE . '/components/com_mailto/helpers/mailto.php';
 		$uri	= JUri::getInstance();
 		$base	= $uri->toString(array('scheme', 'host', 'port'));
-		$link	= $base . JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false);
+		$link	= $base . JRoute::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid, $contact->language), false);
 		$url	= 'index.php?option=com_mailto&tmpl=component&link=' . MailToHelper::addLink($link);
 
 		$status = 'width=400,height=350,menubar=yes,resizable=yes';

--- a/components/com_contact/helpers/icon.php
+++ b/components/com_contact/helpers/icon.php
@@ -19,12 +19,12 @@ defined('_JEXEC') or die;
  */
 class JHtmlIcon
 {
-	public static function email($contact, $params, $attribs = array())
+	public static function email($article, $params, $attribs = array())
 	{
 		require_once JPATH_SITE . '/components/com_mailto/helpers/mailto.php';
 		$uri	= JUri::getInstance();
 		$base	= $uri->toString(array('scheme', 'host', 'port'));
-		$link	= $base . JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid), false);
+		$link	= $base . JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false);
 		$url	= 'index.php?option=com_mailto&tmpl=component&link=' . MailToHelper::addLink($link);
 
 		$status = 'width=400,height=350,menubar=yes,resizable=yes';
@@ -48,7 +48,7 @@ class JHtmlIcon
 
 	public static function print_popup($article, $params, $attribs = array())
 	{
-		$url  = ContentHelperRoute::getContactRoute($contact->slug, $contact->catid);
+		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language);
 		$url .= '&tmpl=component&print=1&layout=default&page=' . @ $request->limitstart;
 
 		$status = 'status=no,toolbar=no,scrollbars=yes,titlebar=no,menubar=no,resizable=yes,width=640,height=480,directories=no,location=no';

--- a/components/com_contact/views/contact/tmpl/default_articles.php
+++ b/components/com_contact/views/contact/tmpl/default_articles.php
@@ -17,7 +17,7 @@ require_once JPATH_SITE . '/components/com_content/helpers/route.php';
 	<ul class="nav nav-tabs nav-stacked">
 		<?php foreach ($this->item->articles as $article) :	?>
 			<li>
-				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catslug)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
+				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
 			</li>
 		<?php endforeach; ?>
 	</ul>

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -86,7 +86,7 @@ abstract class JHtmlIcon
 		$uri      = JUri::getInstance();
 		$base     = $uri->toString(array('scheme', 'host', 'port'));
 		$template = JFactory::getApplication()->getTemplate();
-		$link     = $base . JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid), false);
+		$link     = $base . JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false);
 		$url      = 'index.php?option=com_mailto&tmpl=component&template=' . $template . '&link=' . MailToHelper::addLink($link);
 
 		$status = 'width=400,height=350,menubar=yes,resizable=yes';
@@ -232,7 +232,7 @@ abstract class JHtmlIcon
 		$input = $app->input;
 		$request = $input->request;
 
-		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid);
+		$url  = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language);
 		$url .= '&tmpl=component&print=1&layout=default&page=' . @ $request->limitstart;
 
 		$status = 'status=no,toolbar=no,scrollbars=yes,titlebar=no,menubar=no,resizable=yes,width=640,height=480,directories=no,location=no';

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -20,7 +20,7 @@ $params = $this->params;
 			<div class="page-header">
 				<h2 itemprop="name">
 					<?php if ($params->get('link_titles')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>" itemprop="url">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>" itemprop="url">
 							<?php echo $this->escape($item->title); ?>
 						</a>
 					<?php else: ?>

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -68,7 +68,7 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		// TODO: Change based on shownoauth
-		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 
 		// Merge article params. If this is single-article view, menu params override article params
 		// Otherwise, article params override menu item params

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -52,13 +52,13 @@ $info    = $params->get('info_block_position', 0);
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JUri($link1);
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>

--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
 	foreach ($this->link_items as &$item) :
 ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -111,7 +111,7 @@ if (!empty($this->items))
 				<?php endif; ?>
 					<td headers="categorylist_header_title" class="list-title">
 						<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
-							<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid)); ?>">
+							<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 								<?php echo $this->escape($article->title); ?>
 							</a>
 						<?php else: ?>
@@ -121,7 +121,7 @@ if (!empty($this->items))
 							$active		= $menu->getActive();
 							$itemId		= $active->id;
 							$link = JRoute::_('index.php?option=com_users&view=login&Itemid='.$itemId);
-							$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid));
+							$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language));
 							$fullURL = new JUri($link);
 							$fullURL->setVar('return', base64_encode($returnURL));
 							?>

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -46,7 +46,7 @@ class ContentViewCategory extends JViewCategoryfeed
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// URL link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 
 			$item->description .= '<p class="feed-readmore"><a target="_blank" href ="' . $link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
 		}

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -25,7 +25,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php if ($params->get('show_title')) : ?>
 	<h2 class="item-title" itemprop="name">
 	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>" itemprop="url">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>" itemprop="url">
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
@@ -235,13 +235,13 @@ $info    = $this->item->params->get('info_block_position', 0);
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JUri($link1);
 		$link->setVar('return', base64_encode($returnURL));
 	endif; ?>

--- a/components/com_content/views/featured/tmpl/default_links.php
+++ b/components/com_content/views/featured/tmpl/default_links.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -48,7 +48,7 @@ class ContentViewFeatured extends JViewLegacy
 			$row->slug = $row->alias ? ($row->id . ':' . $row->alias) : $row->id;
 
 			// Url link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
 
 			// Get row fulltext
 			$db = JFactory::getDbo();

--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -21,7 +21,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 			<?php if ($params->get('show_title')) : ?>
 				<h2 itemprop="name">
 					<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>" itemprop="url">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>" itemprop="url">
 						<?php echo $this->escape($displayData->title); ?></a>
 					<?php else : ?>
 						<?php echo $this->escape($displayData->title); ?>

--- a/layouts/joomla/content/blog_style_default_links.php
+++ b/layouts/joomla/content/blog_style_default_links.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($displayData->get('link_items') as $item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -15,7 +15,7 @@ $params  = $displayData->params;
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
 	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> 
 	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-	<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid)); ?>"><img
+	<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"><img
 	<?php if ($images->image_intro_caption):
 		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
 	endif; ?>

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -232,7 +232,7 @@ abstract class ModArticlesCategoryHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 			}
 			else
 			{

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -119,7 +119,7 @@ abstract class ModArticlesLatestHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 			}
 			else
 			{

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -90,7 +90,7 @@ abstract class ModArticlesNewsHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link     = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid));
+				$item->link     = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 				$item->linkText = JText::_('MOD_ARTICLES_NEWS_READMORE');
 			}
 			else

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -83,7 +83,7 @@ abstract class ModArticlesPopularHelper
 			if ($access || in_array($item->access, $authorised))
 			{
 				// We know that user has the privilege to view the article
-				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug));
+				$item->link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 			}
 			else
 			{

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -130,7 +130,7 @@ abstract class ModRelatedItemsHelper
 						{
 							if ($row->cat_state == 1)
 							{
-								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catslug));
+								$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
 								$related[] = $row;
 							}
 						}

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -276,7 +276,9 @@ class PlgContentPagebreak extends JPlugin
 		$row->toc .= '<ul class="nav nav-tabs nav-stacked">
 		<li class="' . $class . '">
 
-			<a href="' . JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=') . '" class="' . $class . '">'
+			<a href="'
+			. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) .
+			'&showall=&limitstart=') . '" class="' . $class . '">'
 			. $heading .
 			'</a>
 

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -276,7 +276,7 @@ class PlgContentPagebreak extends JPlugin
 		$row->toc .= '<ul class="nav nav-tabs nav-stacked">
 		<li class="' . $class . '">
 
-			<a href="' . JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid) . '&showall=&limitstart=') . '" class="' . $class . '">'
+			<a href="' . JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=') . '" class="' . $class . '">'
 			. $heading .
 			'</a>
 
@@ -287,7 +287,7 @@ class PlgContentPagebreak extends JPlugin
 
 		foreach ($matches as $bot)
 		{
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid) . '&showall=&limitstart=' . ($i - 1));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . ($i - 1));
 
 			if (@$bot[0])
 			{
@@ -326,7 +326,7 @@ class PlgContentPagebreak extends JPlugin
 
 		if ($this->params->get('showall'))
 		{
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid) . '&showall=1&limitstart=');
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
 			$class = ($showall == 1) ? 'toclink active' : 'toclink';
 			$row->toc .= '
 			<li>
@@ -366,7 +366,7 @@ class PlgContentPagebreak extends JPlugin
 		{
 			$page_next = $page + 1;
 
-			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid) . '&showall=&limitstart=' . ($page_next));
+			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . ($page_next));
 
 			// Next >>
 			$next = '<a href="' . $link_next . '">' . JText::_('JNEXT') . $pnSpace . JText::_('JGLOBAL_GT') . JText::_('JGLOBAL_GT') . '</a>';
@@ -380,7 +380,7 @@ class PlgContentPagebreak extends JPlugin
 		{
 			$page_prev = $page - 1 == 0 ? '' : $page - 1;
 
-			$link_prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid) . '&showall=&limitstart=' . ($page_prev));
+			$link_prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . ($page_prev));
 
 			// << Prev
 			$prev = '<a href="' . $link_prev . '">' . JText::_('JGLOBAL_LT') . JText::_('JGLOBAL_LT') . $pnSpace . JText::_('JPREV') . '</a>';

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -275,13 +275,9 @@ class PlgContentPagebreak extends JPlugin
 		$class = ($limitstart === 0 && $showall === 0) ? 'toclink active' : 'toclink';
 		$row->toc .= '<ul class="nav nav-tabs nav-stacked">
 		<li class="' . $class . '">
-
 			<a href="'
-			. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) .
-			'&showall=&limitstart=') . '" class="' . $class . '">'
-			. $heading .
-			'</a>
-
+			. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=')
+			. '" class="' . $class . '">' . $heading . '</a>
 		</li>
 		';
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -125,22 +125,16 @@ class PlgContentPagenavigation extends JPlugin
 			$query = $db->getQuery(true);
 
 			// Sqlsrv changes
-			$case_when = ' CASE WHEN ';
-			$case_when .= $query->charLength('a.alias', '!=', '0');
-			$case_when .= ' THEN ';
+			$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0');
 			$a_id = $query->castAsChar('a.id');
-			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
-			$case_when .= ' ELSE ';
-			$case_when .= $a_id . ' END as slug';
+			$case_when .= ' THEN ' . $query->concatenate(array($a_id, 'a.alias'), ':');
+			$case_when .= ' ELSE ' . $a_id . ' END as slug';
 
-			$case_when1 = ' CASE WHEN ';
-			$case_when1 .= $query->charLength('cc.alias', '!=', '0');
-			$case_when1 .= ' THEN ';
+			$case_when1 = ' CASE WHEN ' . $query->charLength('cc.alias', '!=', '0');
 			$c_id = $query->castAsChar('cc.id');
-			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
-			$case_when1 .= ' ELSE ';
-			$case_when1 .= $c_id . ' END as catslug';
-			$query->select('a.id, a.title,' . $case_when . ',' . $case_when1)
+			$case_when1 .= ' THEN ' . $query->concatenate(array($c_id, 'cc.alias'), ':');
+			$case_when1 .= ' ELSE ' . $c_id . ' END as catslug';
+			$query->select('a.id, a.title, a.catid, a.language,' . $case_when . ',' . $case_when1)
 				->from('#__content AS a')
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -187,7 +187,7 @@ class PlgContentPagenavigation extends JPlugin
 			if ($row->prev)
 			{
 				$row->prev_label = ($this->params->get('display', 0) == 0) ? JText::_('JPREV') : $row->prev->title;
-				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catslug));
+				$row->prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->prev->slug, $row->prev->catid, $row->prev->language));
 			}
 			else
 			{
@@ -198,7 +198,7 @@ class PlgContentPagenavigation extends JPlugin
 			if ($row->next)
 			{
 				$row->next_label = ($this->params->get('display', 0) == 0) ? JText::_('JNEXT') : $row->next->title;
-				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catslug));
+				$row->next = JRoute::_(ContentHelperRoute::getArticleRoute($row->next->slug, $row->next->catid, $row->next->language));
 			}
 			else
 			{

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -168,7 +168,7 @@ class PlgSearchContent extends JPlugin
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id . ' END as catslug';
 
-			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created')
+			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section, ' . $case_when . ',' . $case_when1 . ', ' . '\'2\' AS browsernav')
 
@@ -198,7 +198,7 @@ class PlgSearchContent extends JPlugin
 			{
 				foreach ($list as $key => $item)
 				{
-					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug);
+					$list[$key]->href = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 				}
 			}
 

--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -88,6 +88,7 @@ class JFormFieldTos extends JFormFieldRadio
 			$attribs['class'] = 'modal';
 			$attribs['rel'] = '{handler: \'iframe\', size: {x:800, y:500}}';
 
+			// TODO: This is broken!! We need the category ID, too, and the language
 			$url = ContentHelperRoute::getArticleRoute($tosarticle);
 
 			$link = JHtml::_('link', JRoute::_($url . '&tmpl=component'), $text, $attribs);

--- a/templates/beez3/html/com_contact/contact/default_articles.php
+++ b/templates/beez3/html/com_contact/contact/default_articles.php
@@ -18,7 +18,7 @@ require_once JPATH_SITE . '/components/com_content/helpers/route.php';
 	<ol>
 		<?php foreach ($this->item->articles as $article) :	?>
 			<li>
-				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catslug)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
+				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
 			</li>
 		<?php endforeach; ?>
 	</ol>

--- a/templates/beez3/html/com_content/archive/default_items.php
+++ b/templates/beez3/html/com_content/archive/default_items.php
@@ -26,7 +26,7 @@ $params = &$this->params;
 
 		<h2>
 		<?php if ($params->get('link_titles')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 				<?php echo $this->escape($item->title); ?></a>
 		<?php else: ?>
 				<?php echo $this->escape($item->title); ?>

--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -24,7 +24,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -134,13 +134,13 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JUri($link1);
 		$link->setVar('return', base64_encode($returnURL));
 	endif;

--- a/templates/beez3/html/com_content/category/blog_links.php
+++ b/templates/beez3/html/com_content/category/blog_links.php
@@ -25,7 +25,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 	foreach ($this->link_items as &$item) :
 ?>
 		 <li>
-		  		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid)); ?>">
+		  		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 		</li>
 <?php endforeach; ?>

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -98,7 +98,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 
 					<td class="list-title">
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid)); ?>">
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?></a>
 					</td>
 
@@ -141,7 +141,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						$active		= $menu->getActive();
 						$itemId		= $active->id;
 						$link = JRoute::_('index.php?option=com_users&view=login&Itemid='.$itemId);
-						$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug));
+						$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language));
 						$fullURL = new JUri($link);
 						$fullURL->setVar('return', base64_encode($returnURL));
 					?>

--- a/templates/beez3/html/com_content/featured/default_item.php
+++ b/templates/beez3/html/com_content/featured/default_item.php
@@ -25,7 +25,7 @@ $templateparams = $app->getTemplate(true)->params;
 <?php if ($params->get('show_title')) : ?>
 	<h2>
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid)); ?>">
+			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>">
 			<?php echo $this->escape($this->item->title); ?></a>
 		<?php else : ?>
 			<?php echo $this->escape($this->item->title); ?>
@@ -140,13 +140,13 @@ $templateparams = $app->getTemplate(true)->params;
 
 <?php if ($params->get('show_readmore') && $this->item->readmore) :
 	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 	else :
 		$menu = JFactory::getApplication()->getMenu();
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link1 = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid));
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
 		$link = new JUri($link1);
 		$link->setVar('return', base64_encode($returnURL));
 	endif;

--- a/templates/beez3/html/com_content/featured/default_links.php
+++ b/templates/beez3/html/com_content/featured/default_links.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
 <ol class="links">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>


### PR DESCRIPTION
While working on #5140, I noticed that we never use the language value of the article when calculating the URL for it. Basically it means that we don't care if an english article is assigned to a french menu item, etc. Long story short: If you want to get the right URL, you need to provide the article ID, the category ID and the language.

Testing instructions: See that Joomla now creates the same and right URLs everywhere. Except for the TOS in the user plugin... Can't fix that one...
This testing instructions actually mean, that this needs a code review rather than a test.

For those looking for numbers: We have 35 files where ContentHelperRoute::getArticleRoute is called. Only in 3 of those files we are using the right language parameter.
