### PR TITLE
Regression #5484: Install of learning demo fails

### DIFF
--- a/installation/sql/postgresql/sample_learn.sql
+++ b/installation/sql/postgresql/sample_learn.sql
@@ -190,8 +190,8 @@ SELECT setval('#__banners_id_seq', max(id)) FROM #__banners;
 --
 INSERT INTO "#__banner_clients" VALUES
 (1,'Joomla!','Administrator','banner@example.com','',1,0,'1970-01-01 00:00:00','',0,'',-1,-1,-1),
-(2,'Shop','Example','banner@example.com'','',1,0,'1970-01-01 00:00:00','',0,'',-1,0,0),
-(3,'Bookstore','Bookstore Example','banner@example.com'','',1,0,'1970-01-01 00:00:00','',0,'',-1,0,0);
+(2,'Shop','Example','banner@example.com','',1,0,'1970-01-01 00:00:00','',0,'',-1,0,0),
+(3,'Bookstore','Bookstore Example','banner@example.com','',1,0,'1970-01-01 00:00:00','',0,'',-1,0,0);
 
 SELECT setval('#__banner_clients_id_seq', max(id)) FROM #__banner_clients;
 


### PR DESCRIPTION
Bad email used in #__banner_clients of learning demo data of PostgreSQL.
Too many \'  at the end.
