### PR TITLE
Show the Updates by using the Update button

### DIFF
--- a/administrator/components/com_installer/controllers/update.php
+++ b/administrator/components/com_installer/controllers/update.php
@@ -74,11 +74,7 @@ class InstallerControllerUpdate extends JControllerLegacy
 	 */
 	public function find()
 	{
-		/*
-		 * Note: We don't do a token check so we are able force 
-		 * to find updates by the URL. This means that between requests
-		 * the token might change, making it impossible to work.
-		 */
+		(JSession::checkToken() or JSession::checkToken('get')) or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Get the caching duration.
 		$component     = JComponentHelper::getComponent('com_installer');

--- a/administrator/components/com_installer/controllers/update.php
+++ b/administrator/components/com_installer/controllers/update.php
@@ -74,8 +74,11 @@ class InstallerControllerUpdate extends JControllerLegacy
 	 */
 	public function find()
 	{
-		// Check for request forgeries.
-		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		/*
+		 * Note: We don't do a token check so we are able force 
+		 * to find updates by the URL. This means that between requests
+		 * the token might change, making it impossible to work.
+		 */
 
 		// Get the caching duration.
 		$component     = JComponentHelper::getComponent('com_installer');

--- a/administrator/components/com_installer/controllers/update.php
+++ b/administrator/components/com_installer/controllers/update.php
@@ -134,11 +134,16 @@ class InstallerControllerUpdate extends JControllerLegacy
 	 */
 	public function ajax()
 	{
-		/*
-		 * Note: we don't do a token check as we're fetching information
-		 * asynchronously. This means that between requests the token might
-		 * change, making it impossible for AJAX to work.
-		 */
+		$app = JFactory::getApplication();
+
+		if (!JSession::checkToken('get'))
+		{
+			JResponse::setHeader('status', 403, true);
+			$app->sendHeaders();
+			echo JText::_('JINVALID_TOKEN');
+			$app->close();
+		}
+
 		$eid               = $this->input->getInt('eid', 0);
 		$skip              = $this->input->get('skip', array(), 'array');
 		$cache_timeout     = $this->input->getInt('cache_timeout', 0);
@@ -188,6 +193,6 @@ class InstallerControllerUpdate extends JControllerLegacy
 
 		echo json_encode($updates);
 
-		JFactory::getApplication()->close();
+		$app->close();
 	}
 }

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -44,10 +44,10 @@ class PlgQuickiconExtensionupdate extends JPlugin
 
 		JHtml::_('jquery.framework');
 
-		$token = JSession::getFormToken() . '=' . 1;
-		$url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token;
+		$token    = JSession::getFormToken() . '=' . 1;
+		$url      = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token;
 		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax';
-		$script = array();
+		$script   = array();
 		$script[] = 'var plg_quickicon_extensionupdate_url = \'' . $url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_ajax_url = \'' . $ajax_url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_text = {'
@@ -62,11 +62,11 @@ class PlgQuickiconExtensionupdate extends JPlugin
 
 		return array(
 			array(
-				'link' => 'index.php?option=com_installer&view=update&task=update.find&' . $token,
+				'link'  => 'index.php?option=com_installer&view=update&task=update.find&' . $token,
 				'image' => 'asterisk',
-				'icon' => 'header/icon-48-extension.png',
-				'text' => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
-				'id' => 'plg_quickicon_extensionupdate',
+				'icon'  => 'header/icon-48-extension.png',
+				'text'  => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
+				'id'    => 'plg_quickicon_extensionupdate',
 				'group' => 'MOD_QUICKICON_MAINTENANCE'
 			)
 		);

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -44,9 +44,10 @@ class PlgQuickiconExtensionupdate extends JPlugin
 
 		JHtml::_('jquery.framework');
 
-		$url = JUri::base() . 'index.php?option=com_installer&view=update';
+		$url      = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find';
 		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax';
-		$script = array();
+
+		$script   = array();
 		$script[] = 'var plg_quickicon_extensionupdate_url = \'' . $url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_ajax_url = \'' . $ajax_url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_text = {'
@@ -56,17 +57,18 @@ class PlgQuickiconExtensionupdate extends JPlugin
 			. '"UPDATEFOUND_BUTTON": "' . JText::_('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON', true) . '",'
 			. '"ERROR": "' . JText::_('PLG_QUICKICON_EXTENSIONUPDATE_ERROR', true) . '",'
 			. '};';
+
 		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 		JHtml::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.js', false, true);
 
 		return array(
 			array(
-				'link' => 'index.php?option=com_installer&amp;view=update',
+				'link'  => 'index.php?option=com_installer&amp;view=update&amp;task=update.find',
 				'image' => 'asterisk',
-				'icon' => 'header/icon-48-extension.png',
-				'text' => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
-				'id' => 'plg_quickicon_extensionupdate',
-				'group' => 'MOD_QUICKICON_MAINTENANCE'
+				'icon'  => 'header/icon-48-extension.png',
+				'text'  => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
+				'id'    => 'plg_quickicon_extensionupdate',
+				'group' => 'MOD_QUICKICON_MAINTENANCE',
 			)
 		);
 	}

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -44,10 +44,10 @@ class PlgQuickiconExtensionupdate extends JPlugin
 
 		JHtml::_('jquery.framework');
 
-		$url      = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find';
+		$token = JSession::getFormToken() . '=' . 1;
+		$url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token;
 		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax';
-
-		$script   = array();
+		$script = array();
 		$script[] = 'var plg_quickicon_extensionupdate_url = \'' . $url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_ajax_url = \'' . $ajax_url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_text = {'
@@ -57,18 +57,17 @@ class PlgQuickiconExtensionupdate extends JPlugin
 			. '"UPDATEFOUND_BUTTON": "' . JText::_('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON', true) . '",'
 			. '"ERROR": "' . JText::_('PLG_QUICKICON_EXTENSIONUPDATE_ERROR', true) . '",'
 			. '};';
-
 		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 		JHtml::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.js', false, true);
 
 		return array(
 			array(
-				'link'  => 'index.php?option=com_installer&amp;view=update&amp;task=update.find',
+				'link' => 'index.php?option=com_installer&view=update&task=update.find&' . $token,
 				'image' => 'asterisk',
-				'icon'  => 'header/icon-48-extension.png',
-				'text'  => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
-				'id'    => 'plg_quickicon_extensionupdate',
-				'group' => 'MOD_QUICKICON_MAINTENANCE',
+				'icon' => 'header/icon-48-extension.png',
+				'text' => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
+				'id' => 'plg_quickicon_extensionupdate',
+				'group' => 'MOD_QUICKICON_MAINTENANCE'
 			)
 		);
 	}

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -46,7 +46,7 @@ class PlgQuickiconExtensionupdate extends JPlugin
 
 		$token    = JSession::getFormToken() . '=' . 1;
 		$url      = JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token;
-		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax';
+		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax&' . $token;
 		$script   = array();
 		$script[] = 'var plg_quickicon_extensionupdate_url = \'' . $url . '\';';
 		$script[] = 'var plg_quickicon_extensionupdate_ajax_url = \'' . $ajax_url . '\';';

--- a/plugins/quickicon/joomlaupdate/joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.php
@@ -46,8 +46,10 @@ class PlgQuickiconJoomlaupdate extends JPlugin
 		JHtml::_('jquery.framework');
 
 		$cur_template = JFactory::getApplication()->getTemplate();
+
+		$token    = JSession::getFormToken() . '=' . 1;
 		$url = JUri::base() . 'index.php?option=com_joomlaupdate';
-		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax';
+		$ajax_url = JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax&' . $token;
 		$script = array();
 		$script[] = 'var plg_quickicon_joomlaupdate_url = \'' . $url . '\';';
 		$script[] = 'var plg_quickicon_joomlaupdate_ajax_url = \'' . $ajax_url . '\';';


### PR DESCRIPTION
### What this PR do

After this PR the Update button after `x Extension Update(s) are available` redirect to the updates and show the list of updates as expected without clicking the `Find Updates` Button.
### how to test
- Install a outdated extension (e.g. [3.4.0.1 package of the german language pack](http://joomlacode.org/gf/download/frsrelease/19999/162169/de-DE_joomla_lang_full_3.4.0v1.zip))
- access the backend
- see the following screenshot
  ![extensions_updates](https://cloud.githubusercontent.com/assets/11710658/7078345/9bb21fb4-df18-11e4-8db8-e80648d7d35c.PNG)
- try e.g. the Update button
- you get:
  ![befor_patch](https://cloud.githubusercontent.com/assets/11710658/7078343/8f996200-df18-11e4-9fc0-742e9032641d.PNG)
- where are the updates?
- apply this patch
- try the Update button again
- we will show something like this:
  ![fixed_updates](https://cloud.githubusercontent.com/assets/11710658/7078346/a3786d48-df18-11e4-9bce-95c1fb4b9b1c.PNG)
