### PR TITLE
Authentication: Fixing issues with legacy MD5 hashes

### DIFF
--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -368,7 +368,9 @@ abstract class JUserHelper
 
 			$rehash = true;
 
-			$testcrypt = md5($password . $salt) . ($salt ? ':' . $salt : '');
+			// Compile the hash to compare
+			// If the salt is empty AND there is a ':' in the original hash, we must append ':' at the end
+			$testcrypt = md5($password . $salt) . ($salt ? ':' . $salt : (strpos($hash, ':') !== false ? ':' : ''));
 
 			$match = JCrypt::timingSafeCompare($hash, $testcrypt);
 		}

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -355,4 +355,21 @@ class JUserHelperTest extends TestCaseDatabase
 			'Properly verifies a password hashed with Joomla legacy MD5'
 		);
 	}
+
+	/**
+	 * Testing verifyPassword() with a Joomla 1.0 style password with no salt.
+	 *
+	 * @covers  JUserHelper::verifyPassword
+	 * @return  void
+	 *
+	 * @since   3.2
+	 * @see     https://github.com/joomla/joomla-cms/pull/5551
+	 */
+	public function testVerifyPasswordWithNoSalt()
+	{
+		$this->assertTrue(
+			JUserHelper::verifyPassword('test', '098f6bcd4621d373cade4e832627b4f6:'),
+			'Joomla 1.0 passwords without a legacy hash are not verified correctly'
+		);
+	}
 }


### PR DESCRIPTION
Authentication: Fixing issues with legacy MD5 hashes with empty salts that contain a colon (':') in the DB

I upgrade from 3.0.3 to 3.3.6 recently and found some legacy users were unable to login. These users had MD5 hashed password with empty salts. However in the DB the colon (':') was still appended to the password at the end. The hash comparison in helper.php did not take this into account and thusly denied them when trying to login.

Examples:
Plaintext: test
Salt: (empty)
DB Hash: 098f6bcd4621d373cade4e832627b4f6 (no colon)
Result: Login succeeds

Plaintext: test
Salt: (empty)
DB Hash: 098f6bcd4621d373cade4e832627b4f6: (with colon)
Result: **Login fails**

Plaintext: test
Salt: 1234
DB Hash: 16d7a4fca7442dda3ad93c9a726597e4:1234 (with colon and salt)
Result: Login succeeds

The modified code assumes that if there was a ':' found in the original has (strpos), and the salt is empty (second half of the conditional), it must have been at the end of the string. We re-add that so the hash comparison works properly.

After the change, all three of the examples listed above work indicating the original legacy users and my broken users work just fine.
