### PR TITLE
Isis: fixes input.input-large-text rendering (#5456)

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7845,6 +7845,7 @@ th .tooltip-inner {
 }
 input.input-large-text {
 	font-size: 18px;
+	line-height: 22px;
 	height: auto;
 }
 .info-labels {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1003,6 +1003,7 @@ th .tooltip-inner {
 /* Title field */
 input.input-large-text {
 	font-size: 18px;
+	line-height: 22px;
 	height: auto;
 }
 


### PR DESCRIPTION
Fixes input.input-large-text rendering (e.g. "Title" in &view=article&layout=edit) for compatibility with Firefox.
Descenders of lowercase letters were truncated. See: https://github.com/joomla/joomla-cms/issues/5456
