### PR TITLE
Fix sidebar issue with debug console #5976

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -62,17 +62,17 @@
 		{
 			var context = 'jsidebar';
 
-			var $sidebar = $('#j-sidebar-container');
-			var $main = $('#j-main-container');
-			var $message = $('#system-message-container');
-			var $debug = $('#system-debug');
-			var $toggle_sidebar_icon = $('#j-toggle-sidebar-icon');
-			var $toggle_button_wrapper = $('#j-toggle-button-wrapper');
-			var $toggle_button = $('#j-toggle-sidebar-button');
-			var $sidebar_toggle = $('#j-toggle-sidebar');
+			var $sidebar = $('#j-sidebar-container'),
+				$main = $('#j-main-container'),
+				$message = $('#system-message-container'),
+				$debug = $('#system-debug'),
+				$toggle_sidebar_icon = $('#j-toggle-sidebar-icon'),
+				$toggle_button_wrapper = $('#j-toggle-button-wrapper'),
+				$toggle_button = $('#j-toggle-sidebar-button'),
+				$sidebar_toggle = $('#j-toggle-sidebar');
 
-			var open_icon = 'icon-arrow-left-2';
-			var closed_icon = 'icon-arrow-right-2';
+			var open_icon = 'icon-arrow-left-2',
+				closed_icon = 'icon-arrow-right-2';
 
 			var $visible = $sidebar_toggle.is(":visible");
 
@@ -91,14 +91,13 @@
 				$debug.addClass('j-toggle-main');
 			}
 
-			var main_height = $main.outerHeight()+30;
-			var sidebar_height = $sidebar.outerHeight();
-
-			var body_width = $('body').outerWidth();
-			var sidebar_width = $sidebar.outerWidth();
-			var content_width = $('#content').outerWidth();
-			var this_content = content_width / body_width * 100;
-			var this_main = (content_width - sidebar_width) / body_width * 100;
+			var main_height = $main.outerHeight()+30,
+				sidebar_height = $sidebar.outerHeight(),
+				body_width = $('body').outerWidth(),
+				sidebar_width = $sidebar.outerWidth(),
+				content_width = $('#content').outerWidth(),
+				this_content = content_width / body_width * 100,
+				this_main = (content_width - sidebar_width) / body_width * 100;
 
 			if (force)
 			{

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -82,6 +82,8 @@
 				closed_icon = 'icon-arrow-left-2';
 			}
 
+			var isComponent = $('body').hasClass('component');
+
 			$sidebar.removeClass('span2').addClass('j-sidebar-container');
 			$message.addClass('j-toggle-main');
 			$main.addClass('j-toggle-main');
@@ -95,7 +97,6 @@
 			var body_width = $('body').outerWidth();
 			var sidebar_width = $sidebar.outerWidth();
 			var content_width = $('#content').outerWidth();
-			var isComponent = $('body').hasClass('component');
 			var this_content = content_width / body_width * 100;
 			var this_main = (content_width - sidebar_width) / body_width * 100;
 

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -62,12 +62,19 @@
 		{
 			var context = 'jsidebar';
 
-			var $visible = $('#j-toggle-sidebar').is(":visible");
-
 			var $sidebar = $('#j-sidebar-container');
+			var $main = $('#j-main-container');
+			var $message = $('#system-message-container');
+			var $debug = $('#system-debug');
+			var $toggle_sidebar_icon = $('#j-toggle-sidebar-icon');
+			var $toggle_button_wrapper = $('#j-toggle-button-wrapper');
+			var $toggle_button = $('#j-toggle-sidebar-button');
+			var $sidebar_toggle = $('#j-toggle-sidebar');
 
 			var open_icon = 'icon-arrow-left-2';
 			var closed_icon = 'icon-arrow-right-2';
+
+			var $visible = $sidebar_toggle.is(":visible");
 
 			if (jQuery(document.querySelector("html")).attr('dir') == 'rtl')
 			{
@@ -75,8 +82,15 @@
 				closed_icon = 'icon-arrow-left-2';
 			}
 
-			var main_height = $('#j-main-container').outerHeight()+30;
-			var sidebar_height = $('#j-sidebar-container').outerHeight();
+			$sidebar.removeClass('span2').addClass('j-sidebar-container');
+			$message.addClass('j-toggle-main');
+			$main.addClass('j-toggle-main');
+			if (!isComponent) {
+				$debug.addClass('j-toggle-main');
+			}
+
+			var main_height = $main.outerHeight()+30;
+			var sidebar_height = $sidebar.outerHeight();
 
 			var body_width = $('body').outerWidth();
 			var sidebar_width = $sidebar.outerWidth();
@@ -85,47 +99,40 @@
 			var this_content = content_width / body_width * 100;
 			var this_main = (content_width - sidebar_width) / body_width * 100;
 
-			$('#j-sidebar-container').removeClass('span2').addClass('j-sidebar-container');
-			$('#system-message-container').addClass('j-toggle-main');
-			$('#j-main-container').addClass('j-toggle-main');
-			if (!isComponent) {
-				$('#system-debug').addClass('j-toggle-main');
-			}
-
 			if (force)
 			{
 				// Load the value from localStorage
 				if (typeof(Storage) !== "undefined")
 				{
-					var $visible = localStorage.getItem(context);
+					$visible = localStorage.getItem(context);
 				}
 
 				// Need to convert the value to a boolean
-				$visible = ($visible == 'true') ? true : false;
+				$visible = ($visible == 'true');
 			}
 			else
 			{
-				$('#system-message-container').addClass('j-toggle-transition');
-				$('#j-sidebar-container').addClass('j-toggle-transition');
-				$('#j-toggle-button-wrapper').addClass('j-toggle-transition');
-				$('#j-main-container').addClass('j-toggle-transition');
+				$message.addClass('j-toggle-transition');
+				$sidebar.addClass('j-toggle-transition');
+				$toggle_button_wrapper.addClass('j-toggle-transition');
+				$main.addClass('j-toggle-transition');
 				if (!isComponent) {
-					$('#system-debug').addClass('j-toggle-transition');
+					$debug.addClass('j-toggle-transition');
 				}
 			}
 
 			if ($visible)
 			{
-				$('#j-toggle-sidebar').hide();
-				$('#j-sidebar-container').removeClass('j-sidebar-visible').addClass('j-sidebar-hidden');
-				$('#j-toggle-button-wrapper').removeClass('j-toggle-visible').addClass('j-toggle-hidden');
-				$('#j-toggle-sidebar-icon').removeClass('j-toggle-visible').addClass('j-toggle-hidden');
-				$('#system-message-container').removeClass('span10').addClass('span12');
-				$('#j-main-container').removeClass('span10').addClass('span12 expanded');
-				$('#j-toggle-sidebar-icon').removeClass(open_icon).addClass(closed_icon);
-				$('#j-toggle-sidebar-button').attr('data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR'));
+				$sidebar_toggle.hide();
+				$sidebar.removeClass('j-sidebar-visible').addClass('j-sidebar-hidden');
+				$toggle_button_wrapper.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
+				$toggle_sidebar_icon.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
+				$message.removeClass('span10').addClass('span12');
+				$main.removeClass('span10').addClass('span12 expanded');
+				$toggle_sidebar_icon.removeClass(open_icon).addClass(closed_icon);
+				$toggle_button.attr('data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR'));
 				if (!isComponent) {
-					$('#system-debug').css('width', this_content + '%');
+					$debug.css('width', this_content + '%');
 				}
 
 				if (typeof(Storage) !== "undefined")
@@ -136,22 +143,22 @@
 			}
 			else
 			{
-				$('#j-toggle-sidebar').show();
-				$('#j-sidebar-container').removeClass('j-sidebar-hidden').addClass('j-sidebar-visible');
-				$('#j-toggle-button-wrapper').removeClass('j-toggle-hidden').addClass('j-toggle-visible');
-				$('#j-toggle-sidebar-icon').removeClass('j-toggle-hidden').addClass('j-toggle-visible');
-				$('#system-message-container').removeClass('span12').addClass('span10');
-				$('#j-main-container').removeClass('span12 expanded').addClass('span10');
-				$('#j-toggle-sidebar-icon').removeClass(closed_icon).addClass(open_icon);
-				$('#j-toggle-sidebar-button').attr('data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR'));
+				$sidebar_toggle.show();
+				$sidebar.removeClass('j-sidebar-hidden').addClass('j-sidebar-visible');
+				$toggle_button_wrapper.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
+				$toggle_sidebar_icon.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
+				$message.removeClass('span12').addClass('span10');
+				$main.removeClass('span12 expanded').addClass('span10');
+				$toggle_sidebar_icon.removeClass(closed_icon).addClass(open_icon);
+				$toggle_button.attr('data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR'));
 
 				if (!isComponent && body_width > 768 && main_height < sidebar_height)
 				{
-					$('#system-debug').css('width', this_main+'%');
+					$debug.css('width', this_main+'%');
 				}
 				else if (!isComponent)
 				{
-					$('#system-debug').css('width', this_content+'%');
+					$debug.css('width', this_content+'%');
 				}
 
 				if (typeof(Storage) !== "undefined")

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -66,20 +66,20 @@
 				$main = $('#j-main-container'),
 				$message = $('#system-message-container'),
 				$debug = $('#system-debug'),
-				$toggle_sidebar_icon = $('#j-toggle-sidebar-icon'),
-				$toggle_button_wrapper = $('#j-toggle-button-wrapper'),
-				$toggle_button = $('#j-toggle-sidebar-button'),
-				$sidebar_toggle = $('#j-toggle-sidebar');
+				$toggleSidebarIcon = $('#j-toggle-sidebar-icon'),
+				$toggleButtonWrapper = $('#j-toggle-button-wrapper'),
+				$toggleButton = $('#j-toggle-sidebar-button'),
+				$sidebarToggle = $('#j-toggle-sidebar');
 
-			var open_icon = 'icon-arrow-left-2',
-				closed_icon = 'icon-arrow-right-2';
+			var openIcon = 'icon-arrow-left-2',
+				closedIcon = 'icon-arrow-right-2';
 
-			var $visible = $sidebar_toggle.is(":visible");
+			var $visible = $sidebarToggle.is(":visible");
 
 			if (jQuery(document.querySelector("html")).attr('dir') == 'rtl')
 			{
-				open_icon = 'icon-arrow-right-2';
-				closed_icon = 'icon-arrow-left-2';
+				openIcon = 'icon-arrow-right-2';
+				closedIcon = 'icon-arrow-left-2';
 			}
 
 			var isComponent = $('body').hasClass('component');
@@ -91,13 +91,13 @@
 				$debug.addClass('j-toggle-main');
 			}
 
-			var main_height = $main.outerHeight()+30,
-				sidebar_height = $sidebar.outerHeight(),
-				body_width = $('body').outerWidth(),
-				sidebar_width = $sidebar.outerWidth(),
-				content_width = $('#content').outerWidth(),
-				this_content = content_width / body_width * 100,
-				this_main = (content_width - sidebar_width) / body_width * 100;
+			var mainHeight = $main.outerHeight()+30,
+				sidebarHeight = $sidebar.outerHeight(),
+				bodyWidth = $('body').outerWidth(),
+				sidebarWidth = $sidebar.outerWidth(),
+				contentWidth = $('#content').outerWidth(),
+				contentWidthRelative = contentWidth / bodyWidth * 100,
+				mainWidthRelative = (contentWidth - sidebarWidth) / bodyWidth * 100;
 
 			if (force)
 			{
@@ -114,7 +114,7 @@
 			{
 				$message.addClass('j-toggle-transition');
 				$sidebar.addClass('j-toggle-transition');
-				$toggle_button_wrapper.addClass('j-toggle-transition');
+				$toggleButtonWrapper.addClass('j-toggle-transition');
 				$main.addClass('j-toggle-transition');
 				if (!isComponent) {
 					$debug.addClass('j-toggle-transition');
@@ -123,16 +123,16 @@
 
 			if ($visible)
 			{
-				$sidebar_toggle.hide();
+				$sidebarToggle.hide();
 				$sidebar.removeClass('j-sidebar-visible').addClass('j-sidebar-hidden');
-				$toggle_button_wrapper.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
-				$toggle_sidebar_icon.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
+				$toggleButtonWrapper.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
+				$toggleSidebarIcon.removeClass('j-toggle-visible').addClass('j-toggle-hidden');
 				$message.removeClass('span10').addClass('span12');
 				$main.removeClass('span10').addClass('span12 expanded');
-				$toggle_sidebar_icon.removeClass(open_icon).addClass(closed_icon);
-				$toggle_button.attr('data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR'));
+				$toggleSidebarIcon.removeClass(openIcon).addClass(closedIcon);
+				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );
 				if (!isComponent) {
-					$debug.css('width', this_content + '%');
+					$debug.css( 'width', contentWidthRelative + '%' );
 				}
 
 				if (typeof(Storage) !== "undefined")
@@ -143,28 +143,28 @@
 			}
 			else
 			{
-				$sidebar_toggle.show();
+				$sidebarToggle.show();
 				$sidebar.removeClass('j-sidebar-hidden').addClass('j-sidebar-visible');
-				$toggle_button_wrapper.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
-				$toggle_sidebar_icon.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
+				$toggleButtonWrapper.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
+				$toggleSidebarIcon.removeClass('j-toggle-hidden').addClass('j-toggle-visible');
 				$message.removeClass('span12').addClass('span10');
 				$main.removeClass('span12 expanded').addClass('span10');
-				$toggle_sidebar_icon.removeClass(closed_icon).addClass(open_icon);
-				$toggle_button.attr('data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR'));
+				$toggleSidebarIcon.removeClass(closedIcon).addClass(openIcon);
+				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );
 
-				if (!isComponent && body_width > 768 && main_height < sidebar_height)
+				if (!isComponent && bodyWidth > 768 && mainHeight < sidebarHeight)
 				{
-					$debug.css('width', this_main+'%');
+					$debug.css( 'width', mainWidthRelative + '%' );
 				}
 				else if (!isComponent)
 				{
-					$debug.css('width', this_content+'%');
+					$debug.css( 'width', contentWidthRelative + '%' );
 				}
 
 				if (typeof(Storage) !== "undefined")
 				{
 					// Set the last selection in localStorage
-					localStorage.setItem(context, false);
+					localStorage.setItem( context, false );
 				}
 			}
 		}


### PR DESCRIPTION
This PR changes the order of declarations to fix #5976 + some small code style changes (I moved the usage of $('...') selectors to singular variable declarations).
# Testing instructions
1. Enable the debug console in backend (System configuration - Debug System).
2. Navigate to a page in the backend, where the sidebar is longer than the page content (e.g. Extensions - Languages - Overrides if you don't have overrides or Content - Articles with a filter set), so it is next to the debug console.
   - Make sure that the sidebar is displayed correctly and doesn't overlap the debug console or something else. 
   - Close and re-open the sidebar to make sure it behaves correctly.
3. Do the same for a page with more content (e.g. articles or extensions).
