### PR TITLE
Small change to com_tags backend

### DIFF
--- a/administrator/components/com_tags/tags.php
+++ b/administrator/components/com_tags/tags.php
@@ -10,15 +10,11 @@
 defined('_JEXEC') or die;
 JHtml::_('behavior.tabstate');
 
-$input = JFactory::getApplication()->input;
-
 if (!JFactory::getUser()->authorise('core.manage', 'com_tags'))
 {
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$task = $input->get('task');
-
 $controller	= JControllerLegacy::getInstance('Tags');
-$controller->execute($input->get('task'));
+$controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -31,10 +31,10 @@ class TagsViewTags extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->state		= $this->get('State');
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		
+		$this->state      = $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
@@ -42,6 +42,7 @@ class TagsViewTags extends JViewLegacy
 
 			return false;
 		}
+
 		// Preprocess the list of items to find ordering divisions.
 		foreach ($this->items as &$item)
 		{

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -34,9 +34,7 @@ class TagsViewTags extends JViewLegacy
 		$this->state		= $this->get('State');
 		$this->items		= $this->get('Items');
 		$this->pagination	= $this->get('Pagination');
-
-		TagsHelper::addSubmenu('tags');
-
+		
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{


### PR DESCRIPTION
This PR just contains two small changes to com_tags backend:
1. Standardize component entry point, make it the same with other component.
2. Remove call to a wrong implemented method TagsHelper::addSubmenu('tags'); This command doesn't affect the extension at all.
3. This method https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_tags/helpers/tags.php#L28 is based on CategoriesHelper::addSubmenu (https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_categories/helpers/categories.php#L28) but it was implemented in a wrong way, incomplete and not used anywhere (at least in core code), Not sure what to do with it: Leave it there, empty it or remove it :D ?
