### PR TITLE
Undefined $model variable for postDeleteHook() in delete() method in admin.php - $model in wrong scope

### DIFF
--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -113,15 +113,15 @@ class JControllerAdmin extends JControllerLegacy
 		// Get items to remove from the request.
 		$cid = JFactory::getApplication()->input->get('cid', array(), 'array');
 
-		// Get the model.
-		$model = $this->getModel();
-
 		if (!is_array($cid) || count($cid) < 1)
 		{
 			JLog::add(JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), JLog::WARNING, 'jerror');
 		}
 		else
 		{
+			// Get the model.
+			$model = $this->getModel();
+
 			// Make sure the item ids are integers
 			jimport('joomla.utilities.arrayhelper');
 			JArrayHelper::toInteger($cid);
@@ -130,14 +130,15 @@ class JControllerAdmin extends JControllerLegacy
 			if ($model->delete($cid))
 			{
 				$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_DELETED', count($cid)));
+
+				// Invoke the postDelete method to allow for the child class to access the model.
+				$this->postDeleteHook($model, $cid);
 			}
 			else
 			{
 				$this->setMessage($model->getError(), 'error');
 			}
 		}
-		// Invoke the postDelete method to allow for the child class to access the model.
-		$this->postDeleteHook($model, $cid);
 
 		$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 	}

--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -113,15 +113,15 @@ class JControllerAdmin extends JControllerLegacy
 		// Get items to remove from the request.
 		$cid = JFactory::getApplication()->input->get('cid', array(), 'array');
 
+		// Get the model.
+		$model = $this->getModel();
+
 		if (!is_array($cid) || count($cid) < 1)
 		{
 			JLog::add(JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), JLog::WARNING, 'jerror');
 		}
 		else
 		{
-			// Get the model.
-			$model = $this->getModel();
-
 			// Make sure the item ids are integers
 			jimport('joomla.utilities.arrayhelper');
 			JArrayHelper::toInteger($cid);


### PR DESCRIPTION
$model is undefined at line 140 for $this->postDeleteHook($model, $cid);, because $model was instantiated within the scope of the else block. If you try to delete an item from an admin list, you will get a PHP Notice and a PHP Catchable Fatal Error. So, it is better to declare/instantiate the model outside of the else block, within the same scope of the call to postDeleteHook().
