### PR TITLE
Fix pagination broken for articles view

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -84,30 +84,6 @@ class ContentModelArticles extends JModelList
 			$this->context .= '.' . $layout;
 		}
 
-		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
-		$this->setState('filter.search', $search);
-
-		$access = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
-		$this->setState('filter.access', $access);
-
-		$authorId = $app->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
-		$this->setState('filter.author_id', $authorId);
-
-		$published = $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '');
-		$this->setState('filter.published', $published);
-
-		$categoryId = $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
-		$this->setState('filter.category_id', $categoryId);
-
-		$level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
-		$this->setState('filter.level', $level);
-
-		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
-		$this->setState('filter.language', $language);
-
-		$tag = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
-		$this->setState('filter.tag', $tag);
-
 		// List state information.
 		parent::populateState('a.id', 'desc');
 
@@ -167,8 +143,8 @@ class ContentModelArticles extends JModelList
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
-					', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.ordering, a.featured, a.language, a.hits' .
-					', a.publish_up, a.publish_down'
+				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.ordering, a.featured, a.language, a.hits' .
+				', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from('#__content AS a');

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -78,17 +78,49 @@ class ContentModelArticles extends JModelList
 	{
 		$app = JFactory::getApplication();
 
+		$input = $app->input;
+
 		// Adjust the context to support modal layouts.
-		if ($layout = $app->input->get('layout'))
+		if ($layout = $input->get('layout'))
 		{
 			$this->context .= '.' . $layout;
+		}
+
+		// Deal with Hathor which is not using search tools
+		$rawInputData = $input->getArray();
+
+		if (isset($rawInputData['filter_search']))
+		{
+			$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+			$this->setState('filter.search', $search);
+
+			$access = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
+			$this->setState('filter.access', $access);
+
+			$authorId = $app->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
+			$this->setState('filter.author_id', $authorId);
+
+			$published = $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '');
+			$this->setState('filter.published', $published);
+
+			$categoryId = $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
+			$this->setState('filter.category_id', $categoryId);
+
+			$level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
+			$this->setState('filter.level', $level);
+
+			$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
+			$this->setState('filter.language', $language);
+
+			$tag = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+			$this->setState('filter.tag', $tag);
 		}
 
 		// List state information.
 		parent::populateState('a.id', 'desc');
 
 		// Force a language
-		$forcedLanguage = $app->input->get('forcedLanguage');
+		$forcedLanguage = $input->get('forcedLanguage');
 
 		if (!empty($forcedLanguage))
 		{


### PR DESCRIPTION
Please see #6544 for description of the issue.  I just removed the code which is not needed anymore because the model states will be populated automatically in JModelList class using this block of code:

https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/model/list.php#L471-L477

Keep these lines of code will cause pagination always reset to first page and you could not move to any other pages.

If this PR is valid, we will need to fix all other core components as well.
