### PR TITLE
Remove progressbar.js dependency from com_finder (admin)

### DIFF
--- a/administrator/components/com_finder/views/indexer/tmpl/default.php
+++ b/administrator/components/com_finder/views/indexer/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 JHtml::_('jquery.framework');
-JHtml::_('script', 'com_finder/indexer.js', true, true);
+JHtml::_('script', 'com_finder/indexer.js', false, true);
 ?>
 
 <div id="finder-indexer-container">

--- a/administrator/components/com_finder/views/indexer/tmpl/default.php
+++ b/administrator/components/com_finder/views/indexer/tmpl/default.php
@@ -9,8 +9,9 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.framework');
 JHtml::_('behavior.keepalive');
+JHtml::_('jquery.framework');
+JHtml::_('script', 'com_finder/indexer.js', true, true);
 ?>
 
 <div id="finder-indexer-container">
@@ -19,9 +20,9 @@ JHtml::_('behavior.keepalive');
 
 	<p id="finder-progress-message"><?php echo JText::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
 
-	<form id="finder-progress-form"></form>
-
-	<div id="finder-progress-container"></div>
+	<div id="progress" class="progress progress-striped active">
+		<div id="progress-bar" class="bar bar-success" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+	</div>
 
 	<input id="finder-indexer-token" type="hidden" name="<?php echo JFactory::getSession()->getFormToken(); ?>" value="1" />
 </div>

--- a/administrator/components/com_finder/views/indexer/view.html.php
+++ b/administrator/components/com_finder/views/indexer/view.html.php
@@ -16,17 +16,5 @@ defined('_JEXEC') or die;
  */
 class FinderViewIndexer extends JViewLegacy
 {
-	/**
-	 * Method to display the view.
-	 *
-	 * @param   string  $tpl  A template file to load. [optional]
-	 *
-	 * @return  void
-	 *
-	 * @since   2.5
-	 */
-	public function display($tpl = null)
-	{
-		parent::display();
-	}
+
 }

--- a/administrator/components/com_finder/views/indexer/view.html.php
+++ b/administrator/components/com_finder/views/indexer/view.html.php
@@ -27,11 +27,6 @@ class FinderViewIndexer extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		JHtml::_('stylesheet', 'com_finder/indexer.css', false, true, false);
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'com_finder/indexer.js', false, true);
-		JHtml::_('script', 'system/progressbar.js', true, true);
-
 		parent::display();
 	}
 }

--- a/media/com_finder/js/indexer.js
+++ b/media/com_finder/js/indexer.js
@@ -78,10 +78,14 @@ var FinderIndexer = function(){
 		progress = (offset / totalItems) * 100;
 		jQuery('#finder-progress-header').text(header);
 		jQuery('#finder-progress-message').html(message);
-		if (progress <= 100) {
+		if (progress < 100) {
 			jQuery('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
 		}
 		else {
+			jQuery('#progress-bar').removeClass('bar-success').addClass('bar-warning').attr('aria-valuemin', 100).attr('aria-valuemax', 200);
+			jQuery('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
+		}
+		if (progress == 200) {
 			jQuery('#progress').remove();
 		}
 	};

--- a/media/com_finder/js/indexer.js
+++ b/media/com_finder/js/indexer.js
@@ -4,63 +4,58 @@ var FinderIndexer = function(){
 	var offset= null;
 	var progress= null;
 	var optimized= false;
-	var pb;
-	var $ = jQuery.noConflict();
 	var path = 'index.php?option=com_finder&tmpl=component&format=json';
 
 	var initialize = function () {
 		offset = 0;
 		progress = 0;
-		pb = new Fx.ProgressBar(document.getElementById('finder-progress-container'));
-		path = path + '&' + $('#finder-indexer-token').attr('name') + '=1';
+		path = path + '&' + jQuery('#finder-indexer-token').attr('name') + '=1';
 		getRequest('indexer.start');
 	};
 
 	var getRequest= function (task) {
-       $.ajax({
-            type : "GET",
-            url : path,
-            data :  'task=' + task,
-            dataType : 'json',
-            success : handleResponse,
-            error : handleFailure
-        });
+		jQuery.ajax({
+			type : "GET",
+			url : path,
+			data :  'task=' + task,
+			dataType : 'json',
+			success : handleResponse,
+			error : handleFailure
+		});
 	};
 
 	var handleResponse = function (json, resp) {
 		try {
-            if (json === null) {
-                throw resp;
-            }
-            if (json.error) {
-                throw json;
-            }
-            if (json.start) {
-                totalItems = json.totalItems;
-            }
-            offset += json.batchOffset;
-            updateProgress(json.header, json.message);
-            if (offset < totalItems) {
-                getRequest('indexer.batch');
-            } else if (!optimized) {
-                optimized = true;
-                getRequest('indexer.optimize');
-            }
-		} catch (error) {
-			if (pb) {
-			    $(pb.element).remove();
+			if (json === null) {
+				throw resp;
 			}
+			if (json.error) {
+				throw json;
+			}
+			if (json.start) {
+				totalItems = json.totalItems;
+			}
+			offset += json.batchOffset;
+			updateProgress(json.header, json.message);
+			if (offset < totalItems) {
+				getRequest('indexer.batch');
+			} else if (!optimized) {
+				optimized = true;
+				getRequest('indexer.optimize');
+			}
+		} catch (error) {
+			jQuery('#progress').remove();
 			try {
 				if (json.error) {
-					$('#finder-progress-header').text(json.header).addClass('finder-error');
-					$('#finder-progress-message').html(json.message).addClass('finder-error');
+					jQuery('#finder-progress-header').text(json.header).addClass('finder-error');
+					jQuery('#finder-progress-message').html(json.message).addClass('finder-error');
 				}
 			} catch (ignore) {
 				if (error === '') {
 					error = Joomla.JText._('COM_FINDER_NO_ERROR_RETURNED');
 				}
-				$('#finder-progress-header').text(Joomla.JText._('COM_FINDER_AN_ERROR_HAS_OCCURRED')).addClass('finder-error');
-				$('#finder-progress-message').html(error).addClass('finder-error');
+				jQuery('#finder-progress-header').text(Joomla.JText._('COM_FINDER_AN_ERROR_HAS_OCCURRED')).addClass('finder-error');
+				jQuery('#finder-progress-message').html(error).addClass('finder-error');
 			}
 		}
 		return true;
@@ -69,37 +64,35 @@ var FinderIndexer = function(){
 	var handleFailure= function (xhr) {
 		json = (typeof xhr == 'object' && xhr.responseText) ? xhr.responseText : null;
 		json = json ? JSON.decode(json, true) : null;
-        if (pb) {
-            $(pb.element).remove();
-        };
+		jQuery('#progress').remove();
 		if (json) {
 			json = json.responseText != null ? Json.evaluate(json.responseText, true) : json;
 		}
 		var header = json ? json.header : Joomla.JText._('COM_FINDER_AN_ERROR_HAS_OCCURRED');
 		var message = json ? json.message : Joomla.JText._('COM_FINDER_MESSAGE_RETURNED') + ' <br />' + json;
-		$('#finder-progress-header').text(header).addClass('finder-error');
-		$('#finder-progress-message').html(message).addClass('finder-error');
+		jQuery('#finder-progress-header').text(header).addClass('finder-error');
+		jQuery('#finder-progress-message').html(message).addClass('finder-error');
 	};
 
 	var updateProgress = function (header, message) {
 		progress = (offset / totalItems) * 100;
-		$('#finder-progress-header').text(header);
-		$('#finder-progress-message').html(message);
-		if (pb && progress < 100) {
-			pb.set(progress);
-		} else if (pb) {
-	        $(pb.element).remove();
-			pb = false;
+		jQuery('#finder-progress-header').text(header);
+		jQuery('#finder-progress-message').html(message);
+		if (progress <= 100) {
+			jQuery('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
+		}
+		else {
+			jQuery('#progress').remove();
 		}
 	};
 
 	initialize();
 };
 
-jQuery(function ($) {
+jQuery(function () {
 	Indexer = new FinderIndexer();
 	if (typeof window.parent.SqueezeBox == 'object') {
-		$(window.parent.SqueezeBox).on('close', function () {
+		jQuery(window.parent.SqueezeBox).on('close', function () {
 			window.parent.location.reload(true);
 		});
 	}


### PR DESCRIPTION
#### Use the bootstrap javascript for rendering the progress bar

`bootstrap.framework` is always loaded in ISIS and HATHOR so it’s better to use that library instead of loading one more script!
#### B/C

The html markup is changed
The relative css file is not loaded anymore
The relative js file is not loaded anymore
#### Testing

To test this make sure you have plenty of data!
Apply the patch with patch tester ( make sure you are on staging)
purge the indexes if there are any
Re index, and observe that the progress bar is still there, working
