### PR TITLE
Fix the page heading in "List of all tags" view

### DIFF
--- a/components/com_tags/views/tags/tmpl/default.php
+++ b/components/com_tags/views/tags/tmpl/default.php
@@ -16,7 +16,7 @@ $description = $this->params->get('all_tags_description');
 $descriptionImage = $this->params->get('all_tags_description_image');
 ?>
 <div class="tag-category<?php echo $this->pageclass_sfx; ?>">
-	<?php if ($this->state->get('show_page_heading')) : ?>
+	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>
 		</h1>


### PR DESCRIPTION
### Testing instructions
1.  Create a "List of all tags" menu item and set the "Show Page Heading" parameter to "Yes". 
2.  Open this view – the page heading is not being displayed.
3.  Apply the patch.
4.  Open this view – the page heading should be displayed.
5.  Set the "Show Page Heading" parameter to "No". 
6.  Open this view – the page heading should not be displayed.
