### PR TITLE
Allow to use custom JS validation handlers for radio and checkboxes group

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -95,7 +95,7 @@ var JFormValidator = function() {
  	 	 	 	elValue = $el.val();
  	 	 	}
  	 	 	// Execute the validation handler and return result
- 	 	 	if (elValue && handlers[handler].exec($el.val(), $el) !== true) {
+ 	 	 	if (elValue && handlers[handler].exec(elValue, $el) !== true) {
  	 	 	 	handleResponse(false, $el);
  	 	 	 	return false;
  	 	 	}

--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -61,7 +61,7 @@ var JFormValidator = function() {
  	},
 
  	validate = function(el) {
- 	 	var $el = jQuery(el), tagName, handler;
+ 	 	var $el = jQuery(el), elValue, tagName = $el.prop("tagName").toLowerCase(), handler;
  	 	// Ignore the element if its currently disabled, because are not submitted for the http-request. For those case return always true.
  	 	if ($el.attr('disabled')) {
  	 	 	handleResponse(true, $el);
@@ -69,7 +69,6 @@ var JFormValidator = function() {
  	 	}
  	 	// If the field is required make sure it has a value
  	 	if ($el.attr('required') || $el.hasClass('required')) {
- 	 	 	tagName = $el.prop("tagName").toLowerCase();
  	 	 	if (tagName === 'fieldset' && ($el.hasClass('radio') || $el.hasClass('checkboxes'))) {
  	 	 	 	if (!$el.find('input:checked').length){
  	 	 	 	 	handleResponse(false, $el);
@@ -88,9 +87,15 @@ var JFormValidator = function() {
  	 	 	return true;
  	 	}
  	 	// Check the additional validation types
- 	 	if ((handler) && (handler !== 'none') && (handlers[handler]) && $el.val()) {
+ 	 	if ((handler) && (handler !== 'none') && (handlers[handler])) {
+ 	 	 	if (tagName === 'fieldset' && ($el.hasClass('radio') || $el.hasClass('checkboxes'))) {
+ 	 	 	 	elValue = $el.find('input:checked').val();
+ 	 	 	}
+ 	 	 	else {
+ 	 	 	 	elValue = $el.val();
+ 	 	 	}
  	 	 	// Execute the validation handler and return result
- 	 	 	if (handlers[handler].exec($el.val(), $el) !== true) {
+ 	 	 	if (elValue && handlers[handler].exec($el.val(), $el) !== true) {
  	 	 	 	handleResponse(false, $el);
  	 	 	 	return false;
  	 	 	}


### PR DESCRIPTION
If element is a "fieldset" with class "radio" or "checkboxes", then use value of checked input child instead of itself, as fieldset does not have a value. It would allow to have validation handlers also for radio and checkboxes group.

TEST
An example with radio options where if article is featured it requires some tags
- Enable debug in Global Configuration as patch contains only uncompressed file
- Edit file administrator/components/com_content/views/article/tmpl/edit.php
- At the end of file put a test code
- Go to new article view
- Select option that article is featured and do not select any tags
- Try to save
- You will get error with Featured field
- Select some tags
- Try to save
- You will not get that error again

Test code

```
<script type="text/javascript">
jQuery(document).ready(function() {
    jQuery("#jform_featured").addClass("validate-featured");
    document.formvalidator.setHandler("featured", function(value, element) {
        var tags = jQuery("#jform_tags").val() || [];
        return (value == 0 || (value == 1 && tags.length > 0));
    });
});
</script>
```

Which tool do you use in Joomla to compress JS, that I could create one?
