### PR TITLE
RTL: Installation language list. Fix wrongly set parenthesis

### DIFF
--- a/installation/form/field/language.php
+++ b/installation/form/field/language.php
@@ -64,6 +64,15 @@ class InstallationFormFieldLanguage extends JFormFieldList
 		// Get the list of available languages.
 		$options = JLanguageHelper::createLanguageList($native);
 
+		// Fix wrongly set parentheses in RTL languages
+		if (JFactory::getLanguage()->isRTL())
+		{
+			foreach ($options as &$option)
+			{
+				$option['text'] = $option['text'] . '&#x200E;';
+			}
+		}
+
 		if (!$options || $options  instanceof Exception)
 		{
 			$options = array();


### PR DESCRIPTION
This patch is similar to https://github.com/joomla/joomla-cms/pull/6473 and https://github.com/joomla/joomla-cms/pull/6449

Before patch:

To test, install a new Joomla instance and swicth between RTL and LTR languages in the Select Language list.

![language_install_before](https://cloud.githubusercontent.com/assets/869724/6705558/5f513862-cd56-11e4-88de-fbd576100214.png)

after patch

![language_install_after](https://cloud.githubusercontent.com/assets/869724/6705564/6ce1235c-cd56-11e4-8c00-d4d613c277f5.png)
