### PR TITLE
Remove usage of JRouter from Languagefilter Plugin constructor

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -55,8 +55,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->app->isSite())
 		{
 			// Setup language data.
-			$router 			= $this->app->getRouter();
-			$this->mode_sef 	= ($router->getMode() == JROUTER_MODE_SEF);
+			$this->mode_sef 	= $this->app->get('sef', JROUTER_MODE_SEF);
 			$this->sefs 		= JLanguageHelper::getLanguages('sef');
 			$this->lang_codes 	= JLanguageHelper::getLanguages('lang_code');
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -55,7 +55,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->app->isSite())
 		{
 			// Setup language data.
-			$this->mode_sef 	= $this->app->get('sef', JROUTER_MODE_SEF);
+			$this->mode_sef 	= $this->app->get('sef', 0);
 			$this->sefs 		= JLanguageHelper::getLanguages('sef');
 			$this->lang_codes 	= JLanguageHelper::getLanguages('lang_code');
 


### PR DESCRIPTION
In light of the issues that Falang had recently, this PR removes the usage of the router from the constructor, thus giving plugins like Falangs the chance to do their thing.
