### PR TITLE
Fix for Page Navigation Plugin on User Auth View

### DIFF
--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -139,7 +139,7 @@ class PlgContentPagenavigation extends JPlugin
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(
 					'a.catid = ' . (int) $row->catid . ' AND a.state = ' . (int) $row->state
-						. ($canPublish ? '' : ' AND a.access = ' . (int) $row->access) . $xwhere
+						. ($canPublish ? '' : ' AND a.access IN ('.implode(",", JAccess::getAuthorisedViewLevels($user->id)).') '). $xwhere
 				);
 			$query->order($orderby);
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -139,7 +139,7 @@ class PlgContentPagenavigation extends JPlugin
 				->join('LEFT', '#__categories AS cc ON cc.id = a.catid')
 				->where(
 					'a.catid = ' . (int) $row->catid . ' AND a.state = ' . (int) $row->state
-						. ($canPublish ? '' : ' AND a.access IN ('.implode(",", JAccess::getAuthorisedViewLevels($user->id)).') '). $xwhere
+						. ($canPublish ? '' : ' AND a.access IN (' . implode(",", JAccess::getAuthorisedViewLevels($user->id)) . ') ') . $xwhere
 				);
 			$query->order($orderby);
 


### PR DESCRIPTION
Fix for issue: https://github.com/joomla/joomla-cms/issues/5685 (see that issue for testing instruction)

The Article Pagination "Prev" & "Next" used the current article's Access Level (with "AND a.access = ' . (int) $row->access)") to navigate among articles within the same Category. That caused problems with Articles from the same Category that had different Access Levels.

This fix checks the User's authorized Access Levels (with "AND a.access IN ('.implode(",", JAccess::getAuthorisedViewLevels($user->id)).') ')" instead.

Note: using "IN" in SQL queries might be slower than "equal". I have not tested this fix on categories with huge numbers of articles!
