### PR TITLE
Fix Favicon URL issue on Windows platform

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -590,7 +590,7 @@ class JDocumentHTML extends JDocument
 
 			if (file_exists($icon))
 			{
-				$path = str_replace(JPATH_BASE . '/', '', $dir);
+				$path = str_replace(JPATH_BASE . DIRECTORY_SEPARATOR, '', $dir);
 				$path = str_replace('\\', '/', $path);
 				$this->addFavicon(JUri::base(true) . '/' . $path . 'favicon.ico');
 				break;


### PR DESCRIPTION
`JPATH_BASE . '/'` does not always remove the base path as `DIRECTORY_SEPARATOR` varies with platform. This should be replaced with `JPATH_BASE . DIRECTORY_SEPARATOR`.
