### PR TITLE
[fix] only define constants if they are not defined

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -338,9 +338,20 @@ class JComponentHelper
 		$file = substr($option, 4);
 
 		// Define component path.
-		define('JPATH_COMPONENT', JPATH_BASE . '/components/' . $option);
-		define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $option);
-		define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/' . $option);
+		if (!defined('JPATH_COMPONENT'))
+		{
+			define('JPATH_COMPONENT', JPATH_BASE . '/components/' . $option);
+		}
+
+		if (!defined('JPATH_COMPONENT_SITE'))
+		{
+			define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $option);
+		}
+
+		if (!defined('JPATH_COMPONENT_ADMINISTRATOR'))
+		{
+			define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/' . $option);
+		}
 
 		$path = JPATH_COMPONENT . '/' . $file . '.php';
 


### PR DESCRIPTION
## Description

We should never define a constant without checking if it's defined. When trying to use views to process the routes for their own view in my component I found that the component helper is called twice and then it's trying to define a constant that has been already defined.
## Backward compatibility

There is no issue here. Just using the recommended way of doing things. Everything should work.
## Test

Apply the patch and ensure that components are working properly.
