### PR TITLE
[REFACTORING] Removing unnecessary trim in mod_languages

### DIFF
--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$headerText	= JString::trim($params->get('header_text'));
-$footerText	= JString::trim($params->get('footer_text'));
+$headerText	= $params->get('header_text');
+$footerText	= $params->get('footer_text');
 
 $list = ModLanguagesHelper::getList($params);
 


### PR DESCRIPTION
This trim is not necessary. It does not remove any UTF8 characters and multiple spaces in HTML are always contracted into one space. At the same time, the p-tag around the text lets the space vanish completely. This is simply an unnecessary function call and in worst case forces the JString library to be loaded where it doesn't have to be.
