### PR TITLE
Unset reference variable after looping by reference for administrator/modules/mod_[a-z] and hathor admin templates

### DIFF
--- a/administrator/modules/mod_latest/helper.php
+++ b/administrator/modules/mod_latest/helper.php
@@ -100,6 +100,8 @@ abstract class ModLatestHelper
 			}
 		}
 
+		unset($item);
+
 		return $items;
 	}
 

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -133,6 +133,7 @@ abstract class ModMenuHelper
 			}
 		}
 
+		unset($component);
 		$result = JArrayHelper::sortObjects($result, 'text', 1, false, true);
 
 		return $result;

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -11,10 +11,10 @@ defined('_JEXEC') or die;
 
 /* @var $menu JAdminCSSMenu */
 
-$shownew = (boolean) $params->get('shownew', 1);
+$shownew  = (boolean) $params->get('shownew', 1);
 $showhelp = $params->get('showhelp', 1);
-$user = JFactory::getUser();
-$lang = JFactory::getLanguage();
+$user     = JFactory::getUser();
+$lang     = JFactory::getLanguage();
 
 /*
  * Site Submenu
@@ -267,6 +267,8 @@ if ($components)
 			$menu->addChild(new JMenuNode($component->text, $component->link, $component->img));
 		}
 	}
+
+	unset($component);
 
 	$menu->getParent();
 }

--- a/administrator/modules/mod_popular/helper.php
+++ b/administrator/modules/mod_popular/helper.php
@@ -89,6 +89,8 @@ abstract class ModPopularHelper
 			}
 		}
 
+		unset($item);
+
 		return $items;
 	}
 

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -132,6 +132,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						</li>
 						<?php
 						endforeach;
+						unset($module);
 					endif;
 					?>
 				</ul>

--- a/administrator/templates/hathor/html/com_modules/module/edit_assignment.php
+++ b/administrator/templates/hathor/html/com_modules/module/edit_assignment.php
@@ -122,6 +122,7 @@ $menuTypes = MenusHelper::getMenuLinks();
 				<div class="clr"></div>
 				<?php endif; ?>
 			<?php endforeach; ?>
+			<?php unset($type); ?>
 
 			<?php echo JHtml::_('tabs.end');?>
 

--- a/administrator/templates/hathor/html/com_templates/style/edit_assignment.php
+++ b/administrator/templates/hathor/html/com_templates/style/edit_assignment.php
@@ -43,6 +43,7 @@ $user = JFactory::getUser();
 				<?php endforeach; ?>
 			</ul>
 		<?php endforeach; ?>
+		<?php unset($type); ?>
 
 		</div>
 </fieldset>

--- a/administrator/templates/hathor/html/mod_menu/default_enabled.php
+++ b/administrator/templates/hathor/html/mod_menu/default_enabled.php
@@ -240,6 +240,8 @@ if ($components)
 			$menu->addChild(new JMenuNode($component->text, $component->link, $component->img));
 		}
 	}
+
+	unset($component);
 	$menu->getParent();
 }
 


### PR DESCRIPTION
- When looping by reference, reference variable is not unset at the end of the loop.
- and a bit CodeStyle

see: https://github.com/joomla/joomla-cms/issues/5482
