### PR TITLE
Define the minimum supported PHP version as a constant

### DIFF
--- a/administrator/index.php
+++ b/administrator/index.php
@@ -6,9 +6,14 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-if (version_compare(PHP_VERSION, '5.3.10', '<'))
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
-	die('Your host needs to use PHP 5.3.10 or higher to run this version of Joomla!');
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -6,9 +6,14 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-if (version_compare(PHP_VERSION, '5.3.10', '<'))
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
-	die('Your host needs to use PHP 5.3.10 or higher to run this version of Joomla!');
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
 }
 
 /**

--- a/installation/index.php
+++ b/installation/index.php
@@ -6,9 +6,14 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-if (version_compare(PHP_VERSION, '5.3.10', '<'))
+/**
+ * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
+ */
+define('JOOMLA_MINIMUM_PHP', '5.3.10');
+
+if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
-	die('Your host needs to use PHP 5.3.10 or higher to run this version of Joomla!');
+	die('Your host needs to use PHP ' . JOOMLA_MINIMUM_PHP . ' or higher to run this version of Joomla!');
 }
 
 /**

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -233,8 +233,8 @@ class InstallationModelSetup extends JModelBase
 
 		// Check the PHP Version.
 		$option = new stdClass;
-		$option->label  = JText::_('INSTL_PHP_VERSION') . ' >= 5.3.10';
-		$option->state  = version_compare(PHP_VERSION, '5.3.10', '>=');
+		$option->label  = JText::_('INSTL_PHP_VERSION') . ' >= ' . JOOMLA_MINIMUM_PHP;
+		$option->state  = version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '>=');
 		$option->notice = null;
 		$options[] = $option;
 


### PR DESCRIPTION
This PR adds a new constant, `JOOMLA_MINIMUM_PHP`, which defines the minimum supported version of PHP.
### Why?

Presently, the minimum version checks use hardcoded version numbers as needed to make the check.  Also, as it isn't defined anywhere in the application, it means any third parties wanting to make note of the minimum PHP version have to do it themselves and make updates with core.
### Test instructions

This one's really just a "review it" patch.
