### PR TITLE
Correct cache time logic in feed modules

### DIFF
--- a/administrator/modules/mod_feed/helper.php
+++ b/administrator/modules/mod_feed/helper.php
@@ -30,8 +30,16 @@ abstract class modFeedHelper
 
 		// get RSS parsed object
 		$cache_time = 0;
-		if ($params->get('cache')) {
-			$cache_time  = $params->get('cache_time', 15) * 60;
+		if ($params->get('cache'))
+		{
+			/*
+			 * The cache_time will get fed into JCache to initiate the feed_parser cache group and eventually
+			 * JCacheStorage will multiply the value by 60 and use that for its lifetime. The only way to sync
+			 * the feed_parser cache (which caches with an empty dataset anyway) with the module cache is to
+			 * first divide the module's cache time by 60 then inject that forward, which once stored into the
+			 * JCacheStorage object, will be the correct value in minutes.
+			 */
+			$cache_time  = $params->get('cache_time', 15) / 60;
 		}
 
 		$rssDoc = JFactory::getFeedParser($rssurl, $cache_time);

--- a/modules/mod_feed/helper.php
+++ b/modules/mod_feed/helper.php
@@ -18,13 +18,21 @@ class modFeedHelper
 
 		// get RSS parsed object
 		$cache_time = 0;
-		if ($params->get('cache')) {
-			$cache_time  = $params->get('cache_time', 15) * 60;
+		if ($params->get('cache'))
+		{
+			/*
+			 * The cache_time will get fed into JCache to initiate the feed_parser cache group and eventually
+			 * JCacheStorage will multiply the value by 60 and use that for its lifetime. The only way to sync
+			 * the feed_parser cache (which caches with an empty dataset anyway) with the module cache is to
+			 * first divide the module's cache time by 60 then inject that forward, which once stored into the
+			 * JCacheStorage object, will be the correct value in minutes.
+			 */
+			$cache_time  = $params->get('cache_time', 15) / 60;
 		}
 
 		$rssDoc = JFactory::getFeedParser($rssurl, $cache_time);
 
-		$feed = new stdclass();
+		$feed = new stdClass;
 
 		if ($rssDoc != false)
 		{
@@ -34,6 +42,7 @@ class modFeedHelper
 			$feed->description = $rssDoc->get_description();
 
 			// channel image if exists
+			$feed->image = new stdClass;
 			$feed->image->url = $rssDoc->get_image_url();
 			$feed->image->title = $rssDoc->get_image_title();
 


### PR DESCRIPTION
### Short Summary

The feed modules have two caches, the actual module cache and a general feed_parser cache, with different lifetimes.  This causes cached feeds to not update correctly.
### Detailed Description

The cache_time will get fed into JCache to initiate the feed_parser cache group and eventually JCacheStorage will multiply the value by 60 and use that for its lifetime. The only way to sync the feed_parser cache (which caches with an empty dataset anyway) with the module cache is to first divide the module's cache time by 60 then inject that forward, which once stored into the JCacheStorage object, will be the correct value in minutes.
### The fix

As it is presently, the feed_parser cache lifetime appears to be at least the module cache lifetime (value stored in seconds) \* 3600 (the module lifetime which is stored in seconds times 60 as converted in JCacheStorage times at least one more 60 that I can't get my head wrapped around (at one point I thought there might be another multiplier in here, either way the math is beyond wrong)).  This fix divides the module cache lifetime by 60 before injecting it into JFactory to convert the value into minutes (which is then manipulated by JCacheStorage back into seconds).  Confused yet?  I'm confusing myself just typing this out.
### So What About 3.x?

In 3.x, a new Feed package was introduced which handles all mod_feed processing.  This package is in no way interconnected with `JCache` like the `JFactory::getFeedParser()` method is.  Therefore, 3.x is not affected.
### Testing Instructions

1) Set up a new Feed Display module on a 2.5 install and query any RSS feed (http://feeds.joomla.org/JoomlaCommunicationsTeamBlog will do just fine), enable the module's cache, and set a short cache lifetime in the module's config (this value is in seconds, I tested with 5 just to make testing quicker but any value will do)

2) Once saved and enabled, enable the global cache in your Joomla installation

3) Now that the module is enabled and cache is set up, visit whatever page will trigger the feed module and its cache.  Once cached, refresh a few times within the lifetime of the cache to see that the data exists.  Once the cache is expired, you'll end up with an empty block.  If you'd like, you can wait for the feed_parser cache to expire to see if that even works right (or validate my math), but even on a 1 second module cache lifetime, that's an hour to wait on the other cache.  Anywho...

So, now apply the patch.  Delete all the Joomla cached data, and start your request fresh.  You'll get your fresh feed data, now wait for the cache to expire and try again; the data should immediately reload.  Congratulations, you've successfully tested this and didn't have anywhere near as difficult of a night as me :wink: 
