### PR TITLE
Readonly form field list throws warning in list.php

### DIFF
--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -56,35 +56,9 @@ class JFormFieldList extends JFormField
 
 		// Get the field options.
 		$options = (array) $this->getOptions();
-
-		// Create a read-only list (no name) with hidden input(s) to store the value(s).
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true')
-		{
-			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $this->value, $this->id);
-
-			// E.g. form field type tag sends $this->value as array
-			if ($this->multiple && is_array($this->value))
-			{
-				if (!count($this->value))
-				{
-					$this->value[] = '';
-				}
-
-				foreach ($this->value as $value)
-				{
-					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
-				}
-			}
-			else
-			{
-				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
-			}
-		}
-		else
+		
 		// Create a regular list.
-		{
-			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
-		}
+		$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
 
 		return implode($html);
 	}


### PR DESCRIPTION
I have the same issue

https://github.com/joomla/joomla-cms/issues/4260

I find that the proposed solution is not optimal because if there are many selected tags, it will create multiple input controls with the same name cf. code below

```
foreach ($this->value as $value)
{
    $html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
}
```

I find that a simple solution would be to remove the hidden controls and leave the name attribute on the select control that is disabled when the attribute readonly is set (line 51)
