### PR TITLE
setTemplate not working as expected (Fix #6096)

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -809,6 +809,10 @@ final class JApplicationSite extends JApplicationCms
 			{
 				$this->template->params = new Registry($styleParams);
 			}
+
+			// Store the template and its params to the config
+			$this->set('theme', $this->template->template);
+			$this->set('themeParams', $this->template->params);
 		}
 	}
 }


### PR DESCRIPTION
#### Steps to reproduce the issue

In a Joomla 3.3 site, add the following constructor to the top of a component and change <alternative_template> to another template you have available that isn't the site default.

```
function __construct() {
    parent::__construct();        
    $app = JFactory::getApplication();
    $app->setTemplate('<alternative_template>');
}
```
#### Expected result

The component should render its output into the template you used for <alternative_template>. 
#### Actual result

Under 3.3 the component will still render its output into the default site template. Under 2.5 it will use whatever template you used for <alternative_template>.
#### System information (as much as possible)

My website was migrated from 2.5.28 to 3.3 using the automatic migration option, and then all the DS constants in my custom component were replaced with '/' and the appropriate class names updated to include Legacy. The site uses custom templates throughout that were developed by me. It is hosted on a Rackspace managed cloud server behind a load-balancer. The web server runs under Ubuntu LTS 14.4, using Apache 2.4.7, PHP 5.5.9 and MySQL 5.6.19. 
#### Additional comments

Note: I migrated from 2.5 to 3.3 so can't say if earlier subversions of 3 had the problem I describe .

JApplicationSite::setTemplate() stores the template name you give it into the JApplicationCms::template property, but in Joomla 3.3 the render method in the same class uses the getter to retrieve a property called theme, which the getter JApplicationWeb gets from its config property that is a registry object.

So between 2.5 and 3.3 I see there has been a change in the terminology used for template and a change in the way this information is stored and retrieved that hasn't been applied to JApplicationSite::setTemplate().

If I replace JFactory::getApplication('<alternative_template>')->setTemplate() on my component with JFactory::getApplication()->set('theme', '<alternative_template>') it works, so this is my workaround.
