### PR TITLE
Fix nginx 502 Bad gateway because of invalid http status codes

### DIFF
--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -86,7 +86,7 @@ class JDocumentError extends JDocument
 
 		// Set the status header
 		$status = $this->_error->getCode();
-		if ($status < 400 || $status > 599) 
+		if ($status < 400 || $status > 599)
 		{
 			$status = 500;
 		}

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -85,7 +85,11 @@ class JDocumentError extends JDocument
 		}
 
 		// Set the status header
-		JFactory::getApplication()->setHeader('status', $this->_error->getCode() . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
+		$status = $this->_error->getCode();
+                if ($status < 400 || $status > 599) {
+                    $status = 500;
+                }
+		JFactory::getApplication()->setHeader('status',  $status. ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
 		$file = 'error.php';
 
 		// Check template

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -86,10 +86,10 @@ class JDocumentError extends JDocument
 
 		// Set the status header
 		$status = $this->_error->getCode();
-                if ($status < 400 || $status > 599) {
-                    $status = 500;
-                }
-		JFactory::getApplication()->setHeader('status',  $status. ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
+		if ($status < 400 || $status > 599) {
+			$status = 500;
+		}
+		JFactory::getApplication()->setHeader('status',  $status . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
 		$file = 'error.php';
 
 		// Check template

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -86,7 +86,8 @@ class JDocumentError extends JDocument
 
 		// Set the status header
 		$status = $this->_error->getCode();
-		if ($status < 400 || $status > 599) {
+		if ($status < 400 || $status > 599) 
+		{
 			$status = 500;
 		}
 		JFactory::getApplication()->setHeader('status',  $status . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));


### PR DESCRIPTION
Nginx does not allow an invalid status code, in some exception there is no http status code used and it will return an 502 bad gateway.

It will solve many of the problems found related with this: https://encrypted.google.com/search?hl=en&q=nginx%20502%20joomla
