### PR TITLE
Improvements in JInstaller classes

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -115,7 +115,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 *
 	 * @since   3.4
 	 */
-	public function __construct(JInstaller $parent, $db, $options = array())
+	public function __construct(JInstaller $parent, JDatabaseDriver $db, array $options = array())
 	{
 		parent::__construct($parent, $db, $options);
 

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -2297,12 +2297,26 @@ class JInstaller extends JAdapter
 	 */
 	public function loadAdapter($adapter, $options = array())
 	{
-		$class = 'JInstallerAdapter' . ucfirst($adapter);
+		$class = $this->_classprefix . ucfirst($adapter);
 
-		// Verify the class exists
 		if (!class_exists($class))
 		{
-			throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
+			// @deprecated 4.0 - The adapter should be autoloaded or manually included by the caller
+			$path = $this->_basepath . '/' . $this->_adapterfolder . '/' . $adapter . '.php';
+
+			// Try to load the adapter object
+			if (!file_exists($path))
+			{
+				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
+			}
+
+			// Try once more to find the class
+			require_once $path;
+
+			if (!class_exists($class))
+			{
+				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
+			}
 		}
 
 		// Ensure the adapter type is part of the options array

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -119,12 +119,8 @@ class JInstaller extends JAdapter
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($basepath = null, $classprefix = null, $adapterfolder = null)
+	public function __construct($basepath = __DIR__, $classprefix = 'JInstallerAdapter', $adapterfolder = 'adapter')
 	{
-		$basepath      = ($basepath === null) ? __DIR__ : $basepath;
-		$classprefix   = ($classprefix === null) ? 'JInstallerAdapter' : $classprefix;
-		$adapterfolder = ($adapterfolder === null) ? 'adapter' : $adapterfolder;
-
 		parent::__construct($basepath, $classprefix, $adapterfolder);
 
 		$this->extension = JTable::getInstance('extension');
@@ -141,7 +137,7 @@ class JInstaller extends JAdapter
 	 *
 	 * @since   3.1
 	 */
-	public static function getInstance($basepath = null, $classprefix = null, $adapterfolder = null)
+	public static function getInstance($basepath = __DIR__, $classprefix = 'JInstallerAdapter', $adapterfolder = 'adapter')
 	{
 		if (!isset(self::$instance))
 		{

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -113,14 +113,19 @@ class JInstaller extends JAdapter
 	/**
 	 * Constructor
 	 *
+	 * @param   string  $basepath       Base Path of the adapters
+	 * @param   string  $classprefix    Class prefix of adapters
+	 * @param   string  $adapterfolder  Name of folder to append to base path
+	 *
 	 * @since   3.1
 	 */
-	public function __construct()
+	public function __construct($basepath = null, $classprefix = null, $adapterfolder = null)
 	{
-		parent::__construct(__DIR__, 'JInstallerAdapter', __DIR__ . '/adapter');
+		$basepath      = ($basepath === null) ? __DIR__ : $basepath;
+		$classprefix   = ($classprefix === null) ? 'JInstallerAdapter' : $classprefix;
+		$adapterfolder = ($adapterfolder === null) ? 'adapter' : $adapterfolder;
 
-		// Override the default adapter folder
-		$this->_adapterfolder = 'adapter';
+		parent::__construct($basepath, $classprefix, $adapterfolder);
 
 		$this->extension = JTable::getInstance('extension');
 	}

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -131,18 +131,21 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Returns the global Installer object, only creating it
-	 * if it doesn't already exist.
+	 * Returns the global Installer object, only creating it if it doesn't already exist.
+	 *
+	 * @param   string  $basepath       Base Path of the adapters
+	 * @param   string  $classprefix    Class prefix of adapters
+	 * @param   string  $adapterfolder  Name of folder to append to base path
 	 *
 	 * @return  JInstaller  An installer object
 	 *
 	 * @since   3.1
 	 */
-	public static function getInstance()
+	public static function getInstance($basepath = null, $classprefix = null, $adapterfolder = null)
 	{
 		if (!isset(self::$instance))
 		{
-			self::$instance = new JInstaller;
+			self::$instance = new JInstaller($basepath, $classprefix, $adapterfolder);
 		}
 
 		return self::$instance;

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -107,8 +107,17 @@ class JInstaller extends JAdapter
 	 *
 	 * @var    JInstaller
 	 * @since  3.1
+	 * @deprecated  4.0
 	 */
 	protected static $instance;
+
+	/**
+	 * JInstaller instances container.
+	 *
+	 * @var    JInstaller[]
+	 * @since  3.4
+	 */
+	protected static $instances;
 
 	/**
 	 * Constructor
@@ -139,12 +148,18 @@ class JInstaller extends JAdapter
 	 */
 	public static function getInstance($basepath = __DIR__, $classprefix = 'JInstallerAdapter', $adapterfolder = 'adapter')
 	{
-		if (!isset(self::$instance))
+		if (!isset(self::$instances[$basepath]))
 		{
-			self::$instance = new JInstaller($basepath, $classprefix, $adapterfolder);
+			self::$instances[$basepath] = new JInstaller($basepath, $classprefix, $adapterfolder);
+
+			// For B/C, we load the first instance into the static $instance container, remove at 4.0
+			if (!isset(self::$instance))
+			{
+				self::$instance = self::$instances[$basepath];
+			}
 		}
 
-		return self::$instance;
+		return self::$instances[$basepath];
 	}
 
 	/**


### PR DESCRIPTION
A small regression was introduced into `JInstaller` via the `loadAdapter()` method which required all adapter classes to have a `JInstallerAdapter` prefix.  One of the changes in this PR addresses that by restoring the behavior from the foreach loop in `JAdapter::loadAllAdapters()` to allow alternate class names and attempting to manually load the file.  The manual load code is deprecated for 4.0 and the caller should either perform this function themselves or make their code autoloadable.

Next, the `JInstallerAdapter` class which extends from `JAdapterInstance` had a more lenient constructor by not typehinting the database and option params.  This is changed to match the parent class' typehinting.  It should be B/C to 3.3 as the extension adapters previously all extended from `JAdapterInstance` and the `JInstallerAdapter` class is a new intermediary class in that chain.

Lastly, the `JInstaller` constructor did not accept any of the params that its parent, `JAdapter`, and instead always injected its forced params into the class.  The constructor now allows the params to be injected and will fall back to the previous default values if custom values are not injected.
