### PR TITLE
Add "Unfeatured" toolbutton to Article Manager

### DIFF
--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -108,6 +108,7 @@ class ContentViewArticles extends JViewLegacy
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('articles.unpublish', 'JTOOLBAR_UNPUBLISH', true);
 			JToolbarHelper::custom('articles.featured', 'featured.png', 'featured_f2.png', 'JFEATURED', true);
+			JToolbarHelper::custom('articles.unfeatured', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURED', true);
 			JToolbarHelper::archiveList('articles.archive');
 			JToolbarHelper::checkin('articles.checkin');
 		}

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -107,8 +107,8 @@ class ContentViewArticles extends JViewLegacy
 		{
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('articles.unpublish', 'JTOOLBAR_UNPUBLISH', true);
-			JToolbarHelper::custom('articles.featured', 'featured.png', 'featured_f2.png', 'JFEATURED', true);
-			JToolbarHelper::custom('articles.unfeatured', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURED', true);
+			JToolbarHelper::custom('articles.featured', 'featured.png', 'featured_f2.png', 'JFEATURE', true);
+			JToolbarHelper::custom('articles.unfeatured', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURE', true);
 			JToolbarHelper::archiveList('articles.archive');
 			JToolbarHelper::checkin('articles.checkin');
 		}

--- a/administrator/templates/hathor/css/colour_blue.css
+++ b/administrator/templates/hathor/css/colour_blue.css
@@ -1189,6 +1189,10 @@ a img.calendar {
 .icon-32-featured {
 	background-image: url(../images/toolbar/icon-32-featured.png);
 }
+.icon-32-unfeatured {
+	background-image: url(../images/toolbar/icon-32-featured.png);
+	background-position: 0% 100%;
+}
 .icon-32-export {
 	background-image: url(../images/toolbar/icon-32-export.png);
 }

--- a/administrator/templates/hathor/css/colour_brown.css
+++ b/administrator/templates/hathor/css/colour_brown.css
@@ -1189,6 +1189,10 @@ a img.calendar {
 .icon-32-featured {
 	background-image: url(../images/toolbar/icon-32-featured.png);
 }
+.icon-32-unfeatured {
+	background-image: url(../images/toolbar/icon-32-featured.png);
+	background-position: 0% 100%;
+}
 .icon-32-export {
 	background-image: url(../images/toolbar/icon-32-export.png);
 }

--- a/administrator/templates/hathor/css/colour_highcontrast.css
+++ b/administrator/templates/hathor/css/colour_highcontrast.css
@@ -1267,6 +1267,11 @@ a img.calendar {
 	background-image: url(../images/toolbar/icon-32-featured.png);
 }
 
+.icon-32-unfeatured {
+	background-image: url(../images/toolbar/icon-32-featured.png);
+	background-position: 0% 100%;
+}
+
 .icon-32-export {
 	background-image: url(../images/toolbar/icon-32-export.png);
 }

--- a/administrator/templates/hathor/css/colour_standard.css
+++ b/administrator/templates/hathor/css/colour_standard.css
@@ -1189,6 +1189,10 @@ a img.calendar {
 .icon-32-featured {
 	background-image: url(../images/toolbar/icon-32-featured.png);
 }
+.icon-32-unfeatured {
+	background-image: url(../images/toolbar/icon-32-featured.png);
+	background-position: 0% 100%;
+}
 .icon-32-export {
 	background-image: url(../images/toolbar/icon-32-export.png);
 }

--- a/administrator/templates/hathor/less/colour_baseline.less
+++ b/administrator/templates/hathor/less/colour_baseline.less
@@ -959,6 +959,11 @@ a img.calendar {
 	background-image: url(../images/toolbar/icon-32-featured.png);
 }
 
+.icon-32-unfeatured {
+	background-image: url(../images/toolbar/icon-32-featured.png);
+	background-position: 0% 100%;
+}
+
 .icon-32-export {
 	background-image: url(../images/toolbar/icon-32-export.png);
 }


### PR DESCRIPTION
#### With this PR I'm proposing to add an "Unfeatured" toolbutton in article manager.

It all started when while testing something else I did something probably silly: I set all my articles as "Featured". Then I wished to revert them to "_unfeatured_" and... WTF! we don't have a batch operation for that... have to go to the DB...

Then I decided that probably to have an "Unfeatured" button like we have "Unpublish", would probably be a good idea.

After some research I found how to do that (this PR...), but there is something still not working: I couldn't find a way to have the correct icon displayed in Hathor: the icon is there, in `icon-32-featured.png`, but I really don't understand how to activate it, so...  **some help is needed here!** Thanks!
