### PR TITLE
Change "Remove" button to "Unfeature" in featured articles admin view - see PR #5485

### DIFF
--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -95,7 +95,7 @@ class ContentViewFeatured extends JViewLegacy
 		{
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('articles.unpublish', 'JTOOLBAR_UNPUBLISH', true);
-			JToolbarHelper::custom('featured.delete', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURED', true);
+			JToolbarHelper::custom('featured.delete', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURE', true);
 			JToolbarHelper::archiveList('articles.archive');
 			JToolbarHelper::checkin('articles.checkin');
 		}

--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -95,7 +95,7 @@ class ContentViewFeatured extends JViewLegacy
 		{
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);
 			JToolbarHelper::unpublish('articles.unpublish', 'JTOOLBAR_UNPUBLISH', true);
-			JToolbarHelper::custom('featured.delete', 'remove.png', 'remove_f2.png', 'JTOOLBAR_REMOVE', true);
+			JToolbarHelper::custom('featured.delete', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURED', true);
 			JToolbarHelper::archiveList('articles.archive');
 			JToolbarHelper::checkin('articles.checkin');
 		}


### PR DESCRIPTION
# Summary

With this PR, the button "Remove" in the featured articles view of the article manager is changed to a button "Unfeature" as discussed with PR #5485 .

The function of the button stays the same, but text and icon will be less misleading.
# Dependencies

For the Hathor template, the changes in CSS from PR #5485 are required to see the correct icon for the button.
# Testing

Check label, icon and function of the button right beside the "Unpublish" button on the featured articles view of the article manager.
## Before applying patch with this PR

Label = "Remove", icon is an "X" in isis template, with thie button selected featured articles will be changed so they are not featured anymore and so disappear from this list (but still are there, check in article manager's articles view)
## After applying patch

Label = "Unfeature", icon is the same as used in the articles list for unfeatured status of articles (unfilled star in isis template), functions is unchanged
