### PR TITLE
Modules Manager: Normalizing Trash/Batch position

### DIFF
--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -93,15 +93,6 @@ class ModulesViewModules extends JViewLegacy
 			JToolbarHelper::checkin('modules.checkin');
 		}
 
-		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))
-		{
-			JToolbarHelper::deleteList('', 'modules.delete', 'JTOOLBAR_EMPTY_TRASH');
-		}
-		elseif ($canDo->get('core.edit.state'))
-		{
-			JToolbarHelper::trash('modules.trash');
-		}
-
 		// Add a batch button
 		if ($user->authorise('core.create', 'com_modules') && $user->authorise('core.edit', 'com_modules')
 			&& $user->authorise('core.edit.state', 'com_modules'))
@@ -114,6 +105,15 @@ class ModulesViewModules extends JViewLegacy
 
 			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');
+		}
+
+		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))
+		{
+			JToolbarHelper::deleteList('', 'modules.delete', 'JTOOLBAR_EMPTY_TRASH');
+		}
+		elseif ($canDo->get('core.edit.state'))
+		{
+			JToolbarHelper::trash('modules.trash');
 		}
 
 		if ($canDo->get('core.admin'))


### PR DESCRIPTION
When we normalized the position of the Batch and Trash buttons in the toolbars, we forgot the Modules Manager.
This PR pushes the Trash button to the right of the Batch button.
Expected display after merge:

![screen shot 2015-01-13 at 08 00 13](https://cloud.githubusercontent.com/assets/869724/5717067/41169bdc-9afa-11e4-86d2-8876665d16cd.png)
