### PR TITLE
Discovering the right language if not given by URL

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -249,8 +249,10 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 				else
 				{
-					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'),
-						JComponentHelper::getParams('com_languages')->get('site', 'en-GB'));
+					$lang_code = $this->app->input->cookie->getString(
+						JApplicationHelper::getHash('language'),
+						JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+					);
 
 					if ($lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
 					{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -243,7 +243,14 @@ class PlgSystemLanguageFilter extends JPlugin
 			if ($this->params->get('remove_default_prefix', 0) && !isset($this->sefs[$sef]))
 			{
 				$found = true;
-				$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+				if (strlen($sef))
+				{
+					$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+				}
+				else
+				{
+					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), JComponentHelper::getParams('com_languages')->get('site', 'en-GB'));
+				}
 			}
 			else
 			{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -249,7 +249,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 				else
 				{
-					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), JComponentHelper::getParams('com_languages')->get('site', 'en-GB'));
+					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'),
+						JComponentHelper::getParams('com_languages')->get('site', 'en-GB'));
 
 					if ($lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
 					{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -242,14 +242,19 @@ class PlgSystemLanguageFilter extends JPlugin
 			// that we have in our system, its the default language and we "found" the right language
 			if ($this->params->get('remove_default_prefix', 0) && !isset($this->sefs[$sef]))
 			{
-				$found = true;
 				if (strlen($sef))
 				{
+					$found = true;
 					$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 				}
 				else
 				{
 					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), JComponentHelper::getParams('com_languages')->get('site', 'en-GB'));
+
+					if ($lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
+					{
+						$found = true;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Fixes #6213
This fixes the case when the default language SEF-part should not be added to the URL and the user is typing in the domain of the site, already visited the site and thus has a cookie with his prefered language.
