### PR TITLE
Templates sanity for CSS/JS that is directly injected in documents head

### DIFF
--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -88,7 +88,7 @@ else
 <head>
 <jdoc:include type="head" />
 <!--[if lt IE 9]>
-	<script src="../media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 <![endif]-->
 </head>
 <body class="contentpane">

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -85,13 +85,13 @@ else
 <jdoc:include type="head" />
 <!-- Load additional CSS styles for Internet Explorer -->
 <!--[if IE 8]>
-	<link href="templates/<?php echo $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
 <![endif]-->
 <!--[if IE 7]>
-	<link href="templates/<?php echo $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
 <![endif]-->
 <!--[if lt IE 9]>
-	<script src="../media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 <![endif]-->
 </head>
 <body id="minwidth" class="cpanel-page">

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -19,7 +19,7 @@ $app = JFactory::getApplication();
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<!-- Load additional CSS styles for rtl sites -->
 	<?php if ($this->direction == 'rtl') : ?>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -16,14 +16,14 @@ $app = JFactory::getApplication();
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<!-- Load additional CSS styles for rtl sites -->
 	<?php if ($this->direction == 'rtl') : ?>
-		<link href="templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" type="text/css" />
 	<?php endif; ?>
 
 </head>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -19,7 +19,7 @@ $app = JFactory::getApplication();
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<!-- Load additional CSS styles for rtl sites -->
 	<?php if ($this->direction == 'rtl') : ?>

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -86,13 +86,13 @@ else
 	<jdoc:include type="head" />
 	<!-- Load additional CSS styles for Internet Explorer -->
 	<!--[if IE 8]>
-		<link href="templates/<?php echo  $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
 	<![endif]-->
 	<!--[if IE 7]>
-		<link href="templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
 	<![endif]-->
 	<!--[if lt IE 9]>
-		<script src="../media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 	</head>
 <body id="minwidth-body">

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -83,14 +83,14 @@ else
 
 <!-- Load additional CSS styles for Internet Explorer -->
 <!--[if IE 7]>
-	<link href="templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
 <![endif]-->
 <!--[if lt IE 9]>
-	<script src="../media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 <![endif]-->
 
 <!-- Load Template JavaScript -->
-<script type="text/javascript" src="templates/<?php  echo  $this->template;  ?>/js/template.js"></script>
+<script type="text/javascript" src="<?php echo $this->baseurl; ?>/templates/<?php  echo  $this->template;  ?>/js/template.js"></script>
 
 </head>
 <body id="login-page">

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -40,7 +40,7 @@ if (is_file($file))
 <head>
 	<jdoc:include type="head" />
 	<!--[if lt IE 9]>
-		<script src="../media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 
 	<!-- Link color -->

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -68,7 +68,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -72,7 +72,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -72,7 +72,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -68,11 +68,11 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>
@@ -112,12 +112,12 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 			}
 		</style>
 	<?php endif; ?>
-	<script src="../media/jui/js/jquery.js" type="text/javascript"></script>
-	<script src="../media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
-	<script src="../media/jui/js/bootstrap.js" type="text/javascript"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js" type="text/javascript"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js" type="text/javascript"></script>
 	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
 	<!--[if lt IE 9]>
-		<script src="../media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 </head>
 

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -68,7 +68,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -115,7 +115,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js" type="text/javascript"></script>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js" type="text/javascript"></script>
-	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
+	<script src="<?php echo JUri::root(true); ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
 	<!--[if lt IE 9]>
 		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -115,7 +115,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js" type="text/javascript"></script>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js" type="text/javascript"></script>
-	<script src="<?php echo JUri::root(true); ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
+	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
 	<!--[if lt IE 9]>
 		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -121,7 +121,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 	<?php endif; ?>
 
 	<!--[if lt IE 9]>
-	<script src="../media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 </head>
 

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -88,7 +88,7 @@ $sitename = $app->get('sitename');
 		<?php endif; ?>
 	</style>
 	<!--[if lt IE 9]>
-		<script src="../media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 </head>
 

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -53,7 +53,7 @@ if ($this->direction == 'rtl')
 	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" type="text/css" />
 <![endif]-->
 <!--[if lt IE 9]>
-	<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 <![endif]-->
 </head>
 <body class="contentpane">

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -66,7 +66,7 @@ $this->direction = $doc->direction;
 		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
 	<![endif]-->
 	<!--[if lt IE 9]>
-		<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 
 	<style type="text/css">

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -30,7 +30,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <jdoc:include type="head" />
 <!--[if lt IE 9]>
-	<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 <![endif]-->
 </head>
 <body class="contentpane modal">

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -117,7 +117,7 @@ else
 	</style>
 	<?php endif; ?>
 	<!--[if lt IE 9]>
-		<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 </head>
 


### PR DESCRIPTION
see: https://github.com/joomla/joomla-cms/pull/5854
### Testing:

Just test that Beez, protostar, Hathor and Isis still working (css and js files get loaded)

Can you review here @dgt41? :smile: 
