### PR TITLE
Bootstraping com_installer installation messages

### DIFF
--- a/administrator/components/com_installer/views/default/tmpl/default_message.php
+++ b/administrator/components/com_installer/views/default/tmpl/default_message.php
@@ -9,21 +9,18 @@
 
 defined('_JEXEC') or die;
 
-$state			= $this->get('State');
-$message1		= $state->get('message');
-$message2		= $state->get('extension_message');
+$state    = $this->get('State');
+$message1 = $state->get('message');
+$message2 = $state->get('extension_message');
 ?>
-<table class="adminform">
-	<tbody>
-		<?php if ($message1) : ?>
-		<tr>
-			<th><?php echo $message1 ?></th>
-		</tr>
-		<?php endif; ?>
-		<?php if ($message2) : ?>
-		<tr>
-			<td><?php echo $message2; ?></td>
-		</tr>
-		<?php endif; ?>
-	</tbody>
-</table>
+
+<?php if ($message1) : ?> 
+	<div class="span12"> 
+		<strong><?php echo $message1; ?></strong>
+	</div> 
+<?php endif; ?> 
+<?php if ($message2) : ?> 
+	<div class="span12"> 
+		<strong><?php echo $message2; ?></strong>
+	</div> 
+<?php endif; ?>


### PR DESCRIPTION
#### Steps to reproduce the issue

1) login to the backend
2) install an Joomla 3 plugin/component/modul which load the description from an language file (.sys.ini)
3) see the HTML source code there are tables and the description load to the header and not to a table cell
4) apply patch
5) see again the source code
#### Expected result

Description is load into span12 div boxes
#### Actual result

Description is load into a table head
