### PR TITLE
Updated Bootstrap Accordion

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -676,7 +676,7 @@ abstract class JHtmlBootstrap
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
 		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? ' in' : '';
-		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ? 
+		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ?
 			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -583,9 +583,11 @@ abstract class JHtmlBootstrap
 	 *                             - active  string    Sets the active slide during load
 	 * 
 	 *                             - onShow    function  This event fires immediately when the show instance method is called.
-	 *                             - onShown   function  This event is fired when a collapse element has been made visible to the user (will wait for css transitions to complete).
+	 *                             - onShown   function  This event is fired when a collapse element has been made visible to the user 
+	 *                                                   (will wait for css transitions to complete).
 	 *                             - onHide    function  This event is fired immediately when the hide method has been called.
-	 *                             - onHidden  function  This event is fired when a collapse element has been hidden from the user (will wait for css transitions to complete).
+	 *                             - onHidden  function  This event is fired when a collapse element has been hidden from the user 
+	 *                                                   (will wait for css transitions to complete).
 	 *
 	 * @return  string  HTML for the accordian
 	 *
@@ -674,7 +676,8 @@ abstract class JHtmlBootstrap
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
 		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? ' in' : '';
-		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ? ' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
+		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ? 
+			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
 		$html = '<div class="accordion-group' . $class . '">'

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -581,6 +581,11 @@ abstract class JHtmlBootstrap
 	 *                                                 collapsible item is shown. (similar to traditional accordion behavior)
 	 *                             - toggle  boolean   Toggles the collapsible element on invocation
 	 *                             - active  string    Sets the active slide during load
+	 * 
+	 *                             - onShow    function  This event fires immediately when the show instance method is called.
+	 *                             - onShown   function  This event is fired when a collapse element has been made visible to the user (will wait for css transitions to complete).
+	 *                             - onHide    function  This event is fired immediately when the hide method has been called.
+	 *                             - onHidden  function  This event is fired when a collapse element has been hidden from the user (will wait for css transitions to complete).
 	 *
 	 * @return  string  HTML for the accordian
 	 *
@@ -588,9 +593,7 @@ abstract class JHtmlBootstrap
 	 */
 	public static function startAccordion($selector = 'myAccordian', $params = array())
 	{
-		$sig = md5(serialize(array($selector, $params)));
-
-		if (!isset(static::$loaded[__METHOD__][$sig]))
+		if (!isset(static::$loaded[__METHOD__][$selector]))
 		{
 			// Include Bootstrap framework
 			static::framework();
@@ -598,23 +601,49 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['parent'] = isset($params['parent']) ? (boolean) $params['parent'] : false;
 			$opt['toggle'] = isset($params['toggle']) ? (boolean) $params['toggle'] : true;
-			$opt['active'] = isset($params['active']) ? (string) $params['active'] : '';
+			$active = isset($params['active']) ? (string) $params['active'] : '';
+			$onShow = isset($params['onShow']) ? (string) $params['onShow'] : null;
+			$onShown = isset($params['onShown']) ? (string) $params['onShown'] : null;
+			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
+			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
 			$options = JHtml::getJSObject($opt);
 
+			// Build the script.
+			$script = array();
+			$script[] = "jQuery(document).ready(function($){";
+			$script[] = "\t$('#" . $selector . "').collapse(" . $options . ")";
+
+			if ($onShow)
+			{
+				$script[] = "\t.on('show', " . $onShow . ")";
+			}
+
+			if ($onShown)
+			{
+				$script[] = "\t.on('shown', " . $onShown . ")";
+			}
+
+			if ($onHide)
+			{
+				$script[] = "\t.on('hide', " . $onHide . ")";
+			}
+
+			if ($onHidden)
+			{
+				$script[] = "\t.on('hidden', " . $onHidden . ")";
+			}
+
+			$script[] = "});";
+
 			// Attach accordion to document
-			JFactory::getDocument()->addScriptDeclaration(
-				"(function($){
-					$('#$selector').collapse($options);
-				})(jQuery);"
-			);
+			JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 			// Set static array
-			static::$loaded[__METHOD__][$sig] = true;
-			static::$loaded[__METHOD__]['active'] = $opt['active'];
-		}
+			static::$loaded[__METHOD__][$selector] = $active;
 
-		return '<div id="' . $selector . '" class="accordion">';
+			return '<div id="' . $selector . '" class="accordion">';
+		}
 	}
 
 	/**
@@ -643,12 +672,12 @@ abstract class JHtmlBootstrap
 	 */
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
-		$in = (static::$loaded['JHtmlBootstrap::startAccordion']['active'] == $id) ? ' in' : '';
+		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector] == $id) ? ' in' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
 		$html = '<div class="accordion-group' . $class . '">'
 			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-parent="#' . $selector . '" data-toggle="collapse" class="accordion-toggle">'
+			. '<strong><a href="#' . $id . '" data-toggle="collapse" class="accordion-toggle">'
 			. $text
 			. '</a></strong>'
 			. '</div>'

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -599,15 +599,16 @@ abstract class JHtmlBootstrap
 			static::framework();
 
 			// Setup options object
-			$opt['parent'] = isset($params['parent']) ? (boolean) $params['parent'] : false;
-			$opt['toggle'] = isset($params['toggle']) ? (boolean) $params['toggle'] : true;
-			$active = isset($params['active']) ? (string) $params['active'] : '';
+			$opt['parent'] = isset($params['parent']) ? ($params['parent'] == true ? '#' . $selector : $params['parent']) : false;
+			$opt['toggle'] = isset($params['toggle']) ? (boolean) $params['toggle'] : ($opt['parent'] === false || isset($params['active']) ? false : true);
 			$onShow = isset($params['onShow']) ? (string) $params['onShow'] : null;
 			$onShown = isset($params['onShown']) ? (string) $params['onShown'] : null;
 			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
 			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
 			$options = JHtml::getJSObject($opt);
+
+			$opt['active'] = isset($params['active']) ? (string) $params['active'] : '';
 
 			// Build the script.
 			$script = array();
@@ -626,7 +627,7 @@ abstract class JHtmlBootstrap
 
 			if ($onHide)
 			{
-				$script[] = "\t.on('hide', " . $onHide . ")";
+				$script[] = "\t.on('hideme', " . $onHide . ")";
 			}
 
 			if ($onHidden)
@@ -640,7 +641,7 @@ abstract class JHtmlBootstrap
 			JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 			// Set static array
-			static::$loaded[__METHOD__][$selector] = $active;
+			static::$loaded[__METHOD__][$selector] = $opt;
 
 			return '<div id="' . $selector . '" class="accordion">';
 		}
@@ -672,12 +673,13 @@ abstract class JHtmlBootstrap
 	 */
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
-		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector] == $id) ? ' in' : '';
+		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? ' in' : '';
+		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ? ' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
 		$html = '<div class="accordion-group' . $class . '">'
 			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-toggle="collapse" class="accordion-toggle">'
+			. '<strong><a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="accordion-toggle">'
 			. $text
 			. '</a></strong>'
 			. '</div>'


### PR DESCRIPTION
Added JavaScript events, 
fixed behaviour of option 'parent' - previously it was overloaded by data attribute in method addSlide, 
fixed usage of option 'active' - previously there was only one active slide for all accordions while each accordion can have own active slide, 
start accordion only once based on selector which is an HTML ID and should be loaded only once even if params passed to method have changed.
