### PR TITLE
Remove clutter from the user list

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -55,7 +55,7 @@ class JHtmlUsers
 		$title = JText::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-vcard"></i><span class="hidden-phone">' . $title . '</span></a>';
+			. '<i class="icon-vcard"></i><span class="hidden-phone"></span></a>';
 	}
 
 	/**
@@ -101,7 +101,7 @@ class JHtmlUsers
 		$title = JText::plural('COM_USERS_N_USER_NOTES', $count);
 
 		return '<a href="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId . '" data-toggle="modal" class="hasTooltip btn btn-mini" title="' . $title . '">'
-			. '<i class="icon-drawer-2"></i><span class="hidden-phone">' . $title . '</span></a>';
+			. '<i class="icon-drawer-2"></i><span class="hidden-phone"></span></a>';
 	}
 
 	/**


### PR DESCRIPTION
The user list looks quite cluttered with a button "Add a note" being below each user:

![User list before](https://cloud.githubusercontent.com/assets/3502738/6880365/bc9135a2-d52d-11e4-95ed-c012a1b16224.png)

This change removes the text from that button (the text is still shown on a tooltip).
## How to test:

Go to user manager. Without any notes attached to a user, it should look like this:

![after](https://cloud.githubusercontent.com/assets/3502738/6880371/716953b0-d52e-11e4-9f53-f8a9e1dc4328.png)

Then, add a note to a user. Before it looked like this:

![before](https://cloud.githubusercontent.com/assets/3502738/6880369/2b9e6942-d52e-11e4-895f-ebd808b2499b.png)

After applying the patch, it should look like this (the tooltips should still work):

![after](https://cloud.githubusercontent.com/assets/3502738/6880370/408f6478-d52e-11e4-8761-f987e8dd6154.png)
