### PR TITLE
Fix #5859: typo in com_finder (publish up/down)

### DIFF
--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -231,7 +231,7 @@ class FinderModelSearch extends JModelList
 		$nowDate = $db->quote(substr_replace(JFactory::getDate()->toSQL(), '00', -2));
 
 		// Add the publish up and publish down filters.
-		$query->where('(l.publish_start_date = ' . $nullDate . ' OR l.publish_end_date <= ' . $nowDate . ')')
+		$query->where('(l.publish_start_date = ' . $nullDate . ' OR l.publish_start_date <= ' . $nowDate . ')')
 			->where('(l.publish_end_date = ' . $nullDate . ' OR l.publish_end_date >= ' . $nowDate . ')');
 
 		/*


### PR DESCRIPTION
Test:
create articles with
(1) Publish up in past and Publish down in future
(2) Publish up and down in past
(3) Publish up and down in future
(4) Publish up in past, no Publish down
(5) Publish up in future, no Publish down
and let finder find them all.
Before this fix it shows (4) and (5).
With this fix it shows (1) and (4) as expected.
