### PR TITLE
importing media.less is missing in Isis template - replaces PR #6417

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1,4 +1,3 @@
-@import "../../../../media/jui/less/main.less";
 article,
 aside,
 details,
@@ -4212,6 +4211,35 @@ a.thumbnail:focus {
 .thumbnail .caption {
 	padding: 9px;
 	color: #555;
+}
+.media,
+.media-body {
+	overflow: hidden;
+	*overflow: visible;
+	zoom: 1;
+}
+.media,
+.media .media {
+	margin-top: 15px;
+}
+.media:first-child {
+	margin-top: 0;
+}
+.media-object {
+	display: block;
+}
+.media-heading {
+	margin: 0 0 5px;
+}
+.media > .pull-left {
+	margin-right: 10px;
+}
+.media > .pull-right {
+	margin-left: 10px;
+}
+.media-list {
+	margin-left: 0;
+	list-style: none;
 }
 .label,
 .badge {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1,3 +1,4 @@
+@import "../../../../media/jui/less/main.less";
 article,
 aside,
 details,

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1,4 +1,3 @@
-@import "../../../../media/jui/less/main.less";
 article,
 aside,
 details,
@@ -4212,6 +4211,35 @@ a.thumbnail:focus {
 .thumbnail .caption {
 	padding: 9px;
 	color: #555;
+}
+.media,
+.media-body {
+	overflow: hidden;
+	*overflow: visible;
+	zoom: 1;
+}
+.media,
+.media .media {
+	margin-top: 15px;
+}
+.media:first-child {
+	margin-top: 0;
+}
+.media-object {
+	display: block;
+}
+.media-heading {
+	margin: 0 0 5px;
+}
+.media > .pull-left {
+	margin-right: 10px;
+}
+.media > .pull-right {
+	margin-left: 10px;
+}
+.media-list {
+	margin-left: 0;
+	list-style: none;
 }
 .label,
 .badge {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1,3 +1,4 @@
+@import "../../../../media/jui/less/main.less";
 article,
 aside,
 details,

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -36,7 +36,7 @@
 @import "../../../../media/jui/less/popovers.less";
 // Components: Misc
 @import "../../../../media/jui/less/thumbnails.less";
-@import "../../../../media/jui/less/main.less";
+@import "../../../../media/jui/less/media.less";
 @import "../../../../media/jui/less/labels-badges.less";
 @import "../../../../media/jui/less/progress-bars.less";
 @import "../../../../media/jui/less/accordion.less";

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -36,6 +36,7 @@
 @import "../../../../media/jui/less/popovers.less";
 // Components: Misc
 @import "../../../../media/jui/less/thumbnails.less";
+@import "../../../../media/jui/less/main.less";
 @import "../../../../media/jui/less/labels-badges.less";
 @import "../../../../media/jui/less/progress-bars.less";
 @import "../../../../media/jui/less/accordion.less";


### PR DESCRIPTION
This Pull Request replaces #6417 and includes the generated .css files. 

Bootstrap 2.3.2 default available file called media.less is missing in Isis template. 
http://getbootstrap.com/2.3.2/components.html#media

example of use for this css output: when using an image in the description of an installed extension and you want to outline large text next to the image.

run "php build/generatecss.php" from CLI after changing administrator/templates/isis/less/template.less to generate compiled css files.
