### PR TITLE
Adding language string Alternative Layout dropdown

### DIFF
--- a/language/en-GB/en-GB.mod_finder.sys.ini
+++ b/language/en-GB/en-GB.mod_finder.sys.ini
@@ -5,3 +5,4 @@
 
 MOD_FINDER="Smart Search Module"
 MOD_FINDER_XML_DESCRIPTION="This is a search module for the Smart Search system."
+MOD_FINDER_LAYOUT_DEFAULT="Default"


### PR DESCRIPTION
See Extensions > Module Manager > Smart Search Module > [Advanced] settings
Alternative Layout displays "default" instead of "Default" because language string was missing.
