### PR TITLE
Multilanguage: Language switcher bug when sef off

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -111,7 +111,7 @@ abstract class ModLanguagesHelper
 					{
 						if ($language->active)
 						{
-							$language->link = JUri::current();
+							$language->link = JUri::getInstance()->toString(array('scheme', 'host', 'port', 'path', 'query'));
 						}
 						else
 						{


### PR DESCRIPTION
See: http://forum.joomla.org/viewtopic.php?f=711&t=881515

Test conditions:
Install a multingual site with staging or 3.4.1
Set SEF to OFF 
 Set "Active Language" to display in the Language Switcher module parameters
Create some articles and related menu items in each language as usual.
Load a menu item (not the home page) displaying an article in one of the languages. 

Click on the flag for THE SAME LANGUAGE as the one displayed:
One is redirected to the Home page of that language instead of reloading the same page.

Patch and retest.
Test also after setting SEF to ON
