### PR TITLE
[fix] Multilanguage: user site language should also be a published content language

### DIFF
--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -60,7 +60,7 @@ class AdminModelProfile extends UsersModelUser
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// If the user needs to change their password, mark the password fields as required

--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -57,6 +57,12 @@ class AdminModelProfile extends UsersModelUser
 			$form->setFieldAttribute('username', 'description', 'COM_ADMIN_USER_FIELD_NOCHANGE_USERNAME_DESC');
 		}
 
+		// When multilanguage is set, a user's default site language should also be a Content Language
+		if (JLanguageMultilang::isEnabled())
+		{
+			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+		}
+
 		// If the user needs to change their password, mark the password fields as required
 		if (JFactory::getUser()->requireReset)
 		{

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -134,6 +134,12 @@ class UsersModelUser extends JModelAdmin
 			$form->setFieldAttribute('password2', 'required', 'true');
 		}
 
+		// When multilanguage is set, a user's default site language should also be a Content Language
+		if (JLanguageMultilang::isEnabled())
+		{
+			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+		}
+
 		// The user should not be able to set the requireReset value on their own account
 		if ((int) $userId === (int) JFactory::getUser()->id)
 		{

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -137,7 +137,7 @@ class UsersModelUser extends JModelAdmin
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// The user should not be able to set the requireReset value on their own account

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -218,7 +218,7 @@ class UsersModelProfile extends JModelForm
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		// If the user needs to change their password, mark the password fields as required

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -215,6 +215,12 @@ class UsersModelProfile extends JModelForm
 			$form->setFieldAttribute('username', 'required', 'false');
 		}
 
+		// When multilanguage is set, a user's default site language should also be a Content Language
+		if (JLanguageMultilang::isEnabled())
+		{
+			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+		}
+
 		// If the user needs to change their password, mark the password fields as required
 		if (JFactory::getUser()->requireReset)
 		{

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -267,6 +267,12 @@ class UsersModelRegistration extends JModelForm
 		// Get the form.
 		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData));
 
+		// When multilanguage is set, a user's default site language should also be a Content Language
+		if (JLanguageMultilang::isEnabled())
+		{
+			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+		}
+
 		if (empty($form))
 		{
 			return false;

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -270,7 +270,7 @@ class UsersModelRegistration extends JModelForm
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
-			$form->setFieldAttribute('language', 'type', 'frontendlanguage', 'params');
+			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}
 
 		if (empty($form))

--- a/libraries/cms/form/field/frontend_language.php
+++ b/libraries/cms/form/field/frontend_language.php
@@ -16,7 +16,7 @@ JFormHelper::loadFieldClass('list');
  * Provides a list of published content languages with home pages
  *
  * @see    JFormFieldLanguage for a select list of application languages.
- * @since  1.6
+ * @since  3.4.2
  */
 class JFormFieldFrontend_Language extends JFormFieldList
 {
@@ -24,7 +24,7 @@ class JFormFieldFrontend_Language extends JFormFieldList
 	 * The form field type.
 	 *
 	 * @var    string
-	 * @since  1.6
+	 * @since  3.4.2
 	 */
 	public $type = 'Frontend_Language';
 
@@ -48,8 +48,8 @@ class JFormFieldFrontend_Language extends JFormFieldList
 
 		// Select the language home pages.
 		$query->select('l.home, l.language')
-			->join('INNER', $db->quoteName('#__menu') . ' AS l ON l.language=a.lang_code AND l.home=1 AND l.published=1 AND l.language <> ' . $db->quote('*'))
-			->join('LEFT', $db->quoteName('#__extensions') . ' AS e ON e.element = a.lang_code')
+			->innerJoin($db->quoteName('#__menu') . ' AS l ON l.language=a.lang_code AND l.home=1 AND l.published=1 AND l.language <> ' . $db->quote('*'))
+			->innerJoin($db->quoteName('#__extensions') . ' AS e ON e.element = a.lang_code')
 			->where('e.client_id = 0')
 			->where('e.enabled = 1')
 			->where('e.state = 0');

--- a/libraries/cms/form/field/frontend_language.php
+++ b/libraries/cms/form/field/frontend_language.php
@@ -18,7 +18,7 @@ JFormHelper::loadFieldClass('list');
  * @see    JFormFieldLanguage for a select list of application languages.
  * @since  1.6
  */
-class JFormFieldFrontendlanguage extends JFormFieldList
+class JFormFieldFrontend_Language extends JFormFieldList
 {
 	/**
 	 * The form field type.
@@ -26,7 +26,7 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 	 * @var    string
 	 * @since  1.6
 	 */
-	public $type = 'FrontendLanguage';
+	public $type = 'Frontend_Language';
 
 	/**
 	 * Method to get the field options for frontend published content languages with homes.
@@ -41,7 +41,7 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
-		$query->select('a.lang_code AS value, a.title AS text, a.title_native', 'l.home')
+		$query->select('a.lang_code AS value, a.title AS text')
 				->from($db->quoteName('#__languages') . ' AS a')
 				->where('a.published = 1')
 				->order('a.title');
@@ -56,7 +56,19 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 
 		$db->setQuery($query);
 
-		$languages = $db->loadObjectList();
+		try
+		{
+			$languages = $db->loadObjectList();
+		}
+		catch (RuntimeException $e)
+		{
+			$languages = array();
+
+			if (JFactory::getUser()->authorise('core.admin'))
+			{
+				JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			}
+		}
 
 		// Merge any additional options in the XML definition.
 		$options = array_merge(

--- a/libraries/cms/form/field/frontendlanguage.php
+++ b/libraries/cms/form/field/frontendlanguage.php
@@ -48,7 +48,7 @@ class JFormFieldFrontendlanguage extends JFormFieldList
 
 		// Select the language home pages.
 		$query->select('l.home, l.language')
-			->join('INNER', $db->quoteName('#__menu') . ' AS l ON l.language = a.lang_code AND l.home = 1 AND l.published = 1 AND l.language <> ' . $db->quote('*'))
+			->join('INNER', $db->quoteName('#__menu') . ' AS l ON l.language=a.lang_code AND l.home=1 AND l.published=1 AND l.language <> ' . $db->quote('*'))
 			->join('LEFT', $db->quoteName('#__extensions') . ' AS e ON e.element = a.lang_code')
 			->where('e.client_id = 0')
 			->where('e.enabled = 1')

--- a/libraries/cms/form/field/frontendlanguage.php
+++ b/libraries/cms/form/field/frontendlanguage.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+JFormHelper::loadFieldClass('list');
+
+/**
+ * Form Field class for the Joomla Platform.
+ * Provides a list of published content languages with home pages
+ *
+ * @see    JFormFieldLanguage for a select list of application languages.
+ * @since  1.6
+ */
+class JFormFieldFrontendlanguage extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  1.6
+	 */
+	public $type = 'FrontendLanguage';
+
+	/**
+	 * Method to get the field options for frontend published content languages with homes.
+	 *
+	 * @return  array  The options the field is going to show.
+	 *
+	 * @since   3.4.2
+	 */
+	protected function getOptions()
+	{
+		// Get the database object and a new query object.
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		$query->select('a.lang_code AS value, a.title AS text, a.title_native', 'l.home')
+				->from($db->quoteName('#__languages') . ' AS a')
+				->where('a.published = 1')
+				->order('a.title');
+
+		// Select the language home pages.
+		$query->select('l.home, l.language')
+			->join('INNER', $db->quoteName('#__menu') . ' AS l ON l.language = a.lang_code AND l.home = 1 AND l.published = 1 AND l.language <> ' . $db->quote('*'))
+			->join('LEFT', $db->quoteName('#__extensions') . ' AS e ON e.element = a.lang_code')
+			->where('e.client_id = 0')
+			->where('e.enabled = 1')
+			->where('e.state = 0');
+
+		$db->setQuery($query);
+
+		$languages = $db->loadObjectList();
+
+		// Merge any additional options in the XML definition.
+		$options = array_merge(
+			parent::getOptions(),
+			$languages
+		);
+
+		return $options;
+	}
+}


### PR DESCRIPTION
Conditions
Create a multilanguage site with 2 languages for example at Joomla installation time. Then install a 3rd language. Do not create a Content Language for that 3rd language.
1. that installed language is NOT also used as Content Language, OR its related Content Language is unpublished OR the Home page for that Content Language does not exist/is unpublished
2. a registered user is choosing that language as default site language when registering or editing his profile
3. the languagefilter parameter Automatic Language Change is set to Yes

Result => when the user logins, he is redirected to the unexisting Content Language  and it breaks the site.

The reason is that we use the normal $type field 'language' for the user to choose his default site language among all those installed.

This PR creates a new $type field which will only display the choice between installed languages which are enabled, have a related published Content language and a related Home page.
When a site is multilingual, the $type field will be changed from the "normal" one to this specific one to avoid the error.

To test the patch, for the third language installed, create or not a content language and change it to published or not, its home existing or not , published or not.

In this example, I have installed the Catalan language and created a Content Language for it and <b>no specific menu with a Catalan Home page</b>:

Screenshot of the installed languages:

![screen shot 2015-04-09 at 09 01 40](https://cloud.githubusercontent.com/assets/869724/7061848/19c5a682-de97-11e4-8e13-7d2826aa0927.png)

Screenshot of the Content Languages:

![screen shot 2015-04-09 at 09 03 00](https://cloud.githubusercontent.com/assets/869724/7061864/490a2710-de97-11e4-86bd-289171cca990.png)

Screenshot of the "Frontend Language" dropdown choice when editing a user profile
BEFORE PATCH: => Catalan is proposed as a choice

![screen shot 2015-04-09 at 09 15 14](https://cloud.githubusercontent.com/assets/869724/7062001/0a5fd68e-de99-11e4-9dbb-6ae3b578671c.png)

AFTER PATCH: => Catalan is NOT proposed as a choice anymore

![screen shot 2015-04-09 at 09 05 30](https://cloud.githubusercontent.com/assets/869724/7061917/10079690-de98-11e4-9ae2-f7caab4aa93a.png)
