### PR TITLE
Add field for missing section "category"

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -236,5 +236,14 @@
 			validate="rules"
 			component="com_users"
 			section="component" />
+		<field
+			name="rules"
+			type="rules"
+			label="JCONFIG_PERMISSIONS_LABEL"
+			filter="rules"
+			validate="rules"
+			component="com_users"
+			section="category" />
+
 	</fieldset>
 </config>


### PR DESCRIPTION
com_user access.xml includes section name="category" but config.xml lacked a field with this section.
