### PR TITLE
textarea resize control and mass mail

### DIFF
--- a/administrator/components/com_users/models/forms/mail.xml
+++ b/administrator/components/com_users/models/forms/mail.xml
@@ -45,7 +45,7 @@
 		/>
 
 		<field name="message" type="textarea"
-			class="span11"
+			class="span11 vert"
 			cols="70"
 			description="COM_USERS_MAIL_FIELD_MESSAGE_DESC"
 			label="COM_USERS_MAIL_FIELD_MESSAGE_LABEL"

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -1340,6 +1340,15 @@ input#mm_subject {
 textarea#mm_message {
 	width: 100%;
 }
+textarea {
+	resize: both;
+}
+textarea.vert {
+	resize: vertical;
+}
+textarea.noResize {
+	resize: none;
+}
 .pane-sliders {
 	margin: 0;
 	position: relative;

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -487,6 +487,15 @@ input#mm_subject {
 textarea#mm_message {
 	width: 100%;
 }
+textarea { 
+	resize:both; 
+} 
+textarea.vert { 
+	resize:vertical; 
+}
+textarea.noResize { 
+	resize:none; 
+}
 
 /**
  * Pane Slider pane Toggler styles

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8107,6 +8107,15 @@ a.grid_true {
 	word-break: break-all;
 	word-wrap: break-word;
 }
+textarea {
+	resize: both;
+}
+textarea.vert {
+	resize: vertical;
+}
+textarea.noResize {
+	resize: none;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8107,3 +8107,12 @@ a.grid_true {
 	word-break: break-all;
 	word-wrap: break-word;
 }
+textarea {
+	resize: both;
+}
+textarea.vert {
+	resize: vertical;
+}
+textarea.noResize {
+	resize: none;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1172,3 +1172,13 @@ a.grid_true {
 	word-break: break-all;
 	word-wrap: break-word;
 }
+/* Customize Textarea Resizing */
+textarea { 
+	resize:both; 
+} 
+textarea.vert { 
+	resize:vertical; 
+}
+textarea.noResize { 
+	resize:none; 
+}


### PR DESCRIPTION
This PR adds new classes to isis and hathor to Customize Textarea Resizing with CSS

The default in Firefox, Safari, and Chrome is to allow horizontal and vertical resizing of the textarea (IE doesnt allow resizing).

This was causing an issue in the Mass Mail Users message area as reported #5699 

This PR adds an extra class vert to the message area in the Mass Mail component to only allow vertical resizing.
