### PR TITLE
remove index.html from XML of administrator/components/com_[a-m]

### DIFF
--- a/administrator/components/com_admin/admin.xml
+++ b/administrator/components/com_admin/admin.xml
@@ -15,7 +15,6 @@
 		<files folder="admin">
 			<filename>admin.php</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>helpers</folder>
 			<folder>models</folder>
 			<folder>views</folder>

--- a/administrator/components/com_admin/admin.xml
+++ b/administrator/components/com_admin/admin.xml
@@ -3,8 +3,7 @@
 	<name>com_admin</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.
-	</copyright>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/components/com_ajax/ajax.xml
+++ b/administrator/components/com_ajax/ajax.xml
@@ -12,7 +12,6 @@
 
 	<files folder="site">
 		<filename>ajax.php</filename>
-		<filename>index.html</filename>
 	</files>
 	<languages folder="site">
 		<language tag="en-GB">language/en-GB.com_ajax.ini</language>
@@ -21,7 +20,6 @@
 	<administration>
 		<files folder="admin">
 			<filename>ajax.php</filename>
-			<filename>index.html</filename>
 		</files>
 		<languages folder="admin">
 			<language tag="en-GB">language/en-GB.com_ajax.ini</language>

--- a/administrator/components/com_banners/banners.xml
+++ b/administrator/components/com_banners/banners.xml
@@ -3,10 +3,8 @@
 	<name>com_banners</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.
-	</copyright>
-	<license>GNU General Public License version 2 or later; see
-		LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -26,7 +24,6 @@
 	<files folder="site">
 		<filename>banners.php</filename>
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>router.php</filename>
 		<folder>helpers</folder>
 		<folder>models</folder>
@@ -52,7 +49,6 @@
 			<filename>banners.php</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>models</folder>

--- a/administrator/components/com_cache/cache.xml
+++ b/administrator/components/com_cache/cache.xml
@@ -15,7 +15,6 @@
 			<filename>cache.php</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>models</folder>
 			<folder>views</folder>
 		</files>

--- a/administrator/components/com_cache/cache.xml
+++ b/administrator/components/com_cache/cache.xml
@@ -9,7 +9,6 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>COM_CACHE_XML_DESCRIPTION</description>
-
 	<administration>
 		<files folder="admin">
 			<filename>cache.php</filename>

--- a/administrator/components/com_categories/categories.xml
+++ b/administrator/components/com_categories/categories.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<creationDate>December 2007</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>

--- a/administrator/components/com_categories/categories.xml
+++ b/administrator/components/com_categories/categories.xml
@@ -14,7 +14,6 @@
 			<filename>categories.php</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>models</folder>

--- a/administrator/components/com_checkin/checkin.xml
+++ b/administrator/components/com_checkin/checkin.xml
@@ -3,7 +3,7 @@
 	<name>com_checkin</name>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see LICENSE.txtL</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>

--- a/administrator/components/com_checkin/checkin.xml
+++ b/administrator/components/com_checkin/checkin.xml
@@ -2,9 +2,8 @@
 <extension type="component" version="3.1" method="upgrade">
 	<name>com_checkin</name>
 	<author>Joomla! Project</author>
-	<copyright>(C) 2005 - 2008 Open Source Matters. All rights reserved.
-	</copyright>
-	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txtL</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -14,7 +13,6 @@
 			<filename>checkin.php</filename>
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>models</folder>
 			<folder>views</folder>
 		</files>

--- a/administrator/components/com_config/config.xml
+++ b/administrator/components/com_config/config.xml
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.php</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>models</folder>
 			<folder>controller</folder>

--- a/administrator/components/com_contact/contact.xml
+++ b/administrator/components/com_contact/contact.xml
@@ -3,10 +3,8 @@
 	<name>com_contact</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.
-	</copyright>
-	<license>GNU General Public License version 2 or later; see
-		LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -26,7 +24,6 @@
 	<files folder="site">
 		<filename>contact.php</filename>
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>metadata.xml</filename>
 		<filename>router.php</filename>
 		<folder>helpers</folder>
@@ -54,7 +51,6 @@
 			<filename>config.xml</filename>
 			<filename>contact.php</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>elements</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_content/content.xml
+++ b/administrator/components/com_content/content.xml
@@ -3,17 +3,15 @@
 	<name>com_content</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>COM_CONTENT_XML_DESCRIPTION</description>
-
 	<files folder="site">
 		<filename>content.php</filename>
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>router.php</filename>
 		<folder>helpers</folder>
 		<folder>models</folder>
@@ -27,7 +25,6 @@
 			<filename>config.xml</filename>
 			<filename>content.php</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>elements</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_contenthistory/contenthistory.xml
+++ b/administrator/components/com_contenthistory/contenthistory.xml
@@ -9,16 +9,13 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.2.0</version>
 	<description>COM_CONTENTHISTORY_XML_DESCRIPTION</description>
-
 	<files folder="site">
 		<filename>contenthistory.php</filename>
 		<filename>index.html</filename>
 	</files>
-
 	<administration>
 		<files folder="admin">
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>contenthistory.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_cpanel/cpanel.xml
+++ b/administrator/components/com_cpanel/cpanel.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>controller.php</filename>
 			<filename>cpanel.php</filename>
-			<filename>index.html</filename>
 			<folder>views</folder>
 		</files>
 		<languages folder="admin">

--- a/administrator/components/com_finder/finder.xml
+++ b/administrator/components/com_finder/finder.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
 	<creationDate>August 2011</creationDate>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -12,7 +12,6 @@
 	<menu link="option=com_finder">COM_FINDER</menu>
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>finder.php</filename>
 		<filename>router.php</filename>
 		<folder>controllers</folder>
@@ -24,7 +23,6 @@
 		<folder>js</folder>
 		<folder>images</folder>
 		<folder>css</folder>
-		<filename>index.html</filename>
 	</media>
 	<install>
 		<sql>
@@ -47,7 +45,6 @@
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
 			<filename>finder.php</filename>
-			<filename>index.html</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>models</folder>

--- a/administrator/components/com_installer/installer.xml
+++ b/administrator/components/com_installer/installer.xml
@@ -3,8 +3,8 @@
 	<name>com_installer</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>installer.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -3,8 +3,8 @@
 	<name>com_joomlaupdate</name>
 	<author>Joomla! Project</author>
 	<creationDate>February 2012</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>joomlaupdate.php</filename>
 			<filename>restore.php</filename>
 			<folder>controllers</folder>

--- a/administrator/components/com_languages/languages.xml
+++ b/administrator/components/com_languages/languages.xml
@@ -3,10 +3,8 @@
 	<name>com_languages</name>
 	<author>Joomla! Project</author>
 	<creationDate>2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.
-	</copyright>
-	<license>GNU General Public License version 2 or later; see
-		LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -15,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>languages.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_login/login.xml
+++ b/administrator/components/com_login/login.xml
@@ -3,8 +3,8 @@
 	<name>com_login</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -12,7 +12,6 @@
 	<administration>
 		<files folder="admin">
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>login.php</filename>
 			<folder>views</folder>
 			<folder>models</folder>

--- a/administrator/components/com_media/media.xml
+++ b/administrator/components/com_media/media.xml
@@ -3,16 +3,14 @@
 	<name>com_media</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>COM_MEDIA_XML_DESCRIPTION</description>
-
 	<files folder="site">
 		<filename>controller.php</filename>
-		<filename>index.html</filename>
 		<filename>media.php</filename>
 		<folder>helpers</folder>
 	</files>
@@ -23,7 +21,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>media.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_menus/menus.xml
+++ b/administrator/components/com_menus/menus.xml
@@ -3,8 +3,8 @@
 	<name>com_menus</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>menus.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_messages/messages.xml
+++ b/administrator/components/com_messages/messages.xml
@@ -3,8 +3,8 @@
 	<name>com_messages</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -16,7 +16,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>messages.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>

--- a/administrator/components/com_modules/modules.xml
+++ b/administrator/components/com_modules/modules.xml
@@ -3,8 +3,8 @@
 	<name>com_modules</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2006</creationDate>
-	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.	</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -13,7 +13,6 @@
 		<files folder="admin">
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
-			<filename>index.html</filename>
 			<filename>modules.php</filename>
 			<folder>controllers</folder>
 			<folder>helpers</folder>


### PR DESCRIPTION
This PR removes the `<filename>index.html</filename>` from the admin compnents XML from com_[a-m] and fix some CS issues in the XML's too :smile: 
