### PR TITLE
Throw errors from google while generation google maps coordinates

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -687,6 +687,11 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 
 		if ($data['status'] != 'OK')
 		{
+			if (!empty($data['error_message']))
+			{
+				throw new RuntimeException($data['error_message']);
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
At the moment errors like "You have exceeded your daily request quota for this API." are supressed, so if Google gives us an error, let's throw it.
