### PR TITLE
[imp] Media Manager: adding message when no item selected to delete (solves #5785).

### DIFF
--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -50,6 +50,7 @@ class MediaControllerFolder extends JControllerLegacy
 		// Just return if there's nothing to do
 		if (empty($paths))
 		{
+			$this->setMessage(JText::_('COM_MEDIA_ERROR_CHOOSE_DELETE'), 'warning');
 			return true;
 		}
 

--- a/administrator/language/en-GB/en-GB.com_media.ini
+++ b/administrator/language/en-GB/en-GB.com_media.ini
@@ -29,6 +29,7 @@ COM_MEDIA_ERROR_BEFORE_DELETE_MORE="Some errors occur before deleting the media:
 COM_MEDIA_ERROR_BEFORE_SAVE_0="Some error occurs before saving the media"
 COM_MEDIA_ERROR_BEFORE_SAVE_1="An error occurs before saving the media: %s"
 COM_MEDIA_ERROR_BEFORE_SAVE_MORE="Some errors occur before saving the media: %s"
+COM_MEDIA_ERROR_CHOOSE_DELETE="Please first choose an item to delete."
 COM_MEDIA_ERROR_CREATE_NOT_PERMITTED="Create not permitted"
 COM_MEDIA_ERROR_FILE_EXISTS="File already exists"
 COM_MEDIA_ERROR_UNABLE_TO_CREATE_FOLDER_WARNDIRNAME="Unable to create directory. Directory name must only contain alphanumeric characters and no spaces."


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/5785

After Patch, when nothing has been selected in the manager and the delte button has been clicked, one will get:

![screen shot 2015-01-18 at 09 50 22](https://cloud.githubusercontent.com/assets/869724/5791924/25eb484a-9efa-11e4-8db4-cbe8e2469420.png)
