### PR TITLE
Introduce modal footer with close button for bootstrap modals

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -127,11 +127,15 @@ class JHtmlUsers
 
 		return JHtmlBootstrap::renderModal(
 			'userModal_' . (int) $userId, array(
-				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
 				'title' => $title,
-				'width' => '800px',
-				'height' => '500px',
-				'footer' => $footer)
+				'backdrop' => 'static',
+				'keyboard' => true,
+				'closeButton' => true,
+				'footer' => $footer,
+				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
+				'height' => '300px',
+				'width' => '800px'
+				)
 		);
 
 	}

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -122,13 +122,16 @@ class JHtmlUsers
 		}
 
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
+		$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+			. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
 		return JHtmlBootstrap::renderModal(
 			'userModal_' . (int) $userId, array(
 				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
 				'title' => $title,
 				'width' => '800px',
-				'height' => '500px')
+				'height' => '500px',
+				'footer' => $footer)
 		);
 
 	}

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -26,4 +26,15 @@ defined('_JEXEC') or die;
 	</a>
 </div>
 
-<?php echo JHtmlBootstrap::renderModal('multiLangModal', array( 'url' => $link, 'title' => JText::_('MOD_MULTILANGSTATUS'),'height' => '300px', 'width' => '500px', 'footer' => $footer));
+<?php echo JHtmlBootstrap::renderModal(
+	'multiLangModal', array(
+		'title' => JText::_('MOD_MULTILANGSTATUS'),
+		'backdrop' => 'static',
+		'keyboard' => true,
+		'closeButton' => true,
+		'footer' => $footer,
+		'url' => $link,
+		'height' => '300px',
+		'width' => '500px'
+		)
+	);

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -16,6 +16,8 @@ defined('_JEXEC') or die;
 	JFactory::getDocument()->addStyleDeclaration('.navbar-fixed-bottom {z-index:1050;}');
 
 	$link = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
+	$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+		. JText::_('JTOOLBAR_CLOSE') . '</a>';
 ?>
 <div class="btn-group multilanguage">
 	<a href="#multiLangModal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('MOD_MULTILANGSTATUS'); ?>">
@@ -24,4 +26,4 @@ defined('_JEXEC') or die;
 	</a>
 </div>
 
-<?php echo JHtmlBootstrap::renderModal('multiLangModal', array( 'url' => $link, 'title' => JText::_('MOD_MULTILANGSTATUS'),'height' => '300px', 'width' => '500px'));
+<?php echo JHtmlBootstrap::renderModal('multiLangModal', array( 'url' => $link, 'title' => JText::_('MOD_MULTILANGSTATUS'),'height' => '300px', 'width' => '500px', 'footer' => $footer));


### PR DESCRIPTION
#### Minor UX/UI

This PR will attaches a footer on users notes and multilingual status modals
#### Preview

User notes
![screen shot 2015-03-27 at 3 01 04](https://cloud.githubusercontent.com/assets/3889375/6868294/21b98a6a-d493-11e4-92ea-39ba4f71b159.png)

Multilingual status
![screen shot 2015-03-27 at 3 03 02](https://cloud.githubusercontent.com/assets/3889375/6868303/3725de62-d493-11e4-8190-0f6853349b37.png)
#### Testing

Apply patch
goto /administrator/index.php?option=com_users&view=users
and click on multilingual status on the status bar
make sure that the close button closes the modal

I will update also #6408 and #4661
For #4563 PR #6462 needs to be accepted first.
The rest #5871, #5655, #5654 and #5652 needs the new layout render, so I will not touch them yet
