### PR TITLE
[imp] avoid to open div and closing it in different files

### DIFF
--- a/components/com_contact/views/categories/tmpl/default.php
+++ b/components/com_contact/views/categories/tmpl/default.php
@@ -22,8 +22,10 @@ jQuery(function($) {
 		});
 	});
 });");
-
-echo JLayoutHelper::render('joomla.content.categories_default', $this);
-echo $this->loadTemplate('items');
 ?>
+<div class="categories-list<?php echo $this->pageclass_sfx;?>">
+	<?php
+		echo JLayoutHelper::render('joomla.content.categories_default', $this);
+		echo $this->loadTemplate('items');
+	?>
 </div>

--- a/components/com_content/views/categories/tmpl/default.php
+++ b/components/com_content/views/categories/tmpl/default.php
@@ -22,8 +22,10 @@ jQuery(function($) {
 		});
 	});
 });");
-
-echo JLayoutHelper::render('joomla.content.categories_default', $this);
-echo $this->loadTemplate('items');
 ?>
+<div class="categories-list<?php echo $this->pageclass_sfx;?>">
+	<?php
+		echo JLayoutHelper::render('joomla.content.categories_default', $this);
+		echo $this->loadTemplate('items');
+	?>
 </div>

--- a/components/com_newsfeeds/views/categories/tmpl/default.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default.php
@@ -22,8 +22,10 @@ jQuery(function($) {
 		});
 	});
 });");
-
-echo JLayoutHelper::render('joomla.content.categories_default', $this);
-echo $this->loadTemplate('items');
 ?>
+<div class="categories-list<?php echo $this->pageclass_sfx;?>">
+	<?php
+		echo JLayoutHelper::render('joomla.content.categories_default', $this);
+		echo $this->loadTemplate('items');
+	?>
 </div>

--- a/layouts/joomla/content/categories_default.php
+++ b/layouts/joomla/content/categories_default.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 ?>
-<div class="categories-list<?php echo $displayData->pageclass_sfx;?>">
 <?php if ($displayData->params->get('show_page_heading')) : ?>
 <h1>
 	<?php echo $displayData->escape($displayData->params->get('page_heading')); ?>


### PR DESCRIPTION
In the catefories view the parent div was created in a layout. That's a bad practice that can cause unexpected issues when overriding views.
## Test

Ensure that all the categories views are showed correctly. The PR includes articles, newsfeeds & contact categories because they were the only calling that layout but if you find more test it there please. Also in the menu item of each category view add a "Page class" in the "Page display" tab and ensure that is applied correctly.
## Backward compatibility issues

This should only cause issues if someone is already using that layout. In that case they may have created a a dirty fix to close the orphan div. But this is a bug so we should fix it.
