### PR TITLE
Fix array_intersect error in isAuthorisedDisplayDebug

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -313,7 +313,7 @@ class PlgSystemDebug extends JPlugin
 
 		if (!empty($filterGroups))
 		{
-			$userGroups = JFactory::getUser()->get('groups');
+			$userGroups = JFactory::getUser()->get('groups', array());
 
 			if (!array_intersect($filterGroups, $userGroups))
 			{


### PR DESCRIPTION
With system debugging enabled and all debug-plugin options enabled there will an error be thrown `array_intersect()` is called with either parameter not being an array. While `$filterGroups` is explicitely cast as array `$userGroups` is not and neither checked for an empty return value. Defining a fallback value - empty array - fixes this error and array_intersect works properly.
