### PR TITLE
Fixing JTableAsset::rebuild()

### DIFF
--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -123,4 +123,96 @@ class JTableAsset extends JTableNested
 
 		return true;
 	}
+	
+	/**
+	 * Method to recursively rebuild the whole nested set tree.
+	 *
+	 * @param   integer  $parentId  The root of the tree to rebuild.
+	 * @param   integer  $leftId    The left id to start with in building the tree.
+	 * @param   integer  $level     The level to assign to the current nodes.
+	 * @param   string   $path      The path to the current nodes.
+	 *
+	 * @return  integer  1 + value of root rgt on success, false on failure
+	 *
+	 * @link    https://docs.joomla.org/JTableNested/rebuild
+	 * @since   11.1
+	 * @throws  RuntimeException on database error.
+	 */
+	public function rebuild($parentId = null, $leftId = 0, $level = 0, $path = null)
+	{
+		// If no parent is provided, try to find it.
+		if ($parentId === null)
+		{
+			// Get the root item.
+			$parentId = $this->getRootId();
+
+			if ($parentId === false)
+			{
+				return false;
+			}
+		}
+
+		$query = $this->_db->getQuery(true);
+
+		// Build the structure of the recursive query.
+		if (!isset($this->_cache['rebuild.sql']))
+		{
+			$query->clear()
+				->select($this->_tbl_key)
+				->from($this->_tbl)
+				->where('parent_id = %d');
+
+			// If the table has an ordering field, use that for ordering.
+			if (property_exists($this, 'ordering'))
+			{
+				$query->order('parent_id, ordering, lft');
+			}
+			else
+			{
+				$query->order('parent_id, lft');
+			}
+
+			$this->_cache['rebuild.sql'] = (string) $query;
+		}
+
+		// Make a shortcut to database object.
+
+		// Assemble the query to find all children of this node.
+		$this->_db->setQuery(sprintf($this->_cache['rebuild.sql'], (int) $parentId));
+
+		$children = $this->_db->loadObjectList();
+
+		// The right value of this node is the left value + 1
+		$rightId = $leftId + 1;
+
+		// Execute this function recursively over all children
+		foreach ($children as $node)
+		{
+			/*
+			 * $rightId is the current right value, which is incremented on recursion return.
+			 * Increment the level for the children.
+			 * Add this item's alias to the path (but avoid a leading /)
+			 */
+			$rightId = $this->rebuild($node->{$this->_tbl_key}, $rightId, $level + 1);
+
+			// If there is an update failure, return false to break out of the recursion.
+			if ($rightId === false)
+			{
+				return false;
+			}
+		}
+
+		// We've got the left value, and now that we've processed
+		// the children of this node we also know the right value.
+		$query->clear()
+			->update($this->_tbl)
+			->set('lft = ' . (int) $leftId)
+			->set('rgt = ' . (int) $rightId)
+			->set('level = ' . (int) $level)
+			->where($this->_tbl_key . ' = ' . (int) $parentId);
+		$this->_db->setQuery($query)->execute();
+
+		// Return the right value of this node + 1.
+		return $rightId + 1;
+	}
 }

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -123,7 +123,7 @@ class JTableAsset extends JTableNested
 
 		return true;
 	}
-	
+
 	/**
 	 * Method to recursively rebuild the whole nested set tree.
 	 *

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -135,7 +135,7 @@ class JTableAsset extends JTableNested
 	 * @return  integer  1 + value of root rgt on success, false on failure
 	 *
 	 * @link    https://docs.joomla.org/JTableNested/rebuild
-	 * @since   11.1
+	 * @since   3.5
 	 * @throws  RuntimeException on database error.
 	 */
 	public function rebuild($parentId = null, $leftId = 0, $level = 0, $path = null)


### PR DESCRIPTION
Right now, the method JTableNested::rebuild() can not be called from a JTableAsset object, because JTableNested::rebuild() expects the table to have a column named 'alias'. This prevents that table from being repaired. This PR implements a specific method for this table that does not need the alias column.

Not being able to repair this table is a big issue, since the permissions system might be borked with this. The specific example is a large JoomGallery installation with ~20k images. Each of these images has an entry in the assets table. Somehow the categories got messed up and several thousand images were not assigned to a correct parent item in the assets table. This meant that no normal user was able to edit his own images. With some SQL queries I was able to fix the images to their right category, but that still meant that the lft and rgt values were wrong and thus the queries would still result in wrong results. Calling JTableAsset::rebuild() would normally fix that, but a) there is no way to do that from the GUI and b) the method from JTableNested failed.
### Test instructions

Put `JTable::getInstance('Asset')->rebuild();` somewhere in for example a layout of yours and open the page with that layout. See that it fails fatally. Apply the patch. See that it works now. Also see that the assets table has been rebuild.

Maybe we should add this to the "fix database" button in the extension manager.
