### PR TITLE
Fixed mobile menu dropdown

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7556,9 +7556,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.nav-collapse .nav .nav-header {
 		color: #fff;
 	}
-	.nav-collapse.collapse.in {
-		height: auto !important;
-	}
 	.nav-collapse .nav,
 	.navbar .nav-collapse .nav.pull-right {
 		margin: 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7429,6 +7429,9 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
+	.nav-collapse.collapse.in {
+		height: auto !important;
+	}
 }
 @media (max-width: 767px) {
 	.navbar-search.pull-right {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -550,6 +550,9 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 	.row-fluid [class*="span"]{
 		margin-left: 15px;
 	}
+	.nav-collapse.collapse.in {
+		height: auto !important;
+	}
 }
 @media (max-width: 767px) {
 	.navbar-search.pull-right{

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -688,9 +688,6 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 	.nav-collapse .nav .nav-header {
 		color: @white;
 	}
-	.nav-collapse.collapse.in {
-		height: auto !important;
-	}
 	.nav-collapse .nav,
 	.navbar .nav-collapse .nav.pull-right {
 		margin: 0;


### PR DESCRIPTION
see: https://github.com/joomla/joomla-cms/issues/5912

On smaller devices, the mobile menu toggle seems to be acting oddly.

**1st click** = menu slide down
**2nd click** = menu slide up
**3rd click** = menu slide down
**4th click** = Nothing happens

No errors are appearing in the console log when it stops working.

Tested on Firefox (latest stable, developer and beta) and Chrome (latest).

![mobile-menu](https://cloud.githubusercontent.com/assets/2019801/5940466/fe0a2c40-a702-11e4-82d8-e6450e62b8a0.jpg)

I've started trying to debug the issue and will submit a pull request if I find a solution
