### PR TITLE
[fix] After toggling editor on article screen, right side border is not visible

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7964,6 +7964,9 @@ input.input-large-text {
 	overflow: hidden;
 	position: relative;
 }
+.editor textarea.mce_editable {
+	box-sizing: border-box;
+}
 a.grid_false {
 	display: inline-block;
 	height: 16px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7964,6 +7964,9 @@ input.input-large-text {
 	overflow: hidden;
 	position: relative;
 }
+.editor textarea.mce_editable {
+	box-sizing: border-box;
+}
 a.grid_false {
 	display: inline-block;
 	height: 16px;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1038,6 +1038,9 @@ input.input-large-text {
 	overflow: hidden;
 	position: relative
 }
+.editor textarea.mce_editable {
+	box-sizing: border-box;
+}
 
 /* For grid.boolean */
 a.grid_false {


### PR DESCRIPTION
Fixes #5302. Fixes #5299 

This solves the issue avoiding to use inline styles that will affect everything that renders the editor textarea
