### PR TITLE
SQL syntax error on update to 3.4.1-rc with mysql/3.4.0-2015-02-26.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2015-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2015-02-26.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`) VALUES
-(700, 'COM_CPANEL_MSG_LANGUAGEACCESS340_TITLE', 'COM_CPANEL_MSG_LANGUAGEACCESS340_BODY', '', 'com_cpanel', 1, 'message', ', '', 'admin://components/com_admin/postinstall/languageaccess340.php', 'admin_postinstall_languageaccess340_condition', '3.4.1', 1);
+(700, 'COM_CPANEL_MSG_LANGUAGEACCESS340_TITLE', 'COM_CPANEL_MSG_LANGUAGEACCESS340_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/languageaccess340.php', 'admin_postinstall_languageaccess340_condition', '3.4.1', 1);


### PR DESCRIPTION
#### Steps to reproduce the issue

Update a multilingual Joomla <= 3.4.0 to a 3.4.1-rc on a system with msql database.
#### Expected result

The update succeeds. In post-install messages a new message with title COM_CPANEL_MSG_LANGUAGEACCESS340_TITLE should be shown.
#### Actual result

An SQL error is shown as follows for the insert statement for this new post-install message, the syntax error I have marked with bold italics:

```
An error has occurred.

    1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'admin://components/com_admin/postinstall/languageaccess340.php', 'admin_postinst' at line 2 SQL=INSERT INTO `c6gp0_postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`) VALUES (700, 'COM_CPANEL_MSG_LANGUAGEACCESS340_TITLE', 'COM_CPANEL_MSG_LANGUAGEACCESS340_BODY', '', 'com_cpanel', 1, 'message', ', '', 'admin://components/com_admin/postinstall/languageaccess340.php', 'admin_postinstall_languageaccess340_condition', '3.4.1', 1);
```

Note the unclosed single quote of the value for column `action`!
#### System information (as much as possible)

Database driver type is MySQLi, Joomla version see title.
#### Additional comments

Check of the SQL updates scripts 3.4.0-2015-02-26.sql has shown that the error was only in the one for MySQLi.
