### PR TITLE
Fix the jumping toolbar

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7199,6 +7199,9 @@ body .navbar-fixed-top {
 	margin-bottom: 10px;
 	min-height: 43px;
 }
+.subhead-collapse {
+	margin-bottom: 11px;
+}
 .subhead-collapse.collapse {
 	height: auto;
 	overflow: visible;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7199,6 +7199,9 @@ body .navbar-fixed-top {
 	margin-bottom: 10px;
 	min-height: 43px;
 }
+.subhead-collapse {
+	margin-bottom: 11px;
+}
 .subhead-collapse.collapse {
 	height: auto;
 	overflow: visible;

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -272,50 +272,42 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 <jdoc:include type="modules" name="debug" style="none" />
 <?php if ($stickyToolbar) : ?>
 	<script>
-		(function($)
+		jQuery(function($)
 		{
-			// Only apply the scrollspy when the toolbar is not collapsed
-			if (document.body.clientWidth > 480)
+
+			var navTop;
+			var isFixed = false;
+
+			processScrollInit();
+			processScroll();
+
+			$(window).on('resize', processScrollInit);
+			$(window).on('scroll', processScroll);
+
+			function processScrollInit()
 			{
-				$('.subhead-collapse').height($('.subhead').height());
-				$('.subhead').scrollspy({
-					offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}
-				});
-			}
+				navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
 
-			// fix sub nav on scroll
-			var $win = $(window)
-				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>
-				, isFixed = 0
-
-			processScroll()
-
-			// hack sad times - holdover until rewrite for 2.1
-			$nav.on('click', function()
-			{
-				if (!isFixed) {
-					setTimeout(function()
-					{
-						$win.scrollTop($win.scrollTop() - 47)
-					}, 10)
+				// Only apply the scrollspy when the toolbar is not collapsed
+				if (document.body.clientWidth > 480)
+				{
+					$('.subhead-collapse').height($('.subhead').height());
+					$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
 				}
-			})
-
-			$win.on('scroll', processScroll)
+			}
 
 			function processScroll()
 			{
-				var i, scrollTop = $win.scrollTop()
+				var scrollTop = $(window).scrollTop();
 				if (scrollTop >= navTop && !isFixed) {
-					isFixed = 1
-					$nav.addClass('subhead-fixed')
+					isFixed = true;
+					$('.subhead').addClass('subhead-fixed');
 				} else if (scrollTop <= navTop && isFixed) {
-					isFixed = 0
-					$nav.removeClass('subhead-fixed')
+					isFixed = false;
+					$('.subhead').removeClass('subhead-fixed');
 				}
 			}
-		})(jQuery);
+		});
 	</script>
 <?php endif; ?>
 </body>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -125,7 +125,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 	<![endif]-->
 </head>
 
-<body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>" <?php if ($stickyToolbar) : ?>data-spy="scroll" data-target=".subhead" data-offset="87"<?php endif; ?>>
+<body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>">
 <!-- Top Navigation -->
 <nav class="navbar navbar-inverse navbar-fixed-top">
 	<div class="navbar-inner">
@@ -274,10 +274,19 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 	<script>
 		(function($)
 		{
+			// Only apply the scrollspy when the toolbar is not collapsed
+			if (document.body.clientWidth > 480)
+			{
+				$('.subhead-collapse').height($('.subhead').height());
+				$('.subhead').scrollspy({
+					offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}
+				});
+			}
+
 			// fix sub nav on scroll
 			var $win = $(window)
 				, $nav    = $('.subhead')
-				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php if ($displayHeader || !$statusFixed) : ?>40<?php else:?>20<?php endif;?>
+				, navTop  = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>
 				, isFixed = 0
 
 			processScroll()

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -286,25 +286,29 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 
 			function processScrollInit()
 			{
-				navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
-
-				// Only apply the scrollspy when the toolbar is not collapsed
-				if (document.body.clientWidth > 480)
-				{
-					$('.subhead-collapse').height($('.subhead').height());
-					$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
+				if ($('.subhead').length) {
+					navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
+	
+					// Only apply the scrollspy when the toolbar is not collapsed
+					if (document.body.clientWidth > 480)
+					{
+						$('.subhead-collapse').height($('.subhead').height());
+						$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
+					}
 				}
 			}
 
 			function processScroll()
 			{
-				var scrollTop = $(window).scrollTop();
-				if (scrollTop >= navTop && !isFixed) {
-					isFixed = true;
-					$('.subhead').addClass('subhead-fixed');
-				} else if (scrollTop <= navTop && isFixed) {
-					isFixed = false;
-					$('.subhead').removeClass('subhead-fixed');
+				if ($('.subhead').length) {
+					var scrollTop = $(window).scrollTop();
+					if (scrollTop >= navTop && !isFixed) {
+						isFixed = true;
+						$('.subhead').addClass('subhead-fixed');
+					} else if (scrollTop <= navTop && isFixed) {
+						isFixed = false;
+						$('.subhead').removeClass('subhead-fixed');
+					}
 				}
 			}
 		});

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -312,6 +312,9 @@ body .navbar-fixed-top{
 	margin-bottom: 10px;
 	min-height:43px;
 }
+.subhead-collapse {
+	margin-bottom: 11px;
+}
 .subhead-collapse.collapse {
 	height: auto;
 	overflow: visible;


### PR DESCRIPTION
In the Isis template, Bootstrap's scrollspy listener is used to affix the toolbar when the page scrolls down.  Because of how the listener operates, the container is removed from the page layout which can cause a jump when scrolling and the affix action occurs.

This issue has been recently fixed in the joomla.org templates and now is being provided here for the Isis toolbar.
### Testing Instructions

Pre-patch, note that when you scroll down a page, the toolbar jumps to the affix position a few pixels too early and that when the jump happens, the rest of the page content scrolls roughly 43 pixels (the height of the toolbar).  Apply the patch and if necessary clear your cache to reload the updated media.  With the patch applied, the scroll action should now be smooth and there is no page jump when the toolbar affixes itself to the top of the page.
