### PR TITLE
Fixing tag routing

### DIFF
--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -31,7 +31,6 @@ class TagsRouter extends JComponentRouterBase
 
 		// Get a menu item based on Itemid or currently active
 		$params		= JComponentHelper::getParams('com_tags');
-		$advanced	= $params->get('sef_advanced_link', 0);
 
 		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid']))
@@ -51,44 +50,33 @@ class TagsRouter extends JComponentRouterBase
 			JArrayHelper::toInteger($mId);
 		}
 
+		$view = '';
 		if (isset($query['view']))
 		{
 			$view = $query['view'];
 
 			if (empty($query['Itemid']))
 			{
-				$segments[] = $query['view'];
+				$segments[] = $view;
 			}
 
 			unset($query['view']);
 		}
 
 		// Are we dealing with a tag that is attached to a menu item?
-		if (isset($view) && ($mView == $view) and (isset($query['id'])) and ($mId == $query['id']))
+		if ($mView == $view && isset($query['id']) && $mId == $query['id'])
 		{
-			unset($query['view']);
 			unset($query['id']);
-
 			return $segments;
 		}
 
 		if (isset($view) and $view == 'tag')
 		{
-			if ($mId != (int) $query['id'] || $mView != $view)
+			if (($mId != (int) $query['id'] || $mView != $view) && $view == 'tag')
 			{
-				if ($view == 'tag')
-				{
-					if ($advanced)
-					{
-						list($tmp, $id) = explode(':', $query['id'], 2);
-					}
-					else
-					{
-						$id = $query['id'];
-					}
-
-					$segments[] = $id;
-				}
+				// ID in com_tags can be either an integer, a string or an array of IDs
+				$id = is_array($query['id']) ? implode(',', $query['id']) : $query['id'];
+				$segments[] = $id;
 			}
 
 			unset($query['id']);
@@ -96,21 +84,13 @@ class TagsRouter extends JComponentRouterBase
 
 		if (isset($query['layout']))
 		{
-			if (!empty($query['Itemid']) && isset($menuItem->query['layout']))
+			if ((!empty($query['Itemid']) && isset($menuItem->query['layout'])
+				&& $query['layout'] == $menuItem->query['layout'])
+				|| $query['layout'] == 'default')
 			{
-				if ($query['layout'] == $menuItem->query['layout'])
-				{
-					unset($query['layout']);
-				}
+				unset($query['layout']);
 			}
-			else
-			{
-				if ($query['layout'] == 'default')
-				{
-					unset($query['layout']);
-				}
-			}
-		};
+		}
 
 		$total = count($segments);
 
@@ -159,27 +139,8 @@ class TagsRouter extends JComponentRouterBase
 		// From the tags view, we can only jump to a tag.
 		$id = (isset($item->query['id']) && $item->query['id'] > 1) ? $item->query['id'] : 'root';
 
-		$found = 0;
-
-		/*
-		 * TODO: Sort this code out. Makes no sense!
-		 * $found isn't used.
-		 * The foreach loop will always break in first itteration
-		 */
-		foreach ($segments as $segment)
-		{
-			if ($found == 0)
-			{
-				$id = $segment;
-			}
-
-			$vars['id'] = $id;
-			$vars['view'] = 'tag';
-
-			break;
-		}
-
-		$found = 0;
+		$vars['id'] = $segments[0];
+		$vars['view'] = 'tag';
 
 		return $vars;
 	}


### PR DESCRIPTION
This is an improved and complete fix of #4971. Copying the testing instructions to here:
#### Steps to reproduce the issue

Install Joomla (Test English (GB) Sample Data), for example
From the backend set the configuration ‘Search Engine Friendly URLs’ = ‘YES’
Use the url: index.php?option=com_tags&view=tag&layout=list&id[0]=3 (not sef url into a sef one. The id can have another value and NO Itemid has to be set)

You will have 3 times the error:
Notice: Array to string conversion in /libraries/cms/router/site.php on line 465

The proposal to fix is to replace
 $id = $query['id'];
 with
 $id = (int) $query['id'];
 which seems coherent with the test line 80
#### Expected result

No error
#### Actual result

Notice: Array to string conversion in /libraries/cms/router/site.php on line 465
#### System information (as much as possible)

Joomla 3.3.6

I further cleaned up the router. Basically it should work the same as before, except that that notice is gone. And we have quite a bit less code. :wink: 
