### PR TITLE
Remove 2.5 remnant from hathor

### DIFF
--- a/administrator/templates/hathor/html/com_users/debuggroup/default.php
+++ b/administrator/templates/hathor/html/com_users/debuggroup/default.php
@@ -67,7 +67,6 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 	<div>
 		<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>
-		<span class="swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_NO_CHECK', '-');?></span>
 		<span class="check-0 swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_IMPLICIT_DENY', '-');?></span>
 		<span class="check-a swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_EXPLICIT_ALLOW', '&#10003;');?></span>
 		<span class="check-d swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_EXPLICIT_DENY', '&#10007;');?></span>

--- a/administrator/templates/hathor/html/com_users/debuguser/default.php
+++ b/administrator/templates/hathor/html/com_users/debuguser/default.php
@@ -67,7 +67,6 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 	<div>
 		<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>
-		<span class="swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_NO_CHECK', '-');?></span>
 		<span class="check-0 swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_IMPLICIT_DENY', '-');?></span>
 		<span class="check-a swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_EXPLICIT_ALLOW', '&#10003;');?></span>
 		<span class="check-d swatch"><?php echo JText::sprintf('COM_USERS_DEBUG_EXPLICIT_DENY', '&#10007;');?></span>


### PR DESCRIPTION
For testing instructions see #5840
It would appear that this extra string is a remnant from a 2.5 override as the missing string is not used in core
