### PR TITLE
Toolbar buttons fall outside view-poort

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7526,9 +7526,7 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 10px;
-		margin-right: 10px;
-		margin-bottom: 5px;
+		margin: 0px 10px 5px 10px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
 		width: 100% !important;
@@ -8879,7 +8877,6 @@ a.grid_true {
 		margin-right: 0px;
 	}
 	.btn-toolbar .btn-wrapper {
-		margin-right: 10px;
-		margin-left: 10px;
+		margin: 0 10px 5px 10px;
 	}
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7526,12 +7526,12 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 0;
+		margin-left: 10px;
+		margin-right: 10px;
 		margin-bottom: 5px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
-		width: 95% !important;
-		margin-left: 10px;
+		width: 100% !important;
 	}
 	.subhead-fixed {
 		box-shadow: 0 0 0 rgba(0,0,0,0.2);
@@ -8047,13 +8047,13 @@ a.grid_true {
 	padding: 0;
 }
 .j-toggle-button-wrapper.j-toggle-hidden {
-	right: -20px;
+	right: -24px;
 }
 .j-toggle-button-wrapper.j-toggle-visible {
 	right: 10px;
 }
 .j-toggle-sidebar-button {
-	font-size: 14px;
+	font-size: 16px;
 	color: #08c;
 	text-decoration: none;
 	cursor: pointer;
@@ -8081,7 +8081,7 @@ a.grid_true {
 }
 @media (max-width: 979px) {
 	.j-toggle-button-wrapper.j-toggle-hidden {
-		right: -16px;
+		right: -20px;
 	}
 }
 @media (max-width: 767px) {
@@ -8872,4 +8872,14 @@ a.grid_true {
 }
 .row-fluid .modal-batch [class*="span"] {
 	margin-right: 0;
+}
+@media (max-width: 480px) {
+	.btn-toolbar .btn-wrapper .btn {
+		width: 100% !important;
+		margin-right: 0px;
+	}
+	.btn-toolbar .btn-wrapper {
+		margin-right: 10px;
+		margin-left: 10px;
+	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7526,12 +7526,12 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 0;
+		margin-left: 10px;
+		margin-right: 10px;
 		margin-bottom: 5px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
-		width: 95% !important;
-		margin-left: 10px;
+		width: 100% !important;
 	}
 	.subhead-fixed {
 		box-shadow: 0 0 0 rgba(0,0,0,0.2);

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7526,9 +7526,7 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 10px;
-		margin-right: 10px;
-		margin-bottom: 5px;
+		margin: 0px 10px 5px 10px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
 		width: 100% !important;
@@ -7556,7 +7554,7 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 		display: none;
 	}
 	.btn-toolbar .btn-wrapper .btn {
-		width: 93% !important;
+		width: 100% !important;
 	}
 }
 .nav-collapse .nav li a,

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -171,3 +171,15 @@ a.grid_true {
 .row-fluid .modal-batch [class*="span"] {
 	margin-right: 0;
 }
+
+/* Extended Responsive Styles */
+@media (max-width: 480px) {
+	.btn-toolbar .btn-wrapper .btn {
+		width: 100% !important;
+		margin-right:0px;
+	}
+	.btn-toolbar .btn-wrapper {
+		margin-right: 10px;
+		margin-left: 10px;
+	}
+}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -179,7 +179,6 @@ a.grid_true {
 		margin-right:0px;
 	}
 	.btn-toolbar .btn-wrapper {
-		margin-right: 10px;
-		margin-left: 10px;
+		margin:0 10px 5px 10px;
 	}
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -637,12 +637,12 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 0;
+		margin-left: 10px;
+		margin-right: 10px;
 		margin-bottom: 5px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
-		width: 95% !important;
-		margin-left: 10px;
+		width: 100% !important;
 	}
 	.subhead-fixed {
 		box-shadow: 0 0 0 rgba(0, 0, 0, 0.2);

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -637,9 +637,7 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 	}
 	.btn-toolbar .btn-wrapper {
 		display: block;
-		margin-left: 10px;
-		margin-right: 10px;
-		margin-bottom: 5px;
+		margin:0px 10px 5px 10px;
 	}
 	.btn-toolbar .btn-wrapper .btn {
 		width: 100% !important;
@@ -668,7 +666,7 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"],html[dir=rtl] .quick-icons
 		display: none;
 	}
 	.btn-toolbar .btn-wrapper .btn {
-	  width: 93% !important;
+	  width: 100% !important;
 	}
 }
 


### PR DESCRIPTION
## The bug

On some phones, the end of the toolbar buttons fall of the screen. (Screenshots are from a nexus 5).
This problem occurs on LTR and RTL css.

![screenshot_2015-03-12-18-16-59](https://cloud.githubusercontent.com/assets/2659866/6623620/50505b16-c8e4-11e4-952e-7e4f100b9b04.png)
## How to test this patch

You can test this patch on a mobile phone, but it also can be test by using the developer tool of Google Chrome. Press F12, and click on the mobile icon next to the search icon. Select as device: Nexus 5
1. Go to a page with Toolbar, this can be every view. Langue manager for example
2. Confirm the bug on Nexus 5, also confirm the buttons are not 100% page width on iPhone 5.
3. Apply the patch
4. Confirm the buttons are now shown correctly
5. Change device to iPhone 5 and confirm buttons are know shown the same as nexus 5
6. Switch to a RTL language (Persion for example)
7. Test the patch again
## Note

When compiling the less files, some j-sidebar css compiled too. I didn't make changes to that css... I have no idea if that can cause problems.
