### PR TITLE
Kill indexes

### DIFF
--- a/administrator/cache/index.html
+++ b/administrator/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/controllers/index.html
+++ b/administrator/components/com_admin/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/helpers/html/index.html
+++ b/administrator/components/com_admin/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/helpers/index.html
+++ b/administrator/components/com_admin/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/index.html
+++ b/administrator/components/com_admin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/models/forms/index.html
+++ b/administrator/components/com_admin/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/models/index.html
+++ b/administrator/components/com_admin/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/postinstall/index.html
+++ b/administrator/components/com_admin/postinstall/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/sql/index.html
+++ b/administrator/components/com_admin/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/sql/updates/index.html
+++ b/administrator/components/com_admin/sql/updates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/sql/updates/mysql/index.html
+++ b/administrator/components/com_admin/sql/updates/mysql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/sql/updates/postgresql/index.html
+++ b/administrator/components/com_admin/sql/updates/postgresql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/sql/updates/sqlazure/index.html
+++ b/administrator/components/com_admin/sql/updates/sqlazure/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/help/index.html
+++ b/administrator/components/com_admin/views/help/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/help/tmpl/index.html
+++ b/administrator/components/com_admin/views/help/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/index.html
+++ b/administrator/components/com_admin/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/profile/index.html
+++ b/administrator/components/com_admin/views/profile/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/profile/tmpl/index.html
+++ b/administrator/components/com_admin/views/profile/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/sysinfo/index.html
+++ b/administrator/components/com_admin/views/sysinfo/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_admin/views/sysinfo/tmpl/index.html
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_ajax/index.html
+++ b/administrator/components/com_ajax/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/controllers/index.html
+++ b/administrator/components/com_banners/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/helpers/html/index.html
+++ b/administrator/components/com_banners/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/helpers/index.html
+++ b/administrator/components/com_banners/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/index.html
+++ b/administrator/components/com_banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/models/fields/index.html
+++ b/administrator/components/com_banners/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/models/forms/index.html
+++ b/administrator/components/com_banners/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/models/index.html
+++ b/administrator/components/com_banners/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/sql/index.html
+++ b/administrator/components/com_banners/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/tables/index.html
+++ b/administrator/components/com_banners/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/banner/index.html
+++ b/administrator/components/com_banners/views/banner/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/banner/tmpl/index.html
+++ b/administrator/components/com_banners/views/banner/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/banners/index.html
+++ b/administrator/components/com_banners/views/banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/banners/tmpl/index.html
+++ b/administrator/components/com_banners/views/banners/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/client/index.html
+++ b/administrator/components/com_banners/views/client/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/client/tmpl/index.html
+++ b/administrator/components/com_banners/views/client/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/clients/index.html
+++ b/administrator/components/com_banners/views/clients/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/clients/tmpl/index.html
+++ b/administrator/components/com_banners/views/clients/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/download/index.html
+++ b/administrator/components/com_banners/views/download/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/download/tmpl/index.html
+++ b/administrator/components/com_banners/views/download/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/index.html
+++ b/administrator/components/com_banners/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/tracks/index.html
+++ b/administrator/components/com_banners/views/tracks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_banners/views/tracks/tmpl/index.html
+++ b/administrator/components/com_banners/views/tracks/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/helpers/index.html
+++ b/administrator/components/com_cache/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/index.html
+++ b/administrator/components/com_cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/models/index.html
+++ b/administrator/components/com_cache/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/views/cache/index.html
+++ b/administrator/components/com_cache/views/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/views/cache/tmpl/index.html
+++ b/administrator/components/com_cache/views/cache/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/views/index.html
+++ b/administrator/components/com_cache/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/views/purge/index.html
+++ b/administrator/components/com_cache/views/purge/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cache/views/purge/tmpl/index.html
+++ b/administrator/components/com_cache/views/purge/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/controllers/index.html
+++ b/administrator/components/com_categories/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/helpers/html/index.html
+++ b/administrator/components/com_categories/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/helpers/index.html
+++ b/administrator/components/com_categories/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/index.html
+++ b/administrator/components/com_categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/models/fields/index.html
+++ b/administrator/components/com_categories/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/models/fields/modal/index.html
+++ b/administrator/components/com_categories/models/fields/modal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/models/forms/index.html
+++ b/administrator/components/com_categories/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/models/index.html
+++ b/administrator/components/com_categories/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/tables/index.html
+++ b/administrator/components/com_categories/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/views/categories/index.html
+++ b/administrator/components/com_categories/views/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/views/categories/tmpl/index.html
+++ b/administrator/components/com_categories/views/categories/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/views/category/index.html
+++ b/administrator/components/com_categories/views/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/views/category/tmpl/index.html
+++ b/administrator/components/com_categories/views/category/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_categories/views/index.html
+++ b/administrator/components/com_categories/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_checkin/index.html
+++ b/administrator/components/com_checkin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_checkin/models/index.html
+++ b/administrator/components/com_checkin/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_checkin/views/checkin/index.html
+++ b/administrator/components/com_checkin/views/checkin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_checkin/views/checkin/tmpl/index.html
+++ b/administrator/components/com_checkin/views/checkin/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_checkin/views/index.html
+++ b/administrator/components/com_checkin/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/controller/application/index.html
+++ b/administrator/components/com_config/controller/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/controller/component/index.html
+++ b/administrator/components/com_config/controller/component/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/controllers/index.html
+++ b/administrator/components/com_config/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/helper/index.html
+++ b/administrator/components/com_config/helper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/index.html
+++ b/administrator/components/com_config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/model/field/index.html
+++ b/administrator/components/com_config/model/field/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/model/form/index.html
+++ b/administrator/components/com_config/model/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/model/index.html
+++ b/administrator/components/com_config/model/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/models/index.html
+++ b/administrator/components/com_config/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/view/application/index.html
+++ b/administrator/components/com_config/view/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/view/application/tmpl/index.html
+++ b/administrator/components/com_config/view/application/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/view/component/index.html
+++ b/administrator/components/com_config/view/component/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/view/component/tmpl/index.html
+++ b/administrator/components/com_config/view/component/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_config/view/index.html
+++ b/administrator/components/com_config/view/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/controllers/index.html
+++ b/administrator/components/com_contact/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/helpers/html/index.html
+++ b/administrator/components/com_contact/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/helpers/index.html
+++ b/administrator/components/com_contact/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/index.html
+++ b/administrator/components/com_contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/models/fields/index.html
+++ b/administrator/components/com_contact/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/models/fields/modal/index.html
+++ b/administrator/components/com_contact/models/fields/modal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/models/forms/index.html
+++ b/administrator/components/com_contact/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/models/index.html
+++ b/administrator/components/com_contact/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/sql/index.html
+++ b/administrator/components/com_contact/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/tables/index.html
+++ b/administrator/components/com_contact/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/views/contact/index.html
+++ b/administrator/components/com_contact/views/contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/views/contact/tmpl/index.html
+++ b/administrator/components/com_contact/views/contact/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/views/contacts/index.html
+++ b/administrator/components/com_contact/views/contacts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/views/contacts/tmpl/index.html
+++ b/administrator/components/com_contact/views/contacts/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contact/views/index.html
+++ b/administrator/components/com_contact/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/controllers/index.html
+++ b/administrator/components/com_content/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/helpers/html/index.html
+++ b/administrator/components/com_content/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/helpers/index.html
+++ b/administrator/components/com_content/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/index.html
+++ b/administrator/components/com_content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/models/fields/index.html
+++ b/administrator/components/com_content/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/models/fields/modal/index.html
+++ b/administrator/components/com_content/models/fields/modal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/models/forms/index.html
+++ b/administrator/components/com_content/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/models/index.html
+++ b/administrator/components/com_content/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/tables/index.html
+++ b/administrator/components/com_content/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/article/index.html
+++ b/administrator/components/com_content/views/article/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/article/tmpl/index.html
+++ b/administrator/components/com_content/views/article/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/articles/index.html
+++ b/administrator/components/com_content/views/articles/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/articles/tmpl/index.html
+++ b/administrator/components/com_content/views/articles/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/featured/index.html
+++ b/administrator/components/com_content/views/featured/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/featured/tmpl/index.html
+++ b/administrator/components/com_content/views/featured/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_content/views/index.html
+++ b/administrator/components/com_content/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/controllers/index.html
+++ b/administrator/components/com_contenthistory/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/helpers/html/index.html
+++ b/administrator/components/com_contenthistory/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/helpers/index.html
+++ b/administrator/components/com_contenthistory/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/index.html
+++ b/administrator/components/com_contenthistory/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/models/index.html
+++ b/administrator/components/com_contenthistory/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/compare/index.html
+++ b/administrator/components/com_contenthistory/views/compare/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/compare/tmpl/index.html
+++ b/administrator/components/com_contenthistory/views/compare/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/history/index.html
+++ b/administrator/components/com_contenthistory/views/history/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/history/tmpl/index.html
+++ b/administrator/components/com_contenthistory/views/history/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/index.html
+++ b/administrator/components/com_contenthistory/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/preview/index.html
+++ b/administrator/components/com_contenthistory/views/preview/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_contenthistory/views/preview/tmpl/index.html
+++ b/administrator/components/com_contenthistory/views/preview/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cpanel/index.html
+++ b/administrator/components/com_cpanel/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cpanel/views/cpanel/index.html
+++ b/administrator/components/com_cpanel/views/cpanel/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cpanel/views/cpanel/tmpl/index.html
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_cpanel/views/index.html
+++ b/administrator/components/com_cpanel/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/controllers/index.html
+++ b/administrator/components/com_finder/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/html/index.html
+++ b/administrator/components/com_finder/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/index.html
+++ b/administrator/components/com_finder/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/indexer/driver/index.html
+++ b/administrator/components/com_finder/helpers/indexer/driver/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/indexer/index.html
+++ b/administrator/components/com_finder/helpers/indexer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/indexer/parser/index.html
+++ b/administrator/components/com_finder/helpers/indexer/parser/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/helpers/indexer/stemmer/index.html
+++ b/administrator/components/com_finder/helpers/indexer/stemmer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/index.html
+++ b/administrator/components/com_finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/models/fields/index.html
+++ b/administrator/components/com_finder/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/models/forms/index.html
+++ b/administrator/components/com_finder/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/models/index.html
+++ b/administrator/components/com_finder/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/sql/index.html
+++ b/administrator/components/com_finder/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/tables/index.html
+++ b/administrator/components/com_finder/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/filter/index.html
+++ b/administrator/components/com_finder/views/filter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/filter/tmpl/index.html
+++ b/administrator/components/com_finder/views/filter/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/filters/index.html
+++ b/administrator/components/com_finder/views/filters/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/filters/tmpl/index.html
+++ b/administrator/components/com_finder/views/filters/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/index.html
+++ b/administrator/components/com_finder/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/index/index.html
+++ b/administrator/components/com_finder/views/index/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/index/tmpl/index.html
+++ b/administrator/components/com_finder/views/index/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/indexer/index.html
+++ b/administrator/components/com_finder/views/indexer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/indexer/tmpl/index.html
+++ b/administrator/components/com_finder/views/indexer/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/maps/index.html
+++ b/administrator/components/com_finder/views/maps/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/maps/tmpl/index.html
+++ b/administrator/components/com_finder/views/maps/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/statistics/index.html
+++ b/administrator/components/com_finder/views/statistics/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_finder/views/statistics/tmpl/index.html
+++ b/administrator/components/com_finder/views/statistics/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/controllers/index.html
+++ b/administrator/components/com_installer/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/helpers/html/index.html
+++ b/administrator/components/com_installer/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/helpers/index.html
+++ b/administrator/components/com_installer/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/index.html
+++ b/administrator/components/com_installer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/models/index.html
+++ b/administrator/components/com_installer/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/database/index.html
+++ b/administrator/components/com_installer/views/database/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/database/tmpl/index.html
+++ b/administrator/components/com_installer/views/database/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/default/index.html
+++ b/administrator/components/com_installer/views/default/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/default/tmpl/index.html
+++ b/administrator/components/com_installer/views/default/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/discover/index.html
+++ b/administrator/components/com_installer/views/discover/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/discover/tmpl/index.html
+++ b/administrator/components/com_installer/views/discover/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/index.html
+++ b/administrator/components/com_installer/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/install/index.html
+++ b/administrator/components/com_installer/views/install/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/install/tmpl/index.html
+++ b/administrator/components/com_installer/views/install/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/languages/index.html
+++ b/administrator/components/com_installer/views/languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/languages/tmpl/index.html
+++ b/administrator/components/com_installer/views/languages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/manage/index.html
+++ b/administrator/components/com_installer/views/manage/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/manage/tmpl/index.html
+++ b/administrator/components/com_installer/views/manage/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/update/index.html
+++ b/administrator/components/com_installer/views/update/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/update/tmpl/index.html
+++ b/administrator/components/com_installer/views/update/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/updatesites/index.html
+++ b/administrator/components/com_installer/views/updatesites/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/updatesites/tmpl/index.html
+++ b/administrator/components/com_installer/views/updatesites/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/warnings/index.html
+++ b/administrator/components/com_installer/views/warnings/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_installer/views/warnings/tmpl/index.html
+++ b/administrator/components/com_installer/views/warnings/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/controllers/index.html
+++ b/administrator/components/com_joomlaupdate/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/helpers/index.html
+++ b/administrator/components/com_joomlaupdate/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/index.html
+++ b/administrator/components/com_joomlaupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/models/index.html
+++ b/administrator/components/com_joomlaupdate/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/views/default/index.html
+++ b/administrator/components/com_joomlaupdate/views/default/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/index.html
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/views/index.html
+++ b/administrator/components/com_joomlaupdate/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/views/update/index.html
+++ b/administrator/components/com_joomlaupdate/views/update/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_joomlaupdate/views/update/tmpl/index.html
+++ b/administrator/components/com_joomlaupdate/views/update/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/controllers/index.html
+++ b/administrator/components/com_languages/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/helpers/html/index.html
+++ b/administrator/components/com_languages/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/helpers/index.html
+++ b/administrator/components/com_languages/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/index.html
+++ b/administrator/components/com_languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/models/forms/index.html
+++ b/administrator/components/com_languages/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/models/index.html
+++ b/administrator/components/com_languages/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/index.html
+++ b/administrator/components/com_languages/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/installed/index.html
+++ b/administrator/components/com_languages/views/installed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/installed/tmpl/index.html
+++ b/administrator/components/com_languages/views/installed/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/language/index.html
+++ b/administrator/components/com_languages/views/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/language/tmpl/index.html
+++ b/administrator/components/com_languages/views/language/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/languages/index.html
+++ b/administrator/components/com_languages/views/languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/languages/tmpl/index.html
+++ b/administrator/components/com_languages/views/languages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/multilangstatus/index.html
+++ b/administrator/components/com_languages/views/multilangstatus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/multilangstatus/tmpl/index.html
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/override/index.html
+++ b/administrator/components/com_languages/views/override/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/override/tmpl/index.html
+++ b/administrator/components/com_languages/views/override/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/overrides/index.html
+++ b/administrator/components/com_languages/views/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_languages/views/overrides/tmpl/index.html
+++ b/administrator/components/com_languages/views/overrides/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_login/index.html
+++ b/administrator/components/com_login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_login/models/index.html
+++ b/administrator/components/com_login/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_login/views/index.html
+++ b/administrator/components/com_login/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_login/views/login/index.html
+++ b/administrator/components/com_login/views/login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_login/views/login/tmpl/index.html
+++ b/administrator/components/com_login/views/login/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/controllers/index.html
+++ b/administrator/components/com_media/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/helpers/index.html
+++ b/administrator/components/com_media/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/index.html
+++ b/administrator/components/com_media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/layouts/index.html
+++ b/administrator/components/com_media/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/layouts/toolbar/index.html
+++ b/administrator/components/com_media/layouts/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/models/forms/index.html
+++ b/administrator/components/com_media/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/models/index.html
+++ b/administrator/components/com_media/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/images/index.html
+++ b/administrator/components/com_media/views/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/images/tmpl/index.html
+++ b/administrator/components/com_media/views/images/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/imageslist/index.html
+++ b/administrator/components/com_media/views/imageslist/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/imageslist/tmpl/index.html
+++ b/administrator/components/com_media/views/imageslist/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/index.html
+++ b/administrator/components/com_media/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/media/index.html
+++ b/administrator/components/com_media/views/media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/media/tmpl/index.html
+++ b/administrator/components/com_media/views/media/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/medialist/index.html
+++ b/administrator/components/com_media/views/medialist/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/views/medialist/tmpl/index.html
+++ b/administrator/components/com_media/views/medialist/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/controllers/index.html
+++ b/administrator/components/com_menus/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/helpers/html/index.html
+++ b/administrator/components/com_menus/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/helpers/index.html
+++ b/administrator/components/com_menus/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/index.html
+++ b/administrator/components/com_menus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/models/fields/index.html
+++ b/administrator/components/com_menus/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/models/forms/index.html
+++ b/administrator/components/com_menus/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/models/index.html
+++ b/administrator/components/com_menus/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/tables/index.html
+++ b/administrator/components/com_menus/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/index.html
+++ b/administrator/components/com_menus/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/item/index.html
+++ b/administrator/components/com_menus/views/item/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/item/tmpl/index.html
+++ b/administrator/components/com_menus/views/item/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/items/index.html
+++ b/administrator/components/com_menus/views/items/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/items/tmpl/index.html
+++ b/administrator/components/com_menus/views/items/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/menu/index.html
+++ b/administrator/components/com_menus/views/menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/menu/tmpl/index.html
+++ b/administrator/components/com_menus/views/menu/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/menus/index.html
+++ b/administrator/components/com_menus/views/menus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/menus/tmpl/index.html
+++ b/administrator/components/com_menus/views/menus/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_menus/views/menutypes/index.html
+++ b/administrator/components/com_menus/views/menutypes/index.html
@@ -1,1 +1,0 @@
-<html><body></body></html>

--- a/administrator/components/com_menus/views/menutypes/tmpl/index.html
+++ b/administrator/components/com_menus/views/menutypes/tmpl/index.html
@@ -1,1 +1,0 @@
-<html><body></body></html>

--- a/administrator/components/com_messages/controllers/index.html
+++ b/administrator/components/com_messages/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/helpers/html/index.html
+++ b/administrator/components/com_messages/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/helpers/index.html
+++ b/administrator/components/com_messages/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/index.html
+++ b/administrator/components/com_messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/layouts/index.html
+++ b/administrator/components/com_messages/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/layouts/toolbar/index.html
+++ b/administrator/components/com_messages/layouts/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/models/fields/index.html
+++ b/administrator/components/com_messages/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/models/forms/index.html
+++ b/administrator/components/com_messages/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/models/index.html
+++ b/administrator/components/com_messages/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/tables/index.html
+++ b/administrator/components/com_messages/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/config/index.html
+++ b/administrator/components/com_messages/views/config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/config/tmpl/index.html
+++ b/administrator/components/com_messages/views/config/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/index.html
+++ b/administrator/components/com_messages/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/message/index.html
+++ b/administrator/components/com_messages/views/message/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/message/tmpl/index.html
+++ b/administrator/components/com_messages/views/message/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/messages/index.html
+++ b/administrator/components/com_messages/views/messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_messages/views/messages/tmpl/index.html
+++ b/administrator/components/com_messages/views/messages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/controllers/index.html
+++ b/administrator/components/com_modules/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/helpers/html/index.html
+++ b/administrator/components/com_modules/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/helpers/index.html
+++ b/administrator/components/com_modules/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/index.html
+++ b/administrator/components/com_modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/layouts/index.html
+++ b/administrator/components/com_modules/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/layouts/toolbar/index.html
+++ b/administrator/components/com_modules/layouts/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/models/forms/index.html
+++ b/administrator/components/com_modules/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/models/index.html
+++ b/administrator/components/com_modules/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/index.html
+++ b/administrator/components/com_modules/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/module/index.html
+++ b/administrator/components/com_modules/views/module/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/module/tmpl/index.html
+++ b/administrator/components/com_modules/views/module/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/modules/index.html
+++ b/administrator/components/com_modules/views/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/modules/tmpl/index.html
+++ b/administrator/components/com_modules/views/modules/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/positions/index.html
+++ b/administrator/components/com_modules/views/positions/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/positions/tmpl/index.html
+++ b/administrator/components/com_modules/views/positions/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/preview/index.html
+++ b/administrator/components/com_modules/views/preview/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/preview/tmpl/index.html
+++ b/administrator/components/com_modules/views/preview/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/select/index.html
+++ b/administrator/components/com_modules/views/select/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_modules/views/select/tmpl/index.html
+++ b/administrator/components/com_modules/views/select/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/controllers/index.html
+++ b/administrator/components/com_newsfeeds/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/helpers/html/index.html
+++ b/administrator/components/com_newsfeeds/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/helpers/index.html
+++ b/administrator/components/com_newsfeeds/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/index.html
+++ b/administrator/components/com_newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/models/fields/index.html
+++ b/administrator/components/com_newsfeeds/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/models/fields/modal/index.html
+++ b/administrator/components/com_newsfeeds/models/fields/modal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/models/forms/index.html
+++ b/administrator/components/com_newsfeeds/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/models/index.html
+++ b/administrator/components/com_newsfeeds/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/sql/index.html
+++ b/administrator/components/com_newsfeeds/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/tables/index.html
+++ b/administrator/components/com_newsfeeds/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/views/index.html
+++ b/administrator/components/com_newsfeeds/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/views/newsfeed/index.html
+++ b/administrator/components/com_newsfeeds/views/newsfeed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/index.html
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/index.html
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/index.html
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/controllers/index.html
+++ b/administrator/components/com_plugins/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/helpers/index.html
+++ b/administrator/components/com_plugins/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/index.html
+++ b/administrator/components/com_plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/models/fields/index.html
+++ b/administrator/components/com_plugins/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/models/forms/index.html
+++ b/administrator/components/com_plugins/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/models/index.html
+++ b/administrator/components/com_plugins/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/views/index.html
+++ b/administrator/components/com_plugins/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/views/plugin/index.html
+++ b/administrator/components/com_plugins/views/plugin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/views/plugin/tmpl/index.html
+++ b/administrator/components/com_plugins/views/plugin/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/views/plugins/index.html
+++ b/administrator/components/com_plugins/views/plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_plugins/views/plugins/tmpl/index.html
+++ b/administrator/components/com_plugins/views/plugins/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/controllers/index.html
+++ b/administrator/components/com_postinstall/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/index.html
+++ b/administrator/components/com_postinstall/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/models/index.html
+++ b/administrator/components/com_postinstall/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/views/index.html
+++ b/administrator/components/com_postinstall/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/views/messages/index.html
+++ b/administrator/components/com_postinstall/views/messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_postinstall/views/messages/tmpl/index.html
+++ b/administrator/components/com_postinstall/views/messages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/controllers/index.html
+++ b/administrator/components/com_redirect/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/helpers/html/index.html
+++ b/administrator/components/com_redirect/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/helpers/index.html
+++ b/administrator/components/com_redirect/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/index.html
+++ b/administrator/components/com_redirect/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/models/fields/index.html
+++ b/administrator/components/com_redirect/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/models/forms/index.html
+++ b/administrator/components/com_redirect/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/models/index.html
+++ b/administrator/components/com_redirect/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/tables/index.html
+++ b/administrator/components/com_redirect/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/views/index.html
+++ b/administrator/components/com_redirect/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/views/link/index.html
+++ b/administrator/components/com_redirect/views/link/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/views/link/tmpl/index.html
+++ b/administrator/components/com_redirect/views/link/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/views/links/index.html
+++ b/administrator/components/com_redirect/views/links/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_redirect/views/links/tmpl/index.html
+++ b/administrator/components/com_redirect/views/links/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/controllers/index.html
+++ b/administrator/components/com_search/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/helpers/index.html
+++ b/administrator/components/com_search/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/index.html
+++ b/administrator/components/com_search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/models/index.html
+++ b/administrator/components/com_search/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/views/index.html
+++ b/administrator/components/com_search/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/views/searches/index.html
+++ b/administrator/components/com_search/views/searches/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_search/views/searches/tmpl/index.html
+++ b/administrator/components/com_search/views/searches/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/controllers/index.html
+++ b/administrator/components/com_tags/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/helpers/html/index.html
+++ b/administrator/components/com_tags/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/helpers/index.html
+++ b/administrator/components/com_tags/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/index.html
+++ b/administrator/components/com_tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/models/fields/index.html
+++ b/administrator/components/com_tags/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/models/forms/index.html
+++ b/administrator/components/com_tags/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/models/index.html
+++ b/administrator/components/com_tags/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/tables/index.html
+++ b/administrator/components/com_tags/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/views/index.html
+++ b/administrator/components/com_tags/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/views/tag/index.html
+++ b/administrator/components/com_tags/views/tag/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/views/tag/tmpl/index.html
+++ b/administrator/components/com_tags/views/tag/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/views/tags/index.html
+++ b/administrator/components/com_tags/views/tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_tags/views/tags/tmpl/index.html
+++ b/administrator/components/com_tags/views/tags/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/controllers/index.html
+++ b/administrator/components/com_templates/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/helpers/html/index.html
+++ b/administrator/components/com_templates/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/helpers/index.html
+++ b/administrator/components/com_templates/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/index.html
+++ b/administrator/components/com_templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/models/forms/index.html
+++ b/administrator/components/com_templates/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/models/index.html
+++ b/administrator/components/com_templates/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/tables/index.html
+++ b/administrator/components/com_templates/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/index.html
+++ b/administrator/components/com_templates/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/style/index.html
+++ b/administrator/components/com_templates/views/style/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/style/tmpl/index.html
+++ b/administrator/components/com_templates/views/style/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/styles/index.html
+++ b/administrator/components/com_templates/views/styles/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/styles/tmpl/index.html
+++ b/administrator/components/com_templates/views/styles/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/template/index.html
+++ b/administrator/components/com_templates/views/template/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/template/tmpl/index.html
+++ b/administrator/components/com_templates/views/template/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/templates/index.html
+++ b/administrator/components/com_templates/views/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_templates/views/templates/tmpl/index.html
+++ b/administrator/components/com_templates/views/templates/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/controllers/index.html
+++ b/administrator/components/com_users/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/helpers/html/index.html
+++ b/administrator/components/com_users/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/helpers/index.html
+++ b/administrator/components/com_users/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/index.html
+++ b/administrator/components/com_users/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/models/fields/index.html
+++ b/administrator/components/com_users/models/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/models/forms/index.html
+++ b/administrator/components/com_users/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/models/index.html
+++ b/administrator/components/com_users/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/tables/index.html
+++ b/administrator/components/com_users/tables/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/debuggroup/index.html
+++ b/administrator/components/com_users/views/debuggroup/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/debuggroup/tmpl/index.html
+++ b/administrator/components/com_users/views/debuggroup/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/debuguser/index.html
+++ b/administrator/components/com_users/views/debuguser/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/debuguser/tmpl/index.html
+++ b/administrator/components/com_users/views/debuguser/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/group/index.html
+++ b/administrator/components/com_users/views/group/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/group/tmpl/index.html
+++ b/administrator/components/com_users/views/group/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/groups/index.html
+++ b/administrator/components/com_users/views/groups/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/groups/tmpl/index.html
+++ b/administrator/components/com_users/views/groups/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/index.html
+++ b/administrator/components/com_users/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/level/index.html
+++ b/administrator/components/com_users/views/level/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/level/tmpl/index.html
+++ b/administrator/components/com_users/views/level/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/levels/index.html
+++ b/administrator/components/com_users/views/levels/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/levels/tmpl/index.html
+++ b/administrator/components/com_users/views/levels/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/mail/index.html
+++ b/administrator/components/com_users/views/mail/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/mail/tmpl/index.html
+++ b/administrator/components/com_users/views/mail/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/note/index.html
+++ b/administrator/components/com_users/views/note/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/note/tmpl/index.html
+++ b/administrator/components/com_users/views/note/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/notes/index.html
+++ b/administrator/components/com_users/views/notes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/notes/tmpl/index.html
+++ b/administrator/components/com_users/views/notes/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/user/index.html
+++ b/administrator/components/com_users/views/user/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/user/tmpl/index.html
+++ b/administrator/components/com_users/views/user/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/users/index.html
+++ b/administrator/components/com_users/views/users/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_users/views/users/tmpl/index.html
+++ b/administrator/components/com_users/views/users/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/index.html
+++ b/administrator/components/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/help/en-GB/index.html
+++ b/administrator/help/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/help/index.html
+++ b/administrator/help/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/includes/index.html
+++ b/administrator/includes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/language/en-GB/index.html
+++ b/administrator/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/language/index.html
+++ b/administrator/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/language/overrides/index.html
+++ b/administrator/language/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/manifests/files/index.html
+++ b/administrator/manifests/files/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/manifests/index.html
+++ b/administrator/manifests/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/manifests/libraries/index.html
+++ b/administrator/manifests/libraries/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/manifests/packages/index.html
+++ b/administrator/manifests/packages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/index.html
+++ b/administrator/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_custom/index.html
+++ b/administrator/modules/mod_custom/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_custom/tmpl/index.html
+++ b/administrator/modules/mod_custom/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_feed/index.html
+++ b/administrator/modules/mod_feed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_feed/tmpl/index.html
+++ b/administrator/modules/mod_feed/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_latest/index.html
+++ b/administrator/modules/mod_latest/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_latest/tmpl/index.html
+++ b/administrator/modules/mod_latest/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_logged/index.html
+++ b/administrator/modules/mod_logged/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_logged/tmpl/index.html
+++ b/administrator/modules/mod_logged/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_login/index.html
+++ b/administrator/modules/mod_login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_login/tmpl/index.html
+++ b/administrator/modules/mod_login/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_menu/index.html
+++ b/administrator/modules/mod_menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_menu/tmpl/index.html
+++ b/administrator/modules/mod_menu/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_multilangstatus/index.html
+++ b/administrator/modules/mod_multilangstatus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_multilangstatus/language/en-GB/index.html
+++ b/administrator/modules/mod_multilangstatus/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_multilangstatus/language/index.html
+++ b/administrator/modules/mod_multilangstatus/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_multilangstatus/tmpl/index.html
+++ b/administrator/modules/mod_multilangstatus/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_popular/index.html
+++ b/administrator/modules/mod_popular/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_popular/tmpl/index.html
+++ b/administrator/modules/mod_popular/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_quickicon/index.html
+++ b/administrator/modules/mod_quickicon/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_quickicon/tmpl/index.html
+++ b/administrator/modules/mod_quickicon/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_stats_admin/index.html
+++ b/administrator/modules/mod_stats_admin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_stats_admin/language/index.html
+++ b/administrator/modules/mod_stats_admin/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_stats_admin/tmpl/index.html
+++ b/administrator/modules/mod_stats_admin/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_status/index.html
+++ b/administrator/modules/mod_status/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_status/tmpl/index.html
+++ b/administrator/modules/mod_status/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_submenu/index.html
+++ b/administrator/modules/mod_submenu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_submenu/tmpl/index.html
+++ b/administrator/modules/mod_submenu/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_title/index.html
+++ b/administrator/modules/mod_title/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_title/tmpl/index.html
+++ b/administrator/modules/mod_title/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_toolbar/index.html
+++ b/administrator/modules/mod_toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_toolbar/tmpl/index.html
+++ b/administrator/modules/mod_toolbar/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_version/index.html
+++ b/administrator/modules/mod_version/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_version/language/en-GB/index.html
+++ b/administrator/modules/mod_version/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_version/language/index.html
+++ b/administrator/modules/mod_version/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/modules/mod_version/tmpl/index.html
+++ b/administrator/modules/mod_version/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/css/index.html
+++ b/administrator/templates/hathor/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_admin/help/index.html
+++ b/administrator/templates/hathor/html/com_admin/help/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_admin/index.html
+++ b/administrator/templates/hathor/html/com_admin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_admin/profile/index.html
+++ b/administrator/templates/hathor/html/com_admin/profile/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_admin/sysinfo/index.html
+++ b/administrator/templates/hathor/html/com_admin/sysinfo/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/banner/index.html
+++ b/administrator/templates/hathor/html/com_banners/banner/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/banners/index.html
+++ b/administrator/templates/hathor/html/com_banners/banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/client/index.html
+++ b/administrator/templates/hathor/html/com_banners/client/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/clients/index.html
+++ b/administrator/templates/hathor/html/com_banners/clients/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/index.html
+++ b/administrator/templates/hathor/html/com_banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_banners/tracks/index.html
+++ b/administrator/templates/hathor/html/com_banners/tracks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_cache/cache/index.html
+++ b/administrator/templates/hathor/html/com_cache/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_cache/index.html
+++ b/administrator/templates/hathor/html/com_cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_cache/purge/index.html
+++ b/administrator/templates/hathor/html/com_cache/purge/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_categories/categories/index.html
+++ b/administrator/templates/hathor/html/com_categories/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_categories/category/index.html
+++ b/administrator/templates/hathor/html/com_categories/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_categories/index.html
+++ b/administrator/templates/hathor/html/com_categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_checkin/checkin/index.html
+++ b/administrator/templates/hathor/html/com_checkin/checkin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_checkin/index.html
+++ b/administrator/templates/hathor/html/com_checkin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_config/application/index.html
+++ b/administrator/templates/hathor/html/com_config/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_config/component/index.html
+++ b/administrator/templates/hathor/html/com_config/component/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_config/index.html
+++ b/administrator/templates/hathor/html/com_config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_contact/contact/index.html
+++ b/administrator/templates/hathor/html/com_contact/contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_contact/contacts/index.html
+++ b/administrator/templates/hathor/html/com_contact/contacts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_contact/index.html
+++ b/administrator/templates/hathor/html/com_contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_content/article/index.html
+++ b/administrator/templates/hathor/html/com_content/article/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_content/articles/index.html
+++ b/administrator/templates/hathor/html/com_content/articles/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_content/featured/index.html
+++ b/administrator/templates/hathor/html/com_content/featured/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_content/index.html
+++ b/administrator/templates/hathor/html/com_content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_cpanel/cpanel/index.html
+++ b/administrator/templates/hathor/html/com_cpanel/cpanel/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_cpanel/index.html
+++ b/administrator/templates/hathor/html/com_cpanel/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/filter/index.html
+++ b/administrator/templates/hathor/html/com_finder/filter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/filters/index.html
+++ b/administrator/templates/hathor/html/com_finder/filters/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/index.html
+++ b/administrator/templates/hathor/html/com_finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/index/index.html
+++ b/administrator/templates/hathor/html/com_finder/index/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/maps/index.html
+++ b/administrator/templates/hathor/html/com_finder/maps/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_finder/statistics/index.html
+++ b/administrator/templates/hathor/html/com_finder/statistics/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/database/index.html
+++ b/administrator/templates/hathor/html/com_installer/database/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/default/index.html
+++ b/administrator/templates/hathor/html/com_installer/default/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/discover/index.html
+++ b/administrator/templates/hathor/html/com_installer/discover/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/index.html
+++ b/administrator/templates/hathor/html/com_installer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/install/index.html
+++ b/administrator/templates/hathor/html/com_installer/install/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/languages/index.html
+++ b/administrator/templates/hathor/html/com_installer/languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/manage/index.html
+++ b/administrator/templates/hathor/html/com_installer/manage/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/update/index.html
+++ b/administrator/templates/hathor/html/com_installer/update/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_installer/warnings/index.html
+++ b/administrator/templates/hathor/html/com_installer/warnings/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_joomlaupdate/default/index.html
+++ b/administrator/templates/hathor/html/com_joomlaupdate/default/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_joomlaupdate/index.html
+++ b/administrator/templates/hathor/html/com_joomlaupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_languages/index.html
+++ b/administrator/templates/hathor/html/com_languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_languages/installed/index.html
+++ b/administrator/templates/hathor/html/com_languages/installed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_languages/languages/index.html
+++ b/administrator/templates/hathor/html/com_languages/languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_languages/overrides/index.html
+++ b/administrator/templates/hathor/html/com_languages/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/index.html
+++ b/administrator/templates/hathor/html/com_menus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/item/index.html
+++ b/administrator/templates/hathor/html/com_menus/item/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/items/index.html
+++ b/administrator/templates/hathor/html/com_menus/items/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/menu/index.html
+++ b/administrator/templates/hathor/html/com_menus/menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/menus/index.html
+++ b/administrator/templates/hathor/html/com_menus/menus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_menus/menutypes/index.html
+++ b/administrator/templates/hathor/html/com_menus/menutypes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_messages/index.html
+++ b/administrator/templates/hathor/html/com_messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_messages/message/index.html
+++ b/administrator/templates/hathor/html/com_messages/message/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_messages/messages/index.html
+++ b/administrator/templates/hathor/html/com_messages/messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_modules/index.html
+++ b/administrator/templates/hathor/html/com_modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_modules/module/index.html
+++ b/administrator/templates/hathor/html/com_modules/module/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_modules/modules/index.html
+++ b/administrator/templates/hathor/html/com_modules/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_modules/positions/index.html
+++ b/administrator/templates/hathor/html/com_modules/positions/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_newsfeeds/index.html
+++ b/administrator/templates/hathor/html/com_newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeed/index.html
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/index.html
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_plugins/index.html
+++ b/administrator/templates/hathor/html/com_plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_plugins/plugin/index.html
+++ b/administrator/templates/hathor/html/com_plugins/plugin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_plugins/plugins/index.html
+++ b/administrator/templates/hathor/html/com_plugins/plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_postinstall/index.html
+++ b/administrator/templates/hathor/html/com_postinstall/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_postinstall/messages/index.html
+++ b/administrator/templates/hathor/html/com_postinstall/messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_redirect/index.html
+++ b/administrator/templates/hathor/html/com_redirect/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_redirect/links/index.html
+++ b/administrator/templates/hathor/html/com_redirect/links/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_search/index.html
+++ b/administrator/templates/hathor/html/com_search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_search/searches/index.html
+++ b/administrator/templates/hathor/html/com_search/searches/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_tags/index.html
+++ b/administrator/templates/hathor/html/com_tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_tags/tag/index.html
+++ b/administrator/templates/hathor/html/com_tags/tag/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_tags/tags/index.html
+++ b/administrator/templates/hathor/html/com_tags/tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_templates/index.html
+++ b/administrator/templates/hathor/html/com_templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_templates/style/index.html
+++ b/administrator/templates/hathor/html/com_templates/style/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_templates/styles/index.html
+++ b/administrator/templates/hathor/html/com_templates/styles/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_templates/template/index.html
+++ b/administrator/templates/hathor/html/com_templates/template/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_templates/templates/index.html
+++ b/administrator/templates/hathor/html/com_templates/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/debuggroup/index.html
+++ b/administrator/templates/hathor/html/com_users/debuggroup/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/debuguser/index.html
+++ b/administrator/templates/hathor/html/com_users/debuguser/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/groups/index.html
+++ b/administrator/templates/hathor/html/com_users/groups/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/index.html
+++ b/administrator/templates/hathor/html/com_users/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/levels/index.html
+++ b/administrator/templates/hathor/html/com_users/levels/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/notes/index.html
+++ b/administrator/templates/hathor/html/com_users/notes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/user/index.html
+++ b/administrator/templates/hathor/html/com_users/user/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_users/users/index.html
+++ b/administrator/templates/hathor/html/com_users/users/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_weblinks/index.html
+++ b/administrator/templates/hathor/html/com_weblinks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_weblinks/weblink/index.html
+++ b/administrator/templates/hathor/html/com_weblinks/weblink/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/index.html
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/index.html
+++ b/administrator/templates/hathor/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_media/index.html
+++ b/administrator/templates/hathor/html/layouts/com_media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_media/toolbar/index.html
+++ b/administrator/templates/hathor/html/layouts/com_media/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_messages/index.html
+++ b/administrator/templates/hathor/html/layouts/com_messages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_messages/toolbar/index.html
+++ b/administrator/templates/hathor/html/layouts/com_messages/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_modules/index.html
+++ b/administrator/templates/hathor/html/layouts/com_modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/com_modules/toolbar/index.html
+++ b/administrator/templates/hathor/html/layouts/com_modules/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/index.html
+++ b/administrator/templates/hathor/html/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/joomla/edit/index.html
+++ b/administrator/templates/hathor/html/layouts/joomla/edit/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/joomla/index.html
+++ b/administrator/templates/hathor/html/layouts/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/joomla/quickicons/index.html
+++ b/administrator/templates/hathor/html/layouts/joomla/quickicons/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/joomla/sidebars/index.html
+++ b/administrator/templates/hathor/html/layouts/joomla/sidebars/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/layouts/joomla/toolbar/index.html
+++ b/administrator/templates/hathor/html/layouts/joomla/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/mod_login/index.html
+++ b/administrator/templates/hathor/html/mod_login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/mod_menu/index.html
+++ b/administrator/templates/hathor/html/mod_menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/html/mod_quickicon/index.html
+++ b/administrator/templates/hathor/html/mod_quickicon/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/admin/index.html
+++ b/administrator/templates/hathor/images/admin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/header/index.html
+++ b/administrator/templates/hathor/images/header/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/index.html
+++ b/administrator/templates/hathor/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/menu/index.html
+++ b/administrator/templates/hathor/images/menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/system/index.html
+++ b/administrator/templates/hathor/images/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/images/toolbar/index.html
+++ b/administrator/templates/hathor/images/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/index.html
+++ b/administrator/templates/hathor/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/js/index.html
+++ b/administrator/templates/hathor/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/language/en-GB/index.html
+++ b/administrator/templates/hathor/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/language/index.html
+++ b/administrator/templates/hathor/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/hathor/less/index.html
+++ b/administrator/templates/hathor/less/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/index.html
+++ b/administrator/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/css/index.html
+++ b/administrator/templates/isis/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/html/index.html
+++ b/administrator/templates/isis/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/html/layouts/index.html
+++ b/administrator/templates/isis/html/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/html/layouts/joomla/index.html
+++ b/administrator/templates/isis/html/layouts/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/html/layouts/joomla/system/index.html
+++ b/administrator/templates/isis/html/layouts/joomla/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/html/mod_version/index.html
+++ b/administrator/templates/isis/html/mod_version/index.html
@@ -1,1 +1,0 @@
-<html><body bgcolor="#FFFFFF"></body></html>

--- a/administrator/templates/isis/images/admin/index.html
+++ b/administrator/templates/isis/images/admin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/images/index.html
+++ b/administrator/templates/isis/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/images/system/index.html
+++ b/administrator/templates/isis/images/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/img/index.html
+++ b/administrator/templates/isis/img/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/index.html
+++ b/administrator/templates/isis/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/js/index.html
+++ b/administrator/templates/isis/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/language/en-GB/index.html
+++ b/administrator/templates/isis/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/language/index.html
+++ b/administrator/templates/isis/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/isis/less/index.html
+++ b/administrator/templates/isis/less/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/system/css/index.html
+++ b/administrator/templates/system/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/system/html/index.html
+++ b/administrator/templates/system/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/system/images/index.html
+++ b/administrator/templates/system/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/templates/system/index.html
+++ b/administrator/templates/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/bin/index.html
+++ b/bin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/build/index.html
+++ b/build/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/build/phpcs/Joomla/index.html
+++ b/build/phpcs/Joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/build/phpcs/index.html
+++ b/build/phpcs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/cache/index.html
+++ b/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/cli/index.html
+++ b/cli/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_ajax/index.html
+++ b/components/com_ajax/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_banners/helpers/index.html
+++ b/components/com_banners/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_banners/index.html
+++ b/components/com_banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_banners/models/index.html
+++ b/components/com_banners/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/controller/config/index.html
+++ b/components/com_config/controller/config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/controller/index.html
+++ b/components/com_config/controller/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/controller/modules/index.html
+++ b/components/com_config/controller/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/controller/templates/index.html
+++ b/components/com_config/controller/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/index.html
+++ b/components/com_config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/model/form/index.html
+++ b/components/com_config/model/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/model/index.html
+++ b/components/com_config/model/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/cms/index.html
+++ b/components/com_config/view/cms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/config/index.html
+++ b/components/com_config/view/config/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/config/tmpl/index.html
+++ b/components/com_config/view/config/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/index.html
+++ b/components/com_config/view/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/modules/index.html
+++ b/components/com_config/view/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/modules/tmpl/index.html
+++ b/components/com_config/view/modules/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/templates/index.html
+++ b/components/com_config/view/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_config/view/templates/tmpl/index.html
+++ b/components/com_config/view/templates/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/controllers/index.html
+++ b/components/com_contact/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/helpers/index.html
+++ b/components/com_contact/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/index.html
+++ b/components/com_contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/models/forms/index.html
+++ b/components/com_contact/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/models/index.html
+++ b/components/com_contact/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/models/rules/index.html
+++ b/components/com_contact/models/rules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/categories/index.html
+++ b/components/com_contact/views/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/categories/tmpl/index.html
+++ b/components/com_contact/views/categories/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/category/index.html
+++ b/components/com_contact/views/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/category/tmpl/index.html
+++ b/components/com_contact/views/category/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/contact/index.html
+++ b/components/com_contact/views/contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/contact/tmpl/index.html
+++ b/components/com_contact/views/contact/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/featured/index.html
+++ b/components/com_contact/views/featured/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/featured/tmpl/index.html
+++ b/components/com_contact/views/featured/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contact/views/index.html
+++ b/components/com_contact/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/controllers/index.html
+++ b/components/com_content/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/helpers/index.html
+++ b/components/com_content/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/index.html
+++ b/components/com_content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/models/forms/index.html
+++ b/components/com_content/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/models/index.html
+++ b/components/com_content/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/archive/index.html
+++ b/components/com_content/views/archive/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/archive/tmpl/index.html
+++ b/components/com_content/views/archive/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/article/index.html
+++ b/components/com_content/views/article/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/article/tmpl/index.html
+++ b/components/com_content/views/article/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/categories/index.html
+++ b/components/com_content/views/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/categories/tmpl/index.html
+++ b/components/com_content/views/categories/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/category/index.html
+++ b/components/com_content/views/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/category/tmpl/index.html
+++ b/components/com_content/views/category/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/featured/index.html
+++ b/components/com_content/views/featured/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/featured/tmpl/index.html
+++ b/components/com_content/views/featured/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/form/index.html
+++ b/components/com_content/views/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/form/tmpl/index.html
+++ b/components/com_content/views/form/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_content/views/index.html
+++ b/components/com_content/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_contenthistory/index.html
+++ b/components/com_contenthistory/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/controllers/index.html
+++ b/components/com_finder/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/helpers/html/index.html
+++ b/components/com_finder/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/helpers/index.html
+++ b/components/com_finder/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/index.html
+++ b/components/com_finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/models/index.html
+++ b/components/com_finder/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/views/index.html
+++ b/components/com_finder/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/views/search/index.html
+++ b/components/com_finder/views/search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_finder/views/search/tmpl/index.html
+++ b/components/com_finder/views/search/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/helpers/index.html
+++ b/components/com_mailto/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/index.html
+++ b/components/com_mailto/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/views/index.html
+++ b/components/com_mailto/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/views/mailto/index.html
+++ b/components/com_mailto/views/mailto/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/views/mailto/tmpl/index.html
+++ b/components/com_mailto/views/mailto/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/views/sent/index.html
+++ b/components/com_mailto/views/sent/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_mailto/views/sent/tmpl/index.html
+++ b/components/com_mailto/views/sent/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_media/index.html
+++ b/components/com_media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/helpers/index.html
+++ b/components/com_newsfeeds/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/index.html
+++ b/components/com_newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/models/index.html
+++ b/components/com_newsfeeds/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/categories/index.html
+++ b/components/com_newsfeeds/views/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/categories/tmpl/index.html
+++ b/components/com_newsfeeds/views/categories/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/category/index.html
+++ b/components/com_newsfeeds/views/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/category/tmpl/index.html
+++ b/components/com_newsfeeds/views/category/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/index.html
+++ b/components/com_newsfeeds/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/newsfeed/index.html
+++ b/components/com_newsfeeds/views/newsfeed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_newsfeeds/views/newsfeed/tmpl/index.html
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_search/index.html
+++ b/components/com_search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_search/models/index.html
+++ b/components/com_search/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_search/views/index.html
+++ b/components/com_search/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_search/views/search/index.html
+++ b/components/com_search/views/search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_search/views/search/tmpl/index.html
+++ b/components/com_search/views/search/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/controllers/index.html
+++ b/components/com_tags/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/helpers/index.html
+++ b/components/com_tags/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/index.html
+++ b/components/com_tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/models/index.html
+++ b/components/com_tags/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/views/index.html
+++ b/components/com_tags/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/views/tag/index.html
+++ b/components/com_tags/views/tag/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/views/tag/tmpl/index.html
+++ b/components/com_tags/views/tag/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/views/tags/index.html
+++ b/components/com_tags/views/tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_tags/views/tags/tmpl/index.html
+++ b/components/com_tags/views/tags/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/controllers/index.html
+++ b/components/com_users/controllers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/helpers/html/index.html
+++ b/components/com_users/helpers/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/helpers/index.html
+++ b/components/com_users/helpers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/index.html
+++ b/components/com_users/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/models/forms/index.html
+++ b/components/com_users/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/models/index.html
+++ b/components/com_users/models/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/index.html
+++ b/components/com_users/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/login/index.html
+++ b/components/com_users/views/login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/login/tmpl/index.html
+++ b/components/com_users/views/login/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/profile/index.html
+++ b/components/com_users/views/profile/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/profile/tmpl/index.html
+++ b/components/com_users/views/profile/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/registration/index.html
+++ b/components/com_users/views/registration/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/registration/tmpl/index.html
+++ b/components/com_users/views/registration/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/remind/index.html
+++ b/components/com_users/views/remind/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/remind/tmpl/index.html
+++ b/components/com_users/views/remind/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/reset/index.html
+++ b/components/com_users/views/reset/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_users/views/reset/tmpl/index.html
+++ b/components/com_users/views/reset/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_wrapper/index.html
+++ b/components/com_wrapper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_wrapper/views/index.html
+++ b/components/com_wrapper/views/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_wrapper/views/wrapper/index.html
+++ b/components/com_wrapper/views/wrapper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/com_wrapper/views/wrapper/tmpl/index.html
+++ b/components/com_wrapper/views/wrapper/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/index.html
+++ b/components/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/banners/index.html
+++ b/images/banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/headers/index.html
+++ b/images/headers/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/index.html
+++ b/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/sampledata/fruitshop/index.html
+++ b/images/sampledata/fruitshop/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/sampledata/index.html
+++ b/images/sampledata/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/sampledata/parks/animals/index.html
+++ b/images/sampledata/parks/animals/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/sampledata/parks/index.html
+++ b/images/sampledata/parks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/sampledata/parks/landscape/index.html
+++ b/images/sampledata/parks/landscape/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/includes/index.html
+++ b/includes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/application/index.html
+++ b/installation/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/controller/index.html
+++ b/installation/controller/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/controller/install/index.html
+++ b/installation/controller/install/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/helper/html/index.html
+++ b/installation/helper/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/helper/index.html
+++ b/installation/helper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/af-ZA/index.html
+++ b/installation/language/af-ZA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ar-AA/index.html
+++ b/installation/language/ar-AA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/be-BY/index.html
+++ b/installation/language/be-BY/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/bg-BG/index.html
+++ b/installation/language/bg-BG/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/bs-BA/index.html
+++ b/installation/language/bs-BA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ca-ES/index.html
+++ b/installation/language/ca-ES/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ckb-IQ/index.html
+++ b/installation/language/ckb-IQ/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/cs-CZ/index.html
+++ b/installation/language/cs-CZ/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/cy-GB/index.html
+++ b/installation/language/cy-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/da-DK/index.html
+++ b/installation/language/da-DK/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/de-DE/index.html
+++ b/installation/language/de-DE/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/el-GR/index.html
+++ b/installation/language/el-GR/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/en-AU/index.html
+++ b/installation/language/en-AU/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/en-CA/index.html
+++ b/installation/language/en-CA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/en-GB/index.html
+++ b/installation/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/en-US/index.html
+++ b/installation/language/en-US/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/es-ES/index.html
+++ b/installation/language/es-ES/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/et-EE/index.html
+++ b/installation/language/et-EE/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/fa-IR/index.html
+++ b/installation/language/fa-IR/index.html
@@ -1,1 +1,0 @@
-﻿<!DOCTYPE html><title>جومــلـا فـارسـی دات کـام</title>

--- a/installation/language/fi-FI/index.html
+++ b/installation/language/fi-FI/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/fr-CA/index.html
+++ b/installation/language/fr-CA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/fr-FR/index.html
+++ b/installation/language/fr-FR/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/gl-ES/index.html
+++ b/installation/language/gl-ES/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/he-IL/index.html
+++ b/installation/language/he-IL/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/hr-HR/index.html
+++ b/installation/language/hr-HR/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/hu-HU/index.html
+++ b/installation/language/hu-HU/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/id-ID/index.html
+++ b/installation/language/id-ID/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/index.html
+++ b/installation/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/it-IT/index.html
+++ b/installation/language/it-IT/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ja-JP/index.html
+++ b/installation/language/ja-JP/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ko-KR/index.html
+++ b/installation/language/ko-KR/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/lv-LV/index.html
+++ b/installation/language/lv-LV/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/mk-MK/index.html
+++ b/installation/language/mk-MK/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ms-MY/index.html
+++ b/installation/language/ms-MY/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/nb-NO/index.html
+++ b/installation/language/nb-NO/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/nl-NL/index.html
+++ b/installation/language/nl-NL/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/pl-PL/index.html
+++ b/installation/language/pl-PL/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/pt-PT/index.html
+++ b/installation/language/pt-PT/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ro-RO/index.html
+++ b/installation/language/ro-RO/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ru-RU/index.html
+++ b/installation/language/ru-RU/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/si-LK/index.html
+++ b/installation/language/si-LK/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sk-SK/index.html
+++ b/installation/language/sk-SK/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sr-RS/index.html
+++ b/installation/language/sr-RS/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sr-YU/index.html
+++ b/installation/language/sr-YU/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/srp-ME/index.html
+++ b/installation/language/srp-ME/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sv-SE/index.html
+++ b/installation/language/sv-SE/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sw-KE/index.html
+++ b/installation/language/sw-KE/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/sy-IQ/index.html
+++ b/installation/language/sy-IQ/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ta-IN/index.html
+++ b/installation/language/ta-IN/index.html
@@ -1,3 +1,0 @@
-<html>
-<body></body>
-</html>

--- a/installation/language/th-TH/index.html
+++ b/installation/language/th-TH/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/tr-TR/index.html
+++ b/installation/language/tr-TR/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/ug-CN/index.html
+++ b/installation/language/ug-CN/index.html
@@ -1,3 +1,0 @@
-<html>
-<body></body>
-</html>

--- a/installation/language/uk-UA/index.html
+++ b/installation/language/uk-UA/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/vi-VN/index.html
+++ b/installation/language/vi-VN/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/zh-CN/index.html
+++ b/installation/language/zh-CN/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/language/zh-TW/index.html
+++ b/installation/language/zh-TW/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/model/fields/index.html
+++ b/installation/model/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/model/forms/index.html
+++ b/installation/model/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/model/index.html
+++ b/installation/model/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/model/rules/index.html
+++ b/installation/model/rules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/response/index.html
+++ b/installation/response/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/sql/index.html
+++ b/installation/sql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/sql/mysql/index.html
+++ b/installation/sql/mysql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/sql/postgresql/index.html
+++ b/installation/sql/postgresql/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/sql/sqlazure/index.html
+++ b/installation/sql/sqlazure/index.html
@@ -1,1 +1,0 @@
-<html><body></body></html>

--- a/installation/template/css/index.html
+++ b/installation/template/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/template/images/index.html
+++ b/installation/template/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/template/index.html
+++ b/installation/template/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/template/js/index.html
+++ b/installation/template/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/complete/index.html
+++ b/installation/view/complete/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/complete/tmpl/index.html
+++ b/installation/view/complete/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/database/index.html
+++ b/installation/view/database/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/database/tmpl/index.html
+++ b/installation/view/database/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/defaultlanguage/index.html
+++ b/installation/view/defaultlanguage/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/defaultlanguage/tmpl/index.html
+++ b/installation/view/defaultlanguage/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/ftp/index.html
+++ b/installation/view/ftp/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/ftp/tmpl/index.html
+++ b/installation/view/ftp/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/index.html
+++ b/installation/view/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/install/index.html
+++ b/installation/view/install/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/install/tmpl/index.html
+++ b/installation/view/install/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/languages/index.html
+++ b/installation/view/languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/languages/tmpl/index.html
+++ b/installation/view/languages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/preinstall/index.html
+++ b/installation/view/preinstall/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/preinstall/tmpl/index.html
+++ b/installation/view/preinstall/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/remove/index.html
+++ b/installation/view/remove/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/remove/tmpl/index.html
+++ b/installation/view/remove/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/site/index.html
+++ b/installation/view/site/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/site/tmpl/index.html
+++ b/installation/view/site/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/summary/index.html
+++ b/installation/view/summary/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/installation/view/summary/tmpl/index.html
+++ b/installation/view/summary/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/language/en-GB/index.html
+++ b/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/language/index.html
+++ b/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/language/overrides/index.html
+++ b/language/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/content/index.html
+++ b/layouts/joomla/content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/content/info_block/index.html
+++ b/layouts/joomla/content/info_block/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/edit/index.html
+++ b/layouts/joomla/edit/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/editors/buttons/index.html
+++ b/layouts/joomla/editors/buttons/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/editors/index.html
+++ b/layouts/joomla/editors/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/form/index.html
+++ b/layouts/joomla/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/index.html
+++ b/layouts/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/links/index.html
+++ b/layouts/joomla/links/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/pagination/index.html
+++ b/layouts/joomla/pagination/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/quickicons/index.html
+++ b/layouts/joomla/quickicons/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/searchtools/default/index.html
+++ b/layouts/joomla/searchtools/default/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/searchtools/grid/index.html
+++ b/layouts/joomla/searchtools/grid/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/searchtools/index.html
+++ b/layouts/joomla/searchtools/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/sidebars/index.html
+++ b/layouts/joomla/sidebars/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/system/index.html
+++ b/layouts/joomla/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/tinymce/buttons/index.html
+++ b/layouts/joomla/tinymce/buttons/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/tinymce/index.html
+++ b/layouts/joomla/tinymce/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/joomla/toolbar/index.html
+++ b/layouts/joomla/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/libraries/cms/html/bootstrap/index.html
+++ b/layouts/libraries/cms/html/bootstrap/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/libraries/cms/html/index.html
+++ b/layouts/libraries/cms/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/libraries/cms/index.html
+++ b/layouts/libraries/cms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/libraries/index.html
+++ b/layouts/libraries/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/application/index.html
+++ b/libraries/cms/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/captcha/index.html
+++ b/libraries/cms/captcha/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/component/index.html
+++ b/libraries/cms/component/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/editor/index.html
+++ b/libraries/cms/editor/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/error/index.html
+++ b/libraries/cms/error/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/form/field/index.html
+++ b/libraries/cms/form/field/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/form/index.html
+++ b/libraries/cms/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/form/rule/index.html
+++ b/libraries/cms/form/rule/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/help/index.html
+++ b/libraries/cms/help/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/helper/index.html
+++ b/libraries/cms/helper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/html/index.html
+++ b/libraries/cms/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/html/language/en-GB/index.html
+++ b/libraries/cms/html/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/html/language/index.html
+++ b/libraries/cms/html/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/index.html
+++ b/libraries/cms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/installer/adapter/index.html
+++ b/libraries/cms/installer/adapter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/installer/index.html
+++ b/libraries/cms/installer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/installer/manifest/index.html
+++ b/libraries/cms/installer/manifest/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/language/index.html
+++ b/libraries/cms/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/layout/index.html
+++ b/libraries/cms/layout/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/less/formatter/index.html
+++ b/libraries/cms/less/formatter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/less/index.html
+++ b/libraries/cms/less/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/library/index.html
+++ b/libraries/cms/library/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/menu/index.html
+++ b/libraries/cms/menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/module/index.html
+++ b/libraries/cms/module/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/pagination/index.html
+++ b/libraries/cms/pagination/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/pathway/index.html
+++ b/libraries/cms/pathway/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/plugin/index.html
+++ b/libraries/cms/plugin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/response/index.html
+++ b/libraries/cms/response/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/router/index.html
+++ b/libraries/cms/router/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/schema/changeitem/index.html
+++ b/libraries/cms/schema/changeitem/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/schema/index.html
+++ b/libraries/cms/schema/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/search/index.html
+++ b/libraries/cms/search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/table/index.html
+++ b/libraries/cms/table/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/toolbar/button/index.html
+++ b/libraries/cms/toolbar/button/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/toolbar/index.html
+++ b/libraries/cms/toolbar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/ucm/index.html
+++ b/libraries/cms/ucm/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/cms/version/index.html
+++ b/libraries/cms/version/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/fof/config/index.html
+++ b/libraries/fof/config/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/controller/index.html
+++ b/libraries/fof/controller/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/database/iterator/index.html
+++ b/libraries/fof/database/iterator/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/fof/dispatcher/index.html
+++ b/libraries/fof/dispatcher/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/encrypt/index.html
+++ b/libraries/fof/encrypt/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/form/field/index.html
+++ b/libraries/fof/form/field/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/form/header/index.html
+++ b/libraries/fof/form/header/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/form/index.html
+++ b/libraries/fof/form/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/index.html
+++ b/libraries/fof/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/inflector/index.html
+++ b/libraries/fof/inflector/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/input/index.html
+++ b/libraries/fof/input/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/layout/index.html
+++ b/libraries/fof/layout/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/fof/less/formatter/index.html
+++ b/libraries/fof/less/formatter/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/less/index.html
+++ b/libraries/fof/less/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/less/parser/index.html
+++ b/libraries/fof/less/parser/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/model/index.html
+++ b/libraries/fof/model/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/query/index.html
+++ b/libraries/fof/query/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/render/index.html
+++ b/libraries/fof/render/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/string/index.html
+++ b/libraries/fof/string/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/table/index.html
+++ b/libraries/fof/table/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/template/index.html
+++ b/libraries/fof/template/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/toolbar/index.html
+++ b/libraries/fof/toolbar/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/array/index.html
+++ b/libraries/fof/utils/array/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/filescheck/index.html
+++ b/libraries/fof/utils/filescheck/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/index.html
+++ b/libraries/fof/utils/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/object/index.html
+++ b/libraries/fof/utils/object/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/observable/index.html
+++ b/libraries/fof/utils/observable/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/utils/timer/index.html
+++ b/libraries/fof/utils/timer/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/fof/view/index.html
+++ b/libraries/fof/view/index.html
@@ -1,1 +1,0 @@
-<html><head><title></title></head><body></body></html>

--- a/libraries/idna_convert/index.html
+++ b/libraries/idna_convert/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/index.html
+++ b/libraries/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/access/index.html
+++ b/libraries/joomla/access/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/application/index.html
+++ b/libraries/joomla/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/application/web/index.html
+++ b/libraries/joomla/application/web/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/application/web/router/index.html
+++ b/libraries/joomla/application/web/router/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/archive/index.html
+++ b/libraries/joomla/archive/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/base/index.html
+++ b/libraries/joomla/base/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/cache/controller/index.html
+++ b/libraries/joomla/cache/controller/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/cache/index.html
+++ b/libraries/joomla/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/cache/storage/index.html
+++ b/libraries/joomla/cache/storage/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/client/index.html
+++ b/libraries/joomla/client/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/controller/index.html
+++ b/libraries/joomla/controller/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/crypt/cipher/index.html
+++ b/libraries/joomla/crypt/cipher/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/crypt/index.html
+++ b/libraries/joomla/crypt/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/crypt/password/index.html
+++ b/libraries/joomla/crypt/password/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/data/index.html
+++ b/libraries/joomla/data/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/driver/index.html
+++ b/libraries/joomla/database/driver/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/exporter/index.html
+++ b/libraries/joomla/database/exporter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/importer/index.html
+++ b/libraries/joomla/database/importer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/index.html
+++ b/libraries/joomla/database/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/iterator/index.html
+++ b/libraries/joomla/database/iterator/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/database/query/index.html
+++ b/libraries/joomla/database/query/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/date/index.html
+++ b/libraries/joomla/date/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/error/index.html
+++ b/libraries/joomla/document/error/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/feed/index.html
+++ b/libraries/joomla/document/feed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/feed/renderer/index.html
+++ b/libraries/joomla/document/feed/renderer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/html/index.html
+++ b/libraries/joomla/document/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/html/renderer/index.html
+++ b/libraries/joomla/document/html/renderer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/image/index.html
+++ b/libraries/joomla/document/image/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/index.html
+++ b/libraries/joomla/document/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/json/index.html
+++ b/libraries/joomla/document/json/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/opensearch/index.html
+++ b/libraries/joomla/document/opensearch/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/raw/index.html
+++ b/libraries/joomla/document/raw/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/document/xml/index.html
+++ b/libraries/joomla/document/xml/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/environment/index.html
+++ b/libraries/joomla/environment/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/event/index.html
+++ b/libraries/joomla/event/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/facebook/index.html
+++ b/libraries/joomla/facebook/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/feed/index.html
+++ b/libraries/joomla/feed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/feed/parser/index.html
+++ b/libraries/joomla/feed/parser/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/feed/parser/rss/index.html
+++ b/libraries/joomla/feed/parser/rss/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/index.html
+++ b/libraries/joomla/filesystem/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/meta/index.html
+++ b/libraries/joomla/filesystem/meta/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/meta/language/en-GB/index.html
+++ b/libraries/joomla/filesystem/meta/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/meta/language/index.html
+++ b/libraries/joomla/filesystem/meta/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/streams/index.html
+++ b/libraries/joomla/filesystem/streams/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filesystem/support/index.html
+++ b/libraries/joomla/filesystem/support/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/filter/index.html
+++ b/libraries/joomla/filter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/form/fields/index.html
+++ b/libraries/joomla/form/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/form/index.html
+++ b/libraries/joomla/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/form/rule/index.html
+++ b/libraries/joomla/form/rule/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/github/index.html
+++ b/libraries/joomla/github/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/auth/index.html
+++ b/libraries/joomla/google/auth/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/data/index.html
+++ b/libraries/joomla/google/data/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/data/picasa/index.html
+++ b/libraries/joomla/google/data/picasa/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/data/plus/index.html
+++ b/libraries/joomla/google/data/plus/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/embed/index.html
+++ b/libraries/joomla/google/embed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/google/index.html
+++ b/libraries/joomla/google/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/grid/index.html
+++ b/libraries/joomla/grid/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/http/index.html
+++ b/libraries/joomla/http/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/http/transport/index.html
+++ b/libraries/joomla/http/transport/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/image/filter/index.html
+++ b/libraries/joomla/image/filter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/image/index.html
+++ b/libraries/joomla/image/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/index.html
+++ b/libraries/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/input/index.html
+++ b/libraries/joomla/input/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/keychain/index.html
+++ b/libraries/joomla/keychain/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/language/index.html
+++ b/libraries/joomla/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/language/stemmer/index.html
+++ b/libraries/joomla/language/stemmer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/linkedin/index.html
+++ b/libraries/joomla/linkedin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/log/index.html
+++ b/libraries/joomla/log/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/log/logger/index.html
+++ b/libraries/joomla/log/logger/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/mail/index.html
+++ b/libraries/joomla/mail/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/mail/language/index.html
+++ b/libraries/joomla/mail/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/mediawiki/index.html
+++ b/libraries/joomla/mediawiki/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/microdata/index.html
+++ b/libraries/joomla/microdata/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/model/index.html
+++ b/libraries/joomla/model/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/oauth1/index.html
+++ b/libraries/joomla/oauth1/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/oauth2/index.html
+++ b/libraries/joomla/oauth2/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/object/index.html
+++ b/libraries/joomla/object/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/observable/index.html
+++ b/libraries/joomla/observable/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/observer/index.html
+++ b/libraries/joomla/observer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/observer/updater/index.html
+++ b/libraries/joomla/observer/updater/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/openstreetmap/index.html
+++ b/libraries/joomla/openstreetmap/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/profiler/index.html
+++ b/libraries/joomla/profiler/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/session/index.html
+++ b/libraries/joomla/session/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/session/storage/index.html
+++ b/libraries/joomla/session/storage/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/string/index.html
+++ b/libraries/joomla/string/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/table/index.html
+++ b/libraries/joomla/table/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/table/observer/index.html
+++ b/libraries/joomla/table/observer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/twitter/index.html
+++ b/libraries/joomla/twitter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/updater/adapters/index.html
+++ b/libraries/joomla/updater/adapters/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/updater/index.html
+++ b/libraries/joomla/updater/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/uri/index.html
+++ b/libraries/joomla/uri/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/user/index.html
+++ b/libraries/joomla/user/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/utilities/index.html
+++ b/libraries/joomla/utilities/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/joomla/view/index.html
+++ b/libraries/joomla/view/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/access/index.html
+++ b/libraries/legacy/access/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/application/index.html
+++ b/libraries/legacy/application/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/base/index.html
+++ b/libraries/legacy/base/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/categories/index.html
+++ b/libraries/legacy/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/controller/index.html
+++ b/libraries/legacy/controller/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/database/index.html
+++ b/libraries/legacy/database/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/dispatcher/index.html
+++ b/libraries/legacy/dispatcher/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/error/index.html
+++ b/libraries/legacy/error/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/exception/index.html
+++ b/libraries/legacy/exception/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/form/field/index.html
+++ b/libraries/legacy/form/field/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/form/index.html
+++ b/libraries/legacy/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/index.html
+++ b/libraries/legacy/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/log/index.html
+++ b/libraries/legacy/log/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/model/index.html
+++ b/libraries/legacy/model/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/request/index.html
+++ b/libraries/legacy/request/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/response/index.html
+++ b/libraries/legacy/response/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/simplecrypt/index.html
+++ b/libraries/legacy/simplecrypt/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/simplepie/index.html
+++ b/libraries/legacy/simplepie/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/table/index.html
+++ b/libraries/legacy/table/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/table/menu/index.html
+++ b/libraries/legacy/table/menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/utilities/index.html
+++ b/libraries/legacy/utilities/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/view/index.html
+++ b/libraries/legacy/view/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/legacy/web/index.html
+++ b/libraries/legacy/web/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/phpass/index.html
+++ b/libraries/phpass/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/phputf8/index.html
+++ b/libraries/phputf8/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/phputf8/mbstring/index.html
+++ b/libraries/phputf8/mbstring/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/phputf8/native/index.html
+++ b/libraries/phputf8/native/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/phputf8/utils/index.html
+++ b/libraries/phputf8/utils/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/simplepie/idn/index.html
+++ b/libraries/simplepie/idn/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/simplepie/index.html
+++ b/libraries/simplepie/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/logs/index.html
+++ b/logs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/cms/css/index.html
+++ b/media/cms/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/cms/index.html
+++ b/media/cms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_contenthistory/css/index.html
+++ b/media/com_contenthistory/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_contenthistory/index.html
+++ b/media/com_contenthistory/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_contenthistory/js/index.html
+++ b/media/com_contenthistory/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_finder/css/index.html
+++ b/media/com_finder/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_finder/index.html
+++ b/media/com_finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_finder/js/index.html
+++ b/media/com_finder/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/com_joomlaupdate/index.html
+++ b/media/com_joomlaupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/contacts/images/index.html
+++ b/media/contacts/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/contacts/index.html
+++ b/media/contacts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/editors/index.html
+++ b/media/editors/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/editors/tinymce/index.html
+++ b/media/editors/tinymce/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/editors/tinymce/langs/index.html
+++ b/media/editors/tinymce/langs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/editors/tinymce/templates/index.html
+++ b/media/editors/tinymce/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/index.html
+++ b/media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/css/index.html
+++ b/media/jui/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/fonts/index.html
+++ b/media/jui/fonts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/img/index.html
+++ b/media/jui/img/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/index.html
+++ b/media/jui/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/js/index.html
+++ b/media/jui/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/jui/less/index.html
+++ b/media/jui/less/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/mailto/images/index.html
+++ b/media/mailto/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/mailto/index.html
+++ b/media/mailto/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/css/index.html
+++ b/media/media/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/images/index.html
+++ b/media/media/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/images/mime-icon-16/index.html
+++ b/media/media/images/mime-icon-16/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/images/mime-icon-32/index.html
+++ b/media/media/images/mime-icon-32/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/index.html
+++ b/media/media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/media/js/index.html
+++ b/media/media/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/mod_languages/css/index.html
+++ b/media/mod_languages/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/mod_languages/images/index.html
+++ b/media/mod_languages/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/mod_languages/index.html
+++ b/media/mod_languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/overrider/css/index.html
+++ b/media/overrider/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/overrider/index.html
+++ b/media/overrider/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/overrider/js/index.html
+++ b/media/overrider/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/plg_quickicon_extensionupdate/index.html
+++ b/media/plg_quickicon_extensionupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/plg_quickicon_extensionupdate/js/index.html
+++ b/media/plg_quickicon_extensionupdate/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/plg_quickicon_joomlaupdate/index.html
+++ b/media/plg_quickicon_joomlaupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/plg_quickicon_joomlaupdate/js/index.html
+++ b/media/plg_quickicon_joomlaupdate/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/plg_system_highlight/index.html
+++ b/media/plg_system_highlight/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/css/index.html
+++ b/media/system/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/images/index.html
+++ b/media/system/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/images/modal/index.html
+++ b/media/system/images/modal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/images/mooRainbow/index.html
+++ b/media/system/images/mooRainbow/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/index.html
+++ b/media/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/system/js/index.html
+++ b/media/system/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/index.html
+++ b/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_archive/index.html
+++ b/modules/mod_articles_archive/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_archive/tmpl/index.html
+++ b/modules/mod_articles_archive/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_categories/index.html
+++ b/modules/mod_articles_categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_categories/tmpl/index.html
+++ b/modules/mod_articles_categories/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_category/index.html
+++ b/modules/mod_articles_category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_category/tmpl/index.html
+++ b/modules/mod_articles_category/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_latest/index.html
+++ b/modules/mod_articles_latest/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_latest/tmpl/index.html
+++ b/modules/mod_articles_latest/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_news/index.html
+++ b/modules/mod_articles_news/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_news/tmpl/index.html
+++ b/modules/mod_articles_news/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_popular/index.html
+++ b/modules/mod_articles_popular/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_articles_popular/tmpl/index.html
+++ b/modules/mod_articles_popular/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_banners/index.html
+++ b/modules/mod_banners/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_banners/tmpl/index.html
+++ b/modules/mod_banners/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_breadcrumbs/index.html
+++ b/modules/mod_breadcrumbs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_breadcrumbs/tmpl/index.html
+++ b/modules/mod_breadcrumbs/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_custom/index.html
+++ b/modules/mod_custom/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_custom/tmpl/index.html
+++ b/modules/mod_custom/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_feed/index.html
+++ b/modules/mod_feed/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_feed/tmpl/index.html
+++ b/modules/mod_feed/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_finder/index.html
+++ b/modules/mod_finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_finder/tmpl/index.html
+++ b/modules/mod_finder/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_footer/index.html
+++ b/modules/mod_footer/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_footer/tmpl/index.html
+++ b/modules/mod_footer/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_languages/index.html
+++ b/modules/mod_languages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_languages/tmpl/index.html
+++ b/modules/mod_languages/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_login/index.html
+++ b/modules/mod_login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_login/tmpl/index.html
+++ b/modules/mod_login/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_menu/index.html
+++ b/modules/mod_menu/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_menu/tmpl/index.html
+++ b/modules/mod_menu/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_random_image/index.html
+++ b/modules/mod_random_image/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_random_image/tmpl/index.html
+++ b/modules/mod_random_image/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_related_items/index.html
+++ b/modules/mod_related_items/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_related_items/tmpl/index.html
+++ b/modules/mod_related_items/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_search/index.html
+++ b/modules/mod_search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_search/tmpl/index.html
+++ b/modules/mod_search/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_stats/index.html
+++ b/modules/mod_stats/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_stats/tmpl/index.html
+++ b/modules/mod_stats/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_syndicate/index.html
+++ b/modules/mod_syndicate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_syndicate/tmpl/index.html
+++ b/modules/mod_syndicate/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_tags_popular/index.html
+++ b/modules/mod_tags_popular/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_tags_popular/tmpl/index.html
+++ b/modules/mod_tags_popular/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_tags_similar/index.html
+++ b/modules/mod_tags_similar/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_tags_similar/tmpl/index.html
+++ b/modules/mod_tags_similar/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_users_latest/index.html
+++ b/modules/mod_users_latest/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_users_latest/tmpl/index.html
+++ b/modules/mod_users_latest/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_whosonline/index.html
+++ b/modules/mod_whosonline/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_whosonline/tmpl/index.html
+++ b/modules/mod_whosonline/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_wrapper/index.html
+++ b/modules/mod_wrapper/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/mod_wrapper/tmpl/index.html
+++ b/modules/mod_wrapper/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/authentication/cookie/index.html
+++ b/plugins/authentication/cookie/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/authentication/gmail/index.html
+++ b/plugins/authentication/gmail/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/authentication/index.html
+++ b/plugins/authentication/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/authentication/joomla/index.html
+++ b/plugins/authentication/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/authentication/ldap/index.html
+++ b/plugins/authentication/ldap/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/captcha/index.html
+++ b/plugins/captcha/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/captcha/nocaptcha/index.html
+++ b/plugins/captcha/nocaptcha/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/captcha/recaptcha/index.html
+++ b/plugins/captcha/recaptcha/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/contact/index.html
+++ b/plugins/content/contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/emailcloak/index.html
+++ b/plugins/content/emailcloak/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/finder/index.html
+++ b/plugins/content/finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/index.html
+++ b/plugins/content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/joomla/index.html
+++ b/plugins/content/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/loadmodule/index.html
+++ b/plugins/content/loadmodule/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/pagebreak/index.html
+++ b/plugins/content/pagebreak/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/pagenavigation/index.html
+++ b/plugins/content/pagenavigation/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/pagenavigation/tmpl/index.html
+++ b/plugins/content/pagenavigation/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/vote/index.html
+++ b/plugins/content/vote/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors-xtd/article/index.html
+++ b/plugins/editors-xtd/article/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors-xtd/image/index.html
+++ b/plugins/editors-xtd/image/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors-xtd/index.html
+++ b/plugins/editors-xtd/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors-xtd/pagebreak/index.html
+++ b/plugins/editors-xtd/pagebreak/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors-xtd/readmore/index.html
+++ b/plugins/editors-xtd/readmore/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors/codemirror/index.html
+++ b/plugins/editors/codemirror/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors/index.html
+++ b/plugins/editors/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors/none/index.html
+++ b/plugins/editors/none/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/editors/tinymce/index.html
+++ b/plugins/editors/tinymce/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/extension/index.html
+++ b/plugins/extension/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/extension/joomla/index.html
+++ b/plugins/extension/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/categories/index.html
+++ b/plugins/finder/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/contacts/index.html
+++ b/plugins/finder/contacts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/content/index.html
+++ b/plugins/finder/content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/index.html
+++ b/plugins/finder/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/newsfeeds/index.html
+++ b/plugins/finder/newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/finder/tags/index.html
+++ b/plugins/finder/tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/quickicon/extensionupdate/index.html
+++ b/plugins/quickicon/extensionupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/quickicon/index.html
+++ b/plugins/quickicon/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/quickicon/joomlaupdate/index.html
+++ b/plugins/quickicon/joomlaupdate/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/categories/index.html
+++ b/plugins/search/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/contacts/index.html
+++ b/plugins/search/contacts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/content/index.html
+++ b/plugins/search/content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/index.html
+++ b/plugins/search/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/newsfeeds/index.html
+++ b/plugins/search/newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/search/tags/index.html
+++ b/plugins/search/tags/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><html></html>

--- a/plugins/system/cache/index.html
+++ b/plugins/system/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/debug/index.html
+++ b/plugins/system/debug/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/highlight/index.html
+++ b/plugins/system/highlight/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/index.html
+++ b/plugins/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/languagecode/index.html
+++ b/plugins/system/languagecode/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/languagecode/language/en-GB/index.html
+++ b/plugins/system/languagecode/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/languagecode/language/index.html
+++ b/plugins/system/languagecode/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/languagefilter/index.html
+++ b/plugins/system/languagefilter/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/log/index.html
+++ b/plugins/system/log/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/logout/index.html
+++ b/plugins/system/logout/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/p3p/index.html
+++ b/plugins/system/p3p/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/redirect/index.html
+++ b/plugins/system/redirect/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/remember/index.html
+++ b/plugins/system/remember/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/system/sef/index.html
+++ b/plugins/system/sef/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/index.html
+++ b/plugins/twofactorauth/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/totp/index.html
+++ b/plugins/twofactorauth/totp/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/totp/postinstall/index.html
+++ b/plugins/twofactorauth/totp/postinstall/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/totp/tmpl/index.html
+++ b/plugins/twofactorauth/totp/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/yubikey/index.html
+++ b/plugins/twofactorauth/yubikey/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/twofactorauth/yubikey/tmpl/index.html
+++ b/plugins/twofactorauth/yubikey/tmpl/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/contactcreator/index.html
+++ b/plugins/user/contactcreator/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/index.html
+++ b/plugins/user/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/joomla/index.html
+++ b/plugins/user/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/profile/fields/index.html
+++ b/plugins/user/profile/fields/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/profile/index.html
+++ b/plugins/user/profile/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/user/profile/profiles/index.html
+++ b/plugins/user/profile/profiles/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/css/index.html
+++ b/templates/beez3/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_contact/categories/index.html
+++ b/templates/beez3/html/com_contact/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_contact/category/index.html
+++ b/templates/beez3/html/com_contact/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_contact/contact/index.html
+++ b/templates/beez3/html/com_contact/contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_contact/index.html
+++ b/templates/beez3/html/com_contact/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/archive/index.html
+++ b/templates/beez3/html/com_content/archive/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/article/index.html
+++ b/templates/beez3/html/com_content/article/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/categories/index.html
+++ b/templates/beez3/html/com_content/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/category/index.html
+++ b/templates/beez3/html/com_content/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/featured/index.html
+++ b/templates/beez3/html/com_content/featured/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/form/index.html
+++ b/templates/beez3/html/com_content/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_content/index.html
+++ b/templates/beez3/html/com_content/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_newsfeeds/categories/index.html
+++ b/templates/beez3/html/com_newsfeeds/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_newsfeeds/category/index.html
+++ b/templates/beez3/html/com_newsfeeds/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_newsfeeds/index.html
+++ b/templates/beez3/html/com_newsfeeds/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_weblinks/categories/index.html
+++ b/templates/beez3/html/com_weblinks/categories/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_weblinks/category/index.html
+++ b/templates/beez3/html/com_weblinks/category/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_weblinks/form/index.html
+++ b/templates/beez3/html/com_weblinks/form/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/com_weblinks/index.html
+++ b/templates/beez3/html/com_weblinks/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/index.html
+++ b/templates/beez3/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/layouts/index.html
+++ b/templates/beez3/html/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/layouts/joomla/index.html
+++ b/templates/beez3/html/layouts/joomla/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/layouts/joomla/system/index.html
+++ b/templates/beez3/html/layouts/joomla/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/mod_breadcrumbs/index.html
+++ b/templates/beez3/html/mod_breadcrumbs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/html/mod_login/index.html
+++ b/templates/beez3/html/mod_login/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/images/index.html
+++ b/templates/beez3/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/images/nature/index.html
+++ b/templates/beez3/images/nature/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/images/personal/index.html
+++ b/templates/beez3/images/personal/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/images/system/index.html
+++ b/templates/beez3/images/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/index.html
+++ b/templates/beez3/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/javascript/index.html
+++ b/templates/beez3/javascript/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/language/en-GB/index.html
+++ b/templates/beez3/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/beez3/language/index.html
+++ b/templates/beez3/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/css/index.html
+++ b/templates/protostar/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/html/index.html
+++ b/templates/protostar/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/images/index.html
+++ b/templates/protostar/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/images/system/index.html
+++ b/templates/protostar/images/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/img/index.html
+++ b/templates/protostar/img/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/js/index.html
+++ b/templates/protostar/js/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/language/en-GB/index.html
+++ b/templates/protostar/language/en-GB/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/language/index.html
+++ b/templates/protostar/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/protostar/less/index.html
+++ b/templates/protostar/less/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/system/css/index.html
+++ b/templates/system/css/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/system/html/index.html
+++ b/templates/system/html/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/system/images/index.html
+++ b/templates/system/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/system/index.html
+++ b/templates/system/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/tests/_data/index.html
+++ b/tests/_data/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/tmp/index.html
+++ b/tmp/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>


### PR DESCRIPTION
Over in #5232, @infograf768 mentioned that there is some move to remove all `index.html` files from Joomla. Well, here you go. No more `index.html` files. The only ones left are in the build folder because those actually serve some purpose. 
