### PR TITLE
Fix hathor users view broken by #6264

### DIFF
--- a/administrator/templates/hathor/html/com_users/users/default.php
+++ b/administrator/templates/hathor/html/com_users/users/default.php
@@ -141,6 +141,7 @@ $loggeduser = JFactory::getUser();
 						<?php if ($item->requireReset == '1') : ?>
 						<span class="label label-warning"><?php echo JText::_('COM_USERS_PASSWORD_RESET_REQUIRED'); ?></span>
 						<?php endif; ?>
+						<?php echo JHtml::_('users.notesModal', $item->note_count, $item->id); ?>
 					</div>
 					<?php if ($canEdit) : ?>
 					<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id='.(int) $item->id); ?>" title="<?php echo JText::sprintf('COM_USERS_EDIT_USER', $this->escape($item->name)); ?>">


### PR DESCRIPTION
There is a break on functionality with hathor and #6264.

How to test:
select hathor
create a new user note
goto administrator/index.php?option=com_users&view=users
The link `Display 1 note` should bring a modal with the note!

@wilsonge @Kubik-Rubik @Bakual @rdeutz @roland-d 
