### PR TITLE
Introduce jailed behavior for admin area

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 
 JFactory::getDocument()->addScriptDeclaration('

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -10,6 +10,12 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -10,6 +10,12 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -11,6 +11,11 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 // Load tooltips behavior
 JHtml::_('behavior.formvalidator');
 JHtml::_('bootstrap.tooltip');

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 $app = JFactory::getApplication();
 $template = $app->getTemplate();
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 // Load the tooltip behavior.
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -9,6 +9,11 @@
 
 defined('_JEXEC') or die;
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -11,6 +11,11 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_languages/views/override/tmpl/edit.php
+++ b/administrator/components/com_languages/views/override/tmpl/edit.php
@@ -11,6 +11,11 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidation');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.formvalidator');

--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.core');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_messages/views/message/tmpl/edit.php
+++ b/administrator/components/com_messages/views/message/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -11,6 +11,11 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.combobox');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -11,6 +11,11 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 $this->fieldsets = $this->form->getFieldsets('params');

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 
 JFactory::getDocument()->addScriptDeclaration("

--- a/administrator/components/com_users/views/mail/tmpl/default.php
+++ b/administrator/components/com_users/views/mail/tmpl/default.php
@@ -9,6 +9,11 @@
 
 defined('_JEXEC') or die;
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 $script = "\t" . 'Joomla.submitbutton = function(pressbutton) {' . "\n";
 $script .= "\t\t" . 'var form = document.adminForm;' . "\n";
 $script .= "\t\t" . 'if (pressbutton == \'mail.cancel\') {' . "\n";

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -9,6 +9,11 @@
 
 defined('_JEXEC') or die;
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+if (!JFactory::getApplication()->get('debug_lang') && !JFactory::getApplication()->get('debug'))
+{
+	JHtml::_('behavior.jailed');
+}
+
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -53,6 +53,7 @@ JLIB_APPLICATION_ERROR_VIEW_CLASS_NOT_FOUND="View class not found [class, file]:
 JLIB_APPLICATION_ERROR_VIEW_GET_NAME_SUBSTRING="JView: :getName() : Your classname contains the substring 'view'. This causes problems when extracting the classname from the name of your objects view. Avoid Object names with the substring 'view'."
 JLIB_APPLICATION_ERROR_VIEW_GET_NAME="JView: :getName() : Cannot get or parse class name."
 JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND="View not found [name, type, prefix]: %1$s, %2$s, %3$s"
+JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN="You are in the middle of a process. Leaving this page might result in loss of data."
 JLIB_APPLICATION_SAVE_SUCCESS="Item successfully saved."
 JLIB_APPLICATION_SUBMIT_SAVE_SUCCESS="Item successfully submitted."
 JLIB_APPLICATION_SUCCESS_BATCH="Batch process completed successfully."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -53,6 +53,7 @@ JLIB_APPLICATION_ERROR_VIEW_CLASS_NOT_FOUND="View class not found [class, file]:
 JLIB_APPLICATION_ERROR_VIEW_GET_NAME_SUBSTRING="JView: :getName() : Your classname contains the substring 'view'. This causes problems when extracting the classname from the name of your objects view. Avoid Object names with the substring 'view'."
 JLIB_APPLICATION_ERROR_VIEW_GET_NAME="JView: :getName() : Cannot get or parse class name."
 JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND="View not found [name, type, prefix]: %1$s, %2$s, %3$s"
+JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN="You are in the middle of a process. Leaving this page might result in loss of data."
 JLIB_APPLICATION_SAVE_SUCCESS="Item successfully saved."
 JLIB_APPLICATION_SUBMIT_SAVE_SUCCESS="Item successfully submitted."
 JLIB_APPLICATION_SUCCESS_BATCH="Batch process completed successfully."

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -132,7 +132,7 @@ abstract class JHtmlBehavior
 			});
 
 			// Prevent alert for unchanged forms
-			jQuery('form :input').change(function() {
+			jQuery('form :input').on('changed input', function() {
 				jQuery(this).parents('form').attr('data-jailed', 'changed');
 			});
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -130,9 +130,16 @@ abstract class JHtmlBehavior
 			jQuery('input[type=submit]').bind('mousedown', function () {
 				jQuery(window).off('beforeunload.jailed');
 			});
+
+			// Prevent alert for unchanged forms
+			jQuery('form :input').change(function() {
+				jQuery(this).closest('form').data('changed', true);
+			});
 			// Alert on unintentional exit
 			jQuery(window).on('beforeunload.jailed', function (event) {
-				return '" . JText::_('JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN') . "';
+				if(jQuery(this).closest('form').data('changed')) {
+					return '" . JText::_('JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN') . "';
+				}
 			});
 		});
 		");

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -133,11 +133,12 @@ abstract class JHtmlBehavior
 
 			// Prevent alert for unchanged forms
 			jQuery('form :input').change(function() {
-				jQuery(this).closest('form').data('changed', true);
+				jQuery(this).parents('form').attr('data-jailed', 'changed');
 			});
+
 			// Alert on unintentional exit
-			jQuery(window).on('beforeunload.jailed', function (event) {
-				if(jQuery(this).closest('form').data('changed')) {
+			jQuery(window).on('beforeunload.jailed', function () {
+				if(jQuery('form[data-jailed=\"changed\"]').length) {
 					return '" . JText::_('JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN') . "';
 				}
 			});

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -115,23 +115,23 @@ abstract class JHtmlBehavior
 		jQuery(document).ready(function() {
 			// Prevent alert for links
 			jQuery('a').bind('mousedown', function () {
-				jQuery(window).off('beforeunload');
+				jQuery(window).off('beforeunload.jailed');
 			});
 			// Prevent alert for buttons
 			jQuery(':button').bind('mousedown', function () {
-				jQuery(window).off('beforeunload');
+				jQuery(window).off('beforeunload.jailed');
 			});
 			// Prevent alert for forms
 			jQuery('form').bind('submit', function () {
-				jQuery(window).off('beforeunload');
+				jQuery(window).off('beforeunload.jailed');
 			});
 
 			// Prevent alert for forms
 			jQuery('input[type=submit]').bind('mousedown', function () {
-				jQuery(window).off('beforeunload');
+				jQuery(window).off('beforeunload.jailed');
 			});
 			// Alert on unintentional exit
-			jQuery(window).on('beforeunload', function (event) {
+			jQuery(window).on('beforeunload.jailed', function (event) {
 				return '" . JText::_('JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN') . "';
 			});
 		});

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -92,6 +92,56 @@ abstract class JHtmlBehavior
 	}
 
 	/**
+	 * Method to load jailed.js into the document head.
+	 *
+	 * Jailed.js alerts users before leaving the page
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public static function jailed()
+	{
+		// Only load once
+		if (isset(static::$loaded[__METHOD__]))
+		{
+			return;
+		}
+
+		// Include jQuery
+		JHtml::_('jquery.framework');
+
+		JFactory::getDocument()->addScriptDeclaration("
+		jQuery(document).ready(function() {
+			// Prevent alert for links
+			jQuery('a').bind('mousedown', function () {
+				jQuery(window).off('beforeunload');
+			});
+			// Prevent alert for buttons
+			jQuery(':button').bind('mousedown', function () {
+				jQuery(window).off('beforeunload');
+			});
+			// Prevent alert for forms
+			jQuery('form').bind('submit', function () {
+				jQuery(window).off('beforeunload');
+			});
+
+			// Prevent alert for forms
+			jQuery('input[type=submit]').bind('mousedown', function () {
+				jQuery(window).off('beforeunload');
+			});
+			// Alert on unintentional exit
+			jQuery(window).on('beforeunload', function (event) {
+				return '" . JText::_('JLIB_APPLICATION_EXIT_VIEW_FORBIDDEN') . "';
+			});
+		});
+		");
+		static::$loaded[__METHOD__] = true;
+
+		return;
+	}
+
+	/**
 	 * Add unobtrusive JavaScript support for image captions.
 	 *
 	 * @param   string  $selector  The selector for which a caption behaviour is to be applied.


### PR DESCRIPTION
#### This is a redo of #4773
##### Why?

When editing an article, menu, category (anything singular), and press the back button, the refresh or the close button on the browser, user most probably will loose any data without warning. This PR throws a standard browser window with custom message to inform him/her. Of course we are not forcing anything, so he/she can go ahead and close the window, but at least we did informed them!
There is a check for debug and language debug, so this functionality is enabled only when none of these is enabled!
##### Preview:

Safari
![screen shot 2015-01-19 at 1 37 39](https://cloud.githubusercontent.com/assets/3889375/5794584/f18a829a-9f7c-11e4-8a43-5331fec2f3f8.png)

Chrome
![screen shot 2015-01-19 at 1 37 16](https://cloud.githubusercontent.com/assets/3889375/5794585/fbb88a8c-9f7c-11e4-8764-4bde3ad534e8.png)

Firefox (NOTE: FF doesn’t support custom messages in the alert called onbeforeunload!)
![screen shot 2015-01-19 at 1 38 23](https://cloud.githubusercontent.com/assets/3889375/5794586/04383a54-9f7d-11e4-8bc5-c1d174065374.png)

Opera
![screen shot 2015-01-19 at 1 37 59](https://cloud.githubusercontent.com/assets/3889375/5794588/2a33af54-9f7d-11e4-9ceb-153f0a7fc6c6.png)

And IE 8 (YES it even works on IE 
