### PR TITLE
Unittests for Notequals rule

### DIFF
--- a/libraries/cms/form/rule/notequals.php
+++ b/libraries/cms/form/rule/notequals.php
@@ -47,11 +47,6 @@ class JFormRuleNotequals extends JFormRule
 			throw new UnexpectedValueException(sprintf('$field empty in %s::test', get_class($this)));
 		}
 
-		if (is_null($form))
-		{
-			throw new InvalidArgumentException(sprintf('The value for $form must not be null in %s', get_class($this)));
-		}
-
 		if (is_null($input))
 		{
 			throw new InvalidArgumentException(sprintf('The value for $input must not be null in %s', get_class($this)));

--- a/tests/unit/suites/libraries/cms/form/rule/JFormRuleNotequalsTest.php
+++ b/tests/unit/suites/libraries/cms/form/rule/JFormRuleNotequalsTest.php
@@ -34,37 +34,43 @@ class JFormRuleNotequalsTest extends TestCase
 		$this->assertTrue($rule->test($xml->field, 'test', null, $input));
 
 		$this->assertFalse($rule->test($xml->field, 'testvalue', null, $input));
-		
-		$result = true;
+	}
 
-		try
-		{
-			$rule->test($xml, 'test', null, $input);
-		}
-		catch (UnexpectedValueException $e)
-		{
-			$result = false;
-		}
+	/**
+	 * Test the JFormRuleNotequals::test method with UnexpectedValueException
+	 *
+	 * @return void
+	 *
+	 * @covers  JFormRuleNotequals::test
+	 * @expectedException  UnexpectedValueException
+	 * @since   3.4
+	 */
+	public function testNotequalsUnexpectedValueException()
+	{
+		$rule = new JFormRuleNotequals;
+		$xml = simplexml_load_string('<form><field name="foo" field="notequalsfield" /></form>');
+		$input = new Joomla\Registry\Registry;
+		$input->set('notequalsfield', 'testvalue');
 
-		if ($result)
-		{
-			$this->fail('An expected exception has not been raised.');
-		}
+		$rule->test($xml, 'test', null, $input);
+	}
 
-		$result = true;
+	/**
+	 * Test the JFormRuleNotequals::test method with InvalidArgumentException
+	 *
+	 * @return void
+	 *
+	 * @covers  JFormRuleNotequals::test
+	 * @expectedException  InvalidArgumentException
+	 * @since   3.4
+	 */
+	public function testNotequalsInvalidArgumentException()
+	{
+		$rule = new JFormRuleNotequals;
+		$xml = simplexml_load_string('<form><field name="foo" field="notequalsfield" /></form>');
+		$input = new Joomla\Registry\Registry;
+		$input->set('notequalsfield', 'testvalue');
 
-		try
-		{
-			$rule->test($xml->field, 'test');
-		}
-		catch (InvalidArgumentException $e)
-		{
-			$result = false;
-		}
-
-		if ($result)
-		{
-			$this->fail('An expected exception has not been raised.');
-		}
+		$rule->test($xml->field, 'test');
 	}
 }

--- a/tests/unit/suites/libraries/cms/form/rule/JFormRuleNotequalsTest.php
+++ b/tests/unit/suites/libraries/cms/form/rule/JFormRuleNotequalsTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JFormRuleNotequals.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ * @since       3.4
+ */
+class JFormRuleNotequalsTest extends TestCase
+{
+	/**
+	 * Test the JFormRuleNotequals::test method.
+	 *
+	 * @return void
+	 *
+	 * @covers  JFormRuleNotequals::test
+	 * @since   3.4
+	 */
+	public function testNotequals()
+	{
+		$rule = new JFormRuleNotequals;
+		$xml = simplexml_load_string('<form><field name="foo" field="notequalsfield" /></form>');
+		$input = new Joomla\Registry\Registry;
+		$input->set('notequalsfield', 'testvalue');
+
+		$this->assertTrue($rule->test($xml->field, 'test', null, $input));
+
+		$this->assertFalse($rule->test($xml->field, 'testvalue', null, $input));
+		
+		$result = true;
+
+		try
+		{
+			$rule->test($xml, 'test', null, $input);
+		}
+		catch (UnexpectedValueException $e)
+		{
+			$result = false;
+		}
+
+		if ($result)
+		{
+			$this->fail('An expected exception has not been raised.');
+		}
+
+		$result = true;
+
+		try
+		{
+			$rule->test($xml->field, 'test');
+		}
+		catch (InvalidArgumentException $e)
+		{
+			$result = false;
+		}
+
+		if ($result)
+		{
+			$this->fail('An expected exception has not been raised.');
+		}
+	}
+}


### PR DESCRIPTION
This removes the check for the JForm object. If we don't use JForm in this class, we don't have to require it.
