### PR TITLE
Removing unnecessary JDEBUG check

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -143,7 +143,7 @@ abstract class JModuleHelper
 		// Check that $module is a valid module object
 		if (!is_object($module) || !isset($module->module) || !isset($module->params))
 		{
-			if (defined('JDEBUG') && JDEBUG)
+			if (defined('JDEBUG'))
 			{
 				JLog::addLogger(array('text_file' => 'jmodulehelper.log.php'), JLog::ALL, array('modulehelper'));
 				JLog::add('JModuleHelper::renderModule($module) expects a module object', JLog::DEBUG, 'modulehelper');


### PR DESCRIPTION
As can be seen 9 lines further down in the file, JDEBUG is only defined when it is enabled. So we don't need to check if it is defined AND if the value is boolean true.
