### PR TITLE
Fatal error: Call to undefined method JDocumentRaw::getHeadData()

### DIFF
--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -141,7 +141,8 @@ class JCacheControllerCallback extends JCacheController
 			{
 				$document = JFactory::getDocument();
 				$coptions['modulemode'] = 1;
-				if (method_exists($document, 'getHeadData')){
+				if (method_exists($document, 'getHeadData'))
+				{
 					$coptions['headerbefore'] = $document->getHeadData();
 				}	
 			}

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -141,7 +141,9 @@ class JCacheControllerCallback extends JCacheController
 			{
 				$document = JFactory::getDocument();
 				$coptions['modulemode'] = 1;
-				$coptions['headerbefore'] = $document->getHeadData();
+				if (method_exists($document, 'getHeadData')){
+					$coptions['headerbefore'] = $document->getHeadData();
+				}	
 			}
 			else
 			{


### PR DESCRIPTION
Getting Fatal error: Call to undefined method JDocumentRaw::getHeadData()
Case 6028:
http://issues.joomla.org/tracker/joomla-cms/6028

How to repreduce:
I'm using AJAX call to refresh a module.
In javascript I use the following:

```
function moduleRefreshSendAjax (moduleName, moduleId, modulePosition, num){
var data = {
"option": "com_ajax",
"module": moduleName,
"method": "refresh",
"moduleid": moduleId,
"position": modulePosition,
"format": "raw"
};

    jQuery.ajax({
        type: "POST",
        data: data,
        success: function (res) {
            jQuery('.news-' + moduleId).html(res);
        },
        error: function (res) {
            console.log("ERROR: " + res.responseText);
        }
    });
};
```

And in the server side I use the following method:

```
public static function refreshAjax() {

$position = $_POST['position'];
$moduleId = $_POST['moduleid'];
$modules =& JModuleHelper::getModules($position);
foreach ($modules as $module) {
if ($module->id == $moduleId) {
return JModuleHelper::renderModule($module);
}
}
}
```
