### PR TITLE
Fix alignment of number of hits under Hits column

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -103,7 +103,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
 						</th>
-						<th width="10%" class="nowrap hidden-phone">
+						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">


### PR DESCRIPTION
If you change the width of the JGLOBAL_HITS from 10% to 1%, the alignment of the Hits column looks better.
Fix for https://github.com/joomla/joomla-cms/issues/5658
