### PR TITLE
Remove some admin codestyle excemptions

### DIFF
--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -44,7 +44,7 @@ class ModulesController extends JControllerLegacy
 			if ($model = new ModulesModelModule)
 			{
 				// Checkin table entry
-				if(!$model->checkout($id))
+				if (!$model->checkout($id))
 				{
 					JFactory::getApplication()->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), 'error');
 					return false;

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -109,9 +109,9 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_newsfeeds') &&
-			$user->authorise('core.edit', 'com_newsfeeds') &&
-			$user->authorise('core.edit.state', 'com_newsfeeds'))
+		if ($user->authorise('core.create', 'com_newsfeeds')
+			&& $user->authorise('core.edit', 'com_newsfeeds')
+			&& $user->authorise('core.edit.state', 'com_newsfeeds'))
 		{
 			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -87,7 +87,6 @@
 
  <rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
  <!-- These exceptions are temporary -->
-  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
@@ -151,18 +150,12 @@
  <rule ref="Joomla.WhiteSpace.ConcatenationSpacing">
   <!-- We only want this for libraries, language and cli for now -->
   <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <exclude-pattern type="relative">components/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
   <exclude-pattern type="relative">layouts/*</exclude-pattern>
-  <exclude-pattern type="relative">includes/*</exclude-pattern>
  </rule>
 
  <rule ref="Joomla.ControlStructures.ControlSignature">
-  <!-- We only want this for libraries, languages and cli for now -->
-  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
-  <exclude-pattern type="relative">includes/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
@@ -171,8 +164,6 @@
  </rule>
 
  <rule ref="Joomla.ControlStructures.InlineControlStructure">
-  <!-- These exceptions are temporary -->
-  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>
@@ -181,9 +172,6 @@
  </rule>
 
  <rule ref="Joomla.ControlStructures.MultiLineCondition">
-  <!-- We only want this for libraries, language and cli for now -->
-  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-  <exclude-pattern type="relative">administrator/includes/framework.php</exclude-pattern>
   <!-- These exceptions are permanent -->
   <exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
   <exclude-pattern type="relative">templates/*</exclude-pattern>


### PR DESCRIPTION
This removes a bunch more admin codestyle excemptions that we can now run. It also fixes two minor issues in order to allow this to happen.
