### PR TITLE
Fix #5648 Menu Manager: Add Menu :: Display a correct error message

### DIFF
--- a/administrator/components/com_menus/controllers/menu.php
+++ b/administrator/components/com_menus/controllers/menu.php
@@ -125,7 +125,7 @@ class MenusControllerMenu extends JControllerForm
 			$app->setUserState('com_menus.edit.menu.data', $data);
 
 			// Redirect back to the edit screen.
-			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'warning');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit', false));
 
 			return false;


### PR DESCRIPTION
```
This PR fixes this issue: Menu Manager: Add Menu :: Display a correct error message for the better usability #5648
```
