### PR TITLE
Adding access cache to JUser

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -211,6 +211,14 @@ class JUser extends JObject
 	protected $userHelper = null;
 
 	/**
+	 * Cache for access data
+	 *
+	 * @var    array
+	 * @since  3.5
+	 */
+	private $accessCache = array();
+
+	/**
 	 * @var    array  JUser instances container.
 	 * @since  11.3
 	 */
@@ -390,7 +398,26 @@ class JUser extends JObject
 			}
 		}
 
-		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetname);
+		if ($this->isRoot)
+		{
+			return true;
+		}
+		else
+		{
+			$key = md5($this->id . '|' . $action . '|' . $assetname);
+
+			if (!array_key_exists($key, $this->accessCache))
+			{
+				if (count($this->accessCache) > 250)
+				{
+					array_shift($this->accessCache);
+				}
+
+				$this->accessCache[$key] = JAccess::check($this->id, $action, $assetname);
+			}
+
+			return $this->accessCache[$key];
+		}
 	}
 
 	/**
@@ -490,6 +517,7 @@ class JUser extends JObject
 		$this->_authLevels = null;
 		$this->_authGroups = null;
 		$this->isRoot = null;
+		$this->accessCache = array();
 		JAccess::clearStatics();
 	}
 

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -408,6 +408,7 @@ class JUser extends JObject
 
 			if (!array_key_exists($key, $this->accessCache))
 			{
+				// We want to limit the cache to ~250 entries. If the cache gets larger, we purge the oldest element.
 				if (count($this->accessCache) > 250)
 				{
 					array_shift($this->accessCache);


### PR DESCRIPTION
This adds caching to the authorise method of JUser. Instead of doing the whole check each time JUser::authorise() is called, the checks are done once per session and that is it. This is quite a performance improvement.

To prevent the session from being overrun by the access cache, the number of access results to cache is limited to 250 entries. That should be equivalent to around 10-14kb of data.

I did not make scientific tests with this, just some manual comparisons and I did get positive results in terms of performance gain.

There is a potential issue when an extension creates its own login/logout code that does not use JApplicationCMS::login/logout and which does not correctly reset the JUser object. In that case however, that extension has quite large security issues anyway. 

Anyway, I made the caching variable private, so that we can remove it again in case it turns out to be a failure. There is no backwards compatibility issue there.
