### PR TITLE
Improving JComponentHelper::getComponent tests

### DIFF
--- a/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
+++ b/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
@@ -38,16 +38,27 @@ class JComponentHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JComponentHelper::getComponent
 	 */
 	public function testGetComponent()
 	{
 		$component = JComponentHelper::getComponent('com_content');
 
-		$this->assertEquals(
-			$component->id,
-			22,
-			'com_content is extension ID 22'
-		);
+		$this->assertEquals(22, $component->id,	'com_content is extension ID 22');
+		$this->assertInstanceOf('JRegistry', $component->params, 'Parameters need to be of type JRegistry');
+		$this->assertEquals('1', $component->params->get('show_title'), 'The show_title parameter of com_content should be set to 1');
+		$this->assertObjectHasAttribute('enabled', $component, 'The component data needs to have an enabled field');
+		$this->assertSame($component, JComponentHelper::getComponent('com_content'), 'The object returned must always be the same');
+
+		$falsecomponent = JComponentHelper::getComponent('com_false');
+		$this->assertObjectNotHasAttribute('id', $falsecomponent, 'Anonymous component does not have an ID');
+		$this->assertInstanceOf('JRegistry', $falsecomponent->params, 'Parameters need to be of type JRegistry');
+		$this->assertEquals(0, $falsecomponent->params->count(), 'Anonymous component does not have any set parameters');
+		$this->assertObjectHasAttribute('enabled', $falsecomponent, 'The component data needs to have an enabled field');
+		$this->assertTrue($falsecomponent->enabled, 'The anonymous component has to be enabled by default if not strict');
+		
+		$falsecomponent2 = JComponentHelper::getComponent('com_false', true);
+		$this->assertFalse($falsecomponent2->enabled, 'The anonymous component has to be disabled by default if strict');
 	}
 
 	/**
@@ -56,6 +67,7 @@ class JComponentHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JComponentHelper::isEnabled
 	 */
 	public function testIsEnabled()
 	{
@@ -71,6 +83,7 @@ class JComponentHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.4
+	 * @covers  JComponentHelper::isInstalled
 	 */
 	public function testIsInstalled()
 	{
@@ -89,6 +102,7 @@ class JComponentHelperTest extends TestCaseDatabase
 	 * Test JComponentHelper::getParams
 	 *
 	 * @return  void
+	 * @covers  JComponentHelper::getParams
 	 */
 	public function testGetParams()
 	{

--- a/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
+++ b/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
@@ -49,16 +49,38 @@ class JComponentHelperTest extends TestCaseDatabase
 		$this->assertEquals('1', $component->params->get('show_title'), 'The show_title parameter of com_content should be set to 1');
 		$this->assertObjectHasAttribute('enabled', $component, 'The component data needs to have an enabled field');
 		$this->assertSame($component, JComponentHelper::getComponent('com_content'), 'The object returned must always be the same');
+	}
 
-		$falsecomponent = JComponentHelper::getComponent('com_false');
-		$this->assertObjectNotHasAttribute('id', $falsecomponent, 'Anonymous component does not have an ID');
-		$this->assertInstanceOf('JRegistry', $falsecomponent->params, 'Parameters need to be of type JRegistry');
-		$this->assertEquals(0, $falsecomponent->params->count(), 'Anonymous component does not have any set parameters');
-		$this->assertObjectHasAttribute('enabled', $falsecomponent, 'The component data needs to have an enabled field');
-		$this->assertTrue($falsecomponent->enabled, 'The anonymous component has to be enabled by default if not strict');
-		
-		$falsecomponent2 = JComponentHelper::getComponent('com_false', true);
-		$this->assertFalse($falsecomponent2->enabled, 'The anonymous component has to be disabled by default if strict');
+	/**
+	 * Test JComponentHelper::getComponent
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 * @covers  JComponentHelper::getComponent
+	 */
+	public function testGetComponent_falseComponent()
+	{
+		$component = JComponentHelper::getComponent('com_false');
+		$this->assertObjectNotHasAttribute('id', $component, 'Anonymous component does not have an ID');
+		$this->assertInstanceOf('JRegistry', $component->params, 'Parameters need to be of type JRegistry');
+		$this->assertEquals(0, $component->params->count(), 'Anonymous component does not have any set parameters');
+		$this->assertObjectHasAttribute('enabled', $component, 'The component data needs to have an enabled field');
+		$this->assertTrue($component->enabled, 'The anonymous component has to be enabled by default if not strict');
+	}
+
+	/**
+	 * Test JComponentHelper::getComponent
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4
+	 * @covers  JComponentHelper::getComponent
+	 */
+	public function testGetComponent_falseComponent_strict()
+	{		
+		$component = JComponentHelper::getComponent('com_false', true);
+		$this->assertFalse($component->enabled, 'The anonymous component has to be disabled by default if strict');
 	}
 
 	/**


### PR DESCRIPTION
This slightly improves the JComponentHelper::getComponent unittests. It should be noted, that anonymous components don't have an "id" attribute, which could be problematic and that the "enabled" attribute has a boolean value when it is an anonymous component, while it is an integer when it is a known component. Also, JComponentHelper::isInstalled() might return true, even though the component is not installed. (It returns an integer and does not filter for components)
