### PR TITLE
Added change trigger when checking the radio input

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -29,6 +29,7 @@
 					label.addClass('active btn-success');
 				}
 				input.prop('checked', true);
+				input.trigger('change');
 			}
 		});
 		$('.btn-group input[checked=checked]').each(function()


### PR DESCRIPTION
When a radio button group changes its state, the "change" trigger is not called.

Steps to test:
1. Go to Articles => Options
2. Open the Browser console (or Firebug etc.) and type in the following:

``` javascript
jQuery('#jform_show_title0').on('change', function() { alert('Title shown'); });
jQuery('#jform_show_title1').on('change', function() { alert('Title hidden'); });
```
1. Toggle the "Show title" option => nothing happens
2. Apply patch
3. Try again
