### PR TITLE
Update names of Article and Tag modules

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_latest.ini
+++ b/administrator/language/en-GB/en-GB.mod_latest.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-MOD_LATEST="Latest News"
+MOD_LATEST="Articles - Latest"
 MOD_LATEST_CREATED="Created"
 MOD_LATEST_CREATED_BY="Created By"
 MOD_LATEST_FIELD_AUTHORS_DESC="A filter for the Authors"

--- a/administrator/language/en-GB/en-GB.mod_latest.sys.ini
+++ b/administrator/language/en-GB/en-GB.mod_latest.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-MOD_LATEST="Latest News"
+MOD_LATEST="Articles - Latest"
 MOD_LATEST_XML_DESCRIPTION="This Module shows a list of the most recently published Articles that are still current. Some that are shown may have expired even though they are the most recent."
 MOD_LATEST_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_articles_archive.ini
+++ b/language/en-GB/en-GB.mod_articles_archive.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_ARCHIVE="Archived Articles"
+MOD_ARTICLES_ARCHIVE="Articles - Archived"
 MOD_ARTICLES_ARCHIVE_FIELD_COUNT_LABEL="# of Months"
 MOD_ARTICLES_ARCHIVE_FIELD_COUNT_DESC="The number of months to display (the default is 10)"
 MOD_ARTICLES_ARCHIVE_XML_DESCRIPTION="This module shows a list of the calendar months containing archived articles. After you have changed the status of an article to archived, this list will be automatically generated."

--- a/language/en-GB/en-GB.mod_articles_archive.sys.ini
+++ b/language/en-GB/en-GB.mod_articles_archive.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_ARCHIVE="Archived Articles"
+MOD_ARTICLES_ARCHIVE="Articles - Archived"
 MOD_ARTICLES_ARCHIVE_XML_DESCRIPTION="This Module shows a list of the calendar months containing Archived Articles. After you have changed the status of an Article to Archived, this list will be automatically generated."
 MOD_ARTICLES_ARCHIVE_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_articles_categories.ini
+++ b/language/en-GB/en-GB.mod_articles_categories.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_CATEGORIES="Articles Categories"
+MOD_ARTICLES_CATEGORIES="Articles - Categories"
 MOD_ARTICLES_CATEGORIES_FIELD_COUNT_DESC="Select here the number of first level subcategories to display. Default is all."
 MOD_ARTICLES_CATEGORIES_FIELD_COUNT_LABEL="# First Subcategories"
 MOD_ARTICLES_CATEGORIES_FIELD_MAXLEVEL_DESC="Select here the maximum level depth for each subcategory. Default is all."

--- a/language/en-GB/en-GB.mod_articles_categories.sys.ini
+++ b/language/en-GB/en-GB.mod_articles_categories.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_CATEGORIES="Articles Categories"
+MOD_ARTICLES_CATEGORIES="Articles - Categories"
 MOD_ARTICLES_CATEGORIES_XML_DESCRIPTION="This module displays a list of categories from one parent category."
 MOD_ARTICLES_CATEGORIES_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_articles_category.ini
+++ b/language/en-GB/en-GB.mod_articles_category.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_CATEGORY="Articles Category"
+MOD_ARTICLES_CATEGORY="Articles - Category"
 MOD_ARTICLES_CATEGORY_FIELD_ARTICLEGROUPING_DESC="Select how you would like the articles to be grouped."
 MOD_ARTICLES_CATEGORY_FIELD_ARTICLEGROUPING_LABEL="Article Grouping"
 MOD_ARTICLES_CATEGORY_FIELD_ARTICLEGROUPINGDIR_DESC="Select the direction you would like the Article Groupings to be ordered by."

--- a/language/en-GB/en-GB.mod_articles_category.sys.ini
+++ b/language/en-GB/en-GB.mod_articles_category.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_CATEGORY="Articles Category"
+MOD_ARTICLES_CATEGORY="Articles - Category"
 MOD_ARTICLES_CATEGORY_XML_DESCRIPTION="This module displays a list of articles from one or more categories."
 MOD_ARTICLES_CATEGORY_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_articles_latest.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_LATEST="Latest News"
+MOD_ARTICLES_LATEST="Articles - Latest"
 MOD_LATEST_NEWS_FIELD_CATEGORY_DESC="Selects Articles from one or more Categories. If no selection will show all categories as default"
 MOD_LATEST_NEWS_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)"
 MOD_LATEST_NEWS_FIELD_COUNT_LABEL="Count"

--- a/language/en-GB/en-GB.mod_articles_latest.sys.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_LATEST="Latest News"
+MOD_ARTICLES_LATEST="Articles - Latest"
 MOD_LATEST_NEWS_XML_DESCRIPTION="This Module shows a list of the most recently published and current Articles. Some that are shown may have expired even though they are the most recent."
 MOD_ARTICLES_LATEST_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_articles_popular.ini
+++ b/language/en-GB/en-GB.mod_articles_popular.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_POPULAR="Most Read Content"
+MOD_ARTICLES_POPULAR="Articles - Most Read"
 MOD_POPULAR_FIELD_CATEGORY_DESC="Select Articles from a specific Category or a set of Categories. If no selection will show all categories as default"
 MOD_POPULAR_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)"
 MOD_POPULAR_FIELD_COUNT_LABEL="Count"

--- a/language/en-GB/en-GB.mod_articles_popular.sys.ini
+++ b/language/en-GB/en-GB.mod_articles_popular.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_ARTICLES_POPULAR="Most Read Content"
+MOD_ARTICLES_POPULAR="Articles - Most Read"
 MOD_POPULAR_XML_DESCRIPTION="This Module shows a list of the currently published Articles which have the highest number of page views."
 MOD_ARTICLES_POPULAR_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_related_items.ini
+++ b/language/en-GB/en-GB.mod_related_items.ini
@@ -7,5 +7,5 @@ MOD_RELATED_FIELD_MAX_DESC="The maximum number of related articles to display (d
 MOD_RELATED_FIELD_MAX_LABEL="Maximum articles"
 MOD_RELATED_FIELD_SHOWDATE_DESC="Show/Hide Date"
 MOD_RELATED_FIELD_SHOWDATE_LABEL="Show Date"
-MOD_RELATED_ITEMS="Articles - Related Articles"
+MOD_RELATED_ITEMS="Articles - Related"
 MOD_RELATED_XML_DESCRIPTION="This Module displays other Articles that are related to the one currently being viewed. These relations are established by the Meta Keywords. <br />All the keywords of the current Article are searched against all the keywords of all other published Articles. For example, you may have an Article on "_QQ_"Breeding Parrots"_QQ_" and another on "_QQ_"Hand Raising Black Cockatoos"_QQ_". If you include the keyword "_QQ_"parrot"_QQ_" in both Articles, then the Related Items Module will list the "_QQ_"Breeding Parrots"_QQ_" Article when viewing "_QQ_"Hand Raising Black Cockatoos"_QQ_" and vice-versa."

--- a/language/en-GB/en-GB.mod_related_items.sys.ini
+++ b/language/en-GB/en-GB.mod_related_items.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_RELATED_ITEMS="Articles - Related Articles"
+MOD_RELATED_ITEMS="Articles - Related"
 MOD_RELATED_XML_DESCRIPTION="This Module displays other Articles that are related to the one currently being viewed. These relations are established by the Meta Keywords. <br />All the keywords of the current Article are searched against all the keywords of all other published Articles. For example, you may have an Article on "_QQ_"Breeding Parrots"_QQ_" and another on "_QQ_"Hand Raising Black Cockatoos"_QQ_". If you include the keyword "_QQ_"parrot"_QQ_" in both Articles, then the Related Items Module will list the "_QQ_"Breeding Parrots"_QQ_" Article when viewing "_QQ_"Hand Raising Black Cockatoos"_QQ_" and vice-versa."
 MOD_RELATED_ITEMS_LAYOUT_DEFAULT="Default"
 

--- a/language/en-GB/en-GB.mod_tags_popular.ini
+++ b/language/en-GB/en-GB.mod_tags_popular.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_TAGS_POPULAR="Popular Tags"
+MOD_TAGS_POPULAR="Tags - Popular"
 MOD_TAGS_POPULAR_FIELD_ALL_TIME="All time"
 MOD_TAGS_POPULAR_FIELD_DISPLAY_COUNT_DESC="Choose if the number of tagged items should be displayed next to each tag."
 MOD_TAGS_POPULAR_FIELD_DISPLAY_COUNT_LABEL="Display number of items"

--- a/language/en-GB/en-GB.mod_tags_popular.sys.ini
+++ b/language/en-GB/en-GB.mod_tags_popular.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_TAGS_POPULAR="Popular Tags"
+MOD_TAGS_POPULAR="Tags - Popular"
 MOD_TAGS_POPULAR_LAYOUT_CLOUD="Cloud"
 MOD_TAGS_POPULAR_LAYOUT_DEFAULT="Default"
 MOD_TAGS_POPULAR_XML_DESCRIPTION="This Module displays tags used on the site in a list or a cloud layout. Tags can be ordered by title or by the number of tagged items and limited to a specific time period."

--- a/language/en-GB/en-GB.mod_tags_similar.ini
+++ b/language/en-GB/en-GB.mod_tags_similar.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_TAGS_SIMILAR="Similar Tags"
+MOD_TAGS_SIMILAR="Tags - Similar"
 MOD_TAGS_SIMILAR_FIELD_ALL="All"
 MOD_TAGS_SIMILAR_FIELD_HALF="Half"
 MOD_TAGS_SIMILAR_FIELD_MATCHTYPE_DESC="How closely an item's tags need to match. All - requires that all tags in the displayed item be matched. Any - requires that at least one tag match. Half - requires that at least half of the tags match (rounded up in the case of decimals)."

--- a/language/en-GB/en-GB.mod_tags_similar.sys.ini
+++ b/language/en-GB/en-GB.mod_tags_similar.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
-MOD_TAGS_SIMILAR="Similar Tags"
+MOD_TAGS_SIMILAR="Tags - Similar"
 MOD_TAGS_SIMILAR_LAYOUT_DEFAULT="Default"
 MOD_TAGS_SIMILAR_XML_DESCRIPTION="The Similar Tags Module displays links to other items with similar tags. The closeness of the match can be specified."
 


### PR DESCRIPTION
The en-GB user-interface-text WG discussed and agreed it would be better and more consistent if we renamed the article and tag modules as below and this will mean that they are all grouped together in the list of available modules
- Tags - Popular
- Tags - Similar
- Articles - Archived
- Articles - Newsflash
- Articles - Related
- Articles - Categories
- Articles - Category
- Articles - Latest
- Articles - Most Read
