### PR TITLE
Error when creating module/component override

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -653,11 +653,11 @@ class TemplatesModelTemplate extends JModelForm
 
 			if (stristr($name, 'mod_') != false)
 			{
-				$return = $this->createTemplateOverride($override . '/tmpl', $htmlPath);
+				$return = $this->createTemplateOverride(JPath::clean($override . '/tmpl'), $htmlPath);
 			}
 			elseif (stristr($override, 'com_') != false)
 			{
-				$return = $this->createTemplateOverride($override . '/tmpl', $htmlPath);
+				$return = $this->createTemplateOverride(JPath::clean($override . '/tmpl'), $htmlPath);
 			}
 			else
 			{


### PR DESCRIPTION
Fix for #6111: Error when creating module or component overrides on a windows installation.

Before applying this patch creating a module or component override in the template manager on a windows installation resulted in several errors.

After applying this patch overrides can be created successfully.
