### PR TITLE
Cleaning up the checks in Modules renderer for performance

### DIFF
--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -33,16 +33,16 @@ class JDocumentRendererModules extends JDocumentRenderer
 		$buffer = '';
 
 		$app = JFactory::getApplication();
-		$frontediting = $app->get('frontediting', 1);
 		$user = JFactory::getUser();
+		$frontediting = ($app->isSite() && $app->get('frontediting', 1) && !$user->guest);
 
-		$menusEditing = ($frontediting == 2) && $user->authorise('core.edit', 'com_menus');
+		$menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
 
 		foreach (JModuleHelper::getModules($position) as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($app->isSite() && $frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+			if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				JLayoutHelper::render('joomla.edit.frontediting_modules', $displayData);


### PR DESCRIPTION
See #5996. This shuffles around the checks in the modules renderer to bail out as soon as possible for the module editing. The only functional change is, that module editing with this requires that the user is logged in regardless of the permissions set. The situation that an unauthenticated user is allowed to edit modules in the frontend, is VERY uncommon.
### How to test
- Install current staging
- See times of beforeRenderModule module in debugging
- Apply patch
- See times have cut down to about a tenth of the original value

Make sure that you are not logged in when doing this. There should be no change in performance if the user is logged in.
