### PR TITLE
Undefined variable lang_code in plugins/system/languagefilter/languagefilter.php on line 297

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -230,6 +230,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		// Did we find the current and existing language yet?
 		$found = false;
+		$lang_code = false;
 
 		// Are we in SEF mode or not?
 		if ($this->mode_sef)


### PR DESCRIPTION
Fixes #6481. Please refer to there for testing instructions.
