### PR TITLE
Fix for issue #5764: archived articles list filter

### DIFF
--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -134,6 +134,8 @@ class ContentViewArchive extends JViewLegacy
 		$this->params     = &$params;
 		$this->user       = &$user;
 		$this->pagination = &$pagination;
+		$this->pagination->setAdditionalUrlParam("month", $state->get('filter.month'));
+		$this->pagination->setAdditionalUrlParam("year", $state->get('filter.year'));
 
 		$this->_prepareDocument();
 


### PR DESCRIPTION
Please see #5764 for the description of the issue.

---

Hi,

On one of our customers website, we noticed a bug with the filter and pagination of archived articles. 

As long as we do not use the filter except for the number of article, the pagination act normally. If we use the year or month filter, for exemple year 2013, and then click on page 2, the year / month filter does a reset and the archive is displayed the right number of article forward but loosing the year criteria.

We noticed that on a joomla 2.5.27 but as we are going to upgrade to joomla 3 soon, we decided to go for some testing on fresh installations of joomla 2.5.28 and joomla 3.3.6 with just the demo data and some articles for the purpose of the test.

Both show the same bug.

You can see exemples on the fresh installations we used for testing, filtering with year 2013 :

Joomla 3.3.6 http://test.anw-sandbox.ch/index.php/archive

Joomla 2.5.28 http://test25.anw-sandbox.ch/index.php/archive
#### System information (as much as possible)

Joomla 3.3.6 / 2.5.28
PHP 5.5.9 
#### Additional comments

Thanks for your help
