### PR TITLE
Fix minor b/c break in https://github.com/joomla/joomla-cms/pull/4292

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -546,9 +546,11 @@ class JApplicationWeb extends JApplicationBase
 					$status = $status ? 301 : 303;
 				}
 
-				if (!is_int($status) && !isset($this->responseMap[$status]))
+				// Now check if we have an integer status code that maps to a valid redirect. If we don't then set a 303
+				// @deprecated 4.0 From 4.0 if no valid status code is given a InvalidArgumentException will be thrown
+				if (!is_int($status) || is_int($status) && !isset($this->responseMap[$status]))
 				{
-					throw new \InvalidArgumentException('You have not supplied a valid HTTP 1.1 status code');
+					$status = 303;
 				}
 
 				// All other cases use the more efficient HTTP header for redirection.

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -452,6 +452,51 @@ class JApplicationCmsTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Tests the JApplicationCms::redirect method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function testRedirectLegacyWithEmptyMessageAndEmptyStatus()
+	{
+		$base = 'http://mydomain.com/';
+		$url = 'index.php';
+
+		// Inject the client information.
+		TestReflection::setValue(
+			$this->class,
+			'client',
+			(object) array(
+				'engine' => JApplicationWebClient::GECKO,
+			)
+		);
+
+		// Inject the internal configuration.
+		$config = new Registry;
+		$config->set('uri.base.full', $base);
+
+		TestReflection::setValue($this->class, 'config', $config);
+
+		$this->class->redirect($url, '', 'message');
+
+		// The message isn't enqueued as it's an empty string
+		$this->assertEmpty(
+			$this->class->getMessageQueue()
+		);
+
+		// The redirect gives a 303 error code
+		$this->assertEquals(
+			array(
+				array('HTTP/1.1 303 See other', true, null),
+				array('Location: ' . $base . $url, true, null),
+				array('Content-Type: text/html; charset=utf-8', true, null),
+			),
+			$this->class->headers
+		);
+	}
+
+	/**
 	 * Tests the JApplicationCms::redirect method with headers already sent.
 	 *
 	 * @return  void


### PR DESCRIPTION
This fixes a minor b/c break in https://github.com/joomla/joomla-cms/pull/4292 where in some cases you could get the InvalidArgumentException being thrown when you got a 303 message.

Cases involved passing in empty string or null as the message parameter meaning the check at https://github.com/joomla/joomla-cms/pull/4292/files#diff-11a160a70413114ea70faf547cd097ecR976 failed and these values became the moved parameter (and weren't booleans or integers).

This adds a unit test for that scenario and fixes it. Of course all of this relates to the old redirect method and so of course is deprecated.
