### PR TITLE
Articles Related Items - missing "Cache Time"

### DIFF
--- a/modules/mod_related_items/mod_related_items.xml
+++ b/modules/mod_related_items/mod_related_items.xml
@@ -62,6 +62,12 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
+				<field
+					name="cache_time"
+					type="text"
+					default="900"
+					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
+					description="COM_MODULES_FIELD_CACHE_TIME_DESC" />				
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
See: Extensions > Module Manager > Articles Related Items > Advanced
There's a "Caching" option available but "Cache Time" field is missing.
This PR adds a "Cache Time" field.
