### PR TITLE
"Warning: Extension record not found in database" in template edit

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -1138,7 +1138,7 @@ class TemplatesModelTemplate extends JModelForm
 
 		$query->select('id, client_id');
 		$query->from('#__template_styles');
-		$query->where($db->quoteName('template') . ' = ' . $db->quote($this->template->name));
+		$query->where($db->quoteName('template') . ' = ' . $db->quote($this->template->element));
 
 		$db->setQuery($query);
 


### PR DESCRIPTION
### Issue

When you edit the template (not the template style!) in the template manager, you may see a warning "Extension record not found in database.". This doesn't occur for core templates. It only happens for templates where the name specified in the XML file doesn't match the (sanitised) folder that will be created.
You can use my template from http://www.bakual.net/download/less-allrounder/less-allrounder-2-1-0.html to verify that. The template name is "{LESS} Allrounder" which will be sanitised to "lessallrounder". (I know the template is crap, don't judge me on that _g_)
### Explanation

In the #__extension table, we store both a `name` and an `element` for the template. The name is stored as is defined in the XML manifest file, and the element is the sanitised name which will be used for the folder and to reference the template in the #__template_styles table (and probably many more places).
Now we look at the `TemplatesModelTemplate->getPreview()` method and see that the query there looks for the name of the template, when it instead should look for the element.
This is why the query will fail and produce this warning.
### Test Instructions
1. Install the "{LESS} Allrounder" template from http://www.bakual.net/download/less-allrounder/less-allrounder-2-1-0.html
2. Go to the Template Manager -> Templates view and click there on the link to edit the files on this template.
3. Verify you see a warning "Extension record not found in database.". If you have error reporting enabled and set on "maximum" or "development" you will also see two notices like "Trying to get property of non-object in ...\administrator\components\com_templates\views\template\view.html.php on line 224" and "Trying to get property of non-object in ...\administrator\components\com_templates\views\template\view.html.php on line 226". Clicking the "Template Preview" button will load the page with the default template, and not with the one your editing.
4. Apply this PR and reload the page
5. There should be no warning message anymore and the button should properly work.
