### PR TITLE
Fixing finder to format weight as non-locale float

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -597,7 +597,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. number_format($token->weight, 2, '.', '') . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 			);

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -603,7 +603,7 @@ class FinderIndexerDriverPostgresql extends FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. number_format($token->weight, 2, '.', '') . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 			);

--- a/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
@@ -568,7 +568,7 @@ class FinderIndexerDriverSqlsrv extends FinderIndexer
 				. $db->quote($token->stem) . ', '
 				. (int) $token->common . ', '
 				. (int) $token->phrase . ', '
-				. (float) $token->weight . ', '
+				. number_format($token->weight, 2, '.', '') . ', '
 				. (int) $context . ', '
 				. $db->quote($token->language)
 			);


### PR DESCRIPTION
See #5269 

This fixes an SQL error in finder, where the weight is formatted as a locale aware float. When converting a float to a string in PHP, it unfortunately is formatted according to the locale setting. For Germany that means, that a 0.6 float becomes a "0,6" string. That breaks MySQL and is also not parsed by MySQL even when quoted. Using number_format(), we can get around that. However we are truncating the number to 2 digits after the decimal point.

Since I only fixed the code, I don't know how to test this. :wink: maybe @marneu can give testing instructions?

Since this problem is also present in the other database drivers, I will apply this patch there, too.
