### PR TITLE
Complete PR - Fix missing access setting for old entries in #__languages...

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.1-2015-02-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.1-2015-02-25.sql
@@ -1,0 +1,1 @@
+UPDATE `#__languages` SET `access` = '1' WHERE `access` = '0';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.4.1-2015-02-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.4.1-2015-02-25.sql
@@ -1,0 +1,1 @@
+UPDATE "#__languages" SET "access" = '1' WHERE "access" = '0';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.4.1-2015-02-25.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.4.1-2015-02-25.sql
@@ -1,0 +1,1 @@
+UPDATE [#__languages] SET [access] = '1' WHERE [access] = '0';


### PR DESCRIPTION
See #6171 "When content languages have no set access level, it will break peoples sites with 3.4.0."

Problem also described in the forum: http://forum.joomla.org/viewtopic.php?f=707&t=874568
