### PR TITLE
Removed Automatic title option from 4 Administrator Modules

### DIFF
--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -88,17 +88,6 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
-
-				<field
-					name="automatic_title"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
-					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -62,16 +62,6 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
-				<field
-					name="automatic_title"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
-					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -77,17 +77,6 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
-
-				<field
-					name="automatic_title"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
-					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -60,17 +60,6 @@
 					default="900"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC" />
-
-				<field
-					name="automatic_title"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
-					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
Some Administrator Modules have an option called "Automatic title" which is not used anymore.
See discussion: https://groups.google.com/d/msg/joomla-dev-cms/0P6NMtWnYeE/vap2bdgeB0AJ

This PR removes "Automatic title" option from the "Advanced" options of the following 4 admin modules:
Latest News
Popular Articles
Logged-in Users
Quick Icons

For testing instructions, please see: https://github.com/joomla/joomla-cms/pull/5771
(sorry, something went wrong with that PR)
