### PR TITLE
Optimizing mod_login helper

### DIFF
--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -39,7 +39,7 @@ class ModLoginHelper
 		else
 		{
 			// Stay on the same page
-			$vars = $router->getVars();
+			$vars = $app::getRouter()->getVars();
 		}
 
 		return base64_encode('index.php?' . JUri::buildQuery($vars));

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -31,68 +31,19 @@ class ModLoginHelper
 	{
 		$app	= JFactory::getApplication();
 		$router = $app::getRouter();
-		$url = null;
+		$item   = $app->getMenu()->getItem($params->get($type));
 
-		if ($itemid = $params->get($type))
+		if ($item)
 		{
-			$db		= JFactory::getDbo();
-			$query	= $db->getQuery(true)
-				->select($db->quoteName('link'))
-				->from($db->quoteName('#__menu'))
-				->where($db->quoteName('published') . '=1')
-				->where($db->quoteName('id') . '=' . $db->quote($itemid));
-
-			$db->setQuery($query);
-
-			if ($link = $db->loadResult())
-			{
-				if ($router->getMode() == JROUTER_MODE_SEF)
-				{
-					$url = 'index.php?Itemid=' . $itemid;
-				}
-				else
-				{
-					$url = $link . '&Itemid=' . $itemid;
-				}
-			}
+			$vars = $item->query;
 		}
-
-		if (!$url)
+		else
 		{
 			// Stay on the same page
 			$vars = $router->getVars();
-			unset($vars['lang']);
-
-			if ($router->getMode() == JROUTER_MODE_SEF)
-			{
-				if (isset($vars['Itemid']))
-				{
-					$itemid = $vars['Itemid'];
-					$menu = $app->getMenu();
-					$item = $menu->getItem($itemid);
-					unset($vars['Itemid']);
-
-					if (isset($item) && $vars == $item->query)
-					{
-						$url = 'index.php?Itemid=' . $itemid;
-					}
-					else
-					{
-						$url = 'index.php?' . JUri::buildQuery($vars) . '&Itemid=' . $itemid;
-					}
-				}
-				else
-				{
-					$url = 'index.php?' . JUri::buildQuery($vars);
-				}
-			}
-			else
-			{
-				$url = 'index.php?' . JUri::buildQuery($vars);
-			}
 		}
 
-		return base64_encode($url);
+		return base64_encode('index.php?' . JUri::buildQuery($vars));
 	}
 
 	/**

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -30,7 +30,6 @@ class ModLoginHelper
 	public static function getReturnURL($params, $type)
 	{
 		$app	= JFactory::getApplication();
-		$router = $app::getRouter();
 		$item   = $app->getMenu()->getItem($params->get($type));
 
 		if ($item)


### PR DESCRIPTION
We already have loaded all menu items. We don't need to look up an existing menu item again. If JMenu does not return this item, it either does not exist or it is unpublished or not accessible for the user. The router also makes sure that all parameters of a menu item are correctly stripped. There is no need to differentiate between SEF and non-SEF URLs.
### How to test
- See current behavior of mod_login
- Apply patch
- Notice that performance improves and nothing else changes.
