### PR TITLE
Optimizing TRIM in JFilterInput

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -256,9 +256,7 @@ class JFilterInput
 				break;
 
 			case 'TRIM':
-				$result = (string) trim($source);
-				$result = trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = trim($result, chr(0xC2) . chr(0xA0));
+				$result = trim($source, " \t\n\r\0\x0B\xE3\x80\xC2\xA0");
 				break;
 
 			case 'USERNAME':

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -256,7 +256,7 @@ class JFilterInput
 				break;
 
 			case 'TRIM':
-				$result = trim($source, " \t\n\r\0\x0B\xE3\x80\xC2\xA0");
+				$result = JString::trim($source, " \t\n\r\0\x0B\xE3\x80\x80\xC2\xA0");
 				break;
 
 			case 'USERNAME':


### PR DESCRIPTION
This PR improves the TRIM filter-method. trim() itself already casts the result to string, so we don't need the casting in the first line. The second and third call can be merged with the default character mask from trim() to one call and we can remove the double 0x80 character in the second character mask, since it will remove all 0x80 from beginning and end, regardless of it being one, two, three or 50 of those characters.

This is hardly testable. It will most likely require a merge by review. I stumbled over this while doing some codereviewing myself.
