### PR TITLE
Fix notice in mod_related_items on line 138

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -81,6 +81,7 @@ abstract class ModRelatedItemsHelper
 						->select('a.title')
 						->select('DATE(a.created) as created')
 						->select('a.catid')
+						->select('a.language')
 						->select('cc.access AS cat_access')
 						->select('cc.published AS cat_state');
 


### PR DESCRIPTION
To reproduce:
- install "Test English Sample Data"
- take the "Extra Step" and install another Language and "Activate the multilingual feature"
- after successful installation go to the frontend and click on "Related Items" in the "All Modules Menu"

You should get a bunch of notices like: Notice: Undefined property: stdClass::$language in joomla34\modules\mod_related_items\helper.php on line 138

After applying the patch the notices should have gone.
