### PR TITLE
Block instantiation of JDatabaseDriverMysql on PHP 7

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -35,6 +35,14 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 */
 	public function __construct($options)
 	{
+		// PHP's `mysql` extension is not present in PHP 7, block instantiation in this environment
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			throw new RuntimeException(
+				'This driver is unsupported in PHP 7, please use the MySQLi or PDO MySQL driver instead.'
+			);
+		}
+
 		// Get some basic values from the options.
 		$options['host'] = (isset($options['host'])) ? $options['host'] : 'localhost';
 		$options['user'] = (isset($options['user'])) ? $options['user'] : 'root';
@@ -72,7 +80,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		}
 
 		// Make sure the MySQL extension for PHP is installed and enabled.
-		if (!function_exists('mysql_connect'))
+		if (!self::isSupported())
 		{
 			throw new RuntimeException('Could not connect to MySQL.');
 		}


### PR DESCRIPTION
As of [March 4](https://github.com/php/php-src/commit/fd1578c196575c7e120a84ee030bb87c14a199b0), PHP 7 no longer has the `ext/mysql` extension.  This PR blocks instantiating the driver in this environment by throwing an exception if the PHP major version is 7 or greater (6 is left as allowed since the code is presumably present in the once-upon-a-time-in-development PHP 6 branch).
