### PR TITLE
Use the curl default option for get/post/put

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -77,7 +77,7 @@ class JHttpTransportCurl implements JHttpTransport
 			case 'PUT':
 				$options[CURLOPT_PUT] = true;
 				break;
-	
+
 			default:
 				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
 				break;

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -64,7 +64,24 @@ class JHttpTransportCurl implements JHttpTransport
 		$ch = curl_init();
 
 		// Set the request method.
-		$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+		switch (strtoupper($method))
+		{
+			case 'GET':
+				$options[CURLOPT_HTTPGET] = true;
+				break;
+
+			case 'POST':
+				$options[CURLOPT_POST] = true;
+				break;
+
+			case 'PUT':
+				$options[CURLOPT_PUT] = true;
+				break;
+	
+			default:
+				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+				break;
+		}
 
 		// Don't wait for body when $method is HEAD
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');


### PR DESCRIPTION
If you use post/put method curl/PHP offers own options. Some REST-APIs require e.g. CURLOPT_POST instead of CURLOPT_CUSTOMREQUEST = 'POST'. So let's stick to the docs.

see: [http://php.net/manual/en/function.curl-setopt.php]
