### PR TITLE
Menu Sorting

### DIFF
--- a/administrator/components/com_menus/models/menus.php
+++ b/administrator/components/com_menus/models/menus.php
@@ -197,7 +197,7 @@ class MenusModelMenus extends JModelList
 		$this->setState('filter.search', $search);
 
 		// List state information.
-		parent::populateState('a.id', 'asc');
+		parent::populateState('a.title', 'asc');
 	}
 
 	/**


### PR DESCRIPTION
The menu list select in index.php?option=com_menus&view=items is alpha sorted on title
With the PR from @hackwar #5683 the list of menus in the menus dropdown is not alpha sorted

This PR changes the sort in the Menu Manager itself so that menus are displayed by title and not by ID

![screen shot 2015-01-13 at 14 35 50](http://issues.joomla.org/uploads/1/ce038efbf69d7229619968516bd5332d.png)
