### PR TITLE
Fix `$hits_class` generation for backend mod_popular

### DIFF
--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php foreach ($list as $i => $item) : ?>
 			<?php // Calculate popular items ?>
 			<?php $hits = (int) $item->hits; ?>
-			<?php $hits_class = $hits >= 100 ? 'important' : $hits >= 25 ? 'warning' : $hits >= 10 ? 'info' : ''; ?>
+			<?php $hits_class = ($hits >= 100 ? 'important' : ($hits >= 25 ? 'warning' : ($hits >= 10 ? 'info' : ''))); ?>
 			<div class="row-fluid">
 				<div class="span9">
 					<span class="badge badge-<?php echo $hits_class; ?> hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_HITS'); ?>"><?php echo $item->hits; ?></span>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php foreach ($list as $i => $item) : ?>
 			<?php // Calculate popular items ?>
 			<?php $hits = (int) $item->hits; ?>
-			<?php $hits_class = ($hits >= 100 ? 'important' : ($hits >= 25 ? 'warning' : ($hits >= 10 ? 'info' : ''))); ?>
+			<?php $hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : 'info')); ?>
 			<div class="row-fluid">
 				<div class="span9">
 					<span class="badge badge-<?php echo $hits_class; ?> hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_HITS'); ?>"><?php echo $item->hits; ?></span>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php foreach ($list as $i => $item) : ?>
 			<?php // Calculate popular items ?>
 			<?php $hits = (int) $item->hits; ?>
-			<?php $hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : 'info')); ?>
+			<?php $hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : ($hits >= 100 ? 'info' : ''))); ?>
 			<div class="row-fluid">
 				<div class="span9">
 					<span class="badge badge-<?php echo $hits_class; ?> hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_HITS'); ?>"><?php echo $item->hits; ?></span>


### PR DESCRIPTION
This PR fixes the `$hits_class` generation for backend mod_popular
### current behavior

every time the class is `info`
### expected behavior

class should change for the hits. (red/yellow/blue)
### Changes

Why we move it to red if the hits is more than 100? All my artikles have more that 100 hits (thats in that list) Maybe we need to increase the vaules?

Example
10.000 -> `important`
1.000 -> `warning`
all others -> `info`

``` php
$hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : 'info'));
```
### Orginal Bug reported in german

http://www.joomlaportal.de/joomla-3-x-erweiterungen-module/316386-kleiner-bug-mod_popular.html
