### PR TITLE
Link directly to the resources.joomla.org instead of an outdated old pag...

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Where can you get support and help?
 * Find the [information you need](https://docs.joomla.org/Start_here);
 * Find [help and other users](http://www.joomla.org/about-joomla/create-and-share.html);
 * Post questions at [our forums](http://forum.joomla.org);
-* [Joomla Resources Directory](http://resources.joomla.org/tos.html) (JRD).
+* [Joomla Resources Directory](http://resources.joomla.org/) (JRD).
 
 Do you already have a Joomla site that isn't built with Joomla 3.x?
 ---------------------

--- a/README.txt
+++ b/README.txt
@@ -48,7 +48,7 @@
 	* Find the information you need: https://docs.joomla.org/Start_here
 	* Find help and other users: http://www.joomla.org/about-joomla/create-and-share.html
 	* Post questions at our forums: http://forum.joomla.org
-	* Joomla Resources Directory (JRD): http://resources.joomla.org/tos.html
+	* Joomla Resources Directory (JRD): http://resources.joomla.org/
 
 11- Do you already have a Joomla site that's not built with Joomla 3.x ?
 	* What's new in Joomla 3.x: http://www.joomla.org/3


### PR DESCRIPTION
...e

Proposing a Link directly to the resources.joomla.org instead of an outdated old page of http://resources.joomla.org/archive/tos.html which contains old news about a failed SEO migration of the r.j.o pages... doesnt give a good impression really.

If there is a legal reason the original link was the to ToS page, then still the link needs updating to http://resources.joomla.org/en/terms-of-service which is the new URL - but again is not very inviting place to link....
