### PR TITLE
Dont show database prefix when throwing Exception

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -302,7 +302,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		{
 			// Get the error number and message.
 			$this->errorNum = (int) mysql_errno($this->connection);
-			$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $query;
+			$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . (string) $this->sql;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -582,7 +582,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			$this->errorNum = (int) mysqli_errno($this->connection);
-			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $query;
+			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . (string) $this->sql;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -719,7 +719,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			{
 				// Get the error number and message.
 				$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-				$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
+				$this->errorMsg = pg_last_error($this->connection) . "SQL=" . (string) $this->sql;
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -704,7 +704,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-					$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
+					$this->errorMsg = pg_last_error($this->connection) . "SQL=" . (string) $this->sql;
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -644,7 +644,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 					// Get the error number and message.
 					$errors = sqlsrv_errors();
 					$this->errorNum = $errors[0]['SQLSTATE'];
-					$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
+					$this->errorMsg = $errors[0]['message'] . 'SQL=' . (string) $this->sql;
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
@@ -660,7 +660,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				// Get the error number and message.
 				$errors = sqlsrv_errors();
 				$this->errorNum = $errors[0]['SQLSTATE'];
-				$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
+				$this->errorMsg = $errors[0]['message'] . 'SQL=' . (string) $this->sql;
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');


### PR DESCRIPTION
#### Concept

If an SQL error occur, database driver throw a runtimeException containg the SQL with prefix replaced by table prefix.

<code>[code] [error] SQL=[SQL]</code>
eg:
<code>1062 Duplicate entry '1' for key 1 SQL=INSERT INTO 'mysecretdatabaseprefix_table' SET 'key' = '1'</code>

This fix show in exception message the sql before the string identifier was replaced.
eg:
<code>1062 Duplicate entry '1' for key 1 SQL=INSERT INTO '#__table' SET 'key' = '1'</code>

I think this is a tiny security improvment, by that we can't obtain the secret prefix.

Unfortunately, im unable to test on many drivers, moreover, PDO handle the error differently so i actually not modified this driver.
#### Testing instructions

Try to make an SQL error
