### PR TITLE
Add modal for edit article in Single article menu view

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -138,7 +138,7 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a class="modal btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" rel="{handler: \'iframe\', size: {x: 1000, y: 500}}"><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -138,7 +138,9 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="modal btn hasTooltip' . ($value ? '' : ' hidden') . '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" rel="{handler: \'iframe\', size: {x: 1000, y: 500}}"><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a class="modal btn hasTooltip' . ($value ? '' : ' hidden') . '" title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '"
+			href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' .
+			$value . '" rel="{handler: \'iframe\', size: {x: 1000, y: 500}}"><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button


### PR DESCRIPTION
## How to reproduce the bug

1) Go to menu manager -> menu
2) Create a new menu item of the type "Single article"
3) Select an article
4) Click on the edit button, right of the select button
At this moment, there will open a new page so you can edit the article. An modal is expected instead of a new page.
## How to test this page

Apply the patch, click on the edit button and confirm a modal opened.
## Notes

I know all Mootools modals are converted to Bootstrap at this moment. So this is a temporarily solution, in the feature this modal shoulde converted to Bootstrap. Maybe @dgt41 can do this one to?
