### PR TITLE
Templates missing support for rendering error stack traces

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -219,15 +219,18 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 		<section id="content">
 			<!-- Begin Content -->
 			<div class="row-fluid">
-					<div class="span12">
-						<!-- Begin Content -->
-						<h1 class="page-header"><?php echo JText::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
-						<blockquote>
-							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
-						</blockquote>
-						<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
-						<!-- End Content -->
-					</div>
+				<div class="span12">
+					<!-- Begin Content -->
+					<h1 class="page-header"><?php echo JText::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+					<blockquote>
+						<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
+					</blockquote>
+					<?php if ($this->debug) : ?>
+						<?php echo $this->renderBacktrace(); ?>
+					<?php endif; ?>
+					<p><a href="<?php echo $this->baseurl; ?>" class="btn"><i class="icon-dashboard"></i> <?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
+					<!-- End Content -->
+				</div>
 			</div>
 			<!-- End Content -->
 		</section>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -167,6 +167,9 @@ else
 						<blockquote>
 							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
 						</blockquote>
+						<?php if ($this->debug) : ?>
+							<?php echo $this->renderBacktrace(); ?>
+						<?php endif; ?>
 					</div>
 					<!-- End Content -->
 				</div>


### PR DESCRIPTION
The Isis and Protostar templates are missing support for rendering the stack trace on the error template.  This PR adds it.
### Testing Instructions

1) Ensure debug mode is enabled
2) With Isis and Protostar active, trigger an error page on both site and admin, note no trace exists
3) Change the templates to Hathor and Beez3 and again trigger an error on both sides; there should be a stack trace
4) Apply the patch and make Isis and Protostar the active templates again
5) Once again, trigger an error page; there should now be a stack trace
### Why render this information?

A stack trace is a useful debugging tool to show how we got to a point in the execution cycle.  Supporting this allows quicker troubleshooting by instructing users to enable debug mode and trigger the error; if their template supports this feature then there is a clear step-by-step output of what was called to trigger the error and isolate the problematic extension.
