### PR TITLE
Remove optimization bar at the end of the process

### DIFF
--- a/administrator/components/com_finder/views/indexer/tmpl/default.php
+++ b/administrator/components/com_finder/views/indexer/tmpl/default.php
@@ -10,8 +10,10 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
+JHtml::_('behavior.core');
 JHtml::_('jquery.framework');
 JHtml::_('script', 'com_finder/indexer.js', false, true);
+JFactory::getDocument()->addScriptDeclaration('var msg = "' . JText::_('COM_FINDER_INDEXER_MESSAGE_COMPLETE') . '";');
 ?>
 
 <div id="finder-indexer-container">

--- a/media/com_finder/js/indexer.js
+++ b/media/com_finder/js/indexer.js
@@ -85,8 +85,9 @@ var FinderIndexer = function(){
 			jQuery('#progress-bar').removeClass('bar-success').addClass('bar-warning').attr('aria-valuemin', 100).attr('aria-valuemax', 200);
 			jQuery('#progress-bar').css('width', progress + '%').attr('aria-valuenow', progress);
 		}
-		if (progress == 200) {
+		if (message == msg) {
 			jQuery('#progress').remove();
+			window.parent.jQuery('#modal-archive', parent.document).modal('hide');
 		}
 	};
 


### PR DESCRIPTION
#### The new progress bar that appears in optimization process might not disappear at the end of the process

This fixes an anomaly discovered by @waader at #5386
#### Test

Install joomla with test data (staging)
run finder indexer
At the end of the process the optimization bar doesn’t disappear
Apply this patch
Purge and re index
Yellow bar disappears at the end of the process
