### PR TITLE
Remove attempt to translate messages while in debug mode

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -923,14 +923,7 @@ class JLanguage
 			// Check if we encountered any errors.
 			if (count($errors))
 			{
-				if (basename($filename) != $this->lang . '.ini')
-				{
-					$this->errorfiles[$filename] = $filename . JText::sprintf('JERROR_PARSING_LANGUAGE_FILE', implode(', ', $errors));
-				}
-				else
-				{
-					$this->errorfiles[$filename] = $filename . '&#160;: error(s) in line(s) ' . implode(', ', $errors);
-				}
+				$this->errorfiles[$filename] = $filename . ' : error(s) in line(s) ' . implode(', ', $errors);
 			}
 			elseif ($php_errormsg)
 			{


### PR DESCRIPTION
In `JLanguage::parse()` exists a condition to enter a recursive loop involving an improperly formatted override INI file.  In the application bootup, the first call to `JLanguage::getInstance()` is the call that builds the language object that is eventually stored to `JFactory`.  Within JLanguage's constructor, we scan for an override INI file and attempt to load it.  While in debug mode, if the file has any errors, we attempt to display a translated message (since this is not the `en-GB.ini` file), which calls `JText::sprintf()`, and from within that message we call `JFactory::getLanguage()`.  Since the JLanguage object is not yet set, JFactory attempts to create it, and we have now entered our recursive loop.

I propose to just remove the call to `JText::sprintf()` and always throw a hardcoded English message always instead.  As JLanguage is our language parser, I feel it is incorrect that it attempts to create translated error messages, especially in a section of code that is supposed to be scanning for errors, and demonstrated by this use case this can cause a site to error out.

Below is a sample stack trace I was provided by a user troubleshooting this issue which demonstrates the recursive loop being entered into.

``` sh
Call Stack
#    Time    Memory    Function    Location
1    0.0019    145848    {main}( )    ..\index.php:0
2    0.1031    2110856    JApplicationCms->execute( )    ..\index.php:40
3    0.1031    2111064    JApplicationSite->doExecute( )    ..\cms.php:251
4    0.1031    2111344    JApplicationSite->initialiseApp( )    ..\site.php:209
5    0.1467    3369104    JApplicationCms->initialiseApp( )    ..\site.php:649
6    0.1468    3356472    JLanguage::getInstance( )    ..\cms.php:557
7    0.1468    3357712    JLanguage->__construct( )    ..\language.php:301
8    0.1504    3358992    JLanguage->parse( )    ..\language.php:200
9    0.1541    3408640    JText::sprintf( )    ..\language.php:896
10    0.1541    3408680    JFactory::getLanguage( )    ..\text.php:253
11    0.1542    3408720    JFactory::createLanguage( )    ..\factory.php:195
12    0.1542    3408720    JLanguage::getInstance( )    ..\factory.php:706
13    0.1542    3409752    JLanguage->__construct( )    ..\language.php:301
14    0.1582    3410512    JLanguage->parse( )    ..\language.php:200
15    0.1604    3423128    JText::sprintf( )    ..\language.php:896
16    0.1604    3423128    JFactory::getLanguage( )    ..\text.php:253
17    0.1604    3423128    JFactory::createLanguage( )    ..\factory.php:195
18    0.1605    3423128    JLanguage::getInstance( )    ..\factory.php:706
19    0.1605    3424160    JLanguage->__construct( )    ..\language.php:301
20    0.1644    3424920    JLanguage->parse( )    ..\language.php:200
21    0.1666    3437536    JText::sprintf( )    ..\language.php:896
22    0.1666    3437536    JFactory::getLanguage( )    ..\text.php:253
23    0.1666    3437536    JFactory::createLanguage( )    ..\factory.php:195
24    0.1666    3437536    JLanguage::getInstance( )    ..\factory.php:706
25    0.1666    3438568    JLanguage->__construct( )    ..\language.php:301
```
