### PR TITLE
Versions using layouts and bootstrap

### DIFF
--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -111,7 +111,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
-				<th width="1%" class="center hidden-phone">
+				<th width="1%" class="center">
 					<input type="checkbox" name="checkall-toggle" value="" title="<?php echo JText::_('JGLOBAL_CHECK_ALL'); ?>" onclick="Joomla.checkAll(this)" />
 				</th>
 				<th width="15%">
@@ -142,7 +142,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		<?php $i = 0; ?>
 		<?php foreach ($this->items as $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
-				<td class="center hidden-phone">
+				<td class="center">
 					<?php echo JHtml::_('grid.id', $i, $item->version_id); ?>
 				</td>
 				<td align="left">

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -91,19 +91,19 @@ JFactory::getDocument()->addScriptDeclaration("
 <div class="btn-group pull-right">
 	<button id="toolbar-load" type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>"
 		data-url="<?php echo JRoute::_($loadUrl);?>" id="content-url">
-		<span class="icon-upload"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></button>
+		<span class="icon-upload"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span></button>
 	<button id="toolbar-preview" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-search"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></button>
+		<span class="icon-search"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span></button>
 	<button id="toolbar-compare" type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>"
 		data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1');?>">
-		<span class="icon-zoom-in"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></button>
+		<span class="icon-zoom-in"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
-    	<span class="icon-lock"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></button>
+    	<span class="icon-lock"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span></button>
     <button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.delete')}" class="btn hasTooltip"
     	title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
-    	<span class="icon-delete"></span><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></button>
+    	<span class="icon-delete"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span></button>
 </div>
 <div class="clearfix"></div>
 <form action="<?php echo JRoute::_($formUrl);?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -613,8 +613,8 @@ abstract class JToolbarHelper
 	 */
 	public static function versions($typeAlias, $itemId, $height = 800, $width = 500, $alt = 'JTOOLBAR_VERSIONS')
 	{
-		JHtml::_('behavior.modal', 'a.modal_jform_contenthistory');
-
+		$lang = JFactory::getLanguage();
+		$lang->load('com_contenthistory', JPATH_ADMINISTRATOR, $lang->getTag(), true);
 		$contentTypeTable = JTable::getInstance('Contenttype');
 		$typeId           = $contentTypeTable->getTypeId($typeAlias);
 
@@ -645,8 +645,6 @@ abstract class JToolbarHelper
 	 */
 	public static function modal($targetModalId, $icon, $alt)
 	{
-		JHtml::_('bootstrap.framework');
-
 		$title = JText::_($alt);
 		$dhtml = "<button data-toggle='modal' data-target='#" . $targetModalId . "' class='btn btn-small'>
 			<span class='" . $icon . "' title='" . $title . "'></span> " . $title . "</button>";

--- a/administrator/templates/hathor/html/layouts/joomla/toolbar/versions.php
+++ b/administrator/templates/hathor/html/layouts/joomla/toolbar/versions.php
@@ -9,43 +9,11 @@
 
 defined('_JEXEC') or die;
 
-/**
- * Layout variables
- * ---------------------
- *
- * @var  string   $itemId The item id number
- * @var  string   $typeId The type id number
- * @var  string   $title The link text
- * @var  string   $typeAlias The component type
- */
-extract($displayData);
+JHtml::_('behavior.modal', 'a.modal_jform_contenthistory');
 
-$link = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id='
-	. (int) $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
-	. $typeAlias . '&amp;' . JSession::getFormToken() . '=1';
-
-echo JHtml::_(
-	'bootstrap.renderModal',
-	'versionsModal',
-	array(
-		'url'    => $link,
-		'title'  => JText::_('COM_CONTENTHISTORY_MODAL_TITLE'),
-		'height' => '300px',
-		'width'  => '800px',
-		'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-			. JText::_("JTOOLBAR_CLOSE") . '</button>'
-	)
-);
-
-JFactory::getDocument()->addStyleDeclaration(
-	"
-	div.toolbar-box h3 {
-		height: auto;
-		position: relative;
-	}
-	"
-);
 ?>
-<button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-small" data-toggle="modal" title="<?php echo $title; ?>">
-	<span class="icon-32-restore"></span><?php echo $title; ?>
-</button>
+<a rel="{handler: 'iframe', size: {x: <?php echo $displayData['height']; ?>, y: <?php echo $displayData['width']; ?>}}"
+	href="index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id=<?php echo (int) $displayData['itemId']; ?>&amp;type_id=<?php echo $displayData['typeId']; ?>&amp;type_alias=<?php echo $displayData['typeAlias']; ?>&amp;<?php echo JSession::getFormToken(); ?>=1"
+	title="<?php echo $displayData['title']; ?>" class="toolbar modal_jform_contenthistory">
+	<span class="icon-32-restore"></span> <?php echo $displayData['title']; ?>
+</a>

--- a/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
+++ b/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
@@ -36,16 +36,8 @@ echo JHtml::_(
 			. JText::_("JTOOLBAR_CLOSE") . '</button>'
 	)
 );
-
-JFactory::getDocument()->addStyleDeclaration(
-	"
-	div.toolbar-box h3 {
-		height: auto;
-		position: relative;
-	}
-	"
-);
 ?>
 <button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-small" data-toggle="modal" title="<?php echo $title; ?>">
-	<span class="icon-32-restore"></span><?php echo $title; ?>
+	<span class="icon-archive"></span><?php echo $title; ?>
 </button>
+

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $item The item id number
+ * @var  string   $link The link text
+ * @var  string   $label The label text
+ */
+extract($displayData);
+
+JHtml::_('behavior.modal', 'button.modal_' . $item);
+?>
+<button class="btn modal_<?php echo $item; ?>" title="<?php echo $label; ?>" href="<?php echo $link; ?>" rel="{handler: 'iframe', size: {x: 800, y: 500}}">
+	<span class="icon-archive"></span><?php echo $label; ?>
+</button>

--- a/libraries/cms/form/field/contenthistory.php
+++ b/libraries/cms/form/field/contenthistory.php
@@ -38,6 +38,9 @@ class JFormFieldContenthistory extends JFormField
 	 */
 	public function getLayoutData()
 	{
+		// Get the basic field data
+		$data = parent::getLayoutData();
+
 		$typeId = JTable::getInstance('Contenttype')->getTypeId($this->element['data-typeAlias']);
 		$itemId = $this->form->getValue('id');
 		$label  = JText::_('JTOOLBAR_VERSIONS');
@@ -46,12 +49,14 @@ class JFormFieldContenthistory extends JFormField
 			. $this->id . '&amp;item_id=' . $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
 			. $this->element['data-typeAlias'] . '&amp;' . JSession::getFormToken() . '=1';
 
-		return array(
-			'type' => $typeId,
-			'item' => $itemId,
-			'label' => $label,
-			'link' => $link
+		$extraData = array(
+				'type' => $typeId,
+				'item' => $itemId,
+				'label' => $label,
+				'link' => $link
 		);
+
+		return array_merge($data, $extraData);
 	}
 
 	/**

--- a/libraries/cms/form/field/contenthistory.php
+++ b/libraries/cms/form/field/contenthistory.php
@@ -25,6 +25,36 @@ class JFormFieldContenthistory extends JFormField
 	public $type = 'ContentHistory';
 
 	/**
+	 * Layout to render the label
+	 *
+	 * @var  string
+	 */
+	protected $layout = 'joomla.form.field.contenthistory';
+
+	/**
+	 * Get the data that is going to be passed to the layout
+	 *
+	 * @return  array
+	 */
+	public function getLayoutData()
+	{
+		$typeId = JTable::getInstance('Contenttype')->getTypeId($this->element['data-typeAlias']);
+		$itemId = $this->form->getValue('id');
+		$label  = JText::_('JTOOLBAR_VERSIONS');
+
+		$link   = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;field='
+			. $this->id . '&amp;item_id=' . $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
+			. $this->element['data-typeAlias'] . '&amp;' . JSession::getFormToken() . '=1';
+
+		return array(
+			'type' => $typeId,
+			'item' => $itemId,
+			'label' => $label,
+			'link' => $link
+		);
+	}
+
+	/**
 	 * Method to get the content history field input markup.
 	 *
 	 * @return  string  The field input markup.
@@ -33,23 +63,7 @@ class JFormFieldContenthistory extends JFormField
 	 */
 	protected function getInput()
 	{
-		$typeId = JTable::getInstance('Contenttype')->getTypeId($this->element['data-typeAlias']);
-		$itemId = $this->form->getValue('id');
-		$label = JText::_('JTOOLBAR_VERSIONS');
-		$html = array();
-		$link = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;field='
-			. $this->id . '&amp;item_id=' . $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
-			. $this->element['data-typeAlias'] . '&amp;' . JSession::getFormToken() . '=1';
 
-		// Load the modal behavior script.
-		JHtml::_('behavior.modal', 'button.modal_' . $this->id);
-
-		$html[] = '		<button class="btn modal_' . $this->id . '" title="' . $label . '" href="' . $link . '"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';
-		$html[] = '<span class="icon-archive"></span>';
-		$html[] = $label;
-		$html[] = '</button>';
-
-		return implode("\n", $html);
+		return JLayoutHelper::render($this->layout, $this->getLayoutData());
 	}
 }

--- a/libraries/cms/form/field/contenthistory.php
+++ b/libraries/cms/form/field/contenthistory.php
@@ -68,7 +68,11 @@ class JFormFieldContenthistory extends JFormField
 	 */
 	protected function getInput()
 	{
+		if (empty($this->layout))
+		{
+			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+		}
 
-		return JLayoutHelper::render($this->layout, $this->getLayoutData());
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
 	}
 }

--- a/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
+++ b/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $link The link for the content history page
+ * @var  string   $label The label text
+ */
+extract($displayData);
+
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'versionsModal',
+	array(
+		'url'    => $link,
+		'title'  => $label,
+		'height' => '300px',
+		'width'  => '800px',
+		'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+	)
+);
+
+?>
+<button onclick="jQuery('#versionsModal').modal('show')" class="btn" data-toggle="modal" title="<?php echo $label; ?>">
+	<span class="icon-archive"></span><?php echo $label; ?>
+</button>


### PR DESCRIPTION
### Use of layouts for field contenthistory

This is a redone for #4561. Now versions are using layouts and there are two sets:
One on the root/layouts this is for B/C
And another on the templates isis and protostar this is using bootstrap modal
### Actual rendering:

Isis:
![screen shot 2015-01-09 at 10 07 13](https://cloud.githubusercontent.com/assets/3889375/5686567/d13d4b6c-984c-11e4-93e2-f1ecb5044854.png)

Protostar:
![screen shot 2015-01-09 at 10 08 01](https://cloud.githubusercontent.com/assets/3889375/5686573/d9c58f06-984c-11e4-9fd5-a4916834ac7c.png)
### B/C

None
### Testing

Try to re edit an article on backend and front end (make sure that versions are enabled and you have few versions available)
