### PR TITLE
Adding codeCoverageIgnore to deprecated method in JPathway

### DIFF
--- a/libraries/cms/pathway/pathway.php
+++ b/libraries/cms/pathway/pathway.php
@@ -209,6 +209,7 @@ class JPathway
 	 *
 	 * @since   1.5
 	 * @deprecated  4.0  Use makeItem() instead
+	 * @codeCoverageIgnore
 	 */
 	protected function _makeItem($name, $link)
 	{


### PR DESCRIPTION
See title. This brings the coverage of JPathway to 100%.
