### PR TITLE
Fix com_search logic for 'all phrase' type of search #5079

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -95,9 +95,25 @@ class SearchHelper
 		// Next is to remove ignored words from type 'all' or 'any' (not exact) searches with multiple words.
 		if (count($aterms) > 1 && $searchphrase != 'exact')
 		{
-			$pruned     = array_diff($aterms, $search_ignore);
-			$searchword = implode(' ', $pruned);
+			$pruned = array_diff($aterms, $search_ignore);
+			if (count($pruned) > 0)
+			{
+				//if search word has at least one legal word then leave all phrase for type 'all'
+				if ($searchphrase != 'all')
+				{
+					if (count($aterms) != count($pruned))
+					{
+						$ignored = true;
+					}
+					$searchword = implode(' ', $pruned);
+				}
+			}else
+			{
+				$searchword = '';
+				$ignored = true;
+			}
 		}
+
 
 		return $ignored;
 	}

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -114,7 +114,6 @@ class SearchHelper
 			}
 		}
 
-
 		return $ignored;
 	}
 

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -96,6 +96,7 @@ class SearchHelper
 		if (count($aterms) > 1 && $searchphrase != 'exact')
 		{
 			$pruned = array_diff($aterms, $search_ignore);
+			
 			if (count($pruned) > 0)
 			{
 				// If search word has at least one legal word then leave all phrase for type 'all'.
@@ -111,7 +112,7 @@ class SearchHelper
 			else
 			{
 				$searchword = '';
-				$ignored = true;
+				$ignored    = true;
 			}
 		}
 

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -98,7 +98,7 @@ class SearchHelper
 			$pruned = array_diff($aterms, $search_ignore);
 			if (count($pruned) > 0)
 			{
-				//if search word has at least one legal word then leave all phrase for type 'all'
+				// If search word has at least one legal word then leave all phrase for type 'all'.
 				if ($searchphrase != 'all')
 				{
 					if (count($aterms) != count($pruned))
@@ -107,7 +107,8 @@ class SearchHelper
 					}
 					$searchword = implode(' ', $pruned);
 				}
-			}else
+			}
+			else
 			{
 				$searchword = '';
 				$ignored = true;

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -96,7 +96,7 @@ class SearchHelper
 		if (count($aterms) > 1 && $searchphrase != 'exact')
 		{
 			$pruned = array_diff($aterms, $search_ignore);
-			
+
 			if (count($pruned) > 0)
 			{
 				// If search word has at least one legal word then leave all phrase for type 'all'.


### PR DESCRIPTION
If serach phrase consists from several words and choosen search type "by all prase" then if at least one word is not in exclude list and word length satisfy minimum word limitation criteria then search component searches by original phrase, don't trim any short and excluded words as before.
All other logic left untouched and must work as befor. It can be quite a long story to describe all old logic which must be preserved, but could be affected by these changes.
