### PR TITLE
Handle DB errors in newsfeeds search plugin

### DIFF
--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -188,7 +188,8 @@ class PlgSearchNewsfeeds extends JPlugin
 		catch (RuntimeException $e)
 		{
 			$rows = array();
-			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_GENERIC_SQL_ERROR'), 'error');
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 		}
 
 		if ($rows)

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -181,7 +181,15 @@ class PlgSearchNewsfeeds extends JPlugin
 		}
 
 		$db->setQuery($query, 0, $limit);
-		$rows = $db->loadObjectList();
+		try
+		{
+			$rows = $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			$rows = array();
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
 
 		if ($rows)
 		{


### PR DESCRIPTION
updated to handle DB errors like #6710, #6711,#6714, #6632 and for #6591

Testing info
simulate a db error
