### PR TITLE
Icons instead of images in com_messages

### DIFF
--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -69,8 +69,8 @@ class JHtmlMessages
 		// Array of image, task, title, action.
 		$states	= array(
 			-2	=> array('trash',       'messages.unpublish',	'JTRASHED',				        'COM_MESSAGES_MARK_AS_UNREAD'),
-			1	=> array('unpublish',	'messages.unpublish',	'COM_MESSAGES_OPTION_READ',		'COM_MESSAGES_MARK_AS_UNREAD'),
-			0	=> array('publish',	    'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
+			1	=> array('publish',	'messages.unpublish',	'COM_MESSAGES_OPTION_READ',		'COM_MESSAGES_MARK_AS_UNREAD'),
+			0	=> array('unpublish',	    'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
 		);
 		$state	= JArrayHelper::getValue($states, (int) $value, $states[0]);
 		$icon	= $state[0];

--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -80,11 +80,6 @@ class JHtmlMessages
 			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><i class="icon-'
 				. $icon . '"></i></a>';
 		}
-		else
-		{
-			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><i class="icon-'
-				. $icon . '"></i></a>';
-		}
 
 		return $html;
 	}

--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -68,17 +68,22 @@ class JHtmlMessages
 	{
 		// Array of image, task, title, action.
 		$states	= array(
-			-2	=> array('trash.png',		'messages.unpublish',	'JTRASHED',				'COM_MESSAGES_MARK_AS_UNREAD'),
-			1	=> array('tick.png',		'messages.unpublish',	'COM_MESSAGES_OPTION_READ',		'COM_MESSAGES_MARK_AS_UNREAD'),
-			0	=> array('publish_x.png',	'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
+			-2	=> array('trash',       'messages.unpublish',	'JTRASHED',				        'COM_MESSAGES_MARK_AS_UNREAD'),
+			1	=> array('unpublish',	'messages.unpublish',	'COM_MESSAGES_OPTION_READ',		'COM_MESSAGES_MARK_AS_UNREAD'),
+			0	=> array('publish',	    'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
 		);
 		$state	= JArrayHelper::getValue($states, (int) $value, $states[0]);
-		$html	= JHtml::_('image', 'admin/' . $state[0], JText::_($state[2]), null, true);
+        $icon	= $state[0];
 
 		if ($canChange)
 		{
-			$html = '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" title="' . JText::_($state[3]) . '">'
-					. $html . '</a>';
+			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><i class="icon-'
+				. $icon . '"></i></a>';
+		}
+		else
+		{
+			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><i class="icon-'
+				. $icon . '"></i></a>';
 		}
 
 		return $html;

--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -73,7 +73,7 @@ class JHtmlMessages
 			0	=> array('publish',	    'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
 		);
 		$state	= JArrayHelper::getValue($states, (int) $value, $states[0]);
-        $icon	= $state[0];
+		$icon	= $state[0];
 
 		if ($canChange)
 		{


### PR DESCRIPTION
PR that changes the publish/unpublish/trash functions in com_messages to use icons instead of images
## Before patch

![skaermbillede 2015-02-14 kl 02 03 30](https://cloud.githubusercontent.com/assets/1738811/6197849/b765b7b2-b3ed-11e4-82f1-aecda01bc8a5.png)
## After patch

![skaermbillede 2015-02-14 kl 02 03 03](https://cloud.githubusercontent.com/assets/1738811/6197848/b7472a68-b3ed-11e4-9ed0-61d22141b555.png)
