### PR TITLE
JText::_() and JText::loadLanguage() Optimisations

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -368,8 +368,11 @@ class JLanguage
 		}
 		elseif ($interpretBackSlashes)
 		{
-			// Interpret \n and \t characters
-			$string = str_replace(array('\\\\', '\t', '\n'), array("\\", "\t", "\n"), $string);
+			if (strpos($string, '\\') !== false)
+			{
+				// Interpret \n and \t characters
+				$string = str_replace(array('\\\\', '\t', '\n'), array("\\", "\t", "\n"), $string);
+			}
 		}
 
 		return $string;
@@ -799,15 +802,30 @@ class JLanguage
 		{
 			if (is_array($strings))
 			{
-				// Sort the underlying heap by key values to optimize merging
-				ksort($strings, SORT_STRING);
-				$this->strings = array_merge($this->strings, $strings);
+				if (!empty($this->strings))
+				{
+					foreach($strings as $key => $string)
+					{
+						$this->strings[$key] = $string;
+					}
+				}
+				else
+				{
+					// This should assign the larger, initial application language file directly:
+					$this->strings = $strings;
+				}
 			}
 
 			if (is_array($strings) && count($strings))
 			{
-				// Do not bother with ksort here.  Since the originals were sorted, PHP will already have chosen the best heap.
-				$this->strings = array_merge($this->strings, $this->override);
+				if (!empty($this->override))
+				{
+					foreach($this->override as $overrideKey => $overrideString)
+					{
+						$this->strings[$overrideKey] = $overrideString;
+					}
+				}
+
 				$result = true;
 			}
 		}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -804,7 +804,7 @@ class JLanguage
 			{
 				if (!empty($this->strings))
 				{
-					foreach($strings as $key => $string)
+					foreach ($strings as $key => $string)
 					{
 						$this->strings[$key] = $string;
 					}
@@ -820,7 +820,7 @@ class JLanguage
 			{
 				if (!empty($this->override))
 				{
-					foreach($this->override as $overrideKey => $overrideString)
+					foreach ($this->override as $overrideKey => $overrideString)
 					{
 						$this->strings[$overrideKey] = $overrideString;
 					}


### PR DESCRIPTION
This started out as a way of improving the JText::_() method when I had noticed last week that it was adding quite a bit of time to the pages I was testing out. 

Today, I expanded that a little further and took a closer look at JText::loadLanguage() and found a few ways it could be optimized too.
### Overview
### JText::_() Changes

In this method the main change was wrapping the str_replace call on line 372 with an if statement to check whether a backslash existed in the string.

I added the if statement because I observed that the characters in the str_replace call rarely existed inside of our language strings and so avoiding the str_replace improved the performance by a considerable amount (particularly on pages that use JText::_() a lot).
### JText::loadLanguage() Changes

For this method, the initial thing I observed was line 810, which called array_merge() on the override strings that had been loaded.

I'm sure there are folks that use them quite a bit, but I think for most stock Joomla sites the override array is empty, as it was in my case.

Even though the override array was empty, calling array_merge() on it took almost the same amount of time as the array_merge() call on line 804 so it was doubling the amount of time required.

So removing that call cut the time down pretty significantly.

I also recalled though that array_merge() could get fairly slow as the size of the array grows, and since all of the array keys are strings, switching array_merge() out for a simple foreach loop seemed like it would reduce the time a little further.

Since the first set of strings to be loaded is usually a good size (about 950 or so), I also added a check to see if the internal strings array is empty (and instead of doing the foreach loop for that one, it just assigns the array directly to the internal strings variable which sped things up a little more).
### Details on Performance Improvements

Here are the results of some tests I ran on my end that were recorded in PhpEd's profiler:
https://drive.google.com/file/d/0BxOIWStZm809NkpORDhzb011ZEk/view?usp=sharing

Using my testing instructions below I was able to gather the following timing info on my end using the Joomla Profiler (a few more tests are detailed in the PDF link above):

```
Before Patch (5000 Calls, Time = 35.2 ms):
Time: 25.6 ms / 26.4 ms Memory: 2.136 MB / 2.83 MB Application: Before JText::_()
Time: 35.2 ms / 61.7 ms Memory: 0.288 MB / 3.12 MB Application: After JText::_()

After Patch (5000 Calls, Time = 28.2 ms):
Time: 27.0 ms / 27.9 ms Memory: 2.136 MB / 2.83 MB Application: Before JText::_()
Time: 28.2 ms / 56.1 ms Memory: 0.289 MB / 3.12 MB Application: After JText::_()
```
### Testing Instructions

To test the JText::loadLanguage() improvements it's going to be a little tricky because it's difficult to expose the timing information without using a profiling tool (since the method is protected and not public).

For JText::_() you can insert the following snippet after line 44 in the administrator/index.php file and it will call JText::_() 5000 times and add the information to the regular Joomla Profiler so after you insert this snippet and turn on debugging (so you can see the Profile Information) you can get the timing information before you apply the patch, and then you can get the timing information after applying the patch.

For pages that don't use JText that much the speed difference won't be noticeable, but any page generating a reasonable amount of output with use JText a fair amount and these improvements should speed up things a little bit.

Insert the following after line 44 in administrator/index.php (right after this line: "$app = JFactory::getApplication('administrator');")

```
$range = range(1, 5000);

JDEBUG ? $_PROFILER->mark('Before JText::_()') : null;
foreach($range as $i)
{
    JText::_('JADMINISTRATOR');
}
JDEBUG ? $_PROFILER->mark('After JText::_()') : null;
```
