### PR TITLE
fix cancel action on the global configuration page

### DIFF
--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -19,7 +19,7 @@ JHtml::_('formbehavior.chosen', 'select');
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)
 	{
-		if (task == "application.cancel" || document.formvalidator.isValid(document.getElementById("application-form")))
+		if (task === "config.cancel.application" || document.formvalidator.isValid(document.getElementById("application-form")))
 		{
 			Joomla.submitform(task, document.getElementById("application-form"));
 		}

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -20,7 +20,7 @@ JHtml::_('formbehavior.chosen', 'select');
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)
 	{
-		if (task == "config.cancel.component" || document.formvalidator.isValid(document.getElementById("component-form")))
+		if (task === "config.cancel.component" || document.formvalidator.isValid(document.getElementById("component-form")))
 		{
 			Joomla.submitform(task, document.getElementById("component-form"));
 		}


### PR DESCRIPTION
bug found by @anibalsanchez  https://github.com/joomla/joomla-cms/pull/4435#issuecomment-70078535

> In Global Configuration, I try to save an empty Site Name, it shows the message "Invalid field: Site Name"... Cancel button does not work

**test**
after patch the cancel button should work again as expected
