### PR TITLE
Fix check on non-existing element

### DIFF
--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -39,12 +39,12 @@ class JFormRulePassword extends JFormRule
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
-		$meter		= isset($this->element['strengthmeter'])  ? ' meter="0"' : '1';
-		$threshold	= isset($this->element['threshold']) ? (int) $this->element['threshold'] : 66;
-		$minimumLength = isset($this->element['minimum_length']) ? (int) $this->element['minimum_length'] : 4;
-		$minimumIntegers = isset($this->element['minimum_integers']) ? (int) $this->element['minimum_integers'] : 0;
-		$minimumSymbols = isset($this->element['minimum_symbols']) ? (int) $this->element['minimum_symbols'] : 0;
-		$minimumUppercase = isset($this->element['minimum_uppercase']) ? (int) $this->element['minimum_uppercase'] : 0;
+		$meter		= isset($element['strengthmeter'])  ? ' meter="0"' : '1';
+		$threshold	= isset($element['threshold']) ? (int) $element['threshold'] : 66;
+		$minimumLength = isset($element['minimum_length']) ? (int) $element['minimum_length'] : 4;
+		$minimumIntegers = isset($element['minimum_integers']) ? (int) $element['minimum_integers'] : 0;
+		$minimumSymbols = isset($element['minimum_symbols']) ? (int) $element['minimum_symbols'] : 0;
+		$minimumUppercase = isset($element['minimum_uppercase']) ? (int) $element['minimum_uppercase'] : 0;
 
 		// If we have parameters from com_users, use those instead.
 		// Some of these may be empty for legacy reasons.


### PR DESCRIPTION
`$this->element` does not exist in this class nor it's parent `JFormRule`. Instead we should be checking against `$element` which is injected into the method
