### PR TITLE
Issue with content languages access in 3.4.0 (replaces #6172)

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -64,6 +64,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($this->sefs as $sef => $language)
 			{
+				// @todo: In Joomla 2.5.4 and earlier access wasn't set. Non modified Content Languages got 0 as access value
 				if ($language->access && !in_array($language->access, $levels))
 				{
 					unset($this->lang_codes[$language->lang_code]);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -64,7 +64,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($this->sefs as $sef => $language)
 			{
-				if (isset($language->access) && $language->access && !in_array($language->access, $levels))
+				if ($language->access && !in_array($language->access, $levels))
 				{
 					unset($this->lang_codes[$language->lang_code]);
 					unset($this->sefs[$language->sef]);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -64,7 +64,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($this->sefs as $sef => $language)
 			{
-				if (!in_array($language->access, $levels))
+				if (isset($language->access) && $language->access && !in_array($language->access, $levels))
 				{
 					unset($this->lang_codes[$language->lang_code]);
 					unset($this->sefs[$language->sef]);


### PR DESCRIPTION
To test, create a basic multilanguage site with 3.4.0. Easiest is to use the functionnality when installing Joomla.
Then edit  with phpmyadmin the _languages table in the database and set the `access` column values to 0.

Display frontend is broken.
Patch and test again.
