### PR TITLE
[Fix] Version History Limit option from other extension does not have effect

### DIFF
--- a/libraries/cms/helper/contenthistory.php
+++ b/libraries/cms/helper/contenthistory.php
@@ -142,7 +142,10 @@ class JHelperContenthistory extends JHelper
 
 		$result = $historyTable->store();
 
-		if ($maxVersions = JComponentHelper::getParams('com_content')->get('history_limit', 0))
+		// Load history_limit config from extension.
+		$aliasParts = explode('.', $this->typeAlias);
+
+		if ($maxVersions = JComponentHelper::getParams($aliasParts[0])->get('history_limit', 0))
 		{
 			$historyTable->deleteOldVersions($maxVersions);
 		}


### PR DESCRIPTION
Hi guys,

When working on apply "Versioning" feature for my extension, I found a bug that the 'history_limit' is not effected, the Content History always get this option from com_content, not from my extension even I have it in config.xml.

This PR is make Content History load 'history_limit' from other extension like the way load 'save_history' option.
