### PR TITLE
Remove method setting in favor of that used in newer framework packages ...

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -64,24 +64,7 @@ class JHttpTransportCurl implements JHttpTransport
 		$ch = curl_init();
 
 		// Set the request method.
-		switch (strtoupper($method))
-		{
-			case 'GET':
-				$options[CURLOPT_HTTPGET] = true;
-				break;
-
-			case 'POST':
-				$options[CURLOPT_POST] = true;
-				break;
-
-			case 'PUT':
-				$options[CURLOPT_PUT] = true;
-				break;
-
-			default:
-				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
-				break;
-		}
+        $options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
 
 		// Don't wait for body when $method is HEAD
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -66,18 +66,18 @@ class JHttpTransportCurl implements JHttpTransport
 		// Set the request method.
 		switch (strtoupper($method))
 		{
-				case 'GET':
-					$options[CURLOPT_HTTPGET] = true;
-				break;
+			case 'GET':
+				$options[CURLOPT_HTTPGET] = true;
+			break;
 
-				case 'POST':
-					$options[CURLOPT_POST] = true;
-				break;
+			case 'POST':
+				$options[CURLOPT_POST] = true;
+			break;
 
-				case 'PUT':
-				default:
-					$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
-				break;
+			case 'PUT':
+			default:
+				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+			break;
 		}
 
 		// Don't wait for body when $method is HEAD

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -66,18 +66,18 @@ class JHttpTransportCurl implements JHttpTransport
 		// Set the request method.
 		switch (strtoupper($method))
 		{
-		case 'GET':
-			$options[CURLOPT_HTTPGET] = true;
-			break;
+				case 'GET':
+					$options[CURLOPT_HTTPGET] = true;
+				break;
 
-		case 'POST':
-			$options[CURLOPT_POST] = true;
-			break;
+				case 'POST':
+					$options[CURLOPT_POST] = true;
+				break;
 
-		case 'PUT':
-		default:
-			$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
-			break;
+				case 'PUT':
+				default:
+					$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+				break;
 		}
 
 		// Don't wait for body when $method is HEAD

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -68,16 +68,16 @@ class JHttpTransportCurl implements JHttpTransport
 		{
 			case 'GET':
 				$options[CURLOPT_HTTPGET] = true;
-			break;
+				break;
 
 			case 'POST':
 				$options[CURLOPT_POST] = true;
-			break;
+				break;
 
 			case 'PUT':
 			default:
 				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
-			break;
+				break;
 		}
 
 		// Don't wait for body when $method is HEAD

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -64,7 +64,21 @@ class JHttpTransportCurl implements JHttpTransport
 		$ch = curl_init();
 
 		// Set the request method.
-		$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+		switch (strtoupper($method))
+		{
+		case 'GET':
+			$options[CURLOPT_HTTPGET] = true;
+			break;
+
+		case 'POST':
+			$options[CURLOPT_POST] = true;
+			break;
+
+		case 'PUT':
+		default:
+			$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+			break;
+		}
 
 		// Don't wait for body when $method is HEAD
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -64,7 +64,7 @@ class JHttpTransportCurl implements JHttpTransport
 		$ch = curl_init();
 
 		// Set the request method.
-        $options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+		$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
 
 		// Don't wait for body when $method is HEAD
 		$options[CURLOPT_NOBODY] = ($method === 'HEAD');


### PR DESCRIPTION
...and that actually works

Closes #6556 

see comments in original Issue #6556 

This implements the same method of setting the method that is used in the Joomla Framework - I.e not setting the individual curl options, but just sending it with CURLOPT_CUSTOMREQUEST

To test - apply patch and test any apps using JHttp and put - probably a fringe case as Joomla doesnt actually consume this method itself as far as I can tell.

Additionally the gist here has some test cases against a test endpoint https://gist.github.com/PhilETaylor/a4ee67f8f48d3674221d
