### PR TITLE
Users users model - postgresql (case sensitive DDL)

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -390,14 +390,14 @@ class UsersModelUsers extends JModelList
 			if ($range == 'post_year')
 			{
 				$query->where(
-					$db->qn('a.registerDate'). ' < ' . $db->quote($dStart->format('Y-m-d H:i:s'))
+					$db->qn('a.registerDate') . ' < ' . $db->quote($dStart->format('Y-m-d H:i:s'))
 				);
 			}
 			else
 			{
 				$query->where(
-					$db->qn('a.registerDate'). ' >= ' . $db->quote($dStart->format('Y-m-d H:i:s')) .
-					' AND '.$db->qn('a.registerDate'). ' <= ' . $db->quote($dNow->format('Y-m-d H:i:s'))
+					$db->qn('a.registerDate') . ' >= ' . $db->quote($dStart->format('Y-m-d H:i:s')) .
+					' AND ' . $db->qn('a.registerDate') . ' <= ' . $db->quote($dNow->format('Y-m-d H:i:s'))
 				);
 			}
 		}
@@ -425,7 +425,7 @@ class UsersModelUsers extends JModelList
 	 */
 	function _getUserDisplayedGroups($user_id)
 	{
-		$db = JFactory::getDbo();
+		$db    = JFactory::getDbo();
 		$query = "SELECT title FROM " . $db->quoteName('#__usergroups') . " ug left join " .
 			$db->quoteName('#__user_usergroup_map') . " map on (ug.id = map.group_id)" .
 			" WHERE map.user_id=" . (int) $user_id;

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -390,14 +390,14 @@ class UsersModelUsers extends JModelList
 			if ($range == 'post_year')
 			{
 				$query->where(
-					'a.registerDate < ' . $db->quote($dStart->format('Y-m-d H:i:s'))
+					$db->qn('a.registerDate'). ' < ' . $db->quote($dStart->format('Y-m-d H:i:s'))
 				);
 			}
 			else
 			{
 				$query->where(
-					'a.registerDate >= ' . $db->quote($dStart->format('Y-m-d H:i:s')) .
-						' AND a.registerDate <=' . $db->quote($dNow->format('Y-m-d H:i:s'))
+					$db->qn('a.registerDate'). ' >= ' . $db->quote($dStart->format('Y-m-d H:i:s')) .
+					' AND '.$db->qn('a.registerDate'). ' <= ' . $db->quote($dNow->format('Y-m-d H:i:s'))
 				);
 			}
 		}
@@ -411,7 +411,7 @@ class UsersModelUsers extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$query->order($db->escape($this->getState('list.ordering', 'a.name')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
+		$query->order($db->qn($db->escape($this->getState('list.ordering', 'a.name'))) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
 		return $query;
 	}


### PR DESCRIPTION
this PR fix two issue (a, b)
### Steps to reproduce the issue

(a) On administration side
go to User -> User Manager and click to sort for Last Visit Date or Registration Date column

(b) On administration side
go to User -> User Manager and click on search tools and filter on Registration Date
### Expected result

(a) The user list is sorted by registration or visit date
(b) The user list is filtered by register date
### Actual result

(a) but it throws a Database Error
query failed (error # %s): %s SQL=SELECT a.\* FROM "#_users" AS a ORDER BY a.registerDate ASC LIMIT 20

(b)but it throws a Database Error
query failed (error # %s): %s SQL=SELECT a.\* FROM "#_users" AS a WHERE a.registerDate >= '2014-09-15 19:43:46' AND a.registerDate <='2014-12-15 19:43:46' ORDER BY a.name asc LIMIT 20
### System information

Joomla! 3.4.0-alpha
Postgres 9.3.5
PHP 5.5.9
### Additional comments

Postgres is a little bit different than mysql on mixed case columns name , so this is is only a temporary fix
should be better if all joomla fields became lowercase, the user table is the only table that have mixed case fields
