### PR TITLE
Fix filter language in category (issue reported here : https://github.com/joomla/joomla-cms/issues/5734)

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -514,7 +514,7 @@ class ContentModelArticles extends JModelList
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$query->where('a.language in (parent.language, ' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
+			$query->where('a.language in (' . $db->quote('parent.language') . ', ' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -514,7 +514,7 @@ class ContentModelArticles extends JModelList
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$query->where('a.language in (' . $db->quote('parent.language') . ', ' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
+			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -514,7 +514,7 @@ class ContentModelArticles extends JModelList
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
+			$query->where('a.language in (parent.language, ' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 
 		// Add the list ordering clause.

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -400,6 +400,19 @@ class ContentModelCategory extends JModelList
 			$this->getCategory();
 		}
 
+		// Filter Parent category by language
+		if ($this->getState('filter.language'))
+		{
+			if (in_array($this->_item->language, array(JFactory::getLanguage()->getTag(), '*')))
+			{
+				return $this->_parent;
+			}
+			else
+			{
+				return null;
+			}
+		}
+
 		return $this->_parent;
 	}
 

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -451,6 +451,22 @@ class ContentModelCategory extends JModelList
 			$this->getCategory();
 		}
 
+		// Filter subcategories by language
+		if (count($this->_children) && $this->getState('filter.language'))
+		{
+			$children = array();
+
+			foreach ($this->_children as $id => $child)
+			{
+				if (in_array($child->language, array(JFactory::getLanguage()->getTag(), '*')))
+				{
+					$children[] = $child;
+				}
+			}
+
+			$this->_children = $children;
+		}
+
 		// Order subcategories
 		if (count($this->_children))
 		{


### PR DESCRIPTION
Fix for issue reported here : https://github.com/joomla/joomla-cms/issues/5734
Add check of parent category language

<blockquote>
Steps to reproduce the issue

Assume you have a multilanguage site with Lang1 and Lang2 languages activated in frontend. You have 2 menus to show content in Lang1 and Lang2 languages: MenuLang1 and MenuLang2. Create new category CatLang1 in backend category manager and assign Lang1 to it. Create new article ArtLang2 in this category and assign Lang2 to it. Add menu item showing just added category blog to each of menus (MenuLang1 and MenuLang2).

<b>Expected result</b>
On frontend only MenuLang1 item should show CatLang1 category but MenuLang2 should filter it out. No articles should be shown in CatLang1 since ArtLang2 has wrong language.

<b>Actual result</b>
Both MenuLang1 and MenuLang2 shows CatLang1 category. CatLang1 in MenuLang2 shows ArtLang2. Category is not filtered by language.
</blockquote>
