### PR TITLE
Allow Passing Custom Port to mysqli JDatabaseDriver implementation.

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -66,8 +66,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
 		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
 		$options['select']   = (isset($options['select'])) ? (bool) $options['select'] : true;
-		$options['port']     = isset($options['port']) ? $options['port'] : null;
-		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
+		$options['port']     = (isset($options['port'])) ? (int) $options['port'] : null;
+		$options['socket']   = (isset($options['socket'])) ? $options['socket'] : null;
 
 		// Finalize initialisation.
 		parent::__construct($options);

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -66,7 +66,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
 		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
 		$options['select']   = (isset($options['select'])) ? (bool) $options['select'] : true;
-		$options['port']     = null;
+		$options['port']     = isset($options['port']) ? $options['port'] : null;
 		$options['socket']   = null;
 
 		// Finalize initialisation.

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -67,7 +67,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
 		$options['select']   = (isset($options['select'])) ? (bool) $options['select'] : true;
 		$options['port']     = isset($options['port']) ? $options['port'] : null;
-		$options['socket']   = null;
+		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
 
 		// Finalize initialisation.
 		parent::__construct($options);


### PR DESCRIPTION
I ran into an issue where I was attempting to create a database connection with JDatabaseDriver. I was providing the correct configuration through the options array passed to the constructor of JDatabaseDriverMysqli. Unfortunately, the port configuration is immediately disregarded in the constructor code, as it sets the value to null instead of checking if it was provided.

I was able to get around this by passing the port along with the host, but it's unexpected to not be able to do it by providing a port value in the options array. On line 105 in the connect method it checks if the port was set, otherwise it defaults to 3306. This line is basically pointless, since the value will always be null, this leads me to believe that automatically setting the port option to null was not intended.
