### PR TITLE
password requirements are ignored when password reset(fix for #6380)

### DIFF
--- a/components/com_users/models/forms/reset_complete.xml
+++ b/components/com_users/models/forms/reset_complete.xml
@@ -25,6 +25,7 @@
 			label="COM_USERS_FIELD_RESET_PASSWORD2_LABEL"
 			required="true"
 			size="30"
+			validate="password"
 		/>
 	</fieldset>
 </form>


### PR DESCRIPTION
This is a fix for issue #6380.
### The problem

A password reset on front-end ignore the password criteria giving in the User manager configuration
### How to test this patch
1. Go to User Manager --> options and set:
   - minimum password length: 8
   - Password Minimum Integers: 1
   - Password Minimum Symbols: 1
   - Password Upper Case Minimum: 1
2. Go to fron-end and reset your password. Give a password what doesn't contain any of the criteria
3. Notice the password reset was successfully
4. Apply this patch and reset your password again
5. Notice the password criteria are no longer ignored 
