### PR TITLE
Allow Case Sensitive Meta Name

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -390,8 +390,6 @@ class JDocument
 	 */
 	public function getMetaData($name, $httpEquiv = false)
 	{
-		$name = strtolower($name);
-
 		if ($name == 'generator')
 		{
 			$result = $this->getGenerator();
@@ -428,8 +426,6 @@ class JDocument
 	 */
 	public function setMetaData($name, $content, $http_equiv = false)
 	{
-		$name = strtolower($name);
-
 		if ($name == 'generator')
 		{
 			$this->setGenerator($content);


### PR DESCRIPTION
Closes #6330 

Pander to Microsoft to allow custom CaseSensitive meta names - See Issue 6330 for more info

To test, hmmm, try adding your own custom CaseSensitive meta tags with JDocument::setMetaData method.
