### PR TITLE
Set max-height back to 400 px for modals

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -79,7 +79,7 @@
 	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: none;
+	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -3912,7 +3912,7 @@ input[type="submit"].btn.btn-mini {
 	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: none;
+	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -3912,7 +3912,7 @@ input[type="submit"].btn.btn-mini {
 	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: none;
+	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {

--- a/media/jui/less/modals.less
+++ b/media/jui/less/modals.less
@@ -42,7 +42,7 @@
   width: 98%;
   position: relative;
   overflow-y: auto;
-  max-height: none;
+  max-height: 400px;
   padding: 1%;
 }
 // Remove border and scrollbar from iframe modal

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3912,7 +3912,7 @@ input[type="submit"].btn.btn-mini {
 	width: 98%;
 	position: relative;
 	overflow-y: auto;
-	max-height: none;
+	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {


### PR DESCRIPTION
##### Modals don’t have a height limit

This was found by @roland-d.
In the PR for moving multilingual status to bootstrap modal a line in the less fie was wrongly changed to none;
This PR brings back the cap to 400px
#### test

apply patch 
open multilingual status and observe the height of the modal (should be 400px)
