### PR TITLE
Multilanguage: sef url language code length limit according to db

### DIFF
--- a/administrator/components/com_languages/models/forms/language.xml
+++ b/administrator/components/com_languages/models/forms/language.xml
@@ -36,7 +36,7 @@
 		<field name="sef" type="text"
 			description="COM_LANGUAGES_FIELD_LANG_CODE_DESC"
 			label="COM_LANGUAGES_FIELD_LANG_CODE_LABEL"
-			maxlength="7"
+			maxlength="50"
 			required="true"
 			size="10"
 		/>

--- a/administrator/components/com_languages/models/language.php
+++ b/administrator/components/com_languages/models/language.php
@@ -191,6 +191,7 @@ class LanguagesModelLanguage extends JModelAdmin
 
 		$data['lang_code'] = str_replace($spaces, '', $data['lang_code']);
 		$data['sef'] = str_replace($spaces, '', $data['sef']);
+		$data['sef'] = JApplicationHelper::stringURLSafe($data['sef']);
 
 		// Bind the data.
 		if (!$table->bind($data))


### PR DESCRIPTION
See http://forum.joomla.org/viewtopic.php?f=711&t=873043
The URL Language code (sef) for a content language in multilanguage is usually simple (and recommended to be). Example: `fr` in `mysite.com/fr/something`.

Some users may want to use a longer one. In the example from the forum above: 
"nordsee-rerienhaus"

The database provides for it:
``sef` varchar(50) NOT NULL,`

but the language.xml limits it to 7:

```
      <field name="sef" type="text"
         description="COM_LANGUAGES_FIELD_LANG_CODE_DESC"
         label="COM_LANGUAGES_FIELD_LANG_CODE_LABEL"
         maxlength="7"
         required="true"
         size="10"
      />
```

This PR changes the maxlength in the xml to the same as db.
To test, apply the PR and change for a content language the "Url Language Code" to something more than 7 characters.
