### PR TITLE
RFC- Remove edit button from toolbar

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -149,11 +149,6 @@ JFactory::getDocument()->addScriptDeclaration('
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 								<?php
-								if ($canEdit || $canEditOwn)
-								{
-									JHtml::_('actionsdropdown.edit', 'cb' . $i, 'article');
-								}
-
 								// Create dropdown items
 								$action = $archived ? 'unarchive' : 'archive';
 								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
@@ -178,13 +173,14 @@ JFactory::getDocument()->addScriptDeclaration('
 								<?php endif;?>
 								<?php if ($canEdit || $canEditOwn) : ?>
 									<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+										<span class="icon-edit"></span>
 										<?php echo $this->escape($item->title); ?></a>
 								<?php else : ?>
 									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 								<?php endif; ?>
-								<span class="small break-word">
-									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-								</span>
+								<div class="small break-word">
+									<?php echo JText::_('JFIELD_ALIAS_LABEL') . ": " . $this->escape($item->alias); ?>
+								</div>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
 								</div>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -149,6 +149,11 @@ JFactory::getDocument()->addScriptDeclaration('
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 								<?php
+								if ($canEdit || $canEditOwn)
+								{
+									JHtml::_('actionsdropdown.edit', 'cb' . $i, 'article');
+								}
+
 								// Create dropdown items
 								$action = $archived ? 'unarchive' : 'archive';
 								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -98,11 +98,6 @@ class ContentViewArticles extends JViewLegacy
 			JToolbarHelper::addNew('article.add');
 		}
 
-		if (($canDo->get('core.edit')) || ($canDo->get('core.edit.own')))
-		{
-			JToolbarHelper::editList('article.edit');
-		}
-
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::publish('articles.publish', 'JTOOLBAR_PUBLISH', true);

--- a/libraries/cms/html/actionsdropdown.php
+++ b/libraries/cms/html/actionsdropdown.php
@@ -118,6 +118,22 @@ abstract class JHtmlActionsDropdown
 	}
 
 	/**
+	 * Append an edit item to the current dropdown menu
+	 *
+	 * @param   string  $id      ID of corresponding checkbox of the record
+	 * @param   string  $prefix  The task prefix
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public static function edit($id, $prefix = '')
+	{
+		$task = ($prefix ? $prefix . '.' : '') . 'edit';
+		static::addCustomItem(JText::_('JTOOLBAR_EDIT'), 'edit', $id, $task);
+	}
+
+	/**
 	 * Append an archive item to the current dropdown menu
 	 *
 	 * @param   string  $id      ID of corresponding checkbox of the record

--- a/libraries/cms/html/actionsdropdown.php
+++ b/libraries/cms/html/actionsdropdown.php
@@ -118,22 +118,6 @@ abstract class JHtmlActionsDropdown
 	}
 
 	/**
-	 * Append an edit item to the current dropdown menu
-	 *
-	 * @param   string  $id      ID of corresponding checkbox of the record
-	 * @param   string  $prefix  The task prefix
-	 *
-	 * @return  void
-	 *
-	 * @since   3.4
-	 */
-	public static function edit($id, $prefix = '')
-	{
-		$task = ($prefix ? $prefix . '.' : '') . 'edit';
-		static::addCustomItem(JText::_('JTOOLBAR_EDIT'), 'edit', $id, $task);
-	}
-
-	/**
 	 * Append an archive item to the current dropdown menu
 	 *
 	 * @param   string  $id      ID of corresponding checkbox of the record


### PR DESCRIPTION
### This is a proposal for eliminating the problem described at #5703

As reported from @uthorat
#### Steps to reproduce the issue

Go to the any list view ( lets say in article list view)
Select multiple articles and click on edit
It choose the very first article

This PR totally removes the edit button from the toolbar and adds it to every dropdown at the status column of each item (row)
##### Preview:

![screen shot 2015-01-18 at 1 38 33](https://cloud.githubusercontent.com/assets/3889375/5790833/0a0d6f9a-9eb4-11e4-8a0f-2d60332b78a2.png)
###### Notice:

Right now I only touched com_content/articles, but if ppl agree I will do it for all plural views in the admin area
