### PR TITLE
Routing: Discover Itemid in Router for com_contact

### DIFF
--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -16,6 +16,7 @@ defined('_JEXEC') or die;
  * @package     Joomla.Site
  * @subpackage  com_contact
  * @since       1.5
+ * @deprecated 4.0 Simply write non-SEF URLs instead
  */
 abstract class ContactHelperRoute
 {
@@ -31,6 +32,7 @@ abstract class ContactHelperRoute
 	 * @return  string  The link to the contact
 	 *
 	 * @since   1.5
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getContactRoute($id, $catid, $language = 0)
 	{
@@ -64,6 +66,7 @@ abstract class ContactHelperRoute
 	 * @return  string  The link to the contact
 	 *
 	 * @since   1.5
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getCategoryRoute($catid, $language = 0)
 	{
@@ -113,5 +116,15 @@ abstract class ContactHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
+	}
+
+	/**
+	 * Was used to calculate the right Itemid
+	 * 
+	 * @deprecated 4.0
+	 */
+	protected static function _findItem($needles = null)
+	{
+		return null;
 	}
 }

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -49,7 +49,6 @@ abstract class ContactHelperRoute
 			if (isset(self::$lang_lookup[$language]))
 			{
 				$link .= '&lang=' . self::$lang_lookup[$language];
-				$needles['language'] = $language;
 			}
 		}
 
@@ -89,7 +88,6 @@ abstract class ContactHelperRoute
 				if (isset(self::$lang_lookup[$language]))
 				{
 					$link .= '&lang=' . self::$lang_lookup[$language];
-					$needles['language'] = $language;
 				}
 			}
 		}

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -19,8 +19,6 @@ defined('_JEXEC') or die;
  */
 abstract class ContactHelperRoute
 {
-	protected static $lookup;
-
 	protected static $lang_lookup = array();
 
 	/**
@@ -36,23 +34,12 @@ abstract class ContactHelperRoute
 	 */
 	public static function getContactRoute($id, $catid, $language = 0)
 	{
-		$needles = array(
-			'contact'  => array((int) $id)
-		);
 		//Create the link
 		$link = 'index.php?option=com_contact&view=contact&id=' . $id;
 
 		if ($catid > 1)
 		{
-			$categories	= JCategories::getInstance('Contact');
-			$category	= $categories->get($catid);
-
-			if ($category)
-			{
-				$needles['category'] = array_reverse($category->getPath());
-				$needles['categories'] = $needles['category'];
 				$link .= '&catid=' . $catid;
-			}
 		}
 
 		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
@@ -64,11 +51,6 @@ abstract class ContactHelperRoute
 				$link .= '&lang=' . self::$lang_lookup[$language];
 				$needles['language'] = $language;
 			}
-		}
-
-		if ($item = self::_findItem($needles))
-		{
-			$link .= '&Itemid=' . $item;
 		}
 
 		return $link;
@@ -88,29 +70,17 @@ abstract class ContactHelperRoute
 	{
 		if ($catid instanceof JCategoryNode)
 		{
-			$id       = $catid->id;
-			$category = $catid;
-		}
-		else
-		{
-			$id       = (int) $catid;
-			$category = JCategories::getInstance('Contact')->get($id);
+			$catid = $catid->id;
 		}
 
-		if ($id < 1 || !($category instanceof JCategoryNode))
+		if ($catid < 1)
 		{
 			$link = '';
 		}
 		else
 		{
-			$needles = array();
-
 			// Create the link
 			$link = 'index.php?option=com_contact&view=category&id=' . $id;
-
-			$catids                = array_reverse($category->getPath());
-			$needles['category']   = $catids;
-			$needles['categories'] = $catids;
 
 			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
 			{
@@ -121,11 +91,6 @@ abstract class ContactHelperRoute
 					$link .= '&lang=' . self::$lang_lookup[$language];
 					$needles['language'] = $language;
 				}
-			}
-
-			if ($item = self::_findItem($needles))
-			{
-				$link .= '&Itemid=' . $item;
 			}
 		}
 
@@ -150,85 +115,5 @@ abstract class ContactHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
-	}
-
-	protected static function _findItem($needles = null)
-	{
-		$app      = JFactory::getApplication();
-		$menus    = $app->getMenu('site');
-		$language = isset($needles['language']) ? $needles['language'] : '*';
-
-		// Prepare the reverse lookup array.
-		if (!isset(self::$lookup[$language]))
-		{
-			self::$lookup[$language] = array();
-
-			$component  = JComponentHelper::getComponent('com_contact');
-			$attributes = array('component_id');
-			$values     = array($component->id);
-
-			if ($language != '*')
-			{
-				$attributes[] = 'language';
-				$values[] = array($needles['language'], '*');
-			}
-
-			$items = $menus->getItems($attributes, $values);
-
-			foreach ($items as $item)
-			{
-				if (isset($item->query) && isset($item->query['view']))
-				{
-					$view = $item->query['view'];
-
-					if (!isset(self::$lookup[$language][$view]))
-					{
-						self::$lookup[$language][$view] = array();
-					}
-
-					if (isset($item->query['id']))
-					{
-						/**
-						* Here it will become a bit tricky
-						* language != * can override existing entries
-						* language == * cannot override existing entries
-						*/
-						if (!isset(self::$lookup[$language][$view][$item->query['id']]) || $item->language != '*')
-						{
-							self::$lookup[$language][$view][$item->query['id']] = $item->id;
-						}
-					}
-				}
-			}
-		}
-
-		if ($needles)
-		{
-			foreach ($needles as $view => $ids)
-			{
-				if (isset(self::$lookup[$language][$view]))
-				{
-					foreach ($ids as $id)
-					{
-						if (isset(self::$lookup[$language][$view][(int) $id]))
-						{
-							return self::$lookup[$language][$view][(int) $id];
-						}
-					}
-				}
-			}
-		}
-
-		// Check if the active menuitem matches the requested language
-		$active = $menus->getActive();
-		if ($active && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
-		{
-			return $active->id;
-		}
-
-		// If not found, return language specific home link
-		$default = $menus->getDefault($language);
-
-		return !empty($default->id) ? $default->id : null;
 	}
 }

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -17,6 +17,87 @@ defined('_JEXEC') or die;
 class ContactRouter extends JComponentRouterBase
 {
 	/**
+	 * Itemid lookup array
+	 * 
+	 * @var    array
+	 * @since  3.4
+	 */
+	protected $lookup;
+
+	/**
+	 * Find the right Itemid for a com_contact contact
+	 *
+	 * @param   array  $query  An associative array of URL arguments
+	 *
+	 * @return  array  The URL arguments to use to assemble the subsequent URL.
+	 *
+	 * @since   3.4
+	 */
+	public function preprocess($query)
+	{
+		if (isset($query['Itemid']))
+		{
+			return $query;
+		}
+
+		$needles = array();
+
+		if (isset($query['view']))
+		{
+			if ($query['view'] == 'category')
+			{
+				if (isset($query['id']))
+				{
+					$category = JCategories::getInstance('Contact')->get((int) $query['id']);
+
+					if ($id < 1 || !($category instanceof JCategoryNode))
+					{
+						$link = '';
+					}
+					else
+					{
+						$catids                = array_reverse($category->getPath());
+						$needles['category']   = $catids;
+						$needles['categories'] = $catids;
+					}
+				}
+			}
+
+			if ($query['view'] == 'contact')
+			{
+				if (isset($query['id']))
+				{
+					$needles['contact'] = array($query['id']);
+				}
+
+				if (isset($query['catid']) && (int) $query['catid'] > 1)
+				{
+					$categories = JCategories::getInstance('Contact');
+					$category   = $categories->get((int) $query['catid']);
+
+					if ($category)
+					{
+						$needles['category']   = array_reverse($category->getPath());
+						$needles['categories'] = $needles['category'];
+					}
+				}
+			}
+		}
+
+		if (isset($query['language']) && $query['language'] != '*')
+		{
+			$needles['language'] = $query['language'];
+		}
+
+		if ($item = $this->findItem($needles))
+		{
+			$query['Itemid'] = $item;
+		}
+
+		return $query;
+	}
+
+	/**
 	 * Build the route for the com_contact component
 	 *
 	 * @param   array  &$query  An array of URL arguments
@@ -244,6 +325,102 @@ class ContactRouter extends JComponentRouterBase
 		}
 
 		return $vars;
+	}
+
+
+	/**
+	 * Find an item ID.
+	 *
+	 * @param   array  $needles  An array of needles to search for.
+	 *
+	 * @return  mixed  The ID found or null otherwise.
+	 *
+	 * @since   3.4
+	 */
+	private function findItem($needles = null)
+	{
+		$language = isset($needles['language']) ? $needles['language'] : '*';
+
+		// Prepare the reverse lookup array.
+		if (!isset($this->lookup[$language]))
+		{
+			$this->lookup[$language] = array();
+
+			$component  = JComponentHelper::getComponent('com_contact');
+
+			$attributes = array('component_id');
+			$values     = array($component->id);
+
+			if ($language != '*')
+			{
+				$attributes[] = 'language';
+				$values[]     = array($needles['language'], '*');
+			}
+
+			$items = $this->menu->getItems($attributes, $values);
+
+			foreach ($items as $item)
+			{
+				if (isset($item->query) && isset($item->query['view']))
+				{
+					$view = $item->query['view'];
+
+					if (!isset($this->lookup[$language][$view]))
+					{
+						$this->lookup[$language][$view] = array();
+					}
+
+					if (isset($item->query['id']))
+					{
+						/**
+						 * Here it will become a bit tricky
+						 * language != * can override existing entries
+						 * language == * cannot override existing entries
+						 */
+						if (!isset($this->lookup[$language][$view][$item->query['id']]) || $item->language != '*')
+						{
+							$this->lookup[$language][$view][$item->query['id']] = $item->id;
+						}
+					}
+					else
+					{
+						$this->lookup[$language][$view][0] = $item->id;
+					}
+				}
+			}
+		}
+
+		if ($needles)
+		{
+			foreach ($needles as $view => $ids)
+			{
+				if (isset($this->lookup[$language][$view]))
+				{
+					foreach ($ids as $id)
+					{
+						if (isset($this->lookup[$language][$view][(int) $id]))
+						{
+							return $this->lookup[$language][$view][(int) $id];
+						}
+					}
+				}
+			}
+		}
+
+		// Check if the active menuitem matches the requested language
+		$active = $this->menu->getActive();
+
+		if ($active
+			&& $active->component == 'com_content'
+			&& ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+		{
+			return $active->id;
+		}
+
+		// If not found, return language specific home link
+		$default = $this->menu->getDefault($language);
+
+		return !empty($default->id) ? $default->id : null;
 	}
 }
 

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -84,9 +84,9 @@ class ContactRouter extends JComponentRouterBase
 			}
 		}
 
-		if (isset($query['language']) && $query['language'] != '*')
+		if (isset($query['lang']) && $query['lang'] != '*')
 		{
-			$needles['language'] = $query['language'];
+			$needles['language'] = $query['lang'];
 		}
 
 		if ($item = $this->findItem($needles))

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -327,7 +327,6 @@ class ContactRouter extends JComponentRouterBase
 		return $vars;
 	}
 
-
 	/**
 	 * Find an item ID.
 	 *


### PR DESCRIPTION
This change moves the code that discovers the right Itemid for this content item from the ContactHelperRoute class into the component router. This means that also URLs in the content get the right Itemid and we don't need to pre-calculate them during the time the article was written. It also means that all URLs are treated correctly and not just those going through ContactHelperRoute.

This makes ContactHelperRoute obsolete. The changes that I'm proposing might interfer with PR #5140. So #5140 should be merged first in order to test this one properly. That means that also #5264 and #5276 should be merged before this one.

This touches com_contact. Further components are done in other PRs. I also wanted to keep it testable, since no one could be expected to test all components at once. See the first PR for this in #5285.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
