### PR TITLE
second attempt at replacing public private

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -3,14 +3,14 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a public and private key for your domain, go to <a href="_QQ_"http://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">http://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href="_QQ_"http://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">http://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
 PLG_CAPTCHA_RECAPTCHA="Captcha - ReCaptcha"
 
 ; Params
 PLG_RECAPTCHA_PUBLIC_KEY_LABEL="Site key"
-PLG_RECAPTCHA_PUBLIC_KEY_DESC="Used in the JavaScript code that is served to your users. See the plugin description for instructions on getting a public key."
+PLG_RECAPTCHA_PUBLIC_KEY_DESC="Used in the JavaScript code that is served to your users. See the plugin description for instructions on getting a site key."
 PLG_RECAPTCHA_PRIVATE_KEY_LABEL="Secret key"
-PLG_RECAPTCHA_PRIVATE_KEY_DESC="Used in the communication between your server and the ReCaptha server. Be sure to keep it a secret. See the plugin description for instructions on getting a private key."
+PLG_RECAPTCHA_PRIVATE_KEY_DESC="Used in the communication between your server and the ReCaptha server. Be sure to keep it a secret. See the plugin description for instructions on getting a secret key."
 PLG_RECAPTCHA_THEME_LABEL="Theme"
 PLG_RECAPTCHA_THEME_DESC="Defines which theme to use for reCAPTCHA."
 PLG_RECAPTCHA_THEME_RED="Red"

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a public and private key for your domain, go to http://www.google.com/recaptcha. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to http://www.google.com/recaptcha. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
 PLG_CAPTCHA_RECAPTCHA="Captcha - ReCaptcha"


### PR DESCRIPTION
Looks like we still missed some occurrences of public /private in the captcha plugins with #5593. After this PR then they should all now be replaced with site/secret key - thanks to @zero-24 for spotting it
