### PR TITLE
Groups users lost when profile user is saved

### DIFF
--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -400,14 +400,14 @@ class UsersModelProfile extends JModelForm
 		if (!$user->save())
 		{
 			$user->groups = $groups;
-			unset ($groups); 
+			unset ($groups);
 			$this->setError($user->getError());
 
 			return false;
 		}
-		
+
 		$user->groups = $groups;
-		unset ($groups); 
+		unset ($groups);
 
 		$user->tags = new JHelperTags;
 		$user->tags->getTagIds($user->id, 'com_users.user');

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -392,22 +392,17 @@ class UsersModelProfile extends JModelForm
 		// Load the users plugin group.
 		JPluginHelper::importPlugin('user');
 
-		$groups = $user->groups;
-		// Null the user groups so they don't get overwritten
-		$user->groups = null;
+		// Retrieve the user groups so they don't get overwritten
+		unset ($user->groups);
+		$user->groups = JAccess::getGroupsByUser($user->id, false);
 
 		// Store the data.
 		if (!$user->save())
 		{
-			$user->groups = $groups;
-			unset ($groups);
 			$this->setError($user->getError());
 
 			return false;
 		}
-
-		$user->groups = $groups;
-		unset ($groups);
 
 		$user->tags = new JHelperTags;
 		$user->tags->getTagIds($user->id, 'com_users.user');

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -392,16 +392,22 @@ class UsersModelProfile extends JModelForm
 		// Load the users plugin group.
 		JPluginHelper::importPlugin('user');
 
+		$groups = $user->groups;
 		// Null the user groups so they don't get overwritten
 		$user->groups = null;
 
 		// Store the data.
 		if (!$user->save())
 		{
+			$user->groups = $groups;
+			unset ($groups); 
 			$this->setError($user->getError());
 
 			return false;
 		}
+		
+		$user->groups = $groups;
+		unset ($groups); 
 
 		$user->tags = new JHelperTags;
 		$user->tags->getTagIds($user->id, 'com_users.user');


### PR DESCRIPTION
Steps to reproduce the issue

1) An user connects in the front end
2) He edits his profile
3) He saves it
4) When the profile form is reloaded, look the user object with the function of JFactory getUser (JFactory::getUser())
5) You can see that the groups property is null

In fact, the function getUser loads the user object from the session previously saved with the property groups set to null (function save JUser around the line 819).

Suggested solution

To prevent the lost of groups property, I suggest to save the property before save and restore it after
