### PR TITLE
Use formavalidator instead of the deprecated formvalidation

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/modal.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 $app = JFactory::getApplication();

--- a/administrator/components/com_languages/views/override/tmpl/edit.php
+++ b/administrator/components/com_languages/views/override/tmpl/edit.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 //load user_profile plugin language

--- a/components/com_users/views/registration/tmpl/default.php
+++ b/components/com_users/views/registration/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 ?>
 <div class="registration<?php echo $this->pageclass_sfx?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/components/com_users/views/remind/tmpl/default.php
+++ b/components/com_users/views/remind/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 ?>
 <div class="remind<?php echo $this->pageclass_sfx?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/components/com_users/views/reset/tmpl/complete.php
+++ b/components/com_users/views/reset/tmpl/complete.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 ?>
 <div class="reset-complete<?php echo $this->pageclass_sfx?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/components/com_users/views/reset/tmpl/confirm.php
+++ b/components/com_users/views/reset/tmpl/confirm.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 ?>
 <div class="reset-confirm<?php echo $this->pageclass_sfx?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/components/com_users/views/reset/tmpl/default.php
+++ b/components/com_users/views/reset/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 ?>
 <div class="reset<?php echo $this->pageclass_sfx?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -19,7 +19,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.framework', true);
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('script', 'installation/template/js/installation.js');
 
 // Load the JavaScript translated messages


### PR DESCRIPTION
## Why

Recently we introduce formvalidator that depends on jQuery and replaces the deprecated formvalidation that uses mootools.
This PR updates the few last standing usages of formvalidation to the new function.
### Testing

Nothing should really break with this PR since formvalidation is a proxy to formvalidator with the additional call to mootools
