### PR TITLE
Add Tests Scenarios in .txt format

### DIFF
--- a/tests/codeception/tests/acceptance/administrator/setDevelopmentErrorReporting.txt
+++ b/tests/codeception/tests/acceptance/administrator/setDevelopmentErrorReporting.txt
@@ -1,0 +1,12 @@
+I WANT TO SET JOOMLA ERROR REPORTING TO DEVELOPMENT
+
+I do administrator login('admin', 'admin')
+I am on page '/administrator/index.php?option=com_config'
+I wait for text 'Global Configuration',10,'.page-title'
+I click 'Server'
+I wait for element visible "$globalConfiguration['Error Reporting Dropdown']"
+I click "$globalConfiguration['Error Reporting Dropdown']"
+I click "$globalConfiguration['option: Development']"
+I click 'Save'
+I wait for text 'Global Configuration',10,'.page-title'
+I see 'Configuration successfully saved.','#system-message-container'

--- a/tests/codeception/tests/acceptance/installation/InstallJoomla.txt
+++ b/tests/codeception/tests/acceptance/installation/InstallJoomla.txt
@@ -1,0 +1,29 @@
+I WANT TO INSTALL JOOMLA CMS
+
+I expect 'no configuration.php is in the Joomla CMS folder'
+I don't see file found('configuration.php', $i->get configuration 'Joomla folder')"
+I am on page '/installation/index.php'
+I wait for text 'Main Configuration',"10",'h3'
+I click "$configurationPage['Language Selector']"
+I click($configuration page[$i->get configuration 'Language')]"
+I fill field 'Site Name','Joomla CMS test'
+I fill field 'Description','Site for testing Joomla CMS'
+I fill field('admin email',admin@mydomain.com)"
+I fill field('admin username','admin')"
+I fill field('admin password','admin')"
+I fill field('confirm admin password','admin')"
+I click "$configurationPage['No Site Offline']"
+I click 'Next'
+I wait for text 'Database Configuration',10,'h3'
+I select option('database type', 'msqli')"
+I fill field('host name','localhost')"
+I fill field('username','root')"
+I fill field('password','root')"
+I fill field('database name','testjoomla')"
+I fill field('table prefix','jos_')"
+I click "$databasePage['Remove Old Database button']"
+I click 'Next'
+I wait for text 'Finalisation',10," 'h3'
+I select option($overview page['sample data'], 'none')"
+I click 'Install'
+I wait for text 'Congratulations! Joomla! is now installed.',30,'h3'


### PR DESCRIPTION
This .txt are created with the Codeception Generate Scenarios feature:

```
php vendor/bin/codecept generate:scenarios acceptance
```

And have been cleaned manually to document the current tests.
