### PR TITLE
updated return tag to allow for code completion

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -260,7 +260,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 * @param   string  $prefix  An optional prefix for the table class name.
 	 * @param   array   $config  An optional array of configuration values for the JTable object.
 	 *
-	 * @return  mixed    A JTable object if found or boolean false if one could not be found.
+	 * @return  JTable|boolean   A JTable object if found or boolean false on failure.
 	 *
 	 * @link    https://docs.joomla.org/JTable/getInstance
 	 * @since   11.1


### PR DESCRIPTION
This updates the return tag to allow for code completion in IDEs.
If this PR is accepted, i could take a look at some other widely used methods.
#### Test instructions

`$yourTable = JTable::getInstance("YourTable", "YourTablePrefix");` in your IDE.
Code completion should work now (if your IDE supports it).
