### PR TITLE
The Debug Permissions Report don't work correct on Joomla 3.x (Fix #4117)

### DIFF
--- a/administrator/components/com_users/helpers/debug.php
+++ b/administrator/components/com_users/helpers/debug.php
@@ -88,7 +88,7 @@ class UsersHelperDebug
 		// Use default actions from configuration if no component selected or component doesn't have actions
 		if (empty($actions))
 		{
-			$filename = JPATH_ADMINISTRATOR . '/components/com_config/models/forms/application.xml';
+			$filename = JPATH_ADMINISTRATOR . '/components/com_config/model/form/application.xml';
 
 			if (is_file($filename))
 			{

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -36,7 +36,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 		</div>
 		<div class="clearfix"> </div>
-		<table class="table table-striped">
+		<table class="table table-striped table-condensed">
 			<thead>
 				<tr>
 					<th class="left">

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -42,18 +42,18 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<th class="left">
 						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_ASSET_TITLE', 'a.title', $listDirn, $listOrder); ?>
 					</th>
-					<th class="nowrap left">
+					<th class="left">
 						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
 					</th>
 					<?php foreach ($this->actions as $key => $action) : ?>
-					<th width="5%" class="nowrap center">
+					<th width="5%" class="center">
 						<span class="hasTooltip" title="<?php echo JHtml::tooltipText($key, $action[1]); ?>"><?php echo JText::_($key); ?></span>
 					</th>
 					<?php endforeach; ?>
-					<th width="5%" class="nowrap center">
+					<th width="5%" class="center">
 						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
 					</th>
-					<th width="1%" class="nowrap center">
+					<th width="1%" class="center">
 						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>


### PR DESCRIPTION
See #4117 for full background

Test instructions (from original issue)
1. Install J3
2. Enable debug on J3
3. Go to Backend --> Users --> User Manager --> Debug Permissions Report
4. See what is there; Something like:

![screen shot 2014-08-15 at 04 34 34](http://issues.joomla.org/uploads/1/e67d64251b69c2011f00a72631c2e4da.jpg)
1. Apply patch
2. Result should look like this:

![screen shot 2015-01-20 at 8 47 37 pm](https://cloud.githubusercontent.com/assets/368545/5829817/9ec1d120-a0e5-11e4-9f33-2592a20dab68.png)
