### PR TITLE
Handle DB errors in authentication cookie plugin

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -59,7 +59,7 @@ class PlgAuthenticationCookie extends JPlugin
 
 		if (!$cookieValue)
 		{
-			return;
+			return false;
 		}
 
 		$cookieArray = explode('.', $cookieValue);
@@ -84,7 +84,15 @@ class PlgAuthenticationCookie extends JPlugin
 		$query = $this->db->getQuery(true)
 			->delete('#__user_keys')
 			->where($this->db->quoteName('time') . ' < ' . $this->db->quote(time()));
-		$this->db->setQuery($query)->execute();
+
+		try
+		{
+			$this->db->setQuery($query)->execute();
+		}
+		catch (RuntimeException $e)
+		{
+			// We aren't concerned with errors from this query, carry on
+		}
 
 		// Find the matching record if it exists.
 		$query = $this->db->getQuery(true)
@@ -93,7 +101,17 @@ class PlgAuthenticationCookie extends JPlugin
 			->where($this->db->quoteName('series') . ' = ' . $this->db->quote($series))
 			->where($this->db->quoteName('uastring') . ' = ' . $this->db->quote($cookieName))
 			->order($this->db->quoteName('time') . ' DESC');
-		$results = $this->db->setQuery($query)->loadObjectList();
+
+		try
+		{
+			$results = $this->db->setQuery($query)->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			$response->status = JAuthentication::STATUS_FAILURE;
+
+			return false;
+		}
 
 		if (count($results) !== 1)
 		{
@@ -101,32 +119,42 @@ class PlgAuthenticationCookie extends JPlugin
 			$this->app->input->cookie->set($cookieName, false, time() - 42000, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain'));
 			$response->status = JAuthentication::STATUS_FAILURE;
 
-			return;
+			return false;
 		}
 
 		// We have a user with one cookie with a valid series and a corresponding record in the database.
-		else
+		if (!JUserHelper::verifyPassword($cookieArray[0], $results[0]->token))
 		{
-			$token = JUserHelper::hashPassword($cookieArray[0]);
+			/*
+			 * This is a real attack! Either the series was guessed correctly or a cookie was stolen and used twice (once by attacker and once by victim).
+			 * Delete all tokens for this user!
+			 */
+			$query = $this->db->getQuery(true)
+				->delete('#__user_keys')
+				->where($this->db->quoteName('user_id') . ' = ' . $this->db->quote($results[0]->user_id));
 
-			if (!JUserHelper::verifyPassword($cookieArray[0], $results[0]->token))
+			try
 			{
-				// This is a real attack! Either the series was guessed correctly or a cookie was stolen and used twice (once by attacker and once by victim).
-				// Delete all tokens for this user!
-				$query = $this->db->getQuery(true)
-					->delete('#__user_keys')
-					->where($this->db->quoteName('user_id') . ' = ' . $this->db->quote($results[0]->user_id));
 				$this->db->setQuery($query)->execute();
-
-				// Destroy the cookie in the browser.
-				$this->app->input->cookie->set($cookieName, false, time() - 42000, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain'));
-
-				// Issue warning by email to user and/or admin?
-				JLog::add(JText::sprintf('PLG_AUTH_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), JLog::WARNING, 'security');
-				$response->status = JAuthentication::STATUS_FAILURE;
-
-				return false;
 			}
+			catch (RuntimeException $e)
+			{
+				// Log an alert for the site admin
+				JLog::add(
+					sprintf('Failed to delete cookie token for user %s with the following error: %s', $results[0]->user_id, $e->getMessage()),
+					JLog::WARNING,
+					'security'
+				);
+			}
+
+			// Destroy the cookie in the browser.
+			$this->app->input->cookie->set($cookieName, false, time() - 42000, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain'));
+
+			// Issue warning by email to user and/or admin?
+			JLog::add(JText::sprintf('PLG_AUTH_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), JLog::WARNING, 'security');
+			$response->status = JAuthentication::STATUS_FAILURE;
+
+			return false;
 		}
 
 		// Make sure there really is a user with this name and get the data for the session.
@@ -135,7 +163,17 @@ class PlgAuthenticationCookie extends JPlugin
 			->from($this->db->quoteName('#__users'))
 			->where($this->db->quoteName('username') . ' = ' . $this->db->quote($results[0]->user_id))
 			->where($this->db->quoteName('requireReset') . ' = 0');
-		$result = $this->db->setQuery($query)->loadObject();
+
+		try
+		{
+			$result = $this->db->setQuery($query)->loadObject();
+		}
+		catch (RuntimeException $e)
+		{
+			$response->status = JAuthentication::STATUS_FAILURE;
+
+			return false;
+		}
 
 		if ($result)
 		{
@@ -198,7 +236,8 @@ class PlgAuthenticationCookie extends JPlugin
 			$cookieName		= JUserHelper::getShortHashedUserAgent();
 
 			// Create an unique series which will be used over the lifespan of the cookie
-			$unique = false;
+			$unique     = false;
+			$errorCount = 0;
 
 			do
 			{
@@ -208,11 +247,24 @@ class PlgAuthenticationCookie extends JPlugin
 					->from($this->db->quoteName('#__user_keys'))
 					->where($this->db->quoteName('series') . ' = ' . $this->db->quote($series));
 
-				$results = $this->db->setQuery($query)->loadResult();
-
-				if (is_null($results))
+				try
 				{
-					$unique = true;
+					$results = $this->db->setQuery($query)->loadResult();
+
+					if (is_null($results))
+					{
+						$unique = true;
+					}
+				}
+				catch (RuntimeException $e)
+				{
+					$errorCount++;
+
+					// We'll let this query fail up to 5 times before giving up, there's probably a bigger issue at this point
+					if ($errorCount == 5)
+					{
+						return false;
+					}
 				}
 			}
 
@@ -264,7 +316,15 @@ class PlgAuthenticationCookie extends JPlugin
 		$hashed_token = JUserHelper::hashPassword($token);
 
 		$query->set($this->db->quoteName('token') . ' = ' . $this->db->quote($hashed_token));
-		$this->db->setQuery($query)->execute();
+
+		try
+		{
+			$this->db->setQuery($query)->execute();
+		}
+		catch (RuntimeException $e)
+		{
+			return false;
+		}
 
 		return true;
 	}
@@ -302,12 +362,18 @@ class PlgAuthenticationCookie extends JPlugin
 		$series = $filter->clean($cookieArray[1], 'ALNUM');
 
 		// Remove the record from the database
-		$query = $this->db->getQuery(true);
-		$query
+		$query = $this->db->getQuery(true)
 			->delete('#__user_keys')
 			->where($this->db->quoteName('series') . ' = ' . $this->db->quote($series));
 
-		$this->db->setQuery($query)->execute();
+		try
+		{
+			$this->db->setQuery($query)->execute();
+		}
+		catch (RuntimeException $e)
+		{
+			// We aren't concerned with errors from this query, carry on
+		}
 
 		// Destroy the cookie
 		$this->app->input->cookie->set(


### PR DESCRIPTION
Database errors are uncaught/unmanaged in the authentication cookie plugin right now.  This PR adds error handling for the plugin by catching exceptions thrown by the database layer and deciding how to proceed.
### Testing Instructions

Generally just make sure the plugin still works.
