### PR TITLE
Redirect Manager : search broken. Removing required attribute from batch_urls textarea as it was breaking ...

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default_batch.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
 		<div class="row-fluid">
 			<div class="control-group span12">
 				<div class="controls">
-					<textarea class="span12" rows="10" aria-required="true" required="" value="" id="batch_urls" name="batch_urls"></textarea>
+					<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/issues/5659
Since batch_urls (for batch updates) and the search function are all part of the same form having the required attribute on the batch_urls textarea was breaking search functionality. Removing the required attribute restore search. Someone could run a batch process without any content, but it will just give them an error on the redirects links page saying "No links added."
