### PR TITLE
Sort menus in the backend menu alphabetically

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -139,7 +139,8 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addSeparator();
 
 	// Menu Types
-	foreach (ModMenuHelper::getMenus() as $menuType)
+	$menuTypes = JArrayHelper::sortObjects(ModMenuHelper::getMenus(), 'title');
+	foreach ($menuTypes as $menuType)
 	{
 		$alt = '*' . $menuType->sef . '*';
 

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -140,6 +140,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = JArrayHelper::sortObjects(ModMenuHelper::getMenus(), 'title');
+
 	foreach ($menuTypes as $menuType)
 	{
 		$alt = '*' . $menuType->sef . '*';

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -140,7 +140,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
-	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title');
+	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false, true);
 
 	foreach ($menuTypes as $menuType)
 	{

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -139,7 +139,8 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addSeparator();
 
 	// Menu Types
-	$menuTypes = JArrayHelper::sortObjects(ModMenuHelper::getMenus(), 'title');
+	$menuTypes = ModMenuHelper::getMenus();
+	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title');
 
 	foreach ($menuTypes as $menuType)
 	{

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -140,7 +140,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
-	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false, true);
+	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false);
 
 	foreach ($menuTypes as $menuType)
 	{

--- a/administrator/templates/hathor/html/mod_menu/default_enabled.php
+++ b/administrator/templates/hathor/html/mod_menu/default_enabled.php
@@ -130,7 +130,10 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addSeparator();
 
 	// Menu Types
-	foreach (ModMenuHelper::getMenus() as $menuType)
+	$menuTypes = ModMenuHelper::getMenus();
+	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false, true);
+
+	foreach ($menuTypes as $menuType)
 	{
 		$alt = '*' .$menuType->sef. '*';
 		if ($menuType->home == 0)

--- a/administrator/templates/hathor/html/mod_menu/default_enabled.php
+++ b/administrator/templates/hathor/html/mod_menu/default_enabled.php
@@ -131,7 +131,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
-	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false, true);
+	$menuTypes = JArrayHelper::sortObjects($menuTypes, 'title', 1, false);
 
 	foreach ($menuTypes as $menuType)
 	{


### PR DESCRIPTION
This PR sorts the menutypes in the backend in alphabetical order and not in order how they were first created some ancient time ago. :wink:
### How to test
1. Go into the backend, open the "Menus" menu and see that it is not ordered alphabetically.
2. Apply change.
3. See that the menus are now ordered alphabetically.
