### PR TITLE
[fix] Fixing getArticleRoute() calls in finder content plugin

### DIFF
--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -267,7 +267,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 
 		// Build the necessary route and path information.
 		$item->url = $this->getURL($item->id, $this->extension, $this->layout);
-		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catslug, $item->language);
+		$item->route = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 		$item->path = FinderIndexerHelper::getContentPath($item->route);
 
 		// Get the menu title if it exists.


### PR DESCRIPTION
There is no need to use catslug in Joomla 3.x because:
1. Core content component doesn't use catslug in article URLs;
2. Process link function - **ContentHelperRoute::getArticleRoute** - requires only catid.
`/components/com_content/helpers/route.php`
`public static function getArticleRoute($id, $catid = 0, $language = 0)`

See more #4371 and #5276

After this PR all URLs to the articles must be identical as in content component.
