### PR TITLE
Deprecate JLanguage::setLanguage()

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1259,9 +1259,12 @@ class JLanguage
 	 * @return  string  Previous value.
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0 (CMS) - Instantiate a new JLanguage object instead
 	 */
 	public function setLanguage($lang)
 	{
+		JLog::add(__METHOD__ . ' is deprecated. Instantiate a new JLanguage object instead.', JLog::WARNING, 'deprecated');
+
 		$previous = $this->lang;
 		$this->lang = $lang;
 		$this->metadata = $this->getMetadata($this->lang);


### PR DESCRIPTION
Point blank, `JLanguage::setLanguage()` is a terrible API endpoint and can break JLanguage when used.  What the API endpoint suggests to do is essentially overload the current JLanguage instance with a new language, however it does not deal with re-loading pre-loaded language files or JLanguage's internal cache.

Uses of this method should be discouraged and instead a new JLanguage object be instantiated where this behavior was previously used.
