### PR TITLE
Remove setting the lifetime value as it is already set.

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -232,8 +232,6 @@ class JCache
 
 		if (!($handler instanceof Exception) && $this->_options['caching'])
 		{
-			$handler->_lifetime = $this->_options['lifetime'];
-
 			return $handler->store($id, $group, $data);
 		}
 


### PR DESCRIPTION
The lifetime was forced but not changed to minutes, so the cache time would become seconds. Since the lifetime is already set in the constructor, it is not needed to force it in the store() method.

This fixes #2539 as proposed by @ollyja 

**Test Instructions**
Please see the test instructions provided by @ollyja here: http://issues.joomla.org/tracker/joomla-cms/2539#event-71926

After applying the patch the cache file e3ca4ca329e96b6bd2cae4c39f5bcc88-cache-com_test-6ab76d843e7ecfda29171a181cbcd76a.php should not have a changed timestamp.
