### PR TITLE
wrong displaying chars in mod_banner

### DIFF
--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -22,7 +22,7 @@ $baseurl = JUri::base();
 		<?php $link = JRoute::_('index.php?option=com_banners&task=click&id=' . $item->id);?>
 		<?php if ($item->type == 1) :?>
 			<?php // Text based banners ?>
-			<?php echo str_replace(array('{CLICKURL}', '{NAME}'), array($link, $item->name), $item->custombannercode);?>
+			<?php echo str_replace(array('{CLICKURL}', '{NAME}'), array($link, htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8')), $item->custombannercode);?>
 		<?php else:?>
 			<?php $imageurl = $item->params->get('imageurl');?>
 			<?php $width = $item->params->get('width');?>
@@ -30,7 +30,7 @@ $baseurl = JUri::base();
 			<?php if (BannerHelper::isImage($imageurl)) :?>
 				<?php // Image based banner ?>
 				<?php $alt = $item->params->get('alt');?>
-				<?php $alt = $alt ? $alt : $item->name; ?>
+				<?php $alt = $alt ? $alt : htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>
 				<?php $alt = $alt ? $alt : JText::_('MOD_BANNERS_BANNER'); ?>
 				<?php if ($item->clickurl) :?>
 					<?php // Wrap the banner in a link?>


### PR DESCRIPTION
in mod_banner's view 'default.php' are 2 problems, if there are "ÄÖÜ" inside the text

---
### how to test

Teststeps:
- create new item in com_banner
- name 'Facebookseite Gesundes Oberösterreich'
- custom text: `<a href="{CLICKLINK}" target="_blank">{NAME}</a>`
- display the modul which shows the banner on your site
- the problem are the following letters in the german language "äöü" upper- and lower-case. Maybe "ß" also
