### PR TITLE
Fix notice in content search plugin

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -168,7 +168,7 @@ class PlgSearchContent extends JPlugin
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id . ' END as catslug';
 
-			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language')
+			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language, a.catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section, ' . $case_when . ',' . $case_when1 . ', ' . '\'2\' AS browsernav')
 


### PR DESCRIPTION
During #5276 I changed from catslug to catid in the call to ContentHelperRoute::getArticleRoute(). Unfortunately, we don't retrieve the catid from the database. That is why we get a notice here.
### Testinstructions

Search something in your Joomla installation and make sure that you have the content search plugin enabled. Notice the notice in the output for every content link.
Apply the change, see the notice disappear.

Thanks @shur for spotting this bug.
