### PR TITLE
Update installation/model/languages.php

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1189,14 +1189,19 @@ class InstallationModelLanguages extends JModelBase
 			->clear()
 			->select($db->qn('u') . '.' . $db->qn('id'))
 			->from($db->qn('#__users', 'u'))
-			->join('LEFT', $db->qn('#__user_usergroup_map', 'map')
+			->join(
+				'LEFT', $db->qn('#__user_usergroup_map', 'map')
 				. ' ON ' . $db->qn('map') . '.' . $db->qn('user_id')
-				. ' = ' . $db->qn('u') . '.' . $db->qn('id'))
-			->join('LEFT', $db->qn('#__usergroups', 'g')
+				. ' = ' . $db->qn('u') . '.' . $db->qn('id')
+			)
+			->join(
+				'LEFT', $db->qn('#__usergroups', 'g')
 				. ' ON ' . $db->qn('map') . '.' . $db->qn('group_id')
 				. ' = ' . $db->qn('g') . '.' . $db->qn('id'))
-			->where($db->qn('g') . '.' . $db->qn('title')
-				. ' = ' . $db->q('Super Users'));
+			->where(
+				$db->qn('g') . '.' . $db->qn('title')
+				. ' = ' . $db->q('Super Users')
+			);
 
 		$db->setQuery($query);
 		$id = $db->loadResult();

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -77,11 +77,11 @@ class InstallationModelLanguages extends JModelBase
 		$db        = JFactory::getDbo();
 		$extQuery  = $db->getQuery(true);
 
-		$extQuery->select($db->quoteName('extension_id'))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('type') . ' = ' . $db->quote('language'))
-			->where($db->quoteName('element') . ' = ' . $db->quote('en-GB'))
-			->where($db->quoteName('client_id') . ' = 0');
+		$extQuery->select($db->qn('extension_id'))
+			->from($db->qn('#__extensions'))
+			->where($db->qn('type') . ' = ' . $db->q('language'))
+			->where($db->qn('element') . ' = ' . $db->q('en-GB'))
+			->where($db->qn('client_id') . ' = 0');
 
 		$db->setQuery($extQuery);
 
@@ -101,9 +101,9 @@ class InstallationModelLanguages extends JModelBase
 			$query = $db->getQuery(true);
 
 			// Select the required fields from the updates table.
-			$query->select($db->quoteName(array('update_id', 'name', 'version')))
-				->from($db->quoteName('#__updates'))
-				->order($db->quoteName('name'));
+			$query->select($db->qn(array('update_id', 'name', 'version')))
+				->from($db->qn('#__updates'))
+				->order($db->qn('name'));
 
 			$db->setQuery($query);
 			$list = $db->loadObjectList();
@@ -358,12 +358,12 @@ class InstallationModelLanguages extends JModelBase
 		$query = $db->getQuery(true);
 
 		// Select field element from the extensions table.
-		$query->select($db->quoteName(array('a.element', 'a.name')))
-			->from($db->quoteName('#__extensions') . ' AS a')
-			->where($db->quoteName('a.type') . ' = ' . $db->quote('language'))
-			->where($db->quoteName('state') . ' = 0')
-			->where($db->quoteName('enabled') . ' = 1')
-			->where($db->quoteName('client_id') . ' = ' . (int) $client_id);
+		$query->select($db->qn(array('element', 'name')))
+			->from($db->qn('#__extensions'))
+			->where($db->qn('type') . ' = ' . $db->q('language'))
+			->where($db->qn('state') . ' = 0')
+			->where($db->qn('enabled') . ' = 1')
+			->where($db->qn('client_id') . ' = ' . (int) $client_id);
 
 		$db->setQuery($query);
 
@@ -553,10 +553,10 @@ class InstallationModelLanguages extends JModelBase
 
 		$query
 			->clear()
-			->update($db->quoteName('#__extensions'))
-			->set($db->quoteName('enabled') . ' = 1')
-			->where($db->quoteName('name') . ' = ' . $db->quote($pluginName))
-			->where($db->quoteName('type') . ' = ' . $db->quote('plugin'));
+			->update($db->qn('#__extensions'))
+			->set($db->qn('enabled') . ' = 1')
+			->where($db->qn('name') . ' = ' . $db->q($pluginName))
+			->where($db->qn('type') . ' = ' . $db->q('plugin'));
 
 		$db->setQuery($query);
 
@@ -578,10 +578,10 @@ class InstallationModelLanguages extends JModelBase
 				. '}';
 			$query
 				->clear()
-				->update($db->quoteName('#__extensions'))
-				->set($db->quoteName('params') . ' = ' . $db->quote($params))
-				->where($db->quoteName('name') . ' = ' . $db->quote('plg_system_languagefilter'))
-				->where($db->quoteName('type') . ' = ' . $db->quote('plugin'));
+				->update($db->qn('#__extensions'))
+				->set($db->qn('params') . ' = ' . $db->q($params))
+				->where($db->qn('name') . ' = ' . $db->q('plg_system_languagefilter'))
+				->where($db->qn('type') . ' = ' . $db->q('plugin'));
 
 			$db->setQuery($query);
 
@@ -662,8 +662,8 @@ class InstallationModelLanguages extends JModelBase
 
 		// Add Module in Module menus.
 		$query->clear()
-			->insert($db->quoteName('#__modules_menu'))
-			->columns(array($db->quoteName('moduleid'), $db->quoteName('menuid')))
+			->insert($db->qn('#__modules_menu'))
+			->columns(array($db->qn('moduleid'), $db->qn('menuid')))
 			->values($moduleId . ', 0');
 		$db->setQuery($query);
 
@@ -975,12 +975,12 @@ class InstallationModelLanguages extends JModelBase
 		// Add Module in Module menus.
 		$query
 			->clear()
-			->update($db->quoteName('#__modules'))
-			->set($db->quoteName('published') . ' = 0')
-			->where($db->quoteName('module') . ' = ' . $db->quote('mod_menu'))
-			->where($db->quoteName('language') . ' = ' . $db->quote('*'))
-			->where($db->quoteName('client_id') . ' = ' . $db->quote('0'))
-			->where($db->quoteName('position') . ' = ' . $db->quote('position-7'));
+			->update($db->qn('#__modules'))
+			->set($db->qn('published') . ' = 0')
+			->where($db->qn('module') . ' = ' . $db->q('mod_menu'))
+			->where($db->qn('language') . ' = ' . $db->q('*'))
+			->where($db->qn('client_id') . ' = ' . $db->q('0'))
+			->where($db->qn('position') . ' = ' . $db->q('position-7'));
 		$db->setQuery($query);
 
 		if (!$db->execute())
@@ -1008,9 +1008,9 @@ class InstallationModelLanguages extends JModelBase
 
 		$query
 			->clear()
-			->update($db->quoteName('#__modules'))
-			->set($db->quoteName('published') . ' = 1')
-			->where($db->quoteName('module') . ' = ' . $db->quote($moduleName));
+			->update($db->qn('#__modules'))
+			->set($db->qn('published') . ' = 1')
+			->where($db->qn('module') . ' = ' . $db->q($moduleName));
 		$db->setQuery($query);
 
 		if (!$db->execute())
@@ -1153,7 +1153,7 @@ class InstallationModelLanguages extends JModelBase
 		$newId = $article->get('id');
 
 		$query = $db->getQuery(true)
-			->insert($db->quoteName('#__content_frontpage'))
+			->insert($db->qn('#__content_frontpage'))
 			->values($newId . ', 0');
 
 		$db->setQuery($query);
@@ -1187,11 +1187,11 @@ class InstallationModelLanguages extends JModelBase
 		// Select the required fields from the updates table.
 		$query
 			->clear()
-			->select($db->quoteName('u.id'))
-			->from($db->quoteName('#__users') . ' AS u')
-			->join('LEFT', $db->quoteName('#__user_usergroup_map') . ' AS map ON ' . $db->quoteName('map.user_id') . ' = ' . $db->quoteName('u.id'))
-			->join('LEFT', $db->quoteName('#__usergroups') . ' AS g ON ' . $db->quoteName('map.group_id') . ' = ' . $db->quoteName('g.id'))
-			->where($db->quoteName('g.title') . ' = ' . $db->quote('Super Users'));
+			->select('u.id')
+			->from('#__users as u')
+			->join('LEFT', '#__user_usergroup_map AS map ON map.user_id = u.id')
+			->join('LEFT', '#__usergroups AS g ON map.group_id = g.id')
+			->where('g.title = ' . $db->q('Super Users'));
 
 		$db->setQuery($query);
 		$id = $db->loadResult();

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1189,9 +1189,14 @@ class InstallationModelLanguages extends JModelBase
 			->clear()
 			->select($db->qn('u') . '.' . $db->qn('id'))
 			->from($db->qn('#__users', 'u'))
-			->join('LEFT', $db->qn('#__user_usergroup_map', 'map') . ' ON ' . $db->qn('map') . '.' . $db->qn('user_id') . ' = ' . $db->qn('u') . '.' . $db->qn('id'))
-			->join('LEFT', $db->qn('#__usergroups', 'g') . ' ON ' . $db->qn('map') . '.' . $db->qn('group_id') . ' = ' . $db->qn('g') . '.' . $db->qn('id'))
-			->where($db->qn('g') . '.' . $db->qn('title') . ' = ' . $db->q('Super Users'));
+			->join('LEFT', $db->qn('#__user_usergroup_map', 'map')
+				. ' ON ' . $db->qn('map') . '.' . $db->qn('user_id')
+				. ' = ' . $db->qn('u') . '.' . $db->qn('id'))
+			->join('LEFT', $db->qn('#__usergroups', 'g')
+				. ' ON ' . $db->qn('map') . '.' . $db->qn('group_id')
+				. ' = ' . $db->qn('g') . '.' . $db->qn('id'))
+			->where($db->qn('g') . '.' . $db->qn('title')
+				. ' = ' . $db->q('Super Users'));
 
 		$db->setQuery($query);
 		$id = $db->loadResult();

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1190,12 +1190,14 @@ class InstallationModelLanguages extends JModelBase
 			->select($db->qn('u') . '.' . $db->qn('id'))
 			->from($db->qn('#__users', 'u'))
 			->join(
-				'LEFT', $db->qn('#__user_usergroup_map', 'map')
+				'LEFT',
+				$db->qn('#__user_usergroup_map', 'map')
 				. ' ON ' . $db->qn('map') . '.' . $db->qn('user_id')
 				. ' = ' . $db->qn('u') . '.' . $db->qn('id')
 			)
 			->join(
-				'LEFT', $db->qn('#__usergroups', 'g')
+				'LEFT',
+				$db->qn('#__usergroups', 'g')
 				. ' ON ' . $db->qn('map') . '.' . $db->qn('group_id')
 				. ' = ' . $db->qn('g') . '.' . $db->qn('id')
 			)

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1184,13 +1184,13 @@ class InstallationModelLanguages extends JModelBase
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
-		// Select the required fields from the updates table.
+		// Select the admin user ID
 		$query
 			->clear()
 			->select($db->qn('u') . '.' . $db->qn('id'))
-			->from($db->qn('#__users') . ' AS ' . $db->qn('u'))
-			->join('LEFT', $db->qn('#__user_usergroup_map') . ' AS ' . $db->qn('map') . ' ON ' . $db->qn('map') . '.' . $db->qn('user_id') . ' = ' . $db->qn('u') . '.' . $db->qn('id'))
-			->join('LEFT', $db->qn('#__usergroups') . ' AS ' . $db->qn('g') . ' ON ' . $db->qn('map') . '.' . $db->qn('group_id') . ' = ' . $db->qn('g') . '.' . $db->qn('id'))
+			->from($db->qn('#__users', 'u'))
+			->join('LEFT', $db->qn('#__user_usergroup_map', 'map') . ' ON ' . $db->qn('map') . '.' . $db->qn('user_id') . ' = ' . $db->qn('u') . '.' . $db->qn('id'))
+			->join('LEFT', $db->qn('#__usergroups', 'g') . ' ON ' . $db->qn('map') . '.' . $db->qn('group_id') . ' = ' . $db->qn('g') . '.' . $db->qn('id'))
 			->where($db->qn('g') . '.' . $db->qn('title') . ' = ' . $db->q('Super Users'));
 
 		$db->setQuery($query);

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1187,11 +1187,11 @@ class InstallationModelLanguages extends JModelBase
 		// Select the required fields from the updates table.
 		$query
 			->clear()
-			->select('u.id')
-			->from('#__users as u')
-			->join('LEFT', '#__user_usergroup_map AS map ON map.user_id = u.id')
-			->join('LEFT', '#__usergroups AS g ON map.group_id = g.id')
-			->where('g.title = ' . $db->q('Super Users'));
+			->select($db->qn('u') . '.' . $db->qn('id'))
+			->from($db->qn('#__users') . ' AS ' . $db->qn('u'))
+			->join('LEFT', $db->qn('#__user_usergroup_map') . ' AS ' . $db->qn('map') . ' ON ' . $db->qn('map') . '.' . $db->qn('user_id') . ' = ' . $db->qn('u') . '.' . $db->qn('id'))
+			->join('LEFT', $db->qn('#__usergroups') . ' AS ' . $db->qn('g') . ' ON ' . $db->qn('map') . '.' . $db->qn('group_id') . ' = ' . $db->qn('g') . '.' . $db->qn('id'))
+			->where($db->qn('g') . '.' . $db->qn('title') . ' = ' . $db->q('Super Users'));
 
 		$db->setQuery($query);
 		$id = $db->loadResult();

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1197,7 +1197,8 @@ class InstallationModelLanguages extends JModelBase
 			->join(
 				'LEFT', $db->qn('#__usergroups', 'g')
 				. ' ON ' . $db->qn('map') . '.' . $db->qn('group_id')
-				. ' = ' . $db->qn('g') . '.' . $db->qn('id'))
+				. ' = ' . $db->qn('g') . '.' . $db->qn('id')
+			)
 			->where(
 				$db->qn('g') . '.' . $db->qn('title')
 				. ' = ' . $db->q('Super Users')

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1189,10 +1189,8 @@ class InstallationModelLanguages extends JModelBase
 			->clear()
 			->select($db->quoteName('u.id'))
 			->from($db->quoteName('#__users') . ' AS u')
-			->join('LEFT', $db->quoteName('#__user_usergroup_map')
-				. ' AS map ON ' . $db->quoteName('map.user_id') . ' = ' . $db->quoteName('u.id'))
-			->join('LEFT', $db->quoteName('#__usergroups')
-				. ' AS g ON ' . $db->quoteName('map.group_id') . ' = ' . $db->quoteName('g.id'))
+			->join('LEFT', $db->quoteName('#__user_usergroup_map') . ' AS map ON ' . $db->quoteName('map.user_id') . ' = ' . $db->quoteName('u.id'))
+			->join('LEFT', $db->quoteName('#__usergroups') . ' AS g ON ' . $db->quoteName('map.group_id') . ' = ' . $db->quoteName('g.id'))
 			->where($db->quoteName('g.title') . ' = ' . $db->quote('Super Users'));
 
 		$db->setQuery($query);


### PR DESCRIPTION
Replaced hard-coded use of extension id 600 by a query for the en-Gb language pack and added quoteName wherever it was missing in the (optional) additional languages installation step of the installation process (installation/model/languages.php).

This is the last place where the hard-coded extension id 600 is used. With this PR we get rid of this.

The change for this is similar as done for the com_installer with PR #5327 .
## Testing:

There should be no change, all should work as before ;-)

Details:

Perform a new installation of a Joomla! with the changed file from here in the installation/model folder.

A the (normally final) step after the installation has finished, do **NOT** press the button to delete the installation folder.

**Instead of this, choose the optional step for installing additional languages** (button on the right hand side) and go through the language installation, i.e. install some additional language and adjust some of the languages-related setting in the following step.

Then at the end, delete the installation folder on the last page and login to the admin interface.

Verify that additional languages have been installed and changed settings have been applied.

If all this works as it does without this PR, then all is fine.
