### PR TITLE
Checking if the lang_code was already set in POST

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -291,7 +291,11 @@ class PlgSystemLanguageFilter extends JPlugin
 			|| count($this->app->input->files) > 0)
 		{
 			$found = true;
-			$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+			if (!$lang_code)
+			{
+				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+			}
 
 			if ($this->params->get('detect_browser', 1) && !$lang_code)
 			{


### PR DESCRIPTION
If Joomla is requested via POST, we might have already a language defined via the URL and thus don't need to fall back on the cookie value.

Example:
Request via POST to "index.php" => No language given, falling back to cookie or default language
Request via POST to "index.php?lang=en" => Language given, no need to fall back to something else
Request via POST to "/en/component/content/42" => Language given, no need to fall back to something else

Without this path, the last 2 examples will fall back to the default language.
