### PR TITLE
Cleaning com_media allowed and ignored extensions whitespaces

### DIFF
--- a/libraries/cms/helper/media.php
+++ b/libraries/cms/helper/media.php
@@ -105,8 +105,8 @@ class JHelperMedia
 		}
 
 		$filetype = array_pop($filetypes);
-		$allowable = explode(',', $params->get('upload_extensions'));
-		$ignored   = explode(',', $params->get('ignore_extensions'));
+		$allowable = array_map('trim', explode(',', $params->get('upload_extensions')));
+		$ignored   = array_map('trim', explode(',', $params->get('ignore_extensions')));
 
 		if ($filetype == '' || $filetype == false || (!in_array($filetype, $allowable) && !in_array($filetype, $ignored)))
 		{
@@ -126,7 +126,7 @@ class JHelperMedia
 
 		if ($params->get('restrict_uploads', 1))
 		{
-			$images = explode(',', $params->get('image_extensions'));
+			$images = array_map('trim', explode(',', $params->get('image_extensions')));
 
 			if (in_array($filetype, $images))
 			{
@@ -151,8 +151,8 @@ class JHelperMedia
 			elseif (!in_array($filetype, $ignored))
 			{
 				// If it's not an image, and we're not ignoring it
-				$allowed_mime = explode(',', $params->get('upload_mime'));
-				$illegal_mime = explode(',', $params->get('upload_mime_illegal'));
+				$allowed_mime = array_map('trim', explode(',', $params->get('upload_mime')));
+				$illegal_mime = array_map('trim', explode(',', $params->get('upload_mime_illegal')));
 
 				if (function_exists('finfo_open') && $params->get('check_mime', 1))
 				{


### PR DESCRIPTION
This replaces https://github.com/joomla/joomla-cms/pull/5647
## Description

This allows you to use spaces to separate values of some `com_media` options:
- `Legal Extensions (File Types)`
- `Legal Image Extensions (File Types)`
- `Ignored Extensions`
- `Legal MIME Types`
- `Illegal MIME Types`

![radek-whitespaces](https://cloud.githubusercontent.com/assets/1119272/6650476/39d8796e-ca14-11e4-869c-8f8e5e2c7543.png)
## How to test

After applying the patch:
- Ensure that values without spaces still work as expected.
- Add values including spaces between them and test that all the settings still work.
## Backwards compatibility issues

This should be 100% backward compatible.
