### PR TITLE
[Improvement] - Status code 301 for Force SSL option

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -449,7 +449,7 @@ class JApplicationAdministrator extends JApplicationCms
 		{
 			// Forward to https
 			$uri->setScheme('https');
-			$this->redirect((string) $uri);
+			$this->redirect((string) $uri, 301);
 		}
 
 		// Trigger the onAfterRoute event.

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -74,7 +74,7 @@ class JRouterSite extends JRouter
 		{
 			// Forward to https
 			$uri->setScheme('https');
-			$this->app->redirect((string) $uri);
+			$this->app->redirect((string) $uri, 301);
 		}
 
 		// Get the path


### PR DESCRIPTION
Changed status code for SSL redirects (Option: Force SSL in Global Configuration) to "301 Moved Permanently" as Google recommends it.

**How to test**

SSL has to be configured on your server to test this patch!
- Activate the option "Force SSL" in the Global Configuration (for Site and Administrator).
- Open the Developer Tools in your browser (usually button F12 in Windows)
- Go to the frontpage and load the website manually with the scheme http:// (not https://) and check the status code on the tab "Network" in the developer tools.
- Without the patch, you should see a 303 status code:
  ![2015-04-03 14_11_43-test](https://cloud.githubusercontent.com/assets/1976103/6981981/7f3c028a-da0b-11e4-9c76-cef2e1e62deb.png)
- Apply patch with the help of the Patchtester component and check the status code again - 301
  ![2015-04-03 14_12_10-test](https://cloud.githubusercontent.com/assets/1976103/6981983/90d5078a-da0b-11e4-8f1c-a8135bb73e7d.png)
- Do the same test for the backend!

See here for more details:

https://support.google.com/webmasters/answer/6073543
http://moz.com/blog/seo-tips-https-ssl
http://moz.com/learn/seo/redirection
