### PR TITLE
Fixing JDEBUG usage in JModuleHelper

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -143,7 +143,7 @@ abstract class JModuleHelper
 		// Check that $module is a valid module object
 		if (!is_object($module) || !isset($module->module) || !isset($module->params))
 		{
-			if (defined('JDEBUG') && JDEBUG)
+			if (JDEBUG)
 			{
 				JLog::addLogger(array('text_file' => 'jmodulehelper.log.php'), JLog::ALL, array('modulehelper'));
 				JLog::add('JModuleHelper::renderModule($module) expects a module object', JLog::DEBUG, 'modulehelper');
@@ -152,7 +152,7 @@ abstract class JModuleHelper
 			return;
 		}
 
-		if (defined('JDEBUG'))
+		if (JDEBUG)
 		{
 			JProfiler::getInstance('Application')->mark('beforeRenderModule ' . $module->module . ' (' . $module->title . ')');
 		}
@@ -250,7 +250,7 @@ abstract class JModuleHelper
 		// Revert the scope
 		$app->scope = $scope;
 
-		if (defined('JDEBUG'))
+		if (JDEBUG)
 		{
 			JProfiler::getInstance('Application')->mark('afterRenderModule ' . $module->module . ' (' . $module->title . ')');
 		}


### PR DESCRIPTION
Based on #6033 and a discussion in the JBS chat, the constant JDEBUG should always be defined. That means that we don't have to check if JDEBUG is defined, but which value it has. This PR fixes that for JModuleHelper.
