### PR TITLE
[fix] Admin modules: Switch hardcoded date to JText string

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -36,7 +36,7 @@ JHtml::_('bootstrap.tooltip');
 				</div>
 				<div class="span3">
 					<span class="small">
-						<i class="icon-calendar"></i> <?php echo JHtml::_('date', $item->created, 'Y-m-d'); ?>
+						<i class="icon-calendar"></i> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 					</span>
 				</div>
 			</div>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -41,7 +41,7 @@ JHtml::_('bootstrap.tooltip');
 			</div>
 			<div class="span3">
 				<span class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
-					<i class="icon-calendar"></i> <?php echo JHtml::_('date', $user->time, 'Y-m-d'); ?>
+					<i class="icon-calendar"></i> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC4')); ?>
 				</span>
 			</div>
 		</div>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -36,7 +36,7 @@ JHtml::_('bootstrap.tooltip');
 				<div class="span3">
 					<span class="small">
 						<i class="icon-calendar"></i>
-						<?php echo JHtml::_('date', $item->created, 'Y-m-d'); ?>
+						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 					</span>
 				</div>
 			</div>


### PR DESCRIPTION
mod_latest, mod_popular and mod_logged are using hardcoded date format.
See http://forum.joomla.org/viewtopic.php?f=711&t=854857#p3254178
This prevents custom format by specific language strings or overrides.

This PR changes 'Y-m-d' to `JText::_('DATE_FORMAT_LC4')`

For example here, the string is overriden from
`DATE_FORMAT_LC4="Y-m-d"`
to
`DATE_FORMAT_LC4="d/m/y"`

![screen shot 2015-01-02 at 09 44 13](https://cloud.githubusercontent.com/assets/869724/5594936/d75e428c-9264-11e4-8b47-9e82801509c6.png)
