### PR TITLE
Start work on the JInstallerTests

### DIFF
--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -31,22 +31,7 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
-		$this->saveFactoryState();
-
 		$this->object = new JInstaller;
-	}
-
-	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 *
-	 * @return void
-	 */
-	protected function tearDown()
-	{
-		$this->restoreFactoryState();
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -33,7 +33,7 @@ class JInstallerTest extends TestCaseDatabase
 
 		$this->saveFactoryState();
 
-		$this->object = JInstaller::getInstance();
+		$this->object = new JInstaller;
 	}
 
 	/**
@@ -72,10 +72,16 @@ class JInstallerTest extends TestCaseDatabase
 	 */
 	public function testGetInstance()
 	{
-		$this->assertThat(
-			$this->object = JInstaller::getInstance(),
-			$this->isInstanceOf('JInstaller'),
-			'JInstaller::getInstance failed'
+		$object1 = JInstaller::getInstance();
+
+		$this->assertInstanceOf(
+			'JInstaller',
+			$object1
+		);
+
+		$this->assertSame(
+			$object1,
+			JInstaller::getInstance()
 		);
 	}
 
@@ -91,21 +97,18 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		$this->object->setOverwrite(false);
 
-		$this->assertThat(
+		$this->assertFalse(
 			$this->object->isOverwrite(),
-			$this->equalTo(false),
 			'Get or Set overwrite failed'
 		);
 
-		$this->assertThat(
+		$this->assertFalse(
 			$this->object->setOverwrite(true),
-			$this->equalTo(false),
 			'setOverwrite did not return the old value properly.'
 		);
 
-		$this->assertThat(
+		$this->assertTrue(
 			$this->object->isOverwrite(),
-			$this->equalTo(true),
 			'getOverwrite did not return the expected value.'
 		);
 	}
@@ -122,9 +125,9 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		$this->object->setRedirectUrl('http://www.example.com');
 
-		$this->assertThat(
+		$this->assertEquals(
 			$this->object->getRedirectUrl(),
-			$this->equalTo('http://www.example.com'),
+			'http://www.example.com',
 			'Get or Set Redirect Url failed'
 		);
 	}
@@ -141,21 +144,18 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		$this->object->setUpgrade(false);
 
-		$this->assertThat(
+		$this->assertFalse(
 			$this->object->isUpgrade(),
-			$this->equalTo(false),
 			'Get or Set Upgrade failed'
 		);
 
-		$this->assertThat(
+		$this->assertFalse(
 			$this->object->setUpgrade(true),
-			$this->equalTo(false),
 			'setUpgrade did not return the old value properly.'
 		);
 
-		$this->assertThat(
+		$this->assertTrue(
 			$this->object->isUpgrade(),
-			$this->equalTo(true),
 			'getUpgrade did not return the expected value.'
 		);
 	}
@@ -169,17 +169,17 @@ class JInstallerTest extends TestCaseDatabase
 	 */
 	public function testGetPath()
 	{
-		$this->assertThat(
+		$this->assertEquals(
 			$this->object->getPath('path1_getpath', 'default_value'),
-			$this->equalTo('default_value'),
+			'default_value',
 			'getPath did not return the default value for an undefined path'
 		);
 
 		$this->object->setPath('path2_getpath', JPATH_BASE . '/required_path');
 
-		$this->assertThat(
+		$this->assertEquals(
 			$this->object->getPath('path2_getpath', 'default_value'),
-			$this->equalTo(JPATH_BASE . '/required_path'),
+			JPATH_BASE . '/required_path',
 			'getPath did not return the previously set value for the path'
 		);
 	}
@@ -195,9 +195,8 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		$this->object->pushStep(array('type' => 'query'));
 
-		$this->assertThat(
-			$this->object->abort(),
-			$this->isFalse()
+		$this->assertFalse(
+			$this->object->abort()
 		);
 	}
 
@@ -221,9 +220,8 @@ class JInstallerTest extends TestCaseDatabase
 
 		$this->object->pushStep(array('type' => 'testtype'));
 
-		$this->assertThat(
-			$this->object->abort(null, 'testadapter'),
-			$this->isTrue()
+		$this->assertTrue(
+			$this->object->abort(null, 'testadapter')
 		);
 	}
 
@@ -238,9 +236,8 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		$this->object->pushStep(array('type' => 'badstep'));
 
-		$this->assertThat(
-			$this->object->abort(null, false),
-			$this->isFalse()
+		$this->assertFalse(
+			$this->object->abort(null, false)
 		);
 	}
 
@@ -256,16 +253,16 @@ class JInstallerTest extends TestCaseDatabase
 		$xml = JInstaller::parseXMLInstallFile(__DIR__ . '/data/pkg_joomla.xml');
 
 		// Verify the method returns an array of data
-		$this->assertThat(
+		$this->assertInternalType(
+			'array',
 			$xml,
-			$this->isType('array'),
 			'Ensure JInstaller::parseXMLInstallFile returns an array'
 		);
 
 		// Verify the version string in the $xml object matches that from the XML file
-		$this->assertThat(
+		$this->assertEquals(
 			$xml['version'],
-			$this->equalTo('2.5.0'),
+			'2.5.0',
 			'The version string should be 2.5.0 as specified in the parsed XML file'
 		);
 	}
@@ -279,9 +276,9 @@ class JInstallerTest extends TestCaseDatabase
 	 */
 	public function testIsManifest()
 	{
-		$this->assertThat(
+		$this->assertInstanceOf(
+			'SimpleXmlElement',
 			$this->object->isManifest(__DIR__ . '/data/pkg_joomla.xml'),
-			$this->isInstanceOf('SimpleXmlElement'),
 			'Ensure JInstaller::isManifest properly tests a valid manifest file'
 		);
 	}

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -227,6 +227,36 @@ class JInstallerTest extends TestCaseDatabase
 	}
 
 	/**
+	 * @testdox  Ensure parseLanguages() returns 0 when there are no children in the language tag
+	 *
+	 * @covers   JInstaller::parseLanguages
+	 */
+	public function testParseLanguagesWithNoChildren()
+	{
+		$emptyXml = new SimpleXMLElement('<languages></languages>');
+
+		$this->assertEquals(
+			0,
+			$this->object->parseLanguages($emptyXml)
+		);
+	}
+
+	/**
+	 * @testdox  Ensure parseFiles() returns 0 when there are no children in the files tag
+	 *
+	 * @covers   JInstaller::parseFiles
+	 */
+	public function testParseFilesWithNoChildren()
+	{
+		$emptyXml = new SimpleXMLElement('<files></files>');
+
+		$this->assertEquals(
+			0,
+			$this->object->parseFiles($emptyXml)
+		);
+	}
+
+	/**
 	 * Tests the parseXMLInstallFile method
 	 *
 	 * @since   3.1


### PR DESCRIPTION
Only way to check this is check the unit tests continue to function as expected.

Largely this is just making the checks more self-explanatory using the built in assertFalse etc commands rather than assert that.

It creates a new Installer instance instead of using getInstance.

I refactored the testGetInstance to first check the correct type was returned and then calling it again gives the same object

Finally I added two new tests to test basic functionality to `parseLanguages` and `parseFiles`
