### PR TITLE
importing media.less is missing in Isis template

### DIFF
--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -42,6 +42,7 @@
 
 // Components: Misc
 @import "../../../../media/jui/less/thumbnails.less";
+@import "../../../../media/jui/less/media.less";
 @import "../../../../media/jui/less/labels-badges.less";
 @import "../../../../media/jui/less/progress-bars.less";
 @import "../../../../media/jui/less/accordion.less";


### PR DESCRIPTION
Bootstrap 2.3.2 default available file called media.less is missing in Isis template. 
http://getbootstrap.com/2.3.2/components.html#media

example of use for this css output: when using an image in the description of an installed extension and you want to outline large text  next to the image.
