### PR TITLE
[UX] Protostar: Remove hard coded css

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -103,16 +103,10 @@ else
 		{
 			color: <?php echo $this->params->get('templateColor'); ?>;
 		}
-		.navbar-inner, .nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .nav-pills > .active > a, .nav-pills > .active > a:hover,
+		.nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .nav-pills > .active > a, .nav-pills > .active > a:hover,
 		.btn-primary
 		{
 			background: <?php echo $this->params->get('templateColor'); ?>;
-		}
-		.navbar-inner
-		{
-			-moz-box-shadow: 0 1px 3px rgba(0, 0, 0, .25), inset 0 -1px 0 rgba(0, 0, 0, .1), inset 0 30px 10px rgba(0, 0, 0, .2);
-			-webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, .25), inset 0 -1px 0 rgba(0, 0, 0, .1), inset 0 30px 10px rgba(0, 0, 0, .2);
-			box-shadow: 0 1px 3px rgba(0, 0, 0, .25), inset 0 -1px 0 rgba(0, 0, 0, .1), inset 0 30px 10px rgba(0, 0, 0, .2);
 		}
 	</style>
 	<?php endif; ?>


### PR DESCRIPTION
#### The issue

The issue is that the navbar-inner css is hard coded, and you can't override it with you own css or less files.
#### Example

![aftersaving](https://cloud.githubusercontent.com/assets/876623/7048225/06195f5a-de12-11e4-8873-779fd3822e28.jpg)

You see that the navbar-inner get the color from the btn-primary. In this case the default color Blue.
This looks bad at all. 
#### Solution

after apply my fix, you will get a cleaner navbar-inner.

![before](https://cloud.githubusercontent.com/assets/876623/7048282/5fe6eb38-de12-11e4-9a0a-d6d72cc64c22.jpg)
