### PR TITLE
Add type to the extension query

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -99,7 +99,8 @@ class JComponentHelper
 			$db->getQuery(true)
 				->select('COUNT(extension_id)')
 				->from('#__extensions')
-				->where('element = ' . $db->quote($option))
+				->where($db->quoteName('element') . ' = ' . $db->quote($option))
+				->where($db->quoteName('type') . ' = ' . $db->quote('component'))
 		)->loadResult();
 	}
 


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/6697 for initial report and testing instructions.

In short: `JComponentHelper::isInstalled($option)` currently only checks the element column, but it should also filter by the type so only components are returned.
