### PR TITLE
Update default.php to make W3C compliant

### DIFF
--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die;
 
 			if ($button) :
 				if ($imagebutton) :
-					$btn_output = ' <input type="image" value="' . $button_text . '" class="button" src="' . $img . '" onclick="this.form.searchword.focus();"/>';
+					$btn_output = ' <input type="image" alt="' . $button_text . '" class="button" src="' . $img . '" onclick="this.form.searchword.focus();"/>';
 				else :
 					$btn_output = ' <button class="button btn btn-primary" onclick="this.form.searchword.focus();">' . $button_text . '</button>';
 				endif;


### PR DESCRIPTION
W3C doesn't allow attribute of "value" on any input that is of type "file" or "image". W3C also requires the "alt" attribute. Therefore, switching the attribute of "value" with "alt" to make this input W3C compliant.
