### PR TITLE
Templates modal converted to bootstrap

### DIFF
--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -76,12 +76,15 @@ class JHtmlTemplates
 			if (file_exists($preview))
 			{
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
+				$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
 				$html .= JHtmlBootstrap::renderModal(
 					$template . '-Modal', array(
 						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
 						'height' => '500px',
-						'width' => '800px'
+						'width' => '800px',
+						'footer' => $footer
 					),
 					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
 				);

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -42,10 +42,14 @@ class JHtmlTemplates
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
 				$html = '<a href="#' . $template . '-Modal" role="button" class="thumbnail pull-left hasTooltip" data-toggle="modal" title="' .
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
-				$html .= JHtmlBootstrap::renderModal($template . '-Modal', array('url' => $preview,
-												'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-												'height' => '800px',
-												'width' => '800px'));
+				$html .= JHtmlBootstrap::renderModal(
+					$template . '-Modal', array(
+						'url' => $preview,
+						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+						'height' => '800px',
+						'width' => '800px'
+						)
+					);
 			}
 		}
 

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -38,7 +38,7 @@ class JHtmlTemplates
 		if (file_exists($thumb))
 		{
 			JHtml::_('bootstrap.tooltip');
-			JHtml::_('behavior.modal');
+			JHtml::_('bootstrap.modal');
 
 			$clientPath = ($clientId == 0) ? '' : 'administrator/';
 			$thumb = $clientPath . 'templates/' . $template . '/template_thumbnail.png';
@@ -47,8 +47,12 @@ class JHtmlTemplates
 			if (file_exists($preview))
 			{
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
-				$html = '<a href="' . $preview . '" class="thumbnail pull-left modal hasTooltip" title="' .
+				$html = '<a href="#' . $template . '-Modal" role="button" class="thumbnail pull-left hasTooltip" data-toggle="modal" title="' .
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
+				$html .= JHtmlBootstrap::renderModal($template . '-Modal', array( 'url' => $preview,
+													'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+													'height' => '800px',
+													'width' => '800px'));
 			}
 		}
 

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -38,7 +38,6 @@ class JHtmlTemplates
 		if (file_exists($thumb))
 		{
 			JHtml::_('bootstrap.tooltip');
-			JHtml::_('bootstrap.modal');
 
 			$clientPath = ($clientId == 0) ? '' : 'administrator/';
 			$thumb = $clientPath . 'templates/' . $template . '/template_thumbnail.png';

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -49,10 +49,14 @@ class JHtmlTemplates
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
 				$html = '<a href="#' . $template . '-Modal" role="button" class="thumbnail pull-left hasTooltip" data-toggle="modal" title="' .
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
-				$html .= JHtmlBootstrap::renderModal($template . '-Modal', array( 'url' => $preview,
-													'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-													'height' => '800px',
-													'width' => '800px'));
+				$html .= JHtmlBootstrap::renderModal(
+					$template . '-Modal', array(
+						'url' => $preview,
+						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+						'height' => '800px',
+						'width' => '800px'
+						)
+					);
 			}
 		}
 

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -54,7 +54,7 @@ class JHtmlTemplates
 						'height' => '500px',
 						'width' => '800px'
 						),
-					$body = '<div><img src="' . $preview . '" style="width:100%"></div>'
+					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
 					);
 			}
 		}

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -30,7 +30,6 @@ class JHtmlTemplates
 	{
 		$client = JApplicationHelper::getClientInfo($clientId);
 		$basePath = $client->path . '/templates/' . $template;
-		$baseUrl = ($clientId == 0) ? JUri::root(true) : JUri::root(true) . '/administrator';
 		$thumb = $basePath . '/template_thumbnail.png';
 		$preview = $basePath . '/template_preview.png';
 		$html = '';
@@ -45,17 +44,47 @@ class JHtmlTemplates
 
 			if (file_exists($preview))
 			{
-				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
 				$html = '<a href="#' . $template . '-Modal" role="button" class="thumbnail pull-left hasTooltip" data-toggle="modal" title="' .
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
+			}
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Renders the html for the modal linked to thumb.
+	 *
+	 * @param   string	 $template  The name of the template.
+	 * @param   integer  $clientId  The application client ID the template applies to
+	 *
+	 * @return  string  The html string
+	 *
+	 * @since   3.4
+	 */
+	public static function thumbModal($template, $clientId = 0)
+	{
+		$client = JApplicationHelper::getClientInfo($clientId);
+		$basePath = $client->path . '/templates/' . $template;
+		$baseUrl = ($clientId == 0) ? JUri::root(true) : JUri::root(true) . '/administrator';
+		$thumb = $basePath . '/template_thumbnail.png';
+		$preview = $basePath . '/template_preview.png';
+		$html = '';
+
+		if (file_exists($thumb))
+		{
+			if (file_exists($preview))
+			{
+				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
+
 				$html .= JHtmlBootstrap::renderModal(
 					$template . '-Modal', array(
 						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
 						'height' => '500px',
 						'width' => '800px'
-						),
+					),
 					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
-					);
+				);
 			}
 		}
 

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -11,13 +11,20 @@ defined('_JEXEC') or die;
 
 /**
  * JHtml helper class.
+ *
+ * @since  1.6
  */
 class JHtmlTemplates
 {
 	/**
 	 * Display the thumb for the template.
 	 *
-	 * @param   string	The name of the active view.
+	 * @param   string	 $template  The name of the template.
+	 * @param   integer  $clientId  The application client ID the template applies to
+	 *
+	 * @return  string  The html string
+	 *
+	 * @since   1.6
 	 */
 	public static function thumb($template, $clientId = 0)
 	{
@@ -44,11 +51,11 @@ class JHtmlTemplates
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
 				$html .= JHtmlBootstrap::renderModal(
 					$template . '-Modal', array(
-						'url' => $preview,
 						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-						'height' => '800px',
+						'height' => '500px',
 						'width' => '800px'
-						)
+						),
+					$body = '<div><img src="' . $preview . '" style="width:100%"></div>'
 					);
 			}
 		}

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -11,20 +11,13 @@ defined('_JEXEC') or die;
 
 /**
  * JHtml helper class.
- *
- * @since  1.6
  */
 class JHtmlTemplates
 {
 	/**
 	 * Display the thumb for the template.
 	 *
-	 * @param   string	 $template  The name of the template.
-	 * @param   integer  $clientId  The application client ID the template applies to
-	 *
-	 * @return  string  The html string
-	 *
-	 * @since   1.6
+	 * @param   string	The name of the active view.
 	 */
 	public static function thumb($template, $clientId = 0)
 	{
@@ -49,14 +42,10 @@ class JHtmlTemplates
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
 				$html = '<a href="#' . $template . '-Modal" role="button" class="thumbnail pull-left hasTooltip" data-toggle="modal" title="' .
 					JHtml::tooltipText('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</a>';
-				$html .= JHtmlBootstrap::renderModal(
-					$template . '-Modal', array(
-						'url' => $preview,
-						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-						'height' => '800px',
-						'width' => '800px'
-						)
-					);
+				$html .= JHtmlBootstrap::renderModal($template . '-Modal', array('url' => $preview,
+												'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+												'height' => '800px',
+												'width' => '800px'));
 			}
 		}
 

--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -140,8 +140,8 @@ JFactory::getDocument()->addStyleDeclaration("
 
 if($this->type == 'font')
 {
-	JFactory::getDocument()->addStyleDeclaration("
-		/* Styles for font preview */
+	JFactory::getDocument()->addStyleDeclaration(
+		"/* Styles for font preview */
 		@font-face
 		{
 			font-family: previewFont;
@@ -150,8 +150,8 @@ if($this->type == 'font')
 
 		.font-preview{
 			font-family: previewFont !important;
-		}
-	");
+		}"
+	);
 }
 ?>
 <?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'editor')); ?>

--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -140,8 +140,8 @@ JFactory::getDocument()->addStyleDeclaration("
 
 if($this->type == 'font')
 {
-	JFactory::getDocument()->addStyleDeclaration(
-		"/* Styles for font preview */
+	JFactory::getDocument()->addStyleDeclaration("
+		/* Styles for font preview */
 		@font-face
 		{
 			font-family: previewFont;
@@ -150,8 +150,8 @@ if($this->type == 'font')
 
 		.font-preview{
 			font-family: previewFont !important;
-		}"
-	);
+		}
+	");
 }
 ?>
 <?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'editor')); ?>

--- a/administrator/components/com_templates/views/template/tmpl/default_description.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_description.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 <div class="pull-left">
 	<?php echo JHtml::_('templates.thumb', $this->template->element, $this->template->client_id); ?>
+	<?php echo JHtml::_('templates.thumbModal', $this->template->element, $this->template->client_id); ?>
 </div>
 <h2><?php echo ucfirst($this->template->element); ?></h2>
 <?php $client = JApplicationHelper::getClientInfo($this->template->client_id); ?>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -116,6 +116,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 								<?php echo $this->escape($url); ?></a></p>
 						<?php endif; ?>
 					</td>
+					<?php echo JHtml::_('templates.thumbModal', $item->element, $item->client_id); ?>
 				</tr>
 				<?php endforeach; ?>
 			</tbody>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('bootstrap.modal');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.modal');
+JHtml::_('bootstrap.modal');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/templates/hathor/html/com_templates/template/default.php
+++ b/administrator/templates/hathor/html/com_templates/template/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('bootstrap.modal');
 
 $input = JFactory::getApplication()->input;
 if($this->type == 'image')

--- a/administrator/templates/hathor/html/com_templates/template/default.php
+++ b/administrator/templates/hathor/html/com_templates/template/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.modal');
+JHtml::_('bootstrap.modal');
 
 $input = JFactory::getApplication()->input;
 if($this->type == 'image')

--- a/administrator/templates/hathor/html/com_templates/template/default_description.php
+++ b/administrator/templates/hathor/html/com_templates/template/default_description.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 <div class="pull-left">
 	<?php echo JHtml::_('templates.thumb', $this->template->element, $this->template->client_id); ?>
+	<?php echo JHtml::_('templates.thumbModal', $this->template->element, $this->template->client_id); ?>
 </div>
 <h2><?php echo ucfirst($this->template->element); ?></h2>
 <?php $client = JApplicationHelper::getClientInfo($this->template->client_id); ?>

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -120,6 +120,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 							<?php echo $this->escape($url); ?></a></p>
 					<?php endif; ?>
 				</td>
+				<?php echo JHtml::_('templates.thumbModal', $item->element, $item->client_id); ?>
 			</tr>
 			<?php endforeach; ?>
 		</tbody>

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.modal');
 JHtml::_('behavior.multiselect');
 
 $user		= JFactory::getUser();


### PR DESCRIPTION
This is a redo of #4645
#### Scope

Use bootstrap instead of the mootools modal!
#### Testing

Apply patch 
go to `/administrator/index.php?option=com_templates&view=templates`
click on the thumbs
#### Preview

![screen shot 2015-03-12 at 9 25 35](https://cloud.githubusercontent.com/assets/3889375/6626480/86ca0910-c8ff-11e4-985e-f126f06028a2.png)
