### PR TITLE
Fixes #5556 - Cannot disable automatic email notification when user registers

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -506,15 +506,15 @@ class UsersModelRegistration extends JModelForm
 			}
 		}
 
-		// Send the registration email to the user if this feature is enabled
-        if (json_decode(JPluginHelper::getPlugin('user', 'joomla')->params)->mail_to_user)
-        {
-            $return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
-        }
-        else
-        {
-            $return = true;
-        }
+	// Send the registration email to the user if this feature is enabled
+	if (json_decode(JPluginHelper::getPlugin('user', 'joomla')->params)->mail_to_user)
+	{
+		$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
+	}
+	else
+	{
+		$return = true;
+	}
 
 		// Send Notification mail to administrators
 		if (($params->get('useractivation') < 2) && ($params->get('mail_to_admin') == 1))

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -506,15 +506,15 @@ class UsersModelRegistration extends JModelForm
 			}
 		}
 
-	// Send the registration email to the user if this feature is enabled
-	if (json_decode(JPluginHelper::getPlugin('user', 'joomla')->params)->mail_to_user)
-	{
-		$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
-	}
-	else
-	{
-		$return = true;
-	}
+		// Send the registration email to the user if this feature is enabled
+		if (json_decode(JPluginHelper::getPlugin('user', 'joomla')->params)->mail_to_user)
+		{
+			$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
+		}
+		else
+		{
+			$return = true;
+		}
 
 		// Send Notification mail to administrators
 		if (($params->get('useractivation') < 2) && ($params->get('mail_to_admin') == 1))

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -506,8 +506,15 @@ class UsersModelRegistration extends JModelForm
 			}
 		}
 
-		// Send the registration email.
-		$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
+		// Send the registration email to the user if this feature is enabled
+        if (json_decode(JPluginHelper::getPlugin('user', 'joomla')->params)->mail_to_user)
+        {
+            $return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $data['email'], $emailSubject, $emailBody);
+        }
+        else
+        {
+            $return = true;
+        }
 
 		// Send Notification mail to administrators
 		if (($params->get('useractivation') < 2) && ($params->get('mail_to_admin') == 1))


### PR DESCRIPTION
Code from #5556 wrapped up in a easy to test/merge Pull request 

To test - 

1) Set "Send Password" in User Options to YES - Register a new user - You should get an email! 
2) Set "Send Password" in User Options to NO - Register a new user - You should NOT get an email! 
