### PR TITLE
Route the link in the redirect plugin

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -99,7 +99,7 @@ class PlgSystemRedirect extends JPlugin
 				if ($link->header < 400 && $link->header >= 300)
 				{
 					$new_link = JUri::isInternal($link->new_url) ? JRoute::_($link->new_url) : $link->new_url;
-					
+
 					$app->redirect($new_link, intval($link->header));
 				}
 				else

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -98,7 +98,9 @@ class PlgSystemRedirect extends JPlugin
 				// If we have a redirect in the 300 range use JApplicationWeb::redirect().
 				if ($link->header < 400 && $link->header >= 300)
 				{
-					$app->redirect($link->new_url, intval($link->header));
+					$new_link = JUri::isInternal($link->new_url) ? JRoute::_($link->new_url) : $link->new_url;
+					
+					$app->redirect($new_link, intval($link->header));
 				}
 				else
 				{


### PR DESCRIPTION
When redirecting an internal link, call JRoute::_(...)

Test:
- Activate the sef options in the global configuration
- Activate the redirect plugin
- Look for a menu item ID
- Create a redirect and add as goal: index.php?Itemid=xxx where "xxx" is the menu item ID (source could be anything, but we assume "foobar")
- Call www.your-domain.tld/foobar
- Redirect is index.php?Itemid=xxx
- Apply patch
- Call www.your-domain.tld/foobar again
