### PR TITLE
Add Docker Containers separated test suites

### DIFF
--- a/tests/system/webdriver/tests/docker1.xml
+++ b/tests/system/webdriver/tests/docker1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>components</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>

--- a/tests/system/webdriver/tests/docker2.xml
+++ b/tests/system/webdriver/tests/docker2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>content</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>

--- a/tests/system/webdriver/tests/docker3.xml
+++ b/tests/system/webdriver/tests/docker3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>extensions</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>

--- a/tests/system/webdriver/tests/docker4.xml
+++ b/tests/system/webdriver/tests/docker4.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>menus</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>

--- a/tests/system/webdriver/tests/docker5.xml
+++ b/tests/system/webdriver/tests/docker5.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>control_panel</directory>
+			<directory>services</directory>			
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>

--- a/tests/system/webdriver/tests/docker6.xml
+++ b/tests/system/webdriver/tests/docker6.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="tests">
+			<directory>installation</directory>
+			<directory>users</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="junit" target="logs/junit.xml"
+			logIncompleteSkipped="false" />
+	</logging>
+</phpunit>


### PR DESCRIPTION
This pull contains a set of 6 PHPUnit test suites. 

they can be used like:

```
phpunit -c docker4.xml 
```

The idea is to separate the current amount of tests into six smaller chunks that can be executed in parallel in 6 Docker Containers, see https://github.com/joomla-projects/joomla-systemtest-env#joomla-systemtest-environment

The containers would be as follows:
- Docker 1: runs installation and component tests
- Docker 2: runs installation and content tests
- Docker 3: runs installation and extensions tests
- Docker 4: runs installation and menus tests
- Docker 5: runs installation and services and control_panel tests
- Docker 6: runs installation and users tests

@SniperSister, as agreed in the System Testing meeting, after this pull gets merged we can modify https://github.com/joomla-projects/joomla-systemtest-env/blob/master/start.sh to pass the suite parameter when running the Container.
