### PR TITLE
#6688 Toggle ssl off for unverified peer/host.

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -18,263 +18,272 @@ use Joomla\Registry\Registry;
  */
 class JHttpTransportCurl implements JHttpTransport
 {
-	/**
-	 * @var    Registry  The client options.
-	 * @since  11.3
-	 */
-	protected $options;
+    /**
+     * @var    Registry  The client options.
+     * @since  11.3
+     */
+    protected $options;
 
-	/**
-	 * Constructor. CURLOPT_FOLLOWLOCATION must be disabled when open_basedir or safe_mode are enabled.
-	 *
-	 * @param   Registry  $options  Client options object.
-	 *
-	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
-	 * @since   11.3
-	 * @throws  RuntimeException
-	 */
-	public function __construct(Registry $options)
-	{
-		if (!function_exists('curl_init') || !is_callable('curl_init'))
-		{
-			throw new RuntimeException('Cannot use a cURL transport when curl_init() is not available.');
-		}
+    /**
+     * Constructor. CURLOPT_FOLLOWLOCATION must be disabled when open_basedir or safe_mode are enabled.
+     *
+     * @param   Registry  $options  Client options object.
+     *
+     * @see     http://www.php.net/manual/en/function.curl-setopt.php
+     * @since   11.3
+     * @throws  RuntimeException
+     */
+    public function __construct(Registry $options)
+    {
+        if (!function_exists('curl_init') || !is_callable('curl_init'))
+        {
+            throw new RuntimeException('Cannot use a cURL transport when curl_init() is not available.');
+        }
 
-		$this->options = $options;
-	}
+        $this->options = $options;
+    }
 
-	/**
-	 * Send a request to the server and return a JHttpResponse object with the response.
-	 *
-	 * @param   string   $method     The HTTP method for sending the request.
-	 * @param   JUri     $uri        The URI to the resource to request.
-	 * @param   mixed    $data       Either an associative array or a string to be sent with the request.
-	 * @param   array    $headers    An array of request headers to send with the request.
-	 * @param   integer  $timeout    Read timeout in seconds.
-	 * @param   string   $userAgent  The optional user agent string to send with the request.
-	 *
-	 * @return  JHttpResponse
-	 *
-	 * @since   11.3
-	 * @throws  RuntimeException
-	 */
-	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
-	{
-		// Setup the cURL handle.
-		$ch = curl_init();
+    /**
+     * Send a request to the server and return a JHttpResponse object with the response.
+     *
+     * @param   string   $method     The HTTP method for sending the request.
+     * @param   JUri     $uri        The URI to the resource to request.
+     * @param   mixed    $data       Either an associative array or a string to be sent with the request.
+     * @param   array    $headers    An array of request headers to send with the request.
+     * @param   integer  $timeout    Read timeout in seconds.
+     * @param   string   $userAgent  The optional user agent string to send with the request.
+     *
+     * @return  JHttpResponse
+     *
+     * @since   11.3
+     * @throws  RuntimeException
+     */
+    public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
+    {
+        // Setup the cURL handle.
+        $ch = curl_init();
 
-		// Set the request method.
-		switch (strtoupper($method))
-		{
-			case 'GET':
-				$options[CURLOPT_HTTPGET] = true;
-				break;
+        // Set the request method.
+        switch (strtoupper($method))
+        {
+            case 'GET':
+                $options[CURLOPT_HTTPGET] = true;
+                break;
 
-			case 'POST':
-				$options[CURLOPT_POST] = true;
-				break;
+            case 'POST':
+                $options[CURLOPT_POST] = true;
+                break;
 
-			case 'PUT':
-				$options[CURLOPT_PUT] = true;
-				break;
+            case 'PUT':
+                $options[CURLOPT_PUT] = true;
+                break;
 
-			default:
-				$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
-				break;
-		}
+            default:
+                $options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+                break;
+        }
 
-		// Don't wait for body when $method is HEAD
-		$options[CURLOPT_NOBODY] = ($method === 'HEAD');
+        // Don't wait for body when $method is HEAD
+        $options[CURLOPT_NOBODY] = ($method === 'HEAD');
 
-		// Initialize the certificate store
-		$options[CURLOPT_CAINFO] = $this->options->get('curl.certpath', __DIR__ . '/cacert.pem');
+        // Initialize the certificate store
+        $options[CURLOPT_CAINFO] = $this->options->get('curl.certpath', __DIR__ . '/cacert.pem');
 
-		// If data exists let's encode it and make sure our Content-type header is set.
-		if (isset($data))
-		{
-			// If the data is a scalar value simply add it to the cURL post fields.
-			if (is_scalar($data) || (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'multipart/form-data') === 0))
-			{
-				$options[CURLOPT_POSTFIELDS] = $data;
-			}
+        // If data exists let's encode it and make sure our Content-type header is set.
+        if (isset($data))
+        {
+            // If the data is a scalar value simply add it to the cURL post fields.
+            if (is_scalar($data) || (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'multipart/form-data') === 0))
+            {
+                $options[CURLOPT_POSTFIELDS] = $data;
+            }
 
-			// Otherwise we need to encode the value first.
-			else
-			{
-				$options[CURLOPT_POSTFIELDS] = http_build_query($data);
-			}
+            // Otherwise we need to encode the value first.
+            else
+            {
+                $options[CURLOPT_POSTFIELDS] = http_build_query($data);
+            }
 
-			if (!isset($headers['Content-Type']))
-			{
-				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
-			}
+            if (!isset($headers['Content-Type']))
+            {
+                $headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
+            }
 
-			// Add the relevant headers.
-			if (is_scalar($options[CURLOPT_POSTFIELDS]))
-			{
-				$headers['Content-Length'] = strlen($options[CURLOPT_POSTFIELDS]);
-			}
-		}
+            // Add the relevant headers.
+            if (is_scalar($options[CURLOPT_POSTFIELDS]))
+            {
+                $headers['Content-Length'] = strlen($options[CURLOPT_POSTFIELDS]);
+            }
+        }
 
-		// Build the headers string for the request.
-		$headerArray = array();
+        // Build the headers string for the request.
+        $headerArray = array();
 
-		if (isset($headers))
-		{
-			foreach ($headers as $key => $value)
-			{
-				$headerArray[] = $key . ': ' . $value;
-			}
+        if (isset($headers))
+        {
+            foreach ($headers as $key => $value)
+            {
+                $headerArray[] = $key . ': ' . $value;
+            }
 
-			// Add the headers string into the stream context options array.
-			$options[CURLOPT_HTTPHEADER] = $headerArray;
-		}
+            // Add the headers string into the stream context options array.
+            $options[CURLOPT_HTTPHEADER] = $headerArray;
+        }
 
-		// If an explicit timeout is given user it.
-		if (isset($timeout))
-		{
-			$options[CURLOPT_TIMEOUT] = (int) $timeout;
-			$options[CURLOPT_CONNECTTIMEOUT] = (int) $timeout;
-		}
+        // If an explicit timeout is given user it.
+        if (isset($timeout))
+        {
+            $options[CURLOPT_TIMEOUT] = (int) $timeout;
+            $options[CURLOPT_CONNECTTIMEOUT] = (int) $timeout;
+        }
 
-		// If an explicit user agent is given use it.
-		if (isset($userAgent))
-		{
-			$options[CURLOPT_USERAGENT] = $userAgent;
-		}
+        // If an explicit user agent is given use it.
+        if (isset($userAgent))
+        {
+            $options[CURLOPT_USERAGENT] = $userAgent;
+        }
 
-		// Set the request URL.
-		$options[CURLOPT_URL] = (string) $uri;
+        // Set the request URL.
+        $options[CURLOPT_URL] = (string) $uri;
 
-		// We want our headers. :-)
-		$options[CURLOPT_HEADER] = true;
+        // We want our headers. :-)
+        $options[CURLOPT_HEADER] = true;
 
-		// Return it... echoing it would be tacky.
-		$options[CURLOPT_RETURNTRANSFER] = true;
+        // Return it... echoing it would be tacky.
+        $options[CURLOPT_RETURNTRANSFER] = true;
 
-		// Override the Expect header to prevent cURL from confusing itself in its own stupidity.
-		// Link: http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
-		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
+        // Override the Expect header to prevent cURL from confusing itself in its own stupidity.
+        // Link: http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
+        $options[CURLOPT_HTTPHEADER][] = 'Expect:';
 
-		/*
-		 * Follow redirects if server config allows
-		 * @deprecated  safe_mode is removed in PHP 5.4, check will be dropped when PHP 5.3 support is dropped
-		 */
-		if (!ini_get('safe_mode') && !ini_get('open_basedir'))
-		{
-			$options[CURLOPT_FOLLOWLOCATION] = (bool) $this->options->get('follow_location', true);
-		}
+        /*
+         * Follow redirects if server config allows
+         * @deprecated  safe_mode is removed in PHP 5.4, check will be dropped when PHP 5.3 support is dropped
+         */
+        if (!ini_get('safe_mode') && !ini_get('open_basedir'))
+        {
+            $options[CURLOPT_FOLLOWLOCATION] = (bool) $this->options->get('follow_location', true);
+        }
 
-		// Proxy configuration
-		$config = JFactory::getConfig();
+        // Proxy configuration
+        $config = JFactory::getConfig();
 
-		if ($config->get('proxy_enable'))
-		{
-			$options[CURLOPT_PROXY] = $config->get('proxy_host') . ':' . $config->get('proxy_port');
+        if ($config->get('proxy_enable'))
+        {
+            $options[CURLOPT_PROXY] = $config->get('proxy_host') . ':' . $config->get('proxy_port');
 
-			if ($user = $config->get('proxy_user'))
-			{
-				$options[CURLOPT_PROXYUSERPWD] = $user . ':' . $config->get('proxy_pass');
-			}
-		}
+            if ($user = $config->get('proxy_user'))
+            {
+                $options[CURLOPT_PROXYUSERPWD] = $user . ':' . $config->get('proxy_pass');
+            }
+        }
 
-		// Set the cURL options.
-		curl_setopt_array($ch, $options);
+        // Allow for SSL verification to be toggled off
+        if ($this->options->exists('curl.ssl.verifypeer') && !(bool)$this->options->get('curl.ssl.verifypeer')) {
+            $options[CURLOPT_SSL_VERIFYPEER] = 0;
+        }
 
-		// Execute the request and close the connection.
-		$content = curl_exec($ch);
+        if ($this->options->exists('curl.ssl.verifyhost') && !(bool)$this->options->get('curl.ssl.verifyhost')) {
+            $options[CURLOPT_SSL_VERIFYHOST] = 0;
+        }
 
-		// Check if the content is a string. If it is not, it must be an error.
-		if (!is_string($content))
-		{
-			$message = curl_error($ch);
+        // Set the cURL options.
+        curl_setopt_array($ch, $options);
 
-			if (empty($message))
-			{
-				// Error but nothing from cURL? Create our own
-				$message = 'No HTTP response received';
-			}
+        // Execute the request and close the connection.
+        $content = curl_exec($ch);
 
-			throw new RuntimeException($message);
-		}
+        // Check if the content is a string. If it is not, it must be an error.
+        if (!is_string($content))
+        {
+            $message = curl_error($ch);
 
-		// Get the request information.
-		$info = curl_getinfo($ch);
+            if (empty($message))
+            {
+                // Error but nothing from cURL? Create our own
+                $message = 'No HTTP response received';
+            }
 
-		// Close the connection.
-		curl_close($ch);
+            throw new RuntimeException($message);
+        }
 
-		return $this->getResponse($content, $info);
-	}
+        // Get the request information.
+        $info = curl_getinfo($ch);
 
-	/**
-	 * Method to get a response object from a server response.
-	 *
-	 * @param   string  $content  The complete server response, including headers
-	 *                            as a string if the response has no errors.
-	 * @param   array   $info     The cURL request information.
-	 *
-	 * @return  JHttpResponse
-	 *
-	 * @since   11.3
-	 * @throws  UnexpectedValueException
-	 */
-	protected function getResponse($content, $info)
-	{
-		// Create the response object.
-		$return = new JHttpResponse;
+        // Close the connection.
+        curl_close($ch);
 
-		// Get the number of redirects that occurred.
-		$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
+        return $this->getResponse($content, $info);
+    }
 
-		/*
-		 * Split the response into headers and body. If cURL encountered redirects, the headers for the redirected requests will
-		 * also be included. So we split the response into header + body + the number of redirects and only use the last two
-		 * sections which should be the last set of headers and the actual body.
-		 */
-		$response = explode("\r\n\r\n", $content, 2 + $redirects);
+    /**
+     * Method to get a response object from a server response.
+     *
+     * @param   string  $content  The complete server response, including headers
+     *                            as a string if the response has no errors.
+     * @param   array   $info     The cURL request information.
+     *
+     * @return  JHttpResponse
+     *
+     * @since   11.3
+     * @throws  UnexpectedValueException
+     */
+    protected function getResponse($content, $info)
+    {
+        // Create the response object.
+        $return = new JHttpResponse;
 
-		// Set the body for the response.
-		$return->body = array_pop($response);
+        // Get the number of redirects that occurred.
+        $redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
 
-		// Get the last set of response headers as an array.
-		$headers = explode("\r\n", array_pop($response));
+        /*
+         * Split the response into headers and body. If cURL encountered redirects, the headers for the redirected requests will
+         * also be included. So we split the response into header + body + the number of redirects and only use the last two
+         * sections which should be the last set of headers and the actual body.
+         */
+        $response = explode("\r\n\r\n", $content, 2 + $redirects);
 
-		// Get the response code from the first offset of the response headers.
-		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
+        // Set the body for the response.
+        $return->body = array_pop($response);
 
-		$code = count($matches) ? $matches[0] : null;
+        // Get the last set of response headers as an array.
+        $headers = explode("\r\n", array_pop($response));
 
-		if (is_numeric($code))
-		{
-			$return->code = (int) $code;
-		}
+        // Get the response code from the first offset of the response headers.
+        preg_match('/[0-9]{3}/', array_shift($headers), $matches);
 
-		// No valid response code was detected.
-		else
-		{
-			throw new UnexpectedValueException('No HTTP response code found.');
-		}
+        $code = count($matches) ? $matches[0] : null;
 
-		// Add the response headers to the response object.
-		foreach ($headers as $header)
-		{
-			$pos = strpos($header, ':');
-			$return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
-		}
+        if (is_numeric($code))
+        {
+            $return->code = (int) $code;
+        }
 
-		return $return;
-	}
+        // No valid response code was detected.
+        else
+        {
+            throw new UnexpectedValueException('No HTTP response code found.');
+        }
 
-	/**
-	 * Method to check if HTTP transport cURL is available for use
-	 *
-	 * @return boolean true if available, else false
-	 *
-	 * @since   12.1
-	 */
-	public static function isSupported()
-	{
-		return function_exists('curl_version') && curl_version();
-	}
+        // Add the response headers to the response object.
+        foreach ($headers as $header)
+        {
+            $pos = strpos($header, ':');
+            $return->headers[trim(substr($header, 0, $pos))] = trim(substr($header, ($pos + 1)));
+        }
+
+        return $return;
+    }
+
+    /**
+     * Method to check if HTTP transport cURL is available for use
+     *
+     * @return boolean true if available, else false
+     *
+     * @since   12.1
+     */
+    public static function isSupported()
+    {
+        return function_exists('curl_version') && curl_version();
+    }
 }

--- a/tests/unit/suites/libraries/joomla/http/JHttpTransportTest.php
+++ b/tests/unit/suites/libraries/joomla/http/JHttpTransportTest.php
@@ -225,4 +225,36 @@ class JHttpTransportTest extends PHPUnit_Framework_TestCase
 			$this->equalTo('value')
 		);
 	}
+
+	/**
+	 * Tests the request method with a get request without SSL vertification.
+	 *
+	 * @param   string  $transportClass  The transport class to test
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  transportProvider
+	 * @since         3.4
+	 */
+	public function testRequestGetNoVerify($transportClass)
+	{
+        $this->options->set('curl.ssl.verifypeer', false);
+        $this->options->set('curl.ssl.verifyhost', false);
+
+		$transport = new $transportClass($this->options);
+
+		$response = $transport->request('get', new JUri($this->stubUrl));
+
+		$body = json_decode($response->body);
+
+		$this->assertThat(
+			$response->code,
+			$this->equalTo(200)
+		);
+
+		$this->assertThat(
+			$body->method,
+			$this->equalTo('GET')
+		);
+	}
 }


### PR DESCRIPTION
Fix for unverified peer/host certificate.

I have added a unit test but have been unable to test as running JHttpTransportTest tests skips all tests. I've also run phpunit --testsuite libraries-cms but I think it is skipping my test also.

Also this needs an https url with a private cert or a cert with an invalid name attribute.

Alternatively, I have run a test in my dev environment using:

``` php
$array = array(
    'curl'=>array(
        'ssl'=>array(
            "verifypeer"=false,
            "verifyhost"=>false)));

$options = new \Joomla\Registry\Registry($array);
$http = JFactory::getHttp($options);
...
```
