### PR TITLE
Remove unused options in menu manager

### DIFF
--- a/administrator/components/com_menus/config.xml
+++ b/administrator/components/com_menus/config.xml
@@ -6,12 +6,6 @@
 		>
 
 		<field
-			name="page_title"
-			type="text"
-			label="COM_MENUS_ITEM_FIELD_PAGE_TITLE_LABEL"
-			description="COM_MENUS_ITEM_FIELD_PAGE_TITLE_DESC"
-			/>
-		<field
 			name="show_page_heading"
 			type="radio"
 			class="btn-group btn-group-yesno"
@@ -23,18 +17,6 @@
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		<field
-			name="page_heading"
-			type="text"
-			label="COM_MENUS_ITEM_FIELD_PAGE_HEADING_LABEL"
-			description="COM_MENUS_ITEM_FIELD_PAGE_HEADING_DESC"
-			/>
-		<field
-			name="pageclass_sfx"
-			type="text"
-			label="COM_MENUS_ITEM_FIELD_PAGE_CLASS_LABEL"
-			description="COM_MENUS_ITEM_FIELD_PAGE_CLASS_DESC"
-			/>
 	</fieldset>
 
 	<fieldset


### PR DESCRIPTION
Go to Menu Manager and select options. You have 4 items that can be set but only one of those is something that can be set globally. This PR removes the three unused options
