### PR TITLE
JTable::getInstance('Tag', 'TagsTable'); fails in JHelperTags - include path not set

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -675,6 +675,7 @@ class JHelperTags extends JHelper
 	public function getTagTreeArray($id, &$tagTreeArray = array())
 	{
 		// Get a level row instance.
+		JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tags/tables');
 		$table = JTable::getInstance('Tag', 'TagsTable');
 
 		if ($table->isLeaf($id))


### PR DESCRIPTION
When using getTagItemsQuery() in JHelperTags you can specify whether or not to include_children. Setting this to 'true' ends up in a call to getTagTreeArray() (line 511), whereby an attempt is made to instantiate an JTable object (line 642). However, as the include path isn't updated to include the necessary tables folder this fails, and calling the isLeaf() method (line 644) on the supposed JTable results in:

Fatal error: Call to a member function isLeaf() on a non-object in /home/account/public_html/libraries/cms/helper/tags.php on line 647

I think the fix is just to update the include path before the instantiation - tried it on my J! 3.3.6 install and the error disappears.
