### PR TITLE
Fix: Extension Manager: Install Languages:: Display the 'No matching Results' message , If there search result not exist

### DIFF
--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -29,13 +29,13 @@ $version = new JVersion;
 	<?php else : ?>
 		<div id="j-main-container">
 	<?php endif;?>
-		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
-			<?php echo $this->loadTemplate('filter'); ?>
-			<?php if (empty($this->items)) : ?>
-				<div class="alert alert-no-items">
-					<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-				</div>
-			<?php else : ?>
+	<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
+		<?php echo $this->loadTemplate('filter'); ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
 			<table class="table table-striped">
 				<thead>
 					<tr>
@@ -104,7 +104,6 @@ $version = new JVersion;
 		<?php else : ?>
 			<div class="alert"><?php echo JText::_('COM_INSTALLER_MSG_LANGUAGES_NOLANGUAGES'); ?></div>
 		<?php endif; ?>
-
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="boxchecked" value="0" />
 			<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -31,6 +31,11 @@ $version = new JVersion;
 	<?php endif;?>
 		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
 			<?php echo $this->loadTemplate('filter'); ?>
+			<?php if (empty($this->items)) : ?>
+				<div class="alert alert-no-items">
+					<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+				</div>
+			<?php else : ?>
 			<table class="table table-striped">
 				<thead>
 					<tr>
@@ -62,11 +67,6 @@ $version = new JVersion;
 					</tr>
 				</tfoot>
 				<tbody>
-				<?php if (empty($this->items)) : ?>
-					<div class="alert alert-no-items">
-					<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-				<?php else : ?>
-				</div>
 				<?php foreach ($this->items as $i => $language) : ?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center">
@@ -97,9 +97,10 @@ $version = new JVersion;
 						</td>
 					</tr>
 					<?php endforeach; ?>
-				<?php endif; ?>
+				
 				</tbody>
 			</table>
+			<?php endif; ?>
 		<?php else : ?>
 			<div class="alert"><?php echo JText::_('COM_INSTALLER_MSG_LANGUAGES_NOLANGUAGES'); ?></div>
 		<?php endif; ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -75,7 +75,6 @@ $version = new JVersion;
 						<td>
 							<label for="cb<?php echo $i; ?>">
 								<?php echo $language->name; ?>
-
 								<?php // Display a Note if language pack version is not equal to Joomla version ?>
 								<?php if (substr($language->version, 0, 3) != $version->RELEASE
 									|| substr($language->version, 0, 5) != $version->RELEASE . "." . $version->DEV_LEVEL) : ?>
@@ -97,7 +96,6 @@ $version = new JVersion;
 						</td>
 					</tr>
 					<?php endforeach; ?>
-				
 				</tbody>
 			</table>
 			<?php endif; ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -29,8 +29,11 @@ $version = new JVersion;
 	<?php else : ?>
 		<div id="j-main-container">
 	<?php endif;?>
-
-		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php elseif (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
 			<?php echo $this->loadTemplate('filter'); ?>
 			<table class="table table-striped">
 				<thead>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -30,6 +30,7 @@ $version = new JVersion;
 		<div id="j-main-container">
 	<?php endif;?>
 		<?php if (empty($this->items)) : ?>
+			<?php echo $this->loadTemplate('filter'); ?>
 			<div class="alert alert-no-items">
 				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -29,12 +29,7 @@ $version = new JVersion;
 	<?php else : ?>
 		<div id="j-main-container">
 	<?php endif;?>
-		<?php if (empty($this->items)) : ?>
-			<?php echo $this->loadTemplate('filter'); ?>
-			<div class="alert alert-no-items">
-				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-			</div>
-		<?php elseif (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
+		<?php if (count($this->items) || $this->escape($this->state->get('filter.search'))) : ?>
 			<?php echo $this->loadTemplate('filter'); ?>
 			<table class="table table-striped">
 				<thead>
@@ -67,8 +62,12 @@ $version = new JVersion;
 					</tr>
 				</tfoot>
 				<tbody>
-					<?php foreach ($this->items as $i => $language) :
-				?>
+				<?php if (empty($this->items)) : ?>
+					<div class="alert alert-no-items">
+					<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+				<?php else : ?>
+				</div>
+				<?php foreach ($this->items as $i => $language) : ?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $language->update_id, false, 'cid'); ?>
@@ -98,6 +97,7 @@ $version = new JVersion;
 						</td>
 					</tr>
 					<?php endforeach; ?>
+				<?php endif; ?>
 				</tbody>
 			</table>
 		<?php else : ?>


### PR DESCRIPTION
see: #5750

-Go to extension manager>Install Languages
-Search an invalid keyword
-Ideally, application should display a message **'No matching Results'**

![screen shot 2015-01-16 at 03 35 49](http://issues.joomla.org/uploads/1/b050dec61a6adc0a4f1fe028ff5ff2e4.png)![screen shot 2015-01-16 at 03 35 54](http://issues.joomla.org/uploads/1/901343c2d2a118c8162209a8786c121c.png)
