### PR TITLE
PostgreSQL - sql error save category with tag

### DIFF
--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -110,8 +110,8 @@ class JTableCorecontent extends JTable
 		{
 			$this->core_alias = JFactory::getDate()->format('Y-m-d-H-i-s');
 		}
-
-       		// Not Null sanity check
+		
+		// Not Null sanity check
 		if (empty($this->core_images))
 		{
 			$this->core_images = '{}';

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -111,6 +111,15 @@ class JTableCorecontent extends JTable
 			$this->core_alias = JFactory::getDate()->format('Y-m-d-H-i-s');
 		}
 
+       		// Not Null sanity check
+		if (empty($this->core_images))
+		{
+			$this->core_images = '{}';
+		}
+		if (empty($this->core_urls))
+		{
+			$this->core_urls = '{}';
+		}
 		// Check the publish down date is not earlier than publish up.
 		if ($this->core_publish_down > $this->_db->getNullDate() && $this->core_publish_down < $this->core_publish_up)
 		{

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -110,7 +110,6 @@ class JTableCorecontent extends JTable
 		{
 			$this->core_alias = JFactory::getDate()->format('Y-m-d-H-i-s');
 		}
-		
 		// Not Null sanity check
 		if (empty($this->core_images))
 		{


### PR DESCRIPTION
#### Steps to reproduce the issue

go to the category manager and create or edit a category  In the tags field create or add a tag then click  "Save".
#### Expected result

The category is saved with the  tag
#### Actual result

the tag field is cleared and the category is not saved
#### System information

PostgreSQL 9.3.5
Joomla 3.4.0
#### Additional comments

added a sanity check for NOT NULL FIELDS
