### PR TITLE
Fix Issue #6770: Pagination limit results are wrong in Smart Search

### DIFF
--- a/components/com_finder/views/search/tmpl/default_results.php
+++ b/components/com_finder/views/search/tmpl/default_results.php
@@ -72,7 +72,7 @@ defined('_JEXEC') or die;
 			// Prepare the pagination string.  Results X - Y of Z
 			$start = (int) $this->pagination->get('limitstart') + 1;
 			$total = (int) $this->pagination->get('total');
-			$limit = (int) $this->pagination->get('limit') * $this->pagination->pagesTotal;
+			$limit = (int) $this->pagination->get('limit') * $this->pagination->get('pages.current');
 			$limit = (int) ($limit > $total ? $total : $limit);
 
 			echo JText::sprintf('COM_FINDER_SEARCH_RESULTS_OF', $start, $limit, $total);


### PR DESCRIPTION
#### Steps to reproduce the issue

Given the Default List Limit in Global Configuration as 10:

1) Create at least 11 articles with the same content
2) Configure a Smart Search module or component
3) Search in frontend for a word that occurs in all articles
#### Expected result

In the search page at the bottom it should say "1 to PAGE_LIMIT of TOTAL results"
e.g. with the above steps to reproduce the issue it should say "1 to 10 of 11 results"
#### Actual result

In the search page at the bottom it says "1 to TOTAL of TOTAL results"
e.g. with the above steps to reproduce the issue it say "1 to 11 of 11 results"
#### System information (as much as possible)
#### Additional comments

This happens because there is an error in the template, I will shortly submit a PR
