### PR TITLE
Sync changes to hathor override for the com_joomlaupdate default view

### DIFF
--- a/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
+++ b/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
@@ -53,7 +53,7 @@ JHtml::_('formbehavior.chosen', 'select');
 
 <fieldset>
 	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES') ?>
+		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES'); ?>
 	</legend>
 	<p>
 		<?php echo JText::sprintf($langKey, $updateSourceKey); ?>
@@ -67,34 +67,34 @@ JHtml::_('formbehavior.chosen', 'select');
 
 <fieldset>
 	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATEFOUND') ?>
+		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATEFOUND'); ?>
 	</legend>
 
 	<table class="adminlist">
 		<tbody>
 			<tr class="row0">
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLED') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLED'); ?>
 				</td>
 				<td>
-					<?php echo $this->updateInfo['installed'] ?>
+					<?php echo $this->updateInfo['installed']; ?>
 				</td>
 			</tr>
 			<tr class="row1">
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST'); ?>
 				</td>
 				<td>
-					<?php echo $this->updateInfo['latest'] ?>
+					<?php echo $this->updateInfo['latest']; ?>
 				</td>
 			</tr>
 			<tr class="row0">
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data ?>">
-						<?php echo $this->updateInfo['object']->downloadurl->_data ?>
+					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>">
+						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
 					</a>
 				</td>
 			</tr>
@@ -110,50 +110,50 @@ JHtml::_('formbehavior.chosen', 'select');
 			</tr>
 			<tr class="row0">
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_METHOD') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_METHOD'); ?>
 				</td>
 				<td>
-					<?php echo $this->methodSelect ?>
-				</td>
-			</tr>
-			<tr class="row1" id="row_ftp_hostname" <?php echo $ftpFieldsDisplay ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME') ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_host" value="<?php echo $this->ftp['host'] ?>" />
+					<?php echo $this->methodSelect; ?>
 				</td>
 			</tr>
-			<tr class="row0" id="row_ftp_port" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row1" id="row_ftp_hostname" <?php echo $ftpFieldsDisplay; ?>>
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME'); ?>
 				</td>
 				<td>
-					<input type="text" name="ftp_port" value="<?php echo $this->ftp['port'] ?>" />
-				</td>
-			</tr>
-			<tr class="row1" id="row_ftp_username" <?php echo $ftpFieldsDisplay ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME') ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_user" value="<?php echo $this->ftp['username'] ?>" />
+					<input type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>" />
 				</td>
 			</tr>
-			<tr class="row0" id="row_ftp_password" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row0" id="row_ftp_port" <?php echo $ftpFieldsDisplay; ?>>
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT'); ?>
 				</td>
 				<td>
-					<input type="password" name="ftp_pass" value="<?php echo $this->ftp['password'] ?>" />
+					<input type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>" />
 				</td>
 			</tr>
-			<tr class="row1" id="row_ftp_directory" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row1" id="row_ftp_username" <?php echo $ftpFieldsDisplay; ?>>
 				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY') ?>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME'); ?>
 				</td>
 				<td>
-					<input type="text" name="ftp_root" value="<?php echo $this->ftp['directory'] ?>" />
+					<input type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>" />
+				</td>
+			</tr>
+			<tr class="row0" id="row_ftp_password" <?php echo $ftpFieldsDisplay; ?>>
+				<td>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD'); ?>
+				</td>
+				<td>
+					<input type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>" />
+				</td>
+			</tr>
+			<tr class="row1" id="row_ftp_directory" <?php echo $ftpFieldsDisplay; ?>>
+				<td>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY'); ?>
+				</td>
+				<td>
+					<input type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>" />
 				</td>
 			</tr>
 		</tbody>
@@ -164,7 +164,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				</td>
 				<td>
 					<button class="submit" type="submit">
-						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLUPDATE') ?>
+						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLUPDATE'); ?>
 					</button>
 				</td>
 			</tr>
@@ -181,6 +181,8 @@ JHtml::_('formbehavior.chosen', 'select');
 
 <div class="download_message" style="display: none">
 	<p></p>
-	<p class="nowarning"> <?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS'); ?></p>
+	<p class="nowarning">
+		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS'); ?>
+	</p>
 	<div class="joomlaupdate_spinner"></div>
 </div>

--- a/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
+++ b/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
@@ -10,6 +10,40 @@
 defined('_JEXEC') or die;
 
 $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
+$params           = JComponentHelper::getParams('com_joomlaupdate');
+
+switch ($params->get('updatesource', 'default'))
+{
+	// "Minor & Patch Release for Current version AND Next Major Release".
+	case 'sts':
+	case 'next':
+		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_NEXT';
+		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_NEXT');
+		break;
+
+	// "Testing"
+	case 'testing':
+		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_TESTING';
+		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_TESTING');
+		break;
+
+	// "Custom"
+	case 'custom':
+		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_CUSTOM';
+		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_CUSTOM');
+		break;
+
+	// "Minor & Patch Release for Current version (recommended and default)".
+	// The commented "case" below are for documenting where 'default' and legacy options falls
+	// case 'default':
+	// case 'lts':
+	// case 'nochange':
+	default:
+		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_DEFAULT';
+		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_DEFAULT');
+}
+
+JHtml::_('formbehavior.chosen', 'select');
 
 ?>
 
@@ -21,6 +55,9 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 	<legend>
 		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES') ?>
 	</legend>
+	<p>
+		<?php echo JText::sprintf($langKey, $updateSourceKey); ?>
+	</p>
 	<p>
 		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', JVERSION); ?>
 	</p>
@@ -63,13 +100,23 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 			</tr>
 			<tr class="row1">
 				<td>
+					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
+				</td>
+				<td>
+					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>">
+						<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
+					</a>
+				</td>
+			</tr>
+			<tr class="row0">
+				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_METHOD') ?>
 				</td>
 				<td>
 					<?php echo $this->methodSelect ?>
 				</td>
 			</tr>
-			<tr class="row0" id="row_ftp_hostname" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row1" id="row_ftp_hostname" <?php echo $ftpFieldsDisplay ?>>
 				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME') ?>
 				</td>
@@ -77,7 +124,7 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 					<input type="text" name="ftp_host" value="<?php echo $this->ftp['host'] ?>" />
 				</td>
 			</tr>
-			<tr class="row1" id="row_ftp_port" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row0" id="row_ftp_port" <?php echo $ftpFieldsDisplay ?>>
 				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT') ?>
 				</td>
@@ -85,7 +132,7 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 					<input type="text" name="ftp_port" value="<?php echo $this->ftp['port'] ?>" />
 				</td>
 			</tr>
-			<tr class="row0" id="row_ftp_username" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row1" id="row_ftp_username" <?php echo $ftpFieldsDisplay ?>>
 				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME') ?>
 				</td>
@@ -93,15 +140,15 @@ $ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
 					<input type="text" name="ftp_user" value="<?php echo $this->ftp['username'] ?>" />
 				</td>
 			</tr>
-			<tr class="row1" id="row_ftp_password" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row0" id="row_ftp_password" <?php echo $ftpFieldsDisplay ?>>
 				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD') ?>
 				</td>
 				<td>
-					<input type="text" name="ftp_pass" value="<?php echo $this->ftp['password'] ?>" />
+					<input type="password" name="ftp_pass" value="<?php echo $this->ftp['password'] ?>" />
 				</td>
 			</tr>
-			<tr class="row0" id="row_ftp_directory" <?php echo $ftpFieldsDisplay ?>>
+			<tr class="row1" id="row_ftp_directory" <?php echo $ftpFieldsDisplay ?>>
 				<td>
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY') ?>
 				</td>


### PR DESCRIPTION
This PR Sync the changes to hathor override for the com_joomlaupdate default view
### How to test
- Install 3.3.6
- Install patchtester
- apply patch
- switch to the testing update server
- access com_joomlaupdate
- see the update
- see that we now also have the `You are connected on ...` message
- switch to "Write with FTP"
- and see that the password field now is ******

Thanks.
