### PR TITLE
Sort Template positions in module template positions dropdown

### DIFF
--- a/administrator/components/com_modules/helpers/html/modules.php
+++ b/administrator/components/com_modules/helpers/html/modules.php
@@ -165,6 +165,8 @@ abstract class JHtmlModules
 						$isTemplatePosition = true;
 					}
 				}
+
+				$options = JArrayHelper::sortObjects($options, 'text');
 			}
 
 			$templateGroups[$template] = ModulesHelper::createOptionGroup(ucfirst($template), $options);


### PR DESCRIPTION
This PR sorts the template positions in the module manager when selecting the position for the template by template and then by position. It also takes into account the translated name of the position.
### How to test
1. Go into the module manager, edit a module, see that the positions are not in alphabetical order.
2. Apply patch
3. See that the positions are ordered (and grouped) by template first and then in the respective template group, ordered alphabetically by position.
