### PR TITLE
A content language creator should be able to Save, not only Save and Close

### DIFF
--- a/administrator/components/com_languages/views/language/view.html.php
+++ b/administrator/components/com_languages/views/language/view.html.php
@@ -67,14 +67,7 @@ class LanguagesViewLanguage extends JViewLegacy
 			JText::_($isNew ? 'COM_LANGUAGES_VIEW_LANGUAGE_EDIT_NEW_TITLE' : 'COM_LANGUAGES_VIEW_LANGUAGE_EDIT_EDIT_TITLE'), 'comments-2 langmanager'
 		);
 
-		// If a new item, can save.
-		if ($isNew && $canDo->get('core.create'))
-		{
-			JToolbarHelper::save('language.save');
-		}
-
-		// If an existing item, allow to Apply and Save.
-		if (!$isNew && $canDo->get('core.edit'))
+		if (($isNew && $canDo->get('core.create')) || (!$isNew && $canDo->get('core.edit')))
 		{
 			JToolbarHelper::apply('language.apply');
 			JToolbarHelper::save('language.save');


### PR DESCRIPTION
Languages Manager => Content Languages=> New
As title says. The Save toolbar button is absent when creating a new Content Language.
