### PR TITLE
Fix menu icon for trashed menu item state

### DIFF
--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -208,8 +208,8 @@ abstract class MenusHtmlMenus
 				'COM_MENUS_HTML_PUBLISH_DISABLED',
 				'COM_MENUS_EXTENSION_UNPUBLISHED_DISABLED',
 				true,
-				'unpublish',
-				'unpublish'
+				'trash',
+				'trash'
 			),
 		);
 


### PR DESCRIPTION
## Issue description

Trashed menu items use the "unpublished" icon instead of the "trashed" icon in backend. This patch should fix this issue without affecting any other behavior. Issue was originally reported by user Cartho on joomla-bugs.de: http://www.joomla-bugs.de/forum/index.php/topic,665.0.html
## Testing instructions
1. Go to "Menus - Your Menu" in backend to see the list of menu items.
2. Trash one or more menu items.
3. Set the "state" filter to "trashed" or "all" to display trashed items.
4. Apply the patch.
5. Make sure the icon is now correct and all actions still work, in particular:
   - "untrash" an item by clicking the trash icon.
   - "untrash" one or more items by selecting some and clicking the "clear trash" button when the state filter is set to "trashed".
   - trash one or more items by selecting some and clicking the "trash" button.
## Further proposals

As mentioned, the patch only changes the icon. For reasons of consistency, I have two more proposals where I'd like to request for some comments:
### 1) Change the tooltips

  I'm not sure if the tooltips "Publish menu item::Component disabled" and "Component disabled and menu item unpublished." are the correct ones to use for the "trashed" state (-2). 
### 2) Use the same state buttons as in com_content

  In com_content (list of articles), we have a button group containing the status icon, featured icon and a dropdown with the actions "trash" and "archive". Is there any point against doing this the same way in com_menus? Instead of "featured" we could use the "default" marker (instead of having a separate column), the dropdown could be replaced with a single trash icon, because we don't have an "archived" state for menu items AFAIK.
