### PR TITLE
Config doesn't output error message, when we have a required field (PHP ...

### DIFF
--- a/components/com_config/model/form.php
+++ b/components/com_config/model/form.php
@@ -308,7 +308,7 @@ abstract class ConfigModelForm extends ConfigModelCms
 			// Get the validation messages from the form.
 			foreach ($form->getErrors() as $message)
 			{
-				JFactory::getApplication()->enqueueMessage($message, 'error');
+				JFactory::getApplication()->enqueueMessage($message->getMessage(), 'error');
 			}
 
 			return false;

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -344,7 +344,9 @@ class JCategories
 						$this->_nodes[$result->id]->setParent($this->_nodes[$result->parent_id]);
 					}
 
-					if (!isset($this->_nodes[$result->parent_id]))
+					// If the node's parent id is not in the _nodes list and the node is not root (doesn't have parent_id == 0),
+					// then remove the node from the list
+					if (!(isset($this->_nodes[$result->parent_id]) || $result->parent_id == 0))
 					{
 						unset($this->_nodes[$result->id]);
 						continue;


### PR DESCRIPTION
...validation, not JS!).

This is the same fix as here: https://github.com/joomla/joomla-cms/pull/3026, except that in the old pull request I've somehow screwed it up...

When I originally fixed this issue, the configuration didn't have Javascript validation. That is why I was able to run into this. Right now the config has a javascript validation and we can only run into the issue when we turn it off. But despite the fact that we can't run into the issue when js validation is on, it doesn't change the fact that the php code is wrong. 

Testing instructions:
First we need to disable the javascript validation. Go to: 
administrator\components\com_config\view\component\tmpl\default.php
comment out line 23,24 & 27. At the end your code should look like this:

```
Joomla.submitbutton = function(task)
    {
//      if (task === "config.cancel.component" || document.formvalidator.isValid(document.getElementById("component-form")))
//      {
            Joomla.submitform(task, document.getElementById("component-form"));
//      }
    };
```

After that test it with CMandrill:
First download CMandrill from:
https://compojoom.com/downloads/official-releases-stable/mandrill

then install it. Now go to components -> CMandrill options. Go to the permissions tab and try to change any permission. Save. The page will refresh without any error message and the permissions that you've applied shouldn't be saved.

Now apply the patch and try to save the config again. This time you'll see the error message. 
