### PR TITLE
Consistent use of icon

### DIFF
--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -18,7 +18,7 @@ if ($params->get('show_viewsite', 1))
 {
 	$output[] = '<div class="btn-group viewsite">'
 		. '<a href="' . JUri::root() . '" target="_blank">'
-		. '<i class="icon-share-alt"></i> ' . JText::_('JGLOBAL_VIEW_SITE')
+		. '<i class="icon-out-2"></i> ' . JText::_('JGLOBAL_VIEW_SITE')
 		. '</a>'
 		. '</div>'
 		. '<div class="btn-group divider"></div>';


### PR DESCRIPTION
Small change to the "view site" icon i mod_status. This makes it consistent with the icon in the top
## Before PR

![skaermbillede 2015-02-17 kl 23 44 11](https://cloud.githubusercontent.com/assets/1738811/6238903/03299768-b6ff-11e4-8e90-2793c178acd6.png)
![skaermbillede 2015-02-17 kl 23 44 14](https://cloud.githubusercontent.com/assets/1738811/6238904/032c64e8-b6ff-11e4-97e2-4689e2390fe9.png)
## After PR

![skaermbillede 2015-02-17 kl 23 44 20](https://cloud.githubusercontent.com/assets/1738811/6238905/032cfc78-b6ff-11e4-8876-a1e647409bcf.png)
