### PR TITLE
Allow external components to use local help files

### DIFF
--- a/administrator/components/com_config/view/component/html.php
+++ b/administrator/components/com_config/view/component/html.php
@@ -92,6 +92,6 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 		JToolbarHelper::divider();
 		JToolbarHelper::cancel('config.cancel.component');
 		JToolbarHelper::divider();
-		JToolbarHelper::help('JHELP_COMPONENTS_' . $this->currentComponent . '_OPTIONS');
+		JToolbarHelper::help('JHELP_COMPONENTS_OPTIONS', true, null, $this->currentComponent);
 	}
 }

--- a/administrator/components/com_config/view/component/html.php
+++ b/administrator/components/com_config/view/component/html.php
@@ -92,6 +92,6 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 		JToolbarHelper::divider();
 		JToolbarHelper::cancel('config.cancel.component');
 		JToolbarHelper::divider();
-		JToolbarHelper::help('JHELP_COMPONENTS_OPTIONS', true, null, $this->currentComponent);
+		JToolbarHelper::help('JHELP_COMPONENTS_' . strtoupper($this->currentComponent) . '_OPTIONS', true, null, $this->currentComponent);
 	}
 }


### PR DESCRIPTION
Based on: http://issues.joomla.org/tracker/joomla-cms/6627
And the fix provided by @chrisdavenport here: https://github.com/joomla/joomla-cms/issues/6627#issuecomment-88971362

``````
Chris, I think you misunderstood the original request: The issue is not how third-party components can implement a help button in general (which I agree is nicely described in the links you posted). 

The issue is that in J3 **third-party components** have their **configuration page** shown in the **com_config component**, and this component does not provide any way to offer help pages from servers different from the default help server. So if you go to the configuration page of e.g. Kunena or VirtueMart, then the help button in the com_config component will try to use the JHELP_COMPONENTS_com_kunena_OPTIONS or JHELP_COMPONENTS_com_virtuemart_OPTIONS help keys on the Joomla server.

The corresponding code is in administrator/components/com_config/view/component/html.php, function ConfigViewComponentHtml::addToolbar:

```php
    protected function addToolbar()
    {
        [...]
        JToolbarHelper::divider();
        JToolbarHelper::help('JHELP_COMPONENTS_' . $this->currentComponent . '_OPTIONS');
    }
```php

This will always try to load the help page from the **default Joomla help server**, even for third-party applications (which do not have any help pages on the joomla servers, of course).  Those third-party components thus do not have any way to provide help pages for the configuration page on their own servers.

For third-party components, the com_config component needs to be made more flexible to allow help pages on other servers, too... That is the real issue here.
``````

I'm so free to quote @kainhofer from https://github.com/joomla/joomla-cms/issues/6627#issuecomment-88871311
#### How to test
- install a external component (e.g. com_jce)
- Access the global configuration
- Make sure that the help button for core components e.g. com_banners work
- go to the configuration of your external component (e.g. com_jce)
- see that the help button for your external component also try to use docs.joomla.org (some thing like: `https://help.joomla.org/proxy/index.php?option=com_help&keyref=Help35:JHELP_COMPONENTS_com_jce_OPTIONS`)
- apply the patch
- make sure com_banners (and other core components still works)
- see your external component
- the link looks something like this: `http://localhost/34RC/administrator/components/com_jce/help/en-GB/JHELP_COMPONENTS_COM_JCE_OPTIONS.html`
- so the external component can store local screens
#### Developers

This string: JHELP_COMPONENTS_COM_JCE_OPTIONS can be used as language string if needed for a better name e.g. something like
`JHELP_COMPONENTS_COM_JCE_OPTIONS="jce_config"`
