### PR TITLE
Plugin Recaptcha and Mootools on Joomla 3.4

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -76,7 +76,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 				);
 				break;
 		}
-		$document->addScript($file);
+		JHtml::_('script', $file);
 
 		return true;
 	}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -59,8 +59,6 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 				$file = $app->isSSLConnection() ? 'https' : 'http';
 				$file .= '://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
-				JHtml::_('script', $file);
-
 				$document->addScriptDeclaration('jQuery( document ).ready(function()
 				{
 					Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $lang . 'tabindex: 0});});'
@@ -72,15 +70,13 @@ class PlgCaptchaRecaptcha extends JPlugin
 				$file = $app->isSSLConnection() ? 'https' : 'http';
 				$file .= '://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()
 						->getTag() . '&onload=onloadCallback&render=explicit';
-
-				JHtml::_('script', $file, true, true);
-
 				$document->addScriptDeclaration('var onloadCallback = function() {'
 					. 'grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});'
 					. '}'
 				);
 				break;
 		}
+		$document->addScript($file);
 
 		return true;
 	}


### PR DESCRIPTION
Hi everyone,

in /plugins/captcha/recaptcha/recaptcha.php from line 55 to 79, is there any reason why the new recaptcha is loading the mootools library? Especially on line 76 Mootools gets loaded by JHtml::_('script', $file, true, true);

https://github.com/joomla/joomla-cms/issues/6212
