### PR TITLE
Break word for disabled functions in the php system info page

### DIFF
--- a/administrator/components/com_admin/views/sysinfo/tmpl/default_phpsettings.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default_phpsettings.php
@@ -137,7 +137,7 @@ defined('_JEXEC') or die;
 				<td>
 					<?php echo JText::_('COM_ADMIN_DISABLED_FUNCTIONS'); ?>
 				</td>
-				<td>
+				<td class="break-word">
 					<?php echo JHtml::_('phpsetting.string', $this->php_settings['disable_functions']); ?>
 				</td>
 			</tr>


### PR DESCRIPTION
If you have a "crazy" long list of disabled php functions then this can break the layout of the page as there are no spaces in the string. 

You can see this in the screenshots #5686  

This PR add the class word-break to the td to prevent this happening. To test it I had to manual insert a long list of disabled functions using chrome inspector 
