### PR TITLE
IeCursorFix is TinyMCE's issue only.

### DIFF
--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -17,10 +17,10 @@ $button = $displayData;
 		$class    = ($button->get('class')) ? $button->get('class') : null;
 		$class	 .= ($button->get('modal')) ? ' modal-button' : null;
 		$href     = ($button->get('link')) ? ' href="' . JUri::base() . $button->get('link') . '"' : null;
-		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : ' onclick="IeCursorFix(); return false;"';
+		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
 	?>
-	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href . $onclick; ?> rel="<?php echo $button->get('options'); ?>">
+	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href, $onclick; ?> rel="<?php echo $button->get('options'); ?>">
 		<i class="icon-<?php echo $button->get('name'); ?>"></i> <?php echo $button->get('text'); ?>
 	</a>
 <?php endif;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -949,6 +949,12 @@ class PlgEditorTinymce extends JPlugin
 		if (is_array($buttons) || (is_bool($buttons) && $buttons))
 		{
 			$buttons = $this->_subject->getButtons($name, $buttons, $asset, $author);
+
+			foreach ($buttons as &$button)
+			{
+				$button->onclick = 'IeCursorFix(); return false;';
+			}
+
 			$return .= JLayoutHelper::render('joomla.editors.buttons', $buttons);
 		}
 


### PR DESCRIPTION
There is a JS function `IeCursorFix()` which is defined in the TinyMCE package. So why is this function being called as the default in the layout? It certainly shouldn't be. 
## Before

Use CodeMirror (or any editor other than TinyMCE). Click one of the buttons below the editor. Look in your browser's console. Error, right? Function doesn't exist. 
Try TinyMCE. Fine.
## After

Fine in all editors. 
