### PR TITLE
removing an obsolete attribute for a formfield

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -12,7 +12,6 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			statuses="*,0,1,2,-2"
 			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>

--- a/administrator/components/com_banners/models/forms/filter_clients.xml
+++ b/administrator/components/com_banners/models/forms/filter_clients.xml
@@ -12,7 +12,6 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			statuses="*,0,1,2,-2"
 			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -25,7 +25,6 @@
 			name="published"
 			type="status"
 			label="COM_CATEGORIES_FILTER_PUBLISHED"
-			statuses="*,0,1,2,-2"
 			description="COM_CATEGORIES_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -12,7 +12,6 @@
 			name="published"
 			type="status"
 			label="COM_CONTENT_FILTER_PUBLISHED"
-			statuses="*,0,1,2,-2"
 			description="COM_CONTENT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -19,7 +19,6 @@
 			name="published"
 			type="status"
 			label="COM_MENUS_FILTER_PUBLISHED"
-			statuses="*,0,1,2,-2"
 			description="COM_MENUS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>


### PR DESCRIPTION
# Executive summary

This patch removes a useless and wrong attribute from a FormField

The removed line is:

```
statuses="*,0,1,2,-2"
```

It seems that this should be something like a filter but if that is the case it has to be

```
filter="*,0,1,2,-2"
```

but because the filter filters on all states it filters on nothing so it is obsolet.
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Testing instructions

Unfortunately this Patch can’t be testet directly because we aren’t filter on something, so we have two options to make sure I am right.
## A) Option 1 - Changing files

1) Open the file:
    administrator/components/com_banner/models/forms/filter_banners.xml

2) Change the line

```
statuses="*,0,1,2,-2"
```

to

```
statuses="*,0,1"
```

3) Save

4) Log into to backend and go to Banners/Banners and check the Status select

5) You should see all Status:
- Trashed
- Published
- Unpublished
- Archived
- All

6) Now change

```
statuses="*,0,1"
```

to

```
filter="*,0,1"
```

7) You should see the Status:
- Published
- Unpublished
- All
## B) Option 2 - by code review

If you open the file:
libraries/cms/form/field/status.php
you can see that this class is extending „JFormFieldPredefinedList“ in
libraries/joomla/form/fields/predefinedlist.php

in line 73 you can see that the used attribute is „filter“, nothing to find that is called „statuses“
