### PR TITLE
Cleanup flash uploader inline styles

### DIFF
--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -21,12 +21,6 @@ $input = JFactory::getApplication()->input;
 			</div>
 		</div>
 	</div>
-	<style>
-		.overall-progress,
-		.current-progress {
-			width: 150px;
-		}
-	</style>
 	<!-- End Sidebar -->
 	<!-- Begin Content -->
 	<div class="span10">


### PR DESCRIPTION
The flash uploader was removed from Joomla and this inline style is left and does nothing.

(I cant find when the flash uploader was removed in github but this style was added in this same PR as the flash uploader was added)
