### PR TITLE
Fix plugins trigger using cli scripts

### DIFF
--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -101,7 +101,7 @@ abstract class JPlugin extends JEvent
 
 			if ($appProperty->isPrivate() === false && is_null($this->app))
 			{
-				$this->app = JFactory::getApplication();
+				$this->app = (php_sapi_name() === 'cli') ? JFactory::getApplication('administrator') : JFactory::getApplication();
 			}
 		}
 


### PR DESCRIPTION
If we try to trigger authentication plugins we receive the error.

```
Application Instantiation Error
```

The exactly issue is into 'cookies' plugin, enabled by default:

https://github.com/joomla/joomla-cms/blob/staging/plugins/authentication/cookie/cookie.php#L27

The example of the plugin trigger:

https://github.com/fastslack/matware-libraries/blob/master/api/application/web.php#L218
