### PR TITLE
readonly attribute of GroupedList field throws a warning

### DIFF
--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -148,7 +148,7 @@ class JFormFieldGroupedList extends JFormField
 		$attr .= $this->multiple ? ' multiple' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';
 		$attr .= $this->autofocus ? ' autofocus' : '';
-		
+
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
 		if ($this->readonly || $this->disabled)
 		{

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -144,11 +144,16 @@ class JFormFieldGroupedList extends JFormField
 
 		// Initialize some field attributes.
 		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$attr .= $this->disabled ? ' disabled' : '';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 		$attr .= $this->multiple ? ' multiple' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';
 		$attr .= $this->autofocus ? ' autofocus' : '';
+		
+		// To avoid user's confusion, readonly="true" should imply disabled="true".
+		if ($this->readonly || $this->disabled)
+		{
+			$attr .= ' disabled="disabled"';
+		}
 
 		// Initialize JavaScript field attributes.
 		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
@@ -166,7 +171,24 @@ class JFormFieldGroupedList extends JFormField
 					'option.text.toHtml' => false
 				)
 			);
-			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
+
+			// E.g. form field type tag sends $this->value as array
+			if ($this->multiple && is_array($this->value))
+			{
+				if (!count($this->value))
+				{
+					$this->value[] = '';
+				}
+
+				foreach ($this->value as $value)
+				{
+					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
+				}
+			}
+			else
+			{
+				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
+			}
 		}
 
 		// Create a regular list.


### PR DESCRIPTION
Steps to reproduce the issue

1) Set error reporting in Joomla configuration to maximum.
2) Use a form with a GroupedList field.
3) Select some items and save the form
4) Put the attribute readonly of the field by code or by the manifest of the form.
5) Reopen the form
6) You'll see a PHP warning htmlspecialchars() expects parameter 1 to be string, array given in /libraries/joomla/form/fields/groupedlist.php on line 169

Suggested solution
I suggest to do the same thing than in the List field.
