### PR TITLE
Module Similar Tags - missing "Cache Time"

### DIFF
--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -83,6 +83,12 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
+				<field
+					name="cache_time"
+					type="text"
+					default="900"
+					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
+					description="COM_MODULES_FIELD_CACHE_TIME_DESC" />				
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
See: Extensions > Module Manager > Similar Tags > Advanced
There's a "Caching" option available but "Cache Time" field is missing.
This PR adds a "Cache Time" field.
