### PR TITLE
Fix SQL query in mod_articles_archive

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -33,11 +33,12 @@ class ModArchiveHelper
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
 		$query->select($query->month($db->quoteName('created')) . ' AS created_month')
-			->select('created, id, title')
+			->select('MIN(' . $db->quoteName('created') . ') AS created')
 			->select($query->year($db->quoteName('created')) . ' AS created_year')
 			->from('#__content')
 			->where('state = 2 AND checked_out = 0')
-			->group($query->year($db->quoteName('created')) . ', ' . $query->month($db->quoteName('created')) . ', created, id, title');
+			->group($query->year($db->quoteName('created')) . ', ' . $query->month($db->quoteName('created')))
+			->order($query->year($db->quoteName('created')) . ' DESC, ' . $query->month($db->quoteName('created')) . ' DESC');
 
 		// Filter by language
 		if (JFactory::getApplication()->getLanguageFilter())


### PR DESCRIPTION
This is a fix for issue #6246.

After the recent changes (see #3292) the query does not deliver results as expected because the fields `created, id, title` were added to the `group by` clause. The result list actually contains all published archived articles of the last X month. Therefore the module output contains multiple entries for the same month/year.
So these fields have to be removed from the grouping again.

In standard SQL it is not allowed to have nonaggregated columns in the select list which are not in the group by columns, so that is the reason for removing the `->select('created, id, title')`.

But we need a `created` for further calculations.

Therefore I added a `->select('MIN(' . $db->quoteName('created') . ') AS created')` which is an aggregate column and therefore does not need to be part of the `group by`. It contains the smallest date of all articles for a grouped month/year.

For test instructions see also #6246.
Make sure to have more than one archived published article for each month/year and check if you have multiple entries for the same month/year.
Before applying the patch you will have, after the patch you should not have any duplicates.
