### PR TITLE
Fixing URLs for tags that are attached to a menu item

### DIFF
--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -64,7 +64,7 @@ class TagsRouter extends JComponentRouterBase
 		}
 
 		// Are we dealing with a tag that is attached to a menu item?
-		if ($mView == $view && isset($query['id']) && $mId == $query['id'])
+		if ($mView == $view && isset($query['id']) && is_array($mId) && count($mId) == 1 && $mId[0] == $query['id'])
 		{
 			unset($query['id']);
 			return $segments;


### PR DESCRIPTION
This fixes URLs for tags that are attached to a menu item. This is a fix for #6291 
### How to test

Create a menu item that is linked to a specific tag directly and attach the tag to a content item. Click on the tag somewhere and see that it generates URLs like /[menu-item]/[id]-[tagname]. Apply the patch and see that it creates URLs like /[menu-item]
