### PR TITLE
Update hathor to use rss feed for postinstall view

### DIFF
--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -13,7 +13,7 @@ $renderer = JFactory::getDocument()->loadRenderer('module');
 $options  = array('style' => 'raw');
 $mod      = JModuleHelper::getModule('mod_feed');
 $param    = array(
-		"rssurl" => "http://www.joomla.org/announcements/release-news.feed?type=rss",
+		"rssurl" => "https://www.joomla.org/announcements/release-news.feed?type=rss",
 		"rsstitle" => 0,
 		"rssdesc" => 0,
 		"rssimage" => 1,

--- a/administrator/templates/hathor/html/com_postinstall/messages/default.php
+++ b/administrator/templates/hathor/html/com_postinstall/messages/default.php
@@ -8,6 +8,19 @@
  */
 
 defined('_JEXEC') or die;
+
+$renderer       = JFactory::getDocument()->loadRenderer('module');
+$options        = array('style' => 'raw');
+$mod            = JModuleHelper::getModule('mod_feed');
+$param          = array("rssurl" => "http://www.joomla.org/announcements/release-news.feed?type=rss",
+                         +						"rsstitle" => 0,
+                         +						"rssdesc" => 0,
+                         +						"rssimage" => 1,
+                         +						"rssitems" => 5,
+                         +						"rssitemdesc" => 1,
+                         +						"word_count" => 200,
+                         +						"cache" => 0);
+$params         = array('params' => json_encode($param));
 ?>
 
 <?php if (empty($this->items)): ?>
@@ -52,8 +65,7 @@ defined('_JEXEC') or die;
 	if ($this->eid == 700):
 		echo JHtml::_('sliders.panel', JText::_('COM_POSTINSTALL_LBL_RELEASENEWS'), 'postinstall-panel-releasenotes');
 ?>
-		<iframe width="100%" height="1000" src="http://www.joomla.org/announcements/release-news">
-		</iframe>
+		<?php echo $renderer->render($mod, $params, $options); ?>
 <?php
 	echo JHtml::_('sliders.end');
 	endif;

--- a/administrator/templates/hathor/html/com_postinstall/messages/default.php
+++ b/administrator/templates/hathor/html/com_postinstall/messages/default.php
@@ -13,13 +13,13 @@ $renderer       = JFactory::getDocument()->loadRenderer('module');
 $options        = array('style' => 'raw');
 $mod            = JModuleHelper::getModule('mod_feed');
 $param          = array("rssurl" => "http://www.joomla.org/announcements/release-news.feed?type=rss",
-                         +						"rsstitle" => 0,
-                         +						"rssdesc" => 0,
-                         +						"rssimage" => 1,
-                         +						"rssitems" => 5,
-                         +						"rssitemdesc" => 1,
-                         +						"word_count" => 200,
-                         +						"cache" => 0);
+                         						"rsstitle" => 0,
+                         						"rssdesc" => 0,
+                         						"rssimage" => 1,
+                         						"rssitems" => 5,
+                         						"rssitemdesc" => 1,
+                         						"word_count" => 200,
+                         						"cache" => 0);
 $params         = array('params' => json_encode($param));
 ?>
 

--- a/administrator/templates/hathor/html/com_postinstall/messages/default.php
+++ b/administrator/templates/hathor/html/com_postinstall/messages/default.php
@@ -13,13 +13,13 @@ $renderer       = JFactory::getDocument()->loadRenderer('module');
 $options        = array('style' => 'raw');
 $mod            = JModuleHelper::getModule('mod_feed');
 $param          = array("rssurl" => "https://www.joomla.org/announcements/release-news.feed?type=rss",
-                         						"rsstitle" => 0,
-                         						"rssdesc" => 0,
-                         						"rssimage" => 1,
-                         						"rssitems" => 5,
-                         						"rssitemdesc" => 1,
-                         						"word_count" => 200,
-                         						"cache" => 0);
+						"rsstitle" => 0,
+						"rssdesc" => 0,
+						"rssimage" => 1,
+						"rssitems" => 5,
+						"rssitemdesc" => 1,
+						"word_count" => 200,
+						"cache" => 0);
 $params         = array('params' => json_encode($param));
 ?>
 

--- a/administrator/templates/hathor/html/com_postinstall/messages/default.php
+++ b/administrator/templates/hathor/html/com_postinstall/messages/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $renderer       = JFactory::getDocument()->loadRenderer('module');
 $options        = array('style' => 'raw');
 $mod            = JModuleHelper::getModule('mod_feed');
-$param          = array("rssurl" => "http://www.joomla.org/announcements/release-news.feed?type=rss",
+$param          = array("rssurl" => "https://www.joomla.org/announcements/release-news.feed?type=rss",
                          						"rsstitle" => 0,
                          						"rssdesc" => 0,
                          						"rssimage" => 1,
@@ -56,7 +56,7 @@ $params         = array('params' => json_encode($param));
 			<?php if (JFactory::getUser()->authorise('core.edit.state', 'com_postinstall')) : ?>
 			<button onclick="window.location='index.php?option=com_postinstall&view=message&task=unpublish&id=<?php echo $item->postinstall_message_id ?>&<?php echo $this->token ?>=1'; return false;" class="btn btn-inverse btn-small">
 				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE') ?>
-			</a>
+			</button>
 			<?php endif; ?>
 		</div>
 	</fieldset>


### PR DESCRIPTION
#### On #5222 we totally forgot Hathor

This just updates the hathor override to be in line with isis
Also this is the proper solution here for #5477

The actual rendering on the url: `/administrator/index.php?option=com_postinstall&eid=700` should be:

![screen shot 2015-01-13 at 9 18 43](https://cloud.githubusercontent.com/assets/3889375/5727268/656e4dde-9b6a-11e4-8957-4ada75d12a9d.png)
### Testing:

Just ensure that there are no side effects in this url: `/administrator/index.php?option=com_postinstall&eid=700`
