### PR TITLE
Change targetplatform version check to match full CMS version

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -162,14 +162,16 @@ class JUpdaterCollection extends JUpdateAdapter
 				{
 					$values['targetplatform'] = $product;
 				}
+
 				// Set this to ourself as a default
 				if (!isset($values['targetplatformversion']))
 				{
 					$values['targetplatformversion'] = $ver->RELEASE;
 				}
+
 				// Set this to ourselves as a default
 				// validate that we can install the extension
-				if ($product == $values['targetplatform'] && preg_match('/' . $values['targetplatformversion'] . '/', $ver->RELEASE))
+				if ($product == $values['targetplatform'] && preg_match('/^' . $values['targetplatformversion'] . '/', JVERSION))
 				{
 					$update->bind($values);
 					$this->updates[] = $update;

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -97,10 +97,16 @@ class JUpdaterExtension extends JUpdateAdapter
 				// Lower case and remove the exclamation mark
 				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
 
-				// Check that the product matches and that the version matches (optionally a regexp)
-				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
+				/*
+				 * Check that the product matches and that the version matches (optionally a regexp)
+				 *
+				 * NOTE: Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be
+				 * used instead
+				 *
+				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
+				 */
 				if ($product == $this->currentUpdate->targetplatform['NAME']
-					&& preg_match('/' . $this->currentUpdate->targetplatform['VERSION'] . '/', $ver->RELEASE)
+					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
 				{


### PR DESCRIPTION
The manner in which updates check their supported platform is extremely subpar.  The primary version attribute is only checked down to the minor version number (i.e. 3.4) which prevents using the advanced regex possibilities of the `<targetplatform>` tag in an update XML file to match a specific version number.  A "band-aid" style fix was applied in the manner of the `min_dev_level` and `max_dev_level` attributes which further demonstrates the weakness in this check.

This PR proposes to change the check to enable matching a full version number instead of only the major and minor versions.
### Use Case

Had 2.5 supported this, in extensions where versions older than 2.5.6 are unsupported, it would have been possible to use a regexp similar to `2.5.([6-9]|1[0-9]|2[0-8])` to not display updates to 2.5.0 thru 2.5.5 users.  As 2.5 didn't even support the `min_dev_level` and `max_dev_level` attributes, users on those dated versions would always see an extension update that they could not install.
### Testing Instructions

For general testing, the simplest tests are to apply the patch, install older versions of extensions which support Joomla's update platform (as Joomla won't display an update if you're on the latest version), and make sure those extensions still properly load updates.  The language installer can be a good way to check this too.

For advanced use cases, developers are welcome to manipulate the Joomla version number (found in `libraries/cms/version/version.php` and an update XML to create test cases where a regexp would or would not match a version number.  Using my example above, 2.5.0 thru 2.5.5 and anything above 2.5.29 should not match but 2.5.6 thru 2.5.28 should.
