### PR TITLE
Fix call to PHPMailer::addReplyTo

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -200,7 +200,7 @@ class ContactControllerContact extends JControllerForm
 
 			$mail = JFactory::getMailer();
 			$mail->addRecipient($contact->email_to);
-			$mail->addReplyTo(array($email, $name));
+			$mail->addReplyTo($email, $name);
 			$mail->setSender(array($mailfrom, $fromname));
 			$mail->setSubject($sitename . ': ' . $subject);
 			$mail->setBody($body);


### PR DESCRIPTION
AddReplyTo takes two parameters. Without it the ReplyTo-Name is not set when some user submits a contact form
