### PR TITLE
Standardizing the install paths for discover_install

### DIFF
--- a/administrator/components/com_installer/models/discover.php
+++ b/administrator/components/com_installer/models/discover.php
@@ -156,10 +156,9 @@ class InstallerModelDiscover extends InstallerModel
 	 */
 	public function discover_install()
 	{
-		$app       = JFactory::getApplication();
-		$installer = JInstaller::getInstance();
-		$input     = $app->input;
-		$eid       = $input->get('cid', 0, 'array');
+		$app   = JFactory::getApplication();
+		$input = $app->input;
+		$eid   = $input->get('cid', 0, 'array');
 
 		if (is_array($eid) || $eid)
 		{
@@ -173,6 +172,8 @@ class InstallerModelDiscover extends InstallerModel
 
 			foreach ($eid as $id)
 			{
+				$installer = new JInstaller;
+
 				$result = $installer->discover_install($id);
 
 				if (!$result)
@@ -182,6 +183,7 @@ class InstallerModelDiscover extends InstallerModel
 				}
 			}
 
+			// TODO - We are only receiving the message for the last JInstaller instance
 			$this->setState('action', 'remove');
 			$this->setState('name', $installer->get('name'));
 			$app->setUserState('com_installer.message', $installer->message);

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -527,7 +527,7 @@ JLIB_INSTALLER_ERROR_COMP_UPDATE_FAILED_TO_CREATE_DIRECTORY_SITE="Component Upda
 JLIB_INSTALLER_ERROR_CREATE_DIRECTORY="JInstaller: :Install: Failed to create directory: %s"
 JLIB_INSTALLER_ERROR_CREATE_FOLDER_FAILED="Failed to create directory [%s]"
 JLIB_INSTALLER_ERROR_DEPRECATED_FORMAT="Deprecated install format (client="_QQ_"both"_QQ_"), use package installer in future"
-JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="The %s extension does not support discover installs.  Please install this extension via the Extension Manager's Install view."
+JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="A %s extension can not be installed using the discover method. Please install this extension from Extension Manager: Install."
 JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT="Error connecting to the server: %s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER="JInstaller: :Install: Failed to copy folder %1$s to %2$s"

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -527,6 +527,7 @@ JLIB_INSTALLER_ERROR_COMP_UPDATE_FAILED_TO_CREATE_DIRECTORY_SITE="Component Upda
 JLIB_INSTALLER_ERROR_CREATE_DIRECTORY="JInstaller: :Install: Failed to create directory: %s"
 JLIB_INSTALLER_ERROR_CREATE_FOLDER_FAILED="Failed to create directory [%s]"
 JLIB_INSTALLER_ERROR_DEPRECATED_FORMAT="Deprecated install format (client="_QQ_"both"_QQ_"), use package installer in future"
+JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="The %s extension does not support discover installs.  Please install this extension via the Extension Manager's Install view."
 JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT="Error connecting to the server: %s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER="JInstaller: :Install: Failed to copy folder %1$s to %2$s"

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -527,7 +527,7 @@ JLIB_INSTALLER_ERROR_COMP_UPDATE_FAILED_TO_CREATE_DIRECTORY_SITE="Component Upda
 JLIB_INSTALLER_ERROR_CREATE_DIRECTORY="JInstaller: :Install: Failed to create directory: %s"
 JLIB_INSTALLER_ERROR_CREATE_FOLDER_FAILED="Failed to create directory [%s]"
 JLIB_INSTALLER_ERROR_DEPRECATED_FORMAT="Deprecated install format (client="_QQ_"both"_QQ_"), use package installer in future"
-JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="The %s extension does not support discover installs.  Please install this extension via the Extension Manager's Install view."
+JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="A %s extension can not be installed using the discover method. Please install this extension from Extension Manager: Install."
 JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT="Error connecting to the server: %s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER="JInstaller: :Install: Failed to copy folder %1$s to %2$s"

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -527,6 +527,7 @@ JLIB_INSTALLER_ERROR_COMP_UPDATE_FAILED_TO_CREATE_DIRECTORY_SITE="Component Upda
 JLIB_INSTALLER_ERROR_CREATE_DIRECTORY="JInstaller: :Install: Failed to create directory: %s"
 JLIB_INSTALLER_ERROR_CREATE_FOLDER_FAILED="Failed to create directory [%s]"
 JLIB_INSTALLER_ERROR_DEPRECATED_FORMAT="Deprecated install format (client="_QQ_"both"_QQ_"), use package installer in future"
+JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED="The %s extension does not support discover installs.  Please install this extension via the Extension Manager's Install view."
 JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT="Error connecting to the server: %s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER="JInstaller: :Install: Failed to copy folder %1$s to %2$s"

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -27,6 +27,16 @@ class JInstallerAdapterFile extends JInstallerAdapter
 	protected $scriptElement = null;
 
 	/**
+	 * Flag if the adapter supports discover installs
+	 *
+	 * Adapters should override this and set to false if discover install is unsupported
+	 *
+	 * @var    boolean
+	 * @since  3.4
+	 */
+	protected $supportsDiscoverInstall = false;
+
+	/**
 	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
 	 *
 	 * @return  void

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -126,10 +126,13 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		}
 
 		// Lastly, we will copy the manifest file to its appropriate place.
-		if (!$this->parent->copyManifest(-1))
+		if ($this->route != 'discover_install')
 		{
-			// Install failed, rollback changes
-			throw new RuntimeException(JText::_('JLIB_INSTALLER_ABORT_MOD_INSTALL_COPY_SETUP'));
+			if (!$this->parent->copyManifest(-1))
+			{
+				// Install failed, rollback changes
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ABORT_MOD_INSTALL_COPY_SETUP'));
+			}
 		}
 	}
 
@@ -219,6 +222,21 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	}
 
 	/**
+	 * Prepares the adapter for a discover_install task
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	protected function prepareDiscoverInstall()
+	{
+		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
+		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
+		$this->parent->manifest = $this->parent->isManifest($manifestPath);
+		$this->parent->setPath('manifest', $manifestPath);
+	}
+
+	/**
 	 * Method to do any prechecks and setup the install paths for the extension
 	 *
 	 * @return  void
@@ -229,7 +247,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	protected function setupInstallPaths()
 	{
 		// Get the target application
-		$cname = (string) $this->manifest->attributes()->client;
+		$cname = (string) $this->getManifest()->attributes()->client;
 
 		if ($cname)
 		{
@@ -281,6 +299,26 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	 */
 	protected function storeExtension()
 	{
+		// Discover installs are stored a little differently
+		if ($this->route == 'discover_install')
+		{
+			$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
+
+			$this->extension->manifest_cache = json_encode($manifest_details);
+			$this->extension->state = 0;
+			$this->extension->name = $manifest_details['name'];
+			$this->extension->enabled = 1;
+			$this->extension->params = $this->parent->getParams();
+
+			if (!$this->extension->store())
+			{
+				// Install failed, roll back changes
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_MOD_DISCOVER_STORE_DETAILS'));
+			}
+
+			return;
+		}
+
 		// Was there a module already installed with the same name?
 		if ($this->currentExtensionId)
 		{
@@ -289,7 +327,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 				// Install failed, roll back changes
 				throw new RuntimeException(
 					JText::sprintf(
-						'JLIB_INSTALLER_ABORT_PLG_INSTALL_ALLREADY_EXISTS',
+						'JLIB_INSTALLER_ABORT_MOD_INSTALL_ALLREADY_EXISTS',
 						JText::_('JLIB_INSTALLER_' . $this->route),
 						$this->name
 					)
@@ -442,53 +480,6 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		}
 
 		return $results;
-	}
-
-	/**
-	 * Custom discover_install method
-	 *
-	 * @return  mixed  Extension ID on success, boolean false on failure
-	 *
-	 * @since   3.1
-	 */
-	public function discover_install()
-	{
-		// Modules are like templates, and are one of the easiest
-		// If its not in the extensions table we just add it
-		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$description = (string) $this->parent->manifest->description;
-
-		if ($description)
-		{
-			$this->parent->set('message', JText::_($description));
-		}
-		else
-		{
-			$this->parent->set('message', '');
-		}
-
-		$this->parent->setPath('manifest', $manifestPath);
-		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
-
-		// TODO: Re-evaluate this; should we run installation triggers? postflight perhaps?
-		$this->parent->extension->manifest_cache = json_encode($manifest_details);
-		$this->parent->extension->state = 0;
-		$this->parent->extension->name = $manifest_details['name'];
-		$this->parent->extension->enabled = 1;
-		$this->parent->extension->params = $this->parent->getParams();
-
-		if ($this->parent->extension->store())
-		{
-			return $this->parent->extension->get('extension_id');
-		}
-		else
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_MOD_DISCOVER_STORE_DETAILS'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -25,6 +25,16 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 	protected $results = array();
 
 	/**
+	 * Flag if the adapter supports discover installs
+	 *
+	 * Adapters should override this and set to false if discover install is unsupported
+	 *
+	 * @var    boolean
+	 * @since  3.4
+	 */
+	protected $supportsDiscoverInstall = false;
+
+	/**
 	 * Method to check if the extension is present in the filesystem, flags the route as update if so
 	 *
 	 * @return  void

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -141,7 +141,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	 *
 	 * @return  void
 	 *
-	 * @since   3.1
+	 * @since   3.4
 	 * @throws  RuntimeException
 	 */
 	protected function finaliseInstall()
@@ -163,15 +163,18 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		}
 
 		// Lastly, we will copy the manifest file to its appropriate place.
-		if (!$this->parent->copyManifest(-1))
+		if ($this->route != 'discover_install')
 		{
-			// Install failed, rollback changes
-			throw new RuntimeException(
-				JText::sprintf(
-					'JLIB_INSTALLER_ABORT_PLG_INSTALL_COPY_SETUP',
-					JText::_('JLIB_INSTALLER_' . $this->route)
-				)
-			);
+			if (!$this->parent->copyManifest(-1))
+			{
+				// Install failed, rollback changes
+				throw new RuntimeException(
+					JText::sprintf(
+						'JLIB_INSTALLER_ABORT_PLG_INSTALL_COPY_SETUP',
+						JText::_('JLIB_INSTALLER_' . $this->route)
+					)
+				);
+			}
 		}
 	}
 
@@ -182,7 +185,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	 *
 	 * @return  string  The filtered element
 	 *
-	 * @since   3.1
+	 * @since   3.4
 	 */
 	public function getElement($element = null)
 	{
@@ -293,11 +296,37 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	}
 
 	/**
+	 * Prepares the adapter for a discover_install task
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	protected function prepareDiscoverInstall()
+	{
+		$client   = JApplicationHelper::getClientInfo($this->extension->client_id);
+		$basePath = $client->path . '/plugins/' . $this->extension->folder;
+
+		if (is_dir($basePath . '/' . $this->extension->element))
+		{
+			$manifestPath = $basePath . '/' . $this->extension->element . '/' . $this->extension->element . '.xml';
+		}
+		else
+		{
+			// @deprecated 4.0 - This path supports Joomla! 1.5 plugin folder layouts
+			$manifestPath = $basePath . '/' . $this->extension->element . '.xml';
+		}
+
+		$this->parent->manifest = $this->parent->isManifest($manifestPath);
+		$this->parent->setPath('manifest', $manifestPath);
+	}
+
+	/**
 	 * Method to do any prechecks and setup the install paths for the extension
 	 *
 	 * @return  void
 	 *
-	 * @since   3.1
+	 * @since   3.4
 	 * @throws  RuntimeException
 	 */
 	protected function setupInstallPaths()
@@ -322,11 +351,31 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	 *
 	 * @return  void
 	 *
-	 * @since   3.1
+	 * @since   3.4
 	 * @throws  RuntimeException
 	 */
 	protected function storeExtension()
 	{
+		// Discover installs are stored a little differently
+		if ($this->route == 'discover_install')
+		{
+			$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
+
+			$this->extension->manifest_cache = json_encode($manifest_details);
+			$this->extension->state = 0;
+			$this->extension->name = $manifest_details['name'];
+			$this->extension->enabled = ('editors' == $this->extension->folder) ? 1 : 0;
+			$this->extension->params = $this->parent->getParams();
+
+			if (!$this->extension->store())
+			{
+				// Install failed, roll back changes
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_PLG_DISCOVER_STORE_DETAILS'));
+			}
+
+			return;
+		}
+
 		// Was there a plugin with the same name already installed?
 		if ($this->currentExtensionId)
 		{
@@ -654,64 +703,6 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		}
 
 		return $results;
-	}
-
-	/**
-	 * Custom discover_install method.
-	 *
-	 * @return  mixed
-	 *
-	 * @since   3.1
-	 */
-	public function discover_install()
-	{
-		/*
-		 * Plugins use the extensions table as their primary store
-		 * Similar to modules and templates, rather easy
-		 * If it's not in the extensions table we just add it
-		 */
-		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-
-		if (is_dir($client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element))
-		{
-			$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element . '/'
-				. $this->parent->extension->element . '.xml';
-		}
-		else
-		{
-			$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element . '.xml';
-		}
-
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$description = (string) $this->parent->manifest->description;
-
-		if ($description)
-		{
-			$this->parent->set('message', JText::_($description));
-		}
-		else
-		{
-			$this->parent->set('message', '');
-		}
-
-		$this->parent->setPath('manifest', $manifestPath);
-		$manifest_details = JInstaller::parseXMLInstallFile($manifestPath);
-		$this->parent->extension->manifest_cache = json_encode($manifest_details);
-		$this->parent->extension->state = 0;
-		$this->parent->extension->name = $manifest_details['name'];
-		$this->parent->extension->enabled = ('editors' == $this->parent->extension->folder) ? 1 : 0;
-		$this->parent->extension->params = $this->parent->getParams();
-
-		if ($this->parent->extension->store())
-		{
-			return $this->parent->extension->get('extension_id');
-		}
-		else
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_PLG_DISCOVER_STORE_DETAILS'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -149,10 +149,13 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 		}
 
 		// Lastly, we will copy the manifest file to its appropriate place.
-		if (!$this->parent->copyManifest(-1))
+		if ($this->route != 'discover_install')
 		{
-			// Install failed, rollback changes
-			throw new RuntimeException(JText::_('JLIB_INSTALLER_ABORT_TPL_INSTALL_COPY_SETUP'));
+			if (!$this->parent->copyManifest(-1))
+			{
+				// Install failed, rollback changes
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ABORT_TPL_INSTALL_COPY_SETUP'));
+			}
 		}
 	}
 
@@ -186,7 +189,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 		}
 
 		$extension = 'tpl_' . $this->getName();
-		$source    = $path ? $path : ($client) . '/templates/' . $this->getName;
+		$source    = $path ? $path : ($client) . '/templates/' . $this->getName();
 
 		$this->doLoadLanguage($extension, $source, constant('JPATH_' . strtoupper($client)));
 	}
@@ -214,9 +217,9 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	 */
 	protected function parseQueries()
 	{
-		if ($this->route == 'install')
+		if (in_array($this->route, array('install', 'discover_install')))
 		{
-			$db    = $this->parent->getDBO();
+			$db    = $this->db;
 			$lang  = JFactory::getLanguage();
 			$debug = $lang->setDebug(false);
 
@@ -228,8 +231,8 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			);
 
 			$values = array(
-				$db->quote($this->extension->element), $this->clientId, $db->quote(0),
-				$db->quote(JText::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', JText::_($this->name))),
+				$db->quote($this->extension->element), $this->extension->client_id, $db->quote(0),
+				$db->quote(JText::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', JText::_($this->extension->name))),
 				$db->quote($this->extension->params));
 
 			$lang->setDebug($debug);
@@ -243,6 +246,21 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			// There is a chance this could fail but we don't care...
 			$db->setQuery($query)->execute();
 		}
+	}
+
+	/**
+	 * Prepares the adapter for a discover_install task
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	protected function prepareDiscoverInstall()
+	{
+		$client = JApplicationHelper::getClientInfo($this->extension->client_id);
+		$manifestPath = $client->path . '/templates/' . $this->extension->element . '/templateDetails.xml';
+		$this->parent->manifest = $this->parent->isManifest($manifestPath);
+		$this->parent->setPath('manifest', $manifestPath);
 	}
 
 	/**
@@ -302,6 +320,26 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	 */
 	protected function storeExtension()
 	{
+		// Discover installs are stored a little differently
+		if ($this->route == 'discover_install')
+		{
+			$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
+
+			$this->extension->manifest_cache = json_encode($manifest_details);
+			$this->extension->state = 0;
+			$this->extension->name = $manifest_details['name'];
+			$this->extension->enabled = 1;
+			$this->extension->params = $this->parent->getParams();
+
+			if (!$this->extension->store())
+			{
+				// Install failed, roll back changes
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_TPL_DISCOVER_STORE_DETAILS'));
+			}
+
+			return;
+		}
+
 		// Was there a template already installed with the same name?
 		if ($this->currentExtensionId)
 		{
@@ -542,85 +580,6 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 		}
 
 		return $results;
-	}
-
-	/**
-	 * Discover_install
-	 * Perform an install for a discovered extension
-	 *
-	 * @return boolean
-	 *
-	 * @since 3.1
-	 */
-	public function discover_install()
-	{
-		// Templates are one of the easiest
-		// If its not in the extensions table we just add it
-		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/templates/' . $this->parent->extension->element . '/templateDetails.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$description = (string) $this->parent->manifest->description;
-
-		if ($description)
-		{
-			$this->parent->set('message', JText::_($description));
-		}
-		else
-		{
-			$this->parent->set('message', '');
-		}
-
-		$this->parent->setPath('manifest', $manifestPath);
-		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
-		$this->parent->extension->manifest_cache = json_encode($manifest_details);
-		$this->parent->extension->state = 0;
-		$this->parent->extension->name = $manifest_details['name'];
-		$this->parent->extension->enabled = 1;
-
-		$data = new JObject;
-
-		foreach ($manifest_details as $key => $value)
-		{
-			$data->set($key, $value);
-		}
-
-		$this->parent->extension->params = $this->parent->getParams();
-
-		if ($this->parent->extension->store())
-		{
-			$db = $this->parent->getDbo();
-
-			// Insert record in #__template_styles
-			$lang = JFactory::getLanguage();
-			$debug = $lang->setDebug(false);
-			$columns = array($db->quoteName('template'),
-				$db->quoteName('client_id'),
-				$db->quoteName('home'),
-				$db->quoteName('title'),
-				$db->quoteName('params')
-			);
-			$query = $db->getQuery(true)
-				->insert($db->quoteName('#__template_styles'))
-				->columns($columns)
-				->values(
-					$db->quote($this->parent->extension->element)
-						. ',' . $db->quote($this->parent->extension->client_id)
-						. ',' . $db->quote(0)
-						. ',' . $db->quote(JText::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', $this->parent->extension->name))
-						. ',' . $db->quote($this->parent->extension->params)
-				);
-			$lang->setDebug($debug);
-			$db->setQuery($query);
-			$db->execute();
-
-			return $this->parent->extension->get('extension_id');
-		}
-		else
-		{
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_TPL_DISCOVER_STORE_DETAILS'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
 	}
 
 	/**

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -503,25 +503,31 @@ class JInstaller extends JAdapter
 
 			$adapter = null;
 
-			// Lazy load the adapter
-			if (!isset($this->_adapters[$this->extension->type]) || !is_object($this->_adapters[$this->extension->type]))
-			{
-				$params = array('extension' => $this->extension, 'route' => 'discover_install');
+			// Load the adapter(s) for the install manifest
+			$type   = $this->extension->type;
+			$params = array('extension' => $this->extension, 'route' => 'discover_install');
 
-				if (!$this->setAdapter($this->extension->type, $adapter, $params))
+			// Lazy load the adapter
+			if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))
+			{
+				$adapter = $this->loadAdapter($type, $params);
+
+				if (!$adapter)
 				{
 					return false;
 				}
+
+				$this->_adapters[$type] = $adapter;
 			}
 
-			if (is_object($this->_adapters[$this->extension->type]))
+			if (is_object($this->_adapters[$type]))
 			{
-				if (method_exists($this->_adapters[$this->extension->type], 'discover_install'))
+				if (method_exists($this->_adapters[$type], 'discover_install'))
 				{
 					// Add the languages from the package itself
-					if (method_exists($this->_adapters[$this->extension->type], 'loadLanguage'))
+					if (method_exists($this->_adapters[$type], 'loadLanguage'))
 					{
-						$this->_adapters[$this->extension->type]->loadLanguage();
+						$this->_adapters[$type]->loadLanguage();
 					}
 
 					// Fire the onExtensionBeforeInstall event.
@@ -538,7 +544,7 @@ class JInstaller extends JAdapter
 					);
 
 					// Run the install
-					$result = $this->_adapters[$this->extension->type]->discover_install();
+					$result = $this->_adapters[$type]->discover_install();
 
 					// Fire the onExtensionAfterInstall
 					$dispatcher->trigger(


### PR DESCRIPTION
Continuing the `JInstallerAdapter` implementations and standardizing the adapter paths, this PR focuses in on the `discover_install` path.  As you'll see in the `JInstallerAdapter` class itself, the routine has been standardized and is a stripped down version of the main `install` method.

As the component's adapter had support for all features in its implementation of `discover_install`, the other adapters are now updated to support these same features.  This means discover install of modules, for example, will support the use of extension scripts.  Note that the `file` and `package` adapters, which did not previously support discover, continue to not do so; also the `language` adapter is not yet updated (same situation as the previous pull).
### Testing Instructions

Since some of the common methods between `install` and `discover_install` are modified, you'll want to first test that installing components, modules, plugins, libraries, and templates still functions OK.  But this works to our advantage as it will position extension files in place to test discover installs.  After you've verified this continues to work OK, you'll need to prepare your environment to test the discovery of uninstalled extensions and then install them.  One of the easiest things to do is to delete the `configuration.php` file and re-install Joomla (with the same instance you previously installed extensions into).  Another option is to go into the database and manually remove all of the data for your installed extensions (template styles, tables the extensions may add to the database, the extension records themselves, and menu, asset, and module records as appropriate).  Make sure you do not delete the extensions from the filesystem while doing this reset.  Once you've gotten this far, you'll want to go to the Extension Manager's Discover view and click the Discover button; you should now get a list of extensions which are not installed.  Select them and click the install button; all should correctly install.
### Extension Concerns

Components previously supported the `preflight`, `install`, and `postflight` extension script methods and that is the support that has been added for the other extension types.  This could cause some concerns in extension scripts that don't account for the possibility to be triggered via a discover installed (I discovered one such issue with `com_patchtester` while testing this).  If it's decided this specific change may do more harm than good for extensions, we can update the discover routine to only process the script files for components so as to not remove a feature's support in a release that does not allow breaking B/C.
