### PR TITLE
Fix issie with filtereng categories by language

### DIFF
--- a/administrator/components/com_categories/helpers/association.php
+++ b/administrator/components/com_categories/helpers/association.php
@@ -37,22 +37,12 @@ abstract class CategoryHelperAssociation
 
 		if ($id)
 		{
-			// Load route helper
-			jimport('helper.route', JPATH_COMPONENT_SITE);
-			$helperClassname = ucfirst(substr($extension, 4)) . 'HelperRoute';
 
 			$associations = CategoriesHelper::getAssociations($id, $extension);
 
 			foreach ($associations as $tag => $item)
 			{
-				if (class_exists($helperClassname) && is_callable(array($helperClassname, 'getCategoryRoute')))
-				{
-					$return[$tag] = $helperClassname::getCategoryRoute($item, $tag);
-				}
-				else
-				{
-					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item;
-				}
+				$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item;
 			}
 		}
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -242,6 +242,12 @@ class JCategories
 			$query->where('c.published = 1');
 		}
 
+		// Filter category by language
+		if (JLanguageMultilang::isEnabled())
+		{
+			$query->where('c.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
+		}
+
 		$query->order('c.lft');
 
 		// Note: s for selected id

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -100,7 +100,9 @@ abstract class ModLanguagesHelper
 				{
 					if (isset($cassociations[$language->lang_code]))
 					{
-						$language->link = JRoute::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
+						$language->link = JRoute::_($cassociations[$language->lang_code] 
+							. ((isset($associations[$language->lang_code])) ? '&Itemid=' . $associations[$language->lang_code]:'') 
+							. '&lang=' . $language->sef);
 					}
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -101,8 +101,8 @@ abstract class ModLanguagesHelper
 					if (isset($cassociations[$language->lang_code]))
 					{
 						$language->link = JRoute::_(
-							$cassociations[$language->lang_code] 
-							. ((isset($associations[$language->lang_code])) ? '&Itemid=' . $associations[$language->lang_code]:'') 
+							$cassociations[$language->lang_code]
+							. ((isset($associations[$language->lang_code])) ? '&Itemid=' . $associations[$language->lang_code]:'')
 							. '&lang=' . $language->sef
 						);
 					}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -100,9 +100,11 @@ abstract class ModLanguagesHelper
 				{
 					if (isset($cassociations[$language->lang_code]))
 					{
-						$language->link = JRoute::_($cassociations[$language->lang_code] 
+						$language->link = JRoute::_(
+							$cassociations[$language->lang_code] 
 							. ((isset($associations[$language->lang_code])) ? '&Itemid=' . $associations[$language->lang_code]:'') 
-							. '&lang=' . $language->sef);
+							. '&lang=' . $language->sef
+						);
 					}
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{


### PR DESCRIPTION
This patch includes fix https://github.com/joomla/joomla-cms/pull/5756 and fixes another issue which cause Language switcher module to provide wrong URL for a language that is not currently active. The URL was computed using category path helper where inactive languages were blocked. Now only association mechanism is used without path helper
