### PR TITLE
[fix] Adding typealias forgotten in #5338

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -22,6 +22,14 @@ require_once JPATH_COMPONENT . '/helpers/menus.php';
 class MenusModelItem extends JModelAdmin
 {
 	/**
+	 * The type alias for this content type.
+	 *
+	 * @var      string
+	 * @since    3.4
+	 */
+	public $typeAlias = 'com_menus.item';
+
+	/**
 	 * @var        string    The prefix to use with controller messages.
 	 * @since   1.6
 	 */
@@ -46,7 +54,7 @@ class MenusModelItem extends JModelAdmin
 	protected $helpLocal = false;
 
 	/**
-	 * Batch copy/move command. If set to false, 
+	 * Batch copy/move command. If set to false,
 	 * the batch copy/move command is not supported
 	 *
 	 * @var string

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -19,6 +19,14 @@ use Joomla\Registry\Registry;
 class ModulesModelModule extends JModelAdmin
 {
 	/**
+	 * The type alias for this content type.
+	 *
+	 * @var      string
+	 * @since    3.4
+	 */
+	public $typeAlias = 'com_modules.module';
+
+	/**
 	 * @var    string  The prefix to use with controller messages.
 	 * @since  1.6
 	 */
@@ -37,7 +45,7 @@ class ModulesModelModule extends JModelAdmin
 	protected $helpURL;
 
 	/**
-	 * Batch copy/move command. If set to false, 
+	 * Batch copy/move command. If set to false,
 	 * the batch copy/move command is not supported
 	 *
 	 * @var string


### PR DESCRIPTION
After merging #5338, we get 2 errors:
[11-Dec-2014 07:35:44 UTC] PHP Notice:  Undefined property: ModulesModelModule::$typeAlias in /Applications/MAMP/htdocs/trunkgitnew/libraries/legacy/model/admin.php on line 216

and

[11-Dec-2014 07:27:19 UTC] PHP Notice:  Undefined property: MenusModelItem::$typeAlias in /Applications/MAMP/htdocs/trunkgitnew/libraries/legacy/model/admin.php on line 216

This PR solves them.
