### PR TITLE
Removed unused Automatic Title from Admin Templates: Hathor & System

### DIFF
--- a/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
+++ b/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
@@ -36,20 +36,7 @@ if (JFactory::getUser()->authorise('core.manage', 'com_postinstall')) :
 foreach ($this->modules as $module)
 {
 	$output = JModuleHelper::renderModule($module);
-	$params = new Registry;
-	$params->loadString($module->params);
-	if ($params->get('automatic_title', '0') == '0')
-	{
-		echo JHtml::_('sliders.panel', $module->title, 'cpanel-panel-' . $module->name);
-	}
-	elseif (method_exists('mod'.$module->name.'Helper', 'getTitle'))
-	{
-		echo JHtml::_('sliders.panel', call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params)), 'cpanel-panel-' . $module->name);
-	}
-	else
-	{
-		echo JHtml::_('sliders.panel', JText::_('MOD_' . $module->name . '_TITLE'), 'cpanel-panel-' . $module->name);
-	}
+        echo JHtml::_('sliders.panel', $module->title, 'cpanel-panel-' . $module->name);
 	echo $output;
 }
 

--- a/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
+++ b/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
@@ -36,8 +36,8 @@ if (JFactory::getUser()->authorise('core.manage', 'com_postinstall')) :
 foreach ($this->modules as $module)
 {
 	$output = JModuleHelper::renderModule($module);
-        echo JHtml::_('sliders.panel', $module->title, 'cpanel-panel-' . $module->name);
-        echo $output;
+	echo JHtml::_('sliders.panel', $module->title, 'cpanel-panel-' . $module->name);
+	echo $output;
 }
 
 echo JHtml::_('sliders.end');

--- a/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
+++ b/administrator/templates/hathor/html/com_cpanel/cpanel/default.php
@@ -37,7 +37,7 @@ foreach ($this->modules as $module)
 {
 	$output = JModuleHelper::renderModule($module);
         echo JHtml::_('sliders.panel', $module->title, 'cpanel-panel-' . $module->name);
-	echo $output;
+        echo $output;
 }
 
 echo JHtml::_('sliders.end');

--- a/administrator/templates/system/html/modules.php
+++ b/administrator/templates/system/html/modules.php
@@ -80,8 +80,8 @@ function modChrome_sliders($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-                echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
-		echo $content;
+            echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
+            echo $content;
 	}
 }
 
@@ -93,7 +93,7 @@ function modChrome_tabs($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-                echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
-		echo $content;
+            echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
+            echo $content;
 	}
 }

--- a/administrator/templates/system/html/modules.php
+++ b/administrator/templates/system/html/modules.php
@@ -80,18 +80,7 @@ function modChrome_sliders($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-		if ($params->get('automatic_title', '0') == '0')
-		{
-			echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
-		}
-		elseif (method_exists('mod' . $module->name . 'Helper', 'getTitle'))
-		{
-			echo JHtml::_('sliders.panel', call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params, $module)), 'module' . $module->id);
-		}
-		else
-		{
-			echo JHtml::_('sliders.panel', JText::_('MOD_' . $module->name . '_TITLE'), 'module' . $module->id);
-		}
+                echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
 		echo $content;
 	}
 }
@@ -104,18 +93,7 @@ function modChrome_tabs($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-		if ($params->get('automatic_title', '0') == '0')
-		{
-			echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
-		}
-		elseif (method_exists('mod' . $module->name . 'Helper', 'getTitle'))
-		{
-			echo JHtml::_('tabs.panel', call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params)), 'module' . $module->id);
-		}
-		else
-		{
-			echo JHtml::_('tabs.panel', JText::_('MOD_' . $module->name . '_TITLE'), 'module' . $module->id);
-		}
+                echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
 		echo $content;
 	}
 }

--- a/administrator/templates/system/html/modules.php
+++ b/administrator/templates/system/html/modules.php
@@ -81,7 +81,7 @@ function modChrome_sliders($module, &$params, &$attribs)
 	if (!empty($content))
 	{
 		echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
-	echo $content;
+		echo $content;
 	}
 }
 

--- a/administrator/templates/system/html/modules.php
+++ b/administrator/templates/system/html/modules.php
@@ -80,8 +80,8 @@ function modChrome_sliders($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-            echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
-            echo $content;
+		echo JHtml::_('sliders.panel', $module->title, 'module' . $module->id);
+	echo $content;
 	}
 }
 
@@ -93,7 +93,7 @@ function modChrome_tabs($module, &$params, &$attribs)
 	$content = trim($module->content);
 	if (!empty($content))
 	{
-            echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
-            echo $content;
+		echo JHtml::_('tabs.panel', $module->title, 'module' . $module->id);
+		echo $content;
 	}
 }


### PR DESCRIPTION
Removed "Automatic Title" check & use from Admin Templates: Hathor & System",
as the Module "Advanced" option "Automatic Title" is not used anymore.
(see other https://github.com/joomla/joomla-cms/pull/5789 )

Please test Titles of Modules in Admin Cpanel view with Hathor & System admin templates.
