### PR TITLE
Missing URL information breaks menu alias routing

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -578,13 +578,18 @@ class JRouterSite extends JRouter
 	 */
 	protected function processBuildRules(&$uri, $stage = self::PROCESS_DURING)
 	{
-		if ($stage == self::PROCESS_BEFORE)
+		if ($stage == self::PROCESS_DURING)
 		{
 			// Make sure any menu vars are used if no others are specified
-			if (($this->_mode != JROUTER_MODE_SEF) && $uri->getVar('Itemid') && count($uri->getQuery(true)) == 2)
+			$query = $uri->getQuery(true);
+			if ($this->_mode != 1
+				&& isset($query['Itemid'])
+				&& isset($query['option'])
+				&& (count($query) == 2 || (count($query) == 3 && isset($query['lang']))))
 			{
 				// Get the active menu item
 				$itemid = $uri->getVar('Itemid');
+				$lang = $uri->getVar('lang');
 				$item = $this->menu->getItem($itemid);
 
 				if ($item)
@@ -593,6 +598,11 @@ class JRouterSite extends JRouter
 				}
 
 				$uri->setVar('Itemid', $itemid);
+
+				if ($lang)
+				{
+					$uri->setVar('lang', $lang);
+				}
 			}
 		}
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -578,7 +578,7 @@ class JRouterSite extends JRouter
 	 */
 	protected function processBuildRules(&$uri, $stage = self::PROCESS_DURING)
 	{
-		if ($stage == self::PROCESS_DURING)
+		if ($stage == self::PROCESS_BEFORE)
 		{
 			// Make sure any menu vars are used if no others are specified
 			if (($this->_mode != JROUTER_MODE_SEF) && $uri->getVar('Itemid') && count($uri->getQuery(true)) == 2)

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -584,7 +584,6 @@ class JRouterSite extends JRouter
 			$query = $uri->getQuery(true);
 			if ($this->_mode != 1
 				&& isset($query['Itemid'])
-				&& isset($query['option'])
 				&& (count($query) == 2 || (count($query) == 3 && isset($query['lang']))))
 			{
 				// Get the active menu item


### PR DESCRIPTION
This codeblock should actually be run on the process_before stage, since it expects only 2 query elements. If it is run on process_during, the languagefilter plugin already acted and added the language. If this is not executed, the alias menu item does not work correctly.

http://forum.joomla.org/viewtopic.php?f=711&t=875100
