### PR TITLE
Improve JAccess::getAssetRules() Performance ~50%

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -221,9 +221,6 @@ class JAccess
 			->select($recursive ? 'b.rules' : 'a.rules')
 			->from('#__assets AS a');
 
-		// SQLsrv change
-		$query->group($recursive ? 'b.id, b.rules, b.lft' : 'a.id, a.rules, a.lft');
-
 		// If the asset identifier is numeric assume it is a primary key, else lookup by name.
 		if (is_numeric($asset))
 		{


### PR DESCRIPTION
This closes #4107

After considerable discussion on the sql-optimisation-wg between @alikon and @sovainfo and comparing 3 different versions of Nadeeshan's SQL Optimization code for JAccess in issue #4107 we decided that the simplest way to improve the performance would be to make the change suggested here: remove the GROUP BY clause for the query.

Because of the comment about SQL Server mentioned above that line additional testing was performed in MS SQL and Postgres and no issues related to the change were noted.

Here are some test results of each variation (this one is listed under "Omar's Version"):
NOTE: Tests were run in the Backend Articles List View, Logged in as an Administrator User (not Super Admin) with 100 Articles Listed which resulted in 125 calls to JAccess:getAssetRules().

Current Version:
Database queries total: 1238.8 ms
Database queries total: 1082.7 ms
Database queries total: 1134.2 ms
Database queries total: 1051.7 ms
Database queries total: 1167.3 ms

Omar's Version (Remove the GROUP BY clause):
Database queries total: 593.6 ms
Database queries total: 572.2 ms
Database queries total: 592.4 ms
Database queries total: 614.3 ms
Database queries total: 574.2 ms

Nicola's Version (Change the JOIN):
Database queries total: 511.6 ms
Database queries total: 549.0 ms
Database queries total: 530.7 ms
Database queries total: 538.7 ms
Database queries total: 527.3 ms

Marcel's Version (Remove the JOIN):
Database queries total: 517.4 ms
Database queries total: 604.9 ms
Database queries total: 545.6 ms
Database queries total: 550.4 ms
Database queries total: 509.2 ms

Nadeeshan's Version (Decompose into 2 Queries):
Database queries total: 526.6 ms
Database queries total: 556.7 ms
Database queries total: 525.2 ms
Database queries total: 550.8 ms
Database queries total: 546.5 ms
