### PR TITLE
Fix for issue #5286 "UX Issue: Error message should display in Red color instead of green text"

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -158,12 +158,14 @@ class InstallerModelInstall extends JModelLegacy
 			// There was an error installing the package.
 			$msg = JText::sprintf('COM_INSTALLER_INSTALL_ERROR', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = false;
+            $msgType = 'error';
 		}
 		else
 		{
 			// Package installed sucessfully.
 			$msg = JText::sprintf('COM_INSTALLER_INSTALL_SUCCESS', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = true;
+            $msgType = 'message';
 		}
 
 		// This event allows a custom a post-flight:
@@ -171,7 +173,7 @@ class InstallerModelInstall extends JModelLegacy
 
 		// Set some model state values.
 		$app	= JFactory::getApplication();
-		$app->enqueueMessage($msg);
+		$app->enqueueMessage($msg, $msgType);
 		$this->setState('name', $installer->get('name'));
 		$this->setState('result', $result);
 		$app->setUserState('com_installer.message', $installer->message);

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -158,14 +158,14 @@ class InstallerModelInstall extends JModelLegacy
 			// There was an error installing the package.
 			$msg = JText::sprintf('COM_INSTALLER_INSTALL_ERROR', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = false;
-            $msgType = 'error';
+			$msgType = 'error';
 		}
 		else
 		{
 			// Package installed sucessfully.
 			$msg = JText::sprintf('COM_INSTALLER_INSTALL_SUCCESS', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = true;
-            $msgType = 'message';
+			$msgType = 'message';
 		}
 
 		// This event allows a custom a post-flight:


### PR DESCRIPTION
This is a fix for Issue #5286 "Fix for UX Issue: Error message should display in Red color instead of green text"

Call to enqueueMessage didn't have a message type passed to it. As a result enqueueMessage was defaulting to type 'message' (green message box) irrespective of the installation outcome.

Fix - introduced $msgType variable which is set according to installation outcome just after the $msg is initialised. 

Recreated error on local joomla installation. Removed files from a Joomla components zip file, installed Joomla component via "Upload Package File" method, installation failed with green message box. 

Tested installing via "Upload Package File" with both correct and broken zip files, all functioned as expected.

**First pull request ever so please forgive any mistakes!!**
