### PR TITLE
fixed JCrop in Template Manager

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -76,7 +76,7 @@ jQuery(document).ready(function($){
 if($this->type == 'image')
 {
 	JFactory::getDocument()->addScriptDeclaration("
-		jQuery(document).ready(function() {
+		jQuery(document).ready(function($) {
 			var jcrop_api;
 
 			// Configuration for image cropping
@@ -84,7 +84,7 @@ if($this->type == 'image')
 				onChange:   showCoords,
 				onSelect:   showCoords,
 				onRelease:  clearCoords,
-				trueSize:   " . $this->image['width'] . "," . $this->image['height'] . "]
+				trueSize:   [" . $this->image['width'] . "," . $this->image['height'] . "]
 			},function(){
 				jcrop_api = this;
 			});


### PR DESCRIPTION
Cropping images in the Template Manager did not appear to be working and was reported on JSE today

http://joomla.stackexchange.com/questions/8805/using-jquery-jcrop-js-in-custom-extension/8806#8806

It was throwing a console log error:

> SyntaxError: missing : after property id
> 
> > trueSize: 469,159

Also added `$` as an alias to prevent objects being undefined.
