### PR TITLE
This fixes the front-end form alignment in the protostar template.

### DIFF
--- a/components/com_config/view/config/tmpl/default.php
+++ b/components/com_config/view/config/tmpl/default.php
@@ -25,41 +25,37 @@ JFactory::getDocument()->addScriptDeclaration("
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config');?>" id="application-form" method="post" name="adminForm" class="form-validate">
+
 	<div class="row-fluid">
-
 		<!-- Begin Content -->
-		<div class="span12">
 
-			<div class="btn-toolbar">
-				<div class="btn-group">
-					<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.config.apply')">
-						<i class="icon-ok"></i> <?php echo JText::_('JSAVE') ?>
-					</button>
-				</div>
-				<div class="btn-group">
-					<button type="button" class="btn" onclick="Joomla.submitbutton('config.cancel')">
-						<i class="icon-cancel"></i> <?php echo JText::_('JCANCEL') ?>
-					</button>
-				</div>
+		<div class="btn-toolbar">
+			<div class="btn-group">
+				<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.config.apply')">
+					<i class="icon-ok"></i> <?php echo JText::_('JSAVE') ?>
+				</button>
 			</div>
-
-			<hr class="hr-condensed" />
-
-			<div id="page-site" class="tab-pane active">
-				<div class="row-fluid">
-					<div class="span6">
-						<?php echo $this->loadTemplate('site'); ?>
-						<?php echo $this->loadTemplate('metadata'); ?>
-						<?php echo $this->loadTemplate('seo'); ?>
-
-					</div>
-				</div>
+			<div class="btn-group">
+				<button type="button" class="btn" onclick="Joomla.submitbutton('config.cancel')">
+					<i class="icon-cancel"></i> <?php echo JText::_('JCANCEL') ?>
+				</button>
 			</div>
-
-			<input type="hidden" name="task" value="" />
-			<?php echo JHtml::_('form.token'); ?>
-
 		</div>
+
+		<hr class="hr-condensed" />
+
+		<div id="page-site" class="tab-pane active">
+			<div class="row-fluid">
+				<?php echo $this->loadTemplate('site'); ?>
+				<?php echo $this->loadTemplate('metadata'); ?>
+				<?php echo $this->loadTemplate('seo'); ?>
+			</div>
+		</div>
+
+		<input type="hidden" name="task" value="" />
+		<?php echo JHtml::_('form.token'); ?>
+
 		<!-- End Content -->
 	</div>
+
 </form>

--- a/components/com_config/view/templates/tmpl/default.php
+++ b/components/com_config/view/templates/tmpl/default.php
@@ -27,39 +27,33 @@ JFactory::getDocument()->addScriptDeclaration("
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
 	<div class="row-fluid">
-
 		<!-- Begin Content -->
-		<div class="span12">
 
-			<div class="btn-toolbar">
-				<div class="btn-group">
-					<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.templates.apply')">
-						<i class="icon-ok"></i> <?php echo JText::_('JSAVE') ?>
-					</button>
-				</div>
-				<div class="btn-group">
-					<button type="button" class="btn" onclick="Joomla.submitbutton('config.cancel')">
-						<i class="icon-cancel"></i> <?php echo JText::_('JCANCEL') ?>
-					</button>
-				</div>
+		<div class="btn-toolbar">
+			<div class="btn-group">
+				<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.templates.apply')">
+					<i class="icon-ok"></i> <?php echo JText::_('JSAVE') ?>
+				</button>
 			</div>
+			<div class="btn-group">
+				<button type="button" class="btn" onclick="Joomla.submitbutton('config.cancel')">
+					<i class="icon-cancel"></i> <?php echo JText::_('JCANCEL') ?>
+				</button>
+			</div>
+		</div>
 
-	<hr class="hr-condensed" />
+		<hr class="hr-condensed" />
 
-	<div id="page-site" class="tab-pane active">
-				<div class="row-fluid">
-					<div class="span6">
-						<?php // Get the menu parameters that are automatically set but may be modified.
-					echo $this->loadTemplate('options'); ?>
+		<div id="page-site" class="tab-pane active">
+			<div class="row-fluid">
+				<?php // Get the menu parameters that are automatically set but may be modified.
+				echo $this->loadTemplate('options'); ?>
+			</div>
+		</div>
 
-					</div>
-				</div>
-	</div>
+		<input type="hidden" name="task" value="" />
+		<?php echo JHtml::_('form.token'); ?>
 
-	<input type="hidden" name="task" value="" />
-	<?php echo JHtml::_('form.token'); ?>
-
-	</div>
 		<!-- End Content -->
 	</div>
 


### PR DESCRIPTION
## Issue

Both the config and template forms were only occupying 1/2 the container width.
## Reproduction Instructions

To reproduce create a menu item for both the front end "Site" configuration and "Template" configuration. 
Then visit the menu items with the the protostar template as the default.
## Testing Instructions

To test apply the patch and then revisit the menu items. 
## BC concerns

None 
