### PR TITLE
Notice when updating package via Extension Manager=>Install

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -657,7 +657,7 @@ class JInstaller extends JAdapter
 		// Fire the onExtensionBeforeUpdate event.
 		JPluginHelper::importPlugin('extension');
 		$dispatcher = JEventDispatcher::getInstance();
-		$dispatcher->trigger('onExtensionBeforeUpdate', array('type' => $type, 'manifest' => $this->manifest));
+		$dispatcher->trigger('onExtensionBeforeUpdate', array('type' => $this->manifest->attributes()->type, 'manifest' => $this->manifest));
 
 		// Run the update
 		$result = $adapter->update();


### PR DESCRIPTION
When updating a language pack, Installation went fine but I got:
[10-Feb-2015 07:09:28 UTC] PHP Notice:  Undefined variable: type in 
ROOT/libraries/cms/installer/installer.php on line 660

This should solve it.
