### PR TITLE
Catch the potential DB errors when "#__postinstall_messages" is missing

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/view.html.php
+++ b/administrator/components/com_cpanel/views/cpanel/view.html.php
@@ -53,8 +53,18 @@ class CpanelViewCpanel extends JViewLegacy
 			require_once JPATH_LIBRARIES . '/fof/include.php';
 		}
 
-		$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel')->eid(700);
-		$messages = $messages_model->getItemList();
+		try
+		{
+			$messages_model = FOFModel::getTmpInstance('Messages', 'PostinstallModel')->eid(700);
+			$messages       = $messages_model->getItemList();
+		}
+		catch (RuntimeException $e)
+		{
+			$messages = array();
+
+			// Still render the error message from the Exception object
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
 
 		$this->postinstall_message_count = count($messages);
 


### PR DESCRIPTION
Redo of #2840

This try catch the error if the postinstall table can not found. e.g. on upgrade from 2.5; or other Problems with the database table.
### How to test
- setup clean staging.
- remove the #__postinstall_messages table form the database
- you can't open the cpanel.
- apply the patch
- you can access the cpanel but we display the error.

Credits and Thanks goes to @jms2win
