### PR TITLE
Fixing the update failure when cache is enabled.

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -420,7 +420,20 @@ class JComponentHelper
 
 		try
 		{
-			static::$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);
+			$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);
+
+			/**
+			 * Verify $components is an array, some cache handlers return an object even though
+			 * the original was a single object array.
+			 */
+			if (!is_array($components))
+			{
+				static::$components[$option] = $components;
+			}
+			else
+			{
+				static::$components = $components;
+			}
 		}
 		catch (RuntimeException $e)
 		{


### PR DESCRIPTION
This change fixes the fatal error during an update:

> Fatal error: Cannot use object of type stdClass as array in libraries/cms/component/helper.php on line 433
## TESTING

To test this fix is a bit cumbersome but here are the steps for reproducing the issue:
1. Setup a clean Joomla 3.3.6 installation
2. Download the Cache_Lite code from http://download.pear.php.net/package/Cache_Lite-1.7.16.tgz
3. Unpack the files from this archive
4. Copy the Cache folder to the clean Joomla 3.3.6 installation folder libraries\joomla\cache\storage\ so you get the path libraries\joomla\cache\storage\Cache within there the Lite.php file and Lite folder.
5. Go to System -> Global Configuration -> System
6. Set Cache to ON - Conservative caching
7. Set Cache Handler to Cache_Lite
8. Save the configuration
9. Download the Joomla 3.4 beta 2 full package from https://github.com/joomla/joomla-cms/releases/tag/3.4.0-beta2
10. Go to Extensions -> Extension Manager -> Upload Package File
11. Select the file you downloaded in step 11
12. Click on Upload & Install
13. Observe the fatal error

Now that we have the error we need to redo the process to test the fix. Here are the steps to test the fix:
1. Setup a clean Joomla 3.3.6 installation
2. Download the Cache_Lite code from http://download.pear.php.net/package/Cache_Lite-1.7.16.tgz
3. Unpack the files from this archive
4. Copy the Cache folder to the clean Joomla 3.3.6 installation folder libraries\joomla\cache\storage\ so you get the path libraries\joomla\cache\storage\Cache within there the Lite.php file and Lite folder.
5. Go to System -> Global Configuration -> System
6. Set Cache to ON - Conservative caching
7. Set Cache Handler to Cache_Lite
8. Save the configuration
9. Download the Joomla 3.4 beta 2 full package from https://github.com/joomla/joomla-cms/releases/tag/3.4.0-beta2
10. Unpack the package into a folder
11. Go to the file libraries/cms/component/helper.php
12. Replace line 423 which looks like 

``` php
static::$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);
```

with:

``` php
$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);

            /**
             * Verify $components is an array, some cache handlers return an object even though
             * the original was a single object array.
             */
            if (!is_array($components))
            {
                static::$components[$option] = $components;
            }
            else
            {
                static::$components = $components;
            }
```
1. Save the file
2. Pack the files into a zip file again
3. Go to Extensions -> Extension Manager -> Upload Package File
4. Select the file you packed in step 16
5. Click on Upload & Install
6. Observe the update completes successfully

This has been tested with Cache_Lite only but please test as much as possible.
