### PR TITLE
Fix clear button in discover view

### DIFF
--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -46,7 +46,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</div>
 		<div class="btn-group pull-left">
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 		</div>
 	</div>
 	<div class="clearfix"> </div>

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<div id="installer-manage">
+<div id="installer-manage" class="clearfix">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=updatesites'); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">
@@ -36,7 +36,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 		</div>
 		<div class="clearfix"> </div>


### PR DESCRIPTION
In the latest staging version it's not possible to clear the search input field in com_installer&view=discover, since it relies on Mootools, which isn't loaded in that view. This PR fixes it.

![skaermbillede 2014-12-19 kl 19 46 43](https://cloud.githubusercontent.com/assets/1738811/5509408/c9eb10c4-87b7-11e4-98f3-81bb08b5c473.png)
