### PR TITLE
Patch #6712 - FieldCheckbox attribute default

### DIFF
--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -98,7 +98,7 @@ class JFormFieldCheckbox extends JFormField
 	{
 		// Handle the default attribute
 		$default = (string) $element['default'];
-		if($default)
+		if ($default)
 		{
 			$test = $this->form->getValue((string) $element['name'], $group);
 

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -96,6 +96,15 @@ class JFormFieldCheckbox extends JFormField
 	 */
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
+		// Handle the default attribute
+		$default = (string) $element['default'];
+		if($default)
+		{
+			$test = $this->form->getValue((string) $element['name'], $group);
+
+			$value = ($test == $default) ? $default : null;
+		}
+
 		$return = parent::setup($element, $value, $group);
 
 		if ($return)

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -98,6 +98,7 @@ class JFormFieldCheckbox extends JFormField
 	{
 		// Handle the default attribute
 		$default = (string) $element['default'];
+
 		if ($default)
 		{
 			$test = $this->form->getValue((string) $element['name'], $group);


### PR DESCRIPTION
Checkbox field does not allow defining a value without being checked
#6712

For easiest test use this custom component: https://github.com/Devportobello/joomla-attach-PR-6794
## Test

First sry for my bad english, will try my best.

Dunno if we can test with something actually in Joomla, so if you want you can install my custom component then go to frontend "www.yourdomain.com/?option=com_test"
- _"with default" mean the attribute "value" of checkbox are set with something different that 1_
- _"with group" mean the use of fields in xml form definition_

**Test1**
Uncheck all checkbox then submit
-> Checkbox 1 with default and checkbox 2 with default are checked

**Test2**
Patch with the fix,
Uncheck all checkbox then submit
-> All checkbox are unchecked
## DEV

JForm::loadField
-> $field->setup($element, $value, $group) with value = $value or $default
Then
JFormFieldCheckbox::setup
-> empty($this->value) || $this->checked ? null : $this->checked = true;
