### PR TITLE
[REFACTORING] Optimizing system logout plugin

### DIFF
--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -44,7 +44,7 @@ class PlgSystemLogout extends JPlugin
 			$this->app->input->cookie->set($hash, false, time() - 86400, $cookie_path, $cookie_domain);
 
 			// Set the error handler for E_ALL to be the class handleError method.
-			JError::setErrorHandling(E_ALL, 'callback', array('PlgSystemLogout', 'handleError'));
+			JError::setErrorHandling(E_ALL, 'callback', array($this, 'handleError'));
 		}
 	}
 
@@ -81,7 +81,7 @@ class PlgSystemLogout extends JPlugin
 	 *
 	 * @since   1.6
 	 */
-	public static function handleError(&$error)
+	public function handleError(&$error)
 	{
 		// Make sure the error is a 403 and we are in the frontend.
 		if ($error->getCode() == 403 and $this->app->isSite())

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -40,7 +40,7 @@ class PlgSystemLogout extends JPlugin
 		{
 			// Destroy the cookie.
 			$cookie_domain 	= $this->app->get('cookie_domain');
-			$cookie_path 	= $this->app->get('cookie_path', $uri->base(true));
+			$cookie_path 	= $this->app->get('cookie_path', JUri::base(true));
 			$this->app->input->cookie->set($hash, false, time() - 86400, $cookie_path, $cookie_domain);
 
 			// Set the error handler for E_ALL to be the class handleError method.
@@ -65,7 +65,7 @@ class PlgSystemLogout extends JPlugin
 			// Create the cookie.
 			$hash 			= JApplicationHelper::getHash('PlgSystemLogout');
 			$cookie_domain 	= $this->app->get('cookie_domain');
-			$cookie_path 	= $this->app->get('cookie_path', $uri->base(true));
+			$cookie_path 	= $this->app->get('cookie_path', JUri::base(true));
 			$this->app->input->cookie->set($hash, true, time() + 86400, $cookie_path, $cookie_domain);
 		}
 

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -23,7 +23,7 @@ class PlgSystemLogout extends JPlugin
 	 * @since  3.4
 	 */
 	protected $app;
-	
+
 	/**
 	 * Register the custom error handler if the cookie is set
 	 * The cookie is set on logout of the user


### PR DESCRIPTION
This PR does not change the system, but optimizes it in a few key areas. This helps with testing and removes some minor potential issues.

The initialisation is done on onAfterInitialise instead of on constructing the plugin. That saves the additional code to call the parent constructor.

Since there is only one string in this plugin, the autoload feature is disabled and the language file is only loaded right before the string is used.

All calls to the application object or the config object have been replaced by calls to $this->app, which is autoinjected into the plugin. This allows to write unittests for this with a fake application object.

Reading and setting the cookie is done through the input object and not with setCookie. Also, the path for the cookie is set to the root of the Joomla installation. This prevents interferences between different installations on the same host. If you have for example a Joomla in /joomla and cloned version of that installation in /joomla_test, the cookie would be set when you logout of /joomla and /joomla_test would read that cookie and thus register the error handler. The chances are slim, but anyway...
