### PR TITLE
Fix #6173

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -258,7 +258,7 @@ class InstallerModelInstall extends JModelLegacy
 
 		// Move uploaded file.
 		jimport('joomla.filesystem.file');
-		JFile::upload($tmp_src, $tmp_dest);
+		JFile::upload($tmp_src, $tmp_dest, false, true);
 
 		// Unpack the downloaded package file.
 		$package = JInstallerHelper::unpack($tmp_dest, true);

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -201,7 +201,8 @@ class InstallerModelInstall extends JModelLegacy
 	{
 		// Get the uploaded file information.
 		$input    = JFactory::getApplication()->input;
-		$userfile = $input->files->get('install_package', null, 'array');
+		// Do not change the filter type 'raw'. We need this to let files containing PHP code to upload. See JInputFiles::get.
+		$userfile = $input->files->get('install_package', null, 'raw');
 
 		// Make sure that file uploads are enabled in php.
 		if (!(bool) ini_get('file_uploads'))

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -440,16 +440,17 @@ class JFile
 	/**
 	 * Moves an uploaded file to a destination folder
 	 *
-	 * @param   string   $src           The name of the php (temporary) uploaded file
-	 * @param   string   $dest          The path (including filename) to move the uploaded file to
-	 * @param   boolean  $use_streams   True to use streams
-	 * @param   boolean  $allow_unsafe  Allow the upload of unsafe files
+	 * @param   string   $src              The name of the php (temporary) uploaded file
+	 * @param   string   $dest             The path (including filename) to move the uploaded file to
+	 * @param   boolean  $use_streams      True to use streams
+	 * @param   boolean  $allow_unsafe     Allow the upload of unsafe files
+	 * @param   boolean  $safeFileOptions  Options to JFilterInput::isSafeFile
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */
-	public static function upload($src, $dest, $use_streams = false, $allow_unsafe = false)
+	public static function upload($src, $dest, $use_streams = false, $allow_unsafe = false, $safeFileOptions = array())
 	{
 		if (!$allow_unsafe)
 		{

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -462,7 +462,7 @@ class JFile
 				'size'     => '',
 			);
 
-			$isSafe = JFilterInput::isSafeFile($descriptor);
+			$isSafe = JFilterInput::isSafeFile($descriptor, $safeFileOptions);
 
 			if (!$isSafe)
 			{

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -327,13 +327,14 @@ class JFilterInput
 	 * Checks an uploaded for suspicious naming and potential PHP contents which could indicate a hacking attempt.
 	 *
 	 * The options you can define are:
-	 * null_byte Prevent files with a null byte in their name (buffer overflow attack)
-	 * forbidden_extensions Do not allow these strings anywhere in the file's extension
-	 * php_tag_in_content Do not allow <?php tag in content
-	 * shorttag_in_content Do not allow short tag <? in content
-	 * shorttag_extensions Which file extensions to scan for short tags in content
-	 * fobidden_ext_in_content Do not allow forbidden_extensions anywhere in content
-	 * php_ext_content_extensions Which file extensions to scan for .php in content
+	 *
+	 * null_byte                   Prevent files with a null byte in their name (buffer overflow attack)
+	 * forbidden_extensions        Do not allow these strings anywhere in the file's extension
+	 * php_tag_in_content          Do not allow <?php tag in content
+	 * shorttag_in_content         Do not allow short tag <? in content
+	 * shorttag_extensions         Which file extensions to scan for short tags in content
+	 * fobidden_ext_in_content     Do not allow forbidden_extensions anywhere in content
+	 * php_ext_content_extensions  Which file extensions to scan for .php in content
 	 *
 	 * This code is an adaptation and improvement of Admin Tools' UploadShield feature,
 	 * relicensed and contributed by its author.

--- a/libraries/joomla/input/files.php
+++ b/libraries/joomla/input/files.php
@@ -76,7 +76,7 @@ class JInputFiles extends JInput
 	{
 		if (isset($this->data[$name]))
 		{
-			// Prevent returning an unsafe file unless speciffically requested
+			// Prevent returning an unsafe file unless specifically requested
 			if (!$this->data[$name]['safe'])
 			{
 				if ($filter != 'raw')


### PR DESCRIPTION
Reference: gh-6173 J3.4.0 cannot install certain extensions
## Executive summary

An oversight in com_installer caused erroneous scanning of uploaded extension package files for raw PHP code inclusion and rejected them for this reason. This should not happen because installation packages are _supposed_ to have executable PHP code by their very definition. This only happens with certain packages which have the string `<?` or `<?php` in them.
## Test instructions

If you have an affected package, try installing it in vanilla Joomla! 3.4.0 using the Upload & Install method. The upload fails.

Apply the patch, retry installing the package. It now works.
## Technical explanation

JFile::upload was missing the fourth argument, resulting in file content scanning for ZIP file per the default options. Since installation package ZIP files may contain uncompressed .php files OR otherwise the string literals `<?` and `<?php` the upload was rejected. However, installation packages are _supposed_ to contain executable code, therefore we should not pass them through the safe file (UploadShield) code.

 Moreover, this patch adds an optional fifth parameter to JFile::upload to allow developers to pass custom options to the safe file scanning (UploadShield) code, as was the original intention of the UploadShield feature when it was committed two years ago but lost during the refactoring for inclusion in Joomla! 3.4.

 Finally, the docblock for isSafeFile was reformatted for improved clarity of the parameters which can be passed to UploadShield.
## Backwards compatibility

This patch is backwards compatible.
## Translation impact

None
