### PR TITLE
Fix: Empty Sessions / Logged-in in other accounts Ref #5214

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -638,9 +638,9 @@ class JSession implements IteratorAggregate
 			$session_name = session_name();
 
 			// Get the JInputCookie object
-			$cookie = $this->_input->cookie;
+			$cookie      = $this->_input->cookie;
 			$cookieValue = $cookie->get($session_name);
-			
+
 			if (is_null($cookieValue))
 			{
 				$session_clean = $this->_input->get($session_name, false, 'string');

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -639,8 +639,9 @@ class JSession implements IteratorAggregate
 
 			// Get the JInputCookie object
 			$cookie = $this->_input->cookie;
-
-			if (is_null($cookie->get($session_name)))
+			$cookieValue = $cookie->get($session_name);
+			
+			if (is_null($cookieValue))
 			{
 				$session_clean = $this->_input->get($session_name, false, 'string');
 
@@ -649,6 +650,11 @@ class JSession implements IteratorAggregate
 					session_id($session_clean);
 					$cookie->set($session_name, '', time() - 3600);
 				}
+			}
+			elseif ($cookieValue == '')
+			{
+				session_regenerate_id(true);
+				$cookie->set($session_name, '', time() - 3600);
 			}
 		}
 


### PR DESCRIPTION
See: http://issues.joomla.org/tracker/joomla-cms/5214
#### Original report

My community has over 300.000 registered Members and est. 200.000 users daily. When entering joomla, a lot of users get empty sessions. That means, the Session-ID is just "".
If one of these users log in with the empty session, some of the others are also logged in with the same account. They can edit the profile, read/write personal messages etc. That's a huge problem, because no one wants others to enter the profile.
#### Steps to reproduce the issue

Delete all the cookies, and enter Joomla website.
#### Expected result

User gets an unique Session-ID.
#### Actual result

You are logged in as another user and/or share the empty Session-ID with other people. This happens with low likelihood. But if you have lots of users, it happens a lot.
#### System information (as much as possible)

Joomla:  Joomla! 2.5.27 Stable [ Ember ] 30-September-2014 14:00 GMT 
Webserver:  nginx/1.2.1 
Database-version:  5.5.40-0+wheezy1-log 
PHP:  fpm-fcgi 
#### Additional comments

You can also reproduce this issue, if you change your session-id cookie within browser developer tools.
