### PR TITLE
Make all Positive/Negative select boxes Button Groups

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -532,13 +532,14 @@
 	>
 		<field
 			name="filter_field"
-			type="list"
+			type="radio"
+			class="btn-group btn-group-yesno"
 			default="1"
 			description="JGLOBAL_FILTER_FIELD_DESC"
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			>
-				<option value="hide">JHIDE</option>
 				<option value="1">JSHOW</option>
+				<option value="hide">JHIDE</option>		
 		</field>
 
 		<field name="show_pagination_limit" type="radio"

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -298,7 +298,8 @@
 
 		<field
 			name="filter_field"
-			type="list"
+			type="radio"
+			class="btn-group btn-group-yesno"
 			default="1"
 			description="JGLOBAL_FILTER_FIELD_DESC"
 			label="JGLOBAL_FILTER_FIELD_LABEL"

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -154,7 +154,8 @@
 		
 		<field 
 			name="tag_list_show_item_description" 
-			type="list"
+			type="radio"
+			class="btn-group btn-group-yesno"
 			label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 			description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
 		>

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -36,7 +36,8 @@
 
 				<field
 					name="shownew"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_MENU_FIELD_SHOWNEW"
 					description="MOD_MENU_FIELD_SHOWNEW_DESC">
@@ -46,7 +47,8 @@
 
 				<field
 					name="showhelp"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_MENU_FIELD_SHOWHELP"
 					description="MOD_MENU_FIELD_SHOWHELP_DESC">

--- a/administrator/modules/mod_version/mod_version.xml
+++ b/administrator/modules/mod_version/mod_version.xml
@@ -36,7 +36,8 @@
 				</field>
 				<field
 					name="product"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_VERSION_PRODUCT_LABEL"
 					description="MOD_VERSION_PRODUCT_DESC">

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -159,7 +159,8 @@
 
 				<field
 					name="author_alias_filtering_type"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIASFILTERING_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIASFILTERING_DESC"

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -82,7 +82,8 @@
 
 				<field
 					name="category_filtering_type"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_ARTICLES_CATEGORY_FIELD_CATFILTERINGTYPE_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_CATFILTERINGTYPE_DESC"
@@ -105,7 +106,8 @@
 
 				<field
 					name="show_child_category_articles"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="0"
 					label="MOD_ARTICLES_CATEGORY_FIELD_SHOWCHILDCATEGORYARTICLES_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_SHOWCHILDCATEGORYARTICLES_DESC"
@@ -128,7 +130,8 @@
 
 				<field
 					name="author_filtering_type"
-					type="list"
+					type="radio"
+					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHORFILTERING_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_AUTHORFILTERING_DESC"


### PR DESCRIPTION
This PR ensures that all select boxes with just two values of a type positive/negative eg show/hide are displayed as button groups and not select boxes
1. Note that there are some button groups with more than 2 values eg Frontend/Administrator/Both but this is not done consistently
2. Note that there are some button groups with only 2 values eg Left/Right that are displayed as button groups but this is not done consistently

@infograf768 pointed out  in #5641 that the aim is to only use  button groups for positive/negative values due to the green/red styling

This PR does not change anything for Notes 1 & 2 above but they should be reviewed at some point as well
