### PR TITLE
Removed index.html, prepared for installation pack

### DIFF
--- a/plugins/content/contact/contact.xml
+++ b/plugins/content/contact/contact.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.2" type="plugin" group="content">
+<extension version="3.2" type="plugin" group="content" method="upgrade">
 	<name>plg_content_contact</name>
 	<author>Joomla! Project</author>
 	<creationDate>January 2014</creationDate>
@@ -11,11 +11,10 @@
 	<description>PLG_CONTENT_CONTACT_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="contact">contact.php</filename>
-		<filename>index.html</filename>
 	</files>
-	<languages>
-		<language tag="en-GB">en-GB.plg_content_contact.ini</language>
-		<language tag="en-GB">en-GB.plg_content_contact.sys.ini</language>
+	<languages folder="language">
+		<language tag="en-GB">en-GB/en-GB.plg_content_contact.ini</language>
+		<language tag="en-GB">en-GB/en-GB.plg_content_contact.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">


### PR DESCRIPTION
As the index.html files have bin removed should those files be removed from the manifest files.
Not urgent since it only gives an error when trying to (re-)install with an installation package.
I tested uninstall and discover and got no messages. Uninstall removed an existing index.html 
without any message even after I removed it from the manifest file.

In addition I prepared for an installation package.
- added method="upgrade"
- changed the language to be loaded from a language folder language/en-GB/ to get a translated description after installation.

If this is accepted all manifests should be edited at least when they get edited anyway. 
I choose this as an example since it is a new plugin, I think disabled by default and could be uninstalled in a lot of Joomla use cases.
