### PR TITLE
Stop using deprecated JApplication::getHash()

### DIFF
--- a/administrator/components/com_banners/controllers/tracks.raw.php
+++ b/administrator/components/com_banners/controllers/tracks.raw.php
@@ -96,8 +96,8 @@ class BannersControllerTracks extends JControllerLegacy
 			$cookie_domain = $config->get('cookie_domain', '');
 			$cookie_path = $config->get('cookie_path', '/');
 
-			setcookie(JApplication::getHash($this->context . '.basename'), $form['basename'], time() + 365 * 86400, $cookie_path, $cookie_domain);
-			setcookie(JApplication::getHash($this->context . '.compressed'), $form['compressed'], time() + 365 * 86400, $cookie_path, $cookie_domain);
+			setcookie(JApplicationHelper::getHash($this->context . '.basename'), $form['basename'], time() + 365 * 86400, $cookie_path, $cookie_domain);
+			setcookie(JApplicationHelper::getHash($this->context . '.compressed'), $form['compressed'], time() + 365 * 86400, $cookie_path, $cookie_domain);
 
 			// Push the model into the view (as default).
 			$view->setModel($model, true);

--- a/administrator/components/com_banners/models/download.php
+++ b/administrator/components/com_banners/models/download.php
@@ -31,10 +31,10 @@ class BannersModelDownload extends JModelForm
 	{
 		$input = JFactory::getApplication()->input;
 
-		$basename = $input->cookie->getString(JApplication::getHash($this->_context . '.basename'), '__SITE__');
+		$basename = $input->cookie->getString(JApplicationHelper::getHash($this->_context . '.basename'), '__SITE__');
 		$this->setState('basename', $basename);
 
-		$compressed = $input->cookie->getInt(JApplication::getHash($this->_context . '.compressed'), 1);
+		$compressed = $input->cookie->getInt(JApplicationHelper::getHash($this->_context . '.compressed'), 1);
 		$this->setState('compressed', $compressed);
 	}
 

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -78,7 +78,7 @@ class UsersModelRegistration extends JModelForm
 
 			// Compile the admin notification mail values.
 			$data = $user->getProperties();
-			$data['activation'] = JApplication::getHash(JUserHelper::genRandomPassword());
+			$data['activation'] = JApplicationHelper::getHash(JUserHelper::genRandomPassword());
 			$user->set('activation', $data['activation']);
 			$data['siteurl'] = JUri::base();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
@@ -367,7 +367,7 @@ class UsersModelRegistration extends JModelForm
 		// Check if the user needs to activate their account.
 		if (($useractivation == 1) || ($useractivation == 2))
 		{
-			$data['activation'] = JApplication::getHash(JUserHelper::genRandomPassword());
+			$data['activation'] = JApplicationHelper::getHash(JUserHelper::genRandomPassword());
 			$data['block'] = 1;
 		}
 

--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -440,7 +440,7 @@ class UsersModelReset extends JModelForm
 		}
 
 		// Set the confirmation token.
-		$token = JApplication::getHash(JUserHelper::genRandomPassword());
+		$token = JApplicationHelper::getHash(JUserHelper::genRandomPassword());
 		$salt = JUserHelper::getSalt('crypt-md5');
 		$hashedToken = md5($token . $salt) . ':' . $salt;
 		$user->activation = $hashedToken;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -119,8 +119,8 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Create a cookie.
 					$cookie_domain 	= $this->app->get('cookie_domain', '');
 					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
-					$this->app->input->cookie->set(JApplication::getHash('language'), $lang_code);
+					setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code);
 
 					// Set the request var.
 					$this->app->input->set('language', $lang_code);
@@ -267,7 +267,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	public function parseRule(&$router, &$uri)
 	{
-		$lang_code = $this->app->input->cookie->getString(JApplication::getHash('language'));
+		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 
 		// No cookie - let's try to detect browser language or use site default.
 		if (!$lang_code)
@@ -456,7 +456,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Create a cookie.
 					$cookie_domain 	= $this->app->get('cookie_domain', '');
 					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 				}
 			}
 		}
@@ -506,7 +506,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				// Create a cookie.
 				$cookie_domain 	= $this->app->get('cookie_domain', '');
 				$cookie_path 	= $this->app->get('cookie_path', '/');
-				setcookie(JApplication::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 
 				// Change the language code.
 				JFactory::getLanguage()->setLanguage($lang_code);
@@ -573,7 +573,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				$cassociations = call_user_func(array($cName, 'getAssociations'));
 
-				$lang_code = $this->app->input->cookie->getString(JApplication::getHash('language'));
+				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 
 				// No cookie - let's try to detect browser language or use site default.
 				if (!$lang_code)


### PR DESCRIPTION
JApplication::getHash was deprecated in favour of JApplicationHelper::getHash(). The former just proxies to the latter since 3.2.

This moves all calls (except one JSession where the change is contained within the larger refactor at https://github.com/joomla/joomla-cms/pull/5088 ).
