### PR TITLE
PostgreSQL - redirect link not saved

### DIFF
--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -47,6 +47,11 @@ class RedirectTableLink extends JTable
 
 			return false;
 		}
+		// Check for NOT NULL.
+		if (empty($this->referer))
+		{
+			$this->referer = ' ';
+		}
 
 		// Check for valid name if not in advanced mode.
 		if (empty($this->new_url) && JComponentHelper::getParams('com_redirect')->get('mode', 0) == false)

--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -50,7 +50,7 @@ class RedirectTableLink extends JTable
 		// Check for NOT NULL.
 		if (empty($this->referer))
 		{
-			$this->referer = ' ';
+			$this->referer = '';
 		}
 
 		// Check for valid name if not in advanced mode.


### PR DESCRIPTION
#### Steps to reproduce the issue

go to the Redirect manager and create a new link  and Save
#### Expected result

the redirect link is saved
#### Actual result

SQL ERROR not null constraint violation
#### System information

PostgreSQL 9.3.5
Joomla 3.4.0
#### Additional comments

added a sanity check for NOT NULL FIELDS
fix #6349
