### PR TITLE
link not being closed correctly

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -108,7 +108,7 @@ class JHtmlUsers
 				'height' => '500px')
 		);
 
-		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal"'
+		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal">'
 			. '<span class="label label-info"><i class="icon-drawer-2"></i>' . $title . '</span></a>';
 	}
 


### PR DESCRIPTION
In users helper in com_users a link it's closed properly.
## Before patch

![skaermbillede 2015-02-13 kl 22 41 45](https://cloud.githubusercontent.com/assets/1738811/6195774/8942639c-b3d1-11e4-954e-db42cd734aae.png)
## After patch

![skaermbillede 2015-02-13 kl 22 41 53](https://cloud.githubusercontent.com/assets/1738811/6195773/893ed182-b3d1-11e4-9431-1320ac7c50f6.png)
