### PR TITLE
Fix for languagefilter problem

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -231,17 +231,8 @@ class PlgSystemLanguageFilter extends JPlugin
 		// Check if we need to remove the lang prefix
 		if ( ! empty($lang_code))
 		{
-			$parts	 	= explode('/', $uri->getPath());
-			$sef   		= $parts[0];
-
-			// Use the current language sef or the default one.
-			if (1 == $this->params->get('remove_default_prefix', 0)
-				&& $lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
-				&& $sef == $this->lang_codes[$lang_code]->sef)
+			if ($this->removePrefix($uri, $lang_code))
 			{
-				array_shift($parts);
-				$path = implode('/', $parts);
-				$uri->setPath($path);
 				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
 
 				return array('lang' => $lang_code);
@@ -301,12 +292,34 @@ class PlgSystemLanguageFilter extends JPlugin
 		// Create the cookie if needed
 		$this->createCookie($uri, $lang_code);
 
-		$parts = explode('/', $uri->getPath());
-		array_shift($parts);
-		$path = implode('/', $parts);
-		$uri->setPath($path);
+		$this->removePrefix($uri, $lang_code);
 
 		return array('lang' => $lang_code);
+	}
+
+	/**
+	 * remove the prefix from the url
+	 *
+	 * @param   JUri    &$uri       JUri object.
+	 * @param   string  $lang_code  the lang-code
+	 *
+	 * @return bool
+	 */
+	private function removePrefix(&$uri, $lang_code)
+	{
+		$parts	 	= explode('/', $uri->getPath());
+		$sef   		= $parts[0];
+
+		if (array_key_exists($sef, $this->sefs))
+		{
+			array_shift($parts);
+			$path = implode('/', $parts);
+			$uri->setPath($path);
+		}
+
+		return 1 == $this->params->get('remove_default_prefix', 0)
+				&& $lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+				&& $sef == $this->lang_codes[$lang_code]->sef;
 	}
 
 	/**
@@ -316,7 +329,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @return array|mixed|string
 	 */
-	protected function getLangCode(&$uri)
+	private function getLangCode(&$uri)
 	{
 		// We are called via POST. We don't care about the language
 		// and simply set the default language as our current language.
@@ -344,7 +357,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @return mixed|string
 	 */
-	protected function getValidLangCode()
+	private function getValidLangCode()
 	{
 		$lang_code = '';
 
@@ -374,7 +387,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @return void
 	 */
-	protected function createCookie($uri, $lang_code)
+	private function createCookie($uri, $lang_code)
 	{
 		// Create a cookie.
 		$cookie_lang = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
@@ -395,7 +408,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @return void
 	 */
-	protected function loadExtensionsLanguages($lang_code)
+	private function loadExtensionsLanguages($lang_code)
 	{
 		$language = JFactory::getLanguage();
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -235,9 +235,9 @@ class PlgSystemLanguageFilter extends JPlugin
 			$sef   		= $parts[0];
 
 			// Use the current language sef or the default one.
-			if (1 == $this->params->get('remove_default_prefix', 0) &&
-				$lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB') &&
-				$sef == $this->lang_codes[$lang_code]->sef)
+			if (1 == $this->params->get('remove_default_prefix', 0)
+				&& $lang_code == JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+				&& $sef == $this->lang_codes[$lang_code]->sef)
 			{
 				array_shift($parts);
 				$path = implode('/', $parts);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -20,15 +20,64 @@ JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/he
  */
 class PlgSystemLanguageFilter extends JPlugin
 {
+	/**
+	 * default language
+	 *
+	 * @var integer
+	 */
 	protected $mode_sef;
 
+	/**
+	 * the sef codes en, de, fr, he, ....
+	 *
+	 * @var array
+	 */
 	protected $sefs;
 
+	/**
+	 * the land codes en-GB, de-DE, fr-FR, he-IL, ....
+	 *
+	 * @var array
+	 */
 	protected $lang_codes;
 
+	/**
+	 * default language
+	 *
+	 * @var string
+	 */
 	protected $default_lang;
 
+	/**
+	 * the land code set for the user
+	 *
+	 * @var string
+	 */
 	private $user_lang_code;
+
+	/**
+	 * cookie path
+	 *
+	 * @var string
+	 * @since  3.4.1
+	 */
+	private $cookie_path = '';
+
+	/**
+	 * cookie domain
+	 *
+	 * @var string
+	 * @since  3.4.1
+	 */
+	private $cookie_domain = '';
+
+	/**
+	 * That the name of the cookie
+	 *
+	 * @var string
+	 * @since  3.4.1
+	 */
+	private $language_hash = '';
 
 	/**
 	 * Application object.
@@ -49,8 +98,6 @@ class PlgSystemLanguageFilter extends JPlugin
 	public function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
-
-		$this->app = JFactory::getApplication();
 
 		if ($this->app->isSite())
 		{
@@ -75,6 +122,14 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// Detect browser feature.
 			$this->app->setDetectBrowser($this->params->get('detect_browser', '1') == '1');
+
+			$uri = JUri::getInstance();
+
+			$this->cookie_domain = $this->app->get('cookie_domain');
+			$base = $uri->base(true) == '' ? '/' : $uri->base(true);
+			$this->cookie_path = $this->app->get('cookie_path', $base);
+
+			$this->language_hash = JApplicationHelper::getHash('language');
 		}
 	}
 
@@ -173,7 +228,9 @@ class PlgSystemLanguageFilter extends JPlugin
 		}
 
 		if ($this->mode_sef
-			&& (!$this->params->get('remove_default_prefix', 0) || $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')))
+			&& (!$this->params->get('remove_default_prefix', 0)
+			|| $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+			|| $lang != $this->default_lang))
 		{
 			$uri->setPath($uri->getPath() . '/' . $sef . '/');
 		}
@@ -226,69 +283,24 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	public function parseRule(&$router, &$uri)
 	{
-		$lang_code = $this->getLangCode($uri);
+		$lang_code  = $this->getLangCode($uri);
+		$parts	 	= explode('/', $uri->getPath());
+		$sef   		= $parts[0];
 
-		// Check if we need to remove the lang prefix
-		if ( ! empty($lang_code))
+		// Check if a redirect is needed when we haven't a lang prefix but we got lang code from a cookie
+		if ($this->mode_sef && $sef == "" && $lang_code != JComponentHelper::getParams('com_languages')->get('site', 'en-GB') )
 		{
-			$parts	 	= explode('/', $uri->getPath());
-			$sef   		= $parts[0];
-
-			// Check if a redirect is needed when we haven't a lang prefix but we got lang code from a cookie
-			if ($sef == "" && $lang_code != JComponentHelper::getParams('com_languages')->get('site', 'en-GB') )
-			{
-				$path = $this->app->get('sef_rewrite') ? $this->lang_codes[$lang_code]->sef : 'index.php/' . $this->lang_codes[$lang_code]->sef;
-				$uri->setPath($path);
-				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
-			}
-
-			$removePrefix = $this->removePrefix($uri, $lang_code);
-
-			if ($removePrefix)
-			{
-				$this->createCookie($uri, $lang_code);
-				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
-			}
+			$path = $this->app->get('sef_rewrite') ? $this->lang_codes[$lang_code]->sef : 'index.php/' . $this->lang_codes[$lang_code]->sef;
+			$uri->setPath($path);
+			$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
 		}
 
-		// We have not found the language and thus need to redirect
-		if (empty($lang_code))
+		$removePrefix = $this->removePrefix($uri, $lang_code);
+
+		if ($removePrefix)
 		{
-			$path = $uri->getPath();
-
-			// Lets find the default language for this user
-			if (!isset($lang_code) || !isset($this->lang_codes[$lang_code]))
-			{
-				// Either we detected the language via the browser or we got it from the cookie. In worst case
-				// we fall back to the application setting
-				$lang_code = $this->getValidLangCode();
-			}
-
-			if ($this->mode_sef)
-			{
-				// Use the current language sef or the default one.
-				if (!$this->params->get('remove_default_prefix', 0)
-					|| $lang_code != JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
-				{
-					$path = $this->lang_codes[$lang_code]->sef . '/' . $path;
-				}
-
-				$uri->setPath($path);
-
-				if (!$this->app->get('sef_rewrite'))
-				{
-					$uri->setPath('index.php/' . $uri->getPath());
-				}
-
-				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
-			}
-			else
-			{
-				$uri->setVar('lang', $this->lang_codes[$lang_code]->sef);
-				$this->app->redirect($uri->base() . 'index.php?' . $uri->getQuery());
-			}
-
-			return array('lang' => $lang_code);
+			$this->setLanguageCookie($lang_code);
+			$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
 		}
 
 		// We have found our language and now need to set the cookie and the language value in our system
@@ -302,7 +314,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		$this->loadExtensionsLanguages($lang_code);
 
 		// Create the cookie if needed
-		$this->createCookie($uri, $lang_code);
+		$this->setLanguageCookie($lang_code);
 
 		$this->removePrefix($uri, $lang_code);
 
@@ -356,9 +368,9 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ( ! $this->mode_sef)
 		{
 			// We are not in SEF mode
-			$lang = $uri->getVar('lang');
+			$lang = $uri->getVar('lang', '');
 
-			return isset($this->sefs[$lang]) ? $this->sefs[$lang]->lang_code : '';
+			return isset($this->sefs[$lang]) ? $this->sefs[$lang]->lang_code : $this->getValidLangCode();
 		}
 
 		return $this->parseRuleSEF($uri);
@@ -392,25 +404,32 @@ class PlgSystemLanguageFilter extends JPlugin
 	}
 
 	/**
-	 * set the cookie
+	 * set the language cookie, set it only when the lang has changed
 	 *
-	 * @param   JUri    $uri        JUri object.
 	 * @param   string  $lang_code  the lang-code
 	 *
 	 * @return void
 	 */
-	private function createCookie($uri, $lang_code)
+	private function setLanguageCookie($lang_code)
 	{
-		// Create a cookie.
-		$cookie_lang = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+		$cookie_lang = $this->getLanguageCookie();
 
 		if ($cookie_lang != $lang_code)
 		{
-			$cookie_domain = $this->app->get('cookie_domain');
-			$base = $uri->base(true) == '' ? '/' : $uri->base(true);
-			$cookie_path = $this->app->get('cookie_path', $base);
-			$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+			$this->app->input->cookie->set($this->language_hash, $lang_code, $this->getLangCookieTime(), $this->cookie_path, $this->cookie_domain);
 		}
+	}
+
+	/**
+	 * set the language cookie, set it only when the lang has changed
+	 *
+	 * @param   string  $default_lang_code  the lang-code
+	 *
+	 * @return string
+	 */
+	public function getLanguageCookie($default_lang_code = '')
+	{
+		return $this->app->input->cookie->getString($this->language_hash, $default_lang_code);
 	}
 
 	/**
@@ -450,23 +469,22 @@ class PlgSystemLanguageFilter extends JPlugin
 		$path  		= $uri->getPath();
 		$parts	 	= explode('/', $path);
 		$sef   		= $parts[0];
-		$lang_code 	= '';
 
 		// If the default prefix should be removed and the SEF prefix is not among those
 		// that we have in our system, its the default language and we "found" the right language
 		if ($this->params->get('remove_default_prefix', 0) && !isset($this->sefs[$sef]))
 		{
-			return $lang_code = $this->getValidLangCode();
+			return $this->getValidLangCode();
 		}
 
 		// If the language prefix should always be present or it is indeed , we can now look it up in our array
 		if (isset($this->sefs[$sef]))
 		{
 			// We found our language
-			$lang_code = $this->sefs[$sef]->lang_code;
+			return $this->sefs[$sef]->lang_code;
 		}
 
-		return $lang_code;
+		return $this->getValidLangCode();
 	}
 
 	/**
@@ -540,9 +558,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					);
 
 					// Create a cookie.
-					$cookie_domain 	= $this->app->get('cookie_domain', '');
-					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					$this->setLanguageCookie($lang_code);
 				}
 			}
 		}
@@ -590,9 +606,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				$this->default_lang = $lang_code;
 
 				// Create a cookie.
-				$cookie_domain 	= $this->app->get('cookie_domain', '');
-				$cookie_path 	= $this->app->get('cookie_path', '/');
-				setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				$this->setLanguageCookie($lang_code);
 
 				// Change the language code.
 				JFactory::getLanguage()->setLanguage($lang_code);
@@ -738,13 +752,9 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		if ($this->params->get('lang_cookie', 1) == 1)
 		{
-			$lang_cookie = time() + 365 * 86400;
-		}
-		else
-		{
-			$lang_cookie = 0;
+			return  time() + 365 * 86400;
 		}
 
-		return $lang_cookie;
+		return 0;
 	}
 }


### PR DESCRIPTION
# Executive summary

This is the fix for a with 3.4 invented bug. For better understanding it comes with a some more refactoring and removing duplicated code.
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Testing instructions

You need a multi language site to test, with SEF enabled. I have

de == default language
en == other language
## Wrong behaviour
1. access the site without lang code e.g. http://mysite.de

-> you should see the site in default language
1. change the lang code to en

-> you should see the site in english language
1. access the site without lang code e.g. http://mysite.de again

-> you’ll see the site in default language but it should be in english
## Right behaviour
1. access the site without lang code e.g. http://mysite.de

-> you should see the site in default language
1. change the lang code to en

-> you should see the site in english language
1. access the site without lang code e.g. http://mysite.de again

-> you should see the site in english language

Test if switching language works as expected, also test with the setting Remove URL Language Code to yes. It makes also a difference if the site is installed in a subdir or not

Related to #6371 #6213
