### PR TITLE
A better way for JTableUser::store to save groups

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -332,14 +332,13 @@ class JTableUser extends JTable
 				->insert($this->_db->quoteName('#__user_usergroup_map'))
 				->columns(array($this->_db->quoteName('user_id'), $this->_db->quoteName('group_id')));
 
-			// Have to break this up into individual queries for cross-database support.
 			foreach ($this->groups as $group)
 			{
-				$query->clear('values')
-					->values($this->id . ', ' . $group);
-				$this->_db->setQuery($query);
-				$this->_db->execute();
+				$query->values($this->id . ', ' . $group);
 			}
+
+			$this->_db->setQuery($query);
+			$this->_db->execute();
 		}
 
 		// If a user is blocked, delete the cookie login rows

--- a/tests/unit/suites/libraries/joomla/table/JTableUserTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableUserTest.php
@@ -44,6 +44,16 @@ class JTableUserTest extends TestCaseDatabase
 	 */
 	public function testStoreNewUser()
 	{
+		/*
+		 * The updated store method uses syntax not compatible with SQLite < 3.7.11
+		 * and according to PHP's changelog, a version newer than this was not introduced
+		 * until PHP 5.5.11
+		 */
+		if (version_compare(PHP_VERSION, '5.5.11', 'lt'))
+		{
+			$this->markTestSkipped('The store method does not execute properly on SQLite < 3.7.11');
+		}
+
 		$user = new JTableUser(self::$driver);
 
 		$user->name = 'Neil Armstrong';


### PR DESCRIPTION
This is related to #5144. @jaworskimatt says that he has issues with several instances of Jomsocial writing to the DB at the same time and thus messing up the user-group-mapping table. His proposal was a very complex set of several queries and comparisons. I countered that I rather want that to happen in one query and that that should be possible for our database query class. 

So I looked at JDatabaseQuery and it exactly states that you can insert more than one row at a time by simply calling JDatabaseQuery::values() several times. I looked at the existing code and saw that it claims that the several different queries are due to cross-database support. I call bullocks on that one. Every serious DBMS out there supports adding more than one row at a time. If there are problems in our implementation regarding this, then it is because of the JDatabaseQuery class of that RDBMS.

If, for some strange reason, I'm actually wrong and there is a system out there that does not support several rows in one insert, then we can close this PR, but have to open a new one that changes JDatabaseQuery to make it clear that it can only do one row per insert.

In any case, for everything else I refer to #5144
