### PR TITLE
Articles count in "List all categories"

### DIFF
--- a/components/com_content/models/categories.php
+++ b/components/com_content/models/categories.php
@@ -111,7 +111,10 @@ class ContentModelCategories extends JModelList
 
 			$options = array();
 			$options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
+
+			// Setting the 'currentlang' option to 1 filters the returned items count to those assigned to the active language and to "All"
 			$options['currentlang'] = 1;
+
 			$categories = JCategories::getInstance('Content', $options);
 			$this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
 

--- a/components/com_content/models/categories.php
+++ b/components/com_content/models/categories.php
@@ -111,10 +111,6 @@ class ContentModelCategories extends JModelList
 
 			$options = array();
 			$options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
-
-			// Setting the 'currentlang' option to 1 filters the returned items count to those assigned to the active language and to "All"
-			$options['currentlang'] = 1;
-
 			$categories = JCategories::getInstance('Content', $options);
 			$this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
 

--- a/components/com_content/models/categories.php
+++ b/components/com_content/models/categories.php
@@ -111,6 +111,7 @@ class ContentModelCategories extends JModelList
 
 			$options = array();
 			$options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
+			$options['currentlang'] = 1;
 			$categories = JCategories::getInstance('Content', $options);
 			$this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -107,11 +107,7 @@ class JCategories
 		$options['access'] = (isset($options['access'])) ? $options['access'] : 'true';
 		$options['published'] = (isset($options['published'])) ? $options['published'] : 1;
 		$options['countItems'] = (isset($options['countItems'])) ? $options['countItems'] : 0;
-		$options['currentlang'] = (isset($options['currentlang']) && JLanguageMultilang::isEnabled()) ? $options['currentlang'] : 0;
-		if ($options['currentlang'] == 1)
-		{
-			$options['currentlang'] = JFactory::getLanguage()->getTag();
-		}
+		$options['currentlang'] = JLanguageMultilang::isEnabled() ? JFactory::getLanguage()->getTag() : 0;
 		$this->_options = $options;
 
 		return true;

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -106,6 +106,8 @@ class JCategories
 		$this->_statefield = (isset($options['statefield'])) ? $options['statefield'] : 'state';
 		$options['access'] = (isset($options['access'])) ? $options['access'] : 'true';
 		$options['published'] = (isset($options['published'])) ? $options['published'] : 1;
+		$options['countItems'] = (isset($options['countItems'])) ? $options['countItems'] : 0;
+		$options['currentlang'] = (isset($options['currentlang'])) ? (JLanguageMultilang::isEnabled() ? $options['currentlang'] : 0) : 0;
 		$this->_options = $options;
 
 		return true;
@@ -259,20 +261,21 @@ class JCategories
 			->where('badcats.id is null');
 
 		// Note: i for item
-		if (isset($this->_options['countItems']) && $this->_options['countItems'] == 1)
+		if ($this->_options['currentlang'] == 1 || $this->_options['countItems'] == 1)
 		{
+			$queryjoin = $db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id';
+
 			if ($this->_options['published'] == 1)
 			{
-				$query->join(
-					'LEFT',
-					$db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id AND i.' . $this->_statefield . ' = 1'
-				);
-			}
-			else
-			{
-				$query->join('LEFT', $db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id');
+				$queryjoin .=  ' AND i.' . $this->_statefield . ' = 1';
 			}
 
+			if ($this->_options['currentlang'] == 1)
+			{
+				$queryjoin .=  ' AND (i.language = \'*\' OR i.language = ' . $db->quote(JFactory::getLanguage()->getTag()) . ')';
+			}
+
+			$query->join('LEFT', $queryjoin);
 			$query->select('COUNT(i.' . $db->quoteName($this->_key) . ') AS numitems');
 		}
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -272,7 +272,7 @@ class JCategories
 
 			if ($this->_options['currentlang'] !== 0)
 			{
-				$queryjoin .= ' AND (i.language = \'*\' OR i.language = ' . $db->quote($this->_options['currentlang']) . ')';
+				$queryjoin .= ' AND (i.language = ' . $db->quote('*') . ' OR i.language = ' . $db->quote($this->_options['currentlang']) . ')';
 			}
 
 			$query->join('LEFT', $queryjoin);

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -265,7 +265,7 @@ class JCategories
 			->where('badcats.id is null');
 
 		// Note: i for item
-		if ($this->_options['currentlang'] != 0 || $this->_options['countItems'] == 1)
+		if ($this->_options['currentlang'] !== 0 || $this->_options['countItems'] == 1)
 		{
 			$queryjoin = $db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id';
 
@@ -274,7 +274,7 @@ class JCategories
 				$queryjoin .= ' AND i.' . $this->_statefield . ' = 1';
 			}
 
-			if ($this->_options['currentlang'] != 0)
+			if ($this->_options['currentlang'] !== 0)
 			{
 				$queryjoin .= ' AND (i.language = \'*\' OR i.language = ' . $db->quote($this->_options['currentlang']) . ')';
 			}

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -267,12 +267,12 @@ class JCategories
 
 			if ($this->_options['published'] == 1)
 			{
-				$queryjoin .=  ' AND i.' . $this->_statefield . ' = 1';
+				$queryjoin .= ' AND i.' . $this->_statefield . ' = 1';
 			}
 
 			if ($this->_options['currentlang'] == 1)
 			{
-				$queryjoin .=  ' AND (i.language = \'*\' OR i.language = ' . $db->quote(JFactory::getLanguage()->getTag()) . ')';
+				$queryjoin .= ' AND (i.language = \'*\' OR i.language = ' . $db->quote(JFactory::getLanguage()->getTag()) . ')';
 			}
 
 			$query->join('LEFT', $queryjoin);

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -107,7 +107,11 @@ class JCategories
 		$options['access'] = (isset($options['access'])) ? $options['access'] : 'true';
 		$options['published'] = (isset($options['published'])) ? $options['published'] : 1;
 		$options['countItems'] = (isset($options['countItems'])) ? $options['countItems'] : 0;
-		$options['currentlang'] = (isset($options['currentlang'])) ? (JLanguageMultilang::isEnabled() ? $options['currentlang'] : 0) : 0;
+		$options['currentlang'] = (isset($options['currentlang']) && JLanguageMultilang::isEnabled()) ? $options['currentlang'] : 0;
+		if ($options['currentlang'] == 1)
+		{
+			$options['currentlang'] = JFactory::getLanguage()->getTag();
+		}
 		$this->_options = $options;
 
 		return true;
@@ -261,7 +265,7 @@ class JCategories
 			->where('badcats.id is null');
 
 		// Note: i for item
-		if ($this->_options['currentlang'] == 1 || $this->_options['countItems'] == 1)
+		if ($this->_options['currentlang'] != 0 || $this->_options['countItems'] == 1)
 		{
 			$queryjoin = $db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id';
 
@@ -270,9 +274,9 @@ class JCategories
 				$queryjoin .= ' AND i.' . $this->_statefield . ' = 1';
 			}
 
-			if ($this->_options['currentlang'] == 1)
+			if ($this->_options['currentlang'] != 0)
 			{
-				$queryjoin .= ' AND (i.language = \'*\' OR i.language = ' . $db->quote(JFactory::getLanguage()->getTag()) . ')';
+				$queryjoin .= ' AND (i.language = \'*\' OR i.language = ' . $db->quote($this->_options['currentlang']) . ')';
 			}
 
 			$query->join('LEFT', $queryjoin);

--- a/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
+++ b/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
@@ -32,16 +32,29 @@ class JCategoriesTest extends TestCaseDatabase
 	 *
 	 * @since   3.2
 	 */
-	protected function setUp()
+	public function setUp()
 	{
+		parent::setUp();
+
+		// Add JApplication and JLanguage dependencies
+		$this->saveFactoryState();
+		JFactory::$language = $this->getMockLanguage();
+		JFactory::$application = $this->getMockCmsApp();;
 	}
 
 	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   3.2
 	 */
 	protected function tearDown()
 	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
+++ b/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
@@ -39,7 +39,7 @@ class JCategoriesTest extends TestCaseDatabase
 		// Add JApplication and JLanguage dependencies
 		$this->saveFactoryState();
 		JFactory::$language = $this->getMockLanguage();
-		JFactory::$application = $this->getMockCmsApp();;
+		JFactory::$application = $this->getMockCmsApp();
 	}
 
 	/**


### PR DESCRIPTION
Fixes articles count in "List all categories": articles for non active language were erroneously accounted for (see: #5412)
