### PR TITLE
Fix "showon" feature on multiple field

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -913,6 +913,7 @@ abstract class JFormField
 			$showon   = explode(':', $showon, 2);
 			$options['class'] .= ' showon_' . implode(' showon_', explode(',', $showon[1]));
 			$id = $this->getName($showon[0]);
+			$id = $this->multiple ? str_replace('[]', '', $id) : $id;
 			$options['rel'] = ' rel="showon_' . $id . '"';
 			$options['showonEnabled'] = true;
 		}


### PR DESCRIPTION
This patch will fix `showon` [feature](https://docs.joomla.org/Form_field#Showon), when it used on the field with `multiple` attribute

**how to test**
add two field in template, module or menu item configuration:

``` xml
<field name="test1" type="list" label="Test 1">
    <option value="0">JNO</option>
    <option value="1">JYES</option>
</field>
<field name="test2" type="list" multiple="true" showon="test1:1" label="Test 2">
    <option value="1">Val 1</option>
    <option value="2">Val 2</option>
    <option value="3">Val 3</option>
    <option value="4">Val 4</option>
</field>
```

And try change the value in "text 1" field

**expected result**
Field "Test 2" must be visible only when in "Test 1" selected "Yes",

**actual result**
Field "Test 2" always visible

Apply patch and make sure that it work as expected.
