### PR TITLE
Wrong table used to getErrors

### DIFF
--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -145,7 +145,7 @@ class ConfigModelComponent extends ConfigModelForm
 
 			if (!$asset->check() || !$asset->store())
 			{
-				throw new RuntimeException($table->getError());
+				throw new RuntimeException($asset->getError());
 			}
 
 			// We don't need this anymore


### PR DESCRIPTION
While working on the com_config MVSC rebuild I noticed that the wrong table is being used on line 148 to get the error messages from if checks fail on the asset table. =^D
