### PR TITLE
[#33985] Redo of: Add show_tags to article options in blog view

### DIFF
--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
 	<layout title="COM_CONTENT_CATEGORY_VIEW_BLOG_TITLE" option="COM_CONTENT_CATEGORY_VIEW_BLOG_OPTION">
-		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG"
-		/>
+		<help key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG" />
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_BLOG_DESC]]>
 		</message>
@@ -11,10 +9,10 @@
 
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
-		<fieldset name="request"
-		 >
-
-			<field name="id" type="category"
+		<fieldset name="request">
+			<field
+				name="id"
+				type="category"
 				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
@@ -24,250 +22,302 @@
 	</fields>
 
 	<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
+	<fields name="params">
+		<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
+				<field
+					name="layout_type"
+					type="hidden"
+					default="blog"
+				/>
 
-			<field name="layout_type"
-				type="hidden"
-				default="blog"
-			/>
-		  	<field name="show_category_heading_title_text"
-				type="list"
- 				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
+				<field
+					name="show_category_heading_title_text"
+					type="list"
+	 				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+					description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-		</field>
-			<field name="show_category_title" type="list"
-				label="JGLOBAL_SHOW_CATEGORY_TITLE"
-				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-			<field name="show_description" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="show_description_image" type="list"
-				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
-				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="maxLevel" type="list"
-				description="JGLOBAL_MAXLEVEL_DESC"
-				label="JGLOBAL_MAXLEVEL_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="-1">JALL</option>
-				<option value="0">JNONE</option>
-				<option value="1">J1</option>
-				<option value="2">J2</option>
-				<option value="3">J3</option>
-				<option value="4">J4</option>
-				<option value="5">J5</option>
-			</field>
-
-			<field name="show_empty_categories" type="list"
-				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-				description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="show_no_articles" type="list"
-				label="COM_CONTENT_NO_ARTICLES_LABEL"
-				description="COM_CONTENT_NO_ARTICLES_DESC"
+				<field
+					name="show_category_title"
+					type="list"
+					label="JGLOBAL_SHOW_CATEGORY_TITLE"
+					description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-			<field name="show_subcat_desc" type="list"
-			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
+				<field
+					name="show_description"
+					type="list"
+					description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
+					label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-			<field name="show_cat_num_articles" type="list"
-				label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-				description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
+				<field
+					name="show_description_image"
+					type="list"
+					description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
+					label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-			<field name="show_cat_tags"
-				type="list"
-				label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
-				description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
+				<field
+					name="maxLevel"
+					type="list"
+					description="JGLOBAL_MAXLEVEL_DESC"
+					label="JGLOBAL_MAXLEVEL_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="-1">JALL</option>
+					<option value="0">JNONE</option>
+					<option value="1">J1</option>
+					<option value="2">J2</option>
+					<option value="3">J3</option>
+					<option value="4">J4</option>
+					<option value="5">J5</option>
+				</field>
 
-			<field name="page_subheading" type="text"
-				description="JGLOBAL_SUBHEADING_DESC"
-				label="JGLOBAL_SUBHEADING_LABEL"
-				size="20"
-			/>
+				<field
+					name="show_empty_categories"
+					type="list"
+					label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+					description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-</fieldset>
+				<field
+					name="show_no_articles"
+					type="list"
+					label="COM_CONTENT_NO_ARTICLES_LABEL"
+					description="COM_CONTENT_NO_ARTICLES_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-<fieldset name="advanced" label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
+				<field
+					name="show_subcat_desc"
+					type="list"
+					label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+					description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
 
-			<field name="bloglayout" type="spacer" class="text"
+				<field
+					name="show_cat_num_articles"
+					type="list"
+					label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+					description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
+
+				<field name="show_cat_tags"
+					type="list"
+					label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+					description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
+
+				<field
+					name="page_subheading"
+					type="text"
+					description="JGLOBAL_SUBHEADING_DESC"
+					label="JGLOBAL_SUBHEADING_LABEL"
+					size="20"
+				/>
+		</fieldset>
+
+		<fieldset name="advanced" label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
+				<field 
+					name="bloglayout"
+					type="spacer"
+					class="text"
 					label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
-			/>
+				/>
 
-			<field name="num_leading_articles" type="text"
-				description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
-				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-				size="3"
-			/>
+				<field
+					name="num_leading_articles"
+					type="text"
+					description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
+					label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
+					size="3"
+				/>
 
-			<field name="num_intro_articles" type="text"
-				description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
-				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-				size="3"
-			/>
+				<field
+					name="num_intro_articles"
+					type="text"
+					description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
+					label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
+					size="3"
+				/>
 
-			<field name="num_columns" type="text"
-				description="JGLOBAL_NUM_COLUMNS_DESC"
-				label="JGLOBAL_NUM_COLUMNS_LABEL"
-				size="3"
-			/>
+				<field
+					name="num_columns"
+					type="text"
+					description="JGLOBAL_NUM_COLUMNS_DESC"
+					label="JGLOBAL_NUM_COLUMNS_LABEL"
+					size="3"
+				/>
 
-			<field name="num_links" type="text"
-				description="JGLOBAL_NUM_LINKS_DESC"
-				label="JGLOBAL_NUM_LINKS_LABEL"
-				size="3"
-			/>
+				<field
+					name="num_links"
+					type="text"
+					description="JGLOBAL_NUM_LINKS_DESC"
+					label="JGLOBAL_NUM_LINKS_LABEL"
+					size="3"
+				/>
 
-			<field name="multi_column_order" type="list"
-				description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
-				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JGLOBAL_DOWN</option>
-				<option value="1">JGLOBAL_ACROSS</option>
-			</field>
-			<field name="subcategories" type="spacer" class="spacer"
+				<field
+					name="multi_column_order"
+					type="list"
+					description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
+					label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JGLOBAL_DOWN</option>
+					<option value="1">JGLOBAL_ACROSS</option>
+				</field>
+
+				<field
+					name="subcategories"
+					type="spacer"
+					class="spacer"
 					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-			/>
+				/>
 
-		<field name="show_subcategory_content" type="list"
+				<field
+					name="show_subcategory_content"
+					type="list"
+					description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
+					label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JNONE</option>
+					<option value="-1">JALL</option>
+					<option value="1">J1</option>
+					<option value="2">J2</option>
+					<option value="3">J3</option>
+					<option value="4">J4</option>
+					<option value="5">J5</option>
+				</field>
 
-				description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
-				label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JNONE</option>
-				<option value="-1">JALL</option>
-				<option value="1">J1</option>
-				<option value="2">J2</option>
-				<option value="3">J3</option>
-				<option value="4">J4</option>
-				<option value="5">J5</option>
-			</field>
+				<field
+					name="spacer1"
+					type="spacer"
+					hr="true"
+				/>
 
+				<field
+					name="orderby_pri"
+					type="list"
+					description="JGLOBAL_CATEGORY_ORDER_DESC"
+					label="JGLOBAL_CATEGORY_ORDER_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="none">JGLOBAL_NO_ORDER</option>
+					<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
+					<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
+					<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
+				</field>
+
+				<field
+					name="orderby_sec"
+					type="list"
+					description="JGLOBAL_ARTICLE_ORDER_DESC"
+					label="JGLOBAL_ARTICLE_ORDER_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="front">COM_CONTENT_FEATURED_ORDER</option>
+					<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
+					<option value="date">JGLOBAL_OLDEST_FIRST</option>
+					<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
+					<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
+					<option value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
+					<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
+					<option value="hits">JGLOBAL_MOST_HITS</option>
+					<option value="rhits">JGLOBAL_LEAST_HITS</option>
+					<option value="order">JGLOBAL_ORDERING</option>
+				</field>
+
+				<field
+					name="order_date"
+					type="list"
+					description="JGLOBAL_ORDERING_DATE_DESC"
+					label="JGLOBAL_ORDERING_DATE_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="created">JGLOBAL_CREATED</option>
+					<option value="modified">JGLOBAL_MODIFIED</option>
+					<option value="published">JPUBLISHED</option>
+				</field>
+
+				<field
+					name="show_pagination"
+					type="list"
+					description="JGLOBAL_PAGINATION_DESC"
+					label="JGLOBAL_PAGINATION_LABEL"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+					<option value="2">JGLOBAL_AUTO</option>
+				</field>
+
+				<field
+					name="show_pagination_results"
+					type="list"
+					label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+					description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
+
+				<field
+					name="show_featured"
+					type="list"
+					default=""
+					label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
+					description="JGLOBAL_SHOW_FEATURED_ARTICLES_DESC"
+				>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="show">JSHOW</option>
+					<option value="hide">JHIDE</option>
+					<option value="only">JONLY</option>
+				</field>
+		</fieldset>
+
+		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
 			<field
-			name="spacer1"
-			type="spacer"
-			hr="true"
-			/>
-
-			<field name="orderby_pri" type="list"
-				description="JGLOBAL_CATEGORY_ORDER_DESC"
-				label="JGLOBAL_CATEGORY_ORDER_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="none">JGLOBAL_NO_ORDER</option>
-				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
-			</field>
-
-			<field name="orderby_sec" type="list"
-				description="JGLOBAL_ARTICLE_ORDER_DESC"
-				label="JGLOBAL_ARTICLE_ORDER_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
-				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
-				<option value="date">JGLOBAL_OLDEST_FIRST</option>
-				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-				<option value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
-				<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
-				<option value="hits">JGLOBAL_MOST_HITS</option>
-				<option value="rhits">JGLOBAL_LEAST_HITS</option>
-				<option value="order">JGLOBAL_ORDERING</option>
-			</field>
-
-			<field name="order_date" type="list"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="created">JGLOBAL_CREATED</option>
-				<option value="modified">JGLOBAL_MODIFIED</option>
-				<option value="published">JPUBLISHED</option>
-			</field>
-
-			<field name="show_pagination" type="list"
-				description="JGLOBAL_PAGINATION_DESC"
-				label="JGLOBAL_PAGINATION_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-				<option value="2">JGLOBAL_AUTO</option>
-			</field>
-
-			<field name="show_pagination_results" type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field name="show_featured" type="list" default=""
-				   label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
-				   description="JGLOBAL_SHOW_FEATURED_ARTICLES_DESC"
-					>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="show">JSHOW</option>
-				<option value="hide">JHIDE</option>
-				<option value="only">JONLY</option>
-			</field>
-</fieldset>
-
-<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field name="show_title" type="list"
+				name="show_title"
+				type="list"
 				description="JGLOBAL_SHOW_TITLE_DESC"
 				label="JGLOBAL_SHOW_TITLE_LABEL"
 			>
@@ -277,7 +327,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_titles" type="list"
+			<field
+				name="link_titles"
+				type="list"
 				description="JGLOBAL_LINKED_TITLES_DESC"
 				label="JGLOBAL_LINKED_TITLES_LABEL"
 			>
@@ -287,7 +339,9 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="show_intro" type="list"
+			<field
+				name="show_intro"
+				type="list"
 				description="JGLOBAL_SHOW_INTRO_DESC"
 				label="JGLOBAL_SHOW_INTRO_LABEL"
 			>
@@ -310,7 +364,9 @@
 				<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 			</field>
 
-			<field name="show_category" type="list"
+			<field
+				name="show_category"
+				type="list"
 				description="JGLOBAL_SHOW_CATEGORY_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_LABEL"
 			>
@@ -320,7 +376,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_category" type="list"
+			<field
+				name="link_category"
+				type="list"
 				description="JGLOBAL_LINK_CATEGORY_DESC"
 				label="JGLOBAL_LINK_CATEGORY_LABEL"
 			>
@@ -330,7 +388,9 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="show_parent_category" type="list"
+			<field
+				name="show_parent_category"
+				type="list"
 				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
 				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
 			>
@@ -340,7 +400,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_parent_category" type="list"
+			<field
+				name="link_parent_category"
+				type="list"
 				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
 				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 			>
@@ -350,7 +412,9 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="show_author" type="list"
+			<field
+				name="show_author"
+				type="list"
 				description="JGLOBAL_SHOW_AUTHOR_DESC"
 				label="JGLOBAL_SHOW_AUTHOR_LABEL"
 			>
@@ -360,7 +424,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_author" type="list"
+			<field
+				name="link_author"
+				type="list"
 				description="JGLOBAL_LINK_AUTHOR_DESC"
 				label="JGLOBAL_LINK_AUTHOR_LABEL"
 			>
@@ -370,7 +436,9 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field name="show_create_date" type="list"
+			<field
+				name="show_create_date"
+				type="list"
 				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
 				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
 			>
@@ -380,7 +448,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_modify_date" type="list"
+			<field
+				name="show_modify_date"
+				type="list"
 				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
 				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
 			>
@@ -390,7 +460,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_publish_date" type="list"
+			<field
+				name="show_publish_date"
+				type="list"
 				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
 				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
 			>
@@ -400,7 +472,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_item_navigation" type="list"
+			<field
+				name="show_item_navigation"
+				type="list"
 				description="JGLOBAL_SHOW_NAVIGATION_DESC"
 				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
 			>
@@ -411,15 +485,16 @@
 			</field>
 
 			<field
-			name="show_vote" type="list"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-			<option value="0">JHIDE</option>
-			<option	value="1">JSHOW</option>
-		</field>
+				name="show_vote"
+				type="list"
+				label="JGLOBAL_SHOW_VOTE_LABEL"
+				description="JGLOBAL_SHOW_VOTE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option	value="1">JSHOW</option>
+			</field>
 
 			<field
 				name="show_readmore"
@@ -443,7 +518,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_icons" type="list"
+			<field
+				name="show_icons"
+				type="list"
 				description="JGLOBAL_SHOW_ICONS_DESC"
 				label="JGLOBAL_SHOW_ICONS_LABEL"
 			>
@@ -453,7 +530,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_print_icon" type="list"
+			<field
+				name="show_print_icon"
+				type="list"
 				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
 				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 			>
@@ -463,7 +542,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_email_icon" type="list"
+			<field
+				name="show_email_icon"
+				type="list"
 				description="JGLOBAL_Show_Email_Icon_Desc"
 				label="JGLOBAL_Show_Email_Icon_Label"
 			>
@@ -473,7 +554,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_hits" type="list"
+			<field
+				name="show_hits"
+				type="list"
 				description="JGLOBAL_SHOW_HITS_DESC"
 				label="JGLOBAL_SHOW_HITS_LABEL"
 			>
@@ -483,7 +566,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_noauth" type="list"
+			<field
+				name="show_noauth"
+				type="list"
 				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
 				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
 			>
@@ -492,12 +577,12 @@
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
+		</fieldset>
 
-</fieldset>
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL"
-		>
-
-			<field name="show_feed_link" type="list"
+		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL">
+			<field
+				name="show_feed_link"
+				type="list"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 			>
@@ -506,7 +591,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="feed_summary" type="list"
+			<field
+				name="feed_summary"
+				type="list"
 				description="JGLOBAL_FEED_SUMMARY_DESC"
 				label="JGLOBAL_FEED_SUMMARY_LABEL"
 			>
@@ -515,5 +602,5 @@
 				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
-</fields>
+	</fields>
 </metadata>

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -567,6 +567,18 @@
 			</field>
 
 			<field
+				name="show_tags"
+				type="list"
+				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
+				description="COM_CONTENT_FIELD_SHOW_TAGS_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
 				name="show_noauth"
 				type="list"
 				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"


### PR DESCRIPTION
This is a redo of: Add show_tags to article options in blog view #3970

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33985&start=0
Create a menu item of type Category Blog. Go to tabulator "Options". Option "Show tags" is missing.

The main changes are CS: https://github.com/joomla/joomla-cms/commit/bde62d908ad65bea5381459d2f60f4df0b92c4b7

The fix can be found here: https://github.com/joomla/joomla-cms/commit/12f7442870af578da8c3a278ac59fe0988c9dad9
