### PR TITLE
Unpublished Templates are visible in Module's Batch Mode

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 $clientId  = $this->state->get('filter.client_id');
-$published = $this->state->get('filter.published');
+$published = 1; // show only Module Positions of published Templates
 $positions = JHtml::_('modules.positions', $clientId, $published);
 $positions['']['items'][] = ModulesHelper::createOption('nochange', JText::_('COM_MODULES_BATCH_POSITION_NOCHANGE'));
 $positions['']['items'][] = ModulesHelper::createOption('noposition', JText::_('COM_MODULES_BATCH_POSITION_NOPOSITION'));

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -10,7 +10,8 @@
 defined('_JEXEC') or die;
 
 $clientId  = $this->state->get('filter.client_id');
-$published = 1; // show only Module Positions of published Templates
+// show only Module Positions of published Templates
+$published = 1;
 $positions = JHtml::_('modules.positions', $clientId, $published);
 $positions['']['items'][] = ModulesHelper::createOption('nochange', JText::_('COM_MODULES_BATCH_POSITION_NOCHANGE'));
 $positions['']['items'][] = ModulesHelper::createOption('noposition', JText::_('COM_MODULES_BATCH_POSITION_NOPOSITION'));


### PR DESCRIPTION
Batch Mode of Module Manager displays the Positions of unpublished Templates.

Steps to reproduce:
1. In Extensions > Template Manager, 2 admin and 2 front-end templates are listed, "beez3" template is listed. 
2. In Extensions > Extension Manager > Manage > Filter: [Templates], unpublish "beez3"
![screen shot 2015-04-10 at 08 19 52](http://issues.joomla.org/uploads/1/24e229c6b1d9f2bcf345347aa15d74d4.png)
1. In Extensions > Template Manager, the unpublished "beez3" template is not listed anymore. 
2. Extensions > Module Manager > open a Module, under "Position" the "beez3" template is not listed anymore (which is good).
3. Extensions > Module Manager > select a Module & choose "Batch". Under "Set Position" the "beez3" is listed (which is NOT good).
   ![screen shot 2015-04-10 at 08 19 52](http://issues.joomla.org/uploads/1/deb504afdc49aa7baabe0322da7ddf9a.png)

Expected result: 
the unpublished "beez3" Template should not have been listed in the Module Batch Mode popup.

After applying this test, the unpublished "beez3" template positions are not listed anymore. 
![screen shot 2015-04-10 at 08 22 57](http://issues.joomla.org/uploads/1/1b6104bb83eb3df26c70713375a323a5.png)
