### PR TITLE
Fix undefined var for ReCapture 2.0 API calls.

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -128,8 +128,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-				$response = $input->get('g-recaptcha-response', '', 'string');
-				$spam     = ($response == null || strlen($response) == 0);
+				$response  = $input->get('g-recaptcha-response', '', 'string');
+				$spam      = ($response == null || strlen($response) == 0);
 				break;
 		}
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -105,13 +105,13 @@ class PlgCaptchaRecaptcha extends JPlugin
 	/**
 	 * Calls an HTTP POST function to verify if the user's guess was correct
 	 *
-	 * @param   string  $code  Answer provided by user.
+	 * @param   string  $code  Answer provided by user. @Deprecated and not needed for the current implementation
 	 *
 	 * @return  True if the answer is correct, false otherwise
 	 *
 	 * @since  2.5
 	 */
-	public function onCheckAnswer($code)
+	public function onCheckAnswer($code = null)
 	{
 		$input      = JFactory::getApplication()->input;
 		$privatekey = $this->params->get('private_key');

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -126,6 +126,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 				$spam      = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
+				$challenge = NULL; // Not needed in 2.0 but needed for getResponse call
 				$response = $input->get('g-recaptcha-response', '', 'string');
 				$spam     = ($response == null || strlen($response) == 0);
 				break;
@@ -164,7 +165,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 * @param   string  $privatekey  The private key for authentication.
 	 * @param   string  $remoteip    The remote IP of the visitor.
 	 * @param   string  $response    The response received from Google.
-	 * @param   string  $challenge   The challenge field from the reCaptcha.
+	 * @param   string  $challenge   The challenge field from the reCaptcha. Only for 1.0.
 	 *
 	 * @return bool True if response is good | False if response is bad.
 	 *

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -105,7 +105,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 	/**
 	 * Calls an HTTP POST function to verify if the user's guess was correct
 	 *
-	 * @param   string  $code  Answer provided by user. @Deprecated and not needed for the current implementation
+	 * @param   string  $code  Answer provided by user. Not needed for the Recaptcha implementation
 	 *
 	 * @return  True if the answer is correct, false otherwise
 	 *

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -126,7 +126,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 				$spam      = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
-				$challenge = NULL; // Not needed in 2.0 but needed for getResponse call
+				// Challenge Not needed in 2.0 but needed for getResponse call
+				$challenge = null;
 				$response = $input->get('g-recaptcha-response', '', 'string');
 				$spam     = ($response == null || strlen($response) == 0);
 				break;

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -88,7 +88,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 	/**
 	 * Gets the challenge HTML
 	 *
-	 * @param   string  $name   The name of the field.
+	 * @param   string  $name   The name of the field. Not Used.
 	 * @param   string  $id     The id of the field.
 	 * @param   string  $class  The class of the field. This should be passed as
 	 *                          e.g. 'class="required"'.
@@ -97,7 +97,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 *
 	 * @since  2.5
 	 */
-	public function onDisplay($name, $id = 'dynamic_recaptcha_1', $class = '')
+	public function onDisplay($name = null, $id = 'dynamic_recaptcha_1', $class = '')
 	{
 		return '<div id="' . $id . '" ' . $class . '></div>';
 	}


### PR DESCRIPTION
The Google ReCaptcha plugin supports 1.0 and 2.0 API calls. 

Reuse of the getResponse() method is made use of for both API versions but 2.0 doesnt need/require the `$challenge` 

This PR just silences strict warnings by setting the `$challenge` to ``null` and adds a tiny bit of additional documentation, cleans up a couple of other warnings and documents unused vars in method calls/signature

Closes #6227
