### PR TITLE
Fix the quoting on type_alias

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -595,15 +595,14 @@ class JHelperTags extends JHelper
 		// Get the type data, limited to types in the request if there are any specified.
 		$typesarray = self::getTypes('assocList', $typesr, false);
 
-		$typeAliases = '';
+		$typeAliases = array();
 
 		foreach ($typesarray as $type)
 		{
-			$typeAliases .= "'" . $type['type_alias'] . "'" . ',';
+			$typeAliases[] = $db->quote($type['type_alias']);
 		}
 
-		$typeAliases = rtrim($typeAliases, ',');
-		$query->where('m.type_alias IN (' . $typeAliases . ')');
+		$query->where('m.type_alias IN (' . implode(',', $typeAliases) . ')');
 
 		$groups = '0,' . implode(',', array_unique($user->getAuthorisedViewLevels()));
 		$query->where('c.core_access IN (' . $groups . ')')


### PR DESCRIPTION
The manner in which the type_alias lookup is being assembled is rather lousy and has hardcoded `'` style quoting which is not database agnostic.  This PR cleans that mess up.
