### PR TITLE
add call to processLimit to appent the limit and offset to query

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -673,15 +673,16 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	/**
 	 * Sets the SQL statement string for later execution.
 	 *
-	 * @param   mixed    $query   The SQL statement to set either as a JDatabaseQuery object or a string.
-	 * @param   integer  $offset  The affected row offset to set.
-	 * @param   integer  $limit   The maximum affected rows to set.
+	 * @param   mixed    $query          The SQL statement to set either as a JDatabaseQuery object or a string.
+	 * @param   integer  $offset         The affected row offset to set.
+	 * @param   integer  $limit          The maximum affected rows to set.
+	 * @param   array    $driverOptions  The optional PDO driver options.
 	 *
 	 * @return  JDatabaseDriver  This object to support method chaining.
 	 *
 	 * @since   12.1
 	 */
-	public function setQuery($query, $offset = null, $limit = null)
+	public function setQuery($query, $offset = null, $limit = null, $driverOptions = array())
 	{
 		$this->connect();
 
@@ -700,7 +701,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		$query = $this->replacePrefix((string) $query);
 
-		$this->prepared = $this->connection->prepare($query, $this->options);
+		$this->prepared = $this->connection->prepare($query, $driverOptions);
 
 		// Store reference to the JDatabaseQuery instance:
 		parent::setQuery($query, $offset, $limit);

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -695,7 +695,6 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		if ($query instanceof JDatabaseQueryLimitable && !is_null($offset) && !is_null($limit))
 		{
-			$query->setLimit($limit, $offset);
 			$query = $query->processLimit($query, $limit, $offset);
 		}
 

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -697,6 +697,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if ($query instanceof JDatabaseQueryLimitable && !is_null($offset) && !is_null($limit))
 		{
 			$query->setLimit($limit, $offset);
+			$query = $query->processLimit($query, $limit, $offset);
 		}
 
 		$query = $this->replacePrefix((string) $query);

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -673,9 +673,9 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	/**
 	 * Sets the SQL statement string for later execution.
 	 *
-	 * @param   mixed    $query          The SQL statement to set either as a JDatabaseQuery object or a string.
-	 * @param   integer  $offset         The affected row offset to set.
-	 * @param   integer  $limit          The maximum affected rows to set.
+	 * @param   mixed    $query  The SQL statement to set either as a JDatabaseQuery object or a string.
+	 * @param   integer  $offset  The affected row offset to set.
+	 * @param   integer  $limit  The maximum affected rows to set.
 	 *
 	 * @return  JDatabaseDriver  This object to support method chaining.
 	 *

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -673,9 +673,9 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	/**
 	 * Sets the SQL statement string for later execution.
 	 *
-	 * @param   mixed    $query  The SQL statement to set either as a JDatabaseQuery object or a string.
+	 * @param   mixed    $query   The SQL statement to set either as a JDatabaseQuery object or a string.
 	 * @param   integer  $offset  The affected row offset to set.
-	 * @param   integer  $limit  The maximum affected rows to set.
+	 * @param   integer  $limit   The maximum affected rows to set.
 	 *
 	 * @return  JDatabaseDriver  This object to support method chaining.
 	 *

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -676,13 +676,12 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 * @param   mixed    $query          The SQL statement to set either as a JDatabaseQuery object or a string.
 	 * @param   integer  $offset         The affected row offset to set.
 	 * @param   integer  $limit          The maximum affected rows to set.
-	 * @param   array    $driverOptions  The optional PDO driver options
 	 *
 	 * @return  JDatabaseDriver  This object to support method chaining.
 	 *
 	 * @since   12.1
 	 */
-	public function setQuery($query, $offset = null, $limit = null, $driverOptions = array())
+	public function setQuery($query, $offset = null, $limit = null)
 	{
 		$this->connect();
 
@@ -702,7 +701,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		$query = $this->replacePrefix((string) $query);
 
-		$this->prepared = $this->connection->prepare($query, $driverOptions);
+		$this->prepared = $this->connection->prepare($query, $this->options);
 
 		// Store reference to the JDatabaseQuery instance:
 		parent::setQuery($query, $offset, $limit);


### PR DESCRIPTION
This small change is a fix for https://github.com/joomla/joomla-cms/issues/6232 

There might be other ways, but looking at the other drivers it looks like no other driver does this, but no other calls to processLimit that I can find, but PR certainly works for PDO when using Mysql (Not tested with any other PDO backend other than mysql) 
