### PR TITLE
Update layout login view (redo of #6432)

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -83,8 +83,8 @@ JHtml::_('formbehavior.chosen');
 		<?php endif; ?>
 		<div class="control-group">
 			<div class="controls">
-				<div class="btn-group pull-left">
-					<button tabindex="3" class="btn btn-primary btn-large">
+				<div class="btn-group">
+					<button tabindex="3" class="btn btn-primary btn-block btn-large">
 						<i class="icon-lock icon-white"></i> <?php echo JText::_('MOD_LOGIN_LOGIN'); ?>
 					</button>
 				</div>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7037,9 +7037,8 @@ a:focus {
 	left: 50%;
 	height: 24px;
 	width: 24px;
-	text-indent: -9999px;
-	background: url('../images/login-joomla.png') no-repeat;
 	margin-left: -12px;
+	font-size: 22px;
 }
 .navbar-inverse .view-login .login-joomla {
 	background: url('../images/login-joomla-inverse.png') no-repeat;
@@ -7048,18 +7047,21 @@ a:focus {
 	position: absolute;
 }
 .view-login .input-medium {
-	width: 184px;
+	width: 176px;
 }
 .login .chzn-single {
-	width: 230px !important;
+	width: 222px !important;
 }
 .login .chzn-container,
 .login .chzn-drop {
-	width: 238px !important;
-	max-width: 238px !important;
+	width: 230px !important;
+	max-width: 230px !important;
 }
 .login .btn-large {
-	margin-top: 10px;
+	margin-top: 15px;
+}
+.login .form-inline .btn-group {
+	display: block;
 }
 .small {
 	font-size: 11px;
@@ -8079,10 +8081,19 @@ a.grid_true {
 	.j-toggle-button-wrapper {
 		display: none;
 	}
+	.view-login select {
+		width: 232px;
+	}
 }
 @media (max-width: 420px) {
 	.j-sidebar-container {
 		margin: 0;
+	}
+	.view-login .input-medium {
+		width: 180px;
+	}
+	.view-login select {
+		width: 232px;
 	}
 }
 .break-word {
@@ -8771,9 +8782,25 @@ a.grid_true {
 	right: 50%;
 	height: 24px;
 	width: 24px;
-	text-indent: -9999px;
-	background: url('../images/login-joomla.png') no-repeat;
 	margin-right: -12px;
+	font-size: 22px;
+}
+.view-login .input-medium {
+	width: 169px;
+}
+.login .chzn-single {
+	width: 219px !important;
+}
+.login .chzn-container,
+.login .chzn-drop {
+	width: 227px !important;
+	max-width: 227px !important;
+}
+.login .input-prepend .chzn-container-single .chzn-single {
+	-webkit-border-radius: 3px 0 0 3px;
+	-moz-border-radius: 3px 0 0 3px;
+	border-radius: 3px 0 0 3px;
+	border-right: 0px;
 }
 .j-sidebar-container {
 	left: auto;
@@ -8832,6 +8859,9 @@ a.grid_true {
 		margin-left: auto;
 		margin-right: 0;
 	}
+	.view-login select {
+		width: 229px;
+	}
 }
 #j-main-container.expanded {
 	margin-right: 0;
@@ -8855,5 +8885,16 @@ a.grid_true {
 	}
 	.btn-toolbar .btn-wrapper {
 		margin: 0 10px 5px 10px;
+	}
+}
+@media (max-width: 420px) {
+	.j-sidebar-container {
+		margin: 0;
+	}
+	.view-login .input-medium {
+		width: 173px;
+	}
+	.view-login select {
+		width: 229px;
 	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7037,9 +7037,8 @@ a:focus {
 	left: 50%;
 	height: 24px;
 	width: 24px;
-	text-indent: -9999px;
-	background: url('../images/login-joomla.png') no-repeat;
 	margin-left: -12px;
+	font-size: 22px;
 }
 .navbar-inverse .view-login .login-joomla {
 	background: url('../images/login-joomla-inverse.png') no-repeat;
@@ -7048,18 +7047,21 @@ a:focus {
 	position: absolute;
 }
 .view-login .input-medium {
-	width: 184px;
+	width: 176px;
 }
 .login .chzn-single {
-	width: 230px !important;
+	width: 222px !important;
 }
 .login .chzn-container,
 .login .chzn-drop {
-	width: 238px !important;
-	max-width: 238px !important;
+	width: 230px !important;
+	max-width: 230px !important;
 }
 .login .btn-large {
-	margin-top: 10px;
+	margin-top: 15px;
+}
+.login .form-inline .btn-group {
+	display: block;
 }
 .small {
 	font-size: 11px;
@@ -8079,10 +8081,19 @@ a.grid_true {
 	.j-toggle-button-wrapper {
 		display: none;
 	}
+	.view-login select {
+		width: 232px;
+	}
 }
 @media (max-width: 420px) {
 	.j-sidebar-container {
 		margin: 0;
+	}
+	.view-login .input-medium {
+		width: 180px;
+	}
+	.view-login select {
+		width: 232px;
 	}
 }
 .break-word {

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -93,14 +93,32 @@ a.grid_true {
 }
 
 /* Login */
-.view-login .login-joomla {
-	position: absolute;
-	right: 50%;
-	height: 24px;
-	width: 24px;
-	text-indent: -9999px;
-	background: url('../images/login-joomla.png') no-repeat;
-	margin-right: -12px;
+.view-login {
+	.login-joomla {
+		position: absolute;
+		right: 50%;
+		height: 24px;
+		width: 24px;
+		margin-right: -12px;
+		font-size: 22px;
+	}
+	.input-medium {
+		width: 169px;
+	}
+}
+.login {
+	.chzn-single {
+		width: 219px !important;
+	}
+	.chzn-container,
+	.chzn-drop {
+		width: 227px !important;
+		max-width: 227px !important;
+	}
+	.input-prepend .chzn-container-single .chzn-single {
+		.border-radius(3px 0 0 3px);
+		border-right:0px;
+	}
 }
 
 /* For collapsible sidebar */
@@ -174,6 +192,13 @@ a.grid_true {
 		margin-left: auto;
 		margin-right: 0;
 	}
+
+	/* login */
+	.view-login {
+		select {
+			width: 229px
+		}
+	}
 }
 
 #j-main-container.expanded {
@@ -204,5 +229,20 @@ a.grid_true {
 	}
 	.btn-toolbar .btn-wrapper {
 		margin:0 10px 5px 10px;
+	}
+}
+
+@media (max-width: 420px) {
+	.j-sidebar-container {
+		margin: 0;
+	}
+	/* login */
+	.view-login {
+		.input-medium {
+			width: 173px;
+		}
+		select {
+			width: 229px
+		}
 	}
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -115,9 +115,8 @@ a:focus {
 		left: 50%;
 		height: 24px;
 		width: 24px;
-		text-indent: -9999px;
-		background: url('../images/login-joomla.png') no-repeat;
 		margin-left: -12px;
+		font-size: 22px;
 		.navbar-inverse & {
 			background: url('../images/login-joomla-inverse.png') no-repeat;
 		}
@@ -126,21 +125,24 @@ a:focus {
 		position: absolute;
 	}
 	.input-medium {
-		width: 184px;
+		width: 176px;
 	}
 }
 
 .login {
 	.chzn-single {
-		width: 230px !important;
+		width: 222px !important;
 	}
 	.chzn-container,
 	.chzn-drop {
-		width: 238px !important;
-		max-width: 238px !important;
+		width: 230px !important;
+		max-width: 230px !important;
 	}
 	.btn-large {
-		margin-top: 10px;
+		margin-top: 15px;
+	}
+	.form-inline .btn-group {
+		display:block;
 	}
 }
 
@@ -1233,11 +1235,26 @@ a.grid_true {
 	.j-toggle-button-wrapper {
 		display: none;
 	}
+
+	.view-login {
+		select {
+			width: 232px;
+		}
+	}
 }
 
 @media (max-width: 420px) {
 	.j-sidebar-container {
 		margin: 0;
+	}
+
+	.view-login {
+		.input-medium {
+			width: 180px;
+		}
+		select {
+			width: 232px
+		}
 	}
 }
 

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -24,7 +24,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
 // Add Stylesheets
- $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -24,7 +24,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
 // Add Stylesheets
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+ $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
@@ -123,7 +123,7 @@ function colorIsLight($color)
 		<p class="pull-right">
 			&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?>
 		</p>
-		<a class="login-joomla hasTooltip" href="http://www.joomla.org" target="_blank" title="<?php echo JHtml::tooltipText('TPL_ISIS_ISFREESOFTWARE'); ?>">Joomla!&#174;</a>
+		<a class="login-joomla hasTooltip" href="http://www.joomla.org" target="_blank" title="<?php echo JHtml::tooltipText('TPL_ISIS_ISFREESOFTWARE'); ?>"><i class="icon-joomla"></i></a>
 		<a href="<?php echo JUri::root(); ?>" target="_blank" class="pull-left"><i class="icon-out-2"></i> <?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?></a>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />


### PR DESCRIPTION
This is a redo of #6432 because of merge conflicts.
Please see that one for test instructions

---
## The problem

I discovered that the alignment on the login page of isis is not 100% pixel perfect. The field are just a few pixels to width. Hower, on RTL languages the wrong alignment was very good visible. So this patch solves alignment problems on LTR and RTL languages. I also add the possibility to load the `templates-rtl.css` in the login-view.
Farther optimizations:
- font-set icon `icon-joomla` instead of .png icon for the Joomla! logo on bottom of the loginform
- Full width login button
## Before/after screenshots

<b>LTR before</b>
![lrt-before](https://cloud.githubusercontent.com/assets/2659866/6654001/13369dc8-caa9-11e4-835b-f9f777f469d7.PNG)

<b>LTR after (very small difference on the right of the fields)</b>
![ltr after](https://cloud.githubusercontent.com/assets/2659866/6654003/2551c032-caa9-11e4-8aa5-c22b5b71dc2b.PNG)

<b>RTL before</b>
![rtl before](https://cloud.githubusercontent.com/assets/2659866/6654008/6f966e04-caa9-11e4-80b4-f5cf81baa7f2.PNG)

<b>RTL after</b>
![rtl after](https://cloud.githubusercontent.com/assets/2659866/6654020/44831144-caaa-11e4-8861-d9897690e35a.PNG)
## How to test this patch
1. Confirm the before/after screenshots on a LTR language (English)
2. Confirm 100% page width button and sharp Joomla! logo on bottom
3. Change your language to a RTL language (Persion for example)
4. Test step 2 and 3 again.
5. Confirm the login layout is also good shown on mobile devices. Feel free to use the Google Chrome F12 developer tools for this part
## Notes
- Also add some extra spaces for CS on some places
- As idea of @dgt41 the login button is full-width. Please let me know how you're thoughts are about that
