### PR TITLE
[#5424] - removing content router inclusion

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 $com_path = JPATH_SITE . '/components/com_content/';
-require_once $com_path . 'router.php';
 require_once $com_path . 'helpers/route.php';
 
 JModelLegacy::addIncludePath($com_path . '/models', 'ContentModel');

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_SITE . '/components/com_content/router.php';
-
 /**
  * Content search plugin.
  *


### PR DESCRIPTION
modules/mod_articles_category/helper.php and content search plugin implicitely require content router file, so  custom router override is impossible because router class can already be included before.
