### PR TITLE
Correct lookup paths in JPluginHelper::getLayoutPath()

### DIFF
--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -51,8 +51,8 @@ abstract class JPluginHelper
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
-		$bPath = JPATH_BASE . '/plugins/' . $type . '/' . $name . '/tmpl/' . $defaultLayout . '.php';
-		$dPath = JPATH_BASE . '/plugins/' . $type . '/' . $name . '/tmpl/default.php';
+		$bPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/' . $defaultLayout . '.php';
+		$dPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/default.php';
 
 		// If the template has a layout override use it
 		if (file_exists($tPath))


### PR DESCRIPTION
When using JPluginHelper::getLayoutPath() in a plugin executing from the admin application, the lookup paths for the base plugin path are incorrect as the `JPATH_BASE` path constant is used to build the base path.  This constant differs between the site and admin applications.

This PR adjusts the lookup paths to use the `JPATH_PLUGINS` path constant instead.
