### PR TITLE
Improve search syntax in backend User Manager

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -310,7 +310,13 @@ class UsersModelUsers extends JModelList
 		if ($groupId || isset($groups))
 		{
 			$query->join('LEFT', '#__user_usergroup_map AS map2 ON map2.user_id = a.id')
-				->group($db->quoteName(array('a.id', 'a.name', 'a.username', 'a.password', 'a.block', 'a.sendEmail', 'a.registerDate', 'a.lastvisitDate', 'a.activation', 'a.params', 'a.email')));
+				->group(
+					$db->quoteName(
+						array('a.id', 'a.name', 'a.username', 'a.password', 'a.block',
+							'a.sendEmail', 'a.registerDate', 'a.lastvisitDate', 'a.activation', 'a.params', 'a.email'
+						)
+					)
+				);
 
 			if ($groupId)
 			{
@@ -324,19 +330,33 @@ class UsersModelUsers extends JModelList
 		}
 
 		// Filter the items over the search string if set.
-		if ($this->getState('filter.search') !== '' && $this->getState('filter.search') !== null)
+		$search = $this->getState('filter.search');
+
+		if (!empty($search))
 		{
-			// Escape the search token.
-			$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($this->getState('filter.search')), true) . '%'));
+			if (stripos($search, 'id:') === 0)
+			{
+				$query->where('a.id = ' . (int) substr($search, 3));
+			}
+			elseif (stripos($search, 'username:') === 0)
+			{
+				$search = $db->quote('%' . $db->escape(substr($search, 9), true) . '%');
+				$query->where('a.username LIKE ' . $search);
+			}
+			else
+			{
+				// Escape the search token.
+				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
 
-			// Compile the different search clauses.
-			$searches   = array();
-			$searches[] = 'a.name LIKE ' . $search;
-			$searches[] = 'a.username LIKE ' . $search;
-			$searches[] = 'a.email LIKE ' . $search;
+				// Compile the different search clauses.
+				$searches   = array();
+				$searches[] = 'a.name LIKE ' . $search;
+				$searches[] = 'a.username LIKE ' . $search;
+				$searches[] = 'a.email LIKE ' . $search;
 
-			// Add the clauses to the query.
-			$query->where('(' . implode(' OR ', $searches) . ')');
+				// Add the clauses to the query.
+				$query->where('(' . implode(' OR ', $searches) . ')');
+			}
 		}
 
 		// Add filter for registration ranges select list
@@ -423,7 +443,7 @@ class UsersModelUsers extends JModelList
 	 *
 	 * @return  string   Groups titles imploded :$
 	 */
-	function _getUserDisplayedGroups($user_id)
+	protected function _getUserDisplayedGroups($user_id)
 	{
 		$db    = JFactory::getDbo();
 		$query = "SELECT title FROM " . $db->quoteName('#__usergroups') . " ug left join " .

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -446,12 +446,20 @@ class UsersModelUsers extends JModelList
 	protected function _getUserDisplayedGroups($user_id)
 	{
 		$db    = JFactory::getDbo();
-		$query = "SELECT title FROM " . $db->quoteName('#__usergroups') . " ug left join " .
-			$db->quoteName('#__user_usergroup_map') . " map on (ug.id = map.group_id)" .
-			" WHERE map.user_id=" . (int) $user_id;
-
-		$db->setQuery($query);
-		$result = $db->loadColumn();
+		$query = $db->getQuery(true)
+			->select($db->qn('title'))
+			->from($db->qn('#__usergroups', 'ug'))
+			->join('LEFT',$db->qn('#__user_usergroup_map', 'map') . ' ON (ug.id = map.group_id)')
+			->where($db->qn('map.user_id') . ' = ' . (int) $user_id);
+	
+		try
+		{
+			$result = $db->setQuery($query)->loadColumn();
+		}
+		catch (RunTimeException $e)
+		{
+			$result=array();
+		}
 
 		return implode("\n", $result);
 	}

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -449,16 +449,16 @@ class UsersModelUsers extends JModelList
 		$query = $db->getQuery(true)
 			->select($db->qn('title'))
 			->from($db->qn('#__usergroups', 'ug'))
-			->join('LEFT',$db->qn('#__user_usergroup_map', 'map') . ' ON (ug.id = map.group_id)')
+			->join('LEFT', $db->qn('#__user_usergroup_map', 'map') . ' ON (ug.id = map.group_id)')
 			->where($db->qn('map.user_id') . ' = ' . (int) $user_id);
-	
+
 		try
 		{
 			$result = $db->setQuery($query)->loadColumn();
 		}
 		catch (RunTimeException $e)
 		{
-			$result=array();
+			$result = array();
 		}
 
 		return implode("\n", $result);


### PR DESCRIPTION
## PR Summary

This PR makes small improvement to search feature in User Manager from backend to allow searching for exactly user base on given ID or username:
- Enter id:42 will return the user has ID = 42 in your system.
- Enter username:admin will return user has username = admin in your system

This is useful in case you want to find a user when you know username or user id in a site has thousands of users.
## Testing instructions

Login to backend of your site, access to User -> User Manager:
- Try to search for user by enter keyword into the searchbox and make sure the search feature still work well
- Try to use syntax id:ID_OF_USER, for example id:42 and make sure only user with that id is returned
- Try to use syntax username:USER_NAME_OF_USER and make sure only user with that username (or similar) returned.
