### PR TITLE
Including core_params field in SELECT

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -544,6 +544,7 @@ class JHelperTags extends JHelper
 				. ', ' . 'count(m.tag_id) AS match_count'
 				. ', ' . 'MAX(m.tag_date) as tag_date'
 				. ', ' . 'MAX(c.core_title) AS core_title'
+				. ', ' . 'c.core_params'
 			)
 			->select('MAX(c.core_alias) AS core_alias, MAX(c.core_body) AS core_body, MAX(c.core_state) AS core_state, MAX(c.core_access) AS core_access')
 			->select(

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -544,7 +544,7 @@ class JHelperTags extends JHelper
 				. ', ' . 'count(m.tag_id) AS match_count'
 				. ', ' . 'MAX(m.tag_date) as tag_date'
 				. ', ' . 'MAX(c.core_title) AS core_title'
-				. ', ' . 'c.core_params'
+				. ', ' . 'MAX(c.core_params) AS core_params'
 			)
 			->select('MAX(c.core_alias) AS core_alias, MAX(c.core_body) AS core_body, MAX(c.core_state) AS core_state, MAX(c.core_access) AS core_access')
 			->select(


### PR DESCRIPTION
In my project I needed to access `attribs` field from #__content which is stored as `core_params` in #__ucm_content. This commit will allow to access this field when outputting tags related articles. It's especially useful if you have custom parameters associated with your article.
