### PR TITLE
Fix object fatal error

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -261,7 +261,8 @@ abstract class JArrayHelper
 	 */
 	public static function getValue(&$array, $name, $default = null, $type = '')
 	{
-		return ArrayHelper::getValue($array, $name, $default, $type);
+		// Previously we didn't typehint an array. So force any object to be an array
+		return ArrayHelper::getValue((array) $array, $name, $default, $type);
 	}
 
 	/**


### PR DESCRIPTION
I caught this error when editing a list in Fabrik:

( ! ) Catchable fatal error: Argument 1 passed to Joomla\Utilities\ArrayHelper::getValue() must be of the type array, object given, called in \libraries\joomla\utilities\arrayhelper.php on line 264 and defined in \libraries\vendor\joomla\utilities\src\ArrayHelper.php on line 242

If you pass an object into getValue previous it would work. However the framework typehints against the object being an array (correctly imho) so we need to ensure that we pass in an array
