### PR TITLE
remove index.html from XML of administrator/components/com_[n-z]

### DIFF
--- a/administrator/components/com_newsfeeds/newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/newsfeeds.xml
@@ -3,13 +3,12 @@
 	<name>com_newsfeeds</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>COM_NEWSFEEDS_XML_DESCRIPTION</description>
-
 	<install> <!-- Runs on install -->
 		<sql>
 			<file driver="mysql" charset="utf8">sql/install.mysql.utf8.sql</file>
@@ -23,7 +22,6 @@
 
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>metadata.xml</filename>
 		<filename>newsfeeds.php</filename>
 		<filename>router.php</filename>
@@ -50,7 +48,6 @@
 			<filename>access.xml</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>newsfeeds.php</filename>
 			<folder>controllers</folder>
 			<folder>elements</folder>

--- a/administrator/components/com_plugins/plugins.xml
+++ b/administrator/components/com_plugins/plugins.xml
@@ -3,8 +3,8 @@
 	<name>com_plugins</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>plugins.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_postinstall/postinstall.xml
+++ b/administrator/components/com_postinstall/postinstall.xml
@@ -4,12 +4,11 @@
 	<author>Joomla! Project</author>
 	<creationDate>September 2013</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.2.0</version>
 	<description>COM_POSTINSTALL_XML_DESCRIPTION</description>
-
 	<administration>
 		<files folder="admin">
 			<filename>access.xml</filename>
@@ -17,7 +16,6 @@
 			<filename>fof.xml</filename>
 			<filename>postinstall.php</filename>
 			<filename>toolbar.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>models</folder>
 			<folder>views</folder>

--- a/administrator/components/com_redirect/redirect.xml
+++ b/administrator/components/com_redirect/redirect.xml
@@ -3,8 +3,8 @@
 	<name>com_redirect</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -15,7 +15,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>redirect.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_search/search.xml
+++ b/administrator/components/com_search/search.xml
@@ -3,18 +3,14 @@
 	<name>com_search</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.
-	</copyright>
-	<license>GNU General Public License version 2 or later; see
-		LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>COM_SEARCH_XML_DESCRIPTION</description>
-
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>router.php</filename>
 		<filename>search.php</filename>
 		<folder>models</folder>
@@ -28,7 +24,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>search.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_tags/tags.xml
+++ b/administrator/components/com_tags/tags.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="3.1" method="upgrade">
 	<name>com_tags</name>
-		<author>Joomla! Project</author>
+	<author>Joomla! Project</author>
 	<creationDate>December 2013</creationDate>
-		<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-		<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
-		<authorEmail>admin@joomla.org</authorEmail>
-		<authorUrl>www.joomla.org</authorUrl>
-		<version>3.1.0</version>
-		<description>COM_TAGS_XML_DESCRIPTION</description>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.1.0</version>
+	<description>COM_TAGS_XML_DESCRIPTION</description>
 
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>metadata.xml</filename>
 		<filename>newsfeeds.php</filename>
 		<filename>router.php</filename>
@@ -28,7 +27,6 @@
 			<filename>tags.php</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>models</folder>
@@ -42,5 +40,3 @@
 
 	</administration>
 </extension>
-
-

--- a/administrator/components/com_templates/templates.xml
+++ b/administrator/components/com_templates/templates.xml
@@ -3,8 +3,8 @@
 	<name>com_templates</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>templates.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_users/users.xml
+++ b/administrator/components/com_users/users.xml
@@ -3,8 +3,8 @@
 	<name>com_users</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -12,7 +12,6 @@
 
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>router.php</filename>
 		<filename>users.php</filename>
 		<folder>controllers</folder>
@@ -27,7 +26,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>users.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>


### PR DESCRIPTION
This PR removes the `<filename>index.html</filename>` from the admin compnents XML from com_[n-z] and fix some CS issues in the XML's too :smile: 
