### PR TITLE
Front-end module editing is blocked if you do not have component level permission

### DIFF
--- a/components/com_config/controller/modules/display.php
+++ b/components/com_config/controller/modules/display.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * @package     Joomla.Site
  * @subpackage  com_config
@@ -86,7 +86,7 @@ class ConfigControllerModulesDisplay extends ConfigControllerDisplay
 			$user = JFactory::getUser();
 
 			if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $serviceData['id'])
-				|| !$user->authorise('module.edit.frontend', 'com_modules'))
+				&& !$user->authorise('module.edit.frontend', 'com_modules'))
 			{
 				$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 				$app->redirect($redirect);

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -37,7 +37,7 @@ class ConfigControllerModulesSave extends JControllerBase
 		$user = JFactory::getUser();
 
 		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id'))
-			|| !$user->authorise('module.edit.frontend', 'com_modules'))
+			&& !$user->authorise('module.edit.frontend', 'com_modules'))
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
 			$this->app->redirect('index.php');


### PR DESCRIPTION
If a usergroup does not have component level frontend module editing permission but does have module level permission, a user should be able to edit the single module(s) they have permissions to.  However, due to a bad ACL check, the user is given a "You are not authorized to access this resource" message when attempting to edit or save a module.  The failure is caused by a check if either condition is false, whereas the check should be if both conditions are false.  Corrected in PR.
### Testing Instructions

Modified test instructions from what I wrote in #5397 as doing that is how I found the bug.

1) Create a new group and set the Group Parent as Public
2) In the Global Configuration give this group "Site Login" permission. Do not change any other values.
3) In the module(s) you want this group to be able to edit, give them "Frontend Editing" permission.
4) Ensure your group is in at least the "Registered" Viewing Access Level.
5) Create a user and assign them to this group.
6) Try to edit the module(s) the group has access to in the frontend, you should get the error.
7) Patch and try again, ensure your changes get saved.
