### PR TITLE
Correct conditional

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -58,7 +58,7 @@ class PlgSystemRedirect extends JPlugin
 		$app = JFactory::getApplication();
 
 		// Make sure the error is a 404 and we are not in the administrator.
-		if ($app->isAdmin() && $error->getCode() != 404)
+		if ($app->isAdmin() || $error->getCode() != 404)
 		{
 			// Render the error page.
 			JError::customErrorPage($error);


### PR DESCRIPTION
As noted at https://github.com/joomla/joomla-cms/commit/ebc91998b27189d703e0a7b039f2b51e7cbbc73a#commitcomment-10353495 the conditional here is a little messed up.  We should only process for the site app when there's a 404 error, right now the conditional only returns early if both conditions are true.
