### PR TITLE
Fix  #5990: Menu item alias to menu external url is not working

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -97,8 +97,16 @@ class ModMenuHelper
 							break;
 
 						case 'alias':
-							// If this is an alias use the item id stored in the parameters to make the link.
-							$item->flink = 'index.php?Itemid=' . $item->params->get('aliasoptions');
+							$aliasItem = $menu->getItem($item->params->get('aliasoptions'));
+							if ($aliasItem->type == 'url')
+							{
+								$item->flink = $aliasItem->link;
+							}
+							else
+							{
+								// If this is an alias use the item id stored in the parameters to make the link.
+								$item->flink = 'index.php?Itemid=' . $item->params->get('aliasoptions');
+							}
 							break;
 
 						default:

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -98,6 +98,7 @@ class ModMenuHelper
 
 						case 'alias':
 							$aliasItem = $menu->getItem($item->params->get('aliasoptions'));
+
 							if ($aliasItem->type == 'url')
 							{
 								$item->flink = $aliasItem->link;


### PR DESCRIPTION
Please see https://github.com/joomla/joomla-cms/issues/5990 for description of the issue.

To test it:
1. Create a menu item url, called "External", pointing to http://joomla.org for example
2. Create a menu item alias of the above menu item.
3. Apply this PR
4. Check and make sure the two menu items above work well.
