### PR TITLE
SSL improvements to detect HTTP_X_FORWARDED_PRONTO

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -841,7 +841,7 @@ class JApplicationWeb extends JApplicationBase
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 		{
 			$scheme = 'https://';
 		}

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -671,6 +671,6 @@ class JBrowser
 		JLog::add('JBrowser::isSSLConnection() is deprecated. Use the isSSLConnection method on the application object instead.',
 			JLog::WARNING, 'deprecated');
 
-		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'));
 	}
 }

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -63,7 +63,7 @@ class JUri extends Uri
 			if ($uri == 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 				{
 					$https = 's://';
 				}

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1168,7 +1168,7 @@ class JApplication extends JApplicationBase
 	 */
 	public function isSSLConnection()
 	{
-		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'));
 	}
 
 	/**


### PR DESCRIPTION
Simple SSL improvements to detect if they are using the HTTP_X_FORWARDED_PRONTO and is set to https. Used by CloudFlare and many web hosts under clustered hosting environments.
### Steps to reproduce the issue

Simple way to reproduce is to enable cloudflare flexissl without the website having it's own SSL certificate. You are then prompted with many SSL/non-ssl errors. Because we are asking the server for SSL Validation which is cannot provide.

Also this is an issue for hosts like TSOHost, which use the same header to reduce down time for sites which switch to SSL.
#### Expected result

To provide an SSL secured website which is validated.
#### Actual result

Either a redirect loop, if you enable Force SSL in the Joomla! Config.

Or insecure content warnings if just coming through https.

This PR fixes the issues
