### PR TITLE
Fix #5939 | XMLReader::read returns false on invalid xml and error in ph...

### DIFF
--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -66,7 +66,10 @@ class JFeedFactory
 			// Skip ahead to the root node.
 			do
 			{
-				$reader->read();
+				if (!$reader->read())
+				{
+					throw new RuntimeException('Error reading feed.');
+				}
 			}
 
 			while ($reader->nodeType !== XMLReader::ELEMENT);

--- a/libraries/joomla/feed/parser.php
+++ b/libraries/joomla/feed/parser.php
@@ -267,14 +267,21 @@ abstract class JFeedParser
 		$name  = $this->stream->name;
 		$depth = $this->stream->depth;
 
-		// Only keep looking until the end of the stream.
-		while ($this->stream->read())
+		try
 		{
-			// If we have an END_ELEMENT node with the same name and depth as the node we started with we have a bingo. :-)
-			if (($this->stream->name == $name) && ($this->stream->depth == $depth) && ($this->stream->nodeType == XMLReader::END_ELEMENT))
+			// Only keep looking until the end of the stream.
+			while ($this->stream->read())
 			{
-				return;
+				// If we have an END_ELEMENT node with the same name and depth as the node we started with we have a bingo. :-)
+				if (($this->stream->name == $name) && ($this->stream->depth == $depth) && ($this->stream->nodeType == XMLReader::END_ELEMENT))
+				{
+					return;
+				}
 			}
+		}
+		catch (Exception $e)
+		{
+			throw new RuntimeException('Error reading feed.');
 		}
 
 		throw new RuntimeException('Unable to find the closing XML node.');

--- a/tests/unit/stubs/feed/very.bad.test.feed
+++ b/tests/unit/stubs/feed/very.bad.test.feed
@@ -1,0 +1,1 @@
+A text file.

--- a/tests/unit/suites/libraries/joomla/feed/JFeedFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/feed/JFeedFactoryTest.php
@@ -52,12 +52,23 @@ class JFeedFactoryTest extends TestCase
 	 */
 	public function testGetFeedBad()
 	{
-		$this->markTestSkipped('This test is failing to execute and is locking up the test suite.');
 		$this->_instance->getFeed(JPATH_TEST_STUBS . '/feed/test.bad.feed');
 	}
 
 	/**
 	 * Tests JFeedFactory::getFeed() with a bad feed.
+	 *
+	 * @return  void
+	 *
+	 * @expectedException  RuntimeException
+	 */
+	public function testGetFeedWithASimpleTextFile()
+	{
+		$this->_instance->getFeed(JPATH_TEST_STUBS . '/feed/very.bad.test.feed');
+	}
+
+	/**
+	 * Tests JFeedFactory::getFeed() with no parser.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
...p3. Throw an exception and stop loop execution if feed xml is bad.
