### PR TITLE
Smart Search Module Name

### DIFF
--- a/language/en-GB/en-GB.mod_finder.ini
+++ b/language/en-GB/en-GB.mod_finder.ini
@@ -10,7 +10,7 @@ COM_FINDER_ADVANCED_SEARCH="Advanced Search"
 COM_FINDER_SELECT_SEARCH_FILTER="- No Filter -"
 
 ; Module strings
-MOD_FINDER="Smart Search Module"
+MOD_FINDER="Smart Search"
 MOD_FINDER_CONFIG_OPTION_BOTTOM="Bottom"
 MOD_FINDER_CONFIG_OPTION_TOP="Top"
 MOD_FINDER_FIELDSET_ADVANCED_ALT_DESCRIPTION="An alternate label for the search field."

--- a/language/en-GB/en-GB.mod_finder.sys.ini
+++ b/language/en-GB/en-GB.mod_finder.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-MOD_FINDER="Smart Search Module"
+MOD_FINDER="Smart Search"
 MOD_FINDER_XML_DESCRIPTION="This is a search module for the Smart Search system."


### PR DESCRIPTION
In the list of modules only the Smart Search Module has the word Module in it's name.
This PR removes the word module for consistency

You can check it by going to the module manager and clicking on New
