### PR TITLE
fix #6620 - featured frontend editing bug

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -504,7 +504,7 @@ class ContentModelArticle extends JModelAdmin
 		}
 
 		// Automatic handling of alias for empty fields
-		if (in_array($input->get('task'), array('apply', 'save', 'save2new')) && (int) $input->get('id') == 0)
+		if (in_array($input->get('task'), array('apply', 'save', 'save2new')) && (!isset($data['id']) || (int) $data['id'] == 0))
 		{
 			if ($data['alias'] == null)
 			{


### PR DESCRIPTION
fix #6620 - featured frontend editing bug
## Issue

see #6620
## Test Instructions

Create and edit articles in the backend and the frontend from different views (article, category blog, featured...).
Create and edit articles with the same title/alias and category.
Everything, especially the alias generation for new articles, should work as expected.
