### PR TITLE
Update default_item.php to show tags

### DIFF
--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -48,6 +48,10 @@ $info    = $this->item->params->get('info_block_position', 0);
 	<?php echo JLayoutHelper::render('joomla.content.icons', array('params' => $params, 'item' => $this->item, 'print' => false)); ?>
 <?php endif; ?>
 
+<?php if ($params->get('show_tags') && !empty($this->item->tags->itemTags)) : ?>
+	<?php echo JLayoutHelper::render('joomla.content.tags', $this->item->tags->itemTags); ?>
+<?php endif; ?>
+
 <?php // Todo Not that elegant would be nice to group the params ?>
 <?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') ); ?>


### PR DESCRIPTION
In the featured article view tags will never be shown. With this change tags can be show in featured articles depending on the option set in the menu item.
