### PR TITLE
Eliminates minor javascript error in toolbar popup button

### DIFF
--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -16,7 +16,7 @@ $class  = $displayData['class'];
 $text   = $displayData['text'];
 $name   = $displayData['name'];
 ?>
-<button onclick="<?php echo $doTask; ?>" class="btn btn-small modal" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
+<button value="<?php echo $doTask; ?>" class="btn btn-small modal" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
 	<i class="<?php echo $class; ?>"></i>
 	<?php echo $text; ?>
 </button>


### PR DESCRIPTION
#### Whenever a modal is render through a toolbar popup button, an error is logged in the browser.

This is due to `onClick` been set as Url.

This PR changes `onclick` to value (acceptable option for buttons)
#### Testing

Apply #5386
There are two javascript errors logged in your browsers console (the second one `Joomla.toggleSidebar` is solved #5259)
Apply this PR
error should go away
