### PR TITLE
[bug] Client-side form validation : remove aria-invalid on label. Closes #6596

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -50,12 +50,12 @@ var JFormValidator = function() {
  	 	if (state === false) {
  	 	 	$el.addClass('invalid').attr('aria-invalid', 'true');
  	 	 	if ($label) {
- 	 	 	 	$label.addClass('invalid').attr('aria-invalid', 'true');
+ 	 	 	 	$label.addClass('invalid');
  	 	 	}
  	 	} else {
  	 	 	$el.removeClass('invalid').attr('aria-invalid', 'false');
  	 	 	if ($label) {
- 	 	 	 	$label.removeClass('invalid').attr('aria-invalid', 'false');
+ 	 	 	 	$label.removeClass('invalid');
  	 	 	}
  	 	}
  	},


### PR DESCRIPTION
Removing "aria-invalid" attribute on label when form is not valid.
https://www.w3.org/WAI/GL/wiki/Using_Aria-Invalid_to_Indicate_An_Error_Field
Closes #6596

---

<h2>Client-side form validation : aria-invalid on label</h2>


Hello,

When using the client-side form validation system joomla " behavior.formvalidator " when a field is misinformed and when the field is linked to a label, the attribute " aria -invalid = true" is added to the label.
According to accessibility standards this attribute should be only placed on the attribute "input".

Thank you for your answers

http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute

<h3>Example before client-side validation :</h3>

``` html
<form  class="form-validate" method="post">
     <label id="jform_title-lbl" title="" for="jform_title">Title</label>
     <input id="jform_title" type="text" aria-required="true" required="required">
</form>
```

<h3>Example after client-side validation wrong :</h3>

``` html
<form  class="form-validate" method="post">
     <label id="jform_title-lbl" title="" for="jform_title" aria-invalid="true">Title</label>
     <input id="jform_title" type="text" aria-required="true" required="required" aria-invalid="true">
</form>
```

<h3>Example after client-side validation correct:</h3>

``` html
<form  class="form-validate" method="post">
     <label id="jform_title-lbl" title="" for="jform_title">Title</label>
     <input id="jform_title" type="text" aria-required="true" required="required" aria-invalid="true">
</form>
```

<h3>Patch to \media\system\js\validate-uncompressed.js</h3>

Remove line 52

``` javascript
if($label){
     $label.addClass('invalid');
}
```

Remove line 57

``` javascript
if($label){
     $label.removeClass('invalid');
}
```
