### PR TITLE
Remove two references to `index.html` that don't exists

### DIFF
--- a/administrator/manifests/libraries/fof.xml
+++ b/administrator/manifests/libraries/fof.xml
@@ -38,10 +38,8 @@
 		<folder>toolbar</folder>
 		<folder>utils</folder>
 		<folder>view</folder>
-
 		<file>LICENSE.txt</file>
 		<file>include.php</file>
-		<file>index.html</file>
 		<file>version.txt</file>
 	</files>
 </extension>

--- a/administrator/manifests/libraries/phpass.xml
+++ b/administrator/manifests/libraries/phpass.xml
@@ -13,6 +13,5 @@
 
 	<files folder="phpass">
 		<file>PasswordHash.php</file>
-		<file>index.html</file>
 	</files>
 </extension>


### PR DESCRIPTION
This PR simple remove two references to `index.html` that don't exists (note that this files also removed from fof.

see: https://github.com/joomla/joomla-cms/pull/5381#issuecomment-66433013
