### PR TITLE
JInstaller Fixes

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -180,7 +180,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		if (file_exists($this->parent->getPath('extension_root')) && (!$this->parent->isOverwrite() || $this->parent->isUpgrade()))
 		{
 			// Look for an update function or update tag
-			$updateElement = $this->manifest->update;
+			$updateElement = $this->getManifest()->update;
 
 			// Upgrade manually set or update function available or update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
@@ -411,9 +411,9 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		$route = $this->route == 'discover_install' ? 'install' : $this->route;
 
 		// Let's run the install queries for the component
-		if (isset($this->manifest->{$route}->sql))
+		if (isset($this->getManifest()->{$route}->sql))
 		{
-			$result = $this->parent->parseSQLFiles($this->manifest->{$route}->sql);
+			$result = $this->parent->parseSQLFiles($this->getManifest()->{$route}->sql);
 
 			if ($result === false)
 			{
@@ -488,12 +488,6 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 */
 	public function getManifest()
 	{
-		if (!$this->manifest)
-		{
-			// We are trying to find manifest for the installed extension.
-			$this->manifest = $this->parent->getManifest();
-		}
-
 		return $this->manifest;
 	}
 
@@ -758,16 +752,16 @@ abstract class JInstallerAdapter extends JAdapterInstance
 			}
 
 			// Set the schema version to be the latest update version
-			if ($this->manifest->update)
+			if ($this->getManifest()->update)
 			{
-				$this->parent->setSchemaVersion($this->manifest->update->schemas, $this->extension->extension_id);
+				$this->parent->setSchemaVersion($this->getManifest()->update->schemas, $this->extension->extension_id);
 			}
 		}
 		elseif ($this->route == 'update')
 		{
-			if ($this->manifest->update)
+			if ($this->getManifest()->update)
 			{
-				$result = $this->parent->parseSchemaUpdates($this->manifest->update->schemas, $this->extension->extension_id);
+				$result = $this->parent->parseSchemaUpdates($this->getManifest()->update->schemas, $this->extension->extension_id);
 
 				if ($result === false)
 				{
@@ -809,6 +803,22 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	}
 
 	/**
+	 * Set the manifest object.
+	 *
+	 * @param   object  $manifest  The manifest object
+	 *
+	 * @return  JInstallerAdapter  Instance of this class to support chaining
+	 *
+	 * @since   3.4
+	 */
+	public function setManifest($manifest)
+	{
+		$this->manifest = $manifest;
+
+		return $this;
+	}
+
+	/**
 	 * Set the install route being followed
 	 *
 	 * @param   string  $route  The install route being followed
@@ -843,7 +853,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	protected function setupScriptfile()
 	{
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
-		$manifestScript = (string) $this->manifest->scriptfile;
+		$manifestScript = (string) $this->getManifest()->scriptfile;
 
 		if ($manifestScript)
 		{

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -274,29 +274,6 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 */
 	public function discover_install()
 	{
-		// Check if this is supported
-		if (!$this->supportsDiscoverInstall)
-		{
-			$this->parent->abort(
-				JText::sprintf('JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED', $this->type)
-			);
-
-			return false;
-		}
-
-		// Prepare the discover install for the adapter
-		try
-		{
-			$this->prepareDiscoverInstall();
-		}
-		catch (RuntimeException $e)
-		{
-			// Install failed, roll back changes
-			$this->parent->abort($e->getMessage());
-
-			return false;
-		}
-
 		// Get the extension's description
 		$description = (string) $this->getManifest()->description;
 
@@ -451,6 +428,18 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	{
 		$lang = JFactory::getLanguage();
 		$lang->load($extension . '.sys', $source, null, false, true) || $lang->load($extension . '.sys', $base, null, false, true);
+	}
+
+	/**
+	 * Checks if the adapter supports discover_install
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.4
+	 */
+	public function getDiscoverInstallSupported()
+	{
+		return $this->supportsDiscoverInstall;
 	}
 
 	/**
@@ -797,7 +786,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 *
 	 * @since   3.4
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		// Adapters may not support discover install or may have overridden the default task and aren't using this
 	}

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -75,7 +75,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		if (file_exists($this->parent->getPath('extension_site')) || file_exists($this->parent->getPath('extension_administrator')))
 		{
 			// Look for an update function or update tag
-			$updateElement = $this->manifest->update;
+			$updateElement = $this->getManifest()->update;
 
 			// Upgrade manually set or update function available or update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
@@ -122,15 +122,15 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	protected function copyBaseFiles()
 	{
 		// Copy site files
-		if ($this->manifest->files)
+		if ($this->getManifest()->files)
 		{
 			if ($this->route == 'update')
 			{
-				$result = $this->parent->parseFiles($this->manifest->files, 0, $this->oldFiles);
+				$result = $this->parent->parseFiles($this->getManifest()->files, 0, $this->oldFiles);
 			}
 			else
 			{
-				$result = $this->parent->parseFiles($this->manifest->files);
+				$result = $this->parent->parseFiles($this->getManifest()->files);
 			}
 
 			if ($result === false)
@@ -145,15 +145,15 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		}
 
 		// Copy admin files
-		if ($this->manifest->administration->files)
+		if ($this->getManifest()->administration->files)
 		{
 			if ($this->route == 'update')
 			{
-				$result = $this->parent->parseFiles($this->manifest->administration->files, 1, $this->oldAdminFiles);
+				$result = $this->parent->parseFiles($this->getManifest()->administration->files, 1, $this->oldAdminFiles);
 			}
 			else
 			{
-				$result = $this->parent->parseFiles($this->manifest->administration->files, 1);
+				$result = $this->parent->parseFiles($this->getManifest()->administration->files, 1);
 			}
 
 			if ($result === false)
@@ -376,18 +376,16 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$this->parent->setPath('source', $client . '/components/' . $this->parent->extension->element);
 		}
 
-		// Set the manifest object
-		$this->manifest = $this->getManifest();
-		$extension      = $this->getElement();
-		$source         = $path ? $path : $client . '/components/' . $extension;
+		$extension = $this->getElement();
+		$source    = $path ? $path : $client . '/components/' . $extension;
 
-		if ($this->manifest->administration->files)
+		if ($this->getManifest()->administration->files)
 		{
-			$element = $this->manifest->administration->files;
+			$element = $this->getManifest()->administration->files;
 		}
-		elseif ($this->manifest->files)
+		elseif ($this->getManifest()->files)
 		{
-			$element = $this->manifest->files;
+			$element = $this->getManifest()->files;
 		}
 		else
 		{
@@ -417,9 +415,9 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	protected function parseOptionalTags()
 	{
 		// Parse optional tags
-		$this->parent->parseMedia($this->manifest->media);
-		$this->parent->parseLanguages($this->manifest->languages);
-		$this->parent->parseLanguages($this->manifest->administration->languages, 1);
+		$this->parent->parseMedia($this->getManifest()->media);
+		$this->parent->parseLanguages($this->getManifest()->languages);
+		$this->parent->parseLanguages($this->getManifest()->administration->languages, 1);
 	}
 
 	/**
@@ -517,7 +515,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
 
 		// Make sure that we have an admin element
-		if (!$this->manifest->administration)
+		if (!$this->getManifest()->administration)
 		{
 			throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_COMP_INSTALL_ADMIN_ELEMENT'));
 		}
@@ -699,9 +697,9 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		// Get the package manifest object
 		// We do findManifest to avoid problem when uninstalling a list of extension: getManifest cache its manifest file
 		$this->parent->findManifest();
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
-		if (!$this->manifest)
+		if (!$this->getManifest())
 		{
 			// Make sure we delete the folders if no manifest exists
 			JFolder::delete($this->parent->getPath('extension_administrator'));
@@ -761,9 +759,9 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 		// Let's remove those language files and media in the JROOT/images/ folder that are
 		// associated with the component we are uninstalling
-		$this->parent->removeFiles($this->manifest->media);
-		$this->parent->removeFiles($this->manifest->languages);
-		$this->parent->removeFiles($this->manifest->administration->languages, 1);
+		$this->parent->removeFiles($this->getManifest()->media);
+		$this->parent->removeFiles($this->getManifest()->languages);
+		$this->parent->removeFiles($this->getManifest()->administration->languages, 1);
 
 		// Remove the schema version
 		$query = $db->getQuery(true)
@@ -906,7 +904,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		}
 
 		// Ok, now its time to handle the menus.  Start with the component root menu, then handle submenus.
-		$menuElement = $this->manifest->administration->menu;
+		$menuElement = $this->getManifest()->administration->menu;
 
 		// Just do not create the menu if $menuElement not exist
 		if (!$menuElement)
@@ -967,13 +965,13 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		 * Process SubMenus
 		 */
 
-		if (!$this->manifest->administration->submenu)
+		if (!$this->getManifest()->administration->submenu)
 		{
 			// No submenu? We're done.
 			return true;
 		}
 
-		foreach ($this->manifest->administration->submenu->menu as $child)
+		foreach ($this->getManifest()->administration->submenu->menu as $child)
 		{
 			$data = array();
 			$data['menutype'] = 'main';

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -428,7 +428,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	 * @since   3.4
 	 * @throws  RuntimeException
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		// Need to find to find where the XML file is since we don't store this normally
 		$client = JApplicationHelper::getClientInfo($this->extension->client_id);
@@ -438,6 +438,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		$this->parent->setPath('manifest', $manifestPath);
 		$this->parent->setPath('source', $client->path . '/components/' . $this->extension->element);
 		$this->parent->setPath('extension_root', $this->parent->getPath('source'));
+		$this->setManifest($this->parent->getManifest());
 
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->extension->manifest_cache = json_encode($manifest_details);

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -152,7 +152,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 		if (!$element)
 		{
 			// Ensure the element is a string
-			$element = (string) $this->manifest->name;
+			$element = (string) $this->getManifest()->name;
 
 			// Filter the name for illegal characters
 			$element = str_replace('files_', '', JFilterInput::getInstance()->clean($element, 'cmd'));
@@ -186,7 +186,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 	protected function parseOptionalTags()
 	{
 		// Parse optional tags
-		$this->parent->parseLanguages($this->manifest->languages);
+		$this->parent->parseLanguages($this->getManifest()->languages);
 	}
 
 	/**
@@ -332,11 +332,11 @@ class JInstallerAdapterFile extends JInstallerAdapter
 				return false;
 			}
 
-			$this->manifest = $xml;
+			$this->setManifest($xml);
 
 			// If there is an manifest class file, let's load it
-			$this->scriptElement = $this->manifest->scriptfile;
-			$manifestScript = (string) $this->manifest->scriptfile;
+			$this->scriptElement = $this->getManifest()->scriptfile;
+			$manifestScript = (string) $this->getManifest()->scriptfile;
 
 			if ($manifestScript)
 			{
@@ -381,7 +381,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 			$db = JFactory::getDbo();
 
 			// Let's run the uninstall queries for the extension
-			$result = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
+			$result = $this->parent->parseSQLFiles($this->getManifest()->uninstall->sql);
 
 			if ($result === false)
 			{
@@ -531,7 +531,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 		$jRootPath = JPath::clean(JPATH_ROOT);
 
 		// Loop through all elements and get list of files and folders
-		foreach ($this->manifest->fileset->files as $eFiles)
+		foreach ($this->getManifest()->fileset->files as $eFiles)
 		{
 			// Check if the element is files element
 			$folder = (string) $eFiles->attributes()->folder;

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -90,10 +90,10 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			);
 		}
 
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
 		// Get the client application target
-		if ($cname = (string) $this->manifest->attributes()->client)
+		if ($cname = (string) $this->getManifest()->attributes()->client)
 		{
 			// Attempt to map the client to a base path
 			$client = JApplicationHelper::getClientInfo($cname, true);
@@ -107,7 +107,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 			$basePath = $client->path;
 			$clientId = $client->id;
-			$element = $this->manifest->files;
+			$element = $this->getManifest()->files;
 
 			return $this->_install($cname, $basePath, $clientId, $element);
 		}
@@ -117,7 +117,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			$cname = 'site';
 			$basePath = JPATH_SITE;
 			$clientId = 0;
-			$element = $this->manifest->files;
+			$element = $this->getManifest()->files;
 
 			return $this->_install($cname, $basePath, $clientId, $element);
 		}
@@ -137,15 +137,15 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	 */
 	protected function _install($cname, $basePath, $clientId, &$element)
 	{
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
 		// Get the language name
 		// Set the extensions name
-		$name = JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd');
+		$name = JFilterInput::getInstance()->clean((string) $this->getManifest()->name, 'cmd');
 		$this->set('name', $name);
 
 		// Get the Language tag [ISO tag, eg. en-GB]
-		$tag = (string) $this->manifest->tag;
+		$tag = (string) $this->getManifest()->tag;
 
 		// Check if we found the tag - if we didn't, we may be trying to install from an older language package
 		if (!$tag)
@@ -196,7 +196,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 		else
 		{
 			// Look for an update function or update tag
-			$updateElement = $this->manifest->update;
+			$updateElement = $this->getManifest()->update;
 
 			// Upgrade manually set or update tag detected
 			if ($this->parent->isUpgrade() || $updateElement)
@@ -249,13 +249,13 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 		}
 
 		// Parse optional tags
-		$this->parent->parseMedia($this->manifest->media);
+		$this->parent->parseMedia($this->getManifest()->media);
 
 		// Copy all the necessary font files to the common pdf_fonts directory
 		$this->parent->setPath('extension_site', $basePath . '/language/pdf_fonts');
 		$overwrite = $this->parent->setOverwrite(true);
 
-		if ($this->parent->parseFiles($this->manifest->fonts) === false)
+		if ($this->parent->parseFiles($this->getManifest()->fonts) === false)
 		{
 			// Install failed, rollback changes
 			$this->parent->abort();
@@ -266,7 +266,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 		$this->parent->setOverwrite($overwrite);
 
 		// Get the language description
-		$description = (string) $this->manifest->description;
+		$description = (string) $this->getManifest()->description;
 
 		if ($description)
 		{
@@ -323,7 +323,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	{
 		$xml = $this->parent->getManifest();
 
-		$this->manifest = $xml;
+		$this->setManifest($xml);
 
 		$cname = $xml->attributes()->client;
 
@@ -342,7 +342,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Get the language name
 		// Set the extensions name
-		$name = (string) $this->manifest->name;
+		$name = (string) $this->getManifest()->name;
 		$name = JFilterInput::getInstance()->clean($name, 'cmd');
 		$this->set('name', $name);
 
@@ -512,8 +512,8 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// We do findManifest to avoid problem when uninstalling a list of extension: getManifest cache its manifest file
 		$this->parent->findManifest();
-		$this->manifest = $this->parent->getManifest();
-		$this->parent->removeFiles($this->manifest->media);
+		$this->setManifest($this->parent->getManifest());
+		$this->parent->removeFiles($this->getManifest()->media);
 
 		// Check it exists
 		if (!JFolder::exists($path))

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -289,7 +289,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 	{
 		// Since this is just files, an update removes old files
 		// Get the extension manifest object
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
 		/*
 		 * ---------------------------------------------------------------------------------------------
@@ -298,7 +298,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		 */
 
 		// Set the extensions name
-		$name = (string) $this->manifest->name;
+		$name = (string) $this->getManifest()->name;
 		$name = JFilterInput::getInstance()->clean($name, 'string');
 		$element = str_replace('.xml', '', basename($this->parent->getPath('manifest')));
 		$this->set('name', $name);

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -187,11 +187,12 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 	 *
 	 * @since   3.4
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		$manifestPath = JPATH_MANIFESTS . '/libraries/' . $this->extension->element . '.xml';
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
+		$this->setManifest($this->parent->getManifest());
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -78,7 +78,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	protected function copyBaseFiles()
 	{
 		// Copy all necessary files
-		if ($this->parent->parseFiles($this->manifest->files, -1) === false)
+		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
 			throw new RuntimeException(JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'));
 		}
@@ -149,9 +149,9 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	{
 		if (!$element)
 		{
-			if (count($this->manifest->files->children()))
+			if (count($this->getManifest()->files->children()))
 			{
-				foreach ($this->manifest->files->children() as $file)
+				foreach ($this->getManifest()->files->children() as $file)
 				{
 					if ((string) $file->attributes()->module)
 					{
@@ -185,23 +185,23 @@ class JInstallerAdapterModule extends JInstallerAdapter
 			$this->parent->setPath('source', $client . '/modules/' . $this->parent->extension->element);
 		}
 
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
-		if ($this->manifest->files)
+		if ($this->getManifest()->files)
 		{
 			$extension = $this->getElement();
 
 			if ($extension)
 			{
 				$source = $path ? $path : ($this->parent->extension->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $extension;
-				$folder = (string) $this->manifest->files->attributes()->folder;
+				$folder = (string) $this->getManifest()->files->attributes()->folder;
 
 				if ($folder && file_exists($path . '/' . $folder))
 				{
 					$source = $path . '/' . $folder;
 				}
 
-				$client = (string) $this->manifest->attributes()->client;
+				$client = (string) $this->getManifest()->attributes()->client;
 				$this->doLoadLanguage($extension, $source, constant('JPATH_' . strtoupper($client)));
 			}
 		}
@@ -217,8 +217,8 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	protected function parseOptionalTags()
 	{
 		// Parse optional tags
-		$this->parent->parseMedia($this->manifest->media, $this->clientId);
-		$this->parent->parseLanguages($this->manifest->languages, $this->clientId);
+		$this->parent->parseMedia($this->getManifest()->media, $this->clientId);
+		$this->parent->parseLanguages($this->getManifest()->languages, $this->clientId);
 	}
 
 	/**
@@ -544,14 +544,14 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		// Get the module's manifest objecct
 		// We do findManifest to avoid problem when uninstalling a list of extensions: getManifest cache its manifest file.
 		$this->parent->findManifest();
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
 		// Attempt to load the language file; might have uninstall strings
 		$this->loadLanguage(($this->extension->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $element);
 
 		// If there is an manifest class file, let's load it
-		$this->scriptElement = $this->manifest->scriptfile;
-		$manifestScript      = (string) $this->manifest->scriptfile;
+		$this->scriptElement = $this->getManifest()->scriptfile;
+		$manifestScript      = (string) $this->getManifest()->scriptfile;
 
 		if ($manifestScript)
 		{
@@ -578,7 +578,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 
 		$this->triggerManifestScript('uninstall');
 
-		if (!($this->manifest instanceof SimpleXMLElement))
+		if (!($this->getManifest() instanceof SimpleXMLElement))
 		{
 			// Make sure we delete the folders
 			JFolder::delete($this->parent->getPath('extension_root'));
@@ -607,8 +607,8 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		$db->execute();
 
 		// Remove other files
-		$this->parent->removeFiles($this->manifest->media);
-		$this->parent->removeFiles($this->manifest->languages, $this->extension->client_id);
+		$this->parent->removeFiles($this->getManifest()->media);
+		$this->parent->removeFiles($this->getManifest()->languages, $this->extension->client_id);
 
 		// Let's delete all the module copies for the type we are uninstalling
 		$query->clear()

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -228,12 +228,13 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	 *
 	 * @since   3.4
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
+		$this->setManifest($this->parent->getManifest());
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -74,7 +74,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	protected function copyBaseFiles()
 	{
 		// Copy all necessary files
-		if ($this->parent->parseFiles($this->manifest->files, -1, $this->oldFiles) === false)
+		if ($this->parent->parseFiles($this->getManifest()->files, -1, $this->oldFiles) === false)
 		{
 			throw new RuntimeException(
 				JText::sprintf(
@@ -193,11 +193,11 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		{
 			// Backward Compatibility
 			// @todo Deprecate in future version
-			if (count($this->manifest->files->children()))
+			if (count($this->getManifest()->files->children()))
 			{
-				$type = (string) $this->manifest->attributes()->type;
+				$type = (string) $this->getManifest()->attributes()->type;
 
-				foreach ($this->manifest->files->children() as $file)
+				foreach ($this->getManifest()->files->children() as $file)
 				{
 					if ((string) $file->attributes()->$type)
 					{
@@ -245,12 +245,11 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 			);
 		}
 
-		$this->manifest = $this->parent->getManifest();
-		$element        = $this->manifest->files;
+		$element = $this->getManifest()->files;
 
 		if ($element)
 		{
-			$group = strtolower((string) $this->manifest->attributes()->group);
+			$group = strtolower((string) $this->getManifest()->attributes()->group);
 			$name = '';
 
 			if (count($element->children()))
@@ -291,8 +290,8 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	protected function parseOptionalTags()
 	{
 		// Parse optional tags -- media and language files for plugins go in admin app
-		$this->parent->parseMedia($this->manifest->media, 1);
-		$this->parent->parseLanguages($this->manifest->languages, 1);
+		$this->parent->parseMedia($this->getManifest()->media, 1);
+		$this->parent->parseLanguages($this->getManifest()->languages, 1);
 	}
 
 	/**
@@ -494,7 +493,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		$this->parent->setPath('source', $this->parent->getPath('extension_root'));
 
 		$this->parent->findManifest();
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
 		// Attempt to load the language file; might have uninstall strings
 		$this->parent->setPath('source', JPATH_PLUGINS . '/' . $row->folder . '/' . $row->element);
@@ -507,7 +506,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		 */
 
 		// If there is an manifest class file, let's load it; we'll copy it later (don't have dest yet)
-		$manifestScript = (string) $this->manifest->scriptfile;
+		$manifestScript = (string) $this->getManifest()->scriptfile;
 
 		if ($manifestScript)
 		{
@@ -554,7 +553,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		ob_end_clean();
 
 		// Let's run the queries for the plugin
-		$utfresult = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
+		$utfresult = $this->parent->parseSQLFiles($this->getManifest()->uninstall->sql);
 
 		if ($utfresult === false)
 		{
@@ -578,11 +577,11 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		ob_end_clean();
 
 		// Remove the plugin files
-		$this->parent->removeFiles($this->manifest->files, -1);
+		$this->parent->removeFiles($this->getManifest()->files, -1);
 
 		// Remove all media and languages as well
-		$this->parent->removeFiles($this->manifest->media);
-		$this->parent->removeFiles($this->manifest->languages, 1);
+		$this->parent->removeFiles($this->getManifest()->media);
+		$this->parent->removeFiles($this->getManifest()->languages, 1);
 
 		// Remove the schema version
 		$query = $db->getQuery(true)

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -301,7 +301,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	 *
 	 * @since   3.4
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		$client   = JApplicationHelper::getClientInfo($this->extension->client_id);
 		$basePath = $client->path . '/plugins/' . $this->extension->folder;
@@ -318,6 +318,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
+		$this->setManifest($this->parent->getManifest());
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -70,7 +70,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	protected function copyBaseFiles()
 	{
 		// Copy all the necessary files
-		if ($this->parent->parseFiles($this->manifest->files, -1) === false)
+		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
 			throw new RuntimeException(
 				JText::sprintf(
@@ -80,7 +80,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			);
 		}
 
-		if ($this->parent->parseFiles($this->manifest->images, -1) === false)
+		if ($this->parent->parseFiles($this->getManifest()->images, -1) === false)
 		{
 			throw new RuntimeException(
 				JText::sprintf(
@@ -90,7 +90,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			);
 		}
 
-		if ($this->parent->parseFiles($this->manifest->css, -1) === false)
+		if ($this->parent->parseFiles($this->getManifest()->css, -1) === false)
 		{
 			throw new RuntimeException(
 				JText::sprintf(
@@ -178,9 +178,9 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			$this->parent->setPath('source', $basePath . '/templates/' . $this->parent->extension->element);
 		}
 
-		$this->manifest = $this->parent->getManifest();
+		$this->setManifest($this->parent->getManifest());
 
-		$client = (string) $this->manifest->attributes()->client;
+		$client = (string) $this->getManifest()->attributes()->client;
 
 		// Load administrator language if not set.
 		if (!$client)
@@ -203,8 +203,8 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	 */
 	protected function parseOptionalTags()
 	{
-		$this->parent->parseMedia($this->manifest->media);
-		$this->parent->parseLanguages($this->manifest->languages, $this->clientId);
+		$this->parent->parseMedia($this->getManifest()->media);
+		$this->parent->parseLanguages($this->getManifest()->languages, $this->clientId);
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -255,12 +255,13 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	 *
 	 * @since   3.4
 	 */
-	protected function prepareDiscoverInstall()
+	public function prepareDiscoverInstall()
 	{
 		$client = JApplicationHelper::getClientInfo($this->extension->client_id);
 		$manifestPath = $client->path . '/templates/' . $this->extension->element . '/templateDetails.xml';
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
+		$this->setManifest($this->parent->getManifest());
 	}
 
 	/**

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -505,7 +505,9 @@ class JInstaller extends JAdapter
 
 			// Load the adapter(s) for the install manifest
 			$type   = $this->extension->type;
-			$params = array('extension' => $this->extension, 'route' => 'discover_install');
+			$params = array(
+				'extension' => $this->extension, 'route' => 'discover_install', 'manifest' => $this->getManifest()
+			);
 
 			// Lazy load the adapter
 			if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))
@@ -823,7 +825,7 @@ class JInstaller extends JAdapter
 
 		// Load the adapter(s) for the install manifest
 		$type   = (string) $this->manifest->attributes()->type;
-		$params = array('route' => $route);
+		$params = array('route' => $route, 'manifest' => $this->getManifest());
 
 		// Lazy load the adapter
 		if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -424,51 +424,52 @@ class JInstaller extends JAdapter
 			return false;
 		}
 
-		if (!$this->setupInstall())
+		if (!$adapter = $this->setupInstall('install', true))
 		{
 			$this->abort(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'));
 
 			return false;
 		}
 
-		$type = (string) $this->manifest->attributes()->type;
-
-		if (is_object($this->_adapters[$type]))
+		if (!is_object($adapter))
 		{
-			// Add the languages from the package itself
-			if (method_exists($this->_adapters[$type], 'loadLanguage'))
-			{
-				$this->_adapters[$type]->loadLanguage($path);
-			}
+			return false;
+		}
 
-			// Fire the onExtensionBeforeInstall event.
-			JPluginHelper::importPlugin('extension');
-			$dispatcher = JEventDispatcher::getInstance();
-			$dispatcher->trigger(
-				'onExtensionBeforeInstall',
-				array('method' => 'install', 'type' => $type, 'manifest' => $this->manifest, 'extension' => 0)
-			);
+		// Add the languages from the package itself
+		if (method_exists($adapter, 'loadLanguage'))
+		{
+			$adapter->loadLanguage($path);
+		}
 
-			// Run the install
-			$result = $this->_adapters[$type]->install();
+		// Fire the onExtensionBeforeInstall event.
+		JPluginHelper::importPlugin('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger(
+			'onExtensionBeforeInstall',
+			array(
+				'method' => 'install',
+				'type' => $this->manifest->attributes()->type,
+				'manifest' => $this->manifest,
+				'extension' => 0
+			)
+		);
 
-			// Fire the onExtensionAfterInstall
-			$dispatcher->trigger(
-				'onExtensionAfterInstall',
-				array('installer' => clone $this, 'eid' => $result)
-			);
+		// Run the install
+		$result = $adapter->install();
 
-			if ($result !== false)
-			{
-				// Refresh versionable assets cache
-				JFactory::getApplication()->flushAssets();
+		// Fire the onExtensionAfterInstall
+		$dispatcher->trigger(
+			'onExtensionAfterInstall',
+			array('installer' => clone $this, 'eid' => $result)
+		);
 
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+		if ($result !== false)
+		{
+			// Refresh versionable assets cache
+			JFactory::getApplication()->flushAssets();
+
+			return true;
 		}
 
 		return false;
@@ -485,110 +486,107 @@ class JInstaller extends JAdapter
 	 */
 	public function discover_install($eid = null)
 	{
-		if ($eid)
-		{
-			if (!$this->extension->load($eid))
-			{
-				$this->abort(JText::_('JLIB_INSTALLER_ABORT_LOAD_DETAILS'));
-
-				return false;
-			}
-
-			if ($this->extension->state != -1)
-			{
-				$this->abort(JText::_('JLIB_INSTALLER_ABORT_ALREADYINSTALLED'));
-
-				return false;
-			}
-
-			$adapter = null;
-
-			// Load the adapter(s) for the install manifest
-			$type   = $this->extension->type;
-			$params = array(
-				'extension' => $this->extension, 'route' => 'discover_install', 'manifest' => $this->getManifest()
-			);
-
-			// Lazy load the adapter
-			if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))
-			{
-				$adapter = $this->loadAdapter($type, $params);
-
-				if (!$adapter)
-				{
-					return false;
-				}
-
-				$this->_adapters[$type] = $adapter;
-			}
-
-			if (is_object($this->_adapters[$type]))
-			{
-				if (method_exists($this->_adapters[$type], 'discover_install'))
-				{
-					// Add the languages from the package itself
-					if (method_exists($this->_adapters[$type], 'loadLanguage'))
-					{
-						$this->_adapters[$type]->loadLanguage();
-					}
-
-					// Fire the onExtensionBeforeInstall event.
-					JPluginHelper::importPlugin('extension');
-					$dispatcher = JEventDispatcher::getInstance();
-					$dispatcher->trigger(
-						'onExtensionBeforeInstall',
-						array(
-							'method' => 'discover_install',
-							'type' => $this->extension->get('type'),
-							'manifest' => null,
-							'extension' => $this->extension->get('extension_id')
-						)
-					);
-
-					// Run the install
-					$result = $this->_adapters[$type]->discover_install();
-
-					// Fire the onExtensionAfterInstall
-					$dispatcher->trigger(
-						'onExtensionAfterInstall',
-						array('installer' => clone $this, 'eid' => $result)
-					);
-
-					if ($result !== false)
-					{
-						// Refresh versionable assets cache
-						JFactory::getApplication()->flushAssets();
-
-						return true;
-					}
-					else
-					{
-						return false;
-					}
-				}
-				else
-				{
-					$this->abort(JText::_('JLIB_INSTALLER_ABORT_METHODNOTSUPPORTED'));
-
-					return false;
-				}
-			}
-
-			return false;
-		}
-		else
+		if (!$eid)
 		{
 			$this->abort(JText::_('JLIB_INSTALLER_ABORT_EXTENSIONNOTVALID'));
 
 			return false;
 		}
+
+		if (!$this->extension->load($eid))
+		{
+			$this->abort(JText::_('JLIB_INSTALLER_ABORT_LOAD_DETAILS'));
+
+			return false;
+		}
+
+		if ($this->extension->state != -1)
+		{
+			$this->abort(JText::_('JLIB_INSTALLER_ABORT_ALREADYINSTALLED'));
+
+			return false;
+		}
+
+		// Load the adapter(s) for the install manifest
+		$type   = $this->extension->type;
+		$params = array(
+			'extension' => $this->extension, 'route' => 'discover_install'
+		);
+
+		$adapter = $this->getAdapter($type, $params);
+
+		if (!is_object($adapter))
+		{
+			return false;
+		}
+
+		if (!method_exists($adapter, 'discover_install') || !$adapter->getDiscoverInstallSupported())
+		{
+			$this->abort(JText::sprintf('JLIB_INSTALLER_ERROR_DISCOVER_INSTALL_UNSUPPORTED', $type));
+
+			return false;
+		}
+
+		// The adapter needs to prepare itself
+		if (method_exists($adapter, 'prepareDiscoverInstall'))
+		{
+			try
+			{
+				$adapter->prepareDiscoverInstall();
+			}
+			catch (RuntimeException $e)
+			{
+				$this->abort($e->getMessage());
+
+				return false;
+			}
+		}
+
+		// Add the languages from the package itself
+		if (method_exists($adapter, 'loadLanguage'))
+		{
+			$adapter->loadLanguage();
+		}
+
+		// Fire the onExtensionBeforeInstall event.
+		JPluginHelper::importPlugin('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger(
+			'onExtensionBeforeInstall',
+			array(
+				'method' => 'discover_install',
+				'type' => $this->extension->get('type'),
+				'manifest' => null,
+				'extension' => $this->extension->get('extension_id')
+			)
+		);
+
+		// Run the install
+		$result = $adapter->discover_install();
+
+		// Fire the onExtensionAfterInstall
+		$dispatcher->trigger(
+			'onExtensionAfterInstall',
+			array('installer' => clone $this, 'eid' => $result)
+		);
+
+		if ($result !== false)
+		{
+			// Refresh versionable assets cache
+			JFactory::getApplication()->flushAssets();
+
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
 	 * Extension discover method
+	 *
 	 * Asks each adapter to find extensions
 	 *
-	 * @return  array  JExtension
+	 * @return  JInstallerExtension[]
 	 *
 	 * @since   3.1
 	 */
@@ -638,45 +636,41 @@ class JInstaller extends JAdapter
 			return false;
 		}
 
-		if (!$this->setupInstall('update'))
+		if (!$adapter = $this->setupInstall('update', true))
 		{
 			$this->abort(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'));
 
 			return false;
 		}
 
-		$type = (string) $this->manifest->attributes()->type;
-
-		if (is_object($this->_adapters[$type]))
+		if (!is_object($adapter))
 		{
-			// Add the languages from the package itself
-			if (method_exists($this->_adapters[$type], 'loadLanguage'))
-			{
-				$this->_adapters[$type]->loadLanguage($path);
-			}
+			return false;
+		}
 
-			// Fire the onExtensionBeforeUpdate event.
-			JPluginHelper::importPlugin('extension');
-			$dispatcher = JEventDispatcher::getInstance();
-			$dispatcher->trigger('onExtensionBeforeUpdate', array('type' => $type, 'manifest' => $this->manifest));
+		// Add the languages from the package itself
+		if (method_exists($adapter, 'loadLanguage'))
+		{
+			$adapter->loadLanguage($path);
+		}
 
-			// Run the update
-			$result = $this->_adapters[$type]->update();
+		// Fire the onExtensionBeforeUpdate event.
+		JPluginHelper::importPlugin('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger('onExtensionBeforeUpdate', array('type' => $type, 'manifest' => $this->manifest));
 
-			// Fire the onExtensionAfterUpdate
-			$dispatcher->trigger(
-				'onExtensionAfterUpdate',
-				array('installer' => clone $this, 'eid' => $result)
-			);
+		// Run the update
+		$result = $adapter->update();
 
-			if ($result !== false)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+		// Fire the onExtensionAfterUpdate
+		$dispatcher->trigger(
+			'onExtensionAfterUpdate',
+			array('installer' => clone $this, 'eid' => $result)
+		);
+
+		if ($result !== false)
+		{
+			return true;
 		}
 
 		return false;
@@ -695,43 +689,34 @@ class JInstaller extends JAdapter
 	 */
 	public function uninstall($type, $identifier, $cid = 0)
 	{
-		$adapter = null;
+		$params = array('extension' => $this->extension, 'route' => 'uninstall');
 
-		if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))
+		$adapter = $this->getAdapter($type, $params);
+
+		if (!is_object($adapter))
 		{
-			$params = array('extension' => $this->extension, 'route' => 'uninstall');
-
-			if (!$this->setAdapter($type, $adapter, $params))
-			{
-				// We failed to get the right adapter
-				return false;
-			}
+			return false;
 		}
 
-		if (is_object($this->_adapters[$type]))
-		{
-			// We don't load languages here, we get the extension adapter to work it out
-			// Fire the onExtensionBeforeUninstall event.
-			JPluginHelper::importPlugin('extension');
-			$dispatcher = JEventDispatcher::getInstance();
-			$dispatcher->trigger('onExtensionBeforeUninstall', array('eid' => $identifier));
+		// We don't load languages here, we get the extension adapter to work it out
+		// Fire the onExtensionBeforeUninstall event.
+		JPluginHelper::importPlugin('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger('onExtensionBeforeUninstall', array('eid' => $identifier));
 
-			// Run the uninstall
-			$result = $this->_adapters[$type]->uninstall($identifier);
+		// Run the uninstall
+		$result = $adapter->uninstall($identifier);
 
-			// Fire the onExtensionAfterInstall
-			$dispatcher->trigger(
-				'onExtensionAfterUninstall',
-				array('installer' => clone $this, 'eid' => $identifier, 'result' => $result)
-			);
+		// Fire the onExtensionAfterInstall
+		$dispatcher->trigger(
+			'onExtensionAfterUninstall',
+			array('installer' => clone $this, 'eid' => $identifier, 'result' => $result)
+		);
 
-			// Refresh versionable assets cache
-			JFactory::getApplication()->flushAssets();
+		// Refresh versionable assets cache
+		JFactory::getApplication()->flushAssets();
 
-			return $result;
-		}
-
-		return false;
+		return $result;
 	}
 
 	/**
@@ -739,7 +724,7 @@ class JInstaller extends JAdapter
 	 *
 	 * @param   integer  $eid  Extension ID
 	 *
-	 * @return  mixed  void on success, false on error @todo missing return value ?
+	 * @return  boolean
 	 *
 	 * @since   3.1
 	 */
@@ -761,46 +746,36 @@ class JInstaller extends JAdapter
 				return false;
 			}
 
-			// Lazy load the adapter
-			if (!isset($this->_adapters[$this->extension->type]) || !is_object($this->_adapters[$this->extension->type]))
+			// Fetch the adapter
+			$adapter = $this->getAdapter($this->extension->type);
+
+			if (!is_object($adapter))
 			{
-				if (!$this->setAdapter($this->extension->type))
-				{
-					return false;
-				}
+				return false;
 			}
 
-			if (is_object($this->_adapters[$this->extension->type]))
+			if (!method_exists($adapter, 'refreshManifestCache'))
 			{
-				if (method_exists($this->_adapters[$this->extension->type], 'refreshManifestCache'))
-				{
-					$result = $this->_adapters[$this->extension->type]->refreshManifestCache();
+				$this->abort(JText::sprintf('JLIB_INSTALLER_ABORT_METHODNOTSUPPORTED_TYPE', $this->extension->type));
 
-					if ($result !== false)
-					{
-						return true;
-					}
-					else
-					{
-						return false;
-					}
-				}
-				else
-				{
-					$this->abort(JText::sprintf('JLIB_INSTALLER_ABORT_METHODNOTSUPPORTED_TYPE', $this->extension->type));
-
-					return false;
-				}
+				return false;
 			}
 
-			return false;
-		}
-		else
-		{
-			$this->abort(JText::_('JLIB_INSTALLER_ABORT_REFRESH_MANIFEST_CACHE_VALID'));
+			$result = $adapter->refreshManifestCache();
 
-			return false;
+			if ($result !== false)
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
 		}
+
+		$this->abort(JText::_('JLIB_INSTALLER_ABORT_REFRESH_MANIFEST_CACHE_VALID'));
+
+		return false;
 	}
 
 	// Utility functions
@@ -809,13 +784,14 @@ class JInstaller extends JAdapter
 	 * Prepare for installation: this method sets the installation directory, finds
 	 * and checks the installation file and verifies the installation type.
 	 *
-	 * @param   string  $route  The install route being followed
+	 * @param   string   $route          The install route being followed
+	 * @param   boolean  $returnAdapter  Flag to return the instantiated adapter
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean|JInstallerAdapter  JInstallerAdapter object if explicitly requested otherwise boolean
 	 *
 	 * @since   3.1
 	 */
-	public function setupInstall($route = 'install')
+	public function setupInstall($route = 'install', $returnAdapter = false)
 	{
 		// We need to find the installation manifest file
 		if (!$this->findManifest())
@@ -827,17 +803,12 @@ class JInstaller extends JAdapter
 		$type   = (string) $this->manifest->attributes()->type;
 		$params = array('route' => $route, 'manifest' => $this->getManifest());
 
-		// Lazy load the adapter
-		if (!isset($this->_adapters[$type]) || !is_object($this->_adapters[$type]))
+		// Load the adapter
+		$adapter = $this->getAdapter($type, $params);
+
+		if ($returnAdapter)
 		{
-			$adapter = $this->loadAdapter($type, $params);
-
-			if (!$adapter)
-			{
-				return false;
-			}
-
-			$this->_adapters[$type] = $adapter;
+			return $adapter;
 		}
 
 		return true;
@@ -2215,6 +2186,33 @@ class JInstaller extends JAdapter
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Fetches an adapter and adds it to the internal storage if an instance is not set
+	 *
+	 * @param   string  $name     Name of adapter to return
+	 * @param   array   $options  Adapter options
+	 *
+	 * @return  JInstallerAdapter
+	 *
+	 * @since       3.4
+	 * @deprecated  4.0  The internal adapter cache will no longer be supported,
+	 *                   use loadAdapter() to fetch an adapter instance
+	 */
+	public function getAdapter($name, $options = array())
+	{
+		$adapter = $this->loadAdapter($name, $options);
+
+		if (!array_key_exists($name, $this->_adapters))
+		{
+			if (!$this->setAdapter($name, $adapter))
+			{
+				return false;
+			}
+		}
+
+		return $adapter;
 	}
 
 	/**


### PR DESCRIPTION
This PR tries to address issues noted in #5945 and #5977 specifically dealing with the manifest caching in adapter instances and incomplete data when performing a discover install.
- Restructures discover_install so that the adapter's `prepareDiscoverInstall()` method is called to load the correct extension paths to memory before calling `loadLanguage` which is inherently dependent on having access to the manifest XML.
- Modifies JInstaller so that each install route will always fetch a new adapter instance with the injected parameters, however only the first adapter for a given extension type will get cached (which includes its own internal memory).  Support for the internal adapter cache is deprecated and should be removed at 4.0.
- When possible, injects a manifest into the adapter when it is instantiated.
