### PR TITLE
Fix for  Language names appear with parentheses in wrong place

### DIFF
--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -39,7 +39,7 @@ abstract class ModLoginHelper
 		);
 
 		// Fix wrongly set parentheses in RTL languages
-		if(JFactory::getLanguage()->isRTL())
+		if (JFactory::getLanguage()->isRTL())
 		{
 			foreach ($languages as &$language)
 			{

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -38,6 +38,15 @@ abstract class ModLoginHelper
 			}
 		);
 
+		// Fix wrongly set parentheses in RTL languages
+		if(JFactory::getLanguage()->isRTL())
+		{
+			foreach ($languages as &$language)
+			{
+				$language['text'] = $language['text'] . '&#x200E;';
+			}
+		}
+
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 
 		return JHtml::_('select.genericlist', $languages, 'lang', ' class="advancedSelect"', 'value', 'text', null);


### PR DESCRIPTION
Please see #6445 for more details!

**How to test?**

Install a RLT language (e.g. Hebrew) and go to the login screen in the backend (see screenshot in linked issue). After applying this patch the parentheses are set properly in the selection list.

Thank you @credenceweb for reporting this.
