### PR TITLE
Fixes #6350 - com_plugins doesn't delete cache from administrator/cache

### DIFF
--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -363,6 +363,7 @@ class PluginsModelPlugin extends JModelAdmin
 	 */
 	protected function cleanCache($group = null, $client_id = 0)
 	{
-		parent::cleanCache('com_plugins');
+		parent::cleanCache('com_plugins', 0);
+		parent::cleanCache('com_plugins', 1);
 	}
 }


### PR DESCRIPTION
Commit 2d8bf0f introduced a bug described in #6350 - this PR resolves this.

---
# The problem

When Global Configuration Cache is enabled, plugins are stuck in the state recorded at the time of cache creation, meaning that a plugin that's been enabled will stay enabled until cache expires. Manually disabling or enabling a plugin should also refresh the cache so that this operation completes successfuly.
# How to reproduce

This is a little tricky to reproduce but here are the steps
## Prerequisites
- Go to `Extensions` > `Plugin Manager` and make sure `System - Debug` is published.
- Go to `Global Configuration` and make sure `Cache Handler` is set to `File` and `Cache` is set to `OFF - Caching disabled`.
## Testing
- Go to `Global Configuration` > `System` and set `Debug System` to `Yes`. Save your current configuration - you should now see the debug output at the bottom.
- Go to `Extensions` > `Plugin Manager` and unpublish the `System - Debug` plugin. Debug output no longer shows. Publish it again. Debug output shows as expected.
- Go to `Global Configuration` > `System` and set `Cache` to `ON - Conservative caching`. Save your current configuration - debug output is still at the bottom.
- Go to `Extensions > Plugin Manager` and unpublish the `System - Debug` plugin. Debug output still shows - this means that the plugin still runs even though it should not.
# The solution

During my tests I've found out that cache for `com_plugins` is stored in the `cache` folder as well as in `administrator/cache`. My solution would be to clean both of these by adjusting `cleanCache()` in the `administrator/components/com_plugins/models/plugin.php` model, but I'm open to other suggestions. Personally I'd like that we'd keep caching for system objects such as plugins in only one place (let's say on the administrator side).
