### PR TITLE
Added text wrapping to tooltip in installation template CSS

### DIFF
--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -136,3 +136,7 @@ textarea.vert {
 textarea.noResize {
 	resize: none;
 }
+/* Tooltip */
+.tooltip {
+	white-space: pre-wrap;
+}


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Start a new installation of Joomla! where the root directory is not writable.
2. Proceed to pre-installation check. 
3. Mouse-over the warning label saying 'No!' next to 'configuration.php Writable'
#### Expected result

The tooltip text within the message popup should be readable.
#### Actual result

The displayed tooltip text overflows the popup, making it unreadable.
#### System information (as much as possible)

Ubuntu 14.04
PHP 5.5.9
Browsers: Chrome 39.0, Firefox 34.0
#### Additional comments

Please see screenshot
![screen shot 2015-02-21 at 13 05 23](http://issues.joomla.org/uploads/1/90d25eeb9bf12979763c6362f3e105dd.png)
