### PR TITLE
PostgreSQL - categories are not ordered

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -62,9 +62,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.title AS text, a.level, a.published');
+			->select('DISTINCT a.id AS value, a.title AS text, a.level, a.published, a.lft');
 		$subQuery = $db->getQuery(true)
-			->select('DISTINCT id,title,level,published,parent_id,extension,lft,rgt')
+			->select('id,title,level,published,parent_id,extension,lft,rgt')
 			->from('#__categories');
 
 		// Filter by the extension type
@@ -94,10 +94,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$subQuery->where('published IN (' . implode(',', $published) . ')');
 		}
 
-		$subQuery->order('lft ASC');
 		$query->from('(' . $subQuery->__toString() . ') AS a')
 			->join('LEFT', $db->quoteName('#__categories') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
-
+		$query->order('a.lft ASC');
 		// If parent isn't explicitly stated but we are in com_categories assume we want parents
 		if ($oldCat != 0 && ($this->element['parent'] == true || $jinput->get('option') == 'com_categories'))
 		{


### PR DESCRIPTION
#### Steps to reproduce the issue

In the administration side add a new article item 
look on the left to the categories list 
#### Expected result

the categories are ordered
![p340a administration article manager add new article](https://cloud.githubusercontent.com/assets/181681/6313444/6071ef70-b9ab-11e4-9cdd-f67326245735.png)
#### Actual result

the categories are not ordered
![p340a administration category manager add a new articles category](https://cloud.githubusercontent.com/assets/181681/6313441/2ceb1f3c-b9ab-11e4-8fcb-d8bb255f5ea9.png)
#### System information

PostgreSQL 9.3.5
Joomla 3.4.0.rc
#### Additional comments

the old query

```
SELECT DISTINCT a.id AS value, a.title AS text, a.level, a.published

  FROM (
SELECT DISTINCT id,title,level,published,parent_id,extension,lft,rgt

  FROM d7jwf_categories

  WHERE (extension = 'com_content') 
  AND published IN (0,1)

  ORDER BY lft ASC) AS a

  LEFT JOIN `d7jwf_categories` AS b 
  ON a.lft > b.lft 
  AND a.rgt < b.rgt
```

the new one

```
SELECT DISTINCT a.id AS value, a.title AS text, a.level, a.published, a.lft

  FROM (
SELECT id,title,level,published,parent_id,extension,lft,rgt

  FROM d7jwf_categories

  WHERE (extension = 'com_content') 
  AND published IN (0,1)) AS a

  LEFT JOIN `d7jwf_categories` AS b 
  ON a.lft > b.lft 
  AND a.rgt < b.rgt

  ORDER BY a.lft ASC
```
