### PR TITLE
Performance tip. Throw not found category before reading all items

### DIFF
--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -103,20 +103,9 @@ class JViewCategory extends JViewLegacy
 
 		// Get some data from the models
 		$state      = $this->get('State');
-		$items      = $this->get('Items');
 		$category   = $this->get('Category');
 		$children   = $this->get('Children');
 		$parent     = $this->get('Parent');
-		$pagination = $this->get('Pagination');
-
-		// Check for errors.
-		if (count($errors = $this->get('Errors')))
-		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
-		}
-
 		if ($category == false)
 		{
 			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
@@ -125,6 +114,17 @@ class JViewCategory extends JViewLegacy
 		if ($parent == false)
 		{
 			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+		}
+
+		$items      = $this->get('Items');
+		$pagination = $this->get('Pagination');
+
+		// Check for errors.
+		if (count($errors = $this->get('Errors')))
+		{
+			JError::raiseError(500, implode("\n", $errors));
+
+			return false;
 		}
 
 		// Check whether category access level allows access.


### PR DESCRIPTION
Sites with many articles (>20K, in our case), can produce server overloading with urls like http://mysite.com/inexistent-category/inexistent-alias-without-id-prefix

With this fix, we are checking the category before sending the articles query ( $items = $this->get('items') )
