### PR TITLE
Update Version History in  Readme for 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ What is this?
 ---------------------
 * This is a Joomla! 3.x installation/upgrade package.
 * Joomla's [Official website](http://www.joomla.org).
-* Joomla! 3.3 [version history](https://docs.joomla.org/Joomla_3.3_version_history).
+* Joomla! 3.4 [version history](https://docs.joomla.org/Joomla_3.4_version_history).
 * Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/master).
 
 What is Joomla?

--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 1- What is this?
 	* This is a Joomla! installation/upgrade package to version 3.x
 	* Joomla! Official site: http://www.joomla.org
-	* Joomla 3.3 version history - https://docs.joomla.org/Joomla_3.3_version_history
+	* Joomla! 3.4 version history - https://docs.joomla.org/Joomla_3.4_version_history
 	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/master
 
 2- What is Joomla?


### PR DESCRIPTION
Simple PR to change the link to the 3.3 Version history on the docs site to the newly created 3.4 Version history page
