### PR TITLE
Refactoring helper of mod_languages

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -30,19 +30,21 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-		$user	= JFactory::getUser();
-		$lang 	= JFactory::getLanguage();
-		$app	= JFactory::getApplication();
-		$menu 	= $app->getMenu();
+		$user		= JFactory::getUser();
+		$lang		= JFactory::getLanguage();
+		$languages	= JLanguageHelper::getLanguages();
+		$app		= JFactory::getApplication();
+		$menu		= $app->getMenu();
 
 		// Get menu home items
 		$homes = array();
+		$homes['*'] = $menu->getDefault('*');
 
-		foreach ($menu->getMenu() as $item)
+		foreach ($languages as $item)
 		{
-			if ($item->home)
+			if ($menu->getDefault($item->lang_code))
 			{
-				$homes[$item->language] = $item;
+				$homes[$item->lang_code] = $menu->getDefault($item->lang_code);
 			}
 		}
 
@@ -59,20 +61,16 @@ abstract class ModLanguagesHelper
 			}
 
 			// Load component associations
-			$option = $app->input->get('option');
-			$eName = JString::ucfirst(JString::str_ireplace('com_', '', $option));
-			$cName = JString::ucfirst($eName . 'HelperAssociation');
-			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+			$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
+			JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
 
-			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
+			if (class_exists($class) && is_callable(array($class, 'getAssociations')))
 			{
-				$cassociations = call_user_func(array($cName, 'getAssociations'));
+				$cassociations = call_user_func(array($class, 'getAssociations'));
 			}
 		}
 
 		$levels		= $user->getAuthorisedViewLevels();
-		$languages	= JLanguageHelper::getLanguages();
-		$activeLanguage = JFactory::getLanguage()->getTag();
 
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)
@@ -105,30 +103,18 @@ abstract class ModLanguagesHelper
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
-
-						if ($app->get('sef') == '1')
-						{
-							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
-						}
-						else
-						{
-							$language->link = 'index.php?lang=' . $language->sef . '&amp;Itemid=' . $itemid;
-						}
+						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
 					}
 					else
 					{
-						if ($language->lang_code == $activeLanguage)
+						if (isset($language->active))
 						{
 							$language->link = JUri::current();
 						}
-						elseif ($app->get('sef') == '1')
+						else
 						{
 							$itemid = isset($homes[$language->lang_code]) ? $homes[$language->lang_code]->id : $homes['*']->id;
 							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
-						}
-						else
-						{
-							$language->link = 'index.php?lang=' . $language->sef;
 						}
 					}
 				}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -92,7 +92,7 @@ abstract class ModLanguagesHelper
 			}
 			else
 			{
-				$language->active = $language->lang_code == $lang->getTag();
+				$language->active = ($language->lang_code == $lang->getTag());
 
 				if (JLanguageMultilang::isEnabled())
 				{
@@ -107,7 +107,7 @@ abstract class ModLanguagesHelper
 					}
 					else
 					{
-						if (isset($language->active))
+						if ($language->active)
 						{
 							$language->link = JUri::current();
 						}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -42,9 +42,11 @@ abstract class ModLanguagesHelper
 
 		foreach ($languages as $item)
 		{
-			if ($menu->getDefault($item->lang_code))
+			$default = $menu->getDefault($item->lang_code);
+
+			if ($default && $default->language == $item->lang_code)
 			{
-				$homes[$item->lang_code] = $menu->getDefault($item->lang_code);
+				$homes[$item->lang_code] = $default;
 			}
 		}
 


### PR DESCRIPTION
This speeds up the helper of mod_languages a bit and reduces the amount of code.

Line 40-49: Instead of cycling through all menu items and checking each if it is a home menu item, we are cycling through all languages (which should be a lot less than the menu items) and only retrieve the home menu item per language.

Line 64 + 65: The option parameter in Joomla only allows ASCII characters and class names are case insensitive. At the same time, JPATH_COMPONENT_SITE is already sanitized and does not need to be sanitized again. This could prevent loading JString unnecessarily.

Line 106: All links have to be processed by JRoute, regardless of SEF URLs being enabled or not.

Line 110: We are already checking if the currently processed language is the currently active language. We can use that result and thus remove the call in former line 75.

Line 114ff: The Itemid of a home menu item is always removed and thus we don't need a special case for SEF/non-SEF URLs.
