### PR TITLE
Fix installer update error.

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1079,7 +1079,7 @@ class JInstaller extends JAdapter
 
 					if (!count($files))
 					{
-						return false;
+						return $update_count;
 					}
 
 					$query = $db->getQuery(true)


### PR DESCRIPTION
"Nothing to Update" is not an error condition, it's a valid result.

No real BC issue, here. Those using the old workaround for this fall will be unaffected, while any others can either put a blank sql file in, or omit the sql file when there are no schema changes.
