### PR TITLE
[fix] tag menu params ignored. Fixed #6250

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -167,10 +167,11 @@ class TagsModelTag extends JModelList
 	 */
 	protected function populateState($ordering = 'c.core_title', $direction = 'ASC')
 	{
-		$app = JFactory::getApplication('site');
+		$app = JFactory::getApplication();
 
 		// Load the parameters.
-		$params = JComponentHelper::getParams('com_tags');
+		$params = $app->isAdmin() ? JComponentHelper::getParams('com_tags') : $app->getParams();
+
 		$this->setState('params', $params);
 
 		// Load state from the request.


### PR DESCRIPTION
This fixes the issue described in: https://github.com/joomla/joomla-cms/issues/6250

Summary: Tags search plugin uses frontend tag model but in fact you cannot instantiate a different application when another one is already loaded in `JFactory` so `$app = JFactory::getApplication('site');` is returning a `JApplicationAdministrator` instance that does not contain the method to get the page params.

As allowing to get the site application from backend is not an easy task (and I don't really think we need it) this makes things work.
