### PR TITLE
Regression: #4397 dropped tags when info block at the bottom

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -113,6 +113,10 @@ JHtml::_('behavior.caption');
 
 	<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
 		<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'below')); ?>
+		<?php if ($params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+			<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+			<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
+		<?php endif; ?>
 	<?php endif; ?>
 
 	<?php


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/4397 implements the layout of the info block. At the same time it dropped the tags when the info block is configured to appear split or at the bottom.

Testing:
- Create an article with some tags
- Create a menu item Single Article point to the article created
- Verify tags are shown with info block at top, at bottom and split (at the bottom)
