### PR TITLE
JFilterInput PATH filter does not support a leading slash

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -250,7 +250,7 @@ class JFilterInput
 				break;
 
 			case 'PATH':
-				$pattern = '/^[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
 				preg_match($pattern, (string) $source, $matches);
 				$result = @ (string) $matches[0];
 				break;

--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -302,6 +302,12 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'',
 				'From generic cases'
 			),
+			'path_03' => array(
+				'path',
+				'/images/system',
+				'/images/system',
+				'From generic cases'
+			),
 			'user_01' => array(
 				'username',
 				'&<f>r%e\'d',


### PR DESCRIPTION
Test code:

``` php
$filter = JFilterInput::getInstance();
var_dump($filter->clean('/path/to/joomla-cms/index.php', 'path'));
```

Expected Result: '/path/to/joomla-cms/index.php'
Actual Result: ''

Apply patch and re-test

Travis-CI job which should show unit test failure - https://travis-ci.org/mbabker/joomla-cms/builds/43885074
Travis-CI job which should pass with patch (in addition to the job for this PR :smile: ) - https://travis-ci.org/mbabker/joomla-cms/builds/43885122
