### PR TITLE
UX tweaks to notes in com_users

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -54,8 +54,8 @@ class JHtmlUsers
 	{
 		$title = JText::_('COM_USERS_ADD_NOTE');
 
-		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '">'
-			. '<span class="label label-info"><i class="icon-vcard"></i>' . $title . '</span></a>';
+		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="' . $title . '">'
+			. '<i class="icon-vcard"></i> '. $title .'</a>';
 	}
 
 	/**
@@ -77,8 +77,8 @@ class JHtmlUsers
 
 		$title = JText::_('COM_USERS_FILTER_NOTES');
 
-		return '<a href="' . JRoute::_('index.php?option=com_users&view=notes&filter_search=uid:' . (int) $userId) . '">'
-			. JHtml::_('image', 'admin/filter_16.png', 'COM_USERS_NOTES', array('title' => $title), true) . '</a>';
+		return '<a href="' . JRoute::_('index.php?option=com_users&view=notes&filter_search=uid:' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="' . $title . '">'
+			. '<i class="icon-filter"></i></a>';
 	}
 
 	/**
@@ -108,8 +108,8 @@ class JHtmlUsers
 				'height' => '500px')
 		);
 
-		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal">'
-			. '<span class="label label-info"><i class="icon-drawer-2"></i>' . $title . '</span></a>';
+		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
+			. '<i class="icon-drawer-2"></i> '. $title .'</a>';
 	}
 
 	/**

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -103,7 +103,7 @@ class JHtmlUsers
 		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
 			. '<i class="icon-drawer-2"></i><span class="hidden-phone">' . $title . '</span></a>';
 	}
-	
+
 	/**
 	 * Renders the modal html.
 	 *
@@ -123,7 +123,7 @@ class JHtmlUsers
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
 
-        echo JHtmlBootstrap::renderModal(
+		echo JHtmlBootstrap::renderModal(
 			'userModal_' . (int) $userId, array(
 				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
 				'title' => $title,
@@ -133,7 +133,7 @@ class JHtmlUsers
 
 		return null;
 	}
-	
+
 	/**
 	 * Build an array of block/unblock user states to be used by jgrid.state,
 	 * State options will be different for any user

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -55,7 +55,7 @@ class JHtmlUsers
 		$title = JText::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-vcard"></i> '. $title .'</a>';
+			. '<i class="icon-vcard"></i>' . $title . '</a>';
 	}
 
 	/**
@@ -109,7 +109,7 @@ class JHtmlUsers
 		);
 
 		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-drawer-2"></i> '. $title .'</a>';
+			. '<i class="icon-drawer-2"></i>' . $title . '</a>';
 	}
 
 	/**

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -110,7 +110,7 @@ class JHtmlUsers
 	 * @param   integer  $count   The number of notes for the user
 	 * @param   integer  $userId  The user ID
 	 *
-	 * @return	string   The html for the rendered modal
+	 * @return  string   The html for the rendered modal
 	 *
 	 * @since   3.4.1
 	*/

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -110,7 +110,7 @@ class JHtmlUsers
 	 * @param   integer  $count   The number of notes for the user
 	 * @param   integer  $userId  The user ID
 	 *
-	 * @return  null
+	 * @return	string   The html for the rendered modal
 	 *
 	 * @since   3.4.1
 	*/
@@ -123,7 +123,7 @@ class JHtmlUsers
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
 
-		echo JHtmlBootstrap::renderModal(
+		return JHtmlBootstrap::renderModal(
 			'userModal_' . (int) $userId, array(
 				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
 				'title' => $title,
@@ -131,7 +131,6 @@ class JHtmlUsers
 				'height' => '500px')
 		);
 
-		return null;
 	}
 
 	/**

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -100,7 +100,30 @@ class JHtmlUsers
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
 
-		echo JHtmlBootstrap::renderModal(
+		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
+			. '<i class="icon-drawer-2"></i><span class="hidden-phone">' . $title . '</span></a>';
+	}
+	
+	/**
+	 * Renders the modal html.
+	 *
+	 * @param   integer  $count   The number of notes for the user
+	 * @param   integer  $userId  The user ID
+	 *
+	 * @return  null
+	 *
+	 * @since   3.4.1
+	*/
+	public static function notesModal($count, $userId)
+	{
+		if (empty($count))
+		{
+			return '';
+		}
+
+		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
+
+        echo JHtmlBootstrap::renderModal(
 			'userModal_' . (int) $userId, array(
 				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
 				'title' => $title,
@@ -108,10 +131,9 @@ class JHtmlUsers
 				'height' => '500px')
 		);
 
-		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-drawer-2"></i><span class="hidden-phone">' . $title . '</span></a>';
+		return null;
 	}
-
+	
 	/**
 	 * Build an array of block/unblock user states to be used by jgrid.state,
 	 * State options will be different for any user

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -55,7 +55,7 @@ class JHtmlUsers
 		$title = JText::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-vcard"></i>' . $title . '</a>';
+			. '<i class="icon-vcard"></i><span class="hidden-phone">' . $title . '</span></a>';
 	}
 
 	/**
@@ -109,7 +109,7 @@ class JHtmlUsers
 		);
 
 		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-drawer-2"></i>' . $title . '</a>';
+			. '<i class="icon-drawer-2"></i><span class="hidden-phone">' . $title . '</span></a>';
 	}
 
 	/**

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -112,6 +112,7 @@ $loggeduser = JFactory::getUser();
 								<span class="label label-warning"><?php echo JText::_('COM_USERS_PASSWORD_RESET_REQUIRED'); ?></span>
 								<?php endif; ?>
 							</div>
+							<?php echo JHtml::_('users.notesModal', $item->note_count, $item->id); ?>
 							<?php if (JDEBUG) : ?>
 								<div class="small"><a href="<?php echo JRoute::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $item->id);?>">
 								<?php echo JText::_('COM_USERS_DEBUG_USER');?></a></div>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -96,13 +96,15 @@ $loggeduser = JFactory::getUser();
 							<?php endif; ?>
 						</td>
 						<td>
+							<div class="name">
 							<?php if ($canEdit) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->id); ?>" title="<?php echo JText::sprintf('COM_USERS_EDIT_USER', $this->escape($item->name)); ?>">
 									<?php echo $this->escape($item->name); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->name); ?>
 							<?php endif; ?>
-							<div>
+							</div>
+							<div class="btn-group">
 								<?php echo JHtml::_('users.filterNotes', $item->note_count, $item->id); ?>
 								<?php echo JHtml::_('users.notes', $item->note_count, $item->id); ?>
 								<?php echo JHtml::_('users.addNote', $item->id); ?>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -108,11 +108,11 @@ $loggeduser = JFactory::getUser();
 								<?php echo JHtml::_('users.filterNotes', $item->note_count, $item->id); ?>
 								<?php echo JHtml::_('users.notes', $item->note_count, $item->id); ?>
 								<?php echo JHtml::_('users.addNote', $item->id); ?>
-								<?php if ($item->requireReset == '1') : ?>
-								<span class="label label-warning"><?php echo JText::_('COM_USERS_PASSWORD_RESET_REQUIRED'); ?></span>
-								<?php endif; ?>
 							</div>
 							<?php echo JHtml::_('users.notesModal', $item->note_count, $item->id); ?>
+							<?php if ($item->requireReset == '1') : ?>
+								<span class="label label-warning"><?php echo JText::_('COM_USERS_PASSWORD_RESET_REQUIRED'); ?></span>
+							<?php endif; ?>
 							<?php if (JDEBUG) : ?>
 								<div class="small"><a href="<?php echo JRoute::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $item->id);?>">
 								<?php echo JText::_('COM_USERS_DEBUG_USER');?></a></div>


### PR DESCRIPTION
Some small tweaks to the user notes in com_users > users.

The text has become a bit smaller, so I added tooltips to the buttons as well (See last screenshot).
## Before patch

![skaermbillede 2015-03-02 kl 20 52 09](https://cloud.githubusercontent.com/assets/1738811/6449226/965a1f88-c11f-11e4-96ac-b15248af0dfd.png)
## After patch

![skaermbillede 2015-03-02 kl 20 56 52](https://cloud.githubusercontent.com/assets/1738811/6449234/a0346e46-c11f-11e4-883b-c8ad235f9707.png)

![skaermbillede 2015-03-02 kl 21 03 54](https://cloud.githubusercontent.com/assets/1738811/6449239/a7c06ade-c11f-11e4-9a52-b414540e547a.png)
