### PR TITLE
[fix] wrong link when tag is in a menu

### DIFF
--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -147,7 +147,10 @@ class TagsHelperRoute extends JHelperRoute
 						{
 							foreach ($item->query['id'] as $position => $tagId)
 							{
-								self::$lookup[$lang][$view][$item->query['id'][$position]] = $item->id;
+								if (!isset(self::$lookup[$lang][$view][$item->query['id'][$position]]) || count($item->query['id']) == 1)
+								{
+									self::$lookup[$lang][$view][$item->query['id'][$position]] = $item->id;
+								}
 							}
 						}
 					}

--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -143,9 +143,12 @@ class TagsHelperRoute extends JHelperRoute
 						}
 
 						// Only match menu items that list one tag
-						if (isset($item->query['id'][0]) && count($item->query['id']) == 1)
+						if (isset($item->query['id']) && is_array($item->query['id']))
 						{
-							self::$lookup[$lang][$view][$item->query['id'][0]] = $item->id;
+							foreach ($item->query['id'] as $position => $tagId)
+							{
+								self::$lookup[$lang][$view][$item->query['id'][$position]] = $item->id;
+							}
 						}
 					}
 				}

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -72,7 +72,7 @@ class TagsRouter extends JComponentRouterBase
 			return $segments;
 		}
 
-		if (isset($view) && $view == 'tag')
+		if ($view == 'tag')
 		{
 			$notActiveTag = is_array($mId) ? (count($mId) > 1 || $mId[0] != (int) $query['id']) : ($mId != (int) $query['id']);
 

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -51,6 +51,7 @@ class TagsRouter extends JComponentRouterBase
 		}
 
 		$view = '';
+
 		if (isset($query['view']))
 		{
 			$view = $query['view'];
@@ -67,12 +68,15 @@ class TagsRouter extends JComponentRouterBase
 		if ($mView == $view && isset($query['id']) && $mId == $query['id'])
 		{
 			unset($query['id']);
+
 			return $segments;
 		}
 
-		if (isset($view) and $view == 'tag')
+		if (isset($view) && $view == 'tag')
 		{
-			if (($mId != (int) $query['id'] || $mView != $view) && $view == 'tag')
+			$notActiveTag = is_array($mId) ? (count($mId) > 1 || $mId[0] != (int) $query['id']) : ($mId != (int) $query['id']);
+
+			if ($notActiveTag || $mView != $view)
 			{
 				// ID in com_tags can be either an integer, a string or an array of IDs
 				$id = is_array($query['id']) ? implode(',', $query['id']) : $query['id'];
@@ -155,7 +159,7 @@ class TagsRouter extends JComponentRouterBase
  *
  * @deprecated  4.0  Use Class based routers instead
  */
-function TagsBuildRoute(&$query)
+function tagsBuildRoute(&$query)
 {
 	$router = new TagsRouter;
 
@@ -171,7 +175,7 @@ function TagsBuildRoute(&$query)
  *
  * @deprecated  4.0  Use Class based routers instead
  */
-function TagsParseRoute($segments)
+function tagsParseRoute($segments)
 {
 	$router = new TagsRouter;
 


### PR DESCRIPTION
## Description

https://github.com/joomla/joomla-cms/pull/5105 changed the way that tag URLs are returned when a tag has a custom menu item
## How to reproduce the issue
1. Install joomla with `Test English` sample data. 
2. In global configuration enable `Friendly URLs` and `URL rewrititing`. This can be tested also without URL rewriting but the URLs will contain the `index.php` part:

![tag-url-config](https://cloud.githubusercontent.com/assets/1119272/6476308/7d8b74a2-c214-11e4-88c4-186f11b67178.png)
1. Duplicate htaccess.txt and rename the new file to .htaccess. 
2. On main menu create a new menu item of type Tags > Tagged items selecting the `Green` tag and `Article` as content type:

![tag-menu-item](https://cloud.githubusercontent.com/assets/1119272/6476282/23ff71b8-c214-11e4-9e7c-99103b141692.png)
3. Reload the main page. You will see the new menu link in the Main menu. If you put your mouse over the `Green` tag you will see that the URL shown is `http://localhost/jcms3x/tag-test/4-green` (being `tag-test` the menu alias). This is not correct because it should be (and it was before v3.4)  `http://localhost/jcms3x/tag-test`. The issue is that now we are adding the Itemid to the URL instead of using plain `index.php?Itemid=xxx` if a menu item is found for this tag.
## How to test the fix

Apply the patch and just reload the home page. The link should be correct now.
## Backward compatibility issues

This tries to fix an already existing B/C issue that will change existing sites URLs.
## Additional comments

Please @Hackwar can you review this? Thanks!
