### PR TITLE
Routing: Discover Itemid in Router for com_content

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -46,7 +46,6 @@ abstract class ContentHelperRoute
 			if (isset(self::$lang_lookup[$language]))
 			{
 				$link .= '&lang=' . self::$lang_lookup[$language];
-				$needles['language'] = $language;
 			}
 		}
 
@@ -85,7 +84,6 @@ abstract class ContentHelperRoute
 				if (isset(self::$lang_lookup[$language]))
 				{
 					$link .= '&lang=' . self::$lang_lookup[$language];
-					$needles['language'] = $language;
 				}
 			}
 		}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
  * Content Component Route Helper.
  *
  * @since  1.5
+ * @deprecated 4.0 Simply write non-SEF URLs instead
  */
 abstract class ContentHelperRoute
 {
@@ -28,6 +29,7 @@ abstract class ContentHelperRoute
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getArticleRoute($id, $catid = 0, $language = 0)
 	{
@@ -61,6 +63,7 @@ abstract class ContentHelperRoute
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getCategoryRoute($catid, $language = 0)
 	{
@@ -99,6 +102,7 @@ abstract class ContentHelperRoute
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getFormRoute($id)
 	{
@@ -140,5 +144,20 @@ abstract class ContentHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
+	}
+
+	/**
+	 * Find an item ID.
+	 *
+	 * @param   array  $needles  An array of language codes.
+	 *
+	 * @return  mixed  The ID found or null otherwise.
+	 *
+	 * @since   1.5
+	 * @deprecated 4.0
+	 */
+	protected static function _findItem($needles = null)
+	{
+		return null;
 	}
 }

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -16,8 +16,6 @@ defined('_JEXEC') or die;
  */
 abstract class ContentHelperRoute
 {
-	protected static $lookup = array();
-
 	protected static $lang_lookup = array();
 
 	/**
@@ -33,24 +31,12 @@ abstract class ContentHelperRoute
 	 */
 	public static function getArticleRoute($id, $catid = 0, $language = 0)
 	{
-		$needles = array(
-			'article'  => array((int) $id)
-		);
-
 		// Create the link
 		$link = 'index.php?option=com_content&view=article&id=' . $id;
 
 		if ((int) $catid > 1)
 		{
-			$categories = JCategories::getInstance('Content');
-			$category   = $categories->get((int) $catid);
-
-			if ($category)
-			{
-				$needles['category']   = array_reverse($category->getPath());
-				$needles['categories'] = $needles['category'];
-				$link .= '&catid=' . $catid;
-			}
+			$link .= '&catid=' . $catid;
 		}
 
 		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
@@ -62,11 +48,6 @@ abstract class ContentHelperRoute
 				$link .= '&lang=' . self::$lang_lookup[$language];
 				$needles['language'] = $language;
 			}
-		}
-
-		if ($item = self::_findItem($needles))
-		{
-			$link .= '&Itemid=' . $item;
 		}
 
 		return $link;
@@ -86,26 +67,16 @@ abstract class ContentHelperRoute
 	{
 		if ($catid instanceof JCategoryNode)
 		{
-			$id       = $catid->id;
-			$category = $catid;
-		}
-		else
-		{
-			$id       = (int) $catid;
-			$category = JCategories::getInstance('Content')->get($id);
+			$catid       = $catid->id;
 		}
 
-		if ($id < 1 || !($category instanceof JCategoryNode))
+		if ($catid < 1)
 		{
 			$link = '';
 		}
 		else
 		{
-			$needles               = array();
 			$link                  = 'index.php?option=com_content&view=category&id=' . $id;
-			$catids                = array_reverse($category->getPath());
-			$needles['category']   = $catids;
-			$needles['categories'] = $catids;
 
 			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
 			{
@@ -116,11 +87,6 @@ abstract class ContentHelperRoute
 					$link .= '&lang=' . self::$lang_lookup[$language];
 					$needles['language'] = $language;
 				}
-			}
-
-			if ($item = self::_findItem($needles))
-			{
-				$link .= '&Itemid=' . $item;
 			}
 		}
 
@@ -176,98 +142,5 @@ abstract class ContentHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
-	}
-
-	/**
-	 * Find an item ID.
-	 *
-	 * @param   array  $needles  An array of language codes.
-	 *
-	 * @return  mixed  The ID found or null otherwise.
-	 *
-	 * @since   1.5
-	 */
-	protected static function _findItem($needles = null)
-	{
-		$app      = JFactory::getApplication();
-		$menus    = $app->getMenu('site');
-		$language = isset($needles['language']) ? $needles['language'] : '*';
-
-		// Prepare the reverse lookup array.
-		if (!isset(self::$lookup[$language]))
-		{
-			self::$lookup[$language] = array();
-
-			$component  = JComponentHelper::getComponent('com_content');
-
-			$attributes = array('component_id');
-			$values     = array($component->id);
-
-			if ($language != '*')
-			{
-				$attributes[] = 'language';
-				$values[]     = array($needles['language'], '*');
-			}
-
-			$items = $menus->getItems($attributes, $values);
-
-			foreach ($items as $item)
-			{
-				if (isset($item->query) && isset($item->query['view']))
-				{
-					$view = $item->query['view'];
-
-					if (!isset(self::$lookup[$language][$view]))
-					{
-						self::$lookup[$language][$view] = array();
-					}
-
-					if (isset($item->query['id']))
-					{
-						/**
-						 * Here it will become a bit tricky
-						 * language != * can override existing entries
-						 * language == * cannot override existing entries
-						 */
-						if (!isset(self::$lookup[$language][$view][$item->query['id']]) || $item->language != '*')
-						{
-							self::$lookup[$language][$view][$item->query['id']] = $item->id;
-						}
-					}
-				}
-			}
-		}
-
-		if ($needles)
-		{
-			foreach ($needles as $view => $ids)
-			{
-				if (isset(self::$lookup[$language][$view]))
-				{
-					foreach ($ids as $id)
-					{
-						if (isset(self::$lookup[$language][$view][(int) $id]))
-						{
-							return self::$lookup[$language][$view][(int) $id];
-						}
-					}
-				}
-			}
-		}
-
-		// Check if the active menuitem matches the requested language
-		$active = $menus->getActive();
-
-		if ($active
-			&& $active->component == 'com_content'
-			&& ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
-		{
-			return $active->id;
-		}
-
-		// If not found, return language specific home link
-		$default = $menus->getDefault($language);
-
-		return !empty($default->id) ? $default->id : null;
 	}
 }

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -76,7 +76,7 @@ abstract class ContentHelperRoute
 		}
 		else
 		{
-			$link                  = 'index.php?option=com_content&view=category&id=' . $id;
+			$link = 'index.php?option=com_content&view=category&id=' . $catid;
 
 			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
 			{

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -545,7 +545,7 @@ class ContentRouter extends JComponentRouterBase
 	 *
 	 * @since   3.4
 	 */
-	protected function findItem($needles = null)
+	private function findItem($needles = null)
 	{
 		$language = isset($needles['language']) ? $needles['language'] : '*';
 

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -17,6 +17,95 @@ defined('_JEXEC') or die;
 class ContentRouter extends JComponentRouterBase
 {
 	/**
+	 * Itemid lookup array
+	 * 
+	 * @var    array
+	 * @since  3.4
+	 */
+	protected $lookup;
+
+	/**
+	 * Find the right Itemid for a com_content article
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.4
+	 */
+	public function preprocess($query)
+	{
+		if (isset($query['Itemid']))
+		{
+			return $query;
+		}
+
+		$needles = array();
+
+		if (isset($query['view']))
+		{
+			$needles['view'] = $query['view'];
+
+			if ($query['view'] == 'category')
+			{
+				if (isset($query['id']))
+				{
+					$category = JCategories::getInstance('Content')->get((int)$query['id']);
+
+					if ($id < 1 || !($category instanceof JCategoryNode))
+					{
+						$link = '';
+					}
+					else
+					{
+						$catids                = array_reverse($category->getPath());
+						$needles['category']   = $catids;
+						$needles['categories'] = $catids;
+					}
+				}
+			}
+
+			if ($query['view'] == 'article')
+			{
+				if (isset($query['id']))
+				{
+					$needles['article'] = array($query['id']);
+				}
+
+				if (isset($query['catid']) && (int) $query['catid'] > 1)
+				{
+					$categories = JCategories::getInstance('Content');
+					$category   = $categories->get((int) $query['catid']);
+
+					if ($category)
+					{
+						$needles['category']   = array_reverse($category->getPath());
+						$needles['categories'] = $needles['category'];
+					}
+				}
+			}
+		}
+
+		if (isset($query['task']) && $query['task'] == 'article.edit')
+		{
+			$needles['view'] = array('form');
+		}
+
+
+		if (isset($query['language']) && $query['language'] != '*')
+		{
+			$needles['language'] = $query['language'];
+		}
+
+		if ($item = $this->findItem($needles))
+		{
+			$query['Itemid'] = $item;
+		}
+
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_content component
 	 *
 	 * @param   array  &$query  An array of URL arguments
@@ -448,6 +537,97 @@ class ContentRouter extends JComponentRouterBase
 		}
 
 		return $vars;
+	}
+
+	/**
+	 * Find an item ID.
+	 *
+	 * @param   array  $needles  An array of needles to search for.
+	 *
+	 * @return  mixed  The ID found or null otherwise.
+	 *
+	 * @since   3.4
+	 */
+	protected function findItem($needles = null)
+	{
+		$language = isset($needles['language']) ? $needles['language'] : '*';
+
+		// Prepare the reverse lookup array.
+		if (!isset($this->lookup[$language]))
+		{
+			$this->lookup[$language] = array();
+
+			$component  = JComponentHelper::getComponent('com_content');
+
+			$attributes = array('component_id');
+			$values     = array($component->id);
+
+			if ($language != '*')
+			{
+				$attributes[] = 'language';
+				$values[]     = array($needles['language'], '*');
+			}
+
+			$items = $this->menu->getItems($attributes, $values);
+
+			foreach ($items as $item)
+			{
+				if (isset($item->query) && isset($item->query['view']))
+				{
+					$view = $item->query['view'];
+
+					if (!isset($this->lookup[$language][$view]))
+					{
+						$this->lookup[$language][$view] = array();
+					}
+
+					if (isset($item->query['id']))
+					{
+						/**
+						 * Here it will become a bit tricky
+						 * language != * can override existing entries
+						 * language == * cannot override existing entries
+						 */
+						if (!isset($this->lookup[$language][$view][$item->query['id']]) || $item->language != '*')
+						{
+							$this->lookup[$language][$view][$item->query['id']] = $item->id;
+						}
+					}
+				}
+			}
+		}
+
+		if ($needles)
+		{
+			foreach ($needles as $view => $ids)
+			{
+				if (isset($this->lookup[$language][$view]))
+				{
+					foreach ($ids as $id)
+					{
+						if (isset($this->lookup[$language][$view][(int) $id]))
+						{
+							return $this->lookup[$language][$view][(int) $id];
+						}
+					}
+				}
+			}
+		}
+
+		// Check if the active menuitem matches the requested language
+		$active = $this->menu->getActive();
+
+		if ($active
+			&& $active->component == 'com_content'
+			&& ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		{
+			return $active->id;
+		}
+
+		// If not found, return language specific home link
+		$default = $this->menu->getDefault($language);
+
+		return !empty($default->id) ? $default->id : null;
 	}
 }
 

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -44,8 +44,6 @@ class ContentRouter extends JComponentRouterBase
 
 		if (isset($query['view']))
 		{
-			$needles['view'] = $query['view'];
-
 			if ($query['view'] == 'category')
 			{
 				if (isset($query['id']))
@@ -88,7 +86,7 @@ class ContentRouter extends JComponentRouterBase
 
 		if (isset($query['task']) && $query['task'] == 'article.edit')
 		{
-			$needles['view'] = array('form');
+			$needles['form'] = array(0);
 		}
 
 
@@ -592,6 +590,10 @@ class ContentRouter extends JComponentRouterBase
 						{
 							$this->lookup[$language][$view][$item->query['id']] = $item->id;
 						}
+					}
+					else
+					{
+						$this->lookup[$language][$view][0] = $item->id;
 					}
 				}
 			}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -89,9 +89,9 @@ class ContentRouter extends JComponentRouterBase
 			$needles['form'] = array(0);
 		}
 
-		if (isset($query['language']) && $query['language'] != '*')
+		if (isset($query['lang']) && $query['lang'] != '*')
 		{
-			$needles['language'] = $query['language'];
+			$needles['language'] = $query['lang'];
 		}
 
 		if ($item = $this->findItem($needles))

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -48,7 +48,7 @@ class ContentRouter extends JComponentRouterBase
 			{
 				if (isset($query['id']))
 				{
-					$category = JCategories::getInstance('Content')->get((int)$query['id']);
+					$category = JCategories::getInstance('Content')->get((int) $query['id']);
 
 					if ($id < 1 || !($category instanceof JCategoryNode))
 					{
@@ -88,7 +88,6 @@ class ContentRouter extends JComponentRouterBase
 		{
 			$needles['form'] = array(0);
 		}
-
 
 		if (isset($query['language']) && $query['language'] != '*')
 		{


### PR DESCRIPTION
This change moves the code that discovers the right Itemid for this content item from the ContentHelperRoute class into the component router. This means that also URLs in the content get the right Itemid and we don't need to pre-calculate them during the time the article was written. It also means that all URLs are treated correctly and not just those going through ContentHelperRoute. At the same time, this also fixes the Itemid discovery for form views in com_content. If you have a menu item that points to a create article view, this menu item is taken for editing articles in the frontend instead of the homepage.

This makes ContentHelperRoute obsolete, but I did not change that class yet, since that would interfer with PR #5140. So #5140 should be merged first in order to test this one properly. That means that also #5264 and #5276 should be merged before this one.

This only touches com_content for the moment. Further components can be done at a later stage. I also wanted to keep it testable, since no one could be expected to test all components at once.

It should be made clear that this ultimately changes the behavior of ContentHelperRoute in the way that it removes the Itemid from its output. For a sane developer that would not be a problem, since he would not mess with the output any further, but I have the gut feeling that there are developers out there, that take an article, let ContentHelperRoute calculate the right Itemid and then parse that Itemid back from the URL that is returned by ContentHelperRoute. The question is, how far we are going to go to prevent people from shooting themselfs in the foot... (Read: Doing the above described thing would be Homer-Simpson-stabs-himself-with-a-knife-in-the-hand-stupid)

To give you a little insight into the future: In one of the next steps, this code will be moved into a component router rule, which is generalized and where one code works for all components. At that point, this code is removed again from the component routers.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
