### PR TITLE
Correcting RTL Module Manager wrong column width

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -99,7 +99,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<th width="1%" class="hidden-phone">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
-						<th width="1%" class="nowrap center">
+						<th width="1%" class="nowrap center" style="min-width:55px">
 							<?php echo JHtml::_('grid.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
 						</th>
 						<th class="title">


### PR DESCRIPTION
Test:
install Persian language (fa-IR) on staging or 3.4.0
Set Administrator language to Persian
administrator/index.php?option=com_languages&view=installed&client=1

Display Module Manager
administrator/index.php?option=com_modules

before patch:

![modulemanagerrtlbefore](https://cloud.githubusercontent.com/assets/869724/6570311/8abfd74c-c6f8-11e4-95d0-593cc4697248.png)

after patch

![modulemanagerrtlafter](https://cloud.githubusercontent.com/assets/869724/6570315/929d8b08-c6f8-11e4-9146-499b8a309fa8.png)

The element style added is similar to the one used for articles manager:
https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/views/articles/tmpl/default.php#L63
