### PR TITLE
Moves GMail plugin to use the Joomla HTTP library

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -179,12 +179,9 @@ class JHttpTransportCurl implements JHttpTransport
 		}
 
 		// Set any custom transport options
-		if (isset($this->options['transport.curl']))
+		foreach ($this->options->get('transport.curl', array()) as $key => $value)
 		{
-			foreach ($this->options['transport.curl'] as $key => $value)
-			{
-				$options[$key] = $value;
-			}
+			$options[$key] = $value;
 		}
 
 		// Set the cURL options.

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -178,6 +178,15 @@ class JHttpTransportCurl implements JHttpTransport
 			}
 		}
 
+		// Set any custom transport options
+		if (isset($this->options['transport.curl']))
+		{
+			foreach ($this->options['transport.curl'] as $key => $value)
+			{
+				$options[$key] = $value;
+			}
+		}
+
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);
 

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -125,12 +125,9 @@ class JHttpTransportSocket implements JHttpTransport
 		}
 
 		// Set any custom transport options
-		if (isset($this->options['transport.socket']))
+		foreach ($this->options->get('transport.socket', array()) as $value)
 		{
-			foreach ($this->options['transport.socket'] as $value)
-			{
-				$request[] = $value;
-			}
+			$request[] = $value;
 		}
 
 		// If we have data to send add it to the request payload.

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -124,6 +124,15 @@ class JHttpTransportSocket implements JHttpTransport
 			}
 		}
 
+		// Set any custom transport options
+		if (isset($this->options['transport.socket']))
+		{
+			foreach ($this->options['transport.socket'] as $value)
+			{
+				$request[] = $value;
+			}
+		}
+
 		// If we have data to send add it to the request payload.
 		if (!empty($data))
 		{

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -125,12 +125,9 @@ class JHttpTransportStream implements JHttpTransport
 		$options['follow_location'] = (int) $this->options->get('follow_location', 1);
 
 		// Set any custom transport options
-		if (isset($this->options['transport.stream']))
+		foreach ($this->options->get('transport.stream', array()) as $key => $value)
 		{
-			foreach ($this->options['transport.stream'] as $key => $value)
-			{
-				$options[$key] = $value;
-			}
+			$options[$key] = $value;
 		}
 
 		// Create the stream context for the request.

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -124,6 +124,15 @@ class JHttpTransportStream implements JHttpTransport
 		// Follow redirects.
 		$options['follow_location'] = (int) $this->options->get('follow_location', 1);
 
+		// Set any custom transport options
+		if (isset($this->options['transport.stream']))
+		{
+			foreach ($this->options['transport.stream'] as $key => $value)
+			{
+				$options[$key] = $value;
+			}
+		}
+
 		// Create the stream context for the request.
 		$context = stream_context_create(
 			array(

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -44,7 +44,7 @@ class PlgAuthenticationGMail extends JPlugin
 
 		$curlParams = array(
 			'follow_location' => true,
-			'transport.curl'   => array(CURLOPT_SSL_VERIFYPEER => false),
+			'transport.curl'   => array(CURLOPT_SSL_VERIFYPEER => $this->params->get('verifypeer', 1)),
 		);
 		$transportParams = new Registry($curlParams);
 

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -50,7 +50,7 @@ class PlgAuthenticationGMail extends JPlugin
 
 		try
 		{
-			$curlDriver = new JHttpTransportCurl($transportParams);
+			$http = JHttpFactory::getHttp($transportParams, 'curl');
 		}
 		catch (RuntimeException $e)
 		{
@@ -59,8 +59,6 @@ class PlgAuthenticationGMail extends JPlugin
 
 			return;
 		}
-
-		$http = new JHttp($options, $curlDriver);
 
 		// Check if we have a username and password
 		if (strlen($credentials['username']) == 0 || strlen($credentials['password']) == 0)

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -43,9 +43,12 @@ class PlgAuthenticationGMail extends JPlugin
 		$success = false;
 
 		$curlParams = array(
-			'follow_location'  => true,
-			'transport.curl'   => array(CURLOPT_SSL_VERIFYPEER => $this->params->get('verifypeer', 1)),
+			'follow_location' => true,
+			'transport.curl'  => array(
+				CURLOPT_SSL_VERIFYPEER => $this->params->get('verifypeer', 1)
+			),
 		);
+
 		$transportParams = new Registry($curlParams);
 
 		try
@@ -216,8 +219,8 @@ class PlgAuthenticationGMail extends JPlugin
 			}
 		}
 		elseif (JFactory::getApplication()->isAdmin())
-		// We wont' allow backend access without local account
 		{
+			// We wont' allow backend access without local account
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::_('JERROR_LOGIN_DENIED');
 

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -63,7 +63,7 @@ class PlgAuthenticationGMail extends JPlugin
 		$http = new JHttp($options, $curlDriver);
 
 		// Check if we have a username and password
-		if (strlen($credentials['username']) && strlen($credentials['password']))
+		if (strlen($credentials['username']) == 0 || strlen($credentials['password']) == 0)
 		{
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_USER_BLACKLISTED'));
@@ -74,7 +74,7 @@ class PlgAuthenticationGMail extends JPlugin
 		$blacklist = explode(',', $this->params->get('user_blacklist', ''));
 
 		// Check if the username isn't blacklisted
-		if (!in_array($credentials['username'], $blacklist))
+		if (in_array($credentials['username'], $blacklist))
 		{
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_USER_BLACKLISTED'));
@@ -111,7 +111,17 @@ class PlgAuthenticationGMail extends JPlugin
 			'Authorization' => 'Basic ' . base64_encode($credentials['username'] . ':' . $credentials['password'])
 		);
 
-		$result = $http->get('https://mail.google.com/mail/feed/atom', $headers);
+		try
+		{
+			$result = $http->get('https://mail.google.com/mail/feed/atom', $headers);
+		}
+		catch (Exception $e)
+		{
+			// If there was an error in the request then create a 'false' dummy response.
+			$result = new JHttpResponse;
+			$result->code = false;
+		}
+
 		$code = $result->code;
 
 		switch ($code)

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -43,7 +43,7 @@ class PlgAuthenticationGMail extends JPlugin
 		$success = false;
 
 		$curlParams = array(
-			'follow_location' => true,
+			'follow_location'  => true,
 			'transport.curl'   => array(CURLOPT_SSL_VERIFYPEER => $this->params->get('verifypeer', 1)),
 		);
 		$transportParams = new Registry($curlParams);
@@ -55,6 +55,7 @@ class PlgAuthenticationGMail extends JPlugin
 		catch (RuntimeException $e)
 		{
 			$response->status        = JAuthentication::STATUS_FAILURE;
+			$response->type          = 'GMail';
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_CURL_NOT_INSTALLED'));
 
 			return;
@@ -65,6 +66,7 @@ class PlgAuthenticationGMail extends JPlugin
 		// Check if we have a username and password
 		if (strlen($credentials['username']) == 0 || strlen($credentials['password']) == 0)
 		{
+			$response->type          = 'GMail';
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_USER_BLACKLISTED'));
 
@@ -76,6 +78,7 @@ class PlgAuthenticationGMail extends JPlugin
 		// Check if the username isn't blacklisted
 		if (in_array($credentials['username'], $blacklist))
 		{
+			$response->type          = 'GMail';
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_USER_BLACKLISTED'));
 
@@ -142,91 +145,91 @@ class PlgAuthenticationGMail extends JPlugin
 
 		$response->type = 'GMail';
 
-		if ($success)
-		{
-			if (strpos($credentials['username'], '@') === false)
-			{
-				if ($suffix)
-				{
-					// If there is a suffix then we want to apply it
-					$email = $credentials['username'] . '@' . $suffix;
-				}
-				else
-				{
-					// If there isn't a suffix just use the default gmail one
-					$email = $credentials['username'] . '@gmail.com';
-				}
-			}
-			else
-			{
-				// The username looks like an email address (probably is) so use that
-				$email = $credentials['username'];
-			}
-
-			// Extra security checks with existing local accounts
-			$db                  = JFactory::getDbo();
-			$localUsernameChecks = array(strstr($email, '@', true), $email);
-
-			$query = $db->getQuery(true)
-				->select('id, activation, username, email, block')
-				->from('#__users')
-				->where('username IN(' . implode(',', array_map(array($db, 'quote'), $localUsernameChecks)) . ')'
-					. ' OR email = ' . $db->quote($email)
-				);
-
-			$db->setQuery($query);
-
-			if ($localUsers = $db->loadObjectList())
-			{
-				foreach ($localUsers as $localUser)
-				{
-					// Local user exists with same username but different email address
-					if ($email != $localUser->email)
-					{
-						$response->status        = JAuthentication::STATUS_FAILURE;
-						$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('PLG_GMAIL_ERROR_LOCAL_USERNAME_CONFLICT'));
-
-						return;
-					}
-					else
-					{
-						// Existing user disabled locally
-						if ($localUser->block || !empty($localUser->activation))
-						{
-							$response->status        = JAuthentication::STATUS_FAILURE;
-							$response->error_message = JText::_('JGLOBAL_AUTH_ACCESS_DENIED');
-
-							return;
-						}
-
-						// We will always keep the local username for existing accounts
-						$credentials['username'] = $localUser->username;
-
-						break;
-					}
-				}
-			}
-			elseif (JFactory::getApplication()->isAdmin())
-			// We wont' allow backend access without local account
-			{
-				$response->status        = JAuthentication::STATUS_FAILURE;
-				$response->error_message = JText::_('JERROR_LOGIN_DENIED');
-
-				return;
-			}
-
-			$response->status        = JAuthentication::STATUS_SUCCESS;
-			$response->error_message = '';
-			$response->email         = $email;
-
-			// Reset the username to what we ended up using
-			$response->username = $credentials['username'];
-			$response->fullname = $credentials['username'];
-		}
-		else
+		if (!$success)
 		{
 			$response->status        = JAuthentication::STATUS_FAILURE;
 			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', $message);
+
+			return;
 		}
+
+		if (strpos($credentials['username'], '@') === false)
+		{
+			if ($suffix)
+			{
+				// If there is a suffix then we want to apply it
+				$email = $credentials['username'] . '@' . $suffix;
+			}
+			else
+			{
+				// If there isn't a suffix just use the default gmail one
+				$email = $credentials['username'] . '@gmail.com';
+			}
+		}
+		else
+		{
+			// The username looks like an email address (probably is) so use that
+			$email = $credentials['username'];
+		}
+
+		// Extra security checks with existing local accounts
+		$db                  = JFactory::getDbo();
+		$localUsernameChecks = array(strstr($email, '@', true), $email);
+
+		$query = $db->getQuery(true)
+			->select('id, activation, username, email, block')
+			->from('#__users')
+			->where('username IN(' . implode(',', array_map(array($db, 'quote'), $localUsernameChecks)) . ')'
+				. ' OR email = ' . $db->quote($email)
+			);
+
+		$db->setQuery($query);
+
+		if ($localUsers = $db->loadObjectList())
+		{
+			foreach ($localUsers as $localUser)
+			{
+				// Local user exists with same username but different email address
+				if ($email != $localUser->email)
+				{
+					$response->status        = JAuthentication::STATUS_FAILURE;
+					$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('PLG_GMAIL_ERROR_LOCAL_USERNAME_CONFLICT'));
+
+					return;
+				}
+				else
+				{
+					// Existing user disabled locally
+					if ($localUser->block || !empty($localUser->activation))
+					{
+						$response->status        = JAuthentication::STATUS_FAILURE;
+						$response->error_message = JText::_('JGLOBAL_AUTH_ACCESS_DENIED');
+
+						return;
+					}
+
+					// We will always keep the local username for existing accounts
+					$credentials['username'] = $localUser->username;
+
+					break;
+				}
+			}
+		}
+		elseif (JFactory::getApplication()->isAdmin())
+		// We wont' allow backend access without local account
+		{
+			$response->status        = JAuthentication::STATUS_FAILURE;
+			$response->error_message = JText::_('JERROR_LOGIN_DENIED');
+
+			return;
+		}
+
+		$response->status        = JAuthentication::STATUS_SUCCESS;
+		$response->error_message = '';
+		$response->email         = $email;
+
+		// Reset the username to what we ended up using
+		$response->username = $credentials['username'];
+		$response->fullname = $credentials['username'];
 	}
 }


### PR DESCRIPTION
This utilises a framework PR (https://github.com/joomla-framework/http/pull/12) to extend the transport options in Joomla for the SSL request. Currently to keep things incremental the plugin still only uses Curl, but in the future may allow to use other request methods that are available.

To test you can check that the Gmail authentication plugin still verifies users properly
