### PR TITLE
[fix] Error Message if we try `save & close` for a User with YubiKey

### DIFF
--- a/plugins/twofactorauth/totp/totp.php
+++ b/plugins/twofactorauth/totp/totp.php
@@ -183,6 +183,12 @@ class PlgTwofactorauthTotp extends JPlugin
 
 		// Load raw data
 		$rawData = $input->get('jform', array(), 'array');
+
+		if (!isset($rawData['twofactor']['totp']))
+		{
+			return false;
+		}
+
 		$data = $rawData['twofactor']['totp'];
 
 		// Warn if the securitycode is empty

--- a/plugins/twofactorauth/yubikey/yubikey.php
+++ b/plugins/twofactorauth/yubikey/yubikey.php
@@ -173,6 +173,12 @@ class PlgTwofactorauthYubikey extends JPlugin
 
 		// Load raw data
 		$rawData = $input->get('jform', array(), 'array');
+
+		if (!isset($rawData['twofactor']['yubikey']))
+		{
+			return false;
+		}
+
 		$data = $rawData['twofactor']['yubikey'];
 
 		// Warn if the securitycode is empty


### PR DESCRIPTION
Refers to issue gh-5500 "Error Message if we try `save & close` for a User with YubiKey"

Close gh-5500
# Executive summary

There's a misleading error message when saving a user account which has two factor authentication using YubiKey already enabled.
# Testing instructions

You need three tests before and after applying the patch, in the precise order specified. When I say create a new user account I mean it. Do NOT try to reuse an existing user account. The first two ensure that there are no regressions. The third test confirms that the bug is fixed.
1. Create a new user account. Go to the Two Factor Authentication tab. Select the YubiKey authentication method. Leave the secret code blank and save. You get an error. This must be reproduced before AND after the patch.
2. Create a new user account. Go to the Two Factor Authentication tab. Select the YubiKey authentication method. Click in the Secret Code field and press the YubiKey button. Save. This first save works fine. This must be reproduced before AND after the patch.
3. Edit the user account from step 2. Do NOT change anything. Click on Save or Save & Close. Before the patch: you get an error about the code being invalid or YubiCloud servers being unreachable but the user saves. After the patch: the user saves without an error.
# Backwards compatibility

No impact
# Translation impact

No impact
