### PR TITLE
Correct tag matching in truncate

### DIFF
--- a/libraries/cms/html/string.php
+++ b/libraries/cms/html/string.php
@@ -97,7 +97,7 @@ abstract class JHtmlString
 				$openedTags = array_values($openedTags);
 
 				// Put all closed tags into an array
-				preg_match_all("#</([a-z]+)>#iU", $tmp, $result);
+				preg_match_all("#</([a-z][a-z0-9]*)\b(?:[^>]*?)>#iU", $tmp, $result);
 				$closedTags = $result[1];
 
 				$numOpened = count($openedTags);


### PR DESCRIPTION
String truncate doesn't correctly match closing html tags that contain numbers.
This change corrects this.
Fixes #6149

---

Truncated text from articles containing an html element with numerals (currently only "h"(eader) exists) and another html element whose closing tag is removed in the truncation, will produce invalid html.
This is because the regex in string.truncate fails to match closing tags with numerals.
#### Steps to reproduce the issue

Put text like `<h1>Title</h1><p>Enough text to get truncated</p>` at the beginning of an article that is then displayed with string.truncate.
#### Expected result

The html `<h1>Title</h1><p>Partial text</p>...`    is produced
#### Actual result

The html `<h1>Title</h1><p>Partial text</p></h1>...`  is produced.
This is invalid in that it produces a second, unmatched, closing h1 tag.
#### System information (as much as possible)

The incorrect code is in line 100 in /libraries/cms/html/string.php.
The match string is `#</([a-z]+)>#iU` when it should be `#</([a-z][a-z0-9]*)>#iU`
to match closing tags with numerals.
This renders correct html in the above example.
If we wanted to cover the case where a closing tag like `</h1 >` was being matched, the pattern should be `#</([a-z][a-z0-9]*)\b(?:[^>]*?)>#iU`
#### Additional comments

This error, of course, afflicts truncateComplex too, since it calls truncate.
This code is called anywhere where a short extract from html is displayed, six different views in core components (content, tags, finder, newsfeed).
