### PR TITLE
Fix #5955: Search Engine Friendly URLs is not friendly to TOS article

### DIFF
--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -71,25 +71,30 @@ class JFormFieldTos extends JFormFieldRadio
 		{
 			$label .= ' title="'
 				. htmlspecialchars(
-				trim($text, ':') . '<br />' . ($this->translateDescription ? JText::_($this->description) : $this->description),
-				ENT_COMPAT, 'UTF-8'
-			) . '"';
+					trim($text, ':') . '<br />' . ($this->translateDescription ? JText::_($this->description) : $this->description),
+					ENT_COMPAT, 'UTF-8'
+				) . '"';
 		}
 
 		$tosarticle = $this->element['article'] > 0 ? (int) $this->element['article'] : 0;
-
-		$link = '';
 
 		if ($tosarticle)
 		{
 			JLoader::register('ContentHelperRoute', JPATH_BASE . '/components/com_content/helpers/route.php');
 
-			$attribs = array();
+			$attribs          = array();
 			$attribs['class'] = 'modal';
-			$attribs['rel'] = '{handler: \'iframe\', size: {x:800, y:500}}';
+			$attribs['rel']   = '{handler: \'iframe\', size: {x:800, y:500}}';
 
-			// TODO: This is broken!! We need the category ID, too, and the language
-			$url = ContentHelperRoute::getArticleRoute($tosarticle);
+			$db    = JFactory::getDbo();
+			$query = $db->getQuery(true);
+			$query->select('id, alias, catid')
+				->from('#__content')
+				->where('id = ' . $tosarticle);
+			$db->setQuery($query);
+			$article = $db->loadObject();
+			$slug    = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
+			$url     = ContentHelperRoute::getArticleRoute($slug, $article->catid);
 
 			$link = JHtml::_('link', JRoute::_($url . '&tmpl=component'), $text, $attribs);
 		}


### PR DESCRIPTION
Please see https://github.com/joomla/joomla-cms/issues/5955 to understand the issue. 

To test this PR:
1. Enable "User - Profile" plugin and assign an article with TOS
2. Set "Search Engine Friendly URLs" to "Yes" at global configuration
3. Check and make sure When user wants create a account and click "Terms of Service:" link, it will show
   a modal box with TOS article.
