### PR TITLE
Correct PHP strict error in JMediawikiHttp

### DIFF
--- a/libraries/joomla/mediawiki/http.php
+++ b/libraries/joomla/mediawiki/http.php
@@ -42,14 +42,15 @@ class JMediawikiHttp extends JHttp
 	/**
 	 * Method to send the GET command to the server.
 	 *
-	 * @param   string  $url      Path to the resource.
-	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
+	 * @param   string   $url      Path to the resource.
+	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout  Read timeout in seconds.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   12.3
 	 */
-	public function get($url, array $headers = null)
+	public function get($url, array $headers = null, $timeout = null)
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -62,21 +63,28 @@ class JMediawikiHttp extends JHttp
 			}
 		}
 
-		return $this->transport->request('GET', new JUri($url), null, $headers, $this->options->get('api.timeout'), $this->options->get('api.useragent'));
+		// Look for timeout set in the options.
+		if ($timeout === null && $this->options->exists('api.timeout'))
+		{
+			$timeout = $this->options->get('api.timeout');
+		}
+
+		return $this->transport->request('GET', new JUri($url), null, $headers, $timeout, $this->options->get('api.useragent'));
 	}
 
 	/**
 	 * Method to send the POST command to the server.
 	 *
-	 * @param   string  $url      Path to the resource.
-	 * @param   mixed   $data     Either an associative array or a string to be sent with the request.
-	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
+	 * @param   string   $url      Path to the resource.
+	 * @param   mixed    $data     Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers  An array of name-value pairs to include in the header of the request
+	 * @param   integer  $timeout  Read timeout in seconds.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   12.3
 	 */
-	public function post($url, $data, array $headers = null)
+	public function post($url, $data, array $headers = null, $timeout = null)
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -89,6 +97,12 @@ class JMediawikiHttp extends JHttp
 			}
 		}
 
-		return $this->transport->request('POST', new JUri($url), $data, $headers, $this->options->get('api.timeout'), $this->options->get('api.useragent'));
+		// Look for timeout set in the options.
+		if ($timeout === null && $this->options->exists('api.timeout'))
+		{
+			$timeout = $this->options->get('api.timeout');
+		}
+
+		return $this->transport->request('POST', new JUri($url), $data, $headers, $timeout, $this->options->get('api.useragent'));
 	}
 }


### PR DESCRIPTION
The method declarations in JMediawikiHttp, a subclass of JHttp, do not match up and causes PHP strict errors.  This PR updates the subclass to have the correct declarations and implements similar handling of the param as exists in the parent classes.
### Testing Instructions

The only way I can think to directly test this with the CMS repo is to run the `build/helpTOC.php` CLI script.  Pre-patch, you'll get strict standards messages; post-patch, you won't.
