### PR TITLE
Add a class_exists check to PDO MySQL driver

### DIFF
--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -99,7 +99,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 	 */
 	public static function isSupported()
 	{
-		return in_array('mysql', PDO::getAvailableDrivers());
+		return class_exists('PDO') && in_array('mysql', PDO::getAvailableDrivers());
 	}
 
 	/**


### PR DESCRIPTION
There are some reports in the forum about users getting a "class 'PDO' not found" error post upgrade.  This appears to be due to calling a PDO class method which may not be present if PDO isn't supported, so this adds a class_exists check before that call.
