### PR TITLE
Regression: multilanguage user login => default language

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -335,6 +335,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			if (!isset($lang_code) || !isset($this->lang_codes[$lang_code]))
 			{
 				$lang_code = false;
+
 				if ($this->params->get('detect_browser', 1))
 				{
 					$lang_code = JLanguageHelper::detectLanguage();
@@ -343,6 +344,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						$lang_code = false;
 					}
 				}
+
 				if (!$lang_code)
 				{
 					$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
@@ -520,7 +522,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (empty($lang_code))
 			{
-				$lang_code = $this->default_lang;
+				$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 			}
 
 			if ($lang_code != $this->default_lang)


### PR DESCRIPTION
Same error as in https://github.com/joomla/joomla-cms/pull/6569
$this->default_lang is NOT the default site language

To test, create a simple multilingual site and make sure Automatic Language Change is set to Yes in the languagefilter plugin.

Create a registered user and do not set his language ( i.e. "Use Default" in the drop down for his site language when editing his profile, tab : Global Settings)

Load a page, containing a login module, in the language which is NOT the global default Site language.

When the user logins the behaviour is normally to redirect to the global default Site language.
The bug is that it does not redirect there but stays with the same language.

Patch and test again.

Make sure that  setting a specific language for the user also works fine.
