### PR TITLE
Remove code that should be handled via session handlers

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -739,22 +739,7 @@ class JApplicationCms extends JApplicationWeb
 		$session->start();
 
 		// TODO: At some point we need to get away from having session data always in the db.
-		$db = JFactory::getDbo();
-
-		// Remove expired sessions from the database.
 		$time = time();
-
-		if ($time % 2)
-		{
-			// The modulus introduces a little entropy, making the flushing less accurate
-			// but fires the query less than half the time.
-			$query = $db->getQuery(true)
-				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('time') . ' < ' . $db->quote((int) ($time - $session->getExpire())));
-
-			$db->setQuery($query);
-			$db->execute();
-		}
 
 		// Get the session handler from the configuration.
 		$handler = $this->get('session_handler', 'none');


### PR DESCRIPTION
In our application class exists code to clean up dead session data from the database.  This same code exists in the database session handler and is registered to PHP's session management API.  This PR removes the lines from the application class and leaves garbage collection of session data to the session API.
### Testing Instructions

So this one's a little more difficult to test.  You'll probably want to manipulate your session configs (see http://php.net/manual/en/function.session-set-save-handler.php and specifically the settings around the `gc` config).  The `gc` callable is called on a randomized basis, so manipulating the settings will make it more controlled.  With the patch applied, expired session data should still be removed from the database; however instead of the application doing it on pretty much every request on an even numbered second, it'll be left to PHP to decide when it's called.
