### PR TITLE
Regression: Hathor Language Manager: can't set language as default

### DIFF
--- a/administrator/templates/hathor/html/com_languages/installed/default.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+JHtmlBehavior::core();
 // Add specific helper files for html generation
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 $user		= JFactory::getUser();
@@ -94,7 +95,7 @@ $clientId	= $this->state->get('filter.client_id', 0);
 					<?php echo $this->escape($row->author); ?>
 				</td>
 				<td class="center">
-					<?php echo $this->escape($row->authorEmail); ?>
+					<?php echo JStringPunycode::emailToUTF8($this->escape($row->authorEmail)); ?>
 				</td>
 			</tr>
 		<?php endforeach;?>


### PR DESCRIPTION
Set admin template to Hathor.
Load Language Manager and try to set an installed language as default.
This is broken because core.js is not loaded.
Thanks Thomas for the hint.

Patch and test again.
(Note: I also normalized the display of the emails by using the same code as for core, i.e. using punycode)
