### PR TITLE
Redo for: made output of space conditional -> cause problems with gui tests

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -17,17 +17,17 @@ defined('_JEXEC') or die;
  * 	$input           : (string) The input field html code
  */
 
-?>
-
-<?php
 if (!empty($displayData['options']['showonEnabled']))
 {
 	JHtml::_('jquery.framework');
 	JHtml::_('script', 'jui/cms.js', false, true);
 }
+
+$class = empty($displayData['options']['class']) ? "" : " " . $displayData['options']['class'];
+$rel   = empty($displayData['options']['rel']) ? "" : " " .  $displayData['options']['rel'];
 ?>
 
-<div class="control-group<?php echo empty($displayData['options']['class']) ? "" : " " . $displayData['options']['class']; ?>"<?php echo empty($displayData['options']['rel']) ? "" : " " .  $displayData['options']['rel']; ?>>
+<div class="control-group<?php echo $class; ?>"<?php echo $rel; ?>>
 	<?php if (empty($displayData['options']['hiddenLabel'])) : ?>
 		<div class="control-label"><?php echo $displayData['label']; ?></div>
 	<?php endif; ?>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -27,7 +27,7 @@ if (!empty($displayData['options']['showonEnabled']))
 }
 ?>
 
-<div class="control-group <?php echo $displayData['options']['class']; ?>" <?php echo $displayData['options']['rel']; ?>>
+<div class="control-group<?php echo empty($displayData['options']['class']) ? "" : " " . $displayData['options']['class']; ?>"<?php echo empty($displayData['options']['rel']) ? "" : " " .  $displayData['options']['rel']; ?>>
 	<?php if (empty($displayData['options']['hiddenLabel'])) : ?>
 		<div class="control-label"><?php echo $displayData['label']; ?></div>
 	<?php endif; ?>


### PR DESCRIPTION
I changed the template how Joomla renders the fields in an backend edit view. In detail, the template generates a div-element with the css class "control-group ". Always with an additional space at the end of the css class "control-group".

My fix sets the css class to "control-group" if there is no additional css class. (without the additional space) else the space is added.

Use the 'renderFieldset' function in the 'JForm' class, Joomla uses the layout in renderfield.php to create the form fields.

The output of this method is not the same as in the Joomla core extensions. This fix makes the output consistent with the Joomla core extension template.
#### How to test
- Access a article and e.g. use Firebug to see the HTML Code for a renderd field.
- use the `view-source` option of your browser to see the renderd field
- apply this patch e.g. vie com_patchtester
- see the same field again

New PR for: https://github.com/joomla/joomla-cms/pull/5200 against staging. Code and credit by @Wolf-Rost
