### PR TITLE
Fix wrong 'trash' icon actions dropdown item

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -17,7 +17,7 @@ $client		= $this->state->get('filter.client_id') ? 'administrator' : 'site';
 $user		= JFactory::getUser();
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
-$trashed	= $this->state->get('filter.published') == -2 ? true : false;
+$trashed	= $this->state->get('filter.state') == -2 ? true : false;
 $canOrder	= $user->authorise('core.edit.state', 'com_modules');
 $saveOrder	= $listOrder == 'ordering';
 if ($saveOrder)


### PR DESCRIPTION
This PR fix the issue reported here by @aasimali :
- http://issues.joomla.org/tracker/joomla-cms/5726
- https://github.com/joomla/joomla-cms/issues/5726

When a module is trashed, in the actions dropdown menu, you have the icon "trash" (no effect) and it should be "publish".

This PR replace the wrong "trash" icon by the "publish" icon by replacing published by state.
