### PR TITLE
Fix mod_login not considering Itemid when redirecting

### DIFF
--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -29,21 +29,20 @@ class ModLoginHelper
 	 */
 	public static function getReturnURL($params, $type)
 	{
-		$app	= JFactory::getApplication();
-		$item   = $app->getMenu()->getItem($params->get($type));
+		$app  = JFactory::getApplication();
+		$item = $app->getMenu()->getItem($params->get($type));
 
 		if ($item)
 		{
-			$vars           = $item->query;
-			$vars['Itemid'] = $item->id;
+			$url = 'index.php?Itemid=' . $item->id;
 		}
 		else
 		{
 			// Stay on the same page
-			$vars = $app::getRouter()->getVars();
+			$url = JUri::getInstance()->toString();
 		}
 
-		return base64_encode('index.php?' . JUri::buildQuery($vars));
+		return base64_encode($url);
 	}
 
 	/**

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -34,7 +34,8 @@ class ModLoginHelper
 
 		if ($item)
 		{
-			$vars = $item->query;
+			$vars           = $item->query;
+			$vars['Itemid'] = $item->id;
 		}
 		else
 		{

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -32,7 +32,7 @@ class ModLoginHelper
 		$app  = JFactory::getApplication();
 		$item = $app->getMenu()->getItem($params->get($type));
 
-		if ($item && $item->type != 'alias')
+		if ($item)
 		{
 			$url = 'index.php?Itemid=' . $item->id;
 		}

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -32,7 +32,7 @@ class ModLoginHelper
 		$app  = JFactory::getApplication();
 		$item = $app->getMenu()->getItem($params->get($type));
 
-		if ($item)
+		if ($item && $item->type != 'alias')
 		{
 			$url = 'index.php?Itemid=' . $item->id;
 		}

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -42,7 +42,7 @@
 				<field
 					name="login"
 					type="menuitem"
-					disable="separator"
+					disable="separator,alias,heading,url"
 					label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
 					description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC" >
 					<option
@@ -51,7 +51,7 @@
 				<field
 					name="logout"
 					type="menuitem"
-					disable="separator"
+					disable="separator,alias,heading,url"
 					label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
 					description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC" >
 					<option


### PR DESCRIPTION
### Steps to reproduce the issue
- Install a fresh Joomla! 3.4.1 with sample testing data
- Go to the module manager and modify mod_login (Login Form) options **Login Redirection Page** to **mainmenu/Sample Sites** and **Logout Redirection Page** to **mainmenu/Home**
- Ensure **SEO Setting** **Search Engine Friendly URLs** is switched **On** (like it is standard after a fresh installation)
- Login and logout and check if redirection is working correctly, especially whether the correct modules are shown corresponding to the menu item id
### Expected result

Pages redirected to should show the modules belonging to the menu item
### Actual result

Pages redirected to don't show the correct modules
### System information (as much as possible)

Joomla! 3.4.1
### Additional comments

Due to the changes in #6034 now the Itemid is missing when calculating the redirection URL.
The patch should correct that.
