### PR TITLE
[fix] for #6601 Banner Manager

### DIFF
--- a/administrator/components/com_banners/models/forms/client.xml
+++ b/administrator/components/com_banners/models/forms/client.xml
@@ -63,7 +63,7 @@
 			label="COM_BANNERS_FIELD_TRACKIMPRESSION_LABEL"
 			description="COM_BANNERS_FIELD_TRACKIMPRESSION_DESC"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
+			<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
@@ -72,7 +72,7 @@
 			class="chzn-color"
 			label="COM_BANNERS_FIELD_TRACKCLICK_LABEL" description="COM_BANNERS_FIELD_TRACKCLICK_DESC"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
+			<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>


### PR DESCRIPTION
see #6601 for more info

---

Hi,

There is a bug in Joomla 3.4x Banner Manager.

When you try to save a Banner Client with the "Use Global" setting for Track Impressions and Track Clicks, it will save the changes as "No" instead of Use Global.

Steps to reproduce bug error:
1) Go to Banner Manager > Options > save global options as "Yes" for Track Impressions and Track Clicks settings. See attached screenshot 1

2) Go to Banner Manager > Clients > Edit Client screen and select "Use Global" for Track Impressions and Track Clicks settings and Save. It will change to "No" for those settings. See attached screenshot 2

![2015-03-28 banner settings 1](https://cloud.githubusercontent.com/assets/9383382/6882750/3827bb26-d567-11e4-9a01-5b35a1d634ec.JPG)

![2015-03-28 banner settings 2](https://cloud.githubusercontent.com/assets/9383382/6882751/3b2a0004-d567-11e4-86c9-24affdc58883.JPG)
