### PR TITLE
LDAP enforce two-factor authentication

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -166,7 +166,7 @@ class PlgAuthenticationLdap extends JPlugin
 			// Get a database object
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->select('id, password')
+				->select('id')
 				->from('#__users')
 				->where('username=' . $db->quote($credentials['username']));
 

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -159,5 +159,146 @@ class PlgAuthenticationLdap extends JPlugin
 		}
 
 		$ldap->close();
+
+		// Check the two factor authentication
+		if ($response->status == JAuthentication::STATUS_SUCCESS)
+		{
+			// Get a database object
+			$db    = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('id, password')
+				->from('#__users')
+				->where('username=' . $db->quote($credentials['username']));
+
+			$db->setQuery($query);
+			$result = $db->loadObject();
+			
+			require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
+
+			$methods = UsersHelper::getTwoFactorMethods();
+
+			if (count($methods) <= 1)
+			{
+				// No two factor authentication method is enabled
+				return;
+			}
+
+			require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
+
+			$model = new UsersModelUser;
+
+			// Load the user's OTP (one time password, a.k.a. two factor auth) configuration
+			if (!array_key_exists('otp_config', $options))
+			{
+				$otpConfig             = $model->getOtpConfig($result->id);
+				$options['otp_config'] = $otpConfig;
+			}
+			else
+			{
+				$otpConfig = $options['otp_config'];
+			}
+
+			// Check if the user has enabled two factor authentication
+			if (empty($otpConfig->method) || ($otpConfig->method == 'none'))
+			{
+				// Warn the user if he's using a secret code but he has not
+				// enabed two factor auth in his account.
+				if (!empty($credentials['secretkey']))
+				{
+					try
+					{
+						$app = JFactory::getApplication();
+
+						$this->loadLanguage();
+
+						$app->enqueueMessage(JText::_('PLG_AUTH_JOOMLA_ERR_SECRET_CODE_WITHOUT_TFA'), 'warning');
+					}
+					catch (Exception $exc)
+					{
+						// This happens when we are in CLI mode. In this case
+						// no warning is issued
+						return;
+					}
+				}
+
+				return;
+			}
+
+			// Load the Joomla! RAD layer
+			if (!defined('FOF_INCLUDED'))
+			{
+				include_once JPATH_LIBRARIES . '/fof/include.php';
+			}
+
+			// Try to validate the OTP
+			FOFPlatform::getInstance()->importPlugin('twofactorauth');
+
+			$otpAuthReplies = FOFPlatform::getInstance()->runPlugins('onUserTwofactorAuthenticate', array($credentials, $options));
+
+			$check = false;
+
+			/*
+			 * This looks like noob code but DO NOT TOUCH IT and do not convert
+			 * to in_array(). During testing in_array() inexplicably returned
+			 * null when the OTEP begins with a zero! o_O
+			 */
+			if (!empty($otpAuthReplies))
+			{
+				foreach ($otpAuthReplies as $authReply)
+				{
+					$check = $check || $authReply;
+				}
+			}
+
+			// Fall back to one time emergency passwords
+			if (!$check)
+			{
+				// Did the user use an OTEP instead?
+				if (empty($otpConfig->otep))
+				{
+					if (empty($otpConfig->method) || ($otpConfig->method == 'none'))
+					{
+						// Two factor authentication is not enabled on this account.
+						// Any string is assumed to be a valid OTEP.
+
+						return true;
+					}
+					else
+					{
+						/*
+						 * Two factor authentication enabled and no OTEPs defined. The
+						 * user has used them all up. Therefore anything he enters is
+						 * an invalid OTEP.
+						 */
+						return false;
+					}
+				}
+
+				// Clean up the OTEP (remove dashes, spaces and other funny stuff
+				// our beloved users may have unwittingly stuffed in it)
+				$otep  = $credentials['secretkey'];
+				$otep  = filter_var($otep, FILTER_SANITIZE_NUMBER_INT);
+				$otep  = str_replace('-', '', $otep);
+				$check = false;
+
+				// Did we find a valid OTEP?
+				if (in_array($otep, $otpConfig->otep))
+				{
+					// Remove the OTEP from the array
+					$otpConfig->otep = array_diff($otpConfig->otep, array($otep));
+
+					$model->setOtpConfig($result->id, $otpConfig);
+
+					// Return true; the OTEP was a valid one
+					$check = true;
+				}
+			}
+
+			if (!$check)
+			{
+				$response->status        = JAuthentication::STATUS_FAILURE;
+				$response->error_message = JText::_('JGLOBAL_AUTH_INVALID_SECRETKEY');
+			}
+		}
 	}
 }

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -172,7 +172,7 @@ class PlgAuthenticationLdap extends JPlugin
 
 			$db->setQuery($query);
 			$result = $db->loadObject();
-			
+
 			require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
 
 			$methods = UsersHelper::getTwoFactorMethods();


### PR DESCRIPTION
### Summary

Currently the LDAP Authentication plugin does not enforce two-factor authentication, this fixes that.
### Notes

This is just a copy-paste of the logic from the Joomla! Authentication plugin. Although it is beyond the scope of this pull request, it might be beneficial to add a method to a core authentication library/helper as this code would be usable for any future core shipped authentication plugin or one developed by the community.

In the Joomla! Authentication plugin, the block for getting the database object (lines 166-174 of the file changed in this PR) happens near the top before any authentication checking happens. That is because the authentication checking for the Joomla! Authentication plugin requires information from that object.  However, the LDAP Authentication plugin only requires this object _if_ two-factor authentication is enabled for this user. Therefore this query shouldn't happen every time this plugin is triggered, instead only when the user has two-factor authentication enabled. Thus it has been moved after the two-factor method conditional.
### Testing
1. Configure LDAP Authentication Plugin
2. Ensure LDAP Authentication is functioning properly
3. Enable a two-factor authentication plugin
4. Add two-factor authentication to this user
   - Take note of a one time emergency password (used later in testing)
5. Attempt login without supplying secret
   - Should fail, with notice that secret key is invalid
6. Attempt login with appropriate secret key
   - Should Succeed
7. Attempt login with one time password copied in step 3
   - Should succeed
