### PR TITLE
Inline setLanguage functions to JLanguage constructor

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -190,7 +190,8 @@ class JLanguage
 			$lang = $this->default;
 		}
 
-		$this->setLanguage($lang);
+		$this->lang = $lang;
+		$this->metadata = $this->getMetadata($this->lang);
 		$this->setDebug($debug);
 
 		$filename = JPATH_BASE . "/language/overrides/$lang.override.ini";


### PR DESCRIPTION
To avoid a deprecation log message on every request, this PR copies what setLanguage actually performs into the JLanguage constructor.
