### PR TITLE
Remove un-used variables from code

### DIFF
--- a/administrator/components/com_menus/controller.php
+++ b/administrator/components/com_menus/controller.php
@@ -30,10 +30,6 @@ class MenusController extends JControllerLegacy
 	{
 		require_once JPATH_COMPONENT . '/helpers/menus.php';
 
-		$view   = $this->input->get('view', 'menus');
-		$layout = $this->input->get('layout', 'default');
-		$id     = $this->input->getInt('id');
-
 		parent::display();
 
 		return $this;

--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -28,8 +28,6 @@ class ModulesController extends JControllerLegacy
 	 */
 	public function display($cachable = false, $urlparams = false)
 	{
-		$view   = $this->input->get('view', 'modules');
-		$layout = $this->input->get('layout', 'default');
 		$id     = $this->input->getInt('id');
 
 		$document = JFactory::getDocument();


### PR DESCRIPTION
## PR summary

In the ModulesController and MenusController, there are some variables initialized/defined but not being used at all (It can be seen easily from smart IDE like phpstorm). This PR simply remove it.
## Testing instructions

I think this PR just need a quick review from PLT and then it can be merged. However, if you want to test, just apply this PR, login to backend of your site, access to Menus -> Menu Manager, Extensions -> Module Manager, make sure these two pages still being displayed property and test is success.
