### PR TITLE
Added a method to make JAssetRules responsible for its own storage

### DIFF
--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -220,14 +220,14 @@ class JAccessRules
 	/**
 	 * Method to store the rules to the asset table
 	 *
-	 * @param string $assetName the asset name
-	 * @param array $rules to be stored
+	 * @param   string  $assetName  the asset name
+	 * @param   array   $rules      to be stored
 	 *
 	 * @return bool
 	 */
 	public function storeRules($assetName, $rules = null)
 	{
-		if(is_null($rules))
+		if (is_null($rules))
 		{
 			$rules = $this->data;
 		}
@@ -235,7 +235,7 @@ class JAccessRules
 		$rules = new JAccessRules($this->cleanRules($rules));
 		$asset = JTable::getInstance('asset');
 
-		if(!$asset->loadByName($assetName))
+		if (!$asset->loadByName($assetName))
 		{
 			$root = JTable::getInstance('asset');
 			$root->loadByName('root.1');
@@ -258,19 +258,19 @@ class JAccessRules
 	 * Method to remove non-numeric values from the rules array
 	 * This should really be moved over to the JAccess class
 	 *
-	 * @param $rules
+	 * @param   array  $rules  to be cleaned
 	 *
 	 * @return array clean rules array
 	 */
 	protected function cleanRules($rules)
 	{
 		$cleanRules = array();
-		foreach($rules AS $action => $rule)
+		foreach ($rules AS $action => $rule)
 		{
 			$cleanRules[$action] = array();
-			foreach($rule AS $group => $setting)
+			foreach ($rule AS $group => $setting)
 			{
-				if(is_numeric($setting))
+				if (is_numeric($setting))
 				{
 					$cleanRules[$action][$group] = $setting;
 				}

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -223,7 +223,7 @@ class JAccessRules
 	 * @param   string  $assetName  the asset name
 	 * @param   array   $rules      to be stored
 	 *
-	 * @return bool
+	 * @return int  $asset->id
 	 */
 	public function storeRules($assetName, $rules = null)
 	{
@@ -251,7 +251,7 @@ class JAccessRules
 			throw new RuntimeException($asset->getError());
 		}
 
-		return true;
+		return $asset->id;
 	}
 
 	/**


### PR DESCRIPTION
Something like this would allow us to pull all the JTable::getInstance('asset') dependencies out of the components.
I also added self cleaning, so we aren't writing null values as denied. 
