### PR TITLE
Fix Potential PHP Notices/Warnings in JInstallerHelper class

### DIFF
--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -172,7 +172,7 @@ abstract class JInstallerHelper
 		 * List all the items in the installation directory.  If there is only one, and
 		 * it is a folder, then we will set that folder to be the installation folder.
 		 */
-		$dirList = array_merge(JFolder::files($extractdir, ''), JFolder::folders($extractdir, ''));
+		$dirList = array_merge((array)JFolder::files($extractdir, ''), (array)JFolder::folders($extractdir, ''));
 
 		if (count($dirList) == 1)
 		{
@@ -218,7 +218,7 @@ abstract class JInstallerHelper
 		// Search the install dir for an XML file
 		$files = JFolder::files($p_dir, '\.xml$', 1, true);
 
-		if (!count($files))
+		if(!$files || !count($files))
 		{
 			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), JLog::WARNING, 'jerror');
 

--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -172,7 +172,7 @@ abstract class JInstallerHelper
 		 * List all the items in the installation directory.  If there is only one, and
 		 * it is a folder, then we will set that folder to be the installation folder.
 		 */
-		$dirList = array_merge((array)JFolder::files($extractdir, ''), (array)JFolder::folders($extractdir, ''));
+		$dirList = array_merge((array) JFolder::files($extractdir, ''), (array) JFolder::folders($extractdir, ''));
 
 		if (count($dirList) == 1)
 		{
@@ -218,7 +218,7 @@ abstract class JInstallerHelper
 		// Search the install dir for an XML file
 		$files = JFolder::files($p_dir, '\.xml$', 1, true);
 
-		if(!$files || !count($files))
+		if (!$files || !count($files))
 		{
 			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), JLog::WARNING, 'jerror');
 


### PR DESCRIPTION
@see https://github.com/joomla/joomla-cms/issues/6000

I experienced a scenario where I was testing an install package (which was corrupt) and it brought to light a couple of PHP notices in the `JInstallerHelper` class.
#### The File:

**libraries/cms/installer/helper.php** line 197 & 221
#### Issue 1 (line 197):

``` php
$dirList = array_merge(JFolder::files($extractdir, ''), JFolder::folders($extractdir, ''));
```

As `JFolder::files()` & `JFolder::folders()` can return `false` which would break `array_merge()`. One solution would be type casting:

``` php
$dirList = array_merge((array)JFolder::files($extractdir, ''), (array)JFolder::folders($extractdir, ''));
```
#### Issue 2 (line 221):

``` php
if (!count($files))
```

Again `JFolder::files()` could return `false` so the `count()` of `false` would be **1** as opposed to **0**. (see: http://php.net/manual/en/function.count.php#example-5167) Therefore as this is a false positive may I suggest something like:

``` php
if (!$files || !count($files))
```

or

``` php
if (!is_array($files) || !count($files))
```

If everyone likes the suggestions I will happily create a Pull Request.
