### PR TITLE
UI/UX Review for com_banners tracks view on mobile devices

### DIFF
--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -72,7 +72,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<option value="desc" <?php echo $listDirn == 'desc' ? 'selected="selected"' : ''; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING'); ?></option>
 				</select>
 			</div>
-			<div class="btn-group pull-right">
+			<div class="btn-group pull-right hidden-phone">
 				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
 				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
 					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY'); ?></option>


### PR DESCRIPTION
see: #5628

This is a proposal UI/UX review on mobile for the banners component.

This only remove (hide) the `sort by` dropdown on mobile devices (others are ok and mobile is handled)
