### PR TITLE
Fixes #6133 - allows long filenames for TAR archives

### DIFF
--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -182,6 +182,12 @@ class JArchiveTar implements JArchiveExtractable
 					substr($data, $position)
 				);
 			}
+			
+			/* This variable has been set in the previous loop, meaning that the filename was present in the previous block to allow more than 100 characters - see below */
+			if (isset($longlinkfilename)) {
+				$info['filename'] = $longlinkfilename;
+				unset($longlinkfilename);
+			}
 
 			if (!$info)
 			{
@@ -218,6 +224,14 @@ class JArchiveTar implements JArchiveExtractable
 					$file['attr'] = (($info['typeflag'] == 0x35) ? 'd' : '-') . (($mode & 0x400) ? 'r' : '-') . (($mode & 0x200) ? 'w' : '-') .
 						(($mode & 0x100) ? 'x' : '-') . (($mode & 0x040) ? 'r' : '-') . (($mode & 0x020) ? 'w' : '-') . (($mode & 0x010) ? 'x' : '-') .
 						(($mode & 0x004) ? 'r' : '-') . (($mode & 0x002) ? 'w' : '-') . (($mode & 0x001) ? 'x' : '-');
+				}
+				elseif (chr($info['typeflag']) == 'L' && $info['filename'] == '././@LongLink')
+				{
+					/* GNU tar ././@LongLink support - the filename is actually in the contents, setting a variable here so we can test in the next loop */
+					$longlinkfilename = $contents;
+					
+					/* And the file contents are in the next block so we'll need to skip this */
+					continue;
 				}
 				else
 				{

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -182,9 +182,12 @@ class JArchiveTar implements JArchiveExtractable
 					substr($data, $position)
 				);
 			}
-			
-			/* This variable has been set in the previous loop, meaning that the filename was present in the previous block to allow more than 100 characters - see below */
-			if (isset($longlinkfilename)) {
+
+			/* This variable has been set in the previous loop,
+			meaning that the filename was present in the previous block
+			to allow more than 100 characters - see below */
+			if (isset($longlinkfilename))
+			{
 				$info['filename'] = $longlinkfilename;
 				unset($longlinkfilename);
 			}
@@ -229,7 +232,7 @@ class JArchiveTar implements JArchiveExtractable
 				{
 					/* GNU tar ././@LongLink support - the filename is actually in the contents, setting a variable here so we can test in the next loop */
 					$longlinkfilename = $contents;
-					
+
 					/* And the file contents are in the next block so we'll need to skip this */
 					continue;
 				}

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -33,7 +33,7 @@ class JArchiveTar implements JArchiveExtractable
 	 * @since  11.1
 	 */
 	private $_types = array(
-		0x0 => 'Unix file',
+		0x0  => 'Unix file',
 		0x30 => 'File',
 		0x31 => 'Link',
 		0x32 => 'Symbolic link',
@@ -183,9 +183,11 @@ class JArchiveTar implements JArchiveExtractable
 				);
 			}
 
-			/* This variable has been set in the previous loop,
-			meaning that the filename was present in the previous block
-			to allow more than 100 characters - see below */
+			/**
+			 * This variable has been set in the previous loop,
+			 * meaning that the filename was present in the previous block
+			 * to allow more than 100 characters - see below
+			 */
 			if (isset($longlinkfilename))
 			{
 				$info['filename'] = $longlinkfilename;
@@ -220,7 +222,7 @@ class JArchiveTar implements JArchiveExtractable
 
 				if (($info['typeflag'] == 0) || ($info['typeflag'] == 0x30) || ($info['typeflag'] == 0x35))
 				{
-					/* File or folder. */
+					// File or folder.
 					$file['data'] = $contents;
 
 					$mode = hexdec(substr($info['mode'], 4, 3));
@@ -230,15 +232,16 @@ class JArchiveTar implements JArchiveExtractable
 				}
 				elseif (chr($info['typeflag']) == 'L' && $info['filename'] == '././@LongLink')
 				{
-					/* GNU tar ././@LongLink support - the filename is actually in the contents, setting a variable here so we can test in the next loop */
+					// GNU tar ././@LongLink support - the filename is actually in the contents,
+					// setting a variable here so we can test in the next loop
 					$longlinkfilename = $contents;
 
-					/* And the file contents are in the next block so we'll need to skip this */
+					// And the file contents are in the next block so we'll need to skip this
 					continue;
 				}
 				else
 				{
-					/* Some other type. */
+					// Some other type.
 				}
 
 				$return_array[] = $file;


### PR DESCRIPTION
# Issue

Attempting to install tarballed extensions that contain paths with more than 100 characters will result in paths being truncated. The original TAR format only supports paths up to 100 characters [source](http://en.wikipedia.org/wiki/Tar_%28computing%29#Header).
# How to test

I've put a test archive [here](https://onedrive.live.com/redir?resid=C010BBBF057E905F!21825&authkey=!ABY3mmJ9Kf4MOqc&ithint=file%2cgz). The archive contains the following path:

`admin/plugins/vmpayment/amazon/library/OffAmazonPaymentsService/OffAmazonPaymentsService.config.inc.php`

Test it by using `Extensions` > `Extension Manager` > upload the archive and click on `Upload & Install`. You'll see a blank page (the installer script is meant to die so that the archive is extracted to your `tmp` directory). Navigate to the `tmp` directory and look for an `install_<random_hash>` folder. Look at its contents - the `OffAmazonPaymentsService.config.inc.php` filename will be truncated since it exceeds the 100 limit.
# Workaround

In what seems to be a PAX implementation of `tar`, there's an 'L' flag that can be set so that the file name will reside in the contents block and the contents of the actual file are in the next block. This allows for longer paths to be stored. [source 1](http://stackoverflow.com/questions/2078778/what-exactly-is-the-gnu-tar-longlink-trick) [source 2](http://manpages.ubuntu.com/manpages/intrepid/man5/star.5.html)

If you want to test for yourself, you can create a `tar` archive using [7-Zip](http://www.7-zip.org/) which produces this type of archives.

The PR addresses this issue and properly extracts the archive contents (perhaps there are other implementations of TAR long filenames, but I haven't found anything conclusive).
