### PR TITLE
CLEANING-JCacheControllerCallback

### DIFF
--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -120,6 +120,7 @@ class JCacheControllerCallback extends JCacheController
 		{
 			$document = JFactory::getDocument();
 			$coptions['modulemode'] = 1;
+
 			if (method_exists($document, 'getHeadData'))
 			{
 				$coptions['headerbefore'] = $document->getHeadData();

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -120,7 +120,10 @@ class JCacheControllerCallback extends JCacheController
 		{
 			$document = JFactory::getDocument();
 			$coptions['modulemode'] = 1;
-			$coptions['headerbefore'] = $document->getHeadData();
+			if (method_exists($document, 'getHeadData'))
+			{
+				$coptions['headerbefore'] = $document->getHeadData();
+			}
 		}
 
 		ob_start();

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
 class JCacheControllerCallback extends JCacheController
 {
 	/**
-	 * Executes a cacheable callback if not found in cache else returns cached output and result
+	 * Executes a cache-able callback if not found in cache else returns cached output and result
 	 *
 	 * Since arguments to this function are read with func_get_args you can pass any number of
 	 * arguments to this method


### PR DESCRIPTION
1. Removed the long awkward if -> elseif -> elseif -> else structure from JCacheControllerCallback::get
2. Added private methods to normalise the callback.
3. Removed "else" where I felt comfortable doing so.
