### PR TITLE
Allow to set list limit to unlimited

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -872,37 +872,22 @@
 
 		<field
 			name="list_limit"
-			type="list"
+			type="text"
 			default="20"
 			label="COM_CONFIG_FIELD_DEFAULT_LIST_LIMIT_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_LIST_LIMIT_DESC"
-			filter="integer">
-			<option value="5">J5</option>
-			<option value="10">J10</option>
-			<option value="15">J15</option>
-			<option value="20">J20</option>
-			<option value="25">J25</option>
-			<option value="30">J30</option>
-			<option value="50">J50</option>
-			<option value="100">J100</option>
-		</field>
+			filter="integer"
+			required="true"
+			size="6"/>
 
 		<field
 			name="feed_limit"
-			type="list"
+			type="text"
 			default="10"
 			label="COM_CONFIG_FIELD_DEFAULT_FEED_LIMIT_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_FEED_LIMIT_DESC"
-			filter="integer">
-			<option value="5">J5</option>
-			<option value="10">J10</option>
-			<option value="15">J15</option>
-			<option value="20">J20</option>
-			<option value="25">J25</option>
-			<option value="30">J30</option>
-			<option value="50">J50</option>
-			<option value="100">J100</option>
-		</field>
+			required="true"
+			size="6" />
 
 		<field
 			name="feed_email"

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -872,22 +872,39 @@
 
 		<field
 			name="list_limit"
-			type="text"
+			type="list"
 			default="20"
 			label="COM_CONFIG_FIELD_DEFAULT_LIST_LIMIT_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_LIST_LIMIT_DESC"
-			filter="integer"
-			required="true"
-			size="6"/>
+			filter="integer">
+			<option value="5">J5</option>
+			<option value="10">J10</option>
+			<option value="15">J15</option>
+			<option value="20">J20</option>
+			<option value="25">J25</option>
+			<option value="30">J30</option>
+			<option value="50">J50</option>
+			<option value="100">J100</option>
+			<option value="0">JALL</option>
+		</field>
 
 		<field
 			name="feed_limit"
-			type="text"
+			type="list"
 			default="10"
 			label="COM_CONFIG_FIELD_DEFAULT_FEED_LIMIT_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_FEED_LIMIT_DESC"
-			required="true"
-			size="6" />
+			filter="integer">
+			<option value="5">J5</option>
+			<option value="10">J10</option>
+			<option value="15">J15</option>
+			<option value="20">J20</option>
+			<option value="25">J25</option>
+			<option value="30">J30</option>
+			<option value="50">J50</option>
+			<option value="100">J100</option>
+			<option value="0">JALL</option>
+		</field>
 
 		<field
 			name="feed_email"

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -903,7 +903,6 @@
 			<option value="30">J30</option>
 			<option value="50">J50</option>
 			<option value="100">J100</option>
-			<option value="0">JALL</option>
 		</field>
 
 		<field


### PR DESCRIPTION
This allows to change the default list limit to "All" which means, that there is no limit.
## Testing

Go to "Global Configuration" and verify that there is an option "All" for list limit:
![unlimited](https://cloud.githubusercontent.com/assets/3502738/6604031/f6be4c70-c825-11e4-8f38-bd3105c36b44.png)

**Result:** When you change that limit to "All", "All" should be selected by default e.g. in the article view.
