### PR TITLE
Add chosen to the debug permissions views

### DIFF
--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
+JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
+JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
### how to test
- enable debug at the global configuration
- access the User Manager
- access the debug permissions report for one user
- see that the sidebar not use chosen.
- access the Group Manager
- see also there the debug permissions report for one group
- see that the sidebar not use chosen.
- apply this patch
- see the views again :smile: 

BTW: In staging the debug permissions report is broken at all but will be fixed with: https://github.com/joomla/joomla-cms/pull/5841
