### PR TITLE
$_SERVER variables were not overrided with JRequest::setVar().

### DIFF
--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -379,10 +379,10 @@ class JRequest
 				$_FILES[$name] = $value;
 				break;
 			case 'ENV':
-				$_ENV['name'] = $value;
+				$_ENV[$name] = $value;
 				break;
 			case 'SERVER':
-				$_SERVER['name'] = $value;
+				$_SERVER[$name] = $value;
 				break;
 		}
 


### PR DESCRIPTION
$_SERVER variables were not overrided with JRequest::setVar().
