### PR TITLE
Allow jdoc tags to be written with closing tags

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -648,7 +648,7 @@ class JDocumentHTML extends JDocument
 	{
 		$matches = array();
 
-		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)(?:\/|>.*<\/jdoc:include.*)>#iU', $this->_template, $matches))
+		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)(?:\/|>(?:.|\n|\r)*<\/jdoc:include.*)>#iU', $this->_template, $matches))
 		{
 			$template_tags_first = array();
 			$template_tags_last = array();

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -648,7 +648,7 @@ class JDocumentHTML extends JDocument
 	{
 		$matches = array();
 
-		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)\/>#iU', $this->_template, $matches))
+		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)(?:\/|>.*<\/jdoc:include.*)>#iU', $this->_template, $matches))
 		{
 			$template_tags_first = array();
 			$template_tags_last = array();


### PR DESCRIPTION
## What?

Typical `JDoc` tags are self closing, like this:

``` xml
<jdoc:include blahblahblah />
```

With this change, that will still work but now so will this:

``` xml
<jdoc:include blahblahblah></jdoc:include>
```
## Why?

Practically, it makes no difference but why shouldn't we be able to write these tags any way we like? 
OK, there are a couple of nice things about using a closing tag. 
1) If your IDE is 'helping' you by closing your tags, it might not recognize that `<jdoc:include />` is closed because HTML has a finite number of self-closing tags and `<jdoc:include />` is not among them. Therefore, an IDE that knows HTML well will probably see this tag as still open and try to help you close it. 
2) It's a bit silly but, you could do something like this:

``` xml
<jdoc:include type="modules" name="foo">
    This is the 'foo' module space, it will usually be used with 'bar' modules but sometimes may include 'baz' modules. 
</jdoc:include>
```

The text inside the tag will essentially be a comment that will be miraculously stripped away when the template output is parsed. 
## How (to test)?

Well, this is change to a single line of code. It's the line that parses `<jdoc:include>` tags in your template so to test the change: 
1) Load up any page of your site that uses `<jdoc:include />` (i.e. any page). If all of your modules, component, head, etc are loading, the existing functionality is not broken.
2) In your template file, change those `<jdoc:include />` tags (some or all, it doesn't matter) to `<jdoc:include></jdoc:include>` and load the page again. Everything should continue to work exactly as usual. Then the new functionality is also not broken.
3) Just for good measure, change those tags to `<jdoc:include /></jdoc:include>` and load the page. Now you should see that everything appears where it's expected but, in the HTML source of the page there will be some `</jdoc:include>` left behind in those places. This expected because that's not the right way to write these tags. So then, the change is working as it should.
## WTF?

I got some unit test failures with this change but I assure you, they are not related to this change. I will fix them in a different PR. Because they have nothing to do with this. At all.  
