### PR TITLE
Simple SSL improvements to detect if they are using the HTTP_X_FORWARDED...

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -841,7 +841,7 @@ class JApplicationWeb extends JApplicationBase
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 		{
 			$scheme = 'https://';
 		}
@@ -849,6 +849,7 @@ class JApplicationWeb extends JApplicationBase
 		{
 			$scheme = 'http://';
 		}
+
 
 		/*
 		 * There are some differences in the way that Apache and IIS populate server environment variables.  To

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -671,6 +671,6 @@ class JBrowser
 		JLog::add('JBrowser::isSSLConnection() is deprecated. Use the isSSLConnection method on the application object instead.',
 			JLog::WARNING, 'deprecated');
 
-		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'));
 	}
 }

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -63,7 +63,7 @@ class JUri extends Uri
 			if ($uri == 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 				{
 					$https = 's://';
 				}

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1168,7 +1168,7 @@ class JApplication extends JApplicationBase
 	 */
 	public function isSSLConnection()
 	{
-		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'));
 	}
 
 	/**


### PR DESCRIPTION
Simple SSL improvements to detect if they are using the HTTP_X_FORWARDED_PRONTO and is set to https. 

Used by CloudFlare and many web hosts under clustered hosting environments.
