### PR TITLE
complete rebuild of Icon Spacing PR

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -159,7 +159,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' href="index.php?option=com_categories&layout=modal&tmpl=component&task=category.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -170,7 +170,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearCategory(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> ' . JText::_('JCLEAR')
+				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -42,9 +42,9 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">
-					<span class="icon-search"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
+					<span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 				<button type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();">
-					<span class="icon-remove"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
+					<span class="icon-remove"></span><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 			</div>
 			<div class="clearfix"></div>
 		</div>

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -152,7 +152,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' href="index.php?option=com_contact&layout=modal&tmpl=component&task=contact.edit&id=' . $value . '"'
 				. ' target="_blank"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '" >'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -163,7 +163,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' onclick="return jClearContact(\'' . $this->id . '\')">'
-				. '<span class="icon-remove"></span> ' . JText::_('JCLEAR')
+				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -138,14 +138,14 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span> ' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearArticle(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> ' . JText::_('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span>' . JText::_('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -41,9 +41,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
-					<span class="icon-search"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
+					<span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
-					<span class="icon-remove"></span><?php echo '&#160;' . JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
+					<span class="icon-remove"></span><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 			</div>
 			<div class="clearfix"></div>
 		</div>

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -91,19 +91,19 @@ JFactory::getDocument()->addScriptDeclaration("
 <div class="btn-group pull-right">
 	<button id="toolbar-load" type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>"
 		data-url="<?php echo JRoute::_($loadUrl);?>" id="content-url">
-		<span class="icon-upload"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></button>
+		<span class="icon-upload"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></button>
 	<button id="toolbar-preview" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-search"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></button>
+		<span class="icon-search"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></button>
 	<button id="toolbar-compare" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-zoom-in"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></button>
+		<span class="icon-zoom-in"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
-    	<span class="icon-lock"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></button>
+    	<span class="icon-lock"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.delete')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
-    	<span class="icon-delete"></span><?php echo '&#160;' . JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></button>
+    	<span class="icon-delete"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></button>
 </div>
 <div class="clearfix"></div>
 <form action="<?php echo JRoute::_($formUrl);?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -147,14 +147,14 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') .
 				'" href="index.php?option=com_newsfeeds&layout=modal&tmpl=component&task=newsfeed.edit&id=' . $value .
 				'" target="_blank" title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') .
-				'" ><span class="icon-edit"></span> ' . JText::_('JACTION_EDIT') . '</a>';
+				'" ><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear newsfeed button
 		if ($allowClear)
 		{
 			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearNewsfeed(\'' .
-				$this->id . '\')"><span class="icon-remove"></span> ' . JText::_('JCLEAR') . '</button>';
+				$this->id . '\')"><span class="icon-remove"></span>' . JText::_('JCLEAR') . '</button>';
 		}
 
 		$html[] = '</span>';

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -64,8 +64,16 @@
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	*margin-right: .3em;
+	margin-right: .25em;
 	line-height: 14px;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -85,13 +85,13 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				</td>
 				<td class="template-name">
 					<a href="<?php echo JRoute::_('index.php?option=com_templates&view=template&id='.(int) $item->extension_id . '&file=' . $this->file); ?>">
-						<?php echo  JText::sprintf('COM_TEMPLATES_TEMPLATE_DETAILS', $item->name); ?></a>
+						<?php echo JText::sprintf('COM_TEMPLATES_TEMPLATE_DETAILS', $item->name); ?></a>
 					<p>
 					<?php if ($this->preview && $item->client_id == '0') : ?>
 						<a href="<?php echo JUri::root().'index.php?tp=1&template='.$item->element; ?>" target="_blank">
-							<?php echo  JText::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?></a>
+							<?php echo JText::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?></a>
 					<?php elseif ($item->client_id == '1') : ?>
-						<?php echo  JText::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW_ADMIN'); ?>
+						<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW_ADMIN'); ?>
 					<?php else: ?>
 						<span class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NO_PREVIEW', 'COM_TEMPLATES_TEMPLATE_NO_PREVIEW_DESC'); ?>">
 							<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?></span>

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -147,7 +147,7 @@ else
 			<div class="clr"></div>
 		</div><!-- end of element-box -->
 		<noscript>
-			<?php echo  JText::_('JGLOBAL_WARNJAVASCRIPT'); ?>
+			<?php echo JText::_('JGLOBAL_WARNJAVASCRIPT'); ?>
 		</noscript>
 		<div class="clr"></div>
 	</div><!-- end of content -->

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6227,8 +6227,16 @@ div.modal.fade.in {
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	*margin-right: .3em;
+	margin-right: .25em;
 	line-height: 14px;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
@@ -8679,6 +8687,18 @@ input[type="url"] {
 }
 .dropdown-menu {
 	text-align: right;
+}
+[class^="icon-"],
+[class*=" icon-"] {
+	margin-left: .25em;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
 }
 .navbar .admin-logo {
 	float: right;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6227,8 +6227,16 @@ div.modal.fade.in {
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	*margin-right: .3em;
+	margin-right: .25em;
 	line-height: 14px;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -44,7 +44,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-plus"></span>&#160;' . JText::_('JNEW') . '&#160;';
+				$text = '<span class="icon-plus"></span>' . JText::_('JNEW');
 			}
 		}
 		else
@@ -99,7 +99,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-envelope"></span> ' . JText::_('JGLOBAL_EMAIL');
+				$text = '<span class="icon-envelope"></span>' . JText::_('JGLOBAL_EMAIL');
 			}
 		}
 		else
@@ -207,8 +207,8 @@ abstract class JHtmlIcon
 			}
 
 			$text = '<span class="hasTooltip icon-' . $icon . ' tip" title="' . JHtml::tooltipText(JText::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0)
-				. '"></span>&#160;'
-				. JText::_('JGLOBAL_EDIT') . '&#160;';
+				. '"></span>'
+				. JText::_('JGLOBAL_EDIT');
 		}
 
 		$output = JHtml::_('link', JRoute::_($url), $text, $attribs);
@@ -246,7 +246,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-print"></span>&#160;' . JText::_('JGLOBAL_PRINT') . '&#160;';
+				$text = '<span class="icon-print"></span>' . JText::_('JGLOBAL_PRINT');
 			}
 		}
 		else
@@ -282,7 +282,7 @@ abstract class JHtmlIcon
 			}
 			else
 			{
-				$text = '<span class="icon-print"></span>&#160;' . JText::_('JGLOBAL_PRINT') . '&#160;';
+				$text = '<span class="icon-print"></span>' . JText::_('JGLOBAL_PRINT');
 			}
 		}
 		else

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -52,12 +52,12 @@ JFactory::getDocument()->addScriptDeclaration("
 		<div class="btn-toolbar">
 			<div class="btn-group">
 				<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('article.save')">
-					<span class="icon-ok"></span>&#160;<?php echo JText::_('JSAVE') ?>
+					<span class="icon-ok"></span><?php echo JText::_('JSAVE') ?>
 				</button>
 			</div>
 			<div class="btn-group">
 				<button type="button" class="btn" onclick="Joomla.submitbutton('article.cancel')">
-					<span class="icon-cancel"></span>&#160;<?php echo JText::_('JCANCEL') ?>
+					<span class="icon-cancel"></span><?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
 			<?php if ($params->get('save_history', 0)) : ?>

--- a/components/com_newsfeeds/views/category/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/category/tmpl/default_items.php
@@ -48,7 +48,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				<?php endif; ?>
 				<?php  if ($this->params->get('show_articles')) : ?>
 					<span class="list-hits badge badge-info pull-right">
-						<?php echo  JText::sprintf('COM_NEWSFEEDS_NUM_ARTICLES_COUNT', $item->numarticles); ?>
+						<?php echo JText::sprintf('COM_NEWSFEEDS_NUM_ARTICLES_COUNT', $item->numarticles); ?>
 					</span>
 				<?php  endif; ?>
 				<span class="list pull-left">

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -18,7 +18,7 @@ $canEdit = $displayData['params']->get('access-edit');
 
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 			<div class="btn-group pull-right">
-				<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span> <span class="caret"></span> </a>
+				<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span><span class="caret"></span> </a>
 				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
 				<ul class="dropdown-menu">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -613,3 +613,15 @@ input[type="url"] {
 .dropdown-menu {
 	text-align: right;
 }
+[class^="icon-"],
+[class*=" icon-"] {
+	margin-left: .25em;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
+}

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -624,3 +624,17 @@ input[type="url"] {
 .dropdown-menu {
 	text-align: right;
 }
+
+/* Icon whitespacing */
+[class^="icon-"],
+[class*=" icon-"] {
+	margin-left: .25em;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
+ }

--- a/media/jui/less/icomoon.less
+++ b/media/jui/less/icomoon.less
@@ -25,10 +25,19 @@
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	.ie7-restore-right-whitespace();
+	margin-right: .25em;
 	line-height: 14px;
 }
 
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
+ }
+ 
 /* Use the following CSS code if you want to have a class per icon */
 [class^="icon-"]:before, [class*=" icon-"]:before {
 	font-family: 'IcoMoon';

--- a/media/jui/less/sprites.less
+++ b/media/jui/less/sprites.less
@@ -16,18 +16,27 @@
 
 [class^="icon-"],
 [class*=" icon-"] {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  .ie7-restore-right-whitespace();
-  line-height: 14px;
-  vertical-align: text-top;
-  background-image: url("@{iconSpritePath}");
-  background-position: 14px 14px;
-  background-repeat: no-repeat;
-  margin-top: 1px;
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	margin-right: .25em;
+	line-height: 14px;
+	vertical-align: text-top;
+	background-image: url("@{iconSpritePath}");
+	background-position: 14px 14px;
+	background-repeat: no-repeat;
+	margin-top: 1px;
 }
 
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time{
+	margin-left: -.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"]{
+	margin-right: 0;
+ }
+ 
 /* White icons with optional class, or on hover/focus/active states of certain elements */
 .icon-white,
 .nav-pills > .active > a > [class^="icon-"],

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6227,8 +6227,16 @@ div.modal.fade.in {
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	*margin-right: .3em;
+	margin-right: .25em;
 	line-height: 14px;
+}
+dd > span[class^="icon-"] + time,
+dd > span[class*=" icon-"] + time {
+	margin-left: -0.25em;
+}
+dl.article-info dd.hits span[class^="icon-"],
+dl.article-info dd.hits span[class*=" icon-"] {
+	margin-right: 0;
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {


### PR DESCRIPTION
The spacing after drop-down menu icons is not consistent. some use &nbsp; some use SPACE.
to better suit all templates, the spacing before and after all such icons is removed. This allows the spacing to either be in .css or .ini depending on users desires.
Further, the kerning between &nbsp;  and SPACE are not the same due to the very nature of their purpose.

To test:
just check spacing in element inspector as shown in these 2 images. The difference is much more dramatic when using a non-core template such as joostrap base.
BEFORE: 
![after](https://cloud.githubusercontent.com/assets/1850089/5542624/6e879d7a-8aae-11e4-9b21-51a5f4317fd0.JPG)
After
![before](https://cloud.githubusercontent.com/assets/1850089/5542625/6e8ca270-8aae-11e4-8d23-cd4a1dddc90d.JPG)
