### PR TITLE
clean up language filter: remove unneeded "if (!$this->default_lang)" line 66

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -60,75 +60,71 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		parent::__construct($subject, $config);
 
-		// Ensure that constructor is called one time.
 		$this->cookie = SID == '';
 
-		if (!$this->default_lang)
+		$router = $this->app->getRouter();
+
+		if ($this->app->isSite())
 		{
-			$router = $this->app->getRouter();
+			// Setup language data.
+			$this->mode_sef = ($router->getMode() == JROUTER_MODE_SEF) ? true : false;
+			$this->sefs = JLanguageHelper::getLanguages('sef');
+			$this->lang_codes = JLanguageHelper::getLanguages('lang_code');
+			$this->default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+			$this->default_sef = $this->lang_codes[$this->default_lang]->sef;
+			$this->homes = MultilangstatusHelper::getHomepages();
 
-			if ($this->app->isSite())
+			$user = JFactory::getUser();
+			$levels = $user->getAuthorisedViewLevels();
+
+			foreach ($this->sefs as $sef => &$language)
 			{
-				// Setup language data.
-				$this->mode_sef 	= ($router->getMode() == JROUTER_MODE_SEF) ? true : false;
-				$this->sefs 		= JLanguageHelper::getLanguages('sef');
-				$this->lang_codes 	= JLanguageHelper::getLanguages('lang_code');
-				$this->default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
-				$this->default_sef 	= $this->lang_codes[$this->default_lang]->sef;
-				$this->homes		= MultilangstatusHelper::getHomepages();
-
-				$user = JFactory::getUser();
-				$levels = $user->getAuthorisedViewLevels();
-
-				foreach ($this->sefs as $sef => &$language)
+				if (isset($language->access) && $language->access && !in_array($language->access, $levels))
 				{
-					if (isset($language->access) && $language->access && !in_array($language->access, $levels))
-					{
-						unset($this->sefs[$sef]);
-					}
+					unset($this->sefs[$sef]);
 				}
-
-				$this->app->setLanguageFilter(true);
-
-				$uri = JUri::getInstance();
-
-				$sef = $uri->getVar('lang');
-
-				if (!$sef)
-				{
-					// Get the route path from the request.
-					$path = JString::substr($uri->toString(), JString::strlen($uri->base()));
-
-					// Apache mod_rewrite is Off.
-					$path = $this->app->get('sef_rewrite') ? $path : JString::substr($path, 10);
-
-					// Trim any spaces or slashes from the ends of the path and explode into segments.
-					$path  = JString::trim($path, '/ ');
-					$parts = explode('/', $path);
-
-					if (!empty($parts) && empty($sef))
-					{
-						$sef = reset($parts);
-					}
-				}
-
-				if (isset($this->sefs[$sef]))
-				{
-					$lang_code = $this->sefs[$sef]->lang_code;
-
-					// Create a cookie.
-					$cookie_domain 	= $this->app->get('cookie_domain', '');
-					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
-					$this->app->input->cookie->set(JApplication::getHash('language'), $lang_code);
-
-					// Set the request var.
-					$this->app->input->set('language', $lang_code);
-				}
-
-				// Detect browser feature.
-				$this->app->setDetectBrowser($this->params->get('detect_browser', '1') == '1');
 			}
+
+			$this->app->setLanguageFilter(true);
+
+			$uri = JUri::getInstance();
+
+			$sef = $uri->getVar('lang');
+
+			if (!$sef)
+			{
+				// Get the route path from the request.
+				$path = JString::substr($uri->toString(), JString::strlen($uri->base()));
+
+				// Apache mod_rewrite is Off.
+				$path = $this->app->get('sef_rewrite') ? $path : JString::substr($path, 10);
+
+				// Trim any spaces or slashes from the ends of the path and explode into segments.
+				$path = JString::trim($path, '/ ');
+				$parts = explode('/', $path);
+
+				if (!empty($parts) && empty($sef))
+				{
+					$sef = reset($parts);
+				}
+			}
+
+			if (isset($this->sefs[$sef]))
+			{
+				$lang_code = $this->sefs[$sef]->lang_code;
+
+				// Create a cookie.
+				$cookie_domain = $this->app->get('cookie_domain', '');
+				$cookie_path = $this->app->get('cookie_path', '/');
+				setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				$this->app->input->cookie->set(JApplication::getHash('language'), $lang_code);
+
+				// Set the request var.
+				$this->app->input->set('language', $lang_code);
+			}
+
+			// Detect browser feature.
+			$this->app->setDetectBrowser($this->params->get('detect_browser', '1') == '1');
 		}
 	}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -116,8 +116,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				// Create a cookie.
 				$cookie_domain = $this->app->get('cookie_domain', '');
 				$cookie_path = $this->app->get('cookie_path', '/');
-				setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
-				$this->app->input->cookie->set(JApplication::getHash('language'), $lang_code);
+				setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code);
 
 				// Set the request var.
 				$this->app->input->set('language', $lang_code);
@@ -263,7 +263,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	public function parseRule(&$router, &$uri)
 	{
-		$lang_code = $this->app->input->cookie->getString(JApplication::getHash('language'));
+		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 
 		// No cookie - let's try to detect browser language or use site default.
 		if (!$lang_code)
@@ -452,7 +452,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Create a cookie.
 					$cookie_domain 	= $this->app->get('cookie_domain', '');
 					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 				}
 			}
 		}
@@ -502,7 +502,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				// Create a cookie.
 				$cookie_domain 	= $this->app->get('cookie_domain', '');
 				$cookie_path 	= $this->app->get('cookie_path', '/');
-				setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 
 				// Change the language code.
 				JFactory::getLanguage()->setLanguage($lang_code);
@@ -569,7 +569,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				$cassociations = call_user_func(array($cName, 'getAssociations'));
 
-				$lang_code = $this->app->input->cookie->getString(JApplication::getHash('language'));
+				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 
 				// No cookie - let's try to detect browser language or use site default.
 				if (!$lang_code)


### PR DESCRIPTION
Checking if the default_lang property is filled, was a reminiscense of those properties being static and the constructor only being called once. The comment 2 lines higher ("Ensure that constructor is called one time") belonged to this conditional. Now the properties are not static anymore and so the test is not necessary, as the constructor is only called once for every instantiation. 

To TEST this PR: multilanguage should be working exactly the same when applied, for no functionality is changed. Just removed a test that would always evaluate to true.

Comment: there is some deprecated code used:
- JApplication::getHash should now be JApplicationHelper::getHash
- JString should now be \Joomla\String\String

Maybe we shoud clean that up too in one go. 
