### PR TITLE
Fix missing access setting for old entries in #__languages

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/ 3.4.1-2015-02-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/ 3.4.1-2015-02-25.sql
@@ -1,0 +1,1 @@
+UPDATE #__languages SET access = 1 WHERE access = 0;


### PR DESCRIPTION
When content languages have no set access level, it will break peoples sites with 3.4.0. This sets this for all MySQL. Postgres, etc. needs to be done by someone who knows those.
