### PR TITLE
Shorten en-GB name

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.4" client="administrator">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<version>3.4.0</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB administrator language</description>
 	<metadata>
-		<name>English (UK)</name>
+		<name>English (en-GB)</name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB administrator language</description>
 	<metadata>
-		<name>English (United Kingdom)</name>
+		<name>English (UK)</name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB site language</description>
 	<metadata>
-		<name>English (United Kingdom)</name>
+		<name>English (UK)</name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.4" client="site">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<version>3.4.0</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB site language</description>
 	<metadata>
-		<name>English (UK)</name>
+		<name>English (en-GB)</name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -802,9 +802,9 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 			$this->object->get('tag')
 		);
 
-		// Note: property = name, returns English (United Kingdom) (default language)
+		// Note: property = name, returns English (en-GB) (default language)
 		$this->assertEquals(
-			'English (United Kingdom)',
+			'English (en-GB)',
 			$this->object->get('name')
 		);
 	}
@@ -817,7 +817,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testGetName()
 	{
 		$this->assertEquals(
-			'English (United Kingdom)',
+			'English (en-GB)',
 			$this->object->getName()
 		);
 	}
@@ -1006,7 +1006,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 		// In this case, returns array with default language
 		// - same operation of get method with metadata property
 		$options = array(
-			'name' => 'English (United Kingdom)',
+			'name' => 'English (en-GB)',
 			'tag' => 'en-GB',
 			'rtl' => '0',
 			'locale' => $localeString,


### PR DESCRIPTION
This is a really simple but useful change for improving the UI

In the language overrides there is a filter for selecting site or administrator language file BUT as the name is so long "English (United Kingdom) - Administrator"  it wraps and means it is not obvious what the filter is for. See screenshots of both open and closed states

This has no effect on any other language - some already tweak their names to make it fit better

Using UK is probably more common that writing United Kingdom
### Before

![egvs](https://cloud.githubusercontent.com/assets/1296369/6044044/ac8b0e08-ac88-11e4-9ba6-111d204db03f.png)

![p2x1](https://cloud.githubusercontent.com/assets/1296369/6043991/4ab4d952-ac88-11e4-9f41-f30d37a75cd4.png)
### After

![after](https://cloud.githubusercontent.com/assets/1296369/6044021/827958e0-ac88-11e4-98af-a1a4a4c6433c.png)

![ibed](https://cloud.githubusercontent.com/assets/1296369/6043969/255e25f0-ac88-11e4-9d7c-ae6b035c9e60.png)
