### PR TITLE
Fixing getArticleRoute() calls

### DIFF
--- a/layouts/joomla/content/blog_style_default_links.php
+++ b/layouts/joomla/content/blog_style_default_links.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($displayData->get('link_items') as $item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language)); ?>">
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>


### PR DESCRIPTION
There is no need to use catslug in Joomla 3.x because:
1. Core content component doesn't use catslug in article URLs;
2. Process link function - **ContentHelperRoute::getArticleRoute** - requires only catid (integer value).
`/components/com_content/helpers/route.php`
`public static function getArticleRoute($id, $catid = 0, $language = 0)`

See more #4371 and #5276
