### PR TITLE
Ensure the catid is passed into the routing function

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -354,6 +354,7 @@ class ContactModelContact extends JModelForm
 					->select('a.title')
 					->select('a.state')
 					->select('a.access')
+					->select('a.catid')
 					->select('a.created')
 					->select('a.language');
 

--- a/components/com_contact/views/contact/tmpl/default_articles.php
+++ b/components/com_contact/views/contact/tmpl/default_articles.php
@@ -17,7 +17,7 @@ require_once JPATH_SITE . '/components/com_content/helpers/route.php';
 	<ul class="nav nav-tabs nav-stacked">
 		<?php foreach ($this->item->articles as $article) :	?>
 			<li>
-				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catslug, $article->language)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
+				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
 			</li>
 		<?php endforeach; ?>
 	</ul>


### PR DESCRIPTION
This was a change made in https://github.com/joomla/joomla-cms/pull/5937 however it is better that we pass in the catid as JM mentioned in a comment after it was merged. Simply check that the link to articles written by a given contact continue to work after this patch is applied
