### PR TITLE
Fix: Text Banners Limited to 10 Items in Banner module ref: #5773

### DIFF
--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -42,7 +42,7 @@
 					name="count"
 					type="integer"
 					first="1"
-					last="10"
+					last="20"
 					step="1"
 					default="5"
 					label="MOD_BANNERS_FIELD_COUNT_LABEL"


### PR DESCRIPTION
Move the max limit to `20` Ref: https://github.com/joomla/joomla-cms/issues/5773

Quote:

```
In Joomla 1.5 I used a banner module to create a listing of text banner ads. Basically, the module would list about 18 text ads. They appeared as a simple list in the module in alpha order. If you clicked on each text ad (really just a company name) it would open that company's website. The advantage to doing it this way was a simple tracking method built in to the Joomla banner system.

I just tried to do the same thing in Joomla 3.36 and it limits you to a maximum of ten banners. In Joomla 1.5 you could type in your entry - in the case I used I had 18. In Joomla 3.3 you are limited to a pulldown that allows 1 - 10. I believe it would be beneficial to change the pulldown selector to the previous text box option. Thank you.
```
