### PR TITLE
Fix PHP warning for trying to loop over false variable

### DIFF
--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -42,42 +42,45 @@ class TagsViewTag extends JViewLegacy
 
 		// Get some data from the model
 		$items    = $this->get('Items');
-
-		foreach ($items as $item)
+		
+		if ($items !== false)
 		{
-			// Strip HTML from feed item title
-			$title = $this->escape($item->core_title);
-			$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
-
-			// URL link to tagged item
-			// Change to new routing once it is merged
-			$link = JRoute::_($item->link);
-
-			// Strip HTML from feed item description text
-			$description = $item->core_body;
-			$author      = $item->core_created_by_alias ? $item->core_created_by_alias : $item->author;
-			$date        = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
-
-			// Load individual item creator class
-			$feeditem              = new JFeedItem;
-			$feeditem->title       = $title;
-			$feeditem->link        = $link;
-			$feeditem->description = $description;
-			$feeditem->date        = $date;
-			$feeditem->category    = $title;
-			$feeditem->author      = $author;
-
-			if ($feedEmail == 'site')
+			foreach ($items as $item)
 			{
-				$item->authorEmail = $siteEmail;
-			}
-			elseif ($feedEmail === 'author')
-			{
-				$item->authorEmail = $item->author_email;
-			}
+				// Strip HTML from feed item title
+				$title = $this->escape($item->core_title);
+				$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
+	
+				// URL link to tagged item
+				// Change to new routing once it is merged
+				$link = JRoute::_($item->link);
+	
+				// Strip HTML from feed item description text
+				$description = $item->core_body;
+				$author      = $item->core_created_by_alias ? $item->core_created_by_alias : $item->author;
+				$date        = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
 
-			// Loads item info into RSS array
-			$document->addItem($feeditem);
+				// Load individual item creator class
+				$feeditem              = new JFeedItem;
+				$feeditem->title       = $title;
+				$feeditem->link        = $link;
+				$feeditem->description = $description;
+				$feeditem->date        = $date;
+				$feeditem->category    = $title;
+				$feeditem->author      = $author;
+	
+				if ($feedEmail == 'site')
+				{
+					$item->authorEmail = $siteEmail;
+				}
+				elseif ($feedEmail === 'author')
+				{
+					$item->authorEmail = $item->author_email;
+				}
+
+				// Loads item info into RSS array
+				$document->addItem($feeditem);
+			}
 		}
 	}
 }

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -42,7 +42,7 @@ class TagsViewTag extends JViewLegacy
 
 		// Get some data from the model
 		$items    = $this->get('Items');
-		
+
 		if ($items !== false)
 		{
 			foreach ($items as $item)
@@ -50,11 +50,11 @@ class TagsViewTag extends JViewLegacy
 				// Strip HTML from feed item title
 				$title = $this->escape($item->core_title);
 				$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
-	
+
 				// URL link to tagged item
 				// Change to new routing once it is merged
 				$link = JRoute::_($item->link);
-	
+
 				// Strip HTML from feed item description text
 				$description = $item->core_body;
 				$author      = $item->core_created_by_alias ? $item->core_created_by_alias : $item->author;
@@ -68,7 +68,7 @@ class TagsViewTag extends JViewLegacy
 				$feeditem->date        = $date;
 				$feeditem->category    = $title;
 				$feeditem->author      = $author;
-	
+
 				if ($feedEmail == 'site')
 				{
 					$item->authorEmail = $siteEmail;


### PR DESCRIPTION
Search bots are filling my error log because there was no proper check of the variable before looping over it. Note: I just added the same check which already exists in view.html.php and which was missing here.
