### PR TITLE
Some inputs hidden with the same name

### DIFF
--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -144,42 +144,31 @@ class JFormFieldGroupedList extends JFormField
 
 		// Initialize some field attributes.
 		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$attr .= $this->disabled ? ' disabled' : '';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 		$attr .= $this->multiple ? ' multiple' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';
 		$attr .= $this->autofocus ? ' autofocus' : '';
 
+		// To avoid user's confusion, readonly="true" should imply disabled="true".
+		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true' || (string) $this->disabled == '1'|| (string) $this->disabled == 'true')
+		{
+			$attr .= ' disabled="disabled"';
+		}
+		
 		// Initialize JavaScript field attributes.
 		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Get the field groups.
 		$groups = (array) $this->getGroups();
 
-		// Create a read-only list (no name) with a hidden input to store the value.
-		if ($this->readonly)
-		{
-			$html[] = JHtml::_(
-				'select.groupedlist', $groups, null,
-				array(
-					'list.attr' => $attr, 'id' => $this->id, 'list.select' => $this->value, 'group.items' => null, 'option.key.toHtml' => false,
-					'option.text.toHtml' => false
-				)
-			);
-			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
-		}
-
 		// Create a regular list.
-		else
-		{
-			$html[] = JHtml::_(
-				'select.groupedlist', $groups, $this->name,
-				array(
-					'list.attr' => $attr, 'id' => $this->id, 'list.select' => $this->value, 'group.items' => null, 'option.key.toHtml' => false,
-					'option.text.toHtml' => false
-				)
-			);
-		}
+		$html[] = JHtml::_(
+			'select.groupedlist', $groups, $this->name,
+			array(
+				'list.attr' => $attr, 'id' => $this->id, 'list.select' => $this->value, 'group.items' => null, 'option.key.toHtml' => false,
+				'option.text.toHtml' => false
+			)
+		);
 
 		return implode($html);
 	}


### PR DESCRIPTION
Steps to reproduce the issue

1) Use a form with an GroupedList field.
2) Select some items and save the form
3) Put the attribute readonly of the field by code or by the manifest of the form.
4) Reopen the form
5) See the source code
6) You can see some inputs hidden with the name of the GroupedList field

Suggested solution

I find that a simple solution would be to set the disabled attrubute of the GroupedList when the readonly attribute is set (like the list field) remove the hidden controls and leave the name attribute on the GroupedList input
