### PR TITLE
No need to get JFilterInput instance for each cycle in the loop

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -496,13 +496,13 @@ abstract class JModuleHelper
 					$input   = JFactory::getApplication()->input;
 					$uri     = $input->getArray();
 					$safeuri = new stdClass;
+					$noHtmlFilter = JFilterInput::getInstance();
 
 					foreach ($cacheparams->modeparams as $key => $value)
 					{
 						// Use int filter for id/catid to clean out spamy slugs
 						if (isset($uri[$key]))
 						{
-							$noHtmlFilter = JFilterInput::getInstance();
 							$safeuri->$key = $noHtmlFilter->clean($uri[$key], $value);
 						}
 					}


### PR DESCRIPTION
There is no need to retrieve the JFilterInput object for each cycle in the loop. It should be enough to get that object once outside the loop.
