### PR TITLE
Fixing JDEBUG usage in JError

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -536,7 +536,7 @@ abstract class JError
 		$level_human = self::translateErrorLevel($error->get('level'));
 
 		// If system debug is set, then output some more information.
-		if (defined('JDEBUG'))
+		if (JDEBUG)
 		{
 			$backtrace = $error->getTrace();
 			$trace = '';
@@ -564,7 +564,7 @@ abstract class JError
 			// Output as html
 			echo "<br /><b>jos-$level_human</b>: "
 				. $error->get('message') . "<br />\n"
-				. (defined('JDEBUG') ? nl2br($trace) : '');
+				. (JDEBUG ? nl2br($trace) : '');
 		}
 		else
 		{
@@ -573,7 +573,7 @@ abstract class JError
 			{
 				fwrite(STDERR, "J$level_human: " . $error->get('message') . "\n");
 
-				if (defined('JDEBUG'))
+				if (JDEBUG)
 				{
 					fwrite(STDERR, $trace);
 				}
@@ -582,7 +582,7 @@ abstract class JError
 			{
 				echo "J$level_human: " . $error->get('message') . "\n";
 
-				if (defined('JDEBUG'))
+				if (JDEBUG)
 				{
 					echo $trace;
 				}


### PR DESCRIPTION
Based on #6033 and a discussion in the JBS chat, the constant JDEBUG should always be defined. That means that we don't have to check if JDEBUG is defined, but which value it has. This PR fixes that for JError.
