### PR TITLE
PostgreSQL - SQL error when add new tag

### DIFF
--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -182,7 +182,7 @@ class TagsTableTag extends JTableNested
 		if (!(int) $this->modified_time)
 		{
 			$this->modified_time = $date->toSql();
-		}			
+		}
 		if (!(int) $this->publish_up)
 		{
 			$this->publish_up = $date->toSql();

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -144,8 +144,7 @@ class TagsTableTag extends JTableNested
 			$bad_characters = array("\"", "<", ">");
 			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
 		}
-		
-		// NOT NULL sanity check
+		// Not Null sanity check
 		$date	= JFactory::getDate();
 		if (empty($this->params))
 		{

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -144,6 +144,53 @@ class TagsTableTag extends JTableNested
 			$bad_characters = array("\"", "<", ">");
 			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
 		}
+		
+		// NOT NULL sanity check
+		$date	= JFactory::getDate();
+		if (empty($this->params))
+		{
+			$this->params = '{}';
+		}
+		if (empty($this->metadesc))
+		{
+			$this->metadesc = ' ';
+		}
+		if (empty($this->metakey))
+		{
+			$this->metakey = ' ';
+		}
+		if (empty($this->metadata))
+		{
+			$this->metadata = '{}';
+		}
+		if (empty($this->urls))
+		{
+			$this->urls = '{}';
+		}
+		if (empty($this->images))
+		{
+			$this->images = '{}';
+		}
+		if (!(int) $this->checked_out_time)
+		{
+			$this->checked_out_time = $date->toSql();
+		}
+		if (!(int) $this->modified_time)
+		{
+			$this->modified_time = $date->toSql();
+		}
+		if (!(int) $this->modified_time)
+		{
+			$this->modified_time = $date->toSql();
+		}			
+		if (!(int) $this->publish_up)
+		{
+			$this->publish_up = $date->toSql();
+		}
+		if (!(int) $this->publish_down)
+		{
+			$this->publish_down = $date->toSql();
+		}
 
 		return true;
 	}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -397,7 +397,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				{
 					$field->Default = " ";
 				}
-        			if (stristr(strtolower($field->type), "text"))
+				if (stristr(strtolower($field->type), "text"))
 				{
 					$field->Default = " ";
 				}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -393,6 +393,14 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
+				if (stristr(strtolower($field->type) , "character varying"))
+				{
+						$field->Default = " ";		
+				}
+        			if (stristr(strtolower($field->type) , "text"))
+				{
+						$field->Default = " ";				
+				}
 				// Do some dirty translation to MySQL output.
 				// TODO: Come up with and implement a standard across databases.
 				$result[$field->column_name] = (object) array(

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -393,13 +393,13 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->type) , "character varying"))
+				if (stristr(strtolower($field->type), "character varying"))
 				{
-						$field->Default = " ";		
+					$field->Default = " ";
 				}
-        			if (stristr(strtolower($field->type) , "text"))
+        			if (stristr(strtolower($field->type), "text"))
 				{
-						$field->Default = " ";				
+					$field->Default = " ";
 				}
 				// Do some dirty translation to MySQL output.
 				// TODO: Come up with and implement a standard across databases.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -395,11 +395,11 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			{
 				if (stristr(strtolower($field->type), "character varying"))
 				{
-					$field->Default = " ";
+					$field->Default = "";
 				}
 				if (stristr(strtolower($field->type), "text"))
 				{
-					$field->Default = " ";
+					$field->Default = "";
 				}
 				// Do some dirty translation to MySQL output.
 				// TODO: Come up with and implement a standard across databases.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -364,7 +364,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			{
 				if (stristr(strtolower($field->type), "nvarchar"))
 				{
-					$field->Default = " ";
+					$field->Default = "";
 				}
 				$result[$field->Field] = $field;
 			}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -362,7 +362,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->type) , "nvarchar"))
+				if (stristr(strtolower($field->type), "nvarchar"))
 				{
 					$field->Default = " ";
 				}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -362,6 +362,10 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
+				if (stristr(strtolower($field->type) , "nvarchar"))
+				{
+						$field->Default = " ";			
+				}
 				$result[$field->Field] = $field;
 			}
 		}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -364,7 +364,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			{
 				if (stristr(strtolower($field->type) , "nvarchar"))
 				{
-						$field->Default = " ";			
+					$field->Default = " ";
 				}
 				$result[$field->Field] = $field;
 			}


### PR DESCRIPTION
#### Steps to reproduce the issue

go to the article manager and create a new article or edit an existing article In the tags field create a tag on the fly or in other words don´t select an existing tag but put in a new tag. Then hit the "Save".
#### Expected result

The article is saved with the new added tag
#### Actual result

the tag field is cleared and the article is not saved
#### System information

PostgreSQL 9.3.5
Joomla 3.4.0
#### Additional comments

As suggested added a sanity check for NOT NULL FIELDS
fix #6104
