### PR TITLE
Setting mbstring.internal_encoding in PHP 5.6 is deprecated

### DIFF
--- a/libraries/vendor/joomla/string/src/String.php
+++ b/libraries/vendor/joomla/string/src/String.php
@@ -14,9 +14,16 @@ namespace Joomla\String;
 if (extension_loaded('mbstring'))
 {
 	// Make sure to suppress the output in case ini_set is disabled
-	@ini_set('mbstring.internal_encoding', 'UTF-8');
-	@ini_set('mbstring.http_input', 'UTF-8');
-	@ini_set('mbstring.http_output', 'UTF-8');
+	if (version_compare(PHP_VERSION, '5.6', '<'))
+	{
+		@ini_set('mbstring.internal_encoding', 'UTF-8');
+		@ini_set('mbstring.http_input', 'UTF-8');
+		@ini_set('mbstring.http_output', 'UTF-8');
+	}
+	else
+	{
+		@ini_set('default_charset', 'UTF-8');
+	}
 }
 
 // Same for iconv


### PR DESCRIPTION
In PHP 5.6 the internal encoding is deprecated which can result in an error message. The setting default charset should be used instead. Documentation can be found here http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding
