### PR TITLE
[fix] escape language strings double quotes

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -842,7 +842,9 @@ class JLanguage
 		}
 
 		$contents = file_get_contents($filename);
-		$contents = str_replace('_QQ_', '"\""', $contents);
+
+		$contents = $this->prepareContents($contents);
+
 		$strings = @parse_ini_string($contents);
 
 		if (!is_array($strings))
@@ -1403,5 +1405,33 @@ class JLanguage
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Callback for preg_replace_callback to escape double quotes inside language strings.
+	 *
+	 * @param   array  $matches  Array of strings that match with the regular expression
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4
+	 */
+	private function escapeContentsQuotes($matches)
+	{
+		return '"' . str_replace('"', '\"', $matches[1]) . '"';
+	}
+
+	/**
+	 * Sanitize / prepare contents to be used by parse_ini_string.
+	 *
+	 * @param   string  $contents  String containing the contents to prepare
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4
+	 */
+	protected function prepareContents($contents)
+	{
+		return preg_replace_callback('/"(.*)"/', array($this, 'escapeContentsQuotes'), $contents);
 	}
 }


### PR DESCRIPTION
This fixes the issue found in https://github.com/joomla/joomla-cms/pull/5615#issuecomment-71823772

Basically if a language string contains double quotes inside they are removed by `parse_ini_string` and then not shown when rendering. 

To test this fix modify `administrator/language/en-GB/en-GB.plg_system_languagecode.ini` and set the plugin description to something like:

```
PLG_SYSTEM_LANGUAGECODE_XML_DESCRIPTION="Provides the ability to change the language code in the generated HTML document to improve SEO.<br />The fields will "appeara" when the plugin is enabled and saved.<br />More information <span class="label label-important">permet</span> at <a href="_QQ_"http://www.w3.org/TR/xhtml1/#docconf"_QQ_">W3.org</a> "
```

Then go to plugins management and search the `System - Language Code` plugin. Click there to edit it and pay attention to the plugin description.

Before applying the patch the `permet` label should be rendered in grey (only `label` class applied):

![before](https://cloud.githubusercontent.com/assets/1119272/5937861/1f735a9a-a6f5-11e4-9686-9112a27bb7ef.png)

After patching it should be shown in red (all the classes applied):

![after-patch](https://cloud.githubusercontent.com/assets/1119272/5937864/257f4386-a6f5-11e4-9150-71c2affdfd9f.png)
