### PR TITLE
redirect manager word-break

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -108,7 +108,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 						</td>
-						<td>
+						<td class="break-word">
 							<?php echo JHtml::_('redirect.published', $item->published, $i); ?>
 							<?php if ($canEdit) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_redirect&task=link.edit&id=' . $item->id);?>" title="<?php echo $this->escape($item->old_url); ?>">
@@ -117,10 +117,10 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 									<?php echo $this->escape(str_replace(JUri::root(), '', rawurldecode($item->old_url))); ?>
 							<?php endif; ?>
 						</td>
-						<td class="small">
+						<td class="small break-word">
 							<?php echo $this->escape(rawurldecode($item->new_url)); ?>
 						</td>
-						<td class="small">
+						<td class="small break-word">
 							<?php echo $this->escape($item->referer); ?>
 						</td>
 						<td class="small">


### PR DESCRIPTION
If the redirect plugin is enabled then the redirect manager will capture any 404 url including some very long ones from people attempting hacks. These urls are not wrapped and this breaks the interface - see screenshot before.

This PR adds the break-word class as proposed in #5525 and now the interface is not broken - see screenshot after

**\* To test please ensure that you apply #5525 first ***
### Before

![redirec-before](https://cloud.githubusercontent.com/assets/1296369/5697653/98349c3c-99ee-11e4-9522-8f673f75666b.png)
### After

![redirect-after](https://cloud.githubusercontent.com/assets/1296369/5697654/9839a6e6-99ee-11e4-8f3f-4ceb360288bc.png)
