### PR TITLE
Fixed SQL query (Ref #5307)

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -295,7 +295,7 @@ class UsersModelUsers extends JModelList
 		{
 			if ($active == '0')
 			{
-				$query->where('a.activation IN (' . $db->quote('') . ', 0)');
+				$query->where('a.activation IN (' . $db->quote('') . ', ' . $db->quote('0') . ')');
 			}
 			elseif ($active == '1')
 			{


### PR DESCRIPTION
Fixed an issue causing admin user list to be incorrectly filtered for actived state.Because the field ‘activation’ is defined as VARCHAR in MySQL, the integer zero returns an incorrect result. Casting zero as a string in the SQL query corrects the issue.
