### PR TITLE
Updating comment on JModelLegacy to allow for code completion

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -54,7 +54,7 @@ abstract class JModelLegacy extends JObject
 	/**
 	 * A state object
 	 *
-	 * @var    string
+	 * @var    JObject
 	 * @since  12.2
 	 */
 	protected $state;


### PR DESCRIPTION
This one updates the comment for the state object. The state object is supposed to be an object, not a string, and the default is a JObject object, so I think JObject as comment would be right.
