### PR TITLE
Join content to get attribs in a "tagged items" list

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -556,6 +556,7 @@ class JHelperTags extends JHelper
 			->select('MAX(c.core_language) AS core_language, MAX(c.core_catid) AS core_catid')
 			->select('MAX(c.core_publish_up) AS core_publish_up, MAX(c.core_publish_down) as core_publish_down')
 			->select('MAX(ct.type_title) AS content_type_title, MAX(ct.router) AS router')
+			->select('ctnt.attribs AS attribs')
 
 			->from('#__contentitem_tag_map AS m')
 			->join(
@@ -567,6 +568,9 @@ class JHelperTags extends JHelper
 					. ' AND (c.core_publish_down = ' . $nullDate . ' OR  c.core_publish_down >= ' . $nowDate . ')')
 			)
 			->join('INNER', '#__content_types AS ct ON ct.type_alias = m.type_alias')
+
+			// Join over the content to get attribs
+			->join('LEFT', '#__content AS ctnt ON m.content_item_id = ctnt.id')
 
 			// Join over the users for the author and email
 			->select("CASE WHEN c.core_created_by_alias > ' ' THEN c.core_created_by_alias ELSE ua.name END AS author")


### PR DESCRIPTION
Situation before this change:
I have a couple of custom fields added to my article using the same technique as described here:
https://zunostudios.com/blog/development/203-how-to-add-custom-fields-to-articles-in-joomla
I then made a menu item of the type "tagged items" and tried to override the joomla default template for the tagged items list, which I found under components/com_tags/views/tag/tmpl/default_items.php
However the attribs are not available in $item (line 35 and ongoing)

Situation after this change:
The query which returns the items of the "tagged items" now also returns the attribs. And one can use something like this to use the attribs in the tagged items list:
$attrb = json_decode($item->attribs);
echo $attrb->foo;

I hope I didn't break anything - this is my first patch to the joomla project, so I'm happy to hear your feedback and improve my solution.

Have a nice weekend!

Kind regards,
nicolas
