### PR TITLE
module tags similar ignores expired articles - fix

### DIFF
--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -93,8 +93,10 @@ abstract class ModTagssimilarHelper
 
 		// Only return published tags
 		$query->where($db->quoteName('cc.core_state') . ' = 1 ')
-			->where('(' . $db->quoteName('cc.core_publish_up') . '=' . $db->quote($nullDate) . ' OR ' . $db->quoteName('cc.core_publish_up') . '<=' . $db->quote($now) . ')')
-			->where('(' . $db->quoteName('cc.core_publish_down') . '=' . $db->quote($nullDate) . ' OR ' . $db->quoteName('cc.core_publish_down') . '>=' . $db->quote($now) . ')');
+			->where('(' . $db->quoteName('cc.core_publish_up') . '=' . $db->quote($nullDate) . ' OR '
+				. $db->quoteName('cc.core_publish_up') . '<=' . $db->quote($now) . ')')
+			->where('(' . $db->quoteName('cc.core_publish_down') . '=' . $db->quote($nullDate) . ' OR '
+				. $db->quoteName('cc.core_publish_down') . '>=' . $db->quote($now) . ')');
 
 		// Optionally filter on language
 		$language = JComponentHelper::getParams('com_tags')->get('tag_list_language_filter', 'all');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -49,6 +49,8 @@ abstract class ModTagssimilarHelper
 		$tagsHelper = new JHelperTags;
 		$prefix     = $option . '.' . $view;
 		$id         = $app->input->getInt('id');
+		$now        = JFactory::getDate()->toSql();
+		$nullDate   = $db->getNullDate();
 
 		$tagsToMatch = $tagsHelper->getTagIds($id, $prefix);
 
@@ -90,8 +92,9 @@ abstract class ModTagssimilarHelper
 			. ' OR ' . $db->quoteName('m.type_alias') . ' <> ' . $db->quote($prefix) . ')');
 
 		// Only return published tags
-		$query->where($db->quoteName('cc.core_state') . ' = 1 ');
-
+		$query->where($db->quoteName('cc.core_state') . ' = 1 ')
+			  ->where('(' .$db->quoteName('cc.core_publish_up') . '=' . $db->quote($nullDate) . ' OR ' .$db->quoteName('cc.core_publish_up') . '<=' . $db->quote($now) . ')')
+		      ->where('(' . $db->quoteName('cc.core_publish_down') . '=' . $db->quote($nullDate) . ' OR ' .$db->quoteName('cc.core_publish_down') . '>=' . $db->quote($now) . ')');
 		// Optionally filter on language
 		$language = JComponentHelper::getParams('com_tags')->get('tag_list_language_filter', 'all');
 

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -93,8 +93,9 @@ abstract class ModTagssimilarHelper
 
 		// Only return published tags
 		$query->where($db->quoteName('cc.core_state') . ' = 1 ')
-			  ->where('(' .$db->quoteName('cc.core_publish_up') . '=' . $db->quote($nullDate) . ' OR ' .$db->quoteName('cc.core_publish_up') . '<=' . $db->quote($now) . ')')
-		      ->where('(' . $db->quoteName('cc.core_publish_down') . '=' . $db->quote($nullDate) . ' OR ' .$db->quoteName('cc.core_publish_down') . '>=' . $db->quote($now) . ')');
+			->where('(' . $db->quoteName('cc.core_publish_up') . '=' . $db->quote($nullDate) . ' OR ' . $db->quoteName('cc.core_publish_up') . '<=' . $db->quote($now) . ')')
+			->where('(' . $db->quoteName('cc.core_publish_down') . '=' . $db->quote($nullDate) . ' OR ' . $db->quoteName('cc.core_publish_down') . '>=' . $db->quote($now) . ')');
+
 		// Optionally filter on language
 		$language = JComponentHelper::getParams('com_tags')->get('tag_list_language_filter', 'all');
 


### PR DESCRIPTION
Using mod_tags_similar, the helper returns items marked as published using core_state=1 but it also returns items which have expired as no check is made on the core_publish_up or core_publish_down columns

Tested by editing the article published state and publish up and down dates.

I am just creating the PR for the code mentioned in #4979

I did of course confirm the issue and that the PR resolves it
