### PR TITLE
URL-encode at-sign in HTTP Basic Auth credentials

### DIFF
--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -72,16 +72,16 @@ abstract class JGithubObject
 			// Use basic authentication
 			if ($this->options->get('api.username', false))
 			{
-                $username = $this->options->get('api.username');
-                $username = str_replace('@', '%40', $username);
-                $uri->setUser($username);
+				$username = $this->options->get('api.username');
+				$username = str_replace('@', '%40', $username);
+				$uri->setUser($username);
 			}
 
 			if ($this->options->get('api.password', false))
 			{
-                $password = $this->options->get('api.password');
-                $password = str_replace('@', '%40', $password);
-                $uri->setPass($password);
+				$password = $this->options->get('api.password');
+				$password = str_replace('@', '%40', $password);
+				$uri->setPass($password);
 			}
 		}
 

--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -72,12 +72,16 @@ abstract class JGithubObject
 			// Use basic authentication
 			if ($this->options->get('api.username', false))
 			{
-				$uri->setUser($this->options->get('api.username'));
+                $username = $this->options->get('api.username');
+                $username = str_replace('@', '%40', $username);
+                $uri->setUser($username);
 			}
 
 			if ($this->options->get('api.password', false))
 			{
-				$uri->setPass($this->options->get('api.password'));
+                $password = $this->options->get('api.password');
+                $password = str_replace('@', '%40', $password);
+                $uri->setPass($password);
 			}
 		}
 


### PR DESCRIPTION
This is kind of bad ass, but needed. During numerous PBF sessions, we encountered issues when people were using the PatchTester component in combination with GitHub credentials that contained an at-sign (@), so either an username or password that contains the at-sign. When the component fetches the list of issues from GitHub, the username and password are appended to the URL in the form "http://USERNAME:PASSWORD@URL.com". However, because the at-sign serves as separator, the URL is determined from the first at-sign that is encountered. This results in authentication failure.

The solution of this patch is childish but simple: Replace the at-sign in the credentials with an URL-encoded version. Note that this fix is only needed for the at-sign - no other characters are effected. Also, Basic Authentication in GitHub is until now the only place where this issue was encountered. So this patch only fixes that area.

How to test the problem:
1) Install the PatchTester component.
2) Reset your GitHub username or password to contain an at-sign (@)
3) Configure PatchTester component with your credentials
4) Use the "Fetch Data" button to connect

Step 4 should give you an error in the browsers Error Console saying "Bad Credentials". (That the component is not properly showing this error is another unrelated issue.)

Next, apply the patch and test again. Step 4 should now succeed.
