### PR TITLE
Fix for PR #6131 (final)

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -504,15 +504,7 @@ class TemplatesModelTemplate extends JModelForm
 		}
 
 		$return = JFile::write($filePath, $data['source']);
-
-		// Try to make the template file unwritable.
-		if (JPath::isOwner($filePath) && !JPath::setPermissions($filePath, '0444'))
-		{
-			$app->enqueueMessage(JText::_('COM_TEMPLATES_ERROR_SOURCE_FILE_NOT_UNWRITABLE'), 'error');
-
-			return false;
-		}
-		elseif (!$return)
+		if (!$return)
 		{
 			$app->enqueueMessage(JText::sprintf('COM_TEMPLATES_ERROR_FAILED_TO_SAVE_FILENAME', $fileName), 'error');
 


### PR DESCRIPTION
Final Fix for PR #6131 from @n9iels and issue #6126

```
I just found a little bug when changing a file with the editor in the template manager.
My Joomla! version is 3.4.0-rc

1. Go to Template Manager -> Templates and choose a template
2. Open a file and save it (you won't have to change anything).
3. Check the file permission of this file, you now see the changed from 644 to 444.

This can cause problems when editing the same file via a ftp client. You will get a "Permission denied" message
```
