### PR TITLE
Handle DB errors in users latest module

### DIFF
--- a/modules/mod_users_latest/helper.php
+++ b/modules/mod_users_latest/helper.php
@@ -53,8 +53,14 @@ class ModUsersLatestHelper
 		}
 
 		$db->setQuery($query, 0, $params->get('shownumber'));
-		$result = $db->loadObjectList();
 
-		return (array) $result;
+		try
+		{
+			return (array) $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			return array();
+		}
 	}
 }

--- a/modules/mod_users_latest/helper.php
+++ b/modules/mod_users_latest/helper.php
@@ -60,6 +60,8 @@ class ModUsersLatestHelper
 		}
 		catch (RuntimeException $e)
 		{
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_GENERIC_SQL_ERROR'), 'error');
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 			return array();
 		}
 	}


### PR DESCRIPTION
updated to handle DB errors like #6612 ,#6632, #6665 and for #6591

Testing info
set the db offline 
or
simulate a db error 
change line 37 from

```
->from('#__users AS a');
```

to

```
->from('#__users AS z');
```

before patch you get
![trycatch](https://cloud.githubusercontent.com/assets/181681/6996449/a081b79e-db89-11e4-83b2-f40c7d9461b4.png)

after you get
the module is not displayed
