### PR TITLE
Fixes listing of "All" categories (#4937)

### DIFF
--- a/components/com_contact/views/categories/tmpl/default.php
+++ b/components/com_contact/views/categories/tmpl/default.php
@@ -12,8 +12,18 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
 
-echo JLayoutHelper::render('joomla.content.categories_default', $this);
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(function($) {
+	$('.categories-list').find('[id^=category-btn-]').each(function(index, btn) {
+		var btn = $(btn);
+		btn.on('click', function() {
+			btn.find('span').toggleClass('icon-plus');
+			btn.find('span').toggleClass('icon-minus');
+		});
+	});
+});");
 
+echo JLayoutHelper::render('joomla.content.categories_default', $this);
 echo $this->loadTemplate('items');
 ?>
 </div>

--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -33,7 +33,8 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 						</span>
 					<?php endif; ?>
 					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-						<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
+						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+							data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>
 				<?php if ($this->params->get('show_subcat_desc_cat') == 1) :?>

--- a/components/com_content/views/categories/tmpl/default.php
+++ b/components/com_content/views/categories/tmpl/default.php
@@ -11,6 +11,18 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
+
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(function($) {
+	$('.categories-list').find('[id^=category-btn-]').each(function(index, btn) {
+		var btn = $(btn);
+		btn.on('click', function() {
+			btn.find('span').toggleClass('icon-plus');
+			btn.find('span').toggleClass('icon-minus');
+		});
+	});
+});");
+
 echo JLayoutHelper::render('joomla.content.categories_default', $this);
 echo $this->loadTemplate('items');
 ?>

--- a/components/com_content/views/categories/tmpl/default_items.php
+++ b/components/com_content/views/categories/tmpl/default_items.php
@@ -34,7 +34,8 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					</span>
 				<?php endif; ?>
 				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-					<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
+					<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+						data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			</h3>
 			<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>

--- a/components/com_newsfeeds/views/categories/tmpl/default.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default.php
@@ -11,6 +11,18 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
+
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(function($) {
+	$('.categories-list').find('[id^=category-btn-]').each(function(index, btn) {
+		var btn = $(btn);
+		btn.on('click', function() {
+			btn.find('span').toggleClass('icon-plus');
+			btn.find('span').toggleClass('icon-minus');
+		});
+	});
+});");
+
 echo JLayoutHelper::render('joomla.content.categories_default', $this);
 echo $this->loadTemplate('items');
 ?>

--- a/components/com_newsfeeds/views/categories/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default_items.php
@@ -33,7 +33,8 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 						</span>
 					<?php endif; ?>
 					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-						<a href="#category-<?php echo $item->id;?>" data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
+						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+							data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>
 				<?php if ($this->params->get('show_subcat_desc_cat') == 1) :?>

--- a/layouts/joomla/content/categories_default.php
+++ b/layouts/joomla/content/categories_default.php
@@ -9,6 +9,17 @@
 
 defined('_JEXEC') or die;
 
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(function($) {
+	$('.categories-list').find('[id^=category-btn-]').each(function(index, btn) {
+		var btn = $(btn);
+		btn.on('click', function() {
+			btn.find('span').toggleClass('icon-plus');
+			btn.find('span').toggleClass('icon-minus');
+		});
+	});
+});");
+
 ?>
 <div class="categories-list<?php echo $displayData->pageclass_sfx;?>">
 <?php if ($displayData->params->get('show_page_heading')) : ?>

--- a/layouts/joomla/content/categories_default.php
+++ b/layouts/joomla/content/categories_default.php
@@ -9,17 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JFactory::getDocument()->addScriptDeclaration("
-jQuery(function($) {
-	$('.categories-list').find('[id^=category-btn-]').each(function(index, btn) {
-		var btn = $(btn);
-		btn.on('click', function() {
-			btn.find('span').toggleClass('icon-plus');
-			btn.find('span').toggleClass('icon-minus');
-		});
-	});
-});");
-
 ?>
 <div class="categories-list<?php echo $displayData->pageclass_sfx;?>">
 <?php if ($displayData->params->get('show_page_heading')) : ?>

--- a/libraries/legacy/view/categories.php
+++ b/libraries/legacy/view/categories.php
@@ -86,7 +86,7 @@ class JViewCategories extends JViewLegacy
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
 
-		$this->maxLevelcat = $params->get('maxLevelcat', -1);
+		$this->maxLevelcat = $params->get('maxLevelcat', -1) < 0 ? 2147483647 : $params->get('maxLevelcat');
 		$this->params      = &$params;
 		$this->parent      = &$parent;
 		$this->items       = &$items;

--- a/libraries/legacy/view/categories.php
+++ b/libraries/legacy/view/categories.php
@@ -86,7 +86,7 @@ class JViewCategories extends JViewLegacy
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
 
-		$this->maxLevelcat = $params->get('maxLevelcat', -1) < 0 ? 2147483647 : $params->get('maxLevelcat');
+		$this->maxLevelcat = $params->get('maxLevelcat', -1) < 0 ? PHP_INT_MAX : $params->get('maxLevelcat', PHP_INT_MAX);
 		$this->params      = &$params;
 		$this->parent      = &$parent;
 		$this->items       = &$items;


### PR DESCRIPTION
For issue description please see #4937

This first commit is just a kludge (or is it a nice hack?) equating the value of the option for "All" categories (-1) to the really big int `2147483647` (the biggest representable in 32bit PHP compiles)
