### PR TITLE
Custom $pk doesn't work on JLanguageAssociations::getAssociations

### DIFF
--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -42,7 +42,7 @@ class JLanguageAssociations
 		$query = $db->getQuery(true)
 			->select($db->quoteName('c2.language'))
 			->from($db->quoteName($tablename, 'c'))
-			->join('INNER', $db->quoteName('#__associations', 'a') . ' ON a.id = c.id AND a.context=' . $db->quote($context))
+			->join('INNER', $db->quoteName('#__associations', 'a') . ' ON a.id = c.' . $db->quoteName($pk) . ' AND a.context=' . $db->quote($context))
 			->join('INNER', $db->quoteName('#__associations', 'a2') . ' ON a.key = a2.key')
 			->join('INNER', $db->quoteName($tablename, 'c2') . ' ON a2.id = c2.' . $db->quoteName($pk));
 


### PR DESCRIPTION
Hi there,

A small glitch. If we use a custom primary key name the SQL returns an error because the `c.id` is hardcoded.

``` php
JLanguageAssociations::getAssociations(
    'com_mytables',
    '#__mytables',
    'com_mytables.item',
    1, 
    'myId',
    'customAlias'
);
```

```
#1054 - Unknown column 'c.id' in 'on clause' 
```

``` sql
SELECT `c2`.`language`,
    CONCAT_WS(':', `c2`.`myId`, `c2`.`customAlias`) AS `myId`,
    CONCAT_WS(':', ca.id, ca.alias) AS `catid`
FROM `#__mytables` AS `c`
    INNER JOIN `#__associations` AS `a` ON a.id = c.id AND a.context='com_mytables.item'
    INNER JOIN `#__associations` AS `a2` ON a.key = a2.key
    INNER JOIN `#__mytables` AS `c2` ON a2.id = c2.`myId`
    INNER JOIN `#__categories` AS `ca` ON `c2`.`catid` = ca.id AND ca.extension = 'com_mytables'
WHERE c.myId = 1
```
