### PR TITLE
Remove empty space in ul tag

### DIFF
--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 <?php if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>
 <?php else : ?>
-	<ul >
+	<ul>
 	<?php foreach ($list as $item) : ?>
 	<li><?php $route = new TagsHelperRoute; ?>
 		<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">


### PR DESCRIPTION
This removes an empty space in the mod_tags_popular template.
