### PR TITLE
Cleaning up JArchiveBzip2

### DIFF
--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -114,14 +114,11 @@ class JArchiveBzip2 implements JArchiveExtractable
 		{
 			$this->_data = $input->read($input->get('chunksize', 8196));
 
-			if ($this->_data)
+			if ($this->_data && !$output->write($this->_data))
 			{
-				if (!$output->write($this->_data))
-				{
-					$input->close();
+				$input->close();
 
-					return $this->raiseWarning(100, 'Unable to write archive (bz2)');
-				}
+				return $this->raiseWarning(100, 'Unable to write archive (bz2)');
 			}
 		}
 
@@ -137,8 +134,8 @@ class JArchiveBzip2 implements JArchiveExtractable
 	 * Temporary private method to isolate JError from the extract method
 	 * This code should be removed when JError is removed.
 	 *
-	 * @param  int     $code  The application-internal error code for this error
-	 * @param  string  $msg   The error message, which may also be shown the user if need be.
+	 * @param   int     $code  The application-internal error code for this error
+	 * @param   string  $msg   The error message, which may also be shown the user if need be.
 	 *
 	 * @return mixed JError object or Runtime Exception
 	 */

--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -45,125 +45,111 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (!extension_loaded('bz2'))
 		{
-			if (class_exists('JError'))
-			{
-				return JError::raiseWarning(100, 'The bz2 extension is not available.');
-			}
-			else
-			{
-				throw new RuntimeException('The bz2 extension is not available.');
-			}
+			$this->raiseWarning(100, 'The bz2 extension is not available.');
 		}
 
-		if (!isset($options['use_streams']) || $options['use_streams'] == false)
+		if (isset($options['use_streams']) && $options['use_streams'] != false)
 		{
-			// Old style: read the whole file and then parse it
-			$this->_data = file_get_contents($archive);
-
-			if (!$this->_data)
-			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to read archive');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to read archive');
-				}
-			}
-
-			$buffer = bzdecompress($this->_data);
-			unset($this->_data);
-
-			if (empty($buffer))
-			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to decompress data');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to decompress data');
-				}
-			}
-
-			if (JFile::write($destination, $buffer) === false)
-			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to write archive');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to write archive');
-				}
-			}
+			return $this->extractStream($archive, $destination, $options);
 		}
-		else
+
+		// Old style: read the whole file and then parse it
+		$this->_data = file_get_contents($archive);
+
+		if (!$this->_data)
 		{
-			// New style! streams!
-			$input = JFactory::getStream();
+			return $this->raiseWarning(100,'Unable to read archive');
+		}
 
-			// Use bzip
-			$input->set('processingmethod', 'bz');
+		$buffer = bzdecompress($this->_data);
+		unset($this->_data);
 
-			if (!$input->open($archive))
-			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to read archive (bz2)');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to read archive (bz2)');
-				}
-			}
+		if (empty($buffer))
+		{
+			return $this->raiseWarning(100,'Unable to decompress data');
+		}
 
-			$output = JFactory::getStream();
-
-			if (!$output->open($destination, 'w'))
-			{
-				$input->close();
-
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to write archive (bz2)');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to write archive (bz2)');
-				}
-			}
-
-			do
-			{
-				$this->_data = $input->read($input->get('chunksize', 8196));
-
-				if ($this->_data)
-				{
-					if (!$output->write($this->_data))
-					{
-						$input->close();
-
-						if (class_exists('JError'))
-						{
-							return JError::raiseWarning(100, 'Unable to write archive (bz2)');
-						}
-						else
-						{
-							throw new RuntimeException('Unable to write archive (bz2)');
-						}
-					}
-				}
-			}
-
-			while ($this->_data);
-
-			$output->close();
-			$input->close();
+		if (JFile::write($destination, $buffer) === false)
+		{
+			return $this->raiseWarning(100, 'Unable to write archive');
 		}
 
 		return true;
+	}
+
+	/**
+	 * Method to extract archive using stream objects
+	 *
+	 * @param   string  $archive      Path to Bzip2 archive to extract
+	 * @param   string  $destination  Path to extract archive to
+	 * @param   array   $options      Extraction options [unused]
+	 *
+	 * @return  boolean  True if successful
+	 */
+	protected function extractStream($archive, $destination, $options = array ())
+	{
+		// New style! streams!
+		$input = JFactory::getStream();
+
+		// Use bzip
+		$input->set('processingmethod', 'bz');
+
+		if (!$input->open($archive))
+		{
+			return $this->raiseWarning(100,'Unable to read archive (bz2)');
+
+		}
+
+		$output = JFactory::getStream();
+
+		if (!$output->open($destination, 'w'))
+		{
+			$input->close();
+
+			return $this->raiseWarning(100,'Unable to write archive (bz2)');
+
+		}
+
+		do
+		{
+			$this->_data = $input->read($input->get('chunksize', 8196));
+
+			if ($this->_data)
+			{
+				if (!$output->write($this->_data))
+				{
+					$input->close();
+
+					return $this->raiseWarning(100, 'Unable to write archive (bz2)');
+				}
+			}
+		}
+
+		while ($this->_data);
+
+		$output->close();
+		$input->close();
+
+		return true;
+	}
+
+	/**
+	 * Temporary private method to isolate JError from the extract method
+	 * This code should be removed when JError is removed.
+	 *
+	 * @param  int     $code  The application-internal error code for this error
+	 * @param  string  $msg   The error message, which may also be shown the user if need be.
+	 *
+	 * @return mixed JError object or Runtime Exception
+	 */
+	private function raiseWarning($code, $msg)
+	{
+		if(class_exists('JError'))
+		{
+			return JError::raiseWarning($code, $msg);
+		}
+
+		throw new RuntimeException($msg);
 	}
 
 	/**

--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -58,7 +58,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (!$this->_data)
 		{
-			return $this->raiseWarning(100,'Unable to read archive');
+			return $this->raiseWarning(100, 'Unable to read archive');
 		}
 
 		$buffer = bzdecompress($this->_data);
@@ -66,7 +66,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (empty($buffer))
 		{
-			return $this->raiseWarning(100,'Unable to decompress data');
+			return $this->raiseWarning(100, 'Unable to decompress data');
 		}
 
 		if (JFile::write($destination, $buffer) === false)
@@ -96,7 +96,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (!$input->open($archive))
 		{
-			return $this->raiseWarning(100,'Unable to read archive (bz2)');
+			return $this->raiseWarning(100, 'Unable to read archive (bz2)');
 
 		}
 
@@ -106,7 +106,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 		{
 			$input->close();
 
-			return $this->raiseWarning(100,'Unable to write archive (bz2)');
+			return $this->raiseWarning(100, 'Unable to write archive (bz2)');
 
 		}
 
@@ -144,7 +144,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 	 */
 	private function raiseWarning($code, $msg)
 	{
-		if(class_exists('JError'))
+		if (class_exists('JError'))
 		{
 			return JError::raiseWarning($code, $msg);
 		}


### PR DESCRIPTION
Isolated JError into temporary method and separated old extraction logic from streaming logic.

I'm not sure where this is used, but most likely in the installer. 
I did a find usage with PHPStorm, but the only results I got where from the unit tests. 

So if anyone knows where it is used could you let me know.
