### PR TITLE
DB Query count shown in non-admin pages. Issuse 5997.

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1096,6 +1096,11 @@ class PlgSystemDebug extends JPlugin
 			$labelClass = 'label-warning';
 		}
 
+		if ($this->totalQueries == 0)
+		{
+			$this->totalQueries = $db->getCount();
+		}
+
 		$html = array();
 
 		$html[] = '<h4>' . JText::sprintf('PLG_DEBUG_QUERIES_LOGGED', $this->totalQueries)


### PR DESCRIPTION
The `$this->totalQueries` was not getting initialized in the case of non-admin pages. So, I manually initialized that just before it gets included in the code. Issue #5997 
