### PR TITLE
JInstallerAdapterComponent bug fixes related to admin menu build

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1023,7 +1023,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			JFolder::delete($this->parent->getPath('extension_site'));
 
 			// Remove the menu
-			$this->_removeAdminMenus($this->extension);
+			$this->_removeAdminMenus($this->extension->extension_id);
 
 			// Raise a warning
 			JLog::add(JText::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_ERRORREMOVEMANUALLY'), JLog::WARNING, 'jerror');
@@ -1066,7 +1066,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$retval = false;
 		}
 
-		$this->_removeAdminMenus($this->extension);
+		$this->_removeAdminMenus($this->extension->extension_id);
 
 		/**
 		 * ---------------------------------------------------------------------------------------------
@@ -1194,7 +1194,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			if ($option)
 			{
 				// If something goes wrong, there's no way to rollback TODO: Search for better solution
-				$this->_removeAdminMenus($componentrow);
+				$this->_removeAdminMenus($componentrow->extension_id);
 			}
 
 			$component_id = $componentrow->extension_id;
@@ -1440,17 +1440,16 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	/**
 	 * Method to remove admin menu references to a component
 	 *
-	 * @param   object  &$row  Component table object.
+	 * @param   int  $id  The ID of the extension whose admin menus will be removed
 	 *
 	 * @return  boolean  True if successful.
 	 *
 	 * @since   3.1
 	 */
-	protected function _removeAdminMenus(&$row)
+	protected function _removeAdminMenus($id)
 	{
 		$db = $this->parent->getDbo();
 		$table = JTable::getInstance('menu');
-		$id = $row->extension_id;
 
 		// Get the ids of the menu items
 		$query = $db->getQuery(true)
@@ -1463,6 +1462,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 		$ids = $db->loadColumn();
 
+		$result = true;
+
 		// Check for error
 		if (!empty($ids))
 		{
@@ -1473,14 +1474,15 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 				{
 					$this->setError($table->getError());
 
-					return false;
+					$result = false;
 				}
 			}
+
 			// Rebuild the whole tree
 			$table->rebuild();
 		}
 
-		return true;
+		return $result;
 	}
 
 	/**
@@ -1495,7 +1497,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	 */
 	protected function _rollback_menu($step)
 	{
-		return $this->_removeAdminMenus((object) array('extension_id' => $step['id']));
+		return $this->_removeAdminMenus($step['id']);
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1138,9 +1138,9 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 		// Remove categories for this component
 		$query->clear()
-			  ->delete('#__categories')
-			  ->where('extension=' . $db->quote($this->element), 'OR')
-			  ->where('extension LIKE ' . $db->quote($this->element . '.%'));
+			->delete('#__categories')
+			->where('extension=' . $db->quote($this->element), 'OR')
+			->where('extension LIKE ' . $db->quote($this->element . '.%'));
 		$db->setQuery($query);
 		$db->execute();
 
@@ -1252,10 +1252,10 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		{
 			// Lets find the extension id
 			$query->clear()
-				  ->select('e.extension_id')
-				  ->from('#__extensions AS e')
-				  ->where('e.type = ' . $db->quote('component'))
-				  ->where('e.element = ' . $db->quote($option));
+				->select('e.extension_id')
+				->from('#__extensions AS e')
+				->where('e.type = ' . $db->quote('component'))
+				->where('e.element = ' . $db->quote($option));
 
 			$db->setQuery($query);
 			$component_id = $db->loadResult();
@@ -1874,8 +1874,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	/**
 	 * Creates the menu item in the database. If the item already exists it tries to remove it and create it afresh.
 	 *
-	 * @param   array       &$data     The menu item data to create
-	 * @param   integer     $parentId  The parent menu item ID
+	 * @param   array    &$data     The menu item data to create
+	 * @param   integer  $parentId  The parent menu item ID
 	 *
 	 * @return  bool|int  Menu item ID on success, false on failure
 	 */

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1449,6 +1449,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	protected function _removeAdminMenus($id)
 	{
 		$db = $this->parent->getDbo();
+
+		/** @var  JTableMenu  $table */
 		$table = JTable::getInstance('menu');
 
 		// Get the ids of the menu items


### PR DESCRIPTION
As requested by @wilsonge by email
# Executive summary

This patch for JInstallerAdapterComponent deals with issues manifesting themselves as "Can't build admin menus".

The following intertwined bug fixes are applied:
- If building admin menus failed the `#__menus` table was left broken (inconsistent lft/rgt) because rebuild() never ran against it.
- Failed installations without rollback (e.g. due to timeout) can leave behind rubbish `#__extensions` and `#__menus` entries leading to inability to reinstall the component
- A failure in _removeAdminMenus –presumably because of the issue above– would make it impossible to install the component.
- Just do not create the menu if $menuElement not exist (it was a TODO item for as long as I remember developing for Joomla!)
- The extension ID was passed to _buildAdminMenus but completely ignored!
- If a submenu already existed with the same parent item the installation would fail. Now we try removing it first, just like we do for the root menu item.
# Backwards compatibility

The protected _removeAdminMenus method has a different signature. To the best of my knowledge nobody extends JInstallerAdapterComponent directly, therefore the impact is non-existent.
# Translation impact

None
# Testing instructions

As I explained to @wislonge the problems only manifest themselves on bad hosting and when several things go wrong. As a result there is no way to do positive tests which reproduce the bugs. These are "blind" fixes. That said, I've been tracking down these issues since 2007 and applying workarounds on my own extensions ever since. I am pretty darn sure that my code DOES fix these issues.

As a result the only possible testing you can do is regression testing. Try applying this patch and install as many different components as you can on your site (but don't try my extensions, especially the pre-release versions, some have experimental fixes which will not work properly and override this patch in any case!). The installation should succeed and the components should be perfectly usable.
