### PR TITLE
remove html escaping for edit-tooltip

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -206,7 +206,7 @@ abstract class JHtmlIcon
 				$icon = 'eye-close';
 			}
 
-			$text = '<span class="hasTooltip icon-' . $icon . ' tip" title="' . JHtml::tooltipText(JText::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0)
+			$text = '<span class="hasTooltip icon-' . $icon . ' tip" title="' . JHtml::tooltipText(JText::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0, 0)
 				. '"></span>'
 				. JText::_('JGLOBAL_EDIT');
 		}


### PR DESCRIPTION
# How to reproduce the bug

1) Login on the front-end of your website
2) Go to a article
3) Click on the button with the cog icon and hover over the edit icon and see the tooltip
4) Notice the tooltip text say someting like: Published&lt;br /&gt;Saturday, 01 January 2011&lt;br /&gt;Written by Joomla
5) Apply the patch
6) Notice the tooltip is now correct displayed
