### PR TITLE
Fix wincache notice again

### DIFF
--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -30,7 +30,7 @@ class JCacheStorageWincache extends JCacheStorage
 	 */
 	public function get($id, $group, $checkTime = true)
 	{
-		$cache_id = $this->_getCacheId($id, $group);
+		$cache_id      = $this->_getCacheId($id, $group);
 		$cache_content = wincache_ucache_get($cache_id);
 
 		return $cache_content;
@@ -137,8 +137,8 @@ class JCacheStorageWincache extends JCacheStorage
 	public function clean($group, $mode = null)
 	{
 		$allinfo = wincache_ucache_info();
-		$keys = $allinfo['cache_entries'];
-		$secret = $this->_hash;
+		$keys    = $allinfo['ucache_entries'];
+		$secret  = $this->_hash;
 
 		foreach ($keys as $key)
 		{
@@ -161,8 +161,8 @@ class JCacheStorageWincache extends JCacheStorage
 	public function gc()
 	{
 		$allinfo = wincache_ucache_info();
-		$keys = $allinfo['cache_entries'];
-		$secret = $this->_hash;
+		$keys    = $allinfo['ucache_entries'];
+		$secret  = $this->_hash;
 
 		foreach ($keys as $key)
 		{


### PR DESCRIPTION
### Explanation

According to the PHP Docs for wincache_ucache_info():
http://www.php.net/manual/en/function.wincache-ucache-info.php

We have no index called "cache_entries" only a "ucache_entries"
### This PR
1. change "cache_entries" to "ucache_entries"
2. fix mirror CS

Thanks to @davidsteadson at https://github.com/joomla/joomla-cms/pull/3711#issuecomment-70417488
