### PR TITLE
Add tests for JLanguageMultilang

### DIFF
--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -20,11 +20,13 @@ class JLanguageMultilang
 	 * Method to determine if the language filter plugin is enabled.
 	 * This works for both site and administrator.
 	 *
+	 * @param   JApplicationCms  $app  The application object
+	 *
 	 * @return  boolean  True if site is supporting multiple languages; false otherwise.
 	 *
 	 * @since   2.5.4
 	 */
-	public static function isEnabled()
+	public static function isEnabled(JApplicationCms $app = null)
 	{
 		// Flag to avoid doing multiple database queries.
 		static $tested = false;
@@ -32,8 +34,11 @@ class JLanguageMultilang
 		// Status of language filter plugin.
 		static $enabled = false;
 
-		// Get application object.
-		$app = JFactory::getApplication();
+		// Get application object if not injected.
+		if (!$app)
+		{
+			$app = JFactory::getApplication();
+		}
 
 		// If being called from the front-end, we can avoid the database query.
 		if ($app->isSite())

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -65,6 +65,6 @@ class JLanguageMultilang
 			$tested = true;
 		}
 
-		return $enabled;
+		return (bool) $enabled;
 	}
 }

--- a/tests/unit/suites/libraries/cms/language/JLanguageMultilangTest.php
+++ b/tests/unit/suites/libraries/cms/language/JLanguageMultilangTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Language
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+use Joomla\Registry\Registry;
+
+/**
+ * Test class for JLanguageMultiLang.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Language
+ * @since       3.4
+ */
+class JLanguageMultiLangTest extends TestCaseDatabase
+{
+	/**
+	 * Value for test host.
+	 *
+	 * @var    string
+	 * @since  3.2
+	 */
+	const TEST_HTTP_HOST = 'mydomain.com';
+
+	/**
+	 * Value for test user agent.
+	 *
+	 * @var    string
+	 * @since  3.2
+	 */
+	const TEST_USER_AGENT = 'Mozilla/5.0';
+
+	/**
+	 * Value for test user agent.
+	 *
+	 * @var    string
+	 * @since  3.2
+	 */
+	const TEST_REQUEST_URI = '/index.php';
+
+	/**
+	 * Backup of the SERVER superglobal
+	 *
+	 * @var    array
+	 * @since  3.4
+	 */
+	protected $backupServer;
+
+	/**
+	 * Config to be injected into the Application object
+	 *
+	 * @var    Registry
+	 * @since  3.4
+	 */
+	protected $config;
+
+	/**
+	 * Setup for testing.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->saveFactoryState();
+
+		JFactory::$document = $this->getMockDocument();
+		JFactory::$language = $this->getMockLanguage();
+		JFactory::$session  = $this->getMockSession();
+
+		$this->backupServer = $_SERVER;
+
+		$_SERVER['HTTP_HOST'] = self::TEST_HTTP_HOST;
+		$_SERVER['HTTP_USER_AGENT'] = self::TEST_USER_AGENT;
+		$_SERVER['REQUEST_URI'] = self::TEST_REQUEST_URI;
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+
+		// Set the config for the app
+		$this->config = new Registry;
+		$this->config->set('session', false);
+	}
+
+	/**
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   3.2
+	 */
+	protected function tearDown()
+	{
+		// Reset the dispatcher instance.
+		TestReflection::setValue('JEventDispatcher', 'instance', null);
+
+		$_SERVER = $this->backupServer;
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet
+	 *
+	 * @since   3.4
+	 */
+	protected function getDataSet()
+	{
+		$dataSet = new PHPUnit_Extensions_Database_DataSet_CsvDataSet(',', "'", '\\');
+
+		$dataSet->addTable('jos_extensions', JPATH_TEST_DATABASE . '/jos_extensions.csv');
+
+		return $dataSet;
+	}
+
+	/**
+	 * @testdox  Ensure isEnabled() proxies correctly to JApplicationSite
+	 *
+	 * @covers   JLanguageMultiLang::isEnabled
+	 * @uses     JApplicationSite
+	 */
+	public function testIsEnabledWithSiteApp()
+	{
+		$app = new JApplicationSite($this->getMockInput(), $this->config);
+
+		$this->assertFalse(
+			JLanguageMultilang::isEnabled($app)
+		);
+	}
+
+	/**
+	 * @testdox  Ensure isEnabled() database query works correctly
+	 *
+	 * @covers   JLanguageMultiLang::isEnabled
+	 * @uses     JApplicationAdministrator
+	 */
+	public function testIsEnabledWithAdminApp()
+	{
+		$app = new JApplicationAdministrator($this->getMockInput(), $this->config);
+
+		$this->assertFalse(
+			JLanguageMultilang::isEnabled($app)
+		);
+	}
+}


### PR DESCRIPTION
There is a small change to allow the application object to be injected in to allow unit tests this can be tested easily by just navigating around Joomla.

Finally as per the doc block I've typecast the result to be a boolean as it was returning the string 0 on false and 1 on true for the enabled state of the plugin (as these are the values stored in the database). Currently you get true and false in the frontend and 0 and 1 in the backend.
## Testing

All the routing in the frontend depends on this class so navigate around and ensure that with plugin enabled and disabled everything works as expected.

In the backend ensure that the modal views when you are selecting a single item in the menu show everything properly
