### PR TITLE
Maintenance Menu group

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -36,7 +36,7 @@ if ($user->authorise('core.manage', 'com_checkin'))
 
 if ($user->authorise('core.manage', 'com_cache'))
 {
-	$menu->addSeparator();
+
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CLEAR_CACHE'), 'index.php?option=com_cache', 'class:clear'));
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_PURGE_EXPIRED_CACHE'), 'index.php?option=com_cache&view=purge', 'class:purge'));
 }

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -36,7 +36,6 @@ if ($user->authorise('core.manage', 'com_checkin'))
 
 if ($user->authorise('core.manage', 'com_cache'))
 {
-
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_CLEAR_CACHE'), 'index.php?option=com_cache', 'class:clear'));
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_PURGE_EXPIRED_CACHE'), 'index.php?option=com_cache&view=purge', 'class:purge'));
 }


### PR DESCRIPTION
If you look at the system menu you will see that there is a separator between checkin and cache. This is presumably done because they have different components (com_cache and com_checkin)

But whenever you select one then you have all three available in the sidebar and they are all titled Maintenance - so while it makes sense from a code perspective for their to be a separator in the menu it doesnt make sense,nor is it consistent, from a UI perspective.

This PR removes the separator. See screenshots

Before
![before](https://cloud.githubusercontent.com/assets/1296369/5781640/52f1640e-9dac-11e4-9e45-a71e60322e78.png)

After
![after](https://cloud.githubusercontent.com/assets/1296369/5781642/5a4dc1f2-9dac-11e4-9f02-ac31b97688d2.png)

Maintenance Menu
![manage](https://cloud.githubusercontent.com/assets/1296369/5781646/62428e9c-9dac-11e4-8bd1-571737a0c3dd.png)
