### PR TITLE
Routing: Discover Itemid in Router for com_newsfeeds

### DIFF
--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -16,8 +16,6 @@ defined('_JEXEC') or die;
  */
 abstract class NewsfeedsHelperRoute
 {
-	protected static $lookup;
-
 	protected static $lang_lookup = array();
 
 	/**
@@ -31,25 +29,12 @@ abstract class NewsfeedsHelperRoute
 	 */
 	public static function getNewsfeedRoute($id, $catid, $language = 0)
 	{
-		$needles = array(
-			'newsfeed'  => array((int) $id)
-		);
-
 		// Create the link
 		$link = 'index.php?option=com_newsfeeds&view=newsfeed&id=' . $id;
 
 		if ((int) $catid > 1)
 		{
-			$categories = JCategories::getInstance('Newsfeeds');
-			$category = $categories->get((int) $catid);
-
-			if ($category)
-			{
-				// TODO Throw error that the category either not exists or is unpublished
-				$needles['category'] = array_reverse($category->getPath());
-				$needles['categories'] = $needles['category'];
-				$link .= '&catid=' . $catid;
-			}
+			$link .= '&catid=' . $catid;
 		}
 
 		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
@@ -59,13 +44,7 @@ abstract class NewsfeedsHelperRoute
 			if (isset(self::$lang_lookup[$language]))
 			{
 				$link .= '&lang=' . self::$lang_lookup[$language];
-				$needles['language'] = $language;
 			}
-		}
-
-		if ($item = self::_findItem($needles))
-		{
-			$link .= '&Itemid=' . $item;
 		}
 
 		return $link;
@@ -83,29 +62,17 @@ abstract class NewsfeedsHelperRoute
 	{
 		if ($catid instanceof JCategoryNode)
 		{
-			$id = $catid->id;
-			$category = $catid;
-		}
-		else
-		{
-			$id = (int) $catid;
-			$category = JCategories::getInstance('Newsfeeds')->get($id);
+			$catid = $catid->id;
 		}
 
-		if ($id < 1 || !($category instanceof JCategoryNode))
+		if ($catid < 1)
 		{
 			$link = '';
 		}
 		else
 		{
-			$needles = array();
-
 			// Create the link
-			$link = 'index.php?option=com_newsfeeds&view=category&id=' . $id;
-
-			$catids = array_reverse($category->getPath());
-			$needles['category'] = $catids;
-			$needles['categories'] = $catids;
+			$link = 'index.php?option=com_newsfeeds&view=category&id=' . $catid;
 
 			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
 			{
@@ -114,13 +81,7 @@ abstract class NewsfeedsHelperRoute
 				if (isset(self::$lang_lookup[$language]))
 				{
 					$link .= '&lang=' . self::$lang_lookup[$language];
-					$needles['language'] = $language;
 				}
-			}
-
-			if ($item = self::_findItem($needles))
-			{
-				$link .= '&Itemid=' . $item;
 			}
 		}
 
@@ -153,94 +114,5 @@ abstract class NewsfeedsHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
-	}
-
-	/**
-	 * finditem
-	 *
-	 * @param   null  $needles  what we are searching for
-	 *
-	 * @return  int  menu itemid
-	 *
-	 * @throws Exception
-	 */
-	protected static function _findItem($needles = null)
-	{
-		$app		= JFactory::getApplication();
-		$menus		= $app->getMenu('site');
-		$language	= isset($needles['language']) ? $needles['language'] : '*';
-
-		// Prepare the reverse lookup array.
-		if (!isset(self::$lookup[$language]))
-		{
-			self::$lookup[$language] = array();
-
-			$component	= JComponentHelper::getComponent('com_newsfeeds');
-
-			$attributes = array('component_id');
-			$values = array($component->id);
-
-			if ($language != '*')
-			{
-				$attributes[] = 'language';
-				$values[] = array($needles['language'], '*');
-			}
-
-			$items = $menus->getItems($attributes, $values);
-
-			foreach ($items as $item)
-			{
-				if (isset($item->query) && isset($item->query['view']))
-				{
-					$view = $item->query['view'];
-
-					if (!isset(self::$lookup[$language][$view]))
-					{
-						self::$lookup[$language][$view] = array();
-					}
-
-					if (isset($item->query['id']))
-					{
-						/* Here it will become a bit tricky
-						 language != * can override existing entries
-						 language == * cannot override existing entries */
-						if (!isset(self::$lookup[$language][$view][$item->query['id']]) || $item->language != '*')
-						{
-							self::$lookup[$language][$view][$item->query['id']] = $item->id;
-						}
-					}
-				}
-			}
-		}
-
-		if ($needles)
-		{
-			foreach ($needles as $view => $ids)
-			{
-				if (isset(self::$lookup[$language][$view]))
-				{
-					foreach ($ids as $id)
-					{
-						if (isset(self::$lookup[$language][$view][(int) $id]))
-						{
-							return self::$lookup[$language][$view][(int) $id];
-						}
-					}
-				}
-			}
-		}
-
-		// Check if the active menuitem matches the requested language
-		$active = $menus->getActive();
-
-		if ($active && ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
-		{
-			return $active->id;
-		}
-
-		// If not found, return language specific home link
-		$default = $menus->getDefault($language);
-
-		return !empty($default->id) ? $default->id : null;
 	}
 }

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
  * Newsfeeds Component Route Helper
  *
  * @since  1.5
+ * @deprecated 4.0 Simply write non-SEF URLs instead
  */
 abstract class NewsfeedsHelperRoute
 {
@@ -26,6 +27,7 @@ abstract class NewsfeedsHelperRoute
 	 * @param   int  $language  language
 	 *
 	 * @return string
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getNewsfeedRoute($id, $catid, $language = 0)
 	{
@@ -57,6 +59,7 @@ abstract class NewsfeedsHelperRoute
 	 * @param   int  $language  language
 	 *
 	 * @return string
+	 * @deprecated 4.0 Simply write a static non-SEF URL instead
 	 */
 	public static function getCategoryRoute($catid, $language = 0)
 	{
@@ -95,7 +98,6 @@ abstract class NewsfeedsHelperRoute
 	 *
 	 * @throws Exception
 	 */
-
 	protected static function buildLanguageLookup()
 	{
 		if (count(self::$lang_lookup) == 0)
@@ -114,5 +116,20 @@ abstract class NewsfeedsHelperRoute
 				self::$lang_lookup[$lang->lang_code] = $lang->sef;
 			}
 		}
+	}
+
+	/**
+	 * finditem
+	 *
+	 * @param   null  $needles  what we are searching for
+	 *
+	 * @return  int  menu itemid
+	 *
+	 * @throws Exception
+	 * @deprecated 4.0
+	 */
+	protected static function _findItem($needles = null)
+	{
+		return null;
 	}
 }


### PR DESCRIPTION
This change moves the code that discovers the right Itemid for this content item from the NewsfeedsHelperRoute class into the component router. This means that also URLs in the content get the right Itemid and we don't need to pre-calculate them during the time the item was created. It also means that all URLs are treated correctly and not just those going through NewsfeedsHelperRoute.

This makes NewsfeedsHelperRoute obsolete. The changes that I'm proposing might interfer with PR #5140. So #5140 should be merged first in order to test this one properly. That means that also #5264 and #5276 should be merged before this one.

This touches com_newsfeeds. Further components are done in other PRs. I also wanted to keep it testable, since no one could be expected to test all components at once. See the first PR for this in #5285.

This was made possible through the generous donation of the people mentioned in the following link via an Indiegogo campaign: http://joomlager.de/crowdfunding/5-contributors
