### PR TITLE
Try to get the right extension name for files extensions (Fix #5966)

### DIFF
--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -171,7 +171,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 	 */
 	public function loadLanguage($path)
 	{
-		$extension = 'files_' . strtolower(str_replace('files_', '', $this->name));
+		$extension = 'files_' . strtolower(str_replace('files_', '', $this->getElement()));
 
 		$this->doLoadLanguage($extension, $path, JPATH_SITE);
 	}


### PR DESCRIPTION
This should try and get the right element name for a files extension type (such as the Joomla package).  As is, the `$extension` that gets fed into the `doLoadLanguage()` method is `files_` (at least with the Joomla package).
### Testing

1) Provision 2 3.4.0 sites for quick testing
2) On site 1, do not apply the patch and install https://github.com/joomla/joomla-cms/releases/download/3.4.1-rc2/Joomla_3.4.1-rc2-Release_Candidate-Update_Package.zip via the Extension Manager; should see the language constant untranslated.
3) On site 2, apply the patch.
4) Install https://github.com/joomla/joomla-cms/releases/download/3.4.1-rc2/Joomla_3.4.1-rc2-Release_Candidate-Update_Package.zip via the Extension Manager; should have the translated message.

If you know of other files extensions, test them too.
