### PR TITLE
Add onBeforeInitialise event

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -112,8 +112,14 @@ class JApplicationAdministrator extends JApplicationCms
 	 */
 	protected function doExecute()
 	{
+		// Assemble options for the initialisation
+		$options = array('language' => $this->getUserState('application.lang'));
+
+		JPluginHelper::importPlugin('system');
+		$this->triggerEvent('onBeforeInitialise', array(&$options));
+
 		// Initialise the application
-		$this->initialiseApp(array('language' => $this->getUserState('application.lang')));
+		$this->initialiseApp($options);
 
 		// Test for magic quotes
 		if (get_magic_quotes_gpc())

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -649,7 +649,6 @@ class JApplicationCms extends JApplicationWeb
 		$this->set('editor', $editor);
 
 		// Trigger the onAfterInitialise event.
-		JPluginHelper::importPlugin('system');
 		$this->triggerEvent('onAfterInitialise');
 	}
 

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -205,8 +205,14 @@ final class JApplicationSite extends JApplicationCms
 	 */
 	protected function doExecute()
 	{
+		// Assemble options for the initialisation
+		$options = array();
+
+		JPluginHelper::importPlugin('system');
+		$this->triggerEvent('onBeforeInitialise', array(&$options));
+
 		// Initialise the application
-		$this->initialiseApp();
+		$this->initialiseApp($options);
 
 		// Mark afterInitialise in the profiler.
 		JDEBUG ? $this->profiler->mark('afterInitialise') : null;
@@ -568,9 +574,6 @@ final class JApplicationSite extends JApplicationCms
 			$guestUsergroup = JComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
 			$user->groups = array($guestUsergroup);
 		}
-
-		// If a language was specified it has priority, otherwise use user or default language settings
-		JPluginHelper::importPlugin('system', 'languagefilter');
 
 		if (empty($options['language']))
 		{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -71,7 +71,22 @@ class PlgSystemLanguageFilter extends JPlugin
 					unset($this->sefs[$language->sef]);
 				}
 			}
+		}
+	}
 
+	/**
+	 * Before initialise.
+	 *
+	 * @param   array  $options  The array of options to be passed into the application initialisation
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 */
+	public function onBeforeInitialise($options)
+	{
+		if ($this->app->isSite())
+		{
 			$this->app->setLanguageFilter(true);
 
 			// Detect browser feature.


### PR DESCRIPTION
This removes the requirement that the language filter plugin ALWAYS loads before any other system plugin by adding a new plugin event before the app is initialised.

Doing this also gives app's a way to inject their own language object before the rest of the checks are run. Making things more diverse.

I gave this some basic testing and things seemed to be good but it 2 GOOD tests (as well as maybe a performance check?? - I'm not sure what the cost of additional plugin events actually are).
## Potential b/c issue

The system plugin group as a result are now loaded earlier in the load cycle. As an example if a constructor tried to do `JFactory::getLanguage` it would return null
