### PR TITLE
Simply the code in backend controllers

### DIFF
--- a/administrator/components/com_banners/controller.php
+++ b/administrator/components/com_banners/controller.php
@@ -39,8 +39,7 @@ class BannersController extends JControllerLegacy
 		if ($view == 'banner' && $layout == 'edit' && !$this->checkEditId('com_banners.edit.banner', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_banners&view=banners', false));
 
 			return false;
@@ -48,8 +47,7 @@ class BannersController extends JControllerLegacy
 		elseif ($view == 'client' && $layout == 'edit' && !$this->checkEditId('com_banners.edit.client', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_banners&view=clients', false));
 
 			return false;

--- a/administrator/components/com_categories/controller.php
+++ b/administrator/components/com_categories/controller.php
@@ -66,8 +66,7 @@ class CategoriesController extends JControllerLegacy
 		if ($vName == 'category' && $lName == 'edit' && !$this->checkEditId('com_categories.edit.category', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_categories&view=categories&extension=' . $this->extension, false));
 
 			return false;

--- a/administrator/components/com_contact/controller.php
+++ b/administrator/components/com_contact/controller.php
@@ -44,8 +44,7 @@ class ContactController extends JControllerLegacy
 		if ($view == 'contact' && $layout == 'edit' && !$this->checkEditId('com_contact.edit.contact', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contacts', false));
 
 			return false;

--- a/administrator/components/com_content/controller.php
+++ b/administrator/components/com_content/controller.php
@@ -42,8 +42,7 @@ class ContentController extends JControllerLegacy
 		if ($view == 'article' && $layout == 'edit' && !$this->checkEditId('com_content.edit.article', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_content&view=articles', false));
 
 			return false;

--- a/administrator/components/com_languages/controller.php
+++ b/administrator/components/com_languages/controller.php
@@ -44,8 +44,7 @@ class LanguagesController extends JControllerLegacy
 		if ($view == 'language' && $layout == 'edit' && !$this->checkEditId('com_languages.edit.language', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_languages&view=languages', false));
 
 			return false;

--- a/administrator/components/com_messages/controller.php
+++ b/administrator/components/com_messages/controller.php
@@ -38,8 +38,7 @@ class MessagesController extends JControllerLegacy
 		if ($view == 'message' && $layout == 'edit' && !$this->checkEditId('com_messages.edit.message', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_messages&view=messages', false));
 
 			return false;

--- a/administrator/components/com_newsfeeds/controller.php
+++ b/administrator/components/com_newsfeeds/controller.php
@@ -38,8 +38,7 @@ class NewsfeedsController extends JControllerLegacy
 		if ($view == 'newsfeed' && $layout == 'edit' && !$this->checkEditId('com_newsfeeds.edit.newsfeed', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds', false));
 
 			return false;

--- a/administrator/components/com_plugins/controller.php
+++ b/administrator/components/com_plugins/controller.php
@@ -41,8 +41,7 @@ class PluginsController extends JControllerLegacy
 		if ($view == 'plugin' && $layout == 'edit' && !$this->checkEditId('com_plugins.edit.plugin', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_plugins&view=plugins', false));
 
 			return false;

--- a/administrator/components/com_redirect/controller.php
+++ b/administrator/components/com_redirect/controller.php
@@ -47,8 +47,7 @@ class RedirectController extends JControllerLegacy
 		if ($view == 'link' && $layout == 'edit' && !$this->checkEditId('com_redirect.edit.link', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_redirect&view=links', false));
 
 			return false;

--- a/administrator/components/com_tags/controller.php
+++ b/administrator/components/com_tags/controller.php
@@ -38,8 +38,7 @@ class TagsController extends JControllerLegacy
 		if ($view == 'tag' && $layout == 'edit' && !$this->checkEditId('com_tags.edit.tag', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_tags&view=tags', false));
 
 			return false;

--- a/administrator/components/com_templates/controller.php
+++ b/administrator/components/com_templates/controller.php
@@ -63,8 +63,7 @@ class TemplatesController extends JControllerLegacy
 		if ($view == 'style' && $layout == 'edit' && !$this->checkEditId('com_templates.edit.style', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_templates&view=styles', false));
 
 			return false;

--- a/administrator/components/com_users/controller.php
+++ b/administrator/components/com_users/controller.php
@@ -72,8 +72,7 @@ class UsersController extends JControllerLegacy
 		if ($view == 'user' && $layout == 'edit' && !$this->checkEditId('com_users.edit.user', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=users', false));
 
 			return false;
@@ -81,8 +80,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'group' && $layout == 'edit' && !$this->checkEditId('com_users.edit.group', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=groups', false));
 
 			return false;
@@ -90,8 +88,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'level' && $layout == 'edit' && !$this->checkEditId('com_users.edit.level', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=levels', false));
 
 			return false;
@@ -99,8 +96,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'note' && $layout == 'edit' && !$this->checkEditId('com_users.edit.note', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=notes', false));
 
 			return false;


### PR DESCRIPTION
## PR Summary

In display method of many backend controllers, we are having this code:

``` php
$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
$this->setMessage($this->getError(), 'error');
```

These two lines of code is used to set an error message to controller object and display to end-user if users try to edit a record by typing the link directly on browser.

The two lines of code can be replaced with just one line of code:

``` php
$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
```

This is more logic to me. There is no reason to set error message, then call a command to get the same error message to display.

I made change to few classes as a sample. If people think that this change is valid, I will do the same changes on other classes.
