### PR TITLE
Hex colors

### DIFF
--- a/language/en-GB/en-GB.tpl_protostar.ini
+++ b/language/en-GB/en-GB.tpl_protostar.ini
@@ -5,10 +5,10 @@
 
 TPL_PROTOSTAR_XML_DESCRIPTION="Continuing the space theme (Solarflare from 1.0 and Milkyway from 1.5), Protostar is the Joomla 3 site template based on Bootstrap from Twitter and the launch of the Joomla User Interface library (JUI)."
 
-TPL_PROTOSTAR_BACKGROUND_COLOR_DESC="Choose a background colour for static layouts. If left blank the Default (#F4F6F7) is used."
+TPL_PROTOSTAR_BACKGROUND_COLOR_DESC="Choose a background colour for static layouts. If left blank the Default (#f4f6f7) is used."
 TPL_PROTOSTAR_BACKGROUND_COLOR_LABEL="Background Colour"
 TPL_PROTOSTAR_BACKTOTOP="Back to Top"
-TPL_PROTOSTAR_COLOR_DESC="Choose an overall colour for the site template. If left blank the Default (#0088CC) is used."
+TPL_PROTOSTAR_COLOR_DESC="Choose an overall colour for the site template. If left blank the Default (#0088cc) is used."
 TPL_PROTOSTAR_COLOR_LABEL="Template Colour"
 TPL_PROTOSTAR_FLUID="Fluid"
 TPL_PROTOSTAR_FLUID_LABEL="Fluid Layout"

--- a/templates/protostar/language/en-GB/en-GB.tpl_protostar.ini
+++ b/templates/protostar/language/en-GB/en-GB.tpl_protostar.ini
@@ -5,10 +5,10 @@
 
 TPL_PROTOSTAR_XML_DESCRIPTION="Continuing the space theme (Solarflare from 1.0 and Milkyway from 1.5), Protostar is the Joomla 3 site template based on Bootstrap from Twitter and the launch of the Joomla User Interface library (JUI)."
 
-TPL_PROTOSTAR_BACKGROUND_COLOR_DESC="Choose a background colour for static layouts. If left blank the Default (#F4F6F7) is used."
+TPL_PROTOSTAR_BACKGROUND_COLOR_DESC="Choose a background colour for static layouts. If left blank the Default (#f4f6f7) is used."
 TPL_PROTOSTAR_BACKGROUND_COLOR_LABEL="Background Colour"
 TPL_PROTOSTAR_BACKTOTOP="Back to Top"
-TPL_PROTOSTAR_COLOR_DESC="Choose an overall colour for the site template. If left blank the Default (#0088CC) is used."
+TPL_PROTOSTAR_COLOR_DESC="Choose an overall colour for the site template. If left blank the Default (#0088cc) is used."
 TPL_PROTOSTAR_COLOR_LABEL="Template Colour"
 TPL_PROTOSTAR_FLUID="Fluid"
 TPL_PROTOSTAR_FLUID_LABEL="Fluid Layout"


### PR DESCRIPTION
Hex colours are case insensitive so it doesnt matter if we use upper or lower case.

However we should be consistent in our usage. The color selector fields uses lowercase but a few tooltips still refer to uppercase. This could confuse a user who thinks they are case sensitive.

This simple PR makes the tooltips match the displayed code 
