### PR TITLE
Switch to mysqli driver if mysql selected in PHP 7

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -255,6 +255,45 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		$options['database'] = (isset($options['database'])) ? $options['database'] : null;
 		$options['select']   = (isset($options['select'])) ? $options['select'] : true;
 
+		// If the selected driver is `mysql` and we are on PHP 7 or greater, switch to the `mysqli` driver.
+		if ($options['driver'] == 'mysql' && PHP_MAJOR_VERSION >= 7)
+		{
+			// Check if we have support for the other MySQL drivers
+			$mysqliSupported   = JDatabaseDriverMysqli::isSupported();
+			$pdoMysqlSupported = JDatabaseDriverPdomysql::isSupported();
+
+			// If neither is supported, then the user cannot use MySQL; throw an exception
+			if (!$mysqliSupported && !$pdoMysqlSupported)
+			{
+				throw new RuntimeException(
+					'The PHP `ext/mysql` extension is removed in PHP 7, cannot use the `mysql` driver.'
+					. ' Also, this system does not support MySQLi or PDO MySQL.  Cannot instantiate database driver.'
+				);
+			}
+
+			// Prefer MySQLi as it is a closer replacement for the removed MySQL driver, otherwise use the PDO driver
+			if ($mysqliSupported)
+			{
+				JLog::add(
+					'The PHP `ext/mysql` extension is removed in PHP 7, cannot use the `mysql` driver.  Trying `mysqli` instead.',
+					JLog::WARNING,
+					'deprecated'
+				);
+
+				$options['driver'] = 'mysqli';
+			}
+			else
+			{
+				JLog::add(
+					'The PHP `ext/mysql` extension is removed in PHP 7, cannot use the `mysql` driver.  Trying `pdomysql` instead.',
+					JLog::WARNING,
+					'deprecated'
+				);
+
+				$options['driver'] = 'pdomysql';
+			}
+		}
+
 		// Get the options signature for the database connector.
 		$signature = md5(serialize($options));
 


### PR DESCRIPTION
This updates `JDatabaseDriver::getInstance()` to detect if the requested driver is `mysql` which uses the removed `ext/mysql` PHP extension in PHP 7 and changes the driver option to `mysqli` in this environment.  A message is logged to the deprecation logger so that a site admin can pick up on the error without disclosing any info to end users.

Note that this is not a guaranteed failsafe; if for whatever reason an environment doesn't have the `ext/mysqli` PHP extension this will fail.
