### PR TITLE
Fix ReCAPTCHA Version 2 on pageload

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -71,13 +71,13 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 				$file = $app->isSSLConnection() ? 'https' : 'http';
 				$file .= '://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()
-						->getTag() . '&onload=onloadCallback&render=explicit';
+						->getTag() . '&render=explicit';
 
 				JHtml::_('script', $file, true, true);
 
-				$document->addScriptDeclaration('var onloadCallback = function() {'
+				$document->addScriptDeclaration('jQuery(document).ready(function() {'
 					. 'grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});'
-					. '}'
+					. '});'
 				);
 				break;
 		}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -75,9 +75,9 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 				JHtml::_('script', $file, true, true);
 
-				$document->addScriptDeclaration('jQuery(document).ready(function() {'
+				$document->addScriptDeclaration('jQuery(document).ready(function($) {$(window).load(function() {'
 					. 'grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});'
-					. '});'
+					. '});});'
 				);
 				break;
 		}

--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -42,7 +42,7 @@ class JReCaptchaResponse
 class JReCaptcha
 {
 	private static $_signupUrl = "https://www.google.com/recaptcha/admin";
-	private static $_siteVerifyUrl = "https://www.google.com/recaptcha/api/siteverify?";
+	private static $_siteVerifyUrl = "https://www.google.com/recaptcha/api/siteverify";
 	private $_secret;
 	private static $_version = "php_1.0";
 

--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -94,7 +94,7 @@ class JReCaptcha
 	{
 		$req = $this->_encodeQS($data);
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($path.'?'.$req)->body;
+		$response = $http->get($path . '?' . $req)->body;
 
 		return $response;
 	}

--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -83,7 +83,7 @@ class JReCaptcha
 	}
 
 	/**
-	 * Submits an HTTP POST to a reCAPTCHA server.
+	 * Submits an HTTP GET to a reCAPTCHA server.
 	 *
 	 * @param string $path url path to recaptcha server.
 	 * @param array  $data array of parameters to be sent.
@@ -93,7 +93,7 @@ class JReCaptcha
 	private function _submitHTTPGet($path, $data)
 	{
 		$http = JHttpFactory::getHttp();
-		$response = $http->post($path, $data)->body;
+		$response = $http->get($path, $data)->body;
 
 		return $response;
 	}

--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -83,7 +83,7 @@ class JReCaptcha
 	}
 
 	/**
-	 * Submits an HTTP GET to a reCAPTCHA server.
+	 * Submits an HTTP POST to a reCAPTCHA server.
 	 *
 	 * @param string $path url path to recaptcha server.
 	 * @param array  $data array of parameters to be sent.
@@ -92,8 +92,8 @@ class JReCaptcha
 	 */
 	private function _submitHTTPGet($path, $data)
 	{
-		$req = $this->_encodeQS($data);
-		$response = file_get_contents($path . $req);
+		$http = JHttpFactory::getHttp();
+		$response = $http->post($path, $data)->body;
 
 		return $response;
 	}

--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -92,8 +92,9 @@ class JReCaptcha
 	 */
 	private function _submitHTTPGet($path, $data)
 	{
+		$req = $this->_encodeQS($data);
 		$http = JHttpFactory::getHttp();
-		$response = $http->get($path, $data)->body;
+		$response = $http->get($path.'?'.$req)->body;
 
 		return $response;
 	}


### PR DESCRIPTION
### What this PR do

At a german Support Forum we had the report that the new Captcha only loads on the seccond pageload. This PR trys to fix it.
This PR also remove the usage of `file_get_contents` and replace it with `JHttpFactory::getHttp()->post`
### How to test
- Enable the new captcha plugin (set version to 2)
- Set the captcha as default at the global configuration (Backend --> Global Configuration --> Captcha)
- Create a contact form menu entry with capcha enabled
- access the  fronted view the first time
- the v2 captcha should not show
- try to reload the site
- the capcha is shown
- apply the patch
- try again. It should load in the first site load
### See the german forum

http://forum.joomla.de/index.php/Thread/211-Google-recaptcha-ich-bin-kein-Roboter-l%C3%A4dt-nicht-immer/
