### PR TITLE
Unset reference variable after looping by reference for components, modules and templates

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -204,6 +204,8 @@ class BannersModelBanners extends JModelList
 				$parameters->loadString($item->params);
 				$item->params = $parameters;
 			}
+
+			unset($item);
 		}
 
 		return $this->cache['items'];

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -226,6 +226,7 @@ class ContactViewContact extends JViewLegacy
 				$contact->link = JRoute::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid));
 			}
 
+			unset($contact);
 			$item->link = JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid));
 		}
 
@@ -246,6 +247,7 @@ class ContactViewContact extends JViewLegacy
 		// Override the layout only if this is not the active menu item
 		// If it is the active menu item, then the view and item id will match
 		$active	= $app->getMenu()->getActive();
+
 		if ((!$active) || ((strpos($active->link, 'view=contact') === false) || (strpos($active->link, '&id=' . (string) $this->item->id) === false)))
 		{
 			if ($layout = $params->get('contact_layout'))
@@ -273,10 +275,10 @@ class ContactViewContact extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app		= JFactory::getApplication();
-		$menus		= $app->getMenu();
-		$pathway	= $app->getPathway();
-		$title 		= null;
+		$app     = JFactory::getApplication();
+		$menus   = $app->getMenu();
+		$pathway = $app->getPathway();
+		$title   = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -663,6 +663,8 @@ class ContentModelArticles extends JModelList
 			$item->tags->getItemTags('com_content.article', $item->id);
 		}
 
+		unset($item);
+
 		return $items;
 	}
 

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -63,6 +63,7 @@ JHtml::_('behavior.caption');
 				</div>
 				<?php $leadingcount++; ?>
 			<?php endforeach; ?>
+			<?php unset($item); ?>
 		</div><!-- end items-leading -->
 	<?php endif; ?>
 

--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -10,14 +10,12 @@
 defined('_JEXEC') or die;
 ?>
 
-
 <ol class="nav nav-tabs nav-stacked">
-<?php
-	foreach ($this->link_items as &$item) :
-?>
+<?php foreach ($this->link_items as &$item) : ?>
 	<li>
 		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>
+<?php unset($item); ?>
 </ol>

--- a/components/com_content/views/featured/tmpl/default.php
+++ b/components/com_content/views/featured/tmpl/default.php
@@ -20,7 +20,7 @@ JHtml::_('behavior.caption');
 <?php if ($this->params->get('show_page_heading') != 0) : ?>
 <div class="page-header">
 	<h1>
-	<?php echo $this->escape($this->params->get('page_heading')); ?>
+		<?php echo $this->escape($this->params->get('page_heading')); ?>
 	</h1>
 </div>
 <?php endif; ?>
@@ -36,10 +36,9 @@ JHtml::_('behavior.caption');
 				echo $this->loadTemplate('item');
 			?>
 		</div>
-		<?php
-			$leadingcount++;
-		?>
+		<?php $leadingcount++; ?>
 	<?php endforeach; ?>
+	<?php unset($item); ?>
 </div>
 <?php endif; ?>
 <?php

--- a/components/com_content/views/featured/tmpl/default_links.php
+++ b/components/com_content/views/featured/tmpl/default_links.php
@@ -16,4 +16,5 @@ defined('_JEXEC') or die;
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>
+<?php unset($item); ?>
 </ol>

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -103,6 +103,8 @@ class ContentViewFeatured extends JViewLegacy
 			$item->event->afterDisplayContent = trim(implode("\n", $results));
 		}
 
+		unset($item);
+
 		// Preprocess the breakdown of leading, intro and linked articles.
 		// This makes it much easier for the designer to just interogate the arrays.
 		$max = count($items);

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -285,6 +285,8 @@ abstract class ModArticlesCategoryHelper
 			$item->displayReadmore  = $item->alternative_readmore;
 		}
 
+		unset($item);
+
 		return $items;
 	}
 

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -127,6 +127,8 @@ abstract class ModArticlesLatestHelper
 			}
 		}
 
+		unset($item);
+
 		return $items;
 	}
 }

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -114,6 +114,8 @@ abstract class ModArticlesNewsHelper
 			$item->beforeDisplayContent = trim(implode("\n", $results));
 		}
 
+		unset($item);
+
 		return $items;
 	}
 }

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -16,10 +16,7 @@ JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_content/models', 'Con
 /**
  * Helper for mod_articles_popular
  *
- * @package     Joomla.Site
- * @subpackage  mod_articles_popular
- *
- * @since       1.6.0
+ * @since  1.6.0
  */
 abstract class ModArticlesPopularHelper
 {
@@ -90,6 +87,8 @@ abstract class ModArticlesPopularHelper
 				$item->link = JRoute::_('index.php?option=com_users&view=login');
 			}
 		}
+
+		unset($item);
 
 		return $items;
 	}

--- a/templates/beez3/html/com_content/category/blog.php
+++ b/templates/beez3/html/com_content/category/blog.php
@@ -62,6 +62,7 @@ $cparams = JComponentHelper::getParams('com_media');
 		</article>
 		<?php $leadingcount++; ?>
 	<?php endforeach; ?>
+	<?php unset($item); ?>
 </div>
 <?php endif; ?>
 <?php

--- a/templates/beez3/html/com_content/category/blog_links.php
+++ b/templates/beez3/html/com_content/category/blog_links.php
@@ -10,25 +10,21 @@
 defined('_JEXEC') or die;
 
 $params =& $this->item->params;
-$app = JFactory::getApplication();
+$app    = JFactory::getApplication();
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
-
 ?>
 
 <div class="items-more">
-<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
-
-<ol>
-
-<?php
-	foreach ($this->link_items as &$item) :
-?>
-		 <li>
-		  		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
-			<?php echo $item->title; ?></a>
+	<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
+	<ol>
+	<?php foreach ($this->link_items as &$item) : ?>
+		<li>
+		  	<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
+				<?php echo $item->title; ?></a>
 		</li>
-<?php endforeach; ?>
+	<?php endforeach; ?>
+	<?php unset($item); ?>
 	</ol>
 </div>
 

--- a/templates/beez3/html/com_content/featured/default.php
+++ b/templates/beez3/html/com_content/featured/default.php
@@ -34,6 +34,7 @@ JHtml::_('behavior.caption');
 			$leadingcount++;
 		?>
 	<?php endforeach; ?>
+	<?php unset($item); ?>
 </div>
 <?php endif; ?>
 <?php

--- a/templates/beez3/html/com_content/featured/default_links.php
+++ b/templates/beez3/html/com_content/featured/default_links.php
@@ -20,5 +20,6 @@ defined('_JEXEC') or die;
 			<?php echo $item->title; ?></a>
 	</li>
 <?php endforeach; ?>
+<?php unset($item); ?>
 </ol>
 


### PR DESCRIPTION
- When looping by reference, reference variable is not unset at the end of the loop.
- and a bit CodeStyle

see: https://github.com/joomla/joomla-cms/issues/5482
