### PR TITLE
Filter isInstalled query for components, fix #6697

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -100,6 +100,7 @@ class JComponentHelper
 				->select('COUNT(extension_id)')
 				->from('#__extensions')
 				->where('element = ' . $db->quote($option))
+				->where('type = ' . $db->quote('component'))
 		)->loadResult();
 	}
 


### PR DESCRIPTION
Does what we can to fix #6697 by filtering the query on components only.  And if someone else is using `com_weblinks` as a component name, well, that's a condition we can't account for in code.
