### PR TITLE
Fix JForm 'safehtml' filter to use JFilters 'html' filter not 'string'

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1287,7 +1287,7 @@ class JForm
 
 			// Filter safe HTML.
 			case 'SAFEHTML':
-				$return = JFilterInput::getInstance(null, null, 1, 1)->clean($value, 'string');
+				$return = JFilterInput::getInstance(null, null, 1, 1)->clean($value, 'html');
 				break;
 
 			// Convert a date to UTC based on the server timezone offset.


### PR DESCRIPTION
PR for Issue #5799 
Signed-off-by: Craig Phillips craig@craigphillips.biz
