### PR TITLE
Store dynamic variables into the JavaScript language store

### DIFF
--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -364,6 +364,18 @@ class JText
 	/**
 	 * Store dynamic variables into the JavaScript language store.
 	 *
+	 * Examples:
+	 * Delare dynamic script variable in php page
+	 * <?php JText::scriptVar('article_title', $this->item->title); ?>
+	 *
+	 * Use this variable in any javascript file or declaration.
+	 * This will print article title in browser console.
+	 * <script>
+	 * jQuery(window).on('load',  function() {
+	 * 		console.log(Joomla.JText._('ARTICLE_TITLE'));
+	 * });
+	 * </script>
+	 *
 	 * @param   string  $key    The JText key.
 	 * @param   string  $value  Ensure the output is JavaScript safe.
 	 *

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -360,4 +360,25 @@ class JText
 
 		return self::$strings;
 	}
+
+	/**
+	 * Store dynamic variables into the JavaScript language store.
+	 *
+	 * @param   string  $key    The JText key.
+	 * @param   string  $value  Ensure the output is JavaScript safe.
+	 *
+	 * @return  string
+	 *
+	 * @since   11.1
+	 */
+	public static function scriptVar($key, $value)
+	{
+		// Add keys and values into strings array
+		self::$strings[strtoupper($key)] = $value;
+
+		// Load core.js dependence
+		JHtml::_('behavior.core');
+
+		return self::$strings;
+	}
 }

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -376,8 +376,8 @@ class JText
 	 * });
 	 * </script>
 	 *
-	 * @param   string  $key    The JText key.
-	 * @param   string  $value  Ensure the output is JavaScript safe.
+	 * @param   string  $key    Dynamic Variable Key
+	 * @param   string  $value  Value of the variable declaration.
 	 *
 	 * @return  string
 	 *


### PR DESCRIPTION
This patch will improve the functionality of `Joomla.JText._()` javascript function by supporting dynamic variable declaration easily.
#### For Example:

---

**Let's try to get article title in javascript file.**
- In `components/com_content/views/article/tmpl/default.php`

``` Php
JText::scriptVar('article', $this->item->title);
```
- Use this variable in javscript file or declaration

``` javascript
jQuery(window).on('load',  function() {
    // Print in console
    console.log(Joomla.JText._('ARTICLE'));

    // Or try to alert the value
    alert(Joomla.JText._('ARTICLE'));
});
```

This will print article title in browser console.
#### Backwards compatibility

---

Full b/c, no problems are expected
#### Testing instructions

---

Try to follow the given example.
