### PR TITLE
Fix Totp Template Override File Path

### DIFF
--- a/plugins/twofactorauth/totp/totp.php
+++ b/plugins/twofactorauth/totp/totp.php
@@ -141,9 +141,9 @@ class PlgTwofactorauthTotp extends JPlugin
 
 		JLoader::import('joomla.filesystem.file');
 
-		if (JFile::exists($path . 'form.php'))
+		if (JFile::exists($path . '/form.php'))
 		{
-			include_once $path . 'form.php';
+			include_once $path . '/form.php';
 		}
 		else
 		{


### PR DESCRIPTION
Template layout override path is wrongly checked in the plugin and needs to be fixed. 
