### PR TITLE
fix for #6489

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -309,7 +309,7 @@ class ContentModelCategory extends JModelList
 		$secondary			= ContentHelperQuery::orderbySecondary($articleOrderby, $articleOrderDate) . ', ';
 		$primary			= ContentHelperQuery::orderbyPrimary($categoryOrderby);
 
-		$orderby .= $primary . ' ' . $secondary . ' a.created ';
+		$orderby .= $primary . ' ' . $secondary . ' a.created DESC ';
 
 		return $orderby;
 	}


### PR DESCRIPTION
Change to make the secondary ordering consistent and more useful. Related to #6489.

I'm not really sure if this is a bug, but to me it looks like a sub-optimal behavior, from a conceptual point of view. It is really, how the articles are sorted, in addition to the option chosen by the user.
#### Steps to reproduce the issue
1. Create three articles, "article 1", "article 2" and "article 3", created in that order.
2. Set the "Article Manager Options", under the "Shared Options" tab, set the "Article Order" to "Ordering".
3. In the front end, view a "Articles » Category List" page.
4. You'll see the articles are in the order "article 1", "article 2" then "article 3".
#### Expected result

This is maybe a subtlety, but although I set the list to sort by ordering, if all items have the same "ordering" value, I would expect the newest to be at the top.  So they would be listed as "article 3", "article 2" then "article 1".
#### Actual result

You'll see the articles are in the order "article 1", "article 2" then "article 3".
#### System information (as much as possible)

PHP Built On    Linux penguin.directrouter.co.uk 2.6.32-531.23.3.lve1.2.66.el6.x86_64 #1 SMP Fri Sep 12 10:57:40 EDT 2014 x86_64
Database Version    5.6.23
Database Collation  latin1_swedish_ci
PHP Version     5.4.38
Web Server  Apache
WebServer to PHP Interface  cgi-fcgi
Joomla! Version     Joomla! 3.4.0 Stable [ Ember ] 24-February-2015 23:00 GMT
Joomla! Platform Version    Joomla Platform 13.1.0 Stable [ Curiosity ] 24-Apr-2013 00:00 GMT
User Agent  Mozilla/5.0 (Windows NT 6.1; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0 
#### Additional comments

I realize this is quite a subtle one, but it seemed worth mentioning.  It is a one-line fix in the code, which I'd be happy to submit.

To a degree it would resolve an inconsistency.  There are other areas where "created DESC" is used, so the behavior described above seems an anomaly.

Examples of "created DESC" being used can be found at...

components/com_content/models/featured.php
Line 130:       $orderby = $primary . ' ' . $secondary . ' a.created DESC ';

components/com_content/models/archive.php
Line 84:        $orderby = $primary . ' ' . $secondary . ' a.created DESC ';

But the code that causes this to be different is...

components/com_content/models/category.php
Line 312:       $orderby .= $primary . ' ' . $secondary . ' a.created ';

So, there is an argument that this is a bug because within "components/com_content" this is the odd-one-out.
