### PR TITLE
Fix for #6662 - Broken Filter in Articles list modal

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -29,26 +29,25 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1');?>"
       method="post" name="adminForm" id="adminForm" class="form-inline">
-	<fieldset class="filter clearfix">
+	<fieldset class="filter">
 		<div class="btn-toolbar">
-			<div class="btn-group pull-left">
+			<div class="btn-group">
 				<label for="filter_search">
 					<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
 				</label>
 			</div>
-			<div class="btn-group pull-left">
+			<div class="btn-group">
 				<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" />
 			</div>
-			<div class="btn-group pull-left">
+			<div class="btn-group">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
 					<span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
 					<span class="icon-remove"></span><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
 			</div>
-			<div class="clearfix"></div>
 		</div>
 		<hr class="hr-condensed" />
-		<div class="filters pull-left">
+		<div class="filters">
 			<select name="filter_access" class="input-medium" onchange="this.form.submit()">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>

--- a/media/system/css/adminlist.css
+++ b/media/system/css/adminlist.css
@@ -209,15 +209,10 @@ button:hover {
 	border: 1px solid #aaa;
 }
 
-.clearfix {
-	overflow: hidden;
-}
-
 fieldset input,
 fieldset textarea,
 fieldset select,
-fieldset img,
-fieldset button {
+fieldset img {
 	float: left;
 	width: auto;
 	margin: 5px 5px 5px 0;


### PR DESCRIPTION
Fix for broken filter in the Articles list modal , described in #6662 

ps. Here still issue with categories dropdown, it work in admin side but still broken on the site:
![screen 2015-04-05 13 20 14 412x375](https://cloud.githubusercontent.com/assets/1568198/6996560/42bea9ce-db97-11e4-940a-27bedeac6b7e.png)
have no idea how to fix it, there something with styling...
any idea?
