### PR TITLE
Consistent use of input clear button in searchtools

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -38,6 +38,9 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>">
 				<i class="icon-search"></i>
 			</button>
+			<button type="button" class="btn hasTooltip js-stools-btn-clear" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>">
+				<i class="icon-remove"></i>
+			</button>
 		</div>
 		<?php if ($filterButton) : ?>
 			<div class="btn-wrapper hidden-phone">
@@ -46,10 +49,5 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				</button>
 			</div>
 		<?php endif; ?>
-		<div class="btn-wrapper">
-			<button type="button" class="btn hasTooltip js-stools-btn-clear" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>">
-				<?php echo JText::_('JSEARCH_FILTER_CLEAR');?>
-			</button>
-		</div>
 	<?php endif; ?>
 <?php endif;


### PR DESCRIPTION
At the moment, views not using the searchtools have a button group consisting of a search button and a clear button. See this example from com_contact:

![skaermbillede 2015-02-14 kl 02 30 47](https://cloud.githubusercontent.com/assets/1738811/6198030/8329c930-b3f1-11e4-81b7-dd6938f56b28.png)

This PR changes the behaviour of the searchtools to do the same:
## Before patch

![skaermbillede 2015-02-14 kl 02 31 51](https://cloud.githubusercontent.com/assets/1738811/6198036/ad5297a0-b3f1-11e4-8281-b495fd16c920.png)
## After patch

![skaermbillede 2015-02-14 kl 02 31 57](https://cloud.githubusercontent.com/assets/1738811/6198037/b41b829a-b3f1-11e4-8143-f1f916a808cf.png)
