### PR TITLE
JHelperMedia: Make toBytes statically callable

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -50,13 +50,10 @@ class MediaControllerFile extends JControllerLegacy
 		$file   = $this->input->files->get('Filedata', '', 'array');
 		$folder = $this->input->get('folder', '', 'path');
 
-		// Instantiate the media helper
-		$mediaHelper = new JHelperMedia;
-
 		if ($_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024)
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('upload_max_filesize'))
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('post_max_size'))
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('memory_limit')))
+			|| $_SERVER['CONTENT_LENGTH'] > JHelperMedia::toBytes(ini_get('upload_max_filesize'))
+			|| $_SERVER['CONTENT_LENGTH'] > JHelperMedia::toBytes(ini_get('post_max_size'))
+			|| $_SERVER['CONTENT_LENGTH'] > JHelperMedia::toBytes(ini_get('memory_limit')))
 		{
 			$response = array(
 				'status' => '0',

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -63,14 +63,11 @@ class MediaControllerFile extends JControllerLegacy
 		// Total length of post back data in bytes.
 		$contentLength = (int) $_SERVER['CONTENT_LENGTH'];
 
-		// Instantiate the media helper
-		$mediaHelper = new JHelperMedia;
-
 		// Maximum allowed size of post back data in MB.
-		$postMaxSize = $mediaHelper->toBytes(ini_get('post_max_size'));
+		$postMaxSize = JHelperMedia::toBytes(ini_get('post_max_size'));
 
 		// Maximum allowed size of script execution in MB.
-		$memoryLimit = $mediaHelper->toBytes(ini_get('memory_limit'));
+		$memoryLimit = JHelperMedia::toBytes(ini_get('memory_limit'));
 
 		// Check for the total size of post back data.
 		if (($postMaxSize > 0 && $contentLength > $postMaxSize)
@@ -82,7 +79,7 @@ class MediaControllerFile extends JControllerLegacy
 		}
 
 		$uploadMaxSize = $params->get('upload_maxsize', 0) * 1024 * 1024;
-		$uploadMaxFileSize = $mediaHelper->toBytes(ini_get('upload_max_filesize'));
+		$uploadMaxFileSize = JHelperMedia::toBytes(ini_get('upload_max_filesize'));
 
 		// Perform basic checks on file info before attempting anything
 		foreach ($files as &$file)

--- a/libraries/cms/helper/media.php
+++ b/libraries/cms/helper/media.php
@@ -299,7 +299,7 @@ class JHelperMedia
 	 *
 	 * @since 3.3
 	 */
-	public function toBytes($val)
+	public static function toBytes($val)
 	{
 		switch ($val[strlen($val) - 1])
 		{

--- a/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
@@ -211,4 +211,21 @@ class JHelperMediaTest extends TestCaseDatabase
 		$newSize = $this->object->imageResize($width, $height, $target);
 		$this->assertEquals($newSize, $expected);
 	}
+
+	/**
+	 * Tests the toBytes method
+	 *
+	 * @param   int  $val       The value to convert
+	 * @param   int  $expected  Expected result
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  toBytes method
+	 * @since         3.2
+	 */
+	public function testToBytes($val, $expected)
+	{
+		$val = $this->object->toBytes($val);
+		$this->assertEquals($val, $expected);
+	}
 }


### PR DESCRIPTION
While developing an extension i needed to convert some value to bytes several times and found that this should kind of service should be provided by a helper function. Before i started I searched the cms for such a function and found JMediaHelper to do so, but kinda uncomfortable. Asking it for a conversion requires to create an instance first and call its method. I think this is not necessary as the instance serves nothing more than a calculation result. Why to take more memory as necessary for this operation? Also, why to write more code then necessary? Calling `JHelperMedia::toBytes(123)` is a nice one-liner and much more comfortable than writing

```
$mediaHelper = new JHelperMedia;
$value = $mediaHelper->toBytes(123);
```

What do you think?
