### PR TITLE
Add field-type to text filters in global configuration

### DIFF
--- a/administrator/components/com_config/model/field/filters.php
+++ b/administrator/components/com_config/model/field/filters.php
@@ -99,6 +99,7 @@ class JFormFieldFilters extends JFormField
 			$html[] = '		<td>';
 			$html[] = '				<input'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_tags]"'
+				. ' type="text"'
 				. ' id="' . $this->id . $group->value . '_filter_tags"'
 				. ' title="' . JText::_('JGLOBAL_FILTER_TAGS_LABEL') . '"'
 				. ' value="' . $group_filter['filter_tags'] . '"'
@@ -107,6 +108,7 @@ class JFormFieldFilters extends JFormField
 			$html[] = '		<td>';
 			$html[] = '				<input'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_attributes]"'
+				. ' type="text"'
 				. ' id="' . $this->id . $group->value . '_filter_attributes"'
 				. ' title="' . JText::_('JGLOBAL_FILTER_ATTRIBUTES_LABEL') . '"'
 				. ' value="' . $group_filter['filter_attributes'] . '"'


### PR DESCRIPTION
I noticed that the form fields for Text Filters in Global configuration has no field type. That means they have also no bootstrap layout.

Apply the patch en noticed the form fields are now styled by bootstrap
