### PR TITLE
$root_user automatic deletion works now (Ref #5836)

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -420,7 +420,7 @@ class JApplicationAdministrator extends JApplicationCms
 			$this->enqueueMessage(
 				JText::sprintf(
 					'JWARNING_REMOVE_ROOT_USER',
-					'index.php?option=com_config&task=application.removeroot&' . JSession::getFormToken() . '=1'
+					'index.php?option=com_config&task=config.removeroot&' . JSession::getFormToken() . '=1'
 				),
 				'notice'
 			);


### PR DESCRIPTION
The problem was a with a wrong action in the automatic deletion URL. The action has now been changed from `application.removeroot` to `config.removeroot`. See issue #5836 
