### PR TITLE
Fix wrong filtering in JInput::getArray()

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -176,14 +176,14 @@ class JInput implements Serializable, Countable
 	/**
 	 * Gets an array of values from the request.
 	 *
-	 * @param   array  $vars          Associative array of keys and filter types to apply.
-	 *                                If empty and datasource is null, all the input data will be returned
-	 *                                but filtered using the filter given by the parameter defaultFilter in
-	 *                                JFilterInput::clean.
-	 * @param   mixed  $datasource    Array to retrieve data from, or null.
-	 * @param   string $defaultFilter Default filter used in JFilterInput::clean if vars is empty and
-	 *                                datasource is null. If 'unknown', the default case is used in
-	 *                                JFilterInput::clean.
+	 * @param   array   $vars           Associative array of keys and filter types to apply.
+	 *                                  If empty and datasource is null, all the input data will be returned
+	 *                                  but filtered using the filter given by the parameter defaultFilter in
+	 *                                  JFilterInput::clean.
+	 * @param   mixed   $datasource     Array to retrieve data from, or null.
+	 * @param   string  $defaultFilter  Default filter used in JFilterInput::clean if vars is empty and
+	 *                                  datasource is null. If 'unknown', the default case is used in
+	 *                                  JFilterInput::clean.
 	 *
 	 * @return  mixed  The filtered input data.
 	 *
@@ -197,15 +197,15 @@ class JInput implements Serializable, Countable
 	/**
 	 * Gets an array of values from the request.
 	 *
-	 * @param   array  $vars          Associative array of keys and filter types to apply.
-	 *                                If empty and datasource is null, all the input data will be returned
-	 *                                but filtered using the filter given by the parameter defaultFilter in
-	 *                                JFilterInput::clean.
-	 * @param   mixed  $datasource    Array to retrieve data from, or null.
-	 * @param   string $defaultFilter Default filter used in JFilterInput::clean if vars is empty and
-	 *                                datasource is null. If 'unknown', the default case is used in
-	 *                                JFilterInput::clean.
-	 * @param   bool   $recursive     Flag to indicate a recursive function call.
+	 * @param   array   $vars           Associative array of keys and filter types to apply.
+	 *                                  If empty and datasource is null, all the input data will be returned
+	 *                                  but filtered using the filter given by the parameter defaultFilter in
+	 *                                  JFilterInput::clean.
+	 * @param   mixed   $datasource     Array to retrieve data from, or null.
+	 * @param   string  $defaultFilter  Default filter used in JFilterInput::clean if vars is empty and
+	 *                                  datasource is null. If 'unknown', the default case is used in
+	 *                                  JFilterInput::clean.
+	 * @param   bool    $recursion      Flag to indicate a recursive function call.
 	 *
 	 * @return  mixed  The filtered input data.
 	 *

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -176,20 +176,53 @@ class JInput implements Serializable, Countable
 	/**
 	 * Gets an array of values from the request.
 	 *
-	 * @param   array  $vars        Associative array of keys and filter types to apply.
-	 *                              If empty and datasource is null, all the input data will be returned
-	 *                              but filtered using the default case in JFilterInput::clean.
-	 * @param   mixed  $datasource  Array to retrieve data from, or null
+	 * @param   array  $vars          Associative array of keys and filter types to apply.
+	 *                                If empty and datasource is null, all the input data will be returned
+	 *                                but filtered using the filter given by the parameter defaultFilter in
+	 *                                JFilterInput::clean.
+	 * @param   mixed  $datasource    Array to retrieve data from, or null.
+	 * @param   string $defaultFilter Default filter used in JFilterInput::clean if vars is empty and
+	 *                                datasource is null. If 'unknown', the default case is used in
+	 *                                JFilterInput::clean.
 	 *
 	 * @return  mixed  The filtered input data.
 	 *
 	 * @since   11.1
 	 */
-	public function getArray(array $vars = array(), $datasource = null)
+	public function getArray(array $vars = array(), $datasource = null, $defaultFilter = 'unknown')
+	{
+		return $this->getArrayRecursive($vars, $datasource, $defaultFilter, false);
+	}
+
+	/**
+	 * Gets an array of values from the request.
+	 *
+	 * @param   array  $vars          Associative array of keys and filter types to apply.
+	 *                                If empty and datasource is null, all the input data will be returned
+	 *                                but filtered using the filter given by the parameter defaultFilter in
+	 *                                JFilterInput::clean.
+	 * @param   mixed  $datasource    Array to retrieve data from, or null.
+	 * @param   string $defaultFilter Default filter used in JFilterInput::clean if vars is empty and
+	 *                                datasource is null. If 'unknown', the default case is used in
+	 *                                JFilterInput::clean.
+	 * @param   bool   $recursive     Flag to indicate a recursive function call.
+	 *
+	 * @return  mixed  The filtered input data.
+	 *
+	 * @since   ???
+	 */
+	protected function getArrayRecursive(array $vars = array(), $datasource = null, $defaultFilter = 'unknown', $recursion = false)
 	{
 		if (empty($vars) && is_null($datasource))
 		{
 			$vars = $this->data;
+		}
+		else
+		{
+			if (!$recursion)
+			{
+				$defaultFilter = null;
+			}
 		}
 
 		$results = array();
@@ -200,26 +233,28 @@ class JInput implements Serializable, Countable
 			{
 				if (is_null($datasource))
 				{
-					$results[$k] = $this->getArray($v, $this->get($k, null, 'array'));
+					$results[$k] = $this->getArrayRecursive($v, $this->get($k, null, 'array'), $defaultFilter, true);
 				}
 				else
 				{
-					$results[$k] = $this->getArray($v, $datasource[$k]);
+					$results[$k] = $this->getArrayRecursive($v, $datasource[$k], $defaultFilter, true);
 				}
 			}
 			else
 			{
+				$filter = isset($defaultFilter) ? $defaultFilter : $v;
+
 				if (is_null($datasource))
 				{
-					$results[$k] = $this->get($k, null, $v);
+					$results[$k] = $this->get($k, null, $filter);
 				}
 				elseif (isset($datasource[$k]))
 				{
-					$results[$k] = $this->filter->clean($datasource[$k], $v);
+					$results[$k] = $this->filter->clean($datasource[$k], $filter);
 				}
 				else
 				{
-					$results[$k] = $this->filter->clean(null, $v);
+					$results[$k] = $this->filter->clean(null, $filter);
 				}
 			}
 		}


### PR DESCRIPTION
This is a pull request for issue #6008.
It fixes the applying of wrong filters in the case, that the function is called without parameters.

If using the JInput::getArray() function without parameters e.g.

```
        $mypostdata = $myapp->input->post->getArray();
```

and the post data contains variables having values matching a JInputFilter type e.g. 'integer', 'int', 'float' etc. these values will be applied as filter in the following function code:

```
                if (is_null($datasource))
                {
                    $results[$k] = $this->get($k, null, $v);
                }
```

When calling the function without parameters the function uses the class property 'data', which is an associative array with variable names and their values.

So, a POST variable 'myinputstring' containing a string value 'integer' will be returned as an integer containing a 0, which is definetly a wrong behaviour.

Wouldn't it be better to detect a parameterless function call to apply 'RAW' filters in that case?
