### PR TITLE
Consistency in Options com_redirect

### DIFF
--- a/administrator/components/com_redirect/config.xml
+++ b/administrator/components/com_redirect/config.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-	<fieldset
-		name="permissions"
-		label="JCONFIG_PERMISSIONS_LABEL"
-		description="JCONFIG_PERMISSIONS_DESC">
-
-		<field
-			name="rules"
-			type="rules"
-			label="JCONFIG_PERMISSIONS_LABEL"
-			filter="rules"
-			validate="rules"
-			component="com_redirect"
-			section="component" />
-	</fieldset>
 	<fieldset name="redirect"
 		label="COM_REDIRECT_ADVANCED_OPTIONS"
 	>
@@ -28,5 +14,19 @@
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
+	</fieldset>
+	<fieldset
+		name="permissions"
+		label="JCONFIG_PERMISSIONS_LABEL"
+		description="JCONFIG_PERMISSIONS_DESC">
+
+		<field
+			name="rules"
+			type="rules"
+			label="JCONFIG_PERMISSIONS_LABEL"
+			filter="rules"
+			validate="rules"
+			component="com_redirect"
+			section="component" />
 	</fieldset>
 </config>


### PR DESCRIPTION
In all the Options screens Permissions is the last tab except for com_redirect.

This simple PR fixes that - to test go to the redirect component and select Options. 

Before the patch the Permissions is the first tab. After the patch it is the last tab the same as with every other component
