### PR TITLE
Filter Archive View by Category

### DIFF
--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -56,6 +56,9 @@ class ContentModelArchive extends ContentModelArticles
 		// Optional filter text
 		$this->setState('list.filter', $app->input->getString('filter-search'));
 
+		// Optional filter category
+		$this->setState('filter.acatid', $app->input->getInt('acatid', 0));
+
 		// Get list limit
 		$itemid = $app->input->get('Itemid', 0, 'int');
 		$limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
@@ -121,6 +124,14 @@ class ContentModelArchive extends ContentModelArticles
 		if ($year = $this->getState('filter.year'))
 		{
 			$query->where($query->year($queryDate) . ' = ' . $year);
+		}
+
+		// Filter on a category
+		$acatid = $this->getState('filter.acatid');
+
+		if ($acatid != 0)
+		{
+			$query->where('a.catid' . ' = ' . $acatid);
 		}
 
 		return $query;

--- a/components/com_content/views/archive/tmpl/default.xml
+++ b/components/com_content/views/archive/tmpl/default.xml
@@ -9,6 +9,21 @@
 		</message>
 	</layout>
 
+	<!-- Add fields to the request variables for the layout. -->
+	<fields name="request">
+		<fieldset name="request"
+				>
+			<field name="acatid" type="category"
+			       description="JGLOBAL_CHOOSE_CATEGORY_DESC"
+			       extension="com_content"
+			       label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+			       default="0"
+			       required="true"
+			       show_root="true"
+					/>
+		</fieldset>
+	</fields>
+
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">
 


### PR DESCRIPTION
# Executive summary

This patch brings a lost functionality (lost between 1.5 and 2.5 ) back. It allows to filter an archive view by category.
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Testing instructions
- Install a fresh Joomla! with testing data. Check under „All Front End Views“ the „Archived Articles“ view.
- You should see one item.
- Log into to backend and archive all articles at the first page of „Content/Article Manager“
- Go back to the front end and click again on „Archived Articles“
- You should see more then one article
- Now apply patch
- Go back to the front end and click again on „Archived Articles“
- Nothing should have changed
- Go to the backend and change the menu item „Archived Articles“ (menu: All Front End Views)
- You should see a Category selection box

![category-select](https://cloud.githubusercontent.com/assets/467356/5793074/6cc85866-9f36-11e4-9edc-e1816d00131f.png)
- Select „Content Modules“ and save the menu item
- Go back to the front end and check the „Archived Articles“ menu
- Now you should see only 2 Articles „Popular Tags“ „Similar Tags“, if not please check in the backend if both articles are in the archive.
