### PR TITLE
Convert users notes modal to Bootstrap modal

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -100,9 +100,15 @@ class JHtmlUsers
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
 
-		return '<a class="modal"'
-			. ' href="' . JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId) . '"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
+		echo JHtmlBootstrap::renderModal(
+			'userModal_' . (int) $userId, array(
+				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
+				'title' => $title,
+				'width' => '800px',
+				'height' => '500px')
+		);
+
+		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal"'
 			. '<span class="label label-info"><i class="icon-drawer-2"></i>' . $title . '</span></a>';
 	}
 

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.modal', 'a.modal');
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
#### Convert users notes mootools modal to BS modal

In users list view (/administrator/index.php?option=com_users&view=users), there is still a mootools modal. Needs some notes to reveal it!
This PR converts it to Bootstrap modal
#### Preview:

![screen shot 2015-01-23 at 1 37 59](https://cloud.githubusercontent.com/assets/3889375/5867089/89063850-a2a0-11e4-9d98-19d47cec080f.png)
#### Testing

Create some user notes (/administrator/index.php?option=com_users&view=notes)
Apply patch 
go to (/administrator/index.php?option=com_users&view=users) and click "display 1 note"
