### PR TITLE
Fix logical ordering of access levels

### DIFF
--- a/administrator/components/com_users/models/levels.php
+++ b/administrator/components/com_users/models/levels.php
@@ -61,7 +61,7 @@ class UsersModelLevels extends JModelList
 		$this->setState('params', $params);
 
 		// List state information.
-		parent::populateState('a.title', 'asc');
+		parent::populateState('a.ordering', 'asc');
 	}
 
 	/**

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1967,8 +1967,8 @@ CREATE TABLE IF NOT EXISTS `#__viewlevels` (
 --
 
 INSERT INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
-(1, 'Public', 0, '[1]'),
-(2, 'Registered', 1, '[6,2,8]'),
-(3, 'Special', 2, '[6,3,8]'),
+(1, 'Public', 1, '[1]'),
+(2, 'Registered', 2, '[6,2,8]'),
+(3, 'Special', 3, '[6,3,8]'),
 (5, 'Guest', 0, '[9]'),
-(6, 'Super Users', 0, '[8]');
+(6, 'Super Users', 4, '[8]');

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1967,8 +1967,8 @@ CREATE TABLE IF NOT EXISTS `#__viewlevels` (
 --
 
 INSERT INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
-(1, 'Public', 1, '[1]'),
+(1, 'Public', 0, '[1]'),
 (2, 'Registered', 2, '[6,2,8]'),
 (3, 'Special', 3, '[6,3,8]'),
-(5, 'Guest', 0, '[9]'),
+(5, 'Guest', 1, '[9]'),
 (6, 'Super Users', 4, '[8]');

--- a/installation/sql/mysql/sample_learn.sql
+++ b/installation/sql/mysql/sample_learn.sql
@@ -769,10 +769,10 @@ INSERT IGNORE INTO `#__usergroups` (`id`, `parent_id`, `lft`, `rgt`, `title`) VA
 INSERT IGNORE INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
 (1, 'Public', 0, '[1]'),
 (2, 'Registered', 2, '[6,2,8]'),
-(3, 'Special', 3, '[6,3,8]'),
+(3, 'Special', 4, '[6,3,8]'),
 (4, 'Customer Access Level (Example)', 3, '[6,3,12]'),
 (5, 'Guest', 1, '[13]'),
-(6, 'Super Users', 4, '[8]');
+(6, 'Super Users', 5, '[8]');
 
 UPDATE `#__extensions` SET `params`='{"allowUserRegistration":"0","new_usertype":"2","guest_usergroup":"13","sendpassword":"1","useractivation":"1","mail_to_admin":"0","captcha":"","frontend_userparams":"1","site_language":"0","change_login_name":"0","reset_count":"10","reset_time":"1","mailSubjectPrefix":"","mailBodySuffix":"","save_history":"1","history_limit":5}' WHERE extension_id=25;
 

--- a/installation/sql/mysql/sample_learn.sql
+++ b/installation/sql/mysql/sample_learn.sql
@@ -768,11 +768,11 @@ INSERT IGNORE INTO `#__usergroups` (`id`, `parent_id`, `lft`, `rgt`, `title`) VA
 
 INSERT IGNORE INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
 (1, 'Public', 0, '[1]'),
-(2, 'Registered', 1, '[6,2,8]'),
-(3, 'Special', 2, '[6,3,8]'),
+(2, 'Registered', 2, '[6,2,8]'),
+(3, 'Special', 3, '[6,3,8]'),
 (4, 'Customer Access Level (Example)', 3, '[6,3,12]'),
-(5, 'Guest', 0, '[13]'),
-(6, 'Super Users', 0, '[8]');
+(5, 'Guest', 1, '[13]'),
+(6, 'Super Users', 4, '[8]');
 
 UPDATE `#__extensions` SET `params`='{"allowUserRegistration":"0","new_usertype":"2","guest_usergroup":"13","sendpassword":"1","useractivation":"1","mail_to_admin":"0","captcha":"","frontend_userparams":"1","site_language":"0","change_login_name":"0","reset_count":"10","reset_time":"1","mailSubjectPrefix":"","mailBodySuffix":"","save_history":"1","history_limit":5}' WHERE extension_id=25;
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1892,11 +1892,11 @@ COMMENT ON COLUMN "#__viewlevels"."rules" IS 'JSON encoded access control.';
 -- Dumping data for table #__viewlevels
 --
 INSERT INTO "#__viewlevels" ("id", "title", "ordering", "rules") VALUES
-(1, 'Public', 0, '[1]'),
-(2, 'Registered', 1, '[6,2,8]'),
-(3, 'Special', 2, '[6,3,8]'),
+(1, 'Public', 1, '[1]'),
+(2, 'Registered', 2, '[6,2,8]'),
+(3, 'Special', 3, '[6,3,8]'),
 (5, 'Guest', 0, '[9]'),
-(6, 'Super Users', 0, '[8]');
+(6, 'Super Users', 4, '[8]');
 
 SELECT setval('#__viewlevels_id_seq', 7, false);
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1892,10 +1892,10 @@ COMMENT ON COLUMN "#__viewlevels"."rules" IS 'JSON encoded access control.';
 -- Dumping data for table #__viewlevels
 --
 INSERT INTO "#__viewlevels" ("id", "title", "ordering", "rules") VALUES
-(1, 'Public', 1, '[1]'),
+(1, 'Public', 0, '[1]'),
 (2, 'Registered', 2, '[6,2,8]'),
 (3, 'Special', 3, '[6,3,8]'),
-(5, 'Guest', 0, '[9]'),
+(5, 'Guest', 1, '[9]'),
 (6, 'Super Users', 4, '[8]');
 
 SELECT setval('#__viewlevels_id_seq', 7, false);

--- a/installation/sql/postgresql/sample_learn.sql
+++ b/installation/sql/postgresql/sample_learn.sql
@@ -822,10 +822,10 @@ SELECT setval('#__usergroups_id_seq', max(id)) FROM #__usergroups;
 --
 INSERT INTO "#__viewlevels" VALUES
 (1,'Public',0,'[1]'),
-(2,'Registered',1,'[6,2,8]'),
-(3,'Special',2,'[6,3,8]'),
+(2,'Registered',2,'[6,2,8]'),
+(3,'Special',4,'[6,3,8]'),
 (4,'Customer Access Level (Example)',3,'[6,3,12]'),
-(5,'Guest',0,'[13]'),
-(6,'Super Users',0,'[8]');
+(5,'Guest',1,'[13]'),
+(6,'Super Users',5,'[8]');
 
 SELECT setval('#__viewlevels_id_seq', max(id)) FROM #__viewlevels;

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -3006,14 +3006,14 @@ CREATE TABLE [#__viewlevels](
 SET IDENTITY_INSERT [#__viewlevels]  ON;
 
 INSERT INTO [#__viewlevels] ([id], [title], [ordering], [rules])
-SELECT 1, 'Public', 0, '[1]'
+SELECT 1, 'Public', 1, '[1]'
 UNION ALL
-SELECT 2, 'Registered', 1, '[6,2,8]'
+SELECT 2, 'Registered', 2, '[6,2,8]'
 UNION ALL
-SELECT 3, 'Special', 2, '[6,3,8]'
+SELECT 3, 'Special', 3, '[6,3,8]'
 UNION ALL
 SELECT 5, 'Guest', 0, '[9]'
 UNION ALL
-SELECT 6, 'Super Users', 0, '[8]';
+SELECT 6, 'Super Users', 4, '[8]';
 
 SET IDENTITY_INSERT [#__viewlevels]  OFF;

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -3006,13 +3006,13 @@ CREATE TABLE [#__viewlevels](
 SET IDENTITY_INSERT [#__viewlevels]  ON;
 
 INSERT INTO [#__viewlevels] ([id], [title], [ordering], [rules])
-SELECT 1, 'Public', 1, '[1]'
+SELECT 1, 'Public', 0, '[1]'
 UNION ALL
 SELECT 2, 'Registered', 2, '[6,2,8]'
 UNION ALL
 SELECT 3, 'Special', 3, '[6,3,8]'
 UNION ALL
-SELECT 5, 'Guest', 0, '[9]'
+SELECT 5, 'Guest', 1, '[9]'
 UNION ALL
 SELECT 6, 'Super Users', 4, '[8]';
 

--- a/installation/sql/sqlazure/sample_learn.sql
+++ b/installation/sql/sqlazure/sample_learn.sql
@@ -1064,10 +1064,10 @@ SET IDENTITY_INSERT [#__usergroups] OFF;
 SET IDENTITY_INSERT [#__viewlevels] ON;
 
 INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (1, 'Public', 0, '[1]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (2, 'Registered', 1, '[6,2,8]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 2, '[6,3,8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (2, 'Registered', 2, '[6,2,8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 4, '[6,3,8]');
 INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (4, 'Customer Access Level (Example)', 3, '[6,3,12]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 0, '[13]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 0, '[8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 1, '[13]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 5, '[8]');
 
 SET IDENTITY_INSERT [#__viewlevels] OFF;

--- a/installation/sql/sqlazure/sample_testing.sql
+++ b/installation/sql/sqlazure/sample_testing.sql
@@ -1199,9 +1199,9 @@ SET IDENTITY_INSERT [#__usergroups] OFF;
 SET IDENTITY_INSERT [#__viewlevels] ON;
 
 INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (1, 'Public', 0, '[1]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (2, 'Registered', 1, '[6,2,8]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 2, '[6,3,8]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 0, '[9]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 0, '[8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (2, 'Registered', 2, '[6,2,8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 3, '[6,3,8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 1, '[9]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 4, '[8]');
 
 SET IDENTITY_INSERT [#__viewlevels] OFF;


### PR DESCRIPTION
This PR relates to @brianteeman PR #5834

On fresh install, set a logical ordering of pre-defined access levels.

In com_users access levels view, list is order by ordering ASC.
This way, the ordering is the same by default in Access Levels view, in Access filter  and select field.

Ref : https://github.com/joomla/joomla-cms/issues/5834
