### PR TITLE
Run the find language if we open the install language view

### DIFF
--- a/administrator/components/com_installer/views/languages/view.html.php
+++ b/administrator/components/com_installer/views/languages/view.html.php
@@ -2,6 +2,7 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_installer
+ *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -41,6 +42,10 @@ class InstallerViewLanguages extends InstallerViewDefault
 	 */
 	public function display($tpl = null)
 	{
+		// Run findLanguages from the model
+		$this->model = $this->getModel('languages');
+		$this->model->findLanguages();
+
 		// Get data from the model.
 		$this->state      = $this->get('State');
 		$this->items      = $this->get('Items');


### PR DESCRIPTION
On request by @infograf768 https://github.com/joomla/joomla-cms/pull/6727#issuecomment-91481050
### What this do
- run the find language on the pageload. So we don't need to try the `find language` Button
### how to test
- go to BE --> Extensions --> Extensions Manager --> Update
- hit the pruge button (to be sure that the table is clean)
- go to BE --> Extensions --> Extensions Manager --> Install languages
- see that there is nothing
- apply the patch
- go again to BE --> Extensions --> Extensions Manager --> Update
- hit the pruge button again (to be sure that the table is clean)
- go now to BE --> Extensions --> Extensions Manager --> Install languages
- see something like (without clicking the `find language` Button):
  ![fixed](https://cloud.githubusercontent.com/assets/2596554/7086536/9099ba32-df82-11e4-9ab5-f48b62aa1311.PNG)
