### PR TITLE
[imp] Improve font rendering in OSX

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -1001,6 +1001,8 @@ body {
 	font-size: 62.5%;
 	line-height: 1.5em;
 	height: 100%;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 body,
 td,

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -61,6 +61,8 @@ body {
 	font-size: 62.5%;
 	line-height: 1.5em;
 	height: 100%;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 body, td, th, span, a {
@@ -487,14 +489,14 @@ input#mm_subject {
 textarea#mm_message {
 	width: 100%;
 }
-textarea { 
-	resize:both; 
-} 
-textarea.vert { 
-	resize:vertical; 
+textarea {
+	resize:both;
 }
-textarea.noResize { 
-	resize:none; 
+textarea.vert {
+	resize:vertical;
+}
+textarea.noResize {
+	resize:none;
 }
 
 /**

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6993,6 +6993,8 @@ html {
 }
 body {
 	height: 100%;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 a:hover,
 a:active,

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6993,6 +6993,8 @@ html {
 }
 body {
 	height: 100%;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 a:hover,
 a:active,

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -91,6 +91,8 @@ html {
 }
 body {
     height: 100%;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 a:hover,
 a:active,
@@ -1173,12 +1175,12 @@ a.grid_true {
 	word-wrap: break-word;
 }
 /* Customize Textarea Resizing */
-textarea { 
-	resize:both; 
-} 
-textarea.vert { 
-	resize:vertical; 
+textarea {
+	resize:both;
 }
-textarea.noResize { 
-	resize:none; 
+textarea.vert {
+	resize:vertical;
+}
+textarea.noResize {
+	resize:none;
 }

--- a/templates/beez3/css/template.css
+++ b/templates/beez3/css/template.css
@@ -12,21 +12,20 @@
  */
 
 
-body
-{
-        background: #fff;
-        color: #000000;
-        font-size: 100.1%;
-        padding: 0px;
-        text-align: center;
+body {
+    background: #fff;
+    color: #000000;
+    font-size: 100.1%;
+    padding: 0px;
+    text-align: center;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 body.contentpane {
-		width:auto;
-		margin:10px;
-		text-align: left;
+	width:auto;
+	margin:10px;
+	text-align: left;
 }
+
 img { border: 0 none; }
-
-
-

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6963,6 +6963,10 @@ dl.article-info dd.hits span[class*=" icon-"] {
 .icon-expired:before {
 	content: "\4b";
 }
+body {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
 body.site {
 	border-top: 3px solid #0088cc;
 	padding: 20px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -86,6 +86,10 @@
 @import "icomoon.less";
 
 /* Site Body Styles */
+body {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
 body.site{
 	border-top:3px solid #0088cc;
 	padding: 20px;
@@ -294,18 +298,18 @@ figcaption {
 		-webkit-background-clip: padding-box;
 		 -moz-background-clip: padding;
 		      background-clip: padding-box;
-		
+
 		// Aligns the dropdown menu to right
 		&.pull-right {
 			right: 0;
 			left: auto;
 		}
-		
+
 		// Dividers (basically an hr) within the dropdown
 		.divider {
 			.nav-divider(@dropdownDividerTop, @dropdownDividerBottom);
 		}
-		
+
 		// Links within the dropdown menu
 		a {
 			display: block;


### PR DESCRIPTION
These properties switch the OSX sub-pixel antialiasing algorithm to grayscaling, resulting in sharper appearance of fonts. This is especially noticeable on icon fonts, as can be seen here:

http://people.mozilla.org/~jdaggett/tests/social-waterfall.html
## Test

OSX users: Apply patch and check appearance in Chrome, Safari or Firefox.
Other OS users: Apply patch and check appearance in any browser you like.
### Bonus credit

OSX users: Open developer tools, select the `<body>` element and toggle the font-smoothing properties on/off. Marvel at the visual improvement.
## Expected result

OSX users: Clean crisp font rendering throughout. Clear text, clear buttons (labels are vastly improved), and cisp icons. Lovely.
Other OS users: No difference at all.
