### PR TITLE
Allow the language to be overriden via a query variable

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -271,17 +271,14 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 		}
-		else
-		{
-			// We are not in SEF mode
-			$lang = $uri->getVar('lang');
+		// We are not in SEF mode
+		$lang = $uri->getVar('lang', $lang_code);
 
-			if (isset($this->sefs[$lang]))
-			{
-				// We found our language
-				$found = true;
-				$lang_code = $this->sefs[$lang]->lang_code;
-			}
+		if (isset($this->sefs[$lang]))
+		{
+			// We found our language
+			$found = true;
+			$lang_code = $this->sefs[$lang]->lang_code;
 		}
 
 		// We are called via POST. We don't care about the language


### PR DESCRIPTION
This allows to override the language given by the SEF segment via a query variable.
### How to test
1. Open a page on a multilang site. Append ?lang=<lang-sef-code> to the URL with a sef-code different to the current language. See that still the language of the SEF prefix is loaded.
2. Apply patch.
3. Do the same as in 1. and see that the language of the query parameter is loaded.
