### PR TITLE
[imp] Check if joomla language server is enabled

### DIFF
--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -153,7 +153,7 @@ class InstallerHelper
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
 			->from('#__update_sites')
-			->where($db->quoteName('enabled') . ' = 0 AND ' . $db->quoteName('update_site_id') . '= 3');
+			->where($db->quoteName('enabled') . ' = 0 AND ' . $db->quoteName('name') . ' = ' . $db->quote('Accredited Joomla! Translations'));
 		$db->setQuery($query);
 
 		return (int) $db->loadResult();

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -139,4 +139,23 @@ class InstallerHelper
 
 		return $result;
 	}
+
+	/**
+	 * Method to get the number of disabled registered language row.
+	 *
+	 * @return  integer
+	 *
+	 * @since	3.4
+	 */
+	public static function checkLangUpdateSites()
+	{
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from('#__update_sites')
+			->where($db->quoteName('enabled') . ' = 0 AND ' . $db->quoteName('update_site_id') . '= 3');
+		$db->setQuery($query);
+
+		return (int) $db->loadResult();
+	}
 }

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -30,6 +30,9 @@ $version = new JVersion;
 		<div id="j-main-container">
 	<?php endif;?>
 
+		<?php if (InstallerHelper::checkLangUpdateSites() > 0) : ?>
+				<div class="alert"><?php echo JText::_('COM_INSTALLER_MSG_LANGUAGES_CHECK_UPDATE_SITE'); ?></div>
+			<?php endif; ?>
 		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
 			<?php echo $this->loadTemplate('filter'); ?>
 			<table class="table table-striped">

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -98,6 +98,7 @@ COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR="There was an error uploading t
 COM_INSTALLER_MSG_INSTALL_WARNINSTALLZLIB="The installer cannot continue until Zlib is installed."
 COM_INSTALLER_MSG_LANGUAGES_CANT_FIND_REMOTE_MANIFEST="The installer can't get the url to the XML manifest file of the %s language."
 COM_INSTALLER_MSG_LANGUAGES_CANT_FIND_REMOTE_PACKAGE="The installer can't get the url to the remote %s language."
+COM_INSTALLER_MSG_LANGUAGES_CHECK_UPDATE_SITE="The Accredited Joomla! Translations server is disabled. Please enable it in the <a href="_QQ_"index.php?option=com_installer&view=updatesites"_QQ_">Update Sites Manager</a>.<br />Then click on the &quot;Find languages&quot; button to get or update the list of available languages."
 COM_INSTALLER_MSG_LANGUAGES_NOLANGUAGES="There are no available languages to install at the moment. Please click on the &quot;Find languages&quot; button to check for updates on the Joomla Languages server. You will need an internet connection for this to work."
 COM_INSTALLER_MSG_LANGUAGES_TRY_LATER="Try again later or <a href="_QQ_"http://community.joomla.org/translations/joomla-3-translations.html"_QQ_">contact the language team coordinator</a>"
 COM_INSTALLER_MSG_MANAGE_NOEXTENSION="There are no extensions installed matching your query"


### PR DESCRIPTION
This will partially solve https://github.com/joomla/joomla-cms/issues/5274 by displaying a message in the Install Languages Manager if the Joomla! Accredited Translations site is disabled.

The message will be added to the default one when the _updates table is still empty ( you can empty it by going to the Update Manager and use Purge)
![screen shot 2014-12-02 at 10 37 59](https://cloud.githubusercontent.com/assets/869724/5260456/56c34d42-7a0f-11e4-989b-1156f3fc0fa5.png)

Otherwise it displays alone.
![screen shot 2014-12-02 at 10 35 06](https://cloud.githubusercontent.com/assets/869724/5260445/2a5a1f92-7a0f-11e4-869b-c4477161a103.png)

To test, enable and disable the site in Update sites Manager.

NOTE: The best solution would be to FORCE Purge/enable site/FindLanguages when loading the manager. If not proposed for 3.4.0, this PR will help.
