### PR TITLE
Fix dataprovider of JPagination unittest

### DIFF
--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -692,7 +692,7 @@ class JPaginationTest extends TestCase
 		return array(
 			array('JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="" class="hasTooltip pagenav">JLIB_HTML_START</a>'),
 			array('JLIB_HTML_VIEW_ALL', 100, 40, 20, false, '<a title="JLIB_HTML_VIEW_ALL" href="" class="hasTooltip pagenav">JLIB_HTML_VIEW_ALL</a>'),
-			array('JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="#" onclick="document.adminForm.limitstart.value=0; Joomla.submitform();return false;">JLIB_HTML_START</a>')
+			array('JLIB_HTML_START', 100, 40, 20, true, '<a title="JLIB_HTML_START" href="#" onclick="document.adminForm.limitstart.value=0; Joomla.submitform();return false;">JLIB_HTML_START</a>')
 		);
 	}
 

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -690,11 +690,9 @@ class JPaginationTest extends TestCase
 	public function dataTestItemActive()
 	{
 		return array(
-			array(
-				'JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="" class="hasTooltip pagenav">JLIB_HTML_START</a>',
-				'JLIB_HTML_VIEW_ALL', 100, 40, 20, false, '<a title="JLIB_HTML_VIEW_ALL" href="" class="hasTooltip pagenav">JLIB_HTML_VIEW_ALL</a>',
-				'JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="#" onclick="document.adminForm.limitstart.value=0; Joomla.submitform();return false;">JLIB_HTML_START</a>',
-			),
+			array('JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="" class="hasTooltip pagenav">JLIB_HTML_START</a>'),
+			array('JLIB_HTML_VIEW_ALL', 100, 40, 20, false, '<a title="JLIB_HTML_VIEW_ALL" href="" class="hasTooltip pagenav">JLIB_HTML_VIEW_ALL</a>'),
+			array('JLIB_HTML_START', 100, 40, 20, false, '<a title="JLIB_HTML_START" href="#" onclick="document.adminForm.limitstart.value=0; Joomla.submitform();return false;">JLIB_HTML_START</a>')
 		);
 	}
 


### PR DESCRIPTION
This fixes the dataprovider of a JPagination unittest. By fixing this, the test fails. That is expected! We still have to fix the test itself. This PR is basically a work in progress and a reminder. @wilsonge and I will work on this further in the future.
