### PR TITLE
JFormRuleEquals doesnt take into account group

### DIFF
--- a/libraries/joomla/form/rule/equals.php
+++ b/libraries/joomla/form/rule/equals.php
@@ -57,7 +57,7 @@ class JFormRuleEquals extends JFormRule
 			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
 		}
 
-		if (isset($group))
+		if (isset($group) && $group != '')
 		{
 			$test = $input->get($group . '.' . $field);
 		}

--- a/libraries/joomla/form/rule/equals.php
+++ b/libraries/joomla/form/rule/equals.php
@@ -57,8 +57,17 @@ class JFormRuleEquals extends JFormRule
 			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
 		}
 
+		if(isset($group))
+		{
+			$test = $input->get($group.'.'.$field);
+		}
+		else
+		{
+			$test = $input->get($field);
+		}
+
 		// Test the two values against each other.
-		if ($value == $input->get($field))
+		if ($value == $test)
 		{
 			return true;
 		}

--- a/libraries/joomla/form/rule/equals.php
+++ b/libraries/joomla/form/rule/equals.php
@@ -57,9 +57,9 @@ class JFormRuleEquals extends JFormRule
 			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));
 		}
 
-		if(isset($group))
+		if (isset($group))
 		{
-			$test = $input->get($group.'.'.$field);
+			$test = $input->get($group . '.' . $field);
 		}
 		else
 		{


### PR DESCRIPTION
The rule equals doesnt take into account group fields so we cant validate this rule.
## To reproduce the issue

Setup JForm XML form with a group + use field to validate equals:
ex:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<form>
  <fields name="example">
   <field name="name" type="text" ... />
    <field name="password" type="password"
      autocomplete="off"
      class="validate-password"
      description="DESIRED_PASSWORD"
      field="password"
      filter="raw"
      label="PASSWORD_LABEL"
      size="10"
      validate="password"
      required="true"
    />
    <field name="password2" type="password"
      autocomplete="off"
      class="validate-password"
      description="PASSWORD2_DESC"
      field="password"
      filter="raw"
      label="PASSWORD2_LABEL"
      message="PASSWORD1_MESSAGE"
      size="30"
      validate="equals"
      required="true"
    />
 </fields>
</form>
```

OR use this custom component: https://github.com/Devportobello/joomla-attach-PR-5979
## Expected result

Comparing password fields when password == password2 return true
## Actual result

Comparing password fields dont return true if password == password2
## System information

Joomla : Joomla! 3.4.1 Stable [ Ember ] 21-March-2015 20:30 GMT
PHP : 5.5.12
Apache : 2.4.9
## Additional comments

Group are not taked into account when comparing value of those fields
### Test instructions
- Download ZIP of com_test at https://github.com/Devportobello/joomla-attach-PR-5979
- Install it.
- Have a look into components/com_test/models/fields/test.xml if you want to.
- Go to frontend home. Add /?option=com_test to URL.
- Type "test" on all password field
- Submit form, you will see an error message about password2 not equals
- Apply patch
- Type "test" on all password field
- Submit form, you will see <code>string 'OK' (length=2)</code> (used to exit code before save)
