### PR TITLE
Fixing notice in categories finder plugin

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -199,13 +199,11 @@ class PlgFinderCategories extends FinderIndexerAdapter
 			 */
 			foreach ($pks as $pk)
 			{
-				/* TODO: The $item variable does not seem to be used at all
 				$query = clone($this->getStateQuery());
 				$query->where('a.id = ' . (int) $pk);
 
 				$this->db->setQuery($query);
 				$item = $this->db->loadObject();
-				*/
 
 				// Translate the state.
 				$state = null;
@@ -395,6 +393,7 @@ class PlgFinderCategories extends FinderIndexerAdapter
 	{
 		$query = $this->db->getQuery(true)
 			->select($this->db->quoteName('a.id'))
+			->select($this->db->quoteName('a.parent_id'))
 			->select('a.' . $this->state_field . ' AS state, c.published AS cat_state')
 			->select('a.access, c.access AS cat_access')
 			->from($this->db->quoteName('#__categories') . ' AS a')


### PR DESCRIPTION
Fixes #5313 

This fixes a notice when trashing a category and all finder plugins are enabled.
### How to test
1. Make sure that all your finder plugins are enabled.
2. Create a new category in a component of your choice.
3. Trash that category and see the notice.
4. Untrash the category.
5. Apply the patch, trash the category again and see the notices have disappeared.

Thanks @infograf768 for this bug report.
### Comment

I honestly don't know what this code should do. I just changed it to remove the notices. However, it seems as if this is not correct the way this is written. It seems to always use the parent categories state for the state of the actual item... 
