### PR TITLE
Smart Search - Corrects the ordering of loaded JS files ...

### DIFF
--- a/administrator/components/com_finder/views/indexer/view.html.php
+++ b/administrator/components/com_finder/views/indexer/view.html.php
@@ -27,10 +27,9 @@ class FinderViewIndexer extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		JHtml::_('behavior.framework');
 		JHtml::_('stylesheet', 'com_finder/indexer.css', false, true, false);
-		JHtml::_('script', 'com_finder/indexer.js', false, true);
 		JHtml::_('jquery.framework');
+		JHtml::_('script', 'com_finder/indexer.js', false, true);
 		JHtml::_('script', 'system/progressbar.js', true, true);
 
 		parent::display();


### PR DESCRIPTION
 ... and removes the explicit loading of Mootools (loaded automatically by progressbar.js call)

Jquery has to be loaded before indexer.js and Mootools doesn't have to be loaded explicitly because it is loaded automatically. (We should remove the dependency of Mootools in progressbar.js in another PR)

How to test?

Apply this PR and run the indexer in the finder component (Smart Search). Everything should run properly and the items indexed properly.
