### PR TITLE
Rename Credits to Special Thanks which is more appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ Do you want to improve Joomla?
 Copyright
 ---------------------
 * Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
-* [Credits](https://docs.joomla.org/Joomla!_Credits_and_Thanks)
+* [Special Thanks](https://docs.joomla.org/Joomla!_Credits_and_Thanks)
 * Distributed under the GNU General Public License version 2 or later
 * See [License details](https://docs.joomla.org/Joomla_Licenses)

--- a/README.txt
+++ b/README.txt
@@ -66,6 +66,6 @@
 
 Copyright:
 	* Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
-	* Credits: https://docs.joomla.org/Joomla!_Credits_and_Thanks
+	* Special Thanks: https://docs.joomla.org/Joomla!_Credits_and_Thanks
 	* Distributed under the GNU General Public License version 2 or later
 	* See Licenses details at https://docs.joomla.org/Joomla_Licenses


### PR DESCRIPTION
Credits implies something totally different to the page linked to of https://docs.joomla.org/Joomla!_Credits_and_Thanks

The page linked to is more of a Special Thanks page 

Credits is a term, a file name in software development, normally associated with those developing, testing, documenting the software

This PR proposes a rename of the link
