### PR TITLE
Removing unnecessary code from mod_menu

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -102,21 +102,8 @@ class ModMenuHelper
 							break;
 
 						default:
-							$router = $app::getRouter();
+							$item->flink = 'index.php?Itemid=' . $item->id;
 
-							if ($router->getMode() == JROUTER_MODE_SEF)
-							{
-								$item->flink = 'index.php?Itemid=' . $item->id;
-
-								if (isset($item->query['format']) && $app->get('sef_suffix'))
-								{
-									$item->flink .= '&format=' . $item->query['format'];
-								}
-							}
-							else
-							{
-								$item->flink .= '&Itemid=' . $item->id;
-							}
 							break;
 					}
 


### PR DESCRIPTION
The router reads the Itemid from the URL, looks up the right menu item and merges in the query of the menu item into the query to be processed. That means, that you only need to specify the Itemid for a query to be properly constructed both for SEF and non-SEF URLs. Also, if there is a query parameter with name "format", it will also already be part of $item->flink. So the code in former line 113 would create something like `&format=raw&Itemid=42&format=raw` and thus is also unnecessary.
