### PR TITLE
Allow extensions of JLog to add handlers

### DIFF
--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -151,33 +151,33 @@ class JLog
 		self::$instance->addLogEntry($entry);
 	}
 
-    /**
-     * Add a logger to the JLog instance.  Loggers route log entries to the correct files/systems to be logged.
-     *
-     * @param   array    $options     The object configuration array.
-     * @param   integer  $priorities  Message priority
-     * @param   array    $categories  Types of entry
-     * @param   boolean  $exclude     If true, all categories will be logged except those in the $categories array
-     *
-     * @return  void
-     *
-     * @since   11.1
-     */
-    public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
-    {
-        // Automatically instantiate the singleton object if not already done.
-        if (empty(self::$instance))
-        {
-            self::setInstance(new JLog);
-        }
+	/**
+	 * Add a logger to the JLog instance.  Loggers route log entries to the correct files/systems to be logged.
+	 *
+	 * @param   array    $options     The object configuration array.
+	 * @param   integer  $priorities  Message priority
+	 * @param   array    $categories  Types of entry
+	 * @param   boolean  $exclude     If true, all categories will be logged except those in the $categories array
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
+	{
+		// Automatically instantiate the singleton object if not already done.
+		if (empty(self::$instance))
+		{
+			self::setInstance(new JLog);
+		}
 
-        self::$instance->addLoggerInternal($options, $priorities, $categories, $exclude);
-    }
+		self::$instance->addLoggerInternal($options, $priorities, $categories, $exclude);
+	}
 
 	/**
 	 * Add a logger to the JLog instance.  Loggers route log entries to the correct files/systems to be logged.
 	 * This method allows you to extend JLog completely.
-     *
+	 *
 	 * @param   array    $options     The object configuration array.
 	 * @param   integer  $priorities  Message priority
 	 * @param   array    $categories  Types of entry

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -151,9 +151,33 @@ class JLog
 		self::$instance->addLogEntry($entry);
 	}
 
+    /**
+     * Add a logger to the JLog instance.  Loggers route log entries to the correct files/systems to be logged.
+     *
+     * @param   array    $options     The object configuration array.
+     * @param   integer  $priorities  Message priority
+     * @param   array    $categories  Types of entry
+     * @param   boolean  $exclude     If true, all categories will be logged except those in the $categories array
+     *
+     * @return  void
+     *
+     * @since   11.1
+     */
+    public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
+    {
+        // Automatically instantiate the singleton object if not already done.
+        if (empty(self::$instance))
+        {
+            self::setInstance(new JLog);
+        }
+
+        self::$instance->addLoggerInternal($options, $priorities, $categories, $exclude);
+    }
+
 	/**
 	 * Add a logger to the JLog instance.  Loggers route log entries to the correct files/systems to be logged.
-	 *
+	 * This method allows you to extend JLog completely.
+     *
 	 * @param   array    $options     The object configuration array.
 	 * @param   integer  $priorities  Message priority
 	 * @param   array    $categories  Types of entry
@@ -163,14 +187,8 @@ class JLog
 	 *
 	 * @since   11.1
 	 */
-	public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
+	protected function addLoggerInternal(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
 	{
-		// Automatically instantiate the singleton object if not already done.
-		if (empty(self::$instance))
-		{
-			self::setInstance(new JLog);
-		}
-
 		// The default logger is the formatted text log file.
 		if (empty($options['logger']))
 		{
@@ -197,12 +215,12 @@ class JLog
 		}
 
 		// Register the configuration if it doesn't exist.
-		if (empty(self::$instance->configurations[$signature]))
+		if (empty($this->configurations[$signature]))
 		{
-			self::$instance->configurations[$signature] = $options;
+			$this->configurations[$signature] = $options;
 		}
 
-		self::$instance->lookup[$signature] = (object) array(
+		$this->lookup[$signature] = (object) array(
 			'priorities' => $priorities,
 			'categories' => array_map('strtolower', (array) $categories),
 			'exclude' => (bool) $exclude);


### PR DESCRIPTION
This was the only static method accessing class variables via self::$instance .

I want to make a wrapper around Monolog for logging. With this I can just add monolog and my wrapper library to composer (which I include elsewhere) and I am good to go. 
