### PR TITLE
Styles for invalid Chosen plugin drop-down

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6106,6 +6106,11 @@ fieldset.radio.btn-group {
 input.invalid {
 	border: 1px solid #9d261d;
 }
+select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
+select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
+	border-color: #9d261d;
+	color: #9d261d;
+}
 .tooltip {
 	max-width: 400px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6106,6 +6106,11 @@ fieldset.radio.btn-group {
 input.invalid {
 	border: 1px solid #9d261d;
 }
+select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
+select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
+	border-color: #9d261d;
+	color: #9d261d;
+}
 .tooltip {
 	max-width: 400px;
 }

--- a/media/jui/css/bootstrap-extended.css
+++ b/media/jui/css/bootstrap-extended.css
@@ -423,6 +423,11 @@ fieldset.radio.btn-group {
 input.invalid {
 	border: 1px solid #9d261d;
 }
+select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
+select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
+	border-color: #9d261d;
+	color: #9d261d;
+}
 .tooltip {
 	max-width: 400px;
 }

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -470,8 +470,8 @@ input.invalid {
 }
 select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
 select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
-	border-color: #9d261d;
-	color: #9d261d;
+	border-color: @red;
+	color: @red;
 }
 
 /* Tweaking of tooltips */

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -468,6 +468,11 @@ fieldset.radio.btn-group {
 input.invalid {
 	border: 1px solid @red;
 }
+select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
+select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
+	border-color: #9d261d;
+	color: #9d261d;
+}
 
 /* Tweaking of tooltips */
 .tooltip {

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6106,6 +6106,11 @@ fieldset.radio.btn-group {
 input.invalid {
 	border: 1px solid #9d261d;
 }
+select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
+select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
+	border-color: #9d261d;
+	color: #9d261d;
+}
 .tooltip {
 	max-width: 400px;
 }


### PR DESCRIPTION
When a select field is required and no option is selected it will get a red colour if you are using Joomla Validator. But when you enable Chosen plugin then those styles will be lost. This is a fix for invalid select with enabled Chosen plugin.

Test instructions:
- Go to back-end
- Remove all categories for articles
- Go to new article view
- Try to save without filling any data
- You will see notice about invalid category field. Label will be red, but drop-down not because of missing styles for Chosen jQuery plugin
