### PR TITLE
Module Manager: adding option to filter by all statuses

### DIFF
--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -67,6 +67,7 @@ abstract class ModulesHelper
 		$options[]	= JHtml::_('select.option',	'1',	JText::_('JPUBLISHED'));
 		$options[]	= JHtml::_('select.option',	'0',	JText::_('JUNPUBLISHED'));
 		$options[]	= JHtml::_('select.option',	'-2',	JText::_('JTRASHED'));
+		$options[]	= JHtml::_('select.option',	'*',	JText::_('JALL'));
 
 		return $options;
 	}


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/5730#issuecomment-70063849

The Module Manager is only filtering by Published, Unpublished and Trashed.
This PR add the option we have in other managers to display all of them together.

To test, apply the PR, trash a module, make sure you have some unpublished and some published and choose "All" in the Select Status dropdown in the sidebar
