### PR TITLE
Profile plugin: make birth date timezone independent

### DIFF
--- a/plugins/user/profile/profiles/profile.xml
+++ b/plugins/user/profile/profiles/profile.xml
@@ -107,7 +107,7 @@
 				description="PLG_USER_PROFILE_FIELD_DOB_DESC"
 				info="PLG_USER_PROFILE_SPACER_DOB"
 				format="%Y-%m-%d"
-				filter="server_utc"
+				filter="unset"
 			/>
 			<field
 				name="tos"


### PR DESCRIPTION
The birth date is always the same, around the world, independend from any timezone.

Also the combination of date-only + timezone converting filter will make the user one day older each time (s)he clicks Edit.

Test:
- ensure Global Configuration - Server - Server Time Zone is set to a western tz, e.g. New York
- have a User Profile menu item available
- edit user profile and type in a birth date, Save
- edit again -> now it shows date 1 day before

(on com_finder Start Date / End Date you have the same effect but on eastern timezone, e.g. Berlin - but that's another story)
