### PR TITLE
[imp] Speed up the rule field rendering (client side)

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -266,7 +266,7 @@ class JFormFieldRules extends JFormField
 
 				$html[] = '<td headers="settings-th' . $group->value . '">';
 
-				$html[] = '<select class="input-small" name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id
+				$html[] = '<select data-chosen="true" class="input-small" name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id
 					. '_' . $action->name
 					. '_' . $group->value . '" title="'
 					. JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -266,10 +266,10 @@ class JFormFieldRules extends JFormField
 
 				$html[] = '<td headers="settings-th' . $group->value . '">';
 
-				$html[] = '<select data-chosen="true" class="input-small" name="' . $this->name . '[' . $action->name . '][' . $group->value . ']" id="' . $this->id
-					. '_' . $action->name
-					. '_' . $group->value . '" title="'
-					. JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
+				$html[] = '<select data-chosen="true" class="input-small"'
+					. ' name="' . $this->name . '[' . $action->name . '][' . $group->value . ']"'
+					. ' id="' . $this->id . '_' . $action->name	. '_' . $group->value . '"'
+					. ' title="' . JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
 
 				$inheritedRule = JAccess::checkGroup($group->value, $action->name, $assetId);
 


### PR DESCRIPTION
Speed up the rule field, by disabling the Chosen for this field.

**test**
Open global configuration, and make sure that the permission fields do not use Chosen styling.
Also pay attention how fast "Global configuration" now :horse_racing: (if you have Intel i7 or Xeon processor, just ignore it :smile: )

It can have a huge performance boost, if site have a lot User Groups.
Even on test installation, on my PC, I got around -200ms for page rendering:

before patch:
![screen 2015-03-05 11 17 46 1013x385](https://cloud.githubusercontent.com/assets/1568198/6502514/d7fef206-c32c-11e4-9c42-50888f4c4ee4.png)

after patch:
![screen 2015-03-05 11 18 28 1013x385](https://cloud.githubusercontent.com/assets/1568198/6502518/e172f9f4-c32c-11e4-9fe8-f3fdba982f17.png)
