### PR TITLE
Regression: multilang alternate

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -696,7 +696,6 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 				}
 			}
-
 		}
 	}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -641,10 +641,9 @@ class PlgSystemLanguageFilter extends JPlugin
 						$link = JRoute::_($cassociations[$language] . '&lang=' . $lang->sef);
 
 						// Check if language is the default site language and remove url language code is on
-						if ($lang->sef == $this->lang_codes[$this->default_lang]->sef && $this->params->get('remove_default_prefix') == '1')
+						if ($lang->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
+							&& $this->params->get('remove_default_prefix', 0))
 						{
-							$link = preg_replace('|/' . $lang->sef . '/|', '/', $link, 1);
-						}
 
 						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language));
 					}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -616,7 +616,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 					else
 					{
-						$lang_code = $this->default_lang;
+						$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 					}
 				}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -644,7 +644,8 @@ class PlgSystemLanguageFilter extends JPlugin
 						if ($lang->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
 							&& $this->params->get('remove_default_prefix', 0))
 						{
-
+							$link = preg_replace('|/' . $lang->sef . '/|', '/', $link, 1);
+						}
 						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language));
 					}
 					elseif (isset($associations[$language]))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -642,10 +642,12 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						// Check if language is the default site language and remove url language code is on
 						if ($lang->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
-							&& $this->params->get('remove_default_prefix', 0))
+							&& $this->params->get('remove_default_prefix', 0)
+							)
 						{
 							$link = preg_replace('|/' . $lang->sef . '/|', '/', $link, 1);
 						}
+
 						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language));
 					}
 					elseif (isset($associations[$language]))
@@ -657,6 +659,42 @@ class PlgSystemLanguageFilter extends JPlugin
 							$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $lang->sef);
 
 							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language));
+						}
+					}
+				}
+
+				// Create alternate for home pages
+				if ($active && $active->home && $home)
+				{
+					foreach (JLanguageHelper::getLanguages() as $language)
+					{
+						if (!JLanguage::exists($language->lang_code))
+						{
+							continue;
+						}
+
+						$item = $menu->getDefault($language->lang_code);
+
+						if ($item && $item->language != $active->language && $item->language != '*')
+						{
+							if ($this->mode_sef)
+							{
+								$link = JRoute::_('index.php?Itemid=' . $item->id . '&lang=' . $language->sef);
+
+								// Check if language is the default site language and remove url language code is on
+								if ($language->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
+									&& $this->params->get('remove_default_prefix', 0)
+									)
+								{
+									$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
+								}
+							}
+							else
+							{
+								$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+							}
+
+							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
 						}
 					}
 				}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -624,8 +624,42 @@ class PlgSystemLanguageFilter extends JPlugin
 				$assocs = array_merge(array_keys($cassociations), $assocs);
 			}
 
+			// Create alternate for home pages
+			if ($active && $active->home && $home)
+			{
+				foreach (JLanguageHelper::getLanguages() as $language)
+				{
+					if (!JLanguage::exists($language->lang_code))
+					{
+						continue;
+					}
+
+					$item = $menu->getDefault($language->lang_code);
+
+					if ($item && $item->language != $active->language && $item->language != '*')
+					{
+						if ($this->mode_sef)
+						{
+							$link = JRoute::_('index.php?Itemid=' . $item->id . '&lang=' . $language->sef);
+
+							// Check if language is the default site language and remove url language code is on
+							if ($language->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
+								&& $this->params->get('remove_default_prefix', 0))
+							{
+								$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
+							}
+						}
+						else
+						{
+							$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+						}
+
+						$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
+					}
+				}
+			}
 			// Handle the default associations.
-			if ($this->params->get('item_associations') || ($active && $active->home && $home))
+			elseif ($this->params->get('item_associations'))
 			{
 				$languages = JLanguageHelper::getLanguages('lang_code');
 				foreach ($assocs as $language)
@@ -661,42 +695,8 @@ class PlgSystemLanguageFilter extends JPlugin
 						}
 					}
 				}
-
-				// Create alternate for home pages
-				if ($active && $active->home && $home)
-				{
-					foreach (JLanguageHelper::getLanguages() as $language)
-					{
-						if (!JLanguage::exists($language->lang_code))
-						{
-							continue;
-						}
-
-						$item = $menu->getDefault($language->lang_code);
-
-						if ($item && $item->language != $active->language && $item->language != '*')
-						{
-							if ($this->mode_sef)
-							{
-								$link = JRoute::_('index.php?Itemid=' . $item->id . '&lang=' . $language->sef);
-
-								// Check if language is the default site language and remove url language code is on
-								if ($language->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
-									&& $this->params->get('remove_default_prefix', 0))
-								{
-									$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
-								}
-							}
-							else
-							{
-								$link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
-							}
-
-							$doc->addHeadLink($server . $link, 'alternate', 'rel', array('hreflang' => $language->lang_code));
-						}
-					}
-				}
 			}
+
 		}
 	}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -642,8 +642,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						// Check if language is the default site language and remove url language code is on
 						if ($lang->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
-							&& $this->params->get('remove_default_prefix', 0)
-							)
+							&& $this->params->get('remove_default_prefix', 0))
 						{
 							$link = preg_replace('|/' . $lang->sef . '/|', '/', $link, 1);
 						}
@@ -683,8 +682,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 								// Check if language is the default site language and remove url language code is on
 								if ($language->sef == $this->lang_codes[JComponentHelper::getParams('com_languages')->get('site', 'en-GB')]->sef
-									&& $this->params->get('remove_default_prefix', 0)
-									)
+									&& $this->params->get('remove_default_prefix', 0))
 								{
 									$link = preg_replace('|/' . $language->sef . '/|', '/', $link, 1);
 								}


### PR DESCRIPTION
Ref: http://forum.joomla.org/viewtopic.php?f=711&t=880812
Set a multilingual site with associations. 
Set Remove Language Code to Yes in the languagefilter plugin
Load a page with associations in another language than the site default language.

The alternate for the site default language in source will display the sef prefix.
This is wrong.

the error comes from the code introduced in https://github.com/joomla/joomla-cms/pull/5140:
`$this->default_lang;` is not the default site language but the present language in use.

Patch and test again.

NOTE: when looking at this specific issue, I remarked:
1. line 619 is also using `$this->default_lang;` for the site default language. I corrected it.
1. We have another regression vs 3.3.6:
   Home pages were always getting alternate in source whether they were associated or not.
   This is not the case anymore. We need to correct this.
