### PR TITLE
[fix] Bug in setting startOffset to tabs - using localStorage all the time

### DIFF
--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -84,7 +84,7 @@ abstract class JHtmlTabs
 			$opt['onActive']            = (isset($params['onActive'])) ? '\\' . $params['onActive'] : null;
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
-			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
+			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? true : false;
 			$opt['titleSelector']       = "dt.tabs";
 			$opt['descriptionSelector'] = "dd.tabs";
 


### PR DESCRIPTION
#### To reproduce the issue

**Do this before applyting patch**

Add the following code in any joomla template file (for example: `<any-component>/views/tmpl/default.php`)

``` php
// We are setting start offset to 2 and setting browser storage to false
$options = array(
    'startOffset' => 2,
    'useCookie'   => false
);

echo JHtml::_('tabs.start', 'pane', $options);

echo JHtml::_('tabs.panel', "Tab1", 'tab1');

    echo "Tab1 content";

echo JHtml::_('tabs.panel', 'Tab2', 'tab2');

    echo "Tab2 content";

echo JHtml::_('tabs.panel', 'Tab3', 'tab3');

    echo "Tab3 content";

echo JHtml::_('tabs.panel', 'Tab4', 'tab4');

    echo "Tab4 content";
echo JHtml::_('tabs.end');
```

Ideally you should have open `Tab3` as we have set offset to 2. Now, if you have `Tab1` as selected then select `Tab2` and simply refresh the page. We have disabled the broweser storage, it means `Tab3` should be selected. But it's not. 
#### Reason:

https://github.com/joomla/joomla-cms/blob/staging/media/system/js/tabs.js#L45 this line of code is expecting `boolean` but when you will check in cosole with code,

``` javascript
console.log(typeof this.options.useStorage);
```

it will show `string` and because of that condition in above file always become `true`.
#### Test & Confirm fix

Apply this patch and confirm with enabling or disabling browser storage.
