### PR TITLE
Add unit test for magic set method

### DIFF
--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -95,7 +95,7 @@ class JFormFieldPassword extends JFormField
 				break;
 
 			case 'meter':
-				$this->$meter = ($value === 'true' || $value === $name || $value === '1');
+				$this->meter = ($value === 'true' || $value === $name || $value === '1');
 				break;
 
 			default:

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
@@ -147,16 +147,45 @@ class JFormFieldPasswordTest extends TestCase
 		$element = simplexml_load_string(
 			'<field name="myName" type="password" strengthmeter="true" />');
 
-		$this->assertThat(
+		$this->assertTrue(
 			$field->setup($element, ''),
-			$this->isTrue(),
 			'Line:' . __LINE__ . ' The setup method should return true if successful.'
 		);
 
-		$this->assertThat(
+		$this->assertTrue(
 			$field->meter,
-			$this->isTrue(),
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
+		);
+	}
+
+	/**
+	 * Tests meter attribute setup by using the magic set method
+	 *
+	 * @covers JFormFieldPassword::__set
+	 *
+	 * @return void
+	 */
+	public function testSetMeter()
+	{
+		$field = new JFormFieldPassword;
+		$element = simplexml_load_string(
+			'<field name="myName" type="password" />');
+
+		$this->assertTrue(
+			$field->setup($element, ''),
+			'Line:' . __LINE__ . ' The setup method should return true if successful.'
+		);
+
+		$this->assertFalse(
+			$field->meter,
+			'Line:' . __LINE__ . ' The property is false by default.'
+		);
+
+		$field->meter = true;
+
+		$this->assertTrue(
+			$field->meter,
+			'Line:' . __LINE__ . ' The magic set method should set the property correctly.'
 		);
 	}
 


### PR DESCRIPTION
This unit test demonstrates the bug in the setting of the meter property in the password form field. Note if you are going to test this manually then the property when you initially setup the xml field is strengthmeter and works FINE. What you need to test is then setting this property after input of the XML field.
