### PR TITLE
add rtl support for protostar to make the sub-menu aligned correctly

### DIFF
--- a/templates/protostar/css/template_rtl.css
+++ b/templates/protostar/css/template_rtl.css
@@ -1,13 +1,13 @@
 /** RTL for protostart template **/
 .navigation .nav-child {
-	left: initial;
+	left: auto;
 	right:0;
 }
 .navigation .nav > li > .nav-child:before {
-	left: initial;
+	left: auto;
 	right:12px;
 }
 .navigation .nav > li > .nav-child:after {
-	left: initial;
+	left: auto;
 	right:13px;
 }

--- a/templates/protostar/css/template_rtl.css
+++ b/templates/protostar/css/template_rtl.css
@@ -1,0 +1,13 @@
+/** RTL for protostart template **/
+.navigation .nav-child {
+	left: initial;
+	right:0;
+}
+.navigation .nav > li > .nav-child:before {
+	left: initial;
+	right:12px;
+}
+.navigation .nav > li > .nav-child:after {
+	left: initial;
+	right:13px;
+}

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -42,6 +42,10 @@ $doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template
 // Add Stylesheets
 $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
+if ($this->direction == 'rtl') {
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+}
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 


### PR DESCRIPTION
Currently the protostar sub-menu on RTL is not aligned well. This PR fix it.
Before:
![image](https://cloud.githubusercontent.com/assets/1040582/7101170/da53d1ae-e053-11e4-8022-9d0f4f581c1e.png)
After:
![image](https://cloud.githubusercontent.com/assets/1040582/7101174/ec934da4-e053-11e4-9015-8a3c8fd26fc5.png)
