### PR TITLE
PHP7 Unit Test Fixes

### DIFF
--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -97,12 +97,14 @@ if (!defined('JDEBUG'))
 // Import the platform in legacy mode.
 require_once JPATH_PLATFORM . '/import.legacy.php';
 
-// Force library to be in JError legacy mode
-JError::setErrorHandling(E_NOTICE, 'message');
-JError::setErrorHandling(E_WARNING, 'message');
-
 // Bootstrap the CMS libraries.
 require_once JPATH_LIBRARIES . '/cms.php';
+
+// For PHP 7, unset the exception handler
+if (PHP_MAJOR_VERSION >= 7)
+{
+	restore_exception_handler();
+}
 
 // Register the core Joomla test classes.
 JLoader::registerPrefix('Test', __DIR__ . '/core');

--- a/tests/unit/core/case/database/mysql.php
+++ b/tests/unit/core/case/database/mysql.php
@@ -43,6 +43,11 @@ abstract class TestCaseDatabaseMysql extends TestCaseDatabase
 	 */
 	public static function setUpBeforeClass()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			self::markTestSkipped('ext/mysql is unsupported on PHP 7.');
+		}
+
 		// First let's look to see if we have a DSN defined or in the environment variables.
 		if (defined('JTEST_DATABASE_MYSQL_DSN') || getenv('JTEST_DATABASE_MYSQL_DSN'))
 		{

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -496,6 +496,11 @@ class JDatabaseExporterPdomysqlTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testSetDboWithBadInput()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the method.');
+		}
+
 		$instance = new JDatabaseExporterPdomysql;
 
 		try

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
@@ -773,6 +773,11 @@ class JDatabaseImporterPdomysqlTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testSetDboWithBadInput()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the method.');
+		}
+
 		$instance = new JDatabaseImporterPdomysql;
 
 		try

--- a/tests/unit/suites/libraries/joomla/data/JDataSetTest.php
+++ b/tests/unit/suites/libraries/joomla/data/JDataSetTest.php
@@ -69,6 +69,11 @@ class JDataSetTest extends TestCase
 	 */
 	public function test__construct_scalar()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the constructor.');
+		}
+
 		new JDataSet('foo');
 	}
 

--- a/tests/unit/suites/libraries/joomla/feed/JFeedParserTest.php
+++ b/tests/unit/suites/libraries/joomla/feed/JFeedParserTest.php
@@ -110,6 +110,11 @@ class JFeedParserTest extends TestCase
 	 */
 	public function testRegisterNamespaceWithString()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the method.');
+		}
+
 		$this->_instance->registerNamespace('foo', 'bar');
 	}
 
@@ -124,6 +129,11 @@ class JFeedParserTest extends TestCase
 	 */
 	public function testRegisterNamespaceWithObject()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the method.');
+		}
+
 		$this->_instance->registerNamespace('foo', new stdClass);
 	}
 

--- a/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
@@ -348,6 +348,11 @@ class JFormFieldTest extends TestCaseDatabase
 	 */
 	public function testSetupInvalidElement()
 	{
+		if (PHP_MAJOR_VERSION >= 7)
+		{
+			$this->markTestSkipped('A fatal error is thrown on PHP 7 due to the typehinting of the method.');
+		}
+
 		$form = new JFormInspector('form1');
 		$field = new JFormFieldInspector($form);
 


### PR DESCRIPTION
This gets the full unit test suite running on PHP7.  The remaining failures are in line with what we see in the individual Framework repositories right now.  The main changes here are:
- Unset the JErrorPage exception handler for the unit test suite due to the minor B/C break from the [PHP RFC: Exceptions in the engine](https://wiki.php.net/rfc/engine_exceptions)
- Skip tests in PHP 7 which test that typehinted methods do not allow objects that don't match the typehinting (these are poor tests in general, we're validating PHP behavior here!)
- Skip tests which use the `TestCaseDatabaseMysql` test case; the PHP extension does not exist (this is a companion to https://github.com/joomla/joomla-cms/pull/6433)

If you aren't interested in waiting for Travis-CI to take it's time processing the build, you can review the results from https://travis-ci.org/mbabker/joomla-cms/builds/55079491
