### PR TITLE
Improved HTML parser for Smart Search

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -69,7 +69,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 	protected function process($input)
 	{
 		// Replace any amount of white space with a single space.
-		$input = trim(preg_replace('#\s+#u', ' ', $input));
+		$input = preg_replace('#\s+#u', ' ', $input);
 
 		return $input;
 	}
@@ -117,6 +117,8 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 			// If no corresponding end tag, leave the string alone.
 			if ($end === false)
 			{
+				// Fix the offset so part of the string is not duplicated.
+				$offset = $start;
 				break;
 			}
 

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -19,6 +19,45 @@ JLoader::register('FinderIndexerParser', dirname(__DIR__) . '/parser.php');
 class FinderIndexerParserHtml extends FinderIndexerParser
 {
 	/**
+	 * Method to parse input and extract the plain text. Because this method is
+	 * called from both inside and outside the indexer, it needs to be able to
+	 * batch out its parsing functionality to deal with the inefficiencies of
+	 * regular expressions. We will parse recursively in 2KB chunks.
+	 *
+	 * @param   string  $input  The input to parse.
+	 *
+	 * @return  string  The plain text input.
+	 *
+	 * @since   2.5
+	 */
+	public function parse($input)
+	{
+		// Strip invalid UTF-8 characters.
+		$input = iconv("utf-8", "utf-8//IGNORE", $input);
+
+		// Convert <style> tags to <script> tags so we can remove them efficiently.
+		$input = str_replace(array('<style', '</style'), array('<script', '</script'), $input);
+
+		// Strip all script blocks.
+		$input = $this->removeBlocks($input, '<script', '</script>');
+
+		// Decode HTML entities.
+		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
+
+		// Convert entities equivalent to spaces to actual spaces.
+		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
+
+		// This fixes issues such as '<h1>Title</h1><p>Paragraph</p>'
+		// being transformed into 'TitleParagraph' with no space.
+		$input = str_replace('>', '> ', $input);
+
+		// Strip HTML tags.
+		$input = strip_tags($input);
+
+		return parent::parse($input);
+	}
+
+	/**
 	 * Method to process HTML input and extract the plain text.
 	 *
 	 * @param   string  $input  The input to process.
@@ -29,34 +68,68 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 	 */
 	protected function process($input)
 	{
-		// Strip invalid UTF-8 characters.
-		$input = iconv("utf-8", "utf-8//IGNORE", $input);
-
-		// Strip all script tags.
-		$input = preg_replace('#<script[^>]*>.*?</script>#si', ' ', $input);
-
-		// Strip the tags from the input
-		$input = strip_tags($input);
-
-		// Deal with spacing issues in the input
-		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
-		$input = trim(preg_replace('#\s+#u', ' ', $input));
-
-		// Remove last parts of HTML code which may be caused by a cut of the string
-		if (strpos($input, '>') !== false)
-		{
-			$input = substr($input, strpos($input, '>') + 1);
-		}
-
-		if (strpos($input, '<') !== false)
-		{
-			$input = substr($input, 0, strpos($input, '<'));
-		}
-
-		// Decode entities and remove unneeded white spaces
-		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
+		// Replace any amount of white space with a single space.
 		$input = trim(preg_replace('#\s+#u', ' ', $input));
 
 		return $input;
+	}
+
+	/**
+	 * Method to remove blocks of text between a start and an end tag.
+	 * Each block removed is effectively replaced by a single space.
+	 *
+	 * Note: The start tag and the end tag must be different.
+	 * Note: Blocks must not be nested.
+	 * Note: This method will function correctly with multi-byte strings.
+	 *
+	 * @param   string  $input     String to be processed.
+	 * @param   string  $startTag  String representing the start tag.
+	 * @param   string  $endTag    String representing the end tag.
+	 *
+	 * @return  string with blocks removed.
+	 */
+	private function removeBlocks($input, $startTag, $endTag)
+	{
+		$return = '';
+		$blocks = array();
+		$offset = 0;
+		$startTagLength = strlen($startTag);
+		$endTagLength = strlen($endTag);
+
+		// Find the first start tag.
+		$start = stripos($input, $startTag);
+
+		// If no start tags were found, return the string unchanged.
+		if ($start === false)
+		{
+			return $input;
+		}
+
+		// Look for all blocks defined by the start and end tags.
+		while ($start !== false)
+		{
+			// Accumulate the substring up to the start tag.
+			$return .= substr($input, $offset, $start - $offset) . ' ';
+
+			// Look for an end tag corresponding to the start tag.
+			$end = stripos($input, $endTag, $start + $startTagLength);
+
+			// If no corresponding end tag, leave the string alone.
+			if ($end === false)
+			{
+				break;
+			}
+
+			// Advance the start position.
+			$offset = $end + $endTagLength;
+
+			// Look for the next start tag and loop.
+			$start = stripos($input, $startTag, $offset);
+		}
+
+		// Add in the final substring after the last end tag.
+		$return .= substr($input, $offset);
+
+		return $return;
 	}
 }


### PR DESCRIPTION
This PR fixes several known issues with the HTML parser used by Smart Search.  Most of the issues result from breaking the input string into 2Kb chunks to improve performance when saving large articles.

In particular
1. Correctly removes HTML tags even when part of the tag (usually a tag which has attributes) crosses the 2Kb boundary.
2. Correctly removes script blocks even when the block crosses the 2Kb boundary.
3. Removes embedded style blocks.
4. Also incorporates the fix from PR #5206 from @smanzi.

To test this PR
1. Make sure that Smart Search is setup and working.
2. Make sure you can save embedded JavaScript and stylesheet blocks: you might need to adjust your input filter settings and/or change your default editor to "none" in order to do this.
3. Create an article and enter some text then save it.
4. Check that the words in the article have been indexed (the quickest way to do this is to use the auto-completion feature on the front-end search forms).
5. Check that none of the HTML tag names or any words contained in attributes of the HTML tags, have been indexed.
6. Try to embed some JavaScript and check that none of the words contained in the JavaScript code have been indexed.  You don't need to use real JavaScript to do this; just use some dummy text.
7. Try to embed some stylesheet declarations and check that none of the stylesheet keywords have been indexed.  You don't need to use real CSS to do this; just use some dummy text.
8. If you're really clever you can try the same tests with the words or embedded blocks crossing a 2Kb boundary.  
