### PR TITLE
Smart Search Module,Consistency with Search Module

### DIFF
--- a/modules/mod_finder/mod_finder.xml
+++ b/modules/mod_finder/mod_finder.xml
@@ -54,19 +54,6 @@
 					<option
 						value="0">JHIDE</option>
 				</field>
-			</fieldset>
-			<fieldset name="advanced">
-				<field
-					name="layout"
-					type="modulelayout"
-					label="JFIELD_ALT_LAYOUT_LABEL"
-					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
-				<field
-					name="moduleclass_sfx"
-					type="textarea" rows="3"
-					default=""
-					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
-					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 				<field
 					name="field_size"
 					type="text"
@@ -156,6 +143,19 @@
 					description="MOD_FINDER_FIELDSET_ADVANCED_SETITEMID_DESCRIPTION">
 					<option value="0">MOD_FINDER_SELECT_MENU_ITEMID</option>
 				</field>
+			</fieldset>
+			<fieldset name="advanced">
+				<field
+					name="layout"
+					type="modulelayout"
+					label="JFIELD_ALT_LAYOUT_LABEL"
+					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
+				<field
+					name="moduleclass_sfx"
+					type="textarea" rows="3"
+					default=""
+					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
I tried to improve consistency between the 
Smart Search Module (mod_finder) & 
Search Module (mod_search) 
by moving the following options from the [Advanced] tab to the [Module] tab:

Search Field Size
Search Field Label
Label Position
Alternate Label
Search Button
Button Position
OpenSearch autodiscovery
OpenSearch title
Set ItemID

That way the options of the Modules "Smart Search" & "Search" are more consistent.
And the Advanced options of Smart Search are more similar to other Modules.
