### PR TITLE
RTL: Correcting display of Joomla!® in installation + Hathor

### DIFF
--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -151,8 +151,18 @@ else
 	<div id="footer">
 		<jdoc:include type="modules" name="footer" style="none"  />
 		<p class="copyright">
-			<?php $joomla = '<a href="http://www.joomla.org">Joomla!&#174;</a>';
-			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla); ?>
+			<?php
+			// Fix wrong display of Joomla!® in RTL language
+			if (JFactory::getLanguage()->isRTL())
+			{
+				$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
+			}
+			else
+			{
+				$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+			}
+			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla);
+			?>
 		</p>
 	</div>
 </body>

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -163,10 +163,20 @@ else
 </div><!-- end of containerwrap -->
 <!-- Footer -->
 <div id="footer">
-	<jdoc:include type="modules" name="footer" style="none"  />
+	<jdoc:include type="modules" name="footer" style="none" />
 	<p class="copyright">
-		<?php $joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!&#174;</a>';
-			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla); ?>
+		<?php
+		// Fix wrong display of Joomla!® in RTL language
+		if (JFactory::getLanguage()->isRTL())
+		{
+			$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
+		}
+		else
+		{
+			$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+		}
+		echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla);
+		?>
 	</p>
 </div>
 <script type="text/javascript">

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -126,8 +126,18 @@ else
 	<!-- Footer -->
 	<div id="footer">
 		<p class="copyright">
-			<?php $joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!&#174;</a>';
-			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla); ?>
+			<?php
+			// Fix wrong display of Joomla!® in RTL language
+			if (JFactory::getLanguage()->isRTL())
+			{
+				$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
+			}
+			else
+			{
+				$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+			}
+			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla);
+			?>
 		</p>
 	</div>
 </body>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -50,7 +50,15 @@ JText::script('INSTL_FTP_SETTINGS_CORRECT');
 			<hr />
 			<h5>
 				<?php
-				$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+				// Fix wrong display of Joomla!® in RTL language
+				if (JFactory::getLanguage()->isRTL())
+				{
+					$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
+				}
+				else
+				{
+					$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+				}
 				$license = '<a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>';
 				echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla, $license);
 				?>


### PR DESCRIPTION
When using a RTL language, Joomla!® is displayed as ®!joomla.
This patch corrects this in the installation page and in Hathor cpanel, login and main admin

Before patch:

![beforepatch](https://cloud.githubusercontent.com/assets/869724/6727536/dd050460-ce22-11e4-9aeb-e91f06d244c1.png)

after patch

![afterpatch](https://cloud.githubusercontent.com/assets/869724/6727547/e5de63ec-ce22-11e4-931e-55bf30d374fe.png)
