### PR TITLE
Add extendWhere, orWhere and andWhere methods to database query class.

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -115,7 +115,7 @@ class JDatabaseQueryElement
 	 *
 	 * @return  JDatabaseQueryElement  Returns this object to allow chaining.
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function setName($name)
 	{
@@ -1534,7 +1534,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function extendWhere($outerGlue, $conditions, $innerGlue = 'AND')
 	{
@@ -1559,7 +1559,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function orWhere($conditions, $glue = 'AND')
 	{
@@ -1578,7 +1578,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function andWhere($conditions, $glue = 'OR')
 	{

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -111,6 +111,8 @@ class JDatabaseQueryElement
 	/**
 	 * Sets the name of this element.
 	 *
+	 * @param   string  $name  Name of the element.
+	 *
 	 * @return  JDatabaseQueryElement  Returns this object to allow chaining.
 	 *
 	 * @since   3.4

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -109,6 +109,20 @@ class JDatabaseQueryElement
 	}
 
 	/**
+	 * Sets the name of this element.
+	 *
+	 * @return  JDatabaseQueryElement  Returns this object to allow chaining.
+	 *
+	 * @since   3.4
+	 */
+	public function setName($name)
+	{
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
 	 * Method to provide deep copy support to nested objects and arrays
 	 * when cloning.
 	 *
@@ -1502,6 +1516,71 @@ abstract class JDatabaseQuery
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Extend the WHERE clause with a single condition or an array of conditions, with a potentially
+	 * different logical operator from the one in the current WHERE clause.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->extendWhere('XOR', array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) XOR (c = 3 AND d = 4)
+	 *
+	 * @param   string  $outerGlue   The glue by which to join the conditions to the current WHERE conditions.
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $innerGlue   The glue by which to join the conditions. Defaults to AND.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.4
+	 */
+	public function extendWhere($outerGlue, $conditions, $innerGlue = 'AND')
+	{
+		// Replace the current WHERE with a new one which has the old one as an unnamed child.
+		$this->where = new JDatabaseQueryElement('WHERE', $this->where->setName('()'), " $outerGlue ");
+
+		// Append the new conditions as a new unnamed child.
+		$this->where->append(new JDatabaseQueryElement('()', $conditions, " $innerGlue "));
+
+		return $this;
+	}
+
+	/**
+	 * Extend the WHERE clause with an OR and a single condition or an array of conditions.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->orWhere(array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) OR (c = 3 AND d = 4)
+	 *
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to AND.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.4
+	 */
+	public function orWhere($conditions, $glue = 'AND')
+	{
+		return $this->extendWhere('OR', $conditions, $glue);
+	}
+
+	/**
+	 * Extend the WHERE clause with an AND and a single condition or an array of conditions.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->andWhere(array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) AND (c = 3 OR d = 4)
+	 *
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to OR.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.4
+	 */
+	public function andWhere($conditions, $glue = 'OR')
+	{
+		return $this->extendWhere('AND', $conditions, $glue);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1476,7 +1476,7 @@ class JDatabaseQueryTest extends TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function testExtendWhere()
 	{
@@ -1526,7 +1526,7 @@ class JDatabaseQueryTest extends TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function testOrWhere()
 	{
@@ -1576,7 +1576,7 @@ class JDatabaseQueryTest extends TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   3.4
+	 * @since   3.5
 	 */
 	public function testAndWhere()
 	{

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -1451,6 +1451,15 @@ class JDatabaseQueryTest extends TestCase
 			'Tests rendered value after second use and array input.'
 		);
 
+		// Add more columns but specify different glue.
+		// Note that the change of glue is ignored.
+		$this->_instance->where(array('faz = 4', 'gaz = 5'), 'OR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3 AND faz = 4 AND gaz = 5'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+
 		// Clear the where
 		TestReflection::setValue($this->_instance, 'where', null);
 		$this->_instance->where(array('bar = 2', 'goo = 3'), 'OR');
@@ -1459,6 +1468,156 @@ class JDatabaseQueryTest extends TestCase
 			trim(TestReflection::getValue($this->_instance, 'where')),
 			$this->equalTo('WHERE bar = 2 OR goo = 3'),
 			'Tests rendered value with glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::extendWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public function testExtendWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->extendWhere('ABC', 'bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->extendWhere('XYZ', array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)) XYZ '
+				. PHP_EOL . '(baz = 3 AND goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->extendWhere('STU', array('faz = 5', 'gaz = 6'), 'VWX');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)) XYZ '
+				. PHP_EOL . '(baz = 3 AND goo = 4)) STU '
+				. PHP_EOL . '(faz = 5 VWX gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::orWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public function testOrWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->orWhere('bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->orWhere(array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)) OR '
+				. PHP_EOL . '(baz = 3 AND goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->orWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)) OR '
+				. PHP_EOL . '(baz = 3 AND goo = 4)) OR '
+				. PHP_EOL . '(faz = 5 XOR gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::andWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public function testAndWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->andWhere('bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->andWhere(array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)) AND '
+				. PHP_EOL . '(baz = 3 OR goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->andWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)) AND '
+				. PHP_EOL . '(baz = 3 OR goo = 4)) AND '
+				. PHP_EOL . '(faz = 5 XOR gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
 		);
 	}
 


### PR DESCRIPTION
The current implementation of the database query where method is limited by an unfortunate restriction in that the first use of the glue parameter fixes the glue for all subsequent uses.  For example,

```
$query->where(array('foo = 1', 'bar = 2'));
// WHERE foo = 1 AND bar = 2

$query->where(array('foo = 1', 'bar = 2'), 'OR');
// WHERE foo = 1 OR bar = 2

$query
->where(array('foo = 1', 'bar = 2'), 'AND')
->where(array('baz = 3', 'goo = 4'), 'OR');
// WHERE foo = 1 AND bar = 2 AND baz = 3 AND goo = 4
// Note that the OR glue is completely ignored in the second where statement.
```

This behaviour is inconvenient but can't be changed in Joomla 3.x because it would break backwards compatibility.  Consequently, this PR offers the following additional syntax to support more complex WHERE clauses:

**orWhere($conditions, $glue = 'AND')**

```
$query
->where(array('foo = 1', 'bar = 2'))
->orWhere(array('baz = 3', 'goo = 4'));
// WHERE (foo = 1 AND bar = 2) OR (baz = 3 AND goo = 4)

$query
->where(array('foo = 1', 'bar = 2'))
->orWhere(array('baz = 3', 'goo = 4'), 'XOR');
// WHERE (foo = 1 AND bar = 2) OR (baz = 3 XOR goo = 4)
```

**andWhere($conditions, $glue = 'OR')**

```
$query
->where(array('foo = 1', 'bar = 2'))
->andWhere(array('baz = 3', 'goo = 4'));
// WHERE (foo = 1 AND bar = 2) AND (baz = 3 OR goo = 4)

$query
->where(array('foo = 1', 'bar = 2'))
->andWhere(array('baz = 3', 'goo = 4'), 'XOR');
// WHERE (foo = 1 AND bar = 2) AND (baz = 3 XOR goo = 4)
```

**extendWhere($outerGlue, $conditions, $innerGlue = 'AND')**

```
$query
->where(array('foo = 1', 'bar = 2'))
->extendWhere('XOR', array('baz = 3', 'goo = 4'));
// WHERE (foo = 1 AND bar = 2) XOR (baz = 3 AND goo = 4)

$query
->where(array('foo = 1', 'bar = 2'))
->extendWhere('XOR', array('baz = 3', 'goo = 4'), 'OR');
// WHERE (foo = 1 AND bar = 2) XOR (baz = 3 OR goo = 4)
```

The **extendWhere** method allows additional logical operators to be used beyond the commonly used AND and OR operators.  For example, you can use XOR, AND NOT and OR NOT.

**Backwards compatibility**
There are no backwards compatibility issues.  Existing code is unaffected because only new syntax is being added.

**Testing**
The code is accompanied by unit tests for the new methods and an extension to the where method test which verifies the original behaviour.
