### PR TITLE
[#6054] - SQL Errors in search tag with MSSQL.

### DIFF
--- a/plugins/search/contacts/contacts.php
+++ b/plugins/search/contacts/contacts.php
@@ -155,7 +155,6 @@ class PlgSearchContacts extends JPlugin
 					. ' OR a.fax LIKE ' . $text . ') AND a.published IN (' . implode(',', $state) . ') AND c.published=1 '
 					. ' AND a.access IN (' . $groups . ') AND c.access IN (' . $groups . ')'
 			)
-			->group('a.id, a.con_position, a.misc, c.alias, c.id')
 			->order($order);
 
 		// Filter by language.

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -178,7 +178,7 @@ class PlgSearchContent extends JPlugin
 						. 'AND (a.publish_up = ' . $db->quote($nullDate) . ' OR a.publish_up <= ' . $db->quote($now) . ') '
 						. 'AND (a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')'
 				)
-				->group('a.id, a.title, a.metadesc, a.metakey, a.created, a.introtext, a.fulltext, c.title, a.alias, c.alias, c.id')
+				->group('a.id, a.title, a.metadesc, a.metakey, a.created, a.language, a.catid, a.introtext, a.fulltext, c.title, a.alias, c.alias, c.id')
 				->order($order);
 
 			// Filter by language.

--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -105,7 +105,7 @@ class PlgSearchTags extends JPlugin
 		$query->select('a.id, a.title, a.alias, a.note, a.published, a.access' .
 			', a.checked_out, a.checked_out_time, a.created_user_id' .
 			', a.path, a.parent_id, a.level, a.lft, a.rgt' .
-			', a.language, a.created_time AS created, a.note, a.description');
+			', a.language, a.created_time AS created, a.description');
 
 		$case_when_item_alias = ' CASE WHEN ';
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');


### PR DESCRIPTION
2nd error fix: removed the duplicated field "a.node" from the select list
as reported #6054 2º Error: Delete 'a.note', because have 2 in "SELECT" and this can provoke a crash in MSSQL.

---
#### Steps to reproduce the issue

Go to: /index.php?searchword=tag&ordering=newest&searchphrase=all&option=com_search
#### Expected result

Search Results.
#### Actual result
#### 1st error

[Microsoft][SQL Server Native Client 11.0][SQL Server] Column 'yawcx_contact_details.name' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause. SQL=SELECT \* FROM ( SELECT a.name AS title, '' AS created, a.con_position, a.misc, CASE WHEN DATALENGTH(a.alias) != 0 THEN (CAST(a.id as NVARCHAR(10))+':'+a.alias) ELSE CAST(a.id as NVARCHAR(10)) END as slug, CASE WHEN DATALENGTH(c.alias) != 0 THEN (CAST(c.id as NVARCHAR(10))+':'+c.alias) ELSE CAST(c.id as NVARCHAR(10)) END as catslug, (a.name+','+a.con_position+','+a.misc) AS text,('Contacts'+' / '+c.title) AS section,'2' AS browsernav , ROW_NUMBER() OVER (ORDER BY a.name DESC) AS RowNumber FROM yawcx_contact_details AS a INNER JOIN yawcx_categories AS c ON c.id = a.catid WHERE (a.name LIKE '%tag%' OR a.misc LIKE '%tag%' OR a.con_position LIKE '%tag%' OR a.address LIKE '%tag%' OR a.suburb LIKE '%tag%' OR a.state LIKE '%tag%' OR a.country LIKE '%tag%' OR a.postcode LIKE '%tag%' OR a.telephone LIKE '%tag%' OR a.fax LIKE '%tag%') AND a.published IN (1,2) AND c.published=1 AND a.access IN (1,1,2) AND c.access IN (1,1,2) GROUP BY a.id, a.con_position, a.misc, c.alias, c.id ) _myResults WHERE RowNumber BETWEEN 1 AND 50
#### 2nd error

[Microsoft][SQL Server Native Client 11.0][SQL Server]The column 'note' was specified multiple times for '_myResults'. SQL=SELECT \* FROM ( SELECT a.id, a.title, a.alias, a.note, a.published, a.access, a.checked_out, a.checked_out_time, a.created_user_id, a.path, a.parent_id, a.level, a.lft, a.rgt, a.language, a.created_time AS created, a.note, a.description, CASE WHEN DATALENGTH(a.alias) != 0 THEN (CAST(a.id as NVARCHAR(10))+':'+a.alias) ELSE CAST(a.id as NVARCHAR(10)) END as slug , ROW_NUMBER() OVER (ORDER BY a.created_time DESC) AS RowNumber FROM yawcx_tags AS a WHERE a.alias <> 'root' AND (a.title LIKE '%tag%' OR a.alias LIKE '%tag%') AND a.access IN (1,1,2) ) _myResults WHERE RowNumber BETWEEN 1 AND 50
#### System information (as much as possible)

IIS
MSSQL
Joomla 3.3.6
#### Additional comments

1º Error:  group clause a.name, a.alias, c.title because GROUP BY is diferent in MySQL.
(/plugin/search/contacts/contacts.php)
2º Error: Duplicate 'a.note',  2 times in "SELECT" and this can provoke a crash in MSSQL.
(/plugin/search/tags/tags.php)
