### PR TITLE
Load menus before triggering before and after delete events

### DIFF
--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -274,20 +274,23 @@ class MenusModelMenu extends JModelForm
 		// Iterate the items to delete each one.
 		foreach ($itemIds as $itemId)
 		{
-			// Trigger the before delete event.
-			$result = $dispatcher->trigger('onContentBeforeDelete', array($this->_context, $table));
-
-			if (in_array(false, $result, true) || !$table->delete($itemId))
+			if ($table->load($itemId))
 			{
-				$this->setError($table->getError());
+				// Trigger the before delete event.
+				$result = $dispatcher->trigger('onContentBeforeDelete', array($this->_context, $table));
 
-				return false;
+				if (in_array(false, $result, true) || !$table->delete($itemId))
+				{
+					$this->setError($table->getError());
+
+					return false;
+				}
+
+				// Trigger the after delete event.
+				$dispatcher->trigger('onContentAfterDelete', array($this->_context, $table));
+
+				// TODO: Delete the menu associations - Menu items and Modules
 			}
-
-			// Trigger the after delete event.
-			$dispatcher->trigger('onContentAfterDelete', array($this->_context, $table));
-
-			// TODO: Delete the menu associations - Menu items and Modules
 		}
 
 		// Clean the cache


### PR DESCRIPTION
### Problem

Menu objects aren't being loaded before triggering before and after delete events.
### Consequences

With #4308 changes, we are now triggering events on Menu delete actions. If the object isn't loaded before triggering these events, the data being passed to the handlers is incomplete.
### Test instructions
- Download The Joomla Catcher package. This package may be found at https://github.com/nooku/joomla-catcher. Just download the whole repo as a zip. This zip is installable AS IS.
- Install the package that you've just downloaded.
- Enable the Events Catcher - Content plugin and make sure that the onContentBeforeDelete and onContentAfterDelete are selected in the plugin configuration. Also make sure that the "Show data" option is enabled.
- Create a new menu (not a menu item, a menu).
- Delete the menu.

At this point the catcher plugin will raise a message for each event that got triggered. Without the patch, the menu data that gets passed to the event handler is missing (only ID is available in the after delete event). With the patch included in this PR, all the menu data is made available to the handlers, i.e. id, menutype, title and description. 

Thank you in advance for considering this PR.
