### PR TITLE
Allow toolbar popup buttons use bootstrap footer

### DIFF
--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -43,7 +43,7 @@ class JToolbarButtonPopup extends JToolbarButton
 	 * @since   3.0
 	 */
 	public function fetchButton($type = 'Modal', $name = '', $text = '', $url = '', $width = 640, $height = 480, $top = 0, $left = 0,
-		$onClose = '', $title = '', $footer = '')
+		$onClose = '', $title = '', $footer = null)
 	{
 		// If no $title is set, use the $text element
 		if (strlen($title) == 0)
@@ -74,7 +74,7 @@ class JToolbarButtonPopup extends JToolbarButton
 		$params['url']    = $options['doTask'];
 		$params['height'] = $height;
 		$params['width']  = $width;
-		$params['footer']  = $footer;
+		if (isset($footer)) $params['footer'] = $footer;
 		$html[] = JHtml::_('bootstrap.renderModal', 'modal-' . $name, $params);
 
 		// If an $onClose event is passed, add it to the modal JS object

--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -36,13 +36,13 @@ class JToolbarButtonPopup extends JToolbarButton
 	 * @param   integer  $left     Left attribute. [@deprecated  Unused, will be removed in 4.0]
 	 * @param   string   $onClose  JavaScript for the onClose event.
 	 * @param   string   $title    The title text
+	 * @param   string   $footer    The footer html
 	 *
 	 * @return  string  HTML string for the button
 	 *
 	 * @since   3.0
 	 */
-	public function fetchButton($type = 'Modal', $name = '', $text = '', $url = '', $width = 640, $height = 480, $top = 0, $left = 0,
-		$onClose = '', $title = '')
+	public function fetchButton($type = 'Modal', $name = '', $text = '', $url = '', $width = 640, $height = 480, $top = 0, $left = 0, $onClose = '', $title = '', $footer = '')
 	{
 		// If no $title is set, use the $text element
 		if (strlen($title) == 0)
@@ -73,6 +73,7 @@ class JToolbarButtonPopup extends JToolbarButton
 		$params['url']    = $options['doTask'];
 		$params['height'] = $height;
 		$params['width']  = $width;
+		$params['footer']  = $footer;
 		$html[] = JHtml::_('bootstrap.renderModal', 'modal-' . $name, $params);
 
 		// If an $onClose event is passed, add it to the modal JS object

--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -42,7 +42,8 @@ class JToolbarButtonPopup extends JToolbarButton
 	 *
 	 * @since   3.0
 	 */
-	public function fetchButton($type = 'Modal', $name = '', $text = '', $url = '', $width = 640, $height = 480, $top = 0, $left = 0, $onClose = '', $title = '', $footer = '')
+	public function fetchButton($type = 'Modal', $name = '', $text = '', $url = '', $width = 640, $height = 480, $top = 0, $left = 0,
+		$onClose = '', $title = '', $footer = '')
 	{
 		// If no $title is set, use the $text element
 		if (strlen($title) == 0)

--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -36,7 +36,7 @@ class JToolbarButtonPopup extends JToolbarButton
 	 * @param   integer  $left     Left attribute. [@deprecated  Unused, will be removed in 4.0]
 	 * @param   string   $onClose  JavaScript for the onClose event.
 	 * @param   string   $title    The title text
-	 * @param   string   $footer    The footer html
+	 * @param   string   $footer   The footer html
 	 *
 	 * @return  string  HTML string for the button
 	 *

--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -74,7 +74,12 @@ class JToolbarButtonPopup extends JToolbarButton
 		$params['url']    = $options['doTask'];
 		$params['height'] = $height;
 		$params['width']  = $width;
-		if (isset($footer)) $params['footer'] = $footer;
+
+		if (isset($footer))
+		{
+			$params['footer'] = $footer;
+		}
+
 		$html[] = JHtml::_('bootstrap.renderModal', 'modal-' . $name, $params);
 
 		// If an $onClose event is passed, add it to the modal JS object


### PR DESCRIPTION
#### Allow custom footer on BS modals rendered from toolbar button

This is a new feature requested at #4563
#### What it does?

Allows to render modal in the bootstrap official way, where the buttons are on the bottom of the modal window
#### How to test

Apply this patch and #4563
Change line 83 of administrator/components/com_messages/views/messages/view.html.php to

``` php
$bar->appendButton('Popup', 'cog', 'COM_MESSAGES_TOOLBAR_MY_SETTINGS', 'index.php?option=com_messages&amp;view=config&amp;tmpl=component', 600, 250, 0, 0, '', '', '<a href="#" class="btn">Close</a> <a href="#" class="btn btn-primary">Save changes</a>');
```

You should get:
![screen shot 2015-03-16 at 8 10 49](https://cloud.githubusercontent.com/assets/3889375/6672997/a706120c-cc18-11e4-95c0-40e2c1ea8f24.png)

Mind that the buttons are fake, no functionality is attached 
