### PR TITLE
InstallerModelDatabase::fixSchemaVersion() malformed SQL INSERT query

### DIFF
--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -151,9 +151,8 @@ class InstallerModelDatabase extends InstallerModel
 
 			// Add new row.
 			$query->clear()
-				->insert($db->quoteName('#__schemas'))
-				->set($db->quoteName('extension_id') . '= 700')
-				->set($db->quoteName('version_id') . '= ' . $db->quote($schema));
+				->insert($db->quoteName('#__schemas') . " (" . $db->quoteName('extension_id') . "," . $db->quoteName('version_id') . ") ")
+				->values('700, ' . $db->quote($schema));
 			$db->setQuery($query);
 
 			if ($db->execute())

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -151,7 +151,8 @@ class InstallerModelDatabase extends InstallerModel
 
 			// Add new row.
 			$query->clear()
-				->insert($db->quoteName('#__schemas') . " (" . $db->quoteName('extension_id') . "," . $db->quoteName('version_id') . ") ")
+				->insert($db->quoteName('#__schemas'))
+				->columns($db->quoteName('extension_id') . ',' . $db->quoteName('version_id'))
 				->values('700, ' . $db->quote($schema));
 			$db->setQuery($query);
 


### PR DESCRIPTION
Lines [152-157](https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_installer/models/database.php#L152-L157) of `/administrator/components/com_installer/models/database.php` improperly uses the `set` clause with an `insert` query. 

```
// Add new row.
$query->clear()
    ->insert($db->quoteName('#__schemas'))
    ->set($db->quoteName('extension_id') . '= 700')
    ->set($db->quoteName('version_id') . '= ' . $db->quote($schema));
$db->setQuery($query);
```

And should instead be similar to the following:

```
$query->clear()
    ->insert($db->quoteName('#__schemas'))
    ->columns($db->quoteName('extension_id') . ',' . $db->quoteName('version_id'))
    ->values('700, ' . $db->quote($schema));
$db->setQuery($query);
```
