### PR TITLE
Post-Install Messages sometimes ignores records associated to 3rd party extensions

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -53,7 +53,7 @@ class CpanelViewCpanel extends JViewLegacy
 			require_once JPATH_LIBRARIES . '/fof/include.php';
 		}
 
-		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel')->eid(700);
+		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel');
 		$messages = $messages_model->getItemList();
 
 		$this->postinstall_message_count = count($messages);

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -31,10 +31,6 @@ class PostinstallModelMessages extends FOFModel
 
 		$db = $this->getDbo();
 
-		// Add a forced extension filtering to the list
-		$eid = $this->getState('eid', 700);
-		$query->where($db->qn('extension_id') . ' = ' . $db->q($eid));
-
 		// Force filter only enabled messages
 		$published = $this->getState('published', 1, 'int');
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));


### PR DESCRIPTION
As long as at least one post-install message associated to Joomla exists, the control panel displays a warning and leads to com_postinstall.
There, all messages as shown, regardless of they are associated to Joomla or 3rd party extensions.
However, as soon as all the Joomla related messages are marked as read, the control panel no longer indicates that other post-installation messages are present.
Messages associated to 3rd party extension will not be notified in the control panel until at least one message associated to Joomla will added again.
