### PR TITLE
Removing unnecessary code from JModelAdmin

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -197,16 +197,7 @@ abstract class JModelAdmin extends JModelForm
 			$this->type = $type->getTypeByAlias($this->typeAlias);
 		}
 
-		if ($this->type === false)
-		{
-			$type = new JUcmType;
-			$this->type = $type->getTypeByAlias($this->typeAlias);
-			$typeAlias = $this->type->type_alias;
-		}
-		else
-		{
-			$typeAlias = $this->type->type_alias;
-		}
+		$typeAlias = $this->type->type_alias;
 
 		$this->tagsObserver = $this->table->getObserverOfClass('JTableObserverTags');
 


### PR DESCRIPTION
I stumbled over this one during a code review. If this introduces any change, then we have bigger problems...

We are first checking if $this->type equals false. If that is the case, we create a new JUcmType object and get the type by alias. Then we do the same again, except that we assign the typeAlias. If $this->type does not equal false, we again assign the typeAlias. Long story short, double the code, always assigning $typeAlias => we can remove that part.
