### PR TITLE
remove index.html from xml for editors-xtd, editors, extension/joomla, finder plugins

### DIFF
--- a/plugins/editors-xtd/article/article.xml
+++ b/plugins/editors-xtd/article/article.xml
@@ -11,7 +11,6 @@
 	<description>PLG_ARTICLE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="article">article.php</filename>
-		<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors-xtd_article.ini</language>

--- a/plugins/editors-xtd/image/image.xml
+++ b/plugins/editors-xtd/image/image.xml
@@ -11,7 +11,7 @@
 	<description>PLG_IMAGE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="image">image.php</filename>
-		<filename>index.html</filename>	</files>
+	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors-xtd_image.ini</language>
 		<language tag="en-GB">en-GB.plg_editors-xtd_image.sys.ini</language>

--- a/plugins/editors-xtd/pagebreak/pagebreak.xml
+++ b/plugins/editors-xtd/pagebreak/pagebreak.xml
@@ -11,7 +11,6 @@
 	<description>PLG_EDITORSXTD_PAGEBREAK_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="pagebreak">pagebreak.php</filename>
-		<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors-xtd_pagebreak.ini</language>

--- a/plugins/editors-xtd/readmore/readmore.xml
+++ b/plugins/editors-xtd/readmore/readmore.xml
@@ -11,7 +11,6 @@
 	<description>PLG_READMORE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="readmore">readmore.php</filename>
-		<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors-xtd_readmore.ini</language>

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -11,6 +11,8 @@
 	<description>PLG_CODEMIRROR_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="codemirror">codemirror.php</filename>
+		<filename>fonts.json</filename>
+		<filename>fonts.php</filename>
 	</files>
 
 	<languages>
@@ -20,7 +22,6 @@
 
 	<config>
 		<fields name="params">
-
 			<fieldset name="basic">
 				<field name="lineNumbers" type="radio"
 					   class="btn-group btn-group-yesno"

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -11,7 +11,6 @@
 	<description>PLG_CODEMIRROR_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="codemirror">codemirror.php</filename>
-		<filename>index.html</filename>
 	</files>
 
 	<languages>

--- a/plugins/editors/none/none.xml
+++ b/plugins/editors/none/none.xml
@@ -11,7 +11,7 @@
 	<description>PLG_NONE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="none">none.php</filename>
-		<filename>index.html</filename>	</files>
+	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors_none.ini</language>
 		<language tag="en-GB">en-GB.plg_editors_none.sys.ini</language>

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -11,14 +11,14 @@
 	<description>PLG_TINY_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="tinymce">tinymce.php</filename>
-		<filename>index.html</filename>	</files>
+		<folder>fields</folder>
+	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.ini</language>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">
-
 			<fieldset name="basic" addfieldpath="/plugins/editors/tinymce/fields">
 				<field name="skins" type="note"
 					label="PLG_TINY_FIELD_SKIN_INFO_LABEL"

--- a/plugins/extension/joomla/joomla.xml
+++ b/plugins/extension/joomla/joomla.xml
@@ -4,14 +4,13 @@
 	<author>Joomla! Project</author>
 	<creationDate>May 2010</creationDate>
 	<copyright>Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_EXTENSION_JOOMLA_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="joomla">joomla.php</filename>
-		<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_extension_joomla.ini</language>

--- a/plugins/finder/categories/categories.xml
+++ b/plugins/finder/categories/categories.xml
@@ -9,7 +9,6 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_FINDER_CATEGORIES_XML_DESCRIPTION</description>
-	<scriptfile>script.php</scriptfile>
 	<files>
 		<file plugin="categories">categories.php</file>
 	</files>

--- a/plugins/finder/categories/categories.xml
+++ b/plugins/finder/categories/categories.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<creationDate>August 2011</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
@@ -12,7 +12,6 @@
 	<scriptfile>script.php</scriptfile>
 	<files>
 		<file plugin="categories">categories.php</file>
-    	<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_categories.ini</language>

--- a/plugins/finder/categories/categories.xml
+++ b/plugins/finder/categories/categories.xml
@@ -10,7 +10,7 @@
 	<version>3.0.0</version>
 	<description>PLG_FINDER_CATEGORIES_XML_DESCRIPTION</description>
 	<files>
-		<file plugin="categories">categories.php</file>
+		<filename plugin="categories">categories.php</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_categories.ini</language>

--- a/plugins/finder/contacts/contacts.xml
+++ b/plugins/finder/contacts/contacts.xml
@@ -4,15 +4,13 @@
 	<author>Joomla! Project</author>
 	<creationDate>August 2011</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_FINDER_CONTACTS_XML_DESCRIPTION</description>
-	<scriptfile>script.php</scriptfile>
 	<files>
-		<file plugin="contacts">contacts.php</file>
-    	<filename>index.html</filename>
+		<filename plugin="contacts">contacts.php</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_contacts.ini</language>

--- a/plugins/finder/content/content.xml
+++ b/plugins/finder/content/content.xml
@@ -4,15 +4,13 @@
 	<author>Joomla! Project</author>
 	<creationDate>August 2011</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_FINDER_CONTENT_XML_DESCRIPTION</description>
-	<scriptfile>script.php</scriptfile>
 	<files>
-		<file plugin="content">content.php</file>
-    	<filename>index.html</filename>
+		<filename plugin="content">content.php</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_content.ini</language>

--- a/plugins/finder/newsfeeds/newsfeeds.xml
+++ b/plugins/finder/newsfeeds/newsfeeds.xml
@@ -10,7 +10,7 @@
 	<version>3.0.0</version>
 	<description>PLG_FINDER_NEWSFEEDS_XML_DESCRIPTION</description>
 	<files>
-		<file plugin="newsfeeds">newsfeeds.php</file>
+		<filename plugin="newsfeeds">newsfeeds.php</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_newsfeeds.ini</language>

--- a/plugins/finder/newsfeeds/newsfeeds.xml
+++ b/plugins/finder/newsfeeds/newsfeeds.xml
@@ -4,15 +4,13 @@
 	<author>Joomla! Project</author>
 	<creationDate>August 2011</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_FINDER_NEWSFEEDS_XML_DESCRIPTION</description>
-	<scriptfile>script.php</scriptfile>
 	<files>
 		<file plugin="newsfeeds">newsfeeds.php</file>
-    	<filename>index.html</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_newsfeeds.ini</language>

--- a/plugins/finder/tags/tags.xml
+++ b/plugins/finder/tags/tags.xml
@@ -4,15 +4,13 @@
 	<author>Joomla! Project</author>
 	<creationDate>February 2013</creationDate>
 	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
-	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_FINDER_TAGS_XML_DESCRIPTION</description>
-	<scriptfile>script.php</scriptfile>
 	<files>
-		<file plugin="tags">tags.php</file>
-    	<filename>index.html</filename>
+		<filename plugin="tags">tags.php</filename>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/en-GB.plg_finder_tags.ini</language>


### PR DESCRIPTION
This PR remove index.html from xml for editors-xtd, editors, extension/joomla, finder plugins.

And also fix some things from the finder plugins (e.g. `scriptfile`) :smile: 
