### PR TITLE
Removing one superfluous language string

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-08-24.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-08-24.sql
@@ -1,3 +1,3 @@
 INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
 VALUES
-(700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', 'COM_CPANEL_MSG_HTACCESS_BUTTON', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1);
+(700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-08-24.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-08-24.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "action_key", "language_extension", "language_client_id", "type", "action_file", "action", "condition_file", "condition_method", "version_introduced", "enabled") VALUES
-(700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', 'COM_CPANEL_MSG_HTACCESS_BUTTON', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1);
+(700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.4.0-2014-08-24.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.4.0-2014-08-24.sql
@@ -1,2 +1,2 @@
 INSERT INTO #__postinstall_messages ([extension_id], [title_key], [description_key], [action_key], [language_extension], [language_client_id], [type], [action_file], [action], [condition_file], [condition_method], [version_introduced], [enabled])
-SELECT 700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', 'COM_CPANEL_MSG_HTACCESS_BUTTON', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1;
+SELECT 700, 'COM_CPANEL_MSG_HTACCESS_TITLE', 'COM_CPANEL_MSG_HTACCESS_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccess.php', 'admin_postinstall_htaccess_condition', '3.4.0', 1;

--- a/administrator/language/en-GB/en-GB.com_cpanel.ini
+++ b/administrator/language/en-GB/en-GB.com_cpanel.ini
@@ -20,7 +20,6 @@ COM_CPANEL_MSG_EACCELERATOR_BODY="eAccelerator is not compatible with Joomla!. B
 COM_CPANEL_MSG_EACCELERATOR_BUTTON="Change to File."
 COM_CPANEL_MSG_EACCELERATOR_TITLE="eAccelerator is not compatible with Joomla!"
 COM_CPANEL_MSG_HTACCESS_BODY="A change to the default .htaccess and web.config files was made in Joomla! 3.4 to disallow directory listings by default.  Users are recommended to implement this change in their files.  Please see <a href="_QQ_"https://docs.joomla.org/Preconfigured_htaccess"_QQ_">this page</a> for more information."
-COM_CPANEL_MSG_HTACCESS_BUTTON="Acknowledge"
 COM_CPANEL_MSG_HTACCESS_TITLE=".htaccess & web.config Update"
 COM_CPANEL_MSG_PHPVERSION_BODY="Beginning with Joomla! 3.3, the version of PHP this site is using will no longer be supported. Joomla! 3.3 will require at least <a href="_QQ_"http://community.joomla.org/blogs/leadership/1798-raising-the-bar-on-security.html"_QQ_">PHP version 5.3.10 in order to provide enhanced security features to its users</a>."
 COM_CPANEL_MSG_PHPVERSION_TITLE="Your PHP Version Will Be Unsupported in Joomla! 3.3"


### PR DESCRIPTION
With #4171 we introduced a new postinstall message about the changed htaccess.txt and web.config.txt files.
That PR added a language string which isn't needed because we don't have an action assigned to that message. Thus there is no button to press beside the default "Hide Message".

This PR removes that string so translators don't have to translate it.
Since the string is not yet in a stable release (only in alpha and beta) we can still remove it without any backward compatibility issues.

@infograf768 Agree?
