### PR TITLE
Let the com_installer manager helper follow our codestyle

### DIFF
--- a/administrator/components/com_installer/helpers/html/manage.php
+++ b/administrator/components/com_installer/helpers/html/manage.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Installer HTML class.
  *
- * @package     Joomla.Administrator
- * @subpackage  com_installer
- * @since       2.5
+ * @since  2.5
  */
 abstract class InstallerHtmlManage
 {
@@ -35,32 +33,32 @@ abstract class InstallerHtmlManage
 	public static function state($value, $i, $enabled = true, $checkbox = 'cb')
 	{
 		$states	= array(
-			2	=> array(
+			2 => array(
 				'',
 				'COM_INSTALLER_EXTENSION_PROTECTED',
 				'',
 				'COM_INSTALLER_EXTENSION_PROTECTED',
 				true,
 				'protected',
-				'protected'
+				'protected',
 			),
-			1	=> array(
+			1 => array(
 				'unpublish',
 				'COM_INSTALLER_EXTENSION_ENABLED',
 				'COM_INSTALLER_EXTENSION_DISABLE',
 				'COM_INSTALLER_EXTENSION_ENABLED',
 				true,
 				'publish',
-				'publish'
+				'publish',
 			),
-			0	=> array(
+			0 => array(
 				'publish',
 				'COM_INSTALLER_EXTENSION_DISABLED',
 				'COM_INSTALLER_EXTENSION_ENABLE',
 				'COM_INSTALLER_EXTENSION_DISABLED',
 				true,
 				'unpublish',
-				'unpublish'
+				'unpublish',
 			),
 		);
 


### PR DESCRIPTION
This PR let the com_installer manager helper follow our codestyle.

I don't think here is testing required. I hope this can be merged on Review by PLT / Maintainer :smile: Else let me know.
