### PR TITLE
Multilanguage: do not use a language if it has been deleted/disabled

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -78,6 +78,7 @@ abstract class ModLanguagesHelper
 		foreach ($languages as $i => &$language)
 		{
 			JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
+
 			// Do not display language without frontend UI
 			if (!array_key_exists($language->lang_code, MultilangstatusHelper::getSitelangs()))
 			{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -77,8 +77,9 @@ abstract class ModLanguagesHelper
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)
 		{
+			JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
 			// Do not display language without frontend UI
-			if (!JLanguage::exists($language->lang_code))
+			if (!array_key_exists($language->lang_code, MultilangstatusHelper::getSitelangs()))
 			{
 				unset($languages[$i]);
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\Registry\Registry;
 
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
+JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
 
 /**
  * Joomla! Language Filter Plugin.
@@ -60,7 +61,6 @@ class PlgSystemLanguageFilter extends JPlugin
 			$this->lang_codes 	= JLanguageHelper::getLanguages('lang_code');
 
 			$levels = JFactory::getUser()->getAuthorisedViewLevels();
-			JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
 
 			foreach ($this->sefs as $sef => $language)
 			{
@@ -530,8 +530,6 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// The user language has been deleted/disabled or the related content language does not exist/has been unpublished
 			// or the related home page does not exist/has been unpublished
-			JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
-
 			if (!array_key_exists($lang_code, MultilangstatusHelper::getSitelangs())
 				|| !array_key_exists($lang_code, MultilangstatusHelper::getContentlangs())
 				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages()))


### PR DESCRIPTION
On a multilanguage site, <b>when the site language or content language or home page for a formerly existing language in multilang have been disabled/deleted</b>, we can get a lot of different errors, from a simple 404 to a loop.
To avoid this, we have to check in the languagefilter plugin as well as mod_languages (the switcher) if we can use such a language or not.
1. In mod_languages, we checked that the site language existed but did not check if it was also enabled. The patch corrects this. (To test go to Extensions=>Manager=>Manage, filter by language and disable one of the site languages.

In languagefilter 
2. we do not check the existence of the site language (present in J and enabled).
3. When user login and the user language is set and Automatic Language Change is set to Yes, we do not check that this site user language is still installed and enabled, that the related Content Language exists and is published and that the related Home Page exists and is published.

This patch solves 1. by not displaying the flag in that case
This patch solves 2. by unsetting the site lang in case of inexistence/disabled
This patch solves 3. by checking that all these conditions are met, and if not redirects the user loging to the language in use.

Test all conditions by disabling a site language which is used by a user login, unpublishing a home, unpublishing a content language.

Patch and test again.
