### PR TITLE
More inline scripts through API

### DIFF
--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -13,19 +13,17 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-JFactory::getDocument()->addScriptDeclaration('
+JFactory::getDocument()->addScriptDeclaration(
+	'
 	Joomla.submitbutton = function(task)
 	{
 		if (task == "client.cancel" || document.formvalidator.isValid(document.getElementById("client-form")))
 		{
 			Joomla.submitform(task, document.getElementById("client-form"));
 		}
-	};
-');
+	};'
+);
 ?>
-<script type="text/javascript">
-
-</script>
 
 <form action="<?php echo JRoute::_('index.php?option=com_banners&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="client-form" class="form-validate">
 

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -20,7 +20,8 @@ $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $sortFields = $this->getSortFields();
 
-JFactory::getDocument()->addScriptDeclaration('
+JFactory::getDocument()->addScriptDeclaration(
+	'
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -40,12 +41,9 @@ JFactory::getDocument()->addScriptDeclaration('
 	Joomla.closeModalDialog = function()
 	{
 		window.jQuery("#modal-download").modal("hide");
-	};
-');
+	};'
+);
 ?>
-<script type="text/javascript">
-
-</script>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=tracks'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -17,7 +17,8 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-JFactory::getDocument()->addScriptDeclaration('
+JFactory::getDocument()->addScriptDeclaration(
+	'
 	Joomla.submitbutton = function(task)
 	{
 		if (task === "config.cancel.component" || document.formvalidator.isValid(document.getElementById("component-form")))
@@ -25,7 +26,12 @@ JFactory::getDocument()->addScriptDeclaration('
 			Joomla.submitform(task, document.getElementById("component-form"));
 		}
 	};
-');
+
+	// Select first tab
+	jQuery(document).ready(function() {
+		jQuery("#configTabs a:first").tab("show");
+	});'
+);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" id="component-form" method="post" name="adminForm" autocomplete="off" class="form-validate form-horizontal">
@@ -91,6 +97,3 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>
-<script type="text/javascript">
-	jQuery('#configTabs a:first').tab('show'); // Select first tab
-</script>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-JFactory::getDocument()->addScriptDeclaration('
+JFactory::getDocument()->addScriptDeclaration(
+	'
 	Joomla.submitbutton = function(task)
 	{
 		if (task == "language.cancel" || document.formvalidator.isValid(document.getElementById("language-form")))
@@ -22,7 +23,21 @@ JFactory::getDocument()->addScriptDeclaration('
 			Joomla.submitform(task, document.getElementById("language-form"));
 		}
 	};
-');
+
+	jQuery(document).ready(function() {
+		jQuery("#jform_image").on("change", function() {
+			var flag = this.value;
+			if (!jQuery("#flag img").attr("src")) {
+				jQuery("#flag img").attr("src", "' . JUri::root(true) . '" + "/media/mod_languages/images/" + flag + ".gif");
+			} else {
+				jQuery("#flag img").attr("src", function(index, attr) {
+					return attr.replace(jQuery("#flag img").attr("title") + ".gif", flag + ".gif")
+				})
+			}
+			jQuery("#flag img").attr("title", flag).attr("alt", flag);
+	});
+});'
+);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_languages&layout=edit&lang_id=' . (int) $this->item->lang_id); ?>" method="post" name="adminForm" id="language-form" class="form-validate form-horizontal">
@@ -70,19 +85,3 @@ JFactory::getDocument()->addScriptDeclaration('
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>
-<script type="text/javascript">
-	jQuery('#jform_image').on('change', function() {
-		var flag = this.value;
-		if (!jQuery('#flag img').attr('src'))
-		{
-			jQuery('#flag img').attr('src', '<?php echo JUri::root(true);?>' + '/media/mod_languages/images/' + flag + '.gif');
-		}
-		else
-		{
-			jQuery('#flag img').attr('src', function(index, attr) {
-				return attr.replace(jQuery('#flag img').attr('title') + '.gif', flag + '.gif')
-			})
-		}
-		jQuery('#flag img').attr('title', flag).attr('alt', flag);
-	});
-</script>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -16,10 +16,15 @@ JHtml::_('bootstrap.tooltip', '.noHtmlTip', array('html' => false));
 
 $user  = JFactory::getUser();
 $input = JFactory::getApplication()->input;
+
+JFactory::getDocument()->addScriptDeclaration(
+	"
+	var image_base_path = '" . $params = JComponentHelper::getParams('com_media') . $params->get('image_path', 'images') . "';
+	"
+);
 ?>
 <script type='text/javascript'>
-var image_base_path = '<?php $params = JComponentHelper::getParams('com_media');
-echo $params->get('image_path', 'images'); ?>/';
+
 </script>
 <form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
 	<div id="messages" style="display: none;">

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -23,9 +23,6 @@ JFactory::getDocument()->addScriptDeclaration(
 	"
 );
 ?>
-<script type='text/javascript'>
-
-</script>
 <form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
 	<div id="messages" style="display: none;">
 		<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -16,10 +16,11 @@ JHtml::_('bootstrap.tooltip', '.noHtmlTip', array('html' => false));
 
 $user  = JFactory::getUser();
 $input = JFactory::getApplication()->input;
+$params = JComponentHelper::getParams('com_media');
 
 JFactory::getDocument()->addScriptDeclaration(
 	"
-	var image_base_path = '" . $params = JComponentHelper::getParams('com_media') . $params->get('image_path', 'images') . "';
+	var image_base_path = '" . $params->get('image_path', 'images') . "/';
 	"
 );
 ?>

--- a/administrator/components/com_modules/views/preview/tmpl/default.php
+++ b/administrator/components/com_modules/views/preview/tmpl/default.php
@@ -9,20 +9,24 @@
 
 defined('_JEXEC') or die;
 
-JFactory::getDocument()->addScriptDeclaration('
+JFactory::getDocument()->addScriptDeclaration(
+	'
 	var form = window.top.document.adminForm
 	var title = form.title.value;
 	var alltext = window.top.' . $this->editor->getContent('text') . ';
-');
+
+	jQuery(document).ready(function() {
+		document.getElementById("td-title").innerHTML = title;
+		document.getElementById("td-text").innerHTML = alltext;
+	});'
+);
 ?>
 
 <table class="center" width="90%">
 	<tr>
-		<td class="contentheading" colspan="2"><script>document.write(title);</script></td>
+		<td class="contentheading" colspan="2" id="td-title"></td>
 	</tr>
 <tr>
-	<td valign="top" height="90%" colspan="2">
-		<script>document.write(alltext);</script>
-	</td>
+	<td valign="top" height="90%" colspan="2" id="td-text"></td>
 </tr>
 </table>


### PR DESCRIPTION
#### Remove inline script tags from body

Inline scripts should be loaded through API e.g. addScriptDeclaration()
#### Testing

Apply patch 
Goto:
 `/administrator/index.php?option=com_banners&view=client&layout=edit`
`/administrator/index.php?option=com_banners&view=tracks`
`/administrator/index.php?option=com_config&view=component&component=com_content` Make sure the first tab is the default one
`/administrator/index.php?option=com_languages&view=language&layout=edit&lang_id=1` 
`/administrator/index.php?option=com_media`

try the usual form options, submit, cancel etc
#### B/C

NONE
#### Performance impact

This should not degrade performance!
Also using the API might enable us to get all the scripts to the end of the page and thus get a performance increase! (we’re NOT there yet!)
