### PR TITLE
[imp] Articles Manager: adding class hasTooltip to title and author rows

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -172,7 +172,7 @@ JFactory::getDocument()->addScriptDeclaration('
 									<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 								<?php endif;?>
 								<?php if ($canEdit || $canEditOwn) : ?>
-									<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 										<?php echo $this->escape($item->title); ?></a>
 								<?php else : ?>
 									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
@@ -197,11 +197,11 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php endif;?>
 						<td class="small hidden-phone">
 							<?php if ($item->created_by_alias) : ?>
-								<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
 								<?php echo $this->escape($item->author_name); ?></a>
 								<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
 							<?php else : ?>
-								<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
 								<?php echo $this->escape($item->author_name); ?></a>
 							<?php endif; ?>
 						</td>


### PR DESCRIPTION
Similar to https://github.com/joomla/joomla-cms/pull/5835

After patch, we will get

![screen shot 2015-01-21 at 08 31 16](https://cloud.githubusercontent.com/assets/869724/5832678/10106f04-a149-11e4-8221-5cbfc2650d97.png)

and 

![screen shot 2015-01-21 at 08 30 59](https://cloud.githubusercontent.com/assets/869724/5832679/10149854-a149-11e4-98fd-d30a16918404.png)
