### PR TITLE
Namespace install app field/rule classes

### DIFF
--- a/installation/form/field/language.php
+++ b/installation/form/field/language.php
@@ -15,7 +15,7 @@ JFormHelper::loadFieldClass('list');
  *
  * @since  1.6
  */
-class JFormFieldLanguage extends JFormFieldList
+class InstallationFormFieldLanguage extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -91,7 +91,7 @@ class JFormFieldLanguage extends JFormFieldList
 	 *
 	 * @return  string
 	 *
-	 * @since    3.1
+	 * @since   3.1
 	 */
 	protected function _sortLanguages($a, $b)
 	{

--- a/installation/form/field/prefix.php
+++ b/installation/form/field/prefix.php
@@ -13,7 +13,7 @@ defined('JPATH_BASE') or die;
  *
  * @since  1.6
  */
-class JFormFieldPrefix extends JFormField
+class InstallationFormFieldPrefix extends JFormField
 {
 	/**
 	 * The form field type.

--- a/installation/form/field/sample.php
+++ b/installation/form/field/sample.php
@@ -15,7 +15,7 @@ JFormHelper::loadFieldClass('radio');
  *
  * @since  1.6
  */
-class JFormFieldSample extends JFormFieldRadio
+class InstallationFormFieldSample extends JFormFieldRadio
 {
 	/**
 	 * The form field type.

--- a/installation/form/rule/prefix.php
+++ b/installation/form/rule/prefix.php
@@ -13,7 +13,7 @@ defined('JPATH_BASE') or die;
  *
  * @since  1.7
  */
-class JFormRulePrefix extends JFormRule
+class InstallationFormRulePrefix extends JFormRule
 {
 	/**
 	 * The regular expression to use in testing a form field value.

--- a/installation/model/forms/database.xml
+++ b/installation/model/forms/database.xml
@@ -40,10 +40,10 @@
 				<option value="backup">INSTL_DATABASE_FIELD_VALUE_BACKUP</option>
 				<option value="remove">INSTL_DATABASE_FIELD_VALUE_REMOVE</option>
 			</field>
-			<field name="db_prefix" type="prefix" id="db_prefix" class="inputbox"
+			<field name="db_prefix" type="installation.prefix" id="db_prefix" class="inputbox"
 				label="INSTL_DATABASE_PREFIX_LABEL"
 				required="true"
-				validate="prefix"
+				validate="installation.prefix"
 				message="INSTL_DATABASE_PREFIX_MSG"
 			/>
 		</fieldset>

--- a/installation/model/forms/preinstall.xml
+++ b/installation/model/forms/preinstall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset>
-		<field name="language" type="language" id="language"
+		<field name="language" type="installation.language" id="language"
 			class="chzn-select-deselect"
 			label="INSTL_LANGUAGE_LABEL"
 			size="20"

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset>
-		<field name="language" type="language" id="language"
+		<field name="language" type="installation.language" id="language"
 			class="chzn-select-deselect"
 			label="INSTL_LANGUAGE_LABEL"
 			size="20"

--- a/installation/model/forms/summary.xml
+++ b/installation/model/forms/summary.xml
@@ -18,7 +18,7 @@
 
 		<field name="db_type" type="hidden" />
 
-		<field name="sample_file" type="sample" class="inputbox"
+		<field name="sample_file" type="installation.sample" class="inputbox"
 			label="INSTL_SITE_INSTALL_SAMPLE_LABEL"
 		/>
 	</fieldset>

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -66,7 +66,7 @@ class InstallationModelSetup extends JModelBase
 	 *
 	 * @param   string  $view  The view being processed.
 	 *
-	 * @return  mixed  JForm object on success, false on failure.
+	 * @return  JForm|boolean  JForm object on success, false on failure.
 	 *
 	 * @since   3.1
 	 */
@@ -82,8 +82,6 @@ class InstallationModelSetup extends JModelBase
 
 		// Get the form.
 		JForm::addFormPath(JPATH_COMPONENT . '/model/forms');
-		JForm::addFieldPath(JPATH_COMPONENT . '/model/fields');
-		JForm::addRulePath(JPATH_COMPONENT . '/model/rules');
 
 		try
 		{
@@ -415,7 +413,7 @@ class InstallationModelSetup extends JModelBase
 	 * @param   array   $data  The form data.
 	 * @param   string  $view  The view.
 	 *
-	 * @return  mixed   Array of filtered data if valid, false otherwise.
+	 * @return  array|boolean  Array of filtered data if valid, false otherwise.
 	 *
 	 * @since	3.1
 	 */


### PR DESCRIPTION
### Issue

The installation app contains a `JFormFieldLanguage` class which has demonstrated previously why we cannot make the core `JFormField` classes autoloadable (see https://github.com/joomla/joomla-cms/pull/3116).
### Solution

`JForm` supports namespacing of classes by a dotted notation in the `type` attribute of a field's XML declaration.  In this case, `type="language"` expects to load an instance of `JFormFieldLanguage` (which is a duplicated class).  Using namespacing, we can use `type="installation.language"` to ask `JForm` to load a class named `InstallationFormFieldLanguage`.
### Additional Changes

Instead of only moving the problem class in the install app, I've instead moved all of the custom `JFormField` and `JFormRule` classes in the install app to use the `Installation` class prefix versus `J`.  This allows us to demonstrate within core this feature of `JForm` (which truthfully isn't presented very well) and demonstrate that custom field elements can be loaded without the use of `addfieldpath` and `addrulepath` attributes in the form XMLs, which should be a preferred behavior in code that is autoloadable (such as the installation application).
### Testing Instructions

As this requires testing the installer, the patch tester can't be used (feasibly anyway) to apply this patch.  So you'll need to apply the patch using a git client or you can download a full Joomla package via GitHub at https://github.com/mbabker/joomla-cms/archive/InstallLanguageField.zip.  Once applied, simply test installing a new Joomla instance; everything should work as before.
### Backward Compatibility

Typically, the installation application has been excluded from backward compatibility concerns as the app is only used for new Joomla installations and the code immediately removed from a site.  Therefore, class proxies or other practices used in the libraries or components are not applied here.
