### PR TITLE
fix APC(u) cache storage

### DIFF
--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -54,7 +54,9 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			$name = $key['info'];
+
+			// Key name "info" for APC and "key" for APCu
+			$name = !empty($key['info']) ? $key['info'] : $key['key'];
 			$namearr = explode('-', $name);
 
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
@@ -135,9 +137,10 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			$name = !empty($key['info']) ? $key['info'] : $key['key'];
+			if (strpos($name, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
-				apc_delete($key['info']);
+				apc_delete($name);
 			}
 		}
 
@@ -159,9 +162,10 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-'))
+			$name = !empty($key['info']) ? $key['info'] : $key['key'];
+			if (strpos($name, $secret . '-cache-'))
 			{
-				apc_fetch($key['info']);
+				apc_fetch($name);
 			}
 		}
 	}

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -138,6 +138,7 @@ class JCacheStorageApc extends JCacheStorage
 		foreach ($keys as $key)
 		{
 			$name = !empty($key['info']) ? $key['info'] : $key['key'];
+
 			if (strpos($name, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
 				apc_delete($name);
@@ -163,6 +164,7 @@ class JCacheStorageApc extends JCacheStorage
 		foreach ($keys as $key)
 		{
 			$name = !empty($key['info']) ? $key['info'] : $key['key'];
+
 			if (strpos($name, $secret . '-cache-'))
 			{
 				apc_fetch($name);


### PR DESCRIPTION
this fix for APC caching when server use PHP 5.5 with APCu,
in my configuration it:

PHP 5.5.9
APCu 4.0.2

**how to test**
make sure that you have installed PHP 5.5 (or higher) and APCu extension,
enable APC caching in Global Configuration, and go to the "Clean Cache" page, there you will see a lot errors,

then apply patch, and again go to the "Clean Cache" page and check, whether you are now able to see the cache info, and able to clean up the cache

PS: it seems bug in PHP APCu extension,  in compatibility with old APC
