### PR TITLE
Unnecessary condition in mod_articles_category

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -227,7 +227,7 @@ abstract class ModArticlesCategoryHelper
 		foreach ($items as &$item)
 		{
 			$item->slug    = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid ? $item->catid . ':' . $item->category_alias : $item->catid;
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{


### PR DESCRIPTION
Unnecessary checks for parameter $item->catid in this line have no sense.

**How to test**
Just see this line and compare to the same line in other content modules.
Now this line the same.
