### PR TITLE
JLogLoggerCallback throws a non-existing exception

### DIFF
--- a/libraries/joomla/log/logger/callback.php
+++ b/libraries/joomla/log/logger/callback.php
@@ -31,6 +31,7 @@ class JLogLoggerCallback extends JLogLogger
 	 * @param   array  &$options  Log object options.
 	 *
 	 * @since   12.2
+	 * @throws  RuntimeException
 	 */
 	public function __construct(array &$options)
 	{
@@ -38,14 +39,12 @@ class JLogLoggerCallback extends JLogLogger
 		parent::__construct($options);
 
 		// Throw an exception if there is not a valid callback
-		if (isset($this->options['callback']) && is_callable($this->options['callback']))
+		if (!isset($this->options['callback']) || !is_callable($this->options['callback']))
 		{
-			$this->callback = $this->options['callback'];
+			throw new RuntimeException('JLogLoggerCallback created without valid callback function.');
 		}
-		else
-		{
-			throw new JLogException(JText::_('JLogLoggerCallback created without valid callback function.'));
-		}
+
+		$this->callback = $this->options['callback'];
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/log/loggers/JLogLoggerCallbackTest.php
+++ b/tests/unit/suites/libraries/joomla/log/loggers/JLogLoggerCallbackTest.php
@@ -174,6 +174,21 @@ class JLogLoggerCallbackTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the JLogLoggerCallback::__construct method.
+	 *
+	 * @return  null
+	 *
+	 * @since   12.2
+	 * @expectedException  RuntimeException
+	 */
+	public function testConstructorForException()
+	{
+		$options = array();
+
+		new JLogLoggerCallback($options);
+	}
+
+	/**
 	 * Test the JLogLoggerCallback::addEntry method.
 	 *
 	 * @return  null


### PR DESCRIPTION
Note: There are not any uses of this logger in the core CMS, so this one is either going to have to rely on unit tests & code review or I'll have to spend time writing an extension just to make this testable.

JLogLoggerCallback verifies that is has a callback and it is callable in its constructor and throws an exception if these conditions are not met.  The problem here is that we do not have a `JLogException` exception, nor was the error condition unit tested.  This PR addresses that.
