### PR TITLE
[#5332] Fix for menu heading options issue in module

### DIFF
--- a/administrator/components/com_menus/models/forms/item_heading.xml
+++ b/administrator/components/com_menus/models/forms/item_heading.xml
@@ -4,6 +4,27 @@
 		<fieldset name="menu-options"
 			label="COM_MENUS_LINKTYPE_OPTIONS_LABEL"
 		>
+			<field name="menu-anchor_title" type="text"
+				label="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_LABEL"
+				description="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_DESC" />
+
+			<field name="menu-anchor_css" type="text"
+				label="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_LABEL"
+				description="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_DESC" />
+
+			<field name="menu_image" type="media"
+				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
+				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" />
+
+			<field name="menu_text" type="radio"
+				class="btn-group btn-group-yesno"
+				label="COM_MENUS_ITEM_FIELD_MENU_TEXT_LABEL"
+				description="COM_MENUS_ITEM_FIELD_MENU_TEXT_DESC"
+				default="1" filter="integer"
+			>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>		
 		</fieldset>
 	</fields>
 	<help key="JHELP_MENUS_MENU_ITEM_MENU_ITEM_HEADING" />

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -9,5 +9,17 @@
 
 defined('_JEXEC') or die;
 
+$title = $item->anchor_title ? 'title="' . $item->anchor_title . '" ' : '';
+
+if ($item->menu_image)
+{
+	$item->params->get('menu_text', 1) ?
+	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" /><span class="image-title">' . $item->title . '</span> ' :
+	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" />';
+}
+else
+{
+	$linktype = $item->title;
+}
 ?>
-<span class="nav-header"><?php echo $item->title; ?></span>
+<span class="nav-header <?php echo $item->anchor_css; ?>" <?php echo $title; ?>><?php echo $linktype; ?></span>


### PR DESCRIPTION
This is just so that menu headings have the same sort of generic common options as other menu item types.

Bug #5332 

See...
https://github.com/joomla/joomla-cms/issues/5332
...or in...
http://issues.joomla.org/tracker/joomla-cms/5332
