### PR TITLE
Use javascript for placeholder fallback

### DIFF
--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -8,33 +8,17 @@
  */
 
 defined('_JEXEC') or die;
+
+// Including fallback code for the placeholder attribute in the search field.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
 ?>
 <div class="search<?php echo $moduleclass_sfx ?>">
 	<form action="<?php echo JRoute::_('index.php');?>" method="post" class="form-inline">
 		<?php
 			$output = '<label for="mod-search-searchword" class="element-invisible">' . $label . '</label> ';
 			$output .= '<input name="searchword" id="mod-search-searchword" maxlength="' . $maxlength . '"  class="inputbox search-query" type="search" size="' . $width . '"';
-
-			jimport('joomla.environment.browser');
-			$browser        = JBrowser::getInstance();
-			$browserVersion = $browser->getMajor();
-
-			if (($browser->isBrowser('msie') && ($browserVersion < 10))
-				|| ($browser->isBrowser('mozilla') && ($browserVersion < 4))
-				|| ($browser->isBrowser('chrome') && ($browserVersion < 4))
-				|| ($browser->isBrowser('safari') && ($browserVersion < 5))
-				|| ($browser->isBrowser('opera') && ($browserVersion < 11)))
-			{
-				// Show old javascript variant in not HTML 5 compliant browsers
-				$output .= ' value="' . $text . '" onblur="if (this.value==\'\') this.value=\'' . $text . '\';" onfocus="if (this.value==\'' . $text . '\') this.value=\'\';"';
-			}
-			else
-			{
-				// Use HTML 5 placeholder attribute if supported
-				$output .= ' placeholder="' . $text . '"';
-			}
-
-			$output .= ' />';
+			$output .= ' placeholder="' . $text . '" />';
 
 			if ($button) :
 				if ($imagebutton) :


### PR DESCRIPTION
A slight improvement on #5453 keeping the code simpler by using the html5fallback library. We use this in all fields using JForm for the same purpose. And makes more sense than using JBrowser.
