### PR TITLE
RTL: Language Manager: Language Names wrong display of parenthesis

### DIFF
--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -189,6 +189,12 @@ class LanguagesModelInstalled extends JModelList
 					$row->$key = $value;
 				}
 
+				// Fix wrongly set parentheses in RTL languages
+				if (JFactory::getLanguage()->isRTL())
+				{
+					$row->name = html_entity_decode($row->name . '&#x200E;', ENT_QUOTES, 'UTF-8');
+				}
+
 				// If current than set published.
 				$params = JComponentHelper::getParams('com_languages');
 

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -77,7 +77,6 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					</td>
 					<td width="25%">
 						<label for="cb<?php echo $i; ?>">
-							<?php $row->name = html_entity_decode($row->name . '&#x200E;', ENT_QUOTES, 'UTF-8'); ?>
 							<?php echo $this->escape($row->name); ?>
 						</label>
 					</td>

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -77,6 +77,7 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					</td>
 					<td width="25%">
 						<label for="cb<?php echo $i; ?>">
+							<?php $row->name = html_entity_decode($row->name . '&#x200E;', ENT_QUOTES, 'UTF-8'); ?>
 							<?php echo $this->escape($row->name); ?>
 						</label>
 					</td>


### PR DESCRIPTION
This patch is similar to #6445, but for the Language Manager.
To test, install Persian fa-IR or Arabic (ar-AA)
Go to
administrator/index.php?option=com_languages

before patch:

![screen shot 2015-03-17 at 11 31 38](https://cloud.githubusercontent.com/assets/869724/6685386/b07689b2-cc99-11e4-849f-ebe915f1ed50.png)

after patch

![parenthesis_after](https://cloud.githubusercontent.com/assets/869724/6685391/b6fb2112-cc99-11e4-9340-03b081e8497f.png)

test that all works fine when switching to en-GB
