### PR TITLE
Correctly allow PUT Curl requests

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -75,9 +75,6 @@ class JHttpTransportCurl implements JHttpTransport
 				break;
 
 			case 'PUT':
-				$options[CURLOPT_PUT] = true;
-				break;
-
 			default:
 				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
 				break;


### PR DESCRIPTION
This is a fork of the original PR #6550 and closes #6556 

It seems that `some resful apps` require `CURLOPT_POST` (apparently) and so code was added in #6312 to ensure `CURLOPT_POST` was set 

However there seems to be some curl bugs with `CURLOPT_PUT` that doesn't send the data right unless PUT is set in `CURLOPT_CUSTOMREQUEST`

This PR is a compromise between #6312 and the Joomla Framework (which has no large switch and just ALWAYS sets `CURLOPT_CUSTOMREQUEST`)

see comments in original Issue #6556

This implements the same method of setting the method that is used in the Joomla Framework - I.e not setting the individual curl options, but just sending it with `CURLOPT_CUSTOMREQUEST`

To test - apply patch and test any apps using JHttp and put - probably a fringe case as Joomla doesn't actually consume this method itself as far as I can tell.

Additionally the gist here has some test cases against a test endpoint https://gist.github.com/PhilETaylor/a4ee67f8f48d3674221d
