### PR TITLE
Allow line breaks in Contact Address textarea to be rendered as 's

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_address.php
+++ b/components/com_contact/views/contact/tmpl/default_address.php
@@ -28,7 +28,7 @@ defined('_JEXEC') or die;
 		<?php if ($this->contact->address && $this->params->get('show_street_address')) : ?>
 			<dd>
 				<span class="contact-street" itemprop="streetAddress">
-					<?php echo $this->contact->address . '<br />'; ?>
+					<?php echo nl2br($this->contact->address) . '<br />'; ?>
 				</span>
 			</dd>
 		<?php endif; ?>


### PR DESCRIPTION
Contact address is a textarea, so expected behaviour should be that linebreaks are allowed. Closes #6240
