### PR TITLE
Fix gh-6397 isSafeFile fails on deeply nested $_FILES

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -327,13 +327,13 @@ class JFilterInput
 	 * Checks an uploaded for suspicious naming and potential PHP contents which could indicate a hacking attempt.
 	 *
 	 * The options you can define are:
-	 * null_byte Prevent files with a null byte in their name (buffer overflow attack)
-	 * forbidden_extensions Do not allow these strings anywhere in the file's extension
-	 * php_tag_in_content Do not allow <?php tag in content
-	 * shorttag_in_content Do not allow short tag <? in content
-	 * shorttag_extensions Which file extensions to scan for short tags in content
-	 * fobidden_ext_in_content Do not allow forbidden_extensions anywhere in content
-	 * php_ext_content_extensions Which file extensions to scan for .php in content
+	 * null_byte                   Prevent files with a null byte in their name (buffer overflow attack)
+	 * forbidden_extensions        Do not allow these strings anywhere in the file's extension
+	 * php_tag_in_content          Do not allow <?php tag in content
+	 * shorttag_in_content         Do not allow short tag <? in content
+	 * shorttag_extensions         Which file extensions to scan for short tags in content
+	 * fobidden_ext_in_content     Do not allow forbidden_extensions anywhere in content
+	 * php_ext_content_extensions  Which file extensions to scan for .php in content
 	 *
 	 * This code is an adaptation and improvement of Admin Tools' UploadShield feature,
 	 * relicensed and contributed by its author.

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -327,14 +327,13 @@ class JFilterInput
 	 * Checks an uploaded for suspicious naming and potential PHP contents which could indicate a hacking attempt.
 	 *
 	 * The options you can define are:
-	 *
-	 * null_byte                   Prevent files with a null byte in their name (buffer overflow attack)
-	 * forbidden_extensions        Do not allow these strings anywhere in the file's extension
-	 * php_tag_in_content          Do not allow <?php tag in content
-	 * shorttag_in_content         Do not allow short tag <? in content
-	 * shorttag_extensions         Which file extensions to scan for short tags in content
-	 * fobidden_ext_in_content     Do not allow forbidden_extensions anywhere in content
-	 * php_ext_content_extensions  Which file extensions to scan for .php in content
+	 * null_byte Prevent files with a null byte in their name (buffer overflow attack)
+	 * forbidden_extensions Do not allow these strings anywhere in the file's extension
+	 * php_tag_in_content Do not allow <?php tag in content
+	 * shorttag_in_content Do not allow short tag <? in content
+	 * shorttag_extensions Which file extensions to scan for short tags in content
+	 * fobidden_ext_in_content Do not allow forbidden_extensions anywhere in content
+	 * php_ext_content_extensions Which file extensions to scan for .php in content
 	 *
 	 * This code is an adaptation and improvement of Admin Tools' UploadShield feature,
 	 * relicensed and contributed by its author.
@@ -372,207 +371,223 @@ class JFilterInput
 		$options = array_merge($defaultOptions, $options);
 
 		// Make sure we can scan nested file descriptors
-		if (is_array($file) && !array_key_exists('tmp_name', $file))
+		$descriptors = $file;
+
+		if (isset($file['name']) && isset($file['tmp_name']))
 		{
-			$descriptors = $file;
-		}
-		else
-		{
-			$descriptors = array($file);
+			$descriptors = self::decodeFileData(array(
+				$file['name'],
+				$file['type'],
+				$file['tmp_name'],
+				$file['error'],
+				$file['size']
+			));
 		}
 
 		// Scan all descriptors detected
-		foreach ($descriptors as $descriptor)
+		foreach ($descriptors as $fileDescriptor)
 		{
-			// Get the files of the current descriptor
-			$files = array();
-
-			if (is_array($descriptor['tmp_name']))
+			if (!isset($fileDescriptor['name']))
 			{
-				foreach ($descriptor['tmp_name'] as $key => $value)
+				// This is a nested descriptor. We have to recurse.
+				if (!self::isSafeFile($fileDescriptor, $options))
 				{
-					$files[] = array(
-						'name'     => $descriptor['name'][$key],
-						'type'     => $descriptor['type'][$key],
-						'tmp_name' => $descriptor['tmp_name'][$key],
-						'error'    => $descriptor['error'][$key],
-						'size'     => $descriptor['size'][$key],
-					);
+					return false;
 				}
-			}
-			else
-			{
-				$files[] = $descriptor;
+
+				continue;
 			}
 
-			// Scan each file in the descriptor
-			foreach ($files as $fileDescriptor)
+			$tempNames     = $fileDescriptor['tmp_name'];
+			$intendedNames = $fileDescriptor['name'];
+
+			if (!is_array($tempNames))
 			{
-				$tempNames     = $fileDescriptor['tmp_name'];
-				$intendedNames = $fileDescriptor['name'];
+				$tempNames = array($tempNames);
+			}
 
-				if (!is_array($tempNames))
+			if (!is_array($intendedNames))
+			{
+				$intendedNames = array($intendedNames);
+			}
+
+			$len = count($tempNames);
+
+			for ($i = 0; $i < $len; $i++)
+			{
+				$tempName     = array_shift($tempNames);
+				$intendedName = array_shift($intendedNames);
+
+				// 1. Null byte check
+				if ($options['null_byte'])
 				{
-					$tempNames = array($tempNames);
-				}
-
-				if (!is_array($intendedNames))
-				{
-					$intendedNames = array($intendedNames);
-				}
-
-				$len = count($tempNames);
-
-				for ($i = 0; $i < $len; $i++)
-				{
-					$tempName     = array_shift($tempNames);
-					$intendedName = array_shift($intendedNames);
-
-					// 1. Null byte check
-					if ($options['null_byte'])
+					if (strstr($intendedName, "\x00"))
 					{
-						if (strstr($intendedName, "\x00"))
+						return false;
+					}
+				}
+
+				// 2. PHP-in-extension check (.php, .php.xxx[.yyy[.zzz[...]]], .xxx[.yyy[.zzz[...]]].php)
+				if (!empty($options['forbidden_extensions']))
+				{
+					$explodedName = explode('.', $intendedName);
+					array_reverse($explodedName);
+					array_pop($explodedName);
+					array_map('strtolower', $explodedName);
+
+					/*
+					 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+					 * be set, i.e. they should have unique values.
+					 */
+					foreach ($options['forbidden_extensions'] as $ext)
+					{
+						if (in_array($ext, $explodedName))
 						{
 							return false;
 						}
 					}
+				}
 
-					// 2. PHP-in-extension check (.php, .php.xxx[.yyy[.zzz[...]]], .xxx[.yyy[.zzz[...]]].php)
-					if (!empty($options['forbidden_extensions']))
+				// 3. File contents scanner (PHP tag in file contents)
+				if ($options['php_tag_in_content'] || $options['shorttag_in_content']
+					|| ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions'])))
+				{
+					$fp = @fopen($tempName, 'r');
+
+					if ($fp !== false)
 					{
-						$explodedName = explode('.', $intendedName);
-						array_reverse($explodedName);
-						array_pop($explodedName);
-						array_map('strtolower', $explodedName);
+						$data = '';
 
-						/*
-						 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
-						 * be set, i.e. they should have unique values.
-						 */
-						foreach ($options['forbidden_extensions'] as $ext)
+						while (!feof($fp))
 						{
-							if (in_array($ext, $explodedName))
+							$buffer = @fread($fp, 131072);
+							$data .= $buffer;
+
+							if ($options['php_tag_in_content'] && strstr($buffer, '<?php'))
 							{
 								return false;
 							}
-						}
-					}
 
-					// 3. File contents scanner (PHP tag in file contents)
-					if ($options['php_tag_in_content'] || $options['shorttag_in_content']
-						|| ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions'])))
-					{
-						$fp = @fopen($tempName, 'r');
-
-						if ($fp !== false)
-						{
-							$data = '';
-
-							while (!feof($fp))
+							if ($options['shorttag_in_content'])
 							{
-								$buffer = @fread($fp, 131072);
-								$data .= $buffer;
+								$suspiciousExtensions = $options['shorttag_extensions'];
 
-								if ($options['php_tag_in_content'] && strstr($buffer, '<?php'))
+								if (empty($suspiciousExtensions))
 								{
-									return false;
+									$suspiciousExtensions = array(
+										'inc', 'phps', 'class', 'php3', 'php4', 'txt', 'dat', 'tpl', 'tmpl'
+									);
 								}
 
-								if ($options['shorttag_in_content'])
+								/*
+								 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+								 * be set, i.e. they should have unique values.
+								 */
+								$collide = false;
+
+								foreach ($suspiciousExtensions as $ext)
 								{
-									$suspiciousExtensions = $options['shorttag_extensions'];
-
-									if (empty($suspiciousExtensions))
+									if (in_array($ext, $explodedName))
 									{
-										$suspiciousExtensions = array(
-											'inc', 'phps', 'class', 'php3', 'php4', 'txt', 'dat', 'tpl', 'tmpl'
-										);
-									}
+										$collide = true;
 
+										break;
+									}
+								}
+
+								if ($collide)
+								{
+									// These are suspicious text files which may have the short tag (<?) in them
+									if (strstr($buffer, '<?'))
+									{
+										return false;
+									}
+								}
+							}
+
+							if ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions']))
+							{
+								$suspiciousExtensions = $options['php_ext_content_extensions'];
+
+								if (empty($suspiciousExtensions))
+								{
+									$suspiciousExtensions = array(
+										'zip', 'rar', 'tar', 'gz', 'tgz', 'bz2', 'tbz', 'jpa'
+									);
+								}
+
+								/*
+								 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+								 * be set, i.e. they should have unique values.
+								 */
+								$collide = false;
+
+								foreach ($suspiciousExtensions as $ext)
+								{
+									if (in_array($ext, $explodedName))
+									{
+										$collide = true;
+
+										break;
+									}
+								}
+
+								if ($collide)
+								{
 									/*
-									 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
-									 * be set, i.e. they should have unique values.
+									 * These are suspicious text files which may have an executable
+									 * file extension in them
 									 */
-									$collide = false;
-
-									foreach ($suspiciousExtensions as $ext)
+									foreach ($options['forbidden_extensions'] as $ext)
 									{
-										if (in_array($ext, $explodedName))
-										{
-											$collide = true;
-
-											break;
-										}
-									}
-
-									if ($collide)
-									{
-										// These are suspicious text files which may have the short tag (<?) in them
-										if (strstr($buffer, '<?'))
+										if (strstr($buffer, '.' . $ext))
 										{
 											return false;
 										}
 									}
 								}
-
-								if ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions']))
-								{
-									$suspiciousExtensions = $options['php_ext_content_extensions'];
-
-									if (empty($suspiciousExtensions))
-									{
-										$suspiciousExtensions = array(
-											'zip', 'rar', 'tar', 'gz', 'tgz', 'bz2', 'tbz', 'jpa'
-										);
-									}
-
-									/*
-									 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
-									 * be set, i.e. they should have unique values.
-									 */
-									$collide = false;
-
-									foreach ($suspiciousExtensions as $ext)
-									{
-										if (in_array($ext, $explodedName))
-										{
-											$collide = true;
-
-											break;
-										}
-									}
-
-									if ($collide)
-									{
-										/*
-										 * These are suspicious text files which may have an executable
-										 * file extension in them
-										 */
-										foreach ($options['forbidden_extensions'] as $ext)
-										{
-											if (strstr($buffer, '.' . $ext))
-											{
-												return false;
-											}
-										}
-									}
-								}
-
-								/*
-								 * This makes sure that we don't accidentally skip a <?php tag if it's across
-								 * a read boundary, even on multibyte strings
-								 */
-								$data = substr($data, -8);
 							}
 
-							fclose($fp);
+							/*
+							 * This makes sure that we don't accidentally skip a <?php tag if it's across
+							 * a read boundary, even on multibyte strings
+							 */
+							$data = substr($data, -8);
 						}
+
+						fclose($fp);
 					}
 				}
 			}
 		}
 
 		return true;
+	}
+
+	/**
+	 * Method to decode a file data array.
+	 *
+	 * @param   array  $data  The data array to decode.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	protected static function decodeFileData(array $data)
+	{
+		$result = array();
+
+		if (is_array($data[0]))
+		{
+			foreach ($data[0] as $k => $v)
+			{
+				$result[$k] = self::decodeFileData(array($data[0][$k], $data[1][$k], $data[2][$k], $data[3][$k], $data[4][$k]));
+			}
+
+			return $result;
+		}
+
+		return array('name' => $data[0], 'type' => $data[1], 'tmp_name' => $data[2], 'error' => $data[3], 'size' => $data[4]);
 	}
 
 	/**

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -375,13 +375,15 @@ class JFilterInput
 
 		if (isset($file['name']) && isset($file['tmp_name']))
 		{
-			$descriptors = self::decodeFileData(array(
-				$file['name'],
-				$file['type'],
-				$file['tmp_name'],
-				$file['error'],
-				$file['size']
-			));
+			$descriptors = self::decodeFileData(
+				array(
+					$file['name'],
+					$file['type'],
+					$file['tmp_name'],
+					$file['error'],
+					$file['size']
+				)
+			);
 		}
 
 		// Scan all descriptors detected

--- a/libraries/joomla/input/files.php
+++ b/libraries/joomla/input/files.php
@@ -47,15 +47,6 @@ class JInputFiles extends JInput
 		// Set the data source.
 		$this->data = & $_FILES;
 
-		// Scan the files in the array
-		if (!empty($this->data))
-		{
-			foreach ($this->data as $name => &$descriptor)
-			{
-				$descriptor['safe'] = JFilterInput::isSafeFile($descriptor);
-			}
-		}
-
 		// Set the options for the class.
 		$this->options = $options;
 	}
@@ -76,15 +67,6 @@ class JInputFiles extends JInput
 	{
 		if (isset($this->data[$name]))
 		{
-			// Prevent returning an unsafe file unless specifically requested
-			if (!$this->data[$name]['safe'])
-			{
-				if ($filter != 'raw')
-				{
-					return $default;
-				}
-			}
-
 			$results = $this->decodeData(
 				array(
 					$this->data[$name]['name'],
@@ -94,6 +76,17 @@ class JInputFiles extends JInput
 					$this->data[$name]['size']
 				)
 			);
+
+			// Prevent returning an unsafe file unless speciffically requested
+			if ($filter != 'raw')
+			{
+				$isSafe = JFilterInput::isSafeFile($results);
+
+				if (!$isSafe)
+				{
+					return $default;
+				}
+			}
 
 			return $results;
 		}


### PR DESCRIPTION
This PR fixes gh-6397 "JFilterInput::isSafeFile() fail on very deep $_FILES array"
# Testing instructions
- Download and install the Joomla! 3 sample component from https://github.com/joomla/Joomla-3.2-Hello-World-Component/archive/step-10-adding-decorations-to-the-backend.zip
- Open the file administrator/components/com_helloworld/models/forms/helloworld.xml and add the following before the closing `</fieldset>`

``` xml
        <field type="file" name="document"  label="Document" />
        <fields name="files">
            <fields name="files0">
                <field type="file" name="file"  label="File 1" />
            </fields>
            <fields name="files1">
                <field type="file" name="file"  label="File 2" />
            </fields>
            <fields name="files2">
                <field type="file" name="file"  label="File 3" />
            </fields>
        </fields>
        <fields name="images">
            <fields name="images0">
                <field type="file" name="file"  label="Images 1" />
            </fields>
            <fields name="images1">
                <field type="file" name="file"  label="Images 2" />
            </fields>
        </fields>
```
- Open the file administrator/components/com_helloworld/controllers/helloworld.php and add the following between the two curly braces

``` php
    public function save($key = null, $urlVar = null)
    {
        $app = JFactory::getApplication();
        $files = $app->input->files->get('jform');

        die('CHECK');

        return parent::save($key, $urlVar); // TODO: Change the autogenerated stub
    }
```
- Go to Global Configuration and set Error Reporting to Development
- Go to Components, Hello World and click on the "Hello, world" link to edit the item.
- Click each file selection field and choose a small image from your computer. It's best to select files where each one is less than 100Kb to prevent upload issues with PHP itself.
- Click on the Save & Close button

**Result before the patch**
A lot of PHP warnings

**Result after the patch**
No PHP warnings, just the word "CHECK" printed on your page
# Technical notes

There were two corrective actions taken:
- The safe file check was moved into get(). This may have a performance impact on unoptimised code calling $app->input->files->get() repeatedly over the same files, but there's no work around due to the way PHP reports uploaded files. Sorry :(
- The JFilterInput::isSafeFile method was modified to handle nested file arrays, either in the raw $_FILES format or as nested arrays of file descriptors (these are the only two possible variations that exist)

Signed-off-by: Nicholas K. Dionysopoulos nicholas@akeebabackup.com
