### PR TITLE
Update html5fallback-uncompressed.js for fixing placeholder / numberType handling in ie8 / ie9

### DIFF
--- a/media/system/js/html5fallback-uncompressed.js
+++ b/media/system/js/html5fallback-uncompressed.js
@@ -83,6 +83,7 @@
 		polyfill : function(elem){
 			if(elem.nodeName.toLowerCase() === 'form')return true;
 			var	self = elem.form.H5Form;
+			if (typeof self != 'object') return;
 			self.placeholder(self, elem);
 			self.numberType(self, elem);
 		},
@@ -142,8 +143,10 @@
 			if(elem.form === undefined){
 				return null;
 			}
-			var	self = elem.form.H5Form,
-				$elem = $(elem),
+			var	self = elem.form.H5Form;
+			if (typeof self != 'object') return true;
+			
+			$elem = $(elem),
 				isMissing = false,
 				isRequired = !!($(elem).attr("required")),
 				isDisabled = !!($elem.attr("disabled"));

--- a/media/system/js/html5fallback-uncompressed.js
+++ b/media/system/js/html5fallback-uncompressed.js
@@ -82,8 +82,8 @@
 
 		polyfill : function(elem){
 			if(elem.nodeName.toLowerCase() === 'form')return true;
+			if(!elem.form || !elem.form.H5Form) return true; 
 			var	self = elem.form.H5Form;
-			if (typeof self != 'object') return;
 			self.placeholder(self, elem);
 			self.numberType(self, elem);
 		},
@@ -143,9 +143,9 @@
 			if(elem.form === undefined){
 				return null;
 			}
+			if(!elem.form || !elem.form.H5Form) return true; 
 			var	self = elem.form.H5Form;
-			if (typeof self != 'object') return true;
-			
+
 			$elem = $(elem),
 				isMissing = false,
 				isRequired = !!($(elem).attr("required")),


### PR DESCRIPTION
Fix for ie8/ie9 placeholder / numberType support
