### PR TITLE
Handle DB errors in tags search plugin

### DIFF
--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -143,7 +143,8 @@ class PlgSearchTags extends JPlugin
 		catch (RuntimeException $e)
 		{
 			$rows = array();
-			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_GENERIC_SQL_ERROR'), 'error');
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 		}
 
 		if ($rows)

--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -136,7 +136,15 @@ class PlgSearchTags extends JPlugin
 		$query->order($order);
 
 		$db->setQuery($query, 0, $limit);
-		$rows = $db->loadObjectList();
+		try
+		{
+			$rows = $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			$rows = array();
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
 
 		if ($rows)
 		{


### PR DESCRIPTION
updated to handle DB errors like #6710, #6711, #6632 and for #6591

Testing info
simulate a db error
