### PR TITLE
Templates sanity

### DIFF
--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -22,10 +22,10 @@ $doc = JFactory::getDocument();
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet('templates/system/css/system.css');
+$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -37,7 +37,7 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
@@ -50,8 +50,8 @@ if (is_file($file))
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -65,11 +65,11 @@ if (JFile::exists($file))
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/boldtext.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load template javascript
-$doc->addScript('templates/' . $this->template . '/js/template.js', 'text/javascript');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -19,10 +19,10 @@ $user  = JFactory::getUser();
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet('templates/system/css/system.css');
+$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -34,7 +34,7 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
@@ -47,8 +47,8 @@ if (is_file($file))
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -62,11 +62,11 @@ if (JFile::exists($file))
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/boldtext.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load template javascript
-$doc->addScript('templates/' . $this->template . '/js/template.js', 'text/javascript');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -19,10 +19,10 @@ $user  = JFactory::getUser();
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheetVersion('templates/system/css/system.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheetVersion('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -34,7 +34,7 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheetVersion('templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
@@ -47,8 +47,8 @@ if (is_file($file))
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -62,11 +62,11 @@ if (is_file($file))
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/boldtext.css');
+	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load template javascript
-$doc->addScriptVersion('templates/' . $this->template . '/js/template.js');
+$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -19,10 +19,10 @@ JHtml::_('behavior.noframes');
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet('templates/system/css/system.css');
+$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet('templates/'.$this->template.'/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/'.$this->template.'/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -34,7 +34,7 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
@@ -47,8 +47,8 @@ if (is_file($file))
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet('templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -62,7 +62,7 @@ if (JFile::exists($file))
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/boldtext.css');
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Logo file

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -18,10 +18,10 @@ $this->direction = $doc->direction;
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScript('templates/' . $this->template . '/js/template.js');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -19,10 +19,10 @@ $user            = JFactory::getUser();
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
-$doc->addScriptVersion('templates/' . $this->template . '/js/template.js');
+$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion('templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -22,7 +22,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
 // Add Stylesheets
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -43,12 +43,12 @@ if (in_array($option, $bootstrap))
 	JHtml::_('bootstrap.loadCss', true, $this->direction);
 }
 
-$doc->addStyleSheet(JUri::base() . 'templates/system/css/system.css');
-$doc->addStyleSheet(JUri::base() . 'templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet(JUri::base() . 'templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet(JUri::base() . 'templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
-$doc->addStyleSheet(JUri::base() . 'templates/' . $this->template . '/css/general.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet(JUri::base() . 'templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', $type = 'text/css', $media = 'screen,projection');
 
 if ($this->direction == 'rtl')
 {

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -18,7 +18,7 @@ $this->direction = $doc->direction;
 JHtml::_('bootstrap.framework');
 
 // Add Stylesheets
-$doc->addStyleSheet('templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);


### PR DESCRIPTION
#### This PR ensures that all js and css added by Joomla templates follow the same rule

All templates that come with standard Joomla installation add some scripts and some stylesheets files. The problem is that not all of them use the same logic and this ends up with an array like this:
![screen shot 2015-01-21 at 5 45 15](https://cloud.githubusercontent.com/assets/3889375/5840485/9c663114-a19e-11e4-98cc-b6ca69600d59.png)

From processing point of view that is not a problem as the function in head.php will iron this! But why not echo some variable that is already in the memory and get everything in the same line?
So this is hathor before:

``` php
$doc->addStyleSheet('templates/system/css/system.css');
```

And after:

``` php
$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
```
##### B/C

None
##### Testing:

Just test that Beez, protostar, Hathor and Isis still working (css and js files get loaded)
