### PR TITLE
Implementing noResize for textarea on the Installation

### DIFF
--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -40,7 +40,7 @@
 			autocomplete="off"
 		/>
 
-		<field name="site_metadesc" type="textarea" id="site_metadesc" class="text_area vert"
+		<field name="site_metadesc" type="textarea" id="site_metadesc" class="text_area noResize"
 			label="INSTL_SITE_METADESC_LABEL"
 			rows="3"
 		/>

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -40,7 +40,7 @@
 			autocomplete="off"
 		/>
 
-		<field name="site_metadesc" type="textarea" id="site_metadesc" class="text_area"
+		<field name="site_metadesc" type="textarea" id="site_metadesc" class="text_area vert"
 			label="INSTL_SITE_METADESC_LABEL"
 			rows="3"
 		/>

--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -127,3 +127,12 @@
 	text-align: center;
 	font-size: 16px;
 }
+textarea {
+	resize: both;
+}
+textarea.vert {
+	resize: vertical;
+}
+textarea.noResize {
+	resize: none;
+}

--- a/installation/template/css/template_rtl.css
+++ b/installation/template/css/template_rtl.css
@@ -1,6 +1,6 @@
 /**
- * @copyright	Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 body{

--- a/installation/template/css/template_rtl.css
+++ b/installation/template/css/template_rtl.css
@@ -3,7 +3,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-body{
+body {
 	direction: rtl;
 }
 /* Javascript Warning */

--- a/installation/template/css/template_rtl.css
+++ b/installation/template/css/template_rtl.css
@@ -11,3 +11,12 @@ body{
 	text-align: center;
 	font-size: 16px;
 }
+textarea {
+	resize: both;
+}
+textarea.vert {
+	resize: vertical;
+}
+textarea.noResize {
+	resize: none;
+}


### PR DESCRIPTION
This PR Implements noResize for the textarea on the Installation.

Based on code by @brianteeman from here: https://github.com/joomla/joomla-cms/pull/5721
### How to test
- download my branche: https://github.com/zero-24/joomla-cms/archive/patch-16.zip
- extract
- try to install joomla
- try to resize the Site Metadesc textarea
