### PR TITLE
Remove redundant call for modal

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.modal', 'a.modal');
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
This affects /administrator/index.php?option=com_users&view=users
where a modal script is included but never used!

Testing:
Go to http://localhost/administrator/index.php?option=com_users&view=users
and observe (e.g.: firebug) that modal and mootools + mootools-more is present

Apply this patch and revisit the same page
modal, mootools + mootools-more should be absent and everything should work as usual!

This is a no brainer
