### PR TITLE
Fix: Fatal Error with search statistics

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -136,7 +136,7 @@ class TagsModelTag extends JModelList
 		$language = $this->getState('tag.language');
 		$stateFilter = $this->getState('tag.state');
 
-	// Optionally filter on language
+		// Optionally filter on language
 		if (empty($language))
 		{
 			$language = JComponentHelper::getParams('com_tags')->get('tag_list_language_filter', 'all');
@@ -170,7 +170,7 @@ class TagsModelTag extends JModelList
 		$app = JFactory::getApplication('site');
 
 		// Load the parameters.
-		$params = $app->getParams();
+		$params = JComponentHelper::getParams('com_tags');
 		$this->setState('params', $params);
 
 		// Load state from the request.


### PR DESCRIPTION
see: https://github.com/joomla/joomla-cms/issues/5674
#### Steps to reproduce the issue
1. In com_search options enable search statistics
2. in the front end perform various search
3. Set error reporting to maximum
4. open com_search - you might need to press search results but eventually you will get
   `Fatal error: Call to undefined method JApplicationAdministrator::getParams() in components/com_tags/models/tag.php on line 173`

As this completely breaks com_search I am marking this priority 2 according to the docs

Here is a video
https://www.dropbox.com/s/5onz39546941r09/search-fatal-error.mp4?dl=0
