### PR TITLE
Media Manager: Displaying the path to the opened folder

### DIFF
--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -11,6 +11,17 @@ defined('_JEXEC') or die;
 $user = JFactory::getUser();
 ?>
 <form target="_parent" action="index.php?option=com_media&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>" method="post" id="mediamanager-form" name="mediamanager-form">
+	<?php if ($this->state->folder != '') : ?>
+		<div>
+			<ul class="unstyled">
+				<li>
+					<i class="icon-folder"> </i>
+					<?php echo $this->state->folder; ?>
+				</li>
+			</ul>
+		</div>
+	<?php endif; ?>
+
 	<div class="manager">
 	<table class="table table-striped table-condensed">
 	<thead>

--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -9,18 +9,20 @@
 
 defined('_JEXEC') or die;
 $user = JFactory::getUser();
+$params = JComponentHelper::getParams('com_media');
+$path = 'file_path';
 ?>
 <form target="_parent" action="index.php?option=com_media&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>" method="post" id="mediamanager-form" name="mediamanager-form">
-	<?php if ($this->state->folder != '') : ?>
-		<div>
-			<ul class="unstyled">
-				<li>
-					<i class="icon-folder"> </i>
-					<?php echo $this->state->folder; ?>
-				</li>
-			</ul>
-		</div>
-	<?php endif; ?>
+	<div class="muted">
+		<p>
+			<i class="icon-folder"> </i>
+			<?php if ($this->state->folder != '') : ?>
+				<?php echo JText::_('JGLOBAL_ROOT') . ': ' . $params->get($path, 'images') . '/' . $this->state->folder; ?>
+			<?php else : ?>
+				<?php echo JText::_('JGLOBAL_ROOT') . ': ' . $params->get($path, 'images'); ?>
+			<?php endif; ?>
+		</p>
+	</div>
 
 	<div class="manager">
 	<table class="table table-striped table-condensed">

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs.php
@@ -8,18 +8,20 @@
  */
 
 defined('_JEXEC') or die;
+$params = JComponentHelper::getParams('com_media');
+$path = 'file_path';
 ?>
 <form target="_parent" action="index.php?option=com_media&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>" method="post" id="mediamanager-form" name="mediamanager-form">
-	<?php if ($this->state->folder != '') : ?>
-		<div>
-			<ul class="unstyled">
-				<li>
-					<i class="icon-folder"> </i>
-					<?php echo $this->state->folder; ?>
-				</li>
-			</ul>
-		</div>
-	<?php endif; ?>
+	<div class="muted">
+		<p>
+			<i class="icon-folder"> </i>
+			<?php if ($this->state->folder != '') : ?>
+				<?php echo JText::_('JGLOBAL_ROOT') . ': ' . $params->get($path, 'images') . '/' . $this->state->folder; ?>
+			<?php else : ?>
+				<?php echo JText::_('JGLOBAL_ROOT') . ': ' . $params->get($path, 'images'); ?>
+			<?php endif; ?>
+		</p>
+	</div>
 
 	<ul class="manager thumbnails">
 		<?php

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs.php
@@ -10,6 +10,17 @@
 defined('_JEXEC') or die;
 ?>
 <form target="_parent" action="index.php?option=com_media&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>" method="post" id="mediamanager-form" name="mediamanager-form">
+	<?php if ($this->state->folder != '') : ?>
+		<div>
+			<ul class="unstyled">
+				<li>
+					<i class="icon-folder"> </i>
+					<?php echo $this->state->folder; ?>
+				</li>
+			</ul>
+		</div>
+	<?php endif; ?>
+
 	<ul class="manager thumbnails">
 		<?php
 		echo $this->loadTemplate('up');

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3781,6 +3781,6 @@ div.toggle-editor {
 	word-break: break-all;
 	word-wrap: break-word;
 }
-ul.unstyled {
-	list-style: none;
+.muted {
+	color: #999;
 }

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3781,3 +3781,6 @@ div.toggle-editor {
 	word-break: break-all;
 	word-wrap: break-word;
 }
+ul.unstyled {
+	list-style: none;
+}

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3514,6 +3514,6 @@ div.toggle-editor {
 	word-break: break-all;
 	word-wrap: break-word;
 }
-ul.unstyled {
-	list-style: none;
+.muted {
+	color: #999;
 }

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3514,3 +3514,6 @@ div.toggle-editor {
 	word-break: break-all;
 	word-wrap: break-word;
 }
+ul.unstyled {
+	list-style: none;
+}


### PR DESCRIPTION
When browsing through the folders, we do not know where we are...

After patch, we should get:

![screen shot 2015-01-14 at 12 18 32](https://cloud.githubusercontent.com/assets/869724/5738077/3a89c71e-9be8-11e4-9fce-1703db87a5cb.png)
