### PR TITLE
JGoogleEmbedMaps::addMarker with event(s)

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -331,13 +331,13 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	/**
 	 * Add a marker to the map
 	 *
-	 * @param   mixed  $location  A latitude longitude array or an address string
+	 * @param   mixed  $location  A latitude/longitude array or an address string
 	 * @param   mixed  $title     The hover-text for the marker
 	 * @param   array  $options   Options for marker
 	 * @param   array  $events    Events for marker
 	 *
 	 * @example with events call:
-	 *		$map->setCenter(
+	 *		$map->addMarker(
 	 *			array(0, 0),
 	 *			'My Marker',
 	 *			array(),

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -281,7 +281,17 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 * @param   mixed  $location       A latitude/longitude array or an address string
 	 * @param   mixed  $title          Title of marker or false for no marker
 	 * @param   array  $markeroptions  Options for marker
-	 * @param   array  $markerevents   Events for marker - pass in as array('eventtype' => 'function(e){ ... })
+	 * @param   array  $markerevents   Events for marker
+	 *
+	 * @example with events call:
+	 *		$map->setCenter(
+	 *			array(0, 0),
+	 *			'Map Center',
+	 *			array(),
+	 *			array(
+	 *				'click' => 'function() { // code goes here }
+	 *			)
+	 *		)
 	 *
 	 * @return  JGoogleEmbedMaps  The latitude/longitude of the center or false on failure
 	 *
@@ -324,7 +334,17 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 * @param   mixed  $location  A latitude longitude array or an address string
 	 * @param   mixed  $title     The hover-text for the marker
 	 * @param   array  $options   Options for marker
-	 * @param   array  $events    Events for marker - pass in as array('eventtype' => 'function(e){ ... })
+	 * @param   array  $events    Events for marker
+	 *
+	 * @example with events call:
+	 *		$map->setCenter(
+	 *			array(0, 0),
+	 *			'My Marker',
+	 *			array(),
+	 *			array(
+	 *				'click' => 'function() { // code goes here }
+	 *			)
+	 *		)
 	 *
 	 * @return  mixed  The marker or false on failure
 	 *

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -606,7 +606,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 				$setup .= substr(json_encode($options), 1, -1);
 				$setup .= '});';
 
-				if (isset($marker['events']))
+				if (isset($marker['events']) && is_array($marker['events']))
 				{
 					foreach ($marker['events'] as $type => $handler)
 					{

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -354,7 +354,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 		}
 
 		$location = array_values($location);
-		$marker = array('loc' => $location, 'title' => $title, 'options' => $options, 'events' => (array) $events);
+		$marker = array('loc' => $location, 'title' => $title, 'options' => $options, 'events' => $events);
 
 		$markers = $this->listMarkers();
 		$markers[] = $marker;

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -573,7 +573,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 		{
 			$setup .= "var marker;";
 
-			foreach ($this->listMarkers() as $marker)
+			foreach ($markers as $marker)
 			{
 				$loc = $marker['loc'];
 				$title = $marker['title'];

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -352,10 +352,10 @@ class JGoogleEmbedMapsTest extends TestCase
 		$this->http->expects($this->exactly(3))->method('get')->will($this->returnCallback('mapsGeocodeCallback'));
 
 		$marker = $this->object->addMarker(array(37, -122));
-		$this->assertEquals($marker, array('loc' => array(37, -122), 'title' => '37, -122', 'options' => array()));
+		$this->assertEquals($marker, array('loc' => array(37, -122), 'title' => '37, -122', 'options' => array(), 'events' => array()));
 
 		$marker = $this->object->addMarker('Palo Alto');
-		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array()));
+		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array(), 'events' => array()));
 
 		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), array());
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -357,7 +357,7 @@ class JGoogleEmbedMapsTest extends TestCase
 		$marker = $this->object->addMarker('Palo Alto');
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array()));
 
-		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
+		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), 'events' => array());
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));
 
 		$marker = $this->object->addMarker('Nowhere');

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -358,13 +358,7 @@ class JGoogleEmbedMapsTest extends TestCase
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array()));
 
 		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
-		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value')));
-
-		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));
-
-		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
-		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array('click' => 'function(e) {}')));
 
 		$marker = $this->object->addMarker('Nowhere');
 		$this->assertFalse($marker);

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -308,12 +308,12 @@ class JGoogleEmbedMapsTest extends TestCase
 	{
 		$this->http->expects($this->exactly(5))->method('get')->will($this->returnCallback('mapsGeocodeCallback'));
 
-		$reference[] = array('loc' => array(37, -122), 'title' => '37, -122', 'options' => array());
+		$reference[] = array('loc' => array(37, -122), 'title' => '37, -122', 'options' => array(), 'events' => array());
 		$this->object->setCenter(array(37, -122));
 		$center = $this->object->getOption('mapcenter');
 		$this->assertEquals($center, array(37, -122));
 
-		$reference[] = array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array());
+		$reference[] = array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array(), 'events' => array());
 		$this->object->setCenter('Palo Alto');
 		$center = $this->object->getOption('mapcenter');
 		$this->assertEquals($center, array(37.44188340, -122.14301950));
@@ -322,7 +322,7 @@ class JGoogleEmbedMapsTest extends TestCase
 		$center = $this->object->getOption('mapcenter');
 		$this->assertEquals($center, array(37.77492950, -122.41941550));
 
-		$reference[] = array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'));
+		$reference[] = array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array());
 		$this->object->setCenter('Palo Alto', 'somewhere', array('key' => 'value'));
 		$center = $this->object->getOption('mapcenter');
 		$this->assertEquals($center, array(37.44188340, -122.14301950));
@@ -359,6 +359,12 @@ class JGoogleEmbedMapsTest extends TestCase
 
 		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value')));
+
+		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
+		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));
+
+		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'));
+		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array('click' => 'function(e) {}')));
 
 		$marker = $this->object->addMarker('Nowhere');
 		$this->assertFalse($marker);

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -360,6 +360,9 @@ class JGoogleEmbedMapsTest extends TestCase
 		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), array());
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));
 
+		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), array('click' => 'function(e) { map.setCenter(this.getPosition()); }'));
+		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array('click' => 'function(e) { map.setCenter(this.getPosition()); }')));
+
 		$marker = $this->object->addMarker('Nowhere');
 		$this->assertFalse($marker);
 	}

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -349,7 +349,7 @@ class JGoogleEmbedMapsTest extends TestCase
 	 */
 	public function testAddMarker()
 	{
-		$this->http->expects($this->exactly(3))->method('get')->will($this->returnCallback('mapsGeocodeCallback'));
+		$this->http->expects($this->exactly(4))->method('get')->will($this->returnCallback('mapsGeocodeCallback'));
 
 		$marker = $this->object->addMarker(array(37, -122));
 		$this->assertEquals($marker, array('loc' => array(37, -122), 'title' => '37, -122', 'options' => array(), 'events' => array()));

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -357,7 +357,7 @@ class JGoogleEmbedMapsTest extends TestCase
 		$marker = $this->object->addMarker('Palo Alto');
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'Palo Alto', 'options' => array()));
 
-		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), 'events' => array());
+		$marker = $this->object->addMarker('Palo Alto', 'somewhere', array('key' => 'value'), array());
 		$this->assertEquals($marker, array('loc' => array(37.44188340, -122.14301950), 'title' => 'somewhere', 'options' => array('key' => 'value'), 'events' => array()));
 
 		$marker = $this->object->addMarker('Nowhere');


### PR DESCRIPTION
I found that when adding a marker to the map it is not considered to bind events to it. Isn't it a tyical scenario to click on a marker to show a balloon with short info or a link to more details? 

The [Google Maps API](https://developers.google.com/maps/documentation/javascript/reference) presents as an example to create the marker and immediately create the desired event which expects to receive the marker created as reference to bind to. I extended those functions responsible for marker creation by adding them another argument for the events _([find a PR for map events here](https://github.com/joomla/joomla-cms/pull/6472))_. Also, the function creating the script was extended to evaluate the currently set markers not only for their options but also for events to bind.

I tested this functionality by taking a view template and paste the following:

```
// Target element
echo '<h1>JGoogleEmbedMaps Test</h1>';
echo '<div class="row">';
echo    '<div class="col col-xs-12">';
echo        '<div id="map" style="height:500px; background:gainsboro; border:gray">LOADING ...</div>';
echo    '</div>';
echo    '<div class="col col-xs-12">';
echo        '<h5>Monitor</h5>';
echo        '<p id="monitor" style="padding:1em 0.5em; border:1px solid gainsboro; border-radius:3px"></p>';
echo    '</div>';
echo '</div>';

// Config
$options = new JRegistry(array(
    'key'         => '',
    'mapid'       => 'map',
    'mapclass'    => 'mapclass'
));

// Get instance
$google = new JGoogle($options);
$map = $google->embed('Maps');

// Define load type
$map->setAutoload('jquery');

$map->setMapType('HYBRID');
$map->setZoom('3');

// Marker configuration
$markerOptions = array(
    'clickable' => true,
    'draggable' => false,
    'opacity'   => 0.75,
    'optimized' => true,
    'visible'   => true
);

$map->setCenter(array('51.165691','10.451526'), 'Germany', $markerOptions,
array(
    'click' => 'function(e) {
        console.log("event: ", e);
        map.setCenter(this.getPosition());
        document.getElementById("monitor").innerHTML = "Clicked:&nbsp;" + this.title;
    }'
));

// Add markers
$map->addMarker(array('46.227638','2.213749'),  'France');  
$map->addMarker(array('60.472023','8.468946'),  'Norway', $markerOptions);
$map->addMarker(array('51.919437','19.145136'), 'Poland', $markerOptions, array());
$map->addMarker(array('41.871941','12.567380'), 'Italy',  $markerOptions, array(
    'click' => 'function(e) {
        console.log("event: ", e);
        map.setCenter(this.getPosition());
        document.getElementById("monitor").innerHTML = "Clicked:&nbsp;" + this.title;
    }'
));

// Prepare callback
$callback =
<<<ENDSCRIPT
window.gm = map;   // Will execute after initialisation to add reference to the created map as a global.
(function($, gm, element) {
    $('#monitor').append('<em>Callback executed</em>')
})(jQuery.noConflict(), window.google || {}, document.getElementById({$options->get('mapid')}));
ENDSCRIPT;

// Register custom script(s)
$map->setAdditionalJavascript($callback);

$map->echoHeader();
$map->echoBody();
```

So far this works. I wonder why this hasn't been considered yet. What do you think about this?
