### PR TITLE
Deprecate JHtml::getJSObject

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1057,10 +1057,14 @@ abstract class JHtml
 	 *
 	 * @return  string  JavaScript object notation representation of the array
 	 *
+	 * @deprecated 4.0 use json_encode or JRegistry::toString('json')
+	 *
 	 * @since   3.0
 	 */
 	public static function getJSObject(array $array = array())
 	{
+		JLog::add(__METHOD__ . ' is deprecated. Use json_encode instead.', JLog::WARNING, 'deprecated');
+
 		$elements = array();
 
 		foreach ($array as $k => $v)


### PR DESCRIPTION
looks like `JHtml::getJSObject` some Joomla! 1.5 legacy [CMS google group](https://groups.google.com/forum/#!topic/joomla-dev-cms/wEu7yJjS2bo)

in current state it can be replaced by `json_encode`

**how to test**
Here is complicated part: need to catch PLT member, can be need some :beer: or even :beers:, but do not use :bear: 
After that ask him to look at this issue 
