### PR TITLE
Discover function in module & template adapters missing a file exists check

### DIFF
--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -430,32 +430,38 @@ class JInstallerAdapterModule extends JInstallerAdapter
 
 		foreach ($site_list as $module)
 		{
-			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/modules/$module/$module.xml");
-			$extension = JTable::getInstance('extension');
-			$extension->set('type', 'module');
-			$extension->set('client_id', $site_info->id);
-			$extension->set('element', $module);
-			$extension->set('folder', '');
-			$extension->set('name', $module);
-			$extension->set('state', -1);
-			$extension->set('manifest_cache', json_encode($manifest_details));
-			$extension->set('params', '{}');
-			$results[] = clone $extension;
+			if (file_exists(JPATH_SITE . "/modules/$module/$module.xml"))
+			{
+				$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/modules/$module/$module.xml");
+				$extension = JTable::getInstance('extension');
+				$extension->set('type', 'module');
+				$extension->set('client_id', $site_info->id);
+				$extension->set('element', $module);
+				$extension->set('folder', '');
+				$extension->set('name', $module);
+				$extension->set('state', -1);
+				$extension->set('manifest_cache', json_encode($manifest_details));
+				$extension->set('params', '{}');
+				$results[] = clone $extension;
+			}
 		}
 
 		foreach ($admin_list as $module)
 		{
-			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_ADMINISTRATOR . "/modules/$module/$module.xml");
-			$extension = JTable::getInstance('extension');
-			$extension->set('type', 'module');
-			$extension->set('client_id', $admin_info->id);
-			$extension->set('element', $module);
-			$extension->set('folder', '');
-			$extension->set('name', $module);
-			$extension->set('state', -1);
-			$extension->set('manifest_cache', json_encode($manifest_details));
-			$extension->set('params', '{}');
-			$results[] = clone $extension;
+			if (file_exists(JPATH_ADMINISTRATOR . "/modules/$module/$module.xml"))
+			{
+				$manifest_details = JInstaller::parseXMLInstallFile(JPATH_ADMINISTRATOR . "/modules/$module/$module.xml");
+				$extension = JTable::getInstance('extension');
+				$extension->set('type', 'module');
+				$extension->set('client_id', $admin_info->id);
+				$extension->set('element', $module);
+				$extension->set('folder', '');
+				$extension->set('name', $module);
+				$extension->set('state', -1);
+				$extension->set('manifest_cache', json_encode($manifest_details));
+				$extension->set('params', '{}');
+				$results[] = clone $extension;
+			}
 		}
 
 		return $results;

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -526,44 +526,50 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 
 		foreach ($site_list as $template)
 		{
-			if ($template == 'system')
+			if (file_exists(JPATH_SITE . "/templates/$template/templateDetails.xml"))
 			{
-				// Ignore special system template
-				continue;
-			}
+				if ($template == 'system')
+				{
+					// Ignore special system template
+					continue;
+				}
 
-			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/templates/$template/templateDetails.xml");
-			$extension = JTable::getInstance('extension');
-			$extension->set('type', 'template');
-			$extension->set('client_id', $site_info->id);
-			$extension->set('element', $template);
-			$extension->set('folder', '');
-			$extension->set('name', $template);
-			$extension->set('state', -1);
-			$extension->set('manifest_cache', json_encode($manifest_details));
-			$extension->set('params', '{}');
-			$results[] = $extension;
+				$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/templates/$template/templateDetails.xml");
+				$extension = JTable::getInstance('extension');
+				$extension->set('type', 'template');
+				$extension->set('client_id', $site_info->id);
+				$extension->set('element', $template);
+				$extension->set('folder', '');
+				$extension->set('name', $template);
+				$extension->set('state', -1);
+				$extension->set('manifest_cache', json_encode($manifest_details));
+				$extension->set('params', '{}');
+				$results[] = $extension;
+			}
 		}
 
 		foreach ($admin_list as $template)
 		{
-			if ($template == 'system')
+			if (file_exists(JPATH_ADMINISTRATOR . "/templates/$template/templateDetails.xml"))
 			{
-				// Ignore special system template
-				continue;
-			}
+				if ($template == 'system')
+				{
+					// Ignore special system template
+					continue;
+				}
 
-			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_ADMINISTRATOR . "/templates/$template/templateDetails.xml");
-			$extension = JTable::getInstance('extension');
-			$extension->set('type', 'template');
-			$extension->set('client_id', $admin_info->id);
-			$extension->set('element', $template);
-			$extension->set('folder', '');
-			$extension->set('name', $template);
-			$extension->set('state', -1);
-			$extension->set('manifest_cache', json_encode($manifest_details));
-			$extension->set('params', '{}');
-			$results[] = $extension;
+				$manifest_details = JInstaller::parseXMLInstallFile(JPATH_ADMINISTRATOR . "/templates/$template/templateDetails.xml");
+				$extension = JTable::getInstance('extension');
+				$extension->set('type', 'template');
+				$extension->set('client_id', $admin_info->id);
+				$extension->set('element', $template);
+				$extension->set('folder', '');
+				$extension->set('name', $template);
+				$extension->set('state', -1);
+				$extension->set('manifest_cache', json_encode($manifest_details));
+				$extension->set('params', '{}');
+				$results[] = $extension;
+			}
 		}
 
 		return $results;


### PR DESCRIPTION
When discovering new extensions, the module & template adapters fail to check for the presence of an extension manifest XML file which means that extension folders which aren't properly set up are listed as installable.  This PR adds a `file_exists()` check which should block these uninstallable folders from being discovered as installable.
