### PR TITLE
Add bootstrap checkout icon

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -131,7 +131,7 @@ abstract class JHtmlIcon
 	 *
 	 * @since   1.6
 	 */
-	public static function edit($article, $params, $attribs = array(), $legacy = true)
+	public static function edit($article, $params, $attribs = array(), $legacy = false)
 	{
 		$user = JFactory::getUser();
 		$uri  = JUri::getInstance();

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -164,11 +164,11 @@ abstract class JHtmlIcon
 			if($legacy)
 			{
 				$button = JHtml::_('image', 'system/checked_out.png', null, null, true);
-				$text = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JGLOBAL_EDIT');
+				$text = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
 			}
 			else
 			{
-				$text = '<span class="hasTooltip icon-lock" title="' . JHtml::tooltipText($tooltip . '', 0) . '"></span> ' . JText::_('JGLOBAL_EDIT');
+				$text = '<span class="hasTooltip icon-lock" title="' . JHtml::tooltipText($tooltip . '', 0) . '"></span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
 			}
 
 			$output = JHtml::_('link', '#', $text, $attribs);

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -161,10 +161,10 @@ abstract class JHtmlIcon
 			$tooltip      = JText::_('JLIB_HTML_CHECKED_OUT') . ' :: ' . JText::sprintf('COM_CONTENT_CHECKED_OUT_BY', $checkoutUser->name)
 				. ' <br /> ' . $date;
 
-			if($legacy)
+			if ($legacy)
 			{
 				$button = JHtml::_('image', 'system/checked_out.png', null, null, true);
-				$text = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
+				$text   = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
 			}
 			else
 			{

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -164,7 +164,8 @@ abstract class JHtmlIcon
 			if ($legacy)
 			{
 				$button = JHtml::_('image', 'system/checked_out.png', null, null, true);
-				$text   = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
+				$text   = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">'
+					. $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
 			}
 			else
 			{

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -131,7 +131,7 @@ abstract class JHtmlIcon
 	 *
 	 * @since   1.6
 	 */
-	public static function edit($article, $params, $attribs = array(), $legacy = false)
+	public static function edit($article, $params, $attribs = array(), $legacy = true)
 	{
 		$user = JFactory::getUser();
 		$uri  = JUri::getInstance();
@@ -157,12 +157,23 @@ abstract class JHtmlIcon
 			&& $article->checked_out != $user->get('id'))
 		{
 			$checkoutUser = JFactory::getUser($article->checked_out);
-			$button       = JHtml::_('image', 'system/checked_out.png', null, null, true);
 			$date         = JHtml::_('date', $article->checked_out_time);
 			$tooltip      = JText::_('JLIB_HTML_CHECKED_OUT') . ' :: ' . JText::sprintf('COM_CONTENT_CHECKED_OUT_BY', $checkoutUser->name)
 				. ' <br /> ' . $date;
 
-			return '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span>';
+			if($legacy)
+			{
+				$button = JHtml::_('image', 'system/checked_out.png', null, null, true);
+				$text = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JGLOBAL_EDIT');
+			}
+			else
+			{
+				$text = '<span class="hasTooltip icon-lock" title="' . JHtml::tooltipText($tooltip . '', 0) . '"></span> ' . JText::_('JGLOBAL_EDIT');
+			}
+
+			$output = JHtml::_('link', '#', $text, $attribs);
+
+			return $output;
 		}
 
 		$url = 'index.php?option=com_content&task=article.edit&a_id=' . $article->id . '&return=' . base64_encode($uri);


### PR DESCRIPTION
# The problem

When an article is checked out  by another user, you will see on the front-end a legacy icon without text
![checkout-icon old](https://cloud.githubusercontent.com/assets/2659866/6432588/ecfb039e-c056-11e4-8efb-48098412444a.PNG)
# Expected result

It should be nice if see a Bootstrap icon, or a legacy icon, with text
# How to test this patch

1) Make sure you checkout an article on the font-end by following this steps
2) Create a second user who can edit articles on front-end
3) Open two browsers, for example FireFox and Goolge Chrome
4) Login on the front-end with a user on firefox and edit an article, stay in edit mode!
5) Login on the front-end with a second user on Google Chrome and notice the same dropdown as the screenshot above
6) Applay the patch
7) Notice the following dropdown
![checkout-icon new](https://cloud.githubusercontent.com/assets/2659866/6432617/9c38e632-c057-11e4-8cb1-d8ecbf7c7c04.PNG)
8) Go to components/com_content/helpers/icon.php, and edit line 134 to:
`public static function edit($article, $params, $attribs = array(), $legacy = true)`
9) Refresh Google Chrome, and notice the following dropdown:
![checkout-icon legacy new](https://cloud.githubusercontent.com/assets/2659866/6432625/03db255c-c058-11e4-9094-a12075990bd7.PNG)
