### PR TITLE
Removing obsolete file check in JEditor

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -489,18 +489,13 @@ class JEditor extends JObject
 
 		// Build the path to the needed editor plugin
 		$name = JFilterInput::getInstance()->clean($this->_name, 'cmd');
-		$path = JPATH_PLUGINS . '/editors/' . $name . '.php';
+		$path = JPATH_PLUGINS . '/editors/' . $name . '/' . $name . '.php';
 
 		if (!is_file($path))
 		{
-			$path = JPATH_PLUGINS . '/editors/' . $name . '/' . $name . '.php';
+			JLog::add(JText::_('JLIB_HTML_EDITOR_CANNOT_LOAD'), JLog::WARNING, 'jerror');
 
-			if (!is_file($path))
-			{
-				JLog::add(JText::_('JLIB_HTML_EDITOR_CANNOT_LOAD'), JLog::WARNING, 'jerror');
-
-				return false;
-			}
+			return false;
 		}
 
 		// Require plugin file


### PR DESCRIPTION
The check that is removed in this PR was not valid since Joomla 1.6 and there is no way to install an editor in a way that this check would have evaluated to true. So this might as well be removed here and now.
