### PR TITLE
Discover a missing language correctly via the cookie

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -313,7 +313,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				// Either we detected the language via the browser or we got it from the cookie. In worst case
 				// we fall back to the application setting
 				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), false);
-	
+
 				if (!$lang_code && $this->params->get('detect_browser', 1))
 				{
 					$lang_code = JLanguageHelper::detectLanguage();

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -377,7 +377,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->app->input->cookie->getString(JApplicationHelper::getHash('language')) != $lang_code)
 		{
 			$cookie_domain 	= $this->app->get('cookie_domain');
-			$cookie_path 	= $this->app->get('cookie_path', ($uri->base(true) == '' ? '/' : $uri->base(true)));
+			$cookie_path 	= $this->app->get('cookie_path', '/');
 			$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 		}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -310,8 +310,11 @@ class PlgSystemLanguageFilter extends JPlugin
 			// Lets find the default language for this user
 			if (!isset($lang_code) || !isset($this->lang_codes[$lang_code]))
 			{
-				$lang_code = false;
-				if ($this->params->get('detect_browser', 1))
+				// Either we detected the language via the browser or we got it from the cookie. In worst case
+				// we fall back to the application setting
+				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), false);
+	
+				if (!$lang_code && $this->params->get('detect_browser', 1))
 				{
 					$lang_code = JLanguageHelper::detectLanguage();
 					if (!isset($this->lang_codes[$lang_code]))
@@ -323,9 +326,6 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 				}
-				// Either we detected the language via the browser or we got it from the cookie. In worst case
-				// we fall back to the application setting
-				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), $lang_code);
 			}
 
 			if ($this->mode_sef)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -377,7 +377,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->app->input->cookie->getString(JApplicationHelper::getHash('language')) != $lang_code)
 		{
 			$cookie_domain 	= $this->app->get('cookie_domain');
-			$cookie_path 	= $this->app->get('cookie_path', $uri->base(true));
+			$cookie_path 	= $this->app->get('cookie_path', ($uri->base(true) == '' ? '/' : $uri->base(true)));
 			$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
 		}
 


### PR DESCRIPTION
This tries to discover the right language via a potentially set cookie. The cookie overrides the other settings. If no cookie is set, the language is discovered based on the language of the browser. If that language is not supported, we fall back to the application default setting.

This fixes the remaining issue with cookies described in #6213.

Please test.
