### PR TITLE
Making it possible to switch languages by fixing JLanguage::setLanguage()

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1257,7 +1257,7 @@ class JLanguage
 			$this->strings = array();
 			$this->paths = array();
 
-			foreach($extensions as $extension)
+			foreach ($extensions as $extension)
 			{
 				$this->load($extension);
 			}


### PR DESCRIPTION
### Problem

If you want to switch languages, for example because you are a languagefilter plugin and you are defining which language to load via the URL, you are out of luck if you are not the first plugin to be called and if this discovery process is not done in the constructor, because at that point, other plugins might have autoloaded the language and thus forced a language on you. JLanguage however currently is not able to switch between languages. JLanguage::setLanguage() does change the language, but it does not reload previously parsed files and it also does not update the callbacks. So this means that you have mixed-language translation strings, the wrong callbacks registered in the class and the metadata and the language name itself claim to be the new language.
### Proposal

By moving most of the code from the constructor to setLanguage(), we can make sure that with setLanguage() the whole object is in a consistent state. This should also be backwards compatible and rather fix bugs in existing code where people simply use JLanguage::setLanguage() and thus have our above described issues.
It should be made clear that this is not perfect. The code assumes that all files are loaded simply by handing over the extension name. If an extension manually loads files from a different location, then this will break for this pageload. However it will still be less buggy than right now.
