### PR TITLE
Add entry for search module

### DIFF
--- a/installation/sql/mysql/sample_data.sql
+++ b/installation/sql/mysql/sample_data.sql
@@ -160,7 +160,8 @@ INSERT IGNORE INTO `#__modules_menu` (`moduleid`, `menuid`) VALUES
 (89, 0),
 (90, 0),
 (91, 0),
-(92, 0);
+(92, 0),
+(93, 0);
 
 INSERT IGNORE INTO `#__tags` (`id`, `parent_id`, `lft`, `rgt`, `level`, `path`, `title`, `alias`, `note`, `description`, `published`, `checked_out`, `checked_out_time`, `access`, `params`, `metadesc`, `metakey`, `metadata`, `created_user_id`, `created_time`, `created_by_alias`, `modified_user_id`, `modified_time`, `images`, `urls`, `hits`, `language`, `version`, `publish_up`, `publish_down`) VALUES
 (1, 0, 0, 3, 0, '', 'ROOT', 'root', '', '', 1, 0, '0000-00-00 00:00:00', 1, '{}', '', '', '', 0, '2011-01-01 00:00:01', '', 0, '0000-00-00 00:00:00', '', '', 0, '*', 1, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),


### PR DESCRIPTION
Install Joomla with the default sample data set

You will see that there is a search module but it is set to `no pages` so it never appears.

This is confusing to new users and serves no purpose. 

(I didn't do the sql_azure or postgresql data sets as they dont appear to be in sync with the mysql data set - one thing at a time)
