### PR TITLE
Use the new wrapper classes in the filesystem package

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.filesystem.path');
-
 /**
  * A File handling class
  *
@@ -81,11 +79,13 @@ class JFile
 	 */
 	public static function copy($src, $dest, $path = null, $use_streams = false)
 	{
+		$pathObject = new JFilesystemWrapperPath;
+
 		// Prepend a base path if it exists
 		if ($path)
 		{
-			$src = JPath::clean($path . '/' . $src);
-			$dest = JPath::clean($path . '/' . $dest);
+			$src = $pathObject->clean($path . '/' . $src);
+			$dest = $pathObject->clean($path . '/' . $dest);
 		}
 
 		// Check src path
@@ -121,12 +121,12 @@ class JFile
 				// If the parent folder doesn't exist we must create it
 				if (!file_exists(dirname($dest)))
 				{
-					jimport('joomla.filesystem.folder');
-					JFolder::create(dirname($dest));
+					$folderObject = new JFilesystemWrapperFolder;
+					$folderObject->create(dirname($dest));
 				}
 
 				// Translate the destination path for the FTP account
-				$dest = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
+				$dest = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
 
 				if (!$ftp->store($src, $dest))
 				{
@@ -164,6 +164,7 @@ class JFile
 	public static function delete($file)
 	{
 		$FTPOptions = JClientHelper::getCredentials('ftp');
+		$pathObject = new JFilesystemWrapperPath;
 
 		if (is_array($file))
 		{
@@ -183,7 +184,7 @@ class JFile
 
 		foreach ($files as $file)
 		{
-			$file = JPath::clean($file);
+			$file = $pathObject->clean($file);
 
 			if (!is_file($file))
 			{
@@ -202,7 +203,7 @@ class JFile
 			}
 			elseif ($FTPOptions['enabled'] == 1)
 			{
-				$file = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $file), '/');
+				$file = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $file), '/');
 
 				if (!$ftp->delete($file))
 				{
@@ -237,10 +238,12 @@ class JFile
 	 */
 	public static function move($src, $dest, $path = '', $use_streams = false)
 	{
+		$pathObject = new JFilesystemWrapperPath;
+
 		if ($path)
 		{
-			$src = JPath::clean($path . '/' . $src);
-			$dest = JPath::clean($path . '/' . $dest);
+			$src = $pathObject->clean($path . '/' . $src);
+			$dest = $pathObject->clean($path . '/' . $dest);
 		}
 
 		// Check src path
@@ -272,8 +275,8 @@ class JFile
 				$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 				// Translate path for the FTP account
-				$src = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $src), '/');
-				$dest = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
+				$src = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $src), '/');
+				$dest = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
 
 				// Use FTP rename to simulate move
 				if (!$ftp->rename($src, $dest))
@@ -386,9 +389,9 @@ class JFile
 		// If the destination directory doesn't exist we need to create it
 		if (!file_exists(dirname($file)))
 		{
-			jimport('joomla.filesystem.folder');
+			$folderObject = new JFilesystemWrapperFolder;
 
-			if (JFolder::create(dirname($file)) == false)
+			if ($folderObject->create(dirname($file)) == false)
 			{
 				return false;
 			}
@@ -413,6 +416,7 @@ class JFile
 		else
 		{
 			$FTPOptions = JClientHelper::getCredentials('ftp');
+			$pathObject = new JFilesystemWrapperPath;
 
 			if ($FTPOptions['enabled'] == 1)
 			{
@@ -420,12 +424,12 @@ class JFile
 				$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 				// Translate path for the FTP account and use FTP write buffer to file
-				$file = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $file), '/');
+				$file = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $file), '/');
 				$ret = $ftp->write($file, $buffer);
 			}
 			else
 			{
-				$file = JPath::clean($file);
+				$file = $pathObject->clean($file);
 				$ret = is_int(file_put_contents($file, $buffer)) ? true : false;
 			}
 
@@ -447,15 +451,16 @@ class JFile
 	public static function upload($src, $dest, $use_streams = false)
 	{
 		// Ensure that the path is valid and clean
-		$dest = JPath::clean($dest);
+		$pathObject = new JFilesystemWrapperPath;
+		$dest = $pathObject->clean($dest);
 
 		// Create the destination directory if it does not exist
 		$baseDir = dirname($dest);
 
 		if (!file_exists($baseDir))
 		{
-			jimport('joomla.filesystem.folder');
-			JFolder::create($baseDir);
+			$folderObject = new JFilesystemWrapperFolder;
+			$folderObject->create($baseDir);
 		}
 
 		if ($use_streams)
@@ -482,7 +487,7 @@ class JFile
 				$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 				// Translate path for the FTP account
-				$dest = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
+				$dest = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
 
 				// Copy the file to the destination directory
 				if (is_uploaded_file($src) && $ftp->store($src, $dest))
@@ -500,7 +505,7 @@ class JFile
 				if (is_writeable($baseDir) && move_uploaded_file($src, $dest))
 				{
 					// Short circuit to prevent file permission errors
-					if (JPath::setPermissions($dest))
+					if ($pathObject->setPermissions($dest))
 					{
 						$ret = true;
 					}
@@ -530,7 +535,9 @@ class JFile
 	 */
 	public static function exists($file)
 	{
-		return is_file(JPath::clean($file));
+		$pathObject = new JFilesystemWrapperPath;
+
+		return is_file($pathObject->clean($file));
 	}
 
 	/**

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.filesystem.path');
-
 /**
  * A Folder handling class
  *
@@ -37,11 +35,12 @@ abstract class JFolder
 		@set_time_limit(ini_get('max_execution_time'));
 
 		$FTPOptions = JClientHelper::getCredentials('ftp');
+		$pathObject = new JFilesystemWrapperPath;
 
 		if ($path)
 		{
-			$src = JPath::clean($path . '/' . $src);
-			$dest = JPath::clean($path . '/' . $dest);
+			$src  = $pathObject->clean($path . '/' . $src);
+			$dest = $pathObject->clean($path . '/' . $dest);
 		}
 
 		// Eliminate trailing directory separators, if any
@@ -96,7 +95,7 @@ abstract class JFolder
 
 					case 'file':
 						// Translate path for the FTP account
-						$dfid = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dfid), '/');
+						$dfid = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dfid), '/');
 
 						if (!$ftp->store($sfid, $dfid))
 						{
@@ -173,7 +172,8 @@ abstract class JFolder
 		static $nested = 0;
 
 		// Check to make sure the path valid and clean
-		$path = JPath::clean($path);
+		$pathObject = new JFilesystemWrapperPath;
+		$path = $pathObject->clean($path);
 
 		// Check if parent dir exists
 		$parent = dirname($path);
@@ -217,7 +217,7 @@ abstract class JFolder
 			$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 			// Translate path to FTP path
-			$path = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $path), '/');
+			$path = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $path), '/');
 			$ret = $ftp->mkdir($path);
 			$ftp->chmod($path, $mode);
 		}
@@ -245,7 +245,7 @@ abstract class JFolder
 				// Iterate through open_basedir paths looking for a match
 				foreach ($obdArray as $test)
 				{
-					$test = JPath::clean($test);
+					$test = $pathObject->clean($test);
 
 					if (strpos($path, $test) === 0)
 					{
@@ -297,6 +297,7 @@ abstract class JFolder
 	public static function delete($path)
 	{
 		@set_time_limit(ini_get('max_execution_time'));
+		$pathObject = new JFilesystemWrapperPath;
 
 		// Sanity check
 		if (!$path)
@@ -312,7 +313,7 @@ abstract class JFolder
 		try
 		{
 			// Check to make sure the path valid and clean
-			$path = JPath::clean($path);
+			$path = $pathObject->clean($path);
 		}
 		catch (UnexpectedValueException $e)
 		{
@@ -332,9 +333,9 @@ abstract class JFolder
 
 		if (!empty($files))
 		{
-			jimport('joomla.filesystem.file');
+			$file = new JFilesystemWrapperFile;
 
-			if (JFile::delete($files) !== true)
+			if ($file->delete($files) !== true)
 			{
 				// JFile::delete throws an error
 				return false;
@@ -349,9 +350,9 @@ abstract class JFolder
 			if (is_link($folder))
 			{
 				// Don't descend into linked directories, just delete the link.
-				jimport('joomla.filesystem.file');
+				$file = new JFilesystemWrapperFile;
 
-				if (JFile::delete($folder) !== true)
+				if ($file->delete($folder) !== true)
 				{
 					// JFile::delete throws an error
 					return false;
@@ -379,7 +380,7 @@ abstract class JFolder
 		elseif ($FTPOptions['enabled'] == 1)
 		{
 			// Translate path and delete
-			$path = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $path), '/');
+			$path = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $path), '/');
 
 			// FTP connector throws an error
 			$ret = $ftp->delete($path);
@@ -408,11 +409,12 @@ abstract class JFolder
 	public static function move($src, $dest, $path = '', $use_streams = false)
 	{
 		$FTPOptions = JClientHelper::getCredentials('ftp');
+		$pathObject = new JFilesystemWrapperPath;
 
 		if ($path)
 		{
-			$src = JPath::clean($path . '/' . $src);
-			$dest = JPath::clean($path . '/' . $dest);
+			$src = $pathObject->clean($path . '/' . $src);
+			$dest = $pathObject->clean($path . '/' . $dest);
 		}
 
 		if (!self::exists($src))
@@ -444,8 +446,8 @@ abstract class JFolder
 				$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 				// Translate path for the FTP account
-				$src = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $src), '/');
-				$dest = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
+				$src = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $src), '/');
+				$dest = $pathObject->clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $dest), '/');
 
 				// Use FTP rename to simulate move
 				if (!$ftp->rename($src, $dest))
@@ -480,7 +482,9 @@ abstract class JFolder
 	 */
 	public static function exists($path)
 	{
-		return is_dir(JPath::clean($path));
+		$pathObject = new JFilesystemWrapperPath;
+
+		return is_dir($pathObject->clean($path));
 	}
 
 	/**
@@ -502,7 +506,8 @@ abstract class JFolder
 		$excludefilter = array('^\..*', '.*~'), $naturalSort = false)
 	{
 		// Check to make sure the path valid and clean
-		$path = JPath::clean($path);
+		$pathObject = new JFilesystemWrapperPath;
+		$path = $pathObject->clean($path);
 
 		// Is the path a folder?
 		if (!is_dir($path))
@@ -556,7 +561,8 @@ abstract class JFolder
 		$excludefilter = array('^\..*'))
 	{
 		// Check to make sure the path valid and clean
-		$path = JPath::clean($path);
+		$pathObject = new JFilesystemWrapperPath;
+		$path = $pathObject->clean($path);
 
 		// Is the path a folder?
 		if (!is_dir($path))
@@ -683,13 +689,14 @@ abstract class JFolder
 
 		if ($level < $maxLevel)
 		{
-			$folders = self::folders($path, $filter);
+			$folders    = self::folders($path, $filter);
+			$pathObject = new JFilesystemWrapperPath;
 
 			// First path, index foldernames
 			foreach ($folders as $name)
 			{
 				$id = ++$GLOBALS['_JFolder_folder_tree_index'];
-				$fullName = JPath::clean($path . '/' . $name);
+				$fullName = $pathObject->clean($path . '/' . $name);
 				$dirs[] = array('id' => $id, 'parent' => $parent, 'name' => $name, 'fullname' => $fullName,
 					'relname' => str_replace(JPATH_ROOT, '', $fullName));
 				$dirs2 = self::listFolderTree($fullName, $filter, $maxLevel, $level + 1, $id);

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -242,17 +242,18 @@ class JPath
 
 		if ($dir)
 		{
-			$test = $dir . '/' . $tmp;
+			$fileObject = new JFilesystemWrapperFile;
+			$test       = $dir . '/' . $tmp;
 
 			// Create the test file
 			$blank = '';
-			JFile::write($test, $blank, false);
+			$fileObject->write($test, $blank, false);
 
 			// Test ownership
 			$return = (fileowner($test) == fileowner($path));
 
 			// Delete the test file
-			JFile::delete($test);
+			$fileObject->delete($test);
 
 			return $return;
 		}

--- a/libraries/joomla/filesystem/wrapper/file.php
+++ b/libraries/joomla/filesystem/wrapper/file.php
@@ -9,8 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
+jimport('joomla.filesystem.file');
+
 /**
- * Wrapper class for JFilesystemFile
+ * Wrapper class for JFile
  *
  * @package     Joomla.Platform
  * @subpackage  Filesystem

--- a/libraries/joomla/filesystem/wrapper/folder.php
+++ b/libraries/joomla/filesystem/wrapper/folder.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+jimport('joomla.filesystem.folder');
+
 /**
  * Wrapper class for JFilesystemFolder
  *

--- a/libraries/joomla/filesystem/wrapper/path.php
+++ b/libraries/joomla/filesystem/wrapper/path.php
@@ -9,8 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
+jimport('joomla.filesystem.path');
+
 /**
- * Wrapper class for JFilesystemPath
+ * Wrapper class for JPath
  *
  * @package     Joomla.Platform
  * @subpackage  Filesystem
@@ -93,7 +95,7 @@ class JFilesystemWrapperPath
 	 * @since   3.4
 	 * @throws  UnexpectedValueException
 	 */
-	public function clean($path, $ds = '\\')
+	public function clean($path, $ds = DIRECTORY_SEPARATOR)
 	{
 		return JPath::clean($path, $ds);
 	}


### PR DESCRIPTION
Redo of #4827

From our testing sprint in October, we've taken some initial steps to modernize some of our architecture and focus on replacing static methods as able.  To do so without backward compatibility breaks, we've introduced several wrapper classes which are object based and enable developers to utilize these to work with what will be the object based API in a later major release.

This PR demonstrates how the wrappers can be used internally by using the newly created wrappers for the Filesystem package within its classes.  In conjunction with https://github.com/joomla/joomla-cms/pull/4717 this demonstrates how we can begin modernizing the code in phased steps without introducing larger B/C breaks between major releases by providing a compatibility layer in our current releases.
### Testing Instructions
- Apply the patch
- Perform actions in the user interface that interact with the filesystem (the media manager and extension manager are great places to test from)
- Ensure filesystem management still works
