### PR TITLE
Use 0 for ftp_enable as in com_config

### DIFF
--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -95,7 +95,7 @@ class InstallationModelConfiguration extends JModelBase
 		$registry->set('ftp_user', (isset($options->ftp_save) && $options->ftp_save && isset($options->ftp_user)) ? $options->ftp_user : '');
 		$registry->set('ftp_pass', (isset($options->ftp_save) && $options->ftp_save && isset($options->ftp_pass)) ? $options->ftp_pass : '');
 		$registry->set('ftp_root', (isset($options->ftp_save) && $options->ftp_save && isset($options->ftp_root)) ? $options->ftp_root : '');
-		$registry->set('ftp_enable', isset($options->ftp_host) ? $options->ftp_enable : '');
+		$registry->set('ftp_enable', isset($options->ftp_host) ? $options->ftp_enable : 0);
 
 		// Locale settings.
 		$registry->set('offset', 'UTC');


### PR DESCRIPTION
Spin off from the discussion at https://groups.google.com/forum/#!topic/joomla-dev-cms/VfAtj4YOiYs

If you save the global config then you find this has a value of `0` whereas in installation it's an empty string. This standardises it to be an `0`
