### PR TITLE
PostgreSQL - SQL error when adding a user note

### DIFF
--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -45,17 +45,14 @@ class UsersTableNote extends JTable
 		$userId = JFactory::getUser()->get('id');
 
 		$this->modified_time = $date;
+		$this->modified_user_id = $userId;
+		$this->review_time = $date;
 
 		if (empty($this->id))
 		{
 			// New record.
 			$this->created_time = $date;
 			$this->created_user_id = $userId;
-		}
-		else
-		{
-			// Existing record.
-			$this->modified_user_id = $userId;
 		}
 
 		// Attempt to store the data.

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -46,7 +46,7 @@ class UsersTableNote extends JTable
 
 		$this->modified_time = $date;
 		$this->modified_user_id = $userId;
-		
+
 		if (!((int) $this->review_time))
 		{
 			// Null date.

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -46,7 +46,12 @@ class UsersTableNote extends JTable
 
 		$this->modified_time = $date;
 		$this->modified_user_id = $userId;
-		$this->review_time = $date;
+		
+		if (!((int) $this->review_time))
+		{
+			// Null date.
+			$this->review_time = JFactory::getDbo()->getNullDate();
+		}
 
 		if (empty($this->id))
 		{

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -148,7 +148,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php echo JHtml::_('jgrid.published', $item->state, $i, 'notes.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 					</td>
 					<td class="center">
-						<?php if (intval($item->review_time)) : ?>
+						<?php if ($item->review_time !== JFactory::getDbo()->getNullDate()) : ?>
 							<?php echo JHtml::_('date', $item->review_time, JText::_('DATE_FORMAT_LC4')); ?>
 						<?php else : ?>
 							<?php echo JText::_('COM_USERS_EMPTY_REVIEW'); ?>

--- a/administrator/templates/hathor/html/com_users/notes/default.php
+++ b/administrator/templates/hathor/html/com_users/notes/default.php
@@ -125,7 +125,7 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 					<?php echo JHtml::_('jgrid.published', $item->state, $i, 'notes.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 				</td>
 				<td class="center">
-					<?php if ((int) $item->review_time) : ?>
+					<?php if ($item->review_time !== JFactory::getDbo()->getNullDate()) : ?>
 						<?php echo JHtml::_('date', $item->review_time, JText::_('DATE_FORMAT_LC4')); ?>
 					<?php else : ?>
 						<?php echo JText::_('COM_USERS_EMPTY_REVIEW'); ?>


### PR DESCRIPTION
#### Steps to reproduce the issue

 Backend go to the User -> User Note ->  add a note
#### Expected result

the data are saved
#### Actual result

Got an ERROR  SQL NULL VALUE in column modified_user_id
#### System information

PostgreSQL 9.3.5
Joomla 3.4.0
#### Additional comments

Even on new note we need to add a value for NOT NULL FIELDS
fix #6262
