### PR TITLE
Correct UTC Date/Time in Versioning Modal

### DIFF
--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -16,6 +16,8 @@ JHtml::_('behavior.multiselect');
 JHtml::_('jquery.framework');
 
 $input = JFactory::getApplication()->input;
+$config = Jfactory::getConfig();
+$user = JFactory::getUser();
 $field = $input->getCmd('field');
 $function = 'jSelectContenthistory_' . $field;
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -148,7 +150,9 @@ JFactory::getDocument()->addScriptDeclaration("
 				<td align="left">
 					<a class="save-date" onclick="window.open(this.href,'win2','width=800,height=600,resizable=yes,scrollbars=yes'); return false;"
 						href="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1&version_id=' . $item->version_id);?>">
-						<?php echo $item->save_date; ?>
+						<?php $date = JFactory::getDate($item->save_date, 'UTC');
+						$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+						echo $date; ?>
 					</a>
 					<?php if ($item->sha1_hash == $hash) :?>
 						<i class="icon-featured"></i>&nbsp;

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -16,8 +16,6 @@ JHtml::_('behavior.multiselect');
 JHtml::_('jquery.framework');
 
 $input = JFactory::getApplication()->input;
-$config = Jfactory::getConfig();
-$user = JFactory::getUser();
 $field = $input->getCmd('field');
 $function = 'jSelectContenthistory_' . $field;
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -150,9 +148,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				<td align="left">
 					<a class="save-date" onclick="window.open(this.href,'win2','width=800,height=600,resizable=yes,scrollbars=yes'); return false;"
 						href="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1&version_id=' . $item->version_id);?>">
-						<?php $date = JFactory::getDate($item->save_date, 'UTC');
-						$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
-						echo $date; ?>
+						<?php echo JHtml::_('date', $item->save_date, 'Y-m-d H:i:s'); ?>
 					</a>
 					<?php if ($item->sha1_hash == $hash) :?>
 						<i class="icon-featured"></i>&nbsp;


### PR DESCRIPTION
Fix to correct date/time in Versions modal which displays the Version UTC date/time directly from the database, and does not correct it with Server Time Zone and/or User Time Zone.

Test: 
- Configure different Time Zone settings for Server & User (to notice differences from UTC timezone that is used in Joomla's database)
  Local Server Time: Sat 2015-01-17 00:48 (UTC+1)
  System > Global Configuration > Server Time Zone:  e.g. Amsterdam (= UTC+1)
  Users > User Manager > select user account > Basic Settings > e.g. New York (= UTC-5)
- Create an article, and change it
  Content > Article Manager > New > "Some title" > Save
  Created Date = 2015-01-16 18:48:48  ( -> displayed in Timezone of User)

Changed Article a bit > Save
Created Date = 2015-01-16 18:48:48 (= UTC-5)
Modified Date = 2015-01-16 18:50:44 (= UTC-5)

In database the article is stored in UTC time:
created: 2015-01-16 23:48:48 ( = UTC time)
modified: 2015-01-16 23:50:44 (= UTC time)
![edit article- database times](https://cloud.githubusercontent.com/assets/1217850/5786907/2fce5a62-9dee-11e4-931e-24423e075e07.png)
- Use [Versions] button to see the date/time in Versions Modal.
  In Versions the time is displayed as UTC time:
  current version: 2015-01-16 23:50:44 ( = UTC time, directly from database)
  1st version 2015-01-16 23:48:48 ( = UTC time, directly from database)
  ![edit article versioning error](https://cloud.githubusercontent.com/assets/1217850/5786916/71d2a0b2-9dee-11e4-8f5b-fc3c7d897927.png)

This PR fixes the date/time in Versions Modal with Global Timezone setting, and if set User Timezone setting:

![edit article- database times-fixed](https://cloud.githubusercontent.com/assets/1217850/5786919/7f2bd684-9dee-11e4-8113-eac21553c980.png)

Note: I have added this PR before: https://github.com/joomla/joomla-cms/pull/3355
I could not correct it in the model /administrator/components/com_contenthistory/models/history.php and therefore correcting it in the view seems like the best alternative.
