### PR TITLE
removed duplicate fieldset label

### DIFF
--- a/components/com_users/views/reset/tmpl/complete.php
+++ b/components/com_users/views/reset/tmpl/complete.php
@@ -24,8 +24,8 @@ JHtml::_('behavior.formvalidator');
 	<form action="<?php echo JRoute::_('index.php?option=com_users&task=reset.complete'); ?>" method="post" class="form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<fieldset>
+				<p><?php echo JText::_($fieldset->label); ?></p>
 				<?php foreach ($this->form->getFieldset($fieldset->name) as $name => $field) : ?>
-					<p><?php echo JText::_($fieldset->label); ?></p>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $field->label; ?>


### PR DESCRIPTION
Fixes #6538.
Thanks @islavi for reporting the issue.

Before:
![Before Patch](http://fs2.directupload.net/images/150322/ohiec97s.png)

After:
![After Patch](http://fs1.directupload.net/images/150322/5izryzzq.png)
## Test Instructions

Perform password reset.
Everything should work as expected.
The fieldset label should only appear once.
