### PR TITLE
Show proper line number for language debug

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -880,7 +880,7 @@ class JLanguage
 
 				if (!preg_match($regex, $line) || in_array($key, $blacklist))
 				{
-					$errors[] = $lineNumber;
+					$errors[] = $lineNumber + 1;
 				}
 			}
 


### PR DESCRIPTION
When JLanguage parses files in debug mode, it adds a list of line numbers with errors to a string for reference.  The `SplFileObject` starts with the first line as line 0, which means the line number displayed in the output is off by one.  This PR adjusts it.

Test instructions:
1) Add this string to a language file temporarily: `DASHBOARD.NEW.NOTIFICATION.COUNT_1="There is <span class="badge">1</span> new notification."` (yes, this is a valid key and will display properly)
2) Enable language debug mode
3) In the debug output, note the line number that the error appears in; it should be off by one
4) Apply patch
5) Refresh page and re-check debug output
