### PR TITLE
[imp] deprecate buggy usergroup field and replace ocurrences with usergrouplist. Fixes #3419

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -14,7 +14,7 @@
 
 		<field
 			name="new_usertype"
-			type="usergroup"
+			type="usergrouplist"
 			default="2"
 			label="COM_USERS_CONFIG_FIELD_NEW_USER_TYPE_LABEL"
 			description="COM_USERS_CONFIG_FIELD_NEW_USER_TYPE_DESC">
@@ -22,7 +22,7 @@
 
 		<field
 			name="guest_usergroup"
-			type="usergroup"
+			type="usergrouplist"
 			default="1"
 			label="COM_USERS_CONFIG_FIELD_GUEST_USER_GROUP_LABEL"
 			description="COM_USERS_CONFIG_FIELD_GUEST_USER_GROUP_DESC">
@@ -172,11 +172,11 @@
 			default="0">
 			</field>
 	</fieldset>
-	
+
 	<fieldset
 		name="user_notes_history"
 		label="COM_USERS_CONFIG_FIELD_NOTES_HISTORY" >
-		
+
 			<field
 			name="save_history"
 			type="radio"
@@ -188,7 +188,7 @@
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
-		
+
 		<field
 			name="history_limit"
 			type="text"

--- a/administrator/components/com_users/models/forms/mail.xml
+++ b/administrator/components/com_users/models/forms/mail.xml
@@ -13,14 +13,14 @@
 			label="COM_USERS_MAIL_FIELD_SEND_IN_HTML_MODE_LABEL"
 			value="1"
 		/>
-		
+
 		<field name="disabled" type="checkbox"
 			description="COM_USERS_MAIL_FIELD_EMAIL_DISABLED_USERS_DESC"
 			label="COM_USERS_MAIL_FIELD_EMAIL_DISABLED_USERS_LABEL"
 			value="1"
 		/>
 
-		<field name="group" type="usergroup"
+		<field name="group" type="usergrouplist"
 			default="0"
 			description="COM_USERS_MAIL_FIELD_GROUP_DESC"
 			label="COM_USERS_MAIL_FIELD_GROUP_LABEL"

--- a/libraries/joomla/form/fields/usergroup.php
+++ b/libraries/joomla/form/fields/usergroup.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  * Supports a nested check box field listing user groups.
  * Multiselect is available by default.
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  3.5
  */
 class JFormFieldUsergroup extends JFormField
 {
@@ -35,6 +36,8 @@ class JFormFieldUsergroup extends JFormField
 	 */
 	protected function getInput()
 	{
+		JLog::add('JFormFieldUsergroup is deprecated. Use JFormFieldUserGroupList instead.', JLog::WARNING, 'deprecated');
+
 		$options = array();
 		$attr = '';
 

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -19,7 +19,7 @@
 	<config>
 		<fields name="params">
 			<fieldset name="basic">
-				<field name="filter_groups" type="usergroup"
+				<field name="filter_groups" type="usergrouplist"
 					description="PLG_DEBUG_FIELD_ALLOWED_GROUPS_DESC"
 					label="PLG_DEBUG_FIELD_ALLOWED_GROUPS_LABEL"
 					multiple="true"


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/3421
#### Steps to reproduce the issue
- Open this file /plugins/authentication/joomla/joomla.xml
- Before `</extension>` add the following code:

```
 <config>
        <fields name="params">
        <fieldset name="basic">
        <field
                name="myfield"
                type="usergroup"
                label="User Group">
            <option value="">No Group</option>
        </field>
        </fieldset>
        </fields>
 </config>
```
- Go to Extension > Plugin Manager search for "authentication"
- Open the "Authentication - Joomla"
- You should see a dropdown with default option "Show all groups" which is bad because you set `<option value="">No Group</option>` in the above code
- Apply the patch
- Go back to /plugins/authentication/joomla/joomla.xml
- Change type="usergroup" to   type="usergrouplist"
- Go the "Authentication - Joomla" plugin again
- You should now see the dropdown shows "No group"
- If you do see "No group" in the dropdown, it works!
  <hr /><sub>This comment was created with the <a href="https://github.com/joomla/jissues">J!Tracker Application</a> at <a href="http://issues.joomla.org/tracker/joomla-cms/3421">issues.joomla.org/joomla-cms/3421</a>.</sub>
#### Expected result

A dropdown with 'No Group' as the initially selected value.
#### Actual result

A dropdown with 'Show All Groups' as the initially selected value
#### System information (as much as possible)

JFormFieldUsergroup::getInput() returns with:

```
return JHtml::_('access.usergroup', $this->name, $this->value, $attr, $options, $this->id);
```

But the class is defined as:

```
JHtmlAccess::usergroup($name, $selected, $attribs = '', $allowAll = true)
```

Note that $options is being passed to $allowAll. On a slightly related note, the call is passing a fifth argument the method doesn't accept at all.

In addition, there is another form field JFormFieldUsergrouplist which does work as expected. It would seem both form fields are intended to serve the same function and so are duplicates. JFormFieldUsergroup should either be fixed or deprecated.
#### Additional comments

I have a plugin in which I want to have a user group optionally selected. Since it isn't required, JFormFieldUsergroup won't work. JFormFieldUsergrouplist does exactly what I need.
