### PR TITLE
Set a 500 header if we hit the 'Error display the error page' message

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -75,6 +75,12 @@ class JErrorPage
 		}
 		catch (Exception $e)
 		{
+			// Try to set a 500 header if they haven't already been sent
+			if (!headers_sent())
+			{
+				header('HTTP/1.1 500 Internal Server Error');
+			}
+
 			exit('Error displaying the error page: ' . $e->getMessage() . ': ' . $error->getMessage());
 		}
 	}


### PR DESCRIPTION
In error conditions that cannot render the error template, we fall back to just echoing a message.  However, it is possible that this message will send a HTTP 200 OK header.  In reality, we should be sending an error header back.  This PR will try to send a HTTP 500 error header if the headers have not already been sent.
### Test Instructions

The easiest way to get here is to have your database server offline.  Without the patch, you should get a HTTP 200 header when you see this message.  Apply the patch and try the request again; a 500 header should be sent.
