### PR TITLE
Fix display of mootools tooltips

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -308,8 +308,8 @@ abstract class JHtmlBehavior
 				var title = $(this).attr('title');
 				if (title) {
 					var parts = title.split('::', 2);
-					$(this).data('tip:title', parts[0]);
-					$(this).data('tip:text', parts[1]);
+					this.store('tip:title', parts[0]);
+					this.store('tip:text', parts[1]);
 				}
 			});
 			var JTooltips = new Tips($('$selector').get(), $options);

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -308,8 +308,9 @@ abstract class JHtmlBehavior
 				var title = $(this).attr('title');
 				if (title) {
 					var parts = title.split('::', 2);
-					this.store('tip:title', parts[0]);
-					this.store('tip:text', parts[1]);
+					var mtelement = document.id(this);
+					mtelement.store('tip:title', parts[0]);
+					mtelement.store('tip:text', parts[1]);
 				}
 			});
 			var JTooltips = new Tips($('$selector').get(), $options);


### PR DESCRIPTION
When using the old fashioned mootools tooltips they are not displayed correctly like you can see in the following picture.
![screen shot 2015-02-03 at 16 49 56](http://issues.joomla.org/uploads/1/f404493b8948d453a68403cf8840c2d4.jpg)
If using the mootools element storage they display correctly, you can see that in the next screen shot.
![screen shot 2015-02-03 at 16 50 22](http://issues.joomla.org/uploads/1/8fa4258e637af02abd12541ca22cb5f9.jpg)
