### PR TITLE
Library adapter never sets itself to update

### DIFF
--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -37,6 +37,10 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 				$installer = new JInstaller; // we don't want to compromise this instance!
 				$installer->uninstall('library', $this->currentExtensionId);
 
+				// Clear the cached data
+				$this->currentExtensionId = null;
+				$this->extension = JTable::getInstance('Extension', 'JTable', array('dbo' => $this->db));
+
 				// From this point we'll consider this an update
 				$this->setRoute('update');
 			}
@@ -330,6 +334,10 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		{
 			// Already installed, which would make sense
 			$installer->uninstall('library', $result);
+
+			// Clear the cached data
+			$this->currentExtensionId = null;
+			$this->extension = JTable::getInstance('Extension', 'JTable', array('dbo' => $this->db));
 		}
 
 		// Now create the new files

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -36,6 +36,9 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 				// We can upgrade, so uninstall the old one
 				$installer = new JInstaller; // we don't want to compromise this instance!
 				$installer->uninstall('library', $this->currentExtensionId);
+
+				// From this point we'll consider this an update
+				$this->setRoute('update');
 			}
 			else
 			{
@@ -292,6 +295,13 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		// Get the extension manifest object
 		$this->setManifest($this->parent->getManifest());
 
+		// Set the overwrite setting
+		$this->parent->setOverwrite(true);
+		$this->parent->setUpgrade(true);
+
+		// And make sure the route is set correctly
+		$this->setRoute('update');
+
 		/*
 		 * ---------------------------------------------------------------------------------------------
 		 * Manifest Document Setup Section
@@ -321,6 +331,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 			// Already installed, which would make sense
 			$installer->uninstall('library', $result);
 		}
+
 		// Now create the new files
 		return $this->install();
 	}


### PR DESCRIPTION
When updating libraries, the internal route never gets set to the update route so the installer always treats a library as a new install (which I guess is true in some ways since we actually uninstall the library completely then install it fresh).  This changes the route to log it as an update when appropriate.  This really only affects handling for extension install scripts and schema management.
