### PR TITLE
JAsset improve: allow to test multiple assets

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -428,7 +428,8 @@ abstract class JModuleHelper
 		if ($frontediting)
 		{
 			// Check access for each asset rule
-			$access = $user->get('isRoot') ? array_fill_keys($assets, true) : (empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets));
+			$access = $user->get('isRoot') ? array_fill_keys($assets, true) :
+				(empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets));
 			foreach ($clean as $m)
 			{
 				$m->edit_frontend = !empty($access['com_modules.module.' . $m->id]);

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -377,7 +377,6 @@ class JAccess
 		}
 
 		// Make sure that we have the root
-		$root = new JAccessRules;
 		$assetTable = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
 		$rootId = $assetTable->getRootId();
 
@@ -389,6 +388,8 @@ class JAccess
 				->where('id = ' . $db->quote($rootId));
 			$db->setQuery($query);
 			$result = $db->loadResult();
+
+			$root = new JAccessRules;
 			$root->mergeCollection(array($result));
 
 			self::$assetRules['root.' . $rootId] = $root;

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -133,7 +133,7 @@ class JAccess
 		$toLoad = array_diff($assets, array_keys(self::$assetRules));
 
 		// Load rules for give assets
-		if(!empty($toLoad))
+		if (!empty($toLoad))
 		{
 			$rules = self::getAssetRulesMultiple($toLoad, true);
 			self::$assetRules = array_merge(self::$assetRules, $rules);
@@ -147,7 +147,7 @@ class JAccess
 		$authorised = array_fill_keys($assets, null);
 		foreach ($assets as $asset)
 		{
-			if(!empty(self::$assetRules[$asset]))
+			if (!empty(self::$assetRules[$asset]))
 			{
 				$authorised[$asset] = self::$assetRules[$asset]->allow($action, $identities);
 			}

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -119,7 +119,7 @@ class JAccess
 	 *
 	 * @param   integer  $userId  Id of the user for which to check authorisation.
 	 * @param   string   $action  The name of the action to authorise.
-	 * @param   array    $assets   Array of integer asset ids or the names of the asset as a string.
+	 * @param   array    $assets  Array of integer asset ids or the names of the asset as a string.
 	 *
 	 * @return  array  assets name => test result
 	 */
@@ -328,6 +328,7 @@ class JAccess
 	public static function getAssetRulesMultiple($assets, $recursive = false)
 	{
 		$rules = array();
+
 		// Get the database connection object.
 		$db = JFactory::getDbo();
 
@@ -414,7 +415,8 @@ class JAccess
 				{
 					array_pop($parts);
 					$parentAsset = implode('.', $parts);
-					switch (true) {
+					switch (true)
+					{
 						case !empty($parts[$parentAsset]):
 							$parent = $parts[$parentAsset];
 							break 2;

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -248,16 +248,20 @@ class JAccess
 		// Get the root even if the asset is not found and in recursive mode
 		if (empty($result))
 		{
-			$db = JFactory::getDbo();
-			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
-			$rootId = $assets->getRootId();
-			$query->clear()
-				->select('rules')
-				->from('#__assets')
-				->where('id = ' . $db->quote($rootId));
-			$db->setQuery($query);
-			$result = $db->loadResult();
-			$result = array($result);
+			if(empty(self::$assetRules['root']))
+			{
+				$db = JFactory::getDbo();
+				$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
+				$rootId = $assets->getRootId();
+				$query->clear()
+					->select('rules')
+					->from('#__assets')
+					->where('id = ' . $db->quote($rootId));
+				$db->setQuery($query);
+				$result = $db->loadResult();
+				self::$assetRules['root'] = array($result);
+			}
+			$result = self::$assetRules['root'];
 		}
 		// Instantiate and return the JAccessRules object for the asset rules.
 		$rules = new JAccessRules;

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -121,7 +121,7 @@ class JAccess
 	 * @param   string   $action  The name of the action to authorise.
 	 * @param   array    $assets   Array of integer asset ids or the names of the asset as a string.
 	 *
-	 * @return  array  assets name => bool
+	 * @return  array  assets name => test result
 	 */
 	public static function checkMultiple($userId, $action, $assets)
 	{
@@ -322,8 +322,7 @@ class JAccess
 	 *
 	 * @param   array    $assets     Integer asset id or the name of the asset as a string.
 	 *
-	 * @return  array of JAccessRules   JAccessRules object for the asset.
-	 *
+	 * @return  array of JAccessRules for the assets.
 	 */
 	public static function getAssetRulesMultiple($assets)
 	{

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -41,7 +41,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 		$menusEditing = ($editing == 2) && $user->authorise('core.edit', 'com_menus');
 		$access       = array();
 
-		if($frontediting)
+		if($frontediting && !$user->get('isRoot'))
 		{
 			// Collect asset names
 			$assets = array();

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -34,31 +34,14 @@ class JDocumentRendererModules extends JDocumentRenderer
 
 		$app     = JFactory::getApplication();
 		$user    = JFactory::getUser();
-		$modules = JModuleHelper::getModules($position);
 
-		$editing      = $app->get('frontediting', 1);
-		$frontediting = ($app->isSite() && $editing && !$user->guest);
-		$menusEditing = ($editing == 2) && $user->authorise('core.edit', 'com_menus');
-		$access       = array();
-
-		if ($frontediting && !$user->get('isRoot'))
-		{
-			// Collect asset names
-			$assets = array();
-			foreach ($modules as $mod)
-			{
-				$assets[] = 'com_modules.module.' . $mod->id;
-			}
-
-			// Check access for each asset rule
-			$access = empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets);
-		}
+		$menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
 
 		foreach (JModuleHelper::getModules($position) as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($frontediting && trim($moduleHtml) && ($user->get('isRoot') || !empty($access['com_modules.module.' . $mod->id])))
+			if (trim($moduleHtml) && !empty($mod->edit_frontend))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				JLayoutHelper::render('joomla.edit.frontediting_modules', $displayData);

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -37,7 +37,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 
 		$menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
 
-		foreach ($modules as $mod)
+		foreach (JModuleHelper::getModules($position) as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -54,7 +54,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 			$access = empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets);
 		}
 
-		foreach (JModuleHelper::getModules($position) as $mod)
+		foreach ($modules as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -41,7 +41,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 		$menusEditing = ($editing == 2) && $user->authorise('core.edit', 'com_menus');
 		$access       = array();
 
-		if($frontediting && !$user->get('isRoot'))
+		if ($frontediting && !$user->get('isRoot'))
 		{
 			// Collect asset names
 			$assets = array();
@@ -49,6 +49,7 @@ class JDocumentRendererModules extends JDocumentRenderer
 			{
 				$assets[] = 'com_modules.module.' . $mod->id;
 			}
+
 			// Check access for each asset rule
 			$access = empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets);
 		}

--- a/libraries/joomla/document/html/renderer/modules.php
+++ b/libraries/joomla/document/html/renderer/modules.php
@@ -30,19 +30,34 @@ class JDocumentRendererModules extends JDocumentRenderer
 	public function render($position, $params = array(), $content = null)
 	{
 		$renderer = $this->_doc->loadRenderer('module');
-		$buffer = '';
+		$buffer   = '';
 
-		$app = JFactory::getApplication();
-		$frontediting = $app->get('frontediting', 1);
-		$user = JFactory::getUser();
+		$app     = JFactory::getApplication();
+		$user    = JFactory::getUser();
+		$modules = JModuleHelper::getModules($position);
 
-		$menusEditing = ($frontediting == 2) && $user->authorise('core.edit', 'com_menus');
+		$editing      = $app->get('frontediting', 1);
+		$frontediting = ($app->isSite() && $editing && !$user->guest);
+		$menusEditing = ($editing == 2) && $user->authorise('core.edit', 'com_menus');
+		$access       = array();
+
+		if($frontediting)
+		{
+			// Collect asset names
+			$assets = array();
+			foreach ($modules as $mod)
+			{
+				$assets[] = 'com_modules.module.' . $mod->id;
+			}
+			// Check access for each asset rule
+			$access = empty($assets) ? array() : JAccess::checkMultiple($user->get('id'), 'module.edit.frontend', $assets);
+		}
 
 		foreach (JModuleHelper::getModules($position) as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($app->isSite() && $frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+			if ($frontediting && trim($moduleHtml) && ($user->get('isRoot') || !empty($access['com_modules.module.' . $mod->id])))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				JLayoutHelper::render('joomla.edit.frontediting_modules', $displayData);


### PR DESCRIPTION
it alternative solution for improve performance #5996

I added 2 methods to `JAsset` that allow to check authorisation for multiple assets at once, 
and use it for check user access to edit the module

in theory such thing can perform also for articles , but lets test it on the modules

**test**
apply patch and check performance on the page where a loot modules, 
and compare result with test without this patch

**important**
- perform test as guest and as logged in user, as Super User and as user from other group
- try change  edit access for some module and user, then test whether it work

~~ps. have question, is it a good idea move this out from `JDocumentRendererModules` somewhere in `JModuleHelper::load()` ?~~

~~this pull check access by "module position" not by each module, so performance will be depend from how much positions in the template :smile:~~

if it will work good, then similar thing can be done for articles, for more efficient perform access check 
