### PR TITLE
Fix Items Count not displayed in categories list (com_contact)

### DIFF
--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -27,7 +27,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 				<h3 class="page-header item-title">
 					<a href="<?php echo JRoute::_(ContactHelperRoute::getCategoryRoute($item->id)); ?>">
 					<?php echo $this->escape($item->title); ?></a>
-					<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
+					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTACT_NUM_ITEMS'); ?>">
 							<?php echo $item->numitems; ?>
 						</span>


### PR DESCRIPTION
**Issue:** In com_contact the "Items Count" was not displayed in categories list
**Cause:** Wrong parameter name
