### PR TITLE
make spacing for icon class's consistent

### DIFF
--- a/administrator/components/com_banners/models/fields/clicks.php
+++ b/administrator/components/com_banners/models/fields/clicks.php
@@ -37,7 +37,7 @@ class JFormFieldClicks extends JFormField
 
 		return
 			'<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '><i class="icon-refresh"></i> '
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '><i class="icon-refresh"></i>'
 			. JText::_('COM_BANNERS_RESET_CLICKS') . '</a>';
 	}
 }

--- a/administrator/components/com_banners/models/fields/impmade.php
+++ b/administrator/components/com_banners/models/fields/impmade.php
@@ -37,7 +37,7 @@ class JFormFieldImpMade extends JFormField
 
 		return
 			'<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '><i class="icon-refresh"></i> '
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '><i class="icon-refresh"></i>'
 			. JText::_('COM_BANNERS_RESET_IMPMADE') . '</a>';
 	}
 }

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -159,7 +159,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' href="index.php?option=com_categories&layout=modal&tmpl=component&task=category.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
-				. '<span class="icon-edit"></span> .  JText::__('JACTION_EDIT')
+				. '<span class="icon-edit"></span>' . JText::__('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -170,7 +170,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearCategory(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> .  JText::__('JCLEAR')
+				. '<span class="icon-remove"></span>' .  JText::__('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -148,7 +148,7 @@ class JFormFieldModal_Category extends JFormField
 			. ' title="' . JHtml::tooltipText('COM_CATEGORIES_CHANGE_CATEGORY') . '"'
 			. ' href="' . $link . '&amp;' . JSession::getFormToken() . '=1"'
 			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
-			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
+			. '<i class="icon-file"></i>' . JText::_('JSELECT')
 			. '</a>';
 
 		// Edit category button
@@ -159,7 +159,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' href="index.php?option=com_categories&layout=modal&tmpl=component&task=category.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit"></span> .  JText::__('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -170,7 +170,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearCategory(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> ' . JText::_('JCLEAR')
+				. '<span class="icon-remove"></span> .  JText::__('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -1,4 +1,166 @@
 <?php
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_categories
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$app = JFactory::getApplication();
+
+if ($app->isSite())
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
+require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
+
+// Include the component HTML helpers.
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+JHtml::_('bootstrap.tooltip');
+JHtml::_('formbehavior.chosen', 'select');
+
+$extension	= $this->escape($this->state->get('filter.extension'));
+$function  	= $app->input->getCmd('function', 'jSelectCategory');
+$listOrder	= $this->escape($this->state->get('list.ordering'));
+$listDirn	= $this->escape($this->state->get('list.direction'));
+?>
+
+<form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
+	<fieldset class="filter clearfix">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-left">
+				<label for="filter_search">
+					<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
+				</label>
+			</div>
+			<div class="btn-group pull-left">
+				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('COM_CATEGORIES_ITEMS_SEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_CATEGORIES_ITEMS_SEARCH_FILTER'); ?>" />
+			</div>
+			<div class="btn-group pull-left">
+				<button type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">
+					<span class="icon-search"></span><?php echo  JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
+				<button type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();">
+					<span class="icon-remove"></span><?php echo  JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
+			</div>
+			<div class="clearfix"></div>
+		</div>
+		<hr class="hr-condensed" />
+		<div class="filters pull-left">
+			<select name="filter_access" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
+			</select>
+
+			<select name="filter_published" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
+			</select>
+
+			<?php if ($this->state->get('filter.forcedLanguage')) : ?>
+				<input type="hidden" name="forcedLanguage" value="<?php echo $this->escape($this->state->get('filter.forcedLanguage')); ?>" />
+				<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
+			<?php else : ?>
+				<select name="filter_language" class="input-medium" onchange="this.form.submit()">
+					<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
+					<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
+				</select>
+			<?php endif; ?>
+		</div>
+	</fieldset>
+
+	<table class="table table-striped" id="categoryList">
+		<thead>
+			<tr>
+				<th>
+					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+				</th>
+				<th width="10%" class="nowrap hidden-phone">
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+				</th>
+				<th width="5%" class="nowrap hidden-phone">
+					<?php
+					echo JHtml::_(
+						'grid.sort',
+						'JGRID_HEADING_LANGUAGE',
+						'language',
+						$this->state->get('list.direction'),
+						$this->state->get('list.ordering')
+					);
+					?>
+				</th>
+				<th width="1%" class="nowrap hidden-phone">
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+				</th>
+			</tr>
+		</thead>
+		<tfoot>
+			<tr>
+				<td colspan="15">
+					<?php echo $this->pagination->getListFooter(); ?>
+				</td>
+			</tr>
+		</tfoot>
+		<tbody>
+			<?php foreach ($this->items as $i => $item) : ?>
+				<?php if ($item->language && JLanguageMultilang::isEnabled())
+				{
+					$tag = strlen($item->language);
+					if ($tag == 5)
+					{
+						$lang = substr($item->language, 0, 2);
+					}
+					elseif ($tag == 6)
+					{
+						$lang = substr($item->language, 0, 3);
+					}
+					else
+					{
+						$lang = "";
+					}
+				}
+				elseif (!JLanguageMultilang::isEnabled())
+				{
+					$lang = "";
+				}
+				?>
+				<tr class="row<?php echo $i % 2; ?>">
+					<td>
+						<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>
+						<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<?php echo $this->escape($item->title); ?>
+						</a>
+					</td>
+					<td class="small hidden-phone">
+						<?php echo $this->escape($item->access_level); ?>
+					</td>
+					<td class="center nowrap">
+						<?php if ($item->language == '*'): ?>
+							<?php echo JText::alt('JALL', 'language'); ?>
+						<?php else: ?>
+							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+						<?php endif; ?>
+					</td>
+					<td class="center hidden-phone">
+						<?php echo (int) $item->id; ?>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+
+	<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
+	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="boxchecked" value="0" />
+	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
+	<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
+	<?php echo JHtml::_('form.token'); ?>
+
+</form>
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_categories

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -152,7 +152,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' href="index.php?option=com_contact&layout=modal&tmpl=component&task=contact.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '" >'
-				. '<span class="icon-edit"></span> .  JText::__('JACTION_EDIT')
+				. '<span class="icon-edit"></span>' .  JText::__('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -163,7 +163,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearContact(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> .  JText::__('JCLEAR')
+				. '<span class="icon-remove"></span>' .  JText::__('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -141,7 +141,7 @@ class JFormFieldModal_Contact extends JFormField
 			. ' title="' . JHtml::tooltipText('COM_CONTACT_CHANGE_CONTACT') . '"'
 			. ' href="' . $link . '&amp;' . JSession::getFormToken() . '=1"'
 			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
-			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
+			. '<i class="icon-file"></i>' . JText::_('JSELECT')
 			. '</a>';
 
 		// Edit contact button.
@@ -152,7 +152,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' href="index.php?option=com_contact&layout=modal&tmpl=component&task=contact.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '" >'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit"></span> .  JText::__('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -163,7 +163,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearContact(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> ' . JText::_('JCLEAR')
+				. '<span class="icon-remove"></span> .  JText::__('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -133,19 +133,19 @@ class JFormFieldModal_Article extends JFormField
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
 		$html[] = '<a class="modal btn hasTooltip" title="' . JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '"  href="' . $link . '&amp;' . JSession::getFormToken() .
-			'=1" rel="{handler: \'iframe\', size: {x: 800, y: 450}}"><i class="icon-file"></i> ' . JText::_('JSELECT') . '</a>';
+			'=1" rel="{handler: \'iframe\', size: {x: 800, y: 450}}"><i class="icon-file"></i>' . JText::_('JSELECT') . '</a>';
 
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span> ' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span> .  JText::__('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearArticle(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> ' . JText::_('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span> .  JText::__('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -138,14 +138,14 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span> .  JText::__('JACTION_EDIT') . '</a>';
+			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span>' .  JText::__('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearArticle(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> .  JText::__('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span>' .  JText::__('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -1,4 +1,174 @@
 <?php
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$app = JFactory::getApplication();
+
+if ($app->isSite())
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
+require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
+
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+JHtml::_('bootstrap.tooltip');
+JHtml::_('behavior.framework', true);
+JHtml::_('formbehavior.chosen', 'select');
+
+$function  = $app->input->getCmd('function', 'jSelectArticle');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+?>
+<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1');?>"
+      method="post" name="adminForm" id="adminForm" class="form-inline">
+	<fieldset class="filter clearfix">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-left">
+				<label for="filter_search">
+					<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
+				</label>
+			</div>
+			<div class="btn-group pull-left">
+				<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" />
+			</div>
+			<div class="btn-group pull-left">
+				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
+					<span class="icon-search"></span><?php echo  JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
+					<span class="icon-remove"></span><?php echo  JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
+			</div>
+			<div class="clearfix"></div>
+		</div>
+		<hr class="hr-condensed" />
+		<div class="filters pull-left">
+			<select name="filter_access" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+			</select>
+
+			<select name="filter_published" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
+			</select>
+
+			<?php if ($this->state->get('filter.forcedLanguage')) : ?>
+			<select name="filter_category_id" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content', array('filter.language' => array('*', $this->state->get('filter.forcedLanguage')))), 'value', 'text', $this->state->get('filter.category_id'));?>
+			</select>
+			<input type="hidden" name="forcedLanguage" value="<?php echo $this->escape($this->state->get('filter.forcedLanguage')); ?>" />
+			<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
+			<?php else : ?>
+			<select name="filter_category_id" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content'), 'value', 'text', $this->state->get('filter.category_id'));?>
+			</select>
+			<select name="filter_language" class="input-medium" onchange="this.form.submit()">
+				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
+			</select>
+			<?php endif; ?>
+		</div>
+	</fieldset>
+
+	<table class="table table-striped table-condensed">
+		<thead>
+			<tr>
+				<th class="title">
+					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+				</th>
+				<th width="15%" class="center nowrap">
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
+				</th>
+				<th width="15%" class="center nowrap">
+					<?php echo JHtml::_('grid.sort', 'JCATEGORY', 'a.catid', $listDirn, $listOrder); ?>
+				</th>
+				<th width="5%" class="center nowrap">
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+				</th>
+				<th width="5%" class="center nowrap">
+					<?php echo JHtml::_('grid.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
+				</th>
+				<th width="1%" class="center nowrap">
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+				</th>
+			</tr>
+		</thead>
+		<tfoot>
+			<tr>
+				<td colspan="15">
+					<?php echo $this->pagination->getListFooter(); ?>
+				</td>
+			</tr>
+		</tfoot>
+		<tbody>
+		<?php foreach ($this->items as $i => $item) : ?>
+			<?php if ($item->language && JLanguageMultilang::isEnabled())
+			{
+				$tag = strlen($item->language);
+				if ($tag == 5)
+				{
+					$lang = substr($item->language, 0, 2);
+				}
+				elseif ($tag == 6)
+				{
+					$lang = substr($item->language, 0, 3);
+				}
+				else {
+					$lang = "";
+				}
+			}
+			elseif (!JLanguageMultilang::isEnabled())
+			{
+				$lang = "";
+			}
+			?>
+			<tr class="row<?php echo $i % 2; ?>">
+				<td>
+					<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+						<?php echo $this->escape($item->title); ?></a>
+				</td>
+				<td class="center">
+					<?php echo $this->escape($item->access_level); ?>
+				</td>
+				<td class="center">
+					<?php echo $this->escape($item->category_title); ?>
+				</td>
+				<td class="center">
+					<?php if ($item->language == '*'):?>
+						<?php echo JText::alt('JALL', 'language'); ?>
+					<?php else:?>
+						<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+					<?php endif;?>
+				</td>
+				<td class="center nowrap">
+					<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+				</td>
+				<td class="center">
+					<?php echo (int) $item->id; ?>
+				</td>
+			</tr>
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+
+	<div>
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
+		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+	</div>
+</form>
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_content

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -91,19 +91,19 @@ JFactory::getDocument()->addScriptDeclaration("
 <div class="btn-group pull-right">
 	<button id="toolbar-load" type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>"
 		data-url="<?php echo JRoute::_($loadUrl);?>" id="content-url">
-		<span class="icon-upload"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></button>
+		<span class="icon-upload"></span><?php echo  JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></button>
 	<button id="toolbar-preview" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-search"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></button>
+		<span class="icon-search"></span><?php echo  JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></button>
 	<button id="toolbar-compare" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-zoom-in"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></button>
+		<span class="icon-zoom-in"></span><?php echo  JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
-    	<span class="icon-lock"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></button>
+    	<span class="icon-lock"></span><?php echo  JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.delete')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
-    	<span class="icon-delete"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></button>
+    	<span class="icon-delete"></span><?php echo  JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></button>
 </div>
 <div class="clearfix"></div>
 <form action="<?php echo JRoute::_($formUrl);?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -147,14 +147,14 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') .
 				'" href="index.php?option=com_newsfeeds&layout=modal&tmpl=component&task=newsfeed.edit&id=' . $value .
 				'" target="_blank" title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') .
-				'" ><span class="icon-edit"></span> .  JText::__('JACTION_EDIT') . '</a>';
+				'" ><span class="icon-edit"></span>' .  JText::__('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear newsfeed button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearNewsfeed(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> .  JText::__('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span>' .  JText::__('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -147,14 +147,14 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') .
 				'" href="index.php?option=com_newsfeeds&layout=modal&tmpl=component&task=newsfeed.edit&id=' . $value .
 				'" target="_blank" title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') .
-				'" ><span class="icon-edit"></span> ' . JText::_('JACTION_EDIT') . '</a>';
+				'" ><span class="icon-edit"></span> .  JText::__('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear newsfeed button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearNewsfeed(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> ' . JText::_('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span> .  JText::__('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -44,7 +44,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-plus"></span>&#160;' . JText::_('JNEW') . '&#160;';
+				$text = '<span class="icon-plus"></span>  JText::_('JNEW') . '&#160;';
 			}
 		}
 		else
@@ -99,7 +99,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-envelope"></span> ' . JText::_('JGLOBAL_EMAIL');
+				$text = '<span class="icon-envelope"></span> .  JText::__('JGLOBAL_EMAIL');
 			}
 		}
 		else
@@ -246,7 +246,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-print"></span>&#160;' . JText::_('JGLOBAL_PRINT') . '&#160;';
+				$text = '<span class="icon-print"></span>  JText::_('JGLOBAL_PRINT') . '&#160;';
 			}
 		}
 		else
@@ -282,7 +282,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-print"></span>&#160;' . JText::_('JGLOBAL_PRINT') . '&#160;';
+				$text = '<span class="icon-print"></span>  JText::_('JGLOBAL_PRINT') . '&#160;';
 			}
 		}
 		else

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -99,7 +99,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-envelope"></span> .  JText::__('JGLOBAL_EMAIL');
+				$text = '<span class="icon-envelope"></span>' .  JText::__('JGLOBAL_EMAIL');
 			}
 		}
 		else

--- a/installation/helper/html/installation.php
+++ b/installation/helper/html/installation.php
@@ -95,7 +95,7 @@ class JHtmlInstallation
 		$input = JFactory::getApplication()->input;
 		$num   = static::getTabNumber($id, $tabs);
 		$view  = static::getTabNumber($input->getWord('view'), $tabs);
-		$tab   = '<span class="badge">' . $num . '</span> ' . JText::_('INSTL_STEP_' . strtoupper($id) . '_LABEL');
+		$tab   = '<span class="badge">' . $num . '</span> .  JText::__('INSTL_STEP_' . strtoupper($id) . '_LABEL');
 
 		if ($view + 1 == $num)
 		{

--- a/installation/helper/html/installation.php
+++ b/installation/helper/html/installation.php
@@ -95,7 +95,7 @@ class JHtmlInstallation
 		$input = JFactory::getApplication()->input;
 		$num   = static::getTabNumber($id, $tabs);
 		$view  = static::getTabNumber($input->getWord('view'), $tabs);
-		$tab   = '<span class="badge">' . $num . '</span> .  JText::__('INSTL_STEP_' . strtoupper($id) . '_LABEL');
+		$tab   = '<span class="badge">' . $num . '</span>' .  JText::__('INSTL_STEP_' . strtoupper($id) . '_LABEL');
 
 		if ($view + 1 == $num)
 		{

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -624,3 +624,17 @@ input[type="url"] {
 .dropdown-menu {
 	text-align: right;
 }
+
+/* Icon whitespacing */
+[class^="icon-"],
+[class*=" icon-"] {
+	margin-left: .25em;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
+}

--- a/media/jui/less/icomoon.less
+++ b/media/jui/less/icomoon.less
@@ -25,8 +25,16 @@
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	.ie7-restore-right-whitespace();
+	margin-right: .25em;
 	line-height: 14px;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
 }
 
 /* Use the following CSS code if you want to have a class per icon */

--- a/media/jui/less/sprites.less
+++ b/media/jui/less/sprites.less
@@ -19,15 +19,22 @@
   display: inline-block;
   width: 14px;
   height: 14px;
-  .ie7-restore-right-whitespace();
   line-height: 14px;
   vertical-align: text-top;
   background-image: url("@{iconSpritePath}");
   background-position: 14px 14px;
   background-repeat: no-repeat;
   margin-top: 1px;
+  margin-right: .25em;
 }
-
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
+}
 /* White icons with optional class, or on hover/focus/active states of certain elements */
 .icon-white,
 .nav-pills > .active > a > [class^="icon-"],


### PR DESCRIPTION
he spacing after drop-down menu icons is not consistent. some use &nbsp; some use SPACE.
to better suit all templates, the spacing before and after all such icons is removed. This allows the spacing to either be in .css or .ini depending on users desires.
Further, the kerning between   and SPACE are not the same due to the very nature of their purpose.

To test:
just check spacing in element inspector as shown in these 2 images. The difference is much more dramatic when using a non-core template such as joostrap base.
BEFORE: 
![after](https://cloud.githubusercontent.com/assets/1850089/5542624/6e879d7a-8aae-11e4-9b21-51a5f4317fd0.JPG)
After
![before](https://cloud.githubusercontent.com/assets/1850089/5542625/6e8ca270-8aae-11e4-8d23-cd4a1dddc90d.JPG)
