### PR TITLE
fix JInput returning 0 when parameter value is empty and fitler is INT

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -165,7 +165,7 @@ class JInput implements Serializable, Countable
 	 */
 	public function get($name, $default = null, $filter = 'cmd')
 	{
-		if (isset($this->data[$name]) && $this->data[$name] !=="")
+		if (isset($this->data[$name]) && $this->data[$name] != "")
 		{	
 			return $this->filter->clean($this->data[$name], $filter);
 		}

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -166,7 +166,11 @@ class JInput implements Serializable, Countable
 	public function get($name, $default = null, $filter = 'cmd')
 	{
 		if (isset($this->data[$name]))
-		{
+		{	
+			if (($filter == 'int' || $fitler == 'integer' ) && empty($this->data[$name]))
+			{
+				return $default;
+			}
 			return $this->filter->clean($this->data[$name], $filter);
 		}
 

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -165,12 +165,8 @@ class JInput implements Serializable, Countable
 	 */
 	public function get($name, $default = null, $filter = 'cmd')
 	{
-		if (isset($this->data[$name]))
+		if (isset($this->data[$name]) && $this->data[$name] !=="")
 		{	
-			if (($filter == 'int' || $fitler == 'integer') && empty($this->data[$name]))
-			{
-				return $default;
-			}
 			return $this->filter->clean($this->data[$name], $filter);
 		}
 

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -167,7 +167,7 @@ class JInput implements Serializable, Countable
 	{
 		if (isset($this->data[$name]))
 		{	
-			if (($filter == 'int' || $fitler == 'integer' ) && empty($this->data[$name]))
+			if (($filter == 'int' || $fitler == 'integer') && empty($this->data[$name]))
 			{
 				return $default;
 			}


### PR DESCRIPTION
When parameter with empty value is passed to the JInput and filter is INT, JInput will return 0 instead of default value. There is similar problem with other fitlers too as isset will consider "" as set, and afterwards fitlers will perform typecasting on it. 

Fixes #5851 
