### PR TITLE
Missed few mootools modals on com_menus boostrapization

### DIFF
--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -47,7 +47,7 @@ class JFormFieldModal_Contact extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectContact_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
 
 		if ($allowEdit)
@@ -61,6 +61,13 @@ class JFormFieldModal_Contact extends JFormField
 		}
 
 		$script[] = '		jQuery("#modalContact").modal("hide");';
+
+		if ($this->required)
+		{
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+		}
+
 		$script[] = '	}';
 
 		// Clear button script
@@ -71,7 +78,7 @@ class JFormFieldModal_Contact extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearContact(id) {';
-			$script[] = '		document.getElementById(id + "_id").value = "";';
+			$script[] = '		document.getElementById(id).value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "'
 				. htmlspecialchars(JText::_('COM_CONTACT_SELECT_A_CONTACT', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -181,7 +188,7 @@ class JFormFieldModal_Contact extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -145,7 +145,7 @@ class JFormFieldModal_Contact extends JFormField
 							'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
 							'width' => '800px',
 							'height' => '300px',
-						), ''
+						)
 					);
 
 		// Edit contact button.

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -152,6 +152,8 @@ class JFormFieldModal_Contact extends JFormField
 							'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
 							'width' => '800px',
 							'height' => '300px',
+							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						)
 					);
 

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -40,8 +40,6 @@ class JFormFieldModal_Contact extends JFormField
 		JFactory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
 		// Load the javascript
-		JHtml::_('behavior.framework');
-		JHtml::_('behavior.modal', 'a.modal');
 		JHtml::_('bootstrap.tooltip');
 
 		// Build the script.
@@ -62,7 +60,7 @@ class JFormFieldModal_Contact extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jModalClose();';
+		$script[] = '		jQuery("#modalContact").modal("hide");';
 		$script[] = '	}';
 
 		// Clear button script
@@ -136,13 +134,19 @@ class JFormFieldModal_Contact extends JFormField
 		// The current contact display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a'
-			. ' class="modal btn hasTooltip"'
-			. ' title="' . JHtml::tooltipText('COM_CONTACT_CHANGE_CONTACT') . '"'
-			. ' href="' . $link . '&amp;' . JSession::getFormToken() . '=1"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
+		$html[] = '<a href="#modalContact"  class="btn hasTooltip" role="button"  data-toggle="modal"'
+			. ' title="' . JHtml::tooltipText('COM_CONTACT_CHANGE_CONTACT') . '">'
 			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
 			. '</a>';
+
+		$html[] = JHtmlBootstrap::renderModal(
+							'modalContact', array(
+							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+							'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
+							'width' => '800px',
+							'height' => '300px',
+						), ''
+					);
 
 		// Edit contact button.
 		if ($allowEdit)

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -47,7 +47,7 @@ class JFormFieldModal_Contact extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectContact_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
 
 		if ($allowEdit)
@@ -62,12 +62,6 @@ class JFormFieldModal_Contact extends JFormField
 
 		$script[] = '		jQuery("#modalContact").modal("hide");';
 
-		if ($this->required)
-		{
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
-		}
-
 		$script[] = '	}';
 
 		// Clear button script
@@ -78,7 +72,7 @@ class JFormFieldModal_Contact extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearContact(id) {';
-			$script[] = '		document.getElementById(id).value = "";';
+			$script[] = '		document.getElementById(id + "_id").value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "'
 				. htmlspecialchars(JText::_('COM_CONTACT_SELECT_A_CONTACT', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -190,7 +184,7 @@ class JFormFieldModal_Contact extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -39,9 +39,6 @@ class JFormFieldModal_Article extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
-		// Load the modal behavior script.
-		JHtml::_('behavior.modal', 'a.modal');
-
 		// Build the script.
 		$script = array();
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -44,7 +44,7 @@ class JFormFieldModal_Article extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectArticle_' . $this->id . '(id, title, catid, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = title;';
 
 		if ($allowEdit)
@@ -58,6 +58,13 @@ class JFormFieldModal_Article extends JFormField
 		}
 
 		$script[] = '		jQuery("#modalArticle").modal("hide");';
+
+		if ($this->required)
+		{
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+		}
+
 		$script[] = '	}';
 
 		// Clear button script
@@ -68,7 +75,7 @@ class JFormFieldModal_Article extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearArticle(id) {';
-			$script[] = '		document.getElementById(id + "_id").value = "";';
+			$script[] = '		document.getElementById(id).value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "' .
 				htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -158,7 +165,7 @@ class JFormFieldModal_Article extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		$html[] = JHtmlBootstrap::renderModal(
 			'modalArticle', array(

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -173,7 +173,9 @@ class JFormFieldModal_Article extends JFormField
 				'title' => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
 				'width' => '800px',
 				'height' => '300px',
-			), ''
+				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
 		);
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -44,7 +44,7 @@ class JFormFieldModal_Article extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectArticle_' . $this->id . '(id, title, catid, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = title;';
 
 		if ($allowEdit)
@@ -59,12 +59,6 @@ class JFormFieldModal_Article extends JFormField
 
 		$script[] = '		jQuery("#modalArticle").modal("hide");';
 
-		if ($this->required)
-		{
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
-		}
-
 		$script[] = '	}';
 
 		// Clear button script
@@ -75,7 +69,7 @@ class JFormFieldModal_Article extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearArticle(id) {';
-			$script[] = '		document.getElementById(id).value = "";';
+			$script[] = '		document.getElementById(id + "_id").value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "' .
 				htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -165,7 +159,7 @@ class JFormFieldModal_Article extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		$html[] = JHtmlBootstrap::renderModal(
 			'modalArticle', array(

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -166,7 +166,7 @@ class JFormFieldModal_Article extends JFormField
 		$html[] = JHtmlBootstrap::renderModal(
 			'modalArticle', array(
 				'url' => $url,
-				'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+				'title' => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
 				'width' => '800px',
 				'height' => '300px',
 			), ''

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -60,7 +60,7 @@ class JFormFieldModal_Article extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jModalClose();';
+		$script[] = '		jQuery("#modalArticle").modal("hide");';
 		$script[] = '	}';
 
 		// Clear button script
@@ -129,11 +129,14 @@ class JFormFieldModal_Article extends JFormField
 			$value = (int) $this->value;
 		}
 
+		$url = $link . '&amp;'. JSession::getFormToken() . '=1';
 		// The current article display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a class="modal btn hasTooltip" title="' . JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '"  href="' . $link . '&amp;' . JSession::getFormToken() .
-			'=1" rel="{handler: \'iframe\', size: {x: 800, y: 450}}"><i class="icon-file"></i> ' . JText::_('JSELECT') . '</a>';
+		$html[] = '<a href="#modalArticle" class="btn hasTooltip" role="button"  data-toggle="modal" title="'
+			. JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '">
+		 <i class="icon-file"></i> '
+			. JText::_('JSELECT') . '</a>';
 
 		// Edit article button
 		if ($allowEdit)
@@ -160,6 +163,14 @@ class JFormFieldModal_Article extends JFormField
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
+		$html[] = JHtmlBootstrap::renderModal(
+			'modalArticle', array(
+				'url' => $url,
+				'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+				'width' => '800px',
+				'height' => '300px',
+			), ''
+		);
 		return implode("\n", $html);
 	}
 }

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -129,7 +129,7 @@ class JFormFieldModal_Article extends JFormField
 			$value = (int) $this->value;
 		}
 
-		$url = $link . '&amp;'. JSession::getFormToken() . '=1';
+		$url = $link . '&amp;' . JSession::getFormToken() . '=1';
 		// The current article display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -77,7 +77,6 @@ class JFormFieldMenutype extends JFormFieldList
 		JFactory::getDocument()->addScriptDeclaration('
 			function jSelectPosition_' . $this->id . '(name) {
 				document.getElementById("' . $this->id . '").value = name;
-				jQuery("#menuTypeModal").modal("hide");
 			}
 		');
 

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -82,9 +82,16 @@ class JFormFieldMenutype extends JFormFieldList
 		');
 
 		$link = JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&recordId=' . $recordId);
-		$html[] = '<span class="input-append"><input type="text" ' . $required . ' disabled="disabled" readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' />';
+		$html[] = '<span class="input-append"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id . '" value="' . $value . '"' . $size . $class . ' />';
 		$html[] = '<a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="' . JText::_('JSELECT') . '"><i class="icon-list icon-white"></i> ' . JText::_('JSELECT') . '</a></span>';
-		$html[] = JHtmlBootstrap::renderModal('menuTypeModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),'height' => '600px', 'width' => '800px'), '');
+		$html[] = JHtmlBootstrap::renderModal(
+						'menuTypeModal', array(
+							'url' => $link,
+							'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+							'width' => '800px',
+							'height' => '300px'
+						), ''
+					);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 
 		return implode("\n", $html);

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -89,7 +89,9 @@ class JFormFieldMenutype extends JFormFieldList
 							'url' => $link,
 							'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
 							'width' => '800px',
-							'height' => '300px'
+							'height' => '300px',
+							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						)
 					);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -90,7 +90,7 @@ class JFormFieldMenutype extends JFormFieldList
 							'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
 							'width' => '800px',
 							'height' => '300px'
-						), ''
+						)
 					);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -66,10 +66,8 @@ Joomla.submitbutton = function(task, type){
 		// special case for modal popups validation response
 		jQuery('#item-form .modal-value.invalid').each(function(){
 			var field = jQuery(this),
-				idReversed = field.attr('id').split('').reverse().join(''),
-				separatorLocation = idReversed.indexOf('_'),
-				nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
-			jQuery(nameId).addClass('invalid');
+				nameId = '#' + field.attr('id') + '_name';
+				jQuery(nameId).addClass('invalid');
 		});
 	}
 };

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -66,19 +66,10 @@ Joomla.submitbutton = function(task, type){
 		// special case for modal popups validation response
 		jQuery('#item-form .modal-value.invalid').each(function(){
 			var field = jQuery(this),
-			nameId = '#' + field.attr('id') + '_name';
-			if (jQuery(nameId).length)
-			{
-				jQuery(nameId).addClass('invalid');
-				return;
-			}
-			var idReversed = field.attr('id').split('').reverse().join('');
-			var separatorLocation = idReversed.indexOf('_');
-			nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
-			if (jQuery(nameId).length)
-			{
-				jQuery(nameId).addClass('invalid');
-			}
+				idReversed = field.attr('id').split('').reverse().join(''),
+				separatorLocation = idReversed.indexOf('_'),
+				nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
+			jQuery(nameId).addClass('invalid');
 		});
 	}
 };

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -66,8 +66,19 @@ Joomla.submitbutton = function(task, type){
 		// special case for modal popups validation response
 		jQuery('#item-form .modal-value.invalid').each(function(){
 			var field = jQuery(this),
-				nameId = '#' + field.attr('id') + '_name';
+			nameId = '#' + field.attr('id') + '_name';
+			if (jQuery(nameId).length)
+			{
 				jQuery(nameId).addClass('invalid');
+				return;
+			}
+			var idReversed = field.attr('id').split('').reverse().join('');
+			var separatorLocation = idReversed.indexOf('_');
+			nameId = '#' + idReversed.substr(separatorLocation).split('').reverse().join('') + 'name';
+			if (jQuery(nameId).length)
+			{
+				jQuery(nameId).addClass('invalid');
+			}
 		});
 	}
 };

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -28,17 +28,6 @@ JFactory::getDocument()->addScriptDeclaration('
 		});
 	});
 ');
-
-foreach ($this->modules as $i => &$module)
-{
-	JFactory::getDocument()->addScriptDeclaration('
-	jQuery(document).ready(function() {
-		jQuery("#btn_' . $module->id . '").on("click", function() {
-			jQuery("#module' . $module->id . 'Modal iframe").contents().find("#saveBtn").click();
-		})
-	});
-');
-}
 ?>
 <?php
 // Set main fields.
@@ -119,7 +108,7 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 								'width' => '800px',
 								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-									. '<button id="btn_' . $module->id . '" class="btn btn-success" data-dismiss="modal" aria-hidden="true">'
+									. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 									. JText::_("JSAVE") . '</button>'
 							)
 						); ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -99,7 +99,14 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 						</span>
 					<?php endif; ?>
 				</td>
-			<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+			<?php echo JHtmlBootstrap::renderModal(
+							'module' . $module->id . 'Modal',
+							array(
+								'url' => $link,
+								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+								'height' => '300px',
+								'width' => '800px'), ''
+						); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -28,6 +28,17 @@ JFactory::getDocument()->addScriptDeclaration('
 		});
 	});
 ');
+
+foreach ($this->modules as $i => &$module)
+{
+	JFactory::getDocument()->addScriptDeclaration('
+	jQuery(document).ready(function() {
+		jQuery("#btn_' . $module->id . '").on("click", function() {
+			jQuery("#module' . $module->id . 'Modal iframe").contents().find("#saveBtn").click();
+		})
+	});
+');
+}
 ?>
 <?php
 // Set main fields.
@@ -105,7 +116,12 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 								'url' => $link,
 								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 								'height' => '300px',
-								'width' => '800px')
+								'width' => '800px',
+								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+									. '<button id="btn_' . $module->id . '" class="btn btn-success" data-dismiss="modal" aria-hidden="true">'
+									. JText::_("JSAVE") . '</button>'
+							)
 						); ?>
 			</tr>
 		<?php endforeach; ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -105,7 +105,7 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 								'url' => $link,
 								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 								'height' => '300px',
-								'width' => '800px'), ''
+								'width' => '800px')
 						); ?>
 			</tr>
 		<?php endforeach; ?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -43,13 +43,6 @@ foreach ($this->items as $item) :
 		$script[] = '		document.getElementById("' . $item->id . '").value = name;';
 		$script[] = '		jQuery(".modal").modal("hide");';
 		$script[] = '	};';
-
-		foreach ($this->modules[$item->menutype] as &$module)
-		{
-			$script[] = '	jQuery("#btn_' . $module->id . '").on("click", function() {';
-			$script[] = '		jQuery("#module' . $module->id . 'Modal iframe").contents().find("#saveBtn").click();';
-			$script[] = '	})';
-		}
 	endif;
 endforeach;
 
@@ -192,7 +185,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									'width' => '800px',
 									'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-										. '<button id="btn_' . $module->id . '" class="btn btn-success" data-dismiss="modal" aria-hidden="true">'
+										. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 										. JText::_("JSAVE") . '</button>'
 								)
 							);

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -43,6 +43,13 @@ foreach ($this->items as $item) :
 		$script[] = '		document.getElementById("' . $item->id . '").value = name;';
 		$script[] = '		jQuery(".modal").modal("hide");';
 		$script[] = '	};';
+
+		foreach ($this->modules[$item->menutype] as &$module)
+		{
+			$script[] = '	jQuery("#btn_' . $module->id . '").on("click", function() {';
+			$script[] = '		jQuery("#module' . $module->id . 'Modal iframe").contents().find("#saveBtn").click();';
+			$script[] = '	})';
+		}
 	endif;
 endforeach;
 
@@ -175,7 +182,21 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 									<?php if ($canEdit) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
-										<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+										<?php echo
+							JHtmlBootstrap::renderModal(
+								'module' . $module->id . 'Modal',
+								array(
+									'url' => $link,
+									'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+									'height' => '300px',
+									'width' => '800px',
+									'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+										. '<button id="btn_' . $module->id . '" class="btn btn-success" data-dismiss="modal" aria-hidden="true">'
+										. JText::_("JSAVE") . '</button>'
+								)
+							);
+										?>
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			if (tmpl)
 			{
 				window.parent.Joomla.submitbutton("item.setType", type);
-				window.parent.jModalClose();
+				window.parent.jQuery("#menuTypeModal").modal("hide");
 			}
 			else
 			{

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -120,7 +120,7 @@ $script .= "
 							jQuery('#position-" . $this->item->id . "', parent.document).text(updPosition);
 							jQuery('#access-" . $this->item->id . "', parent.document).html(parent.viewLevels[updAccess]);
 					}
-					window.parent.jQuery('.modal').modal('hide');
+					window.parent.jQuery('#module" . $this->item->id . "Modal').modal('hide');
 				}
 			}
 	};";

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -10,21 +10,10 @@
 defined('_JEXEC') or die;
 
 JFactory::getDocument()->addScriptDeclaration('
-	window.parent.jQuery(".modal").on("hidden", function () { Joomla.submitbutton("module.cancel"); });
+	jQuery(".modal").on("hidden", function () { Joomla.submitbutton("module.cancel"); });
 ');
 ?>
-<div class="btn-toolbar">
-	<div class="btn-group">
-		<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('module.save');">
-		<?php echo JText::_('JSAVE');?></button>
-	</div>
-	<div class="btn-group">
-		<button type="button" class="btn" onclick="Joomla.submitbutton('module.cancel'); window.parent.jQuery('#module<?php echo $this->item->id; ?>Modal').modal('hide');">
-		<?php echo JText::_('JCANCEL');?></button>
-	</div>
-	<div class="clearfix"></div>
-</div>
-
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
 <?php
 $this->setLayout('edit');
 echo $this->loadTemplate();

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -11,7 +11,9 @@ defined('_JEXEC') or die;
 
 // This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
-	window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
+	window.parent.jQuery(".modal").on("hidden", function () {
+		window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
+	});
 ');
 ?>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -12,9 +12,8 @@ defined('_JEXEC') or die;
 // This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
 	window.parent.jQuery(".modal").on("hidden", function () {
-		var buttonClose = window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn");
-		if (buttonClose) {
-			buttonClose.click();
+	if (typeof window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn") !== "undefined") {
+		window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
 		}
 	});
 ');

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -9,11 +9,14 @@
 
 defined('_JEXEC') or die;
 
+// This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
-	jQuery(".modal").on("hidden", function () { Joomla.submitbutton("module.cancel"); });
+	window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
 ');
 ?>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
+<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
+
 <?php
 $this->setLayout('edit');
 echo $this->loadTemplate();

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -12,7 +12,10 @@ defined('_JEXEC') or die;
 // This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
 	window.parent.jQuery(".modal").on("hidden", function () {
-		window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
+		var buttonClose = window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn");
+		if (buttonClose) {
+			buttonClose.click();
+		}
 	});
 ');
 ?>

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -19,7 +19,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JText::_('JSAVE');?></button>
 	</div>
 	<div class="btn-group">
-		<button type="button" class="btn" onclick="Joomla.submitbutton('module.cancel'); window.parent.jQuery('.modal').modal('hide');">
+		<button type="button" class="btn" onclick="Joomla.submitbutton('module.cancel'); window.parent.jQuery('#module<?php echo $this->item->id; ?>Modal').modal('hide');">
 		<?php echo JText::_('JCANCEL');?></button>
 	</div>
 	<div class="clearfix"></div>

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -153,6 +153,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 							'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
 							'width' => '800px',
 							'height' => '300px',
+							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						)
 					);
 

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -141,13 +141,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 			. '</a>';
 
 		$html[] = JHtmlBootstrap::renderModal(
-			'modalNewsfeed', array(
-				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-				'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
-				'width' => '800px',
-				'height' => '300px',
-			), ''
-		);
+						'modalNewsfeed', array(
+							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+							'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
+							'width' => '800px',
+							'height' => '300px',
+						)
+					);
 
 		// Edit newsfeed button
 		if ($allowEdit)

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -40,8 +40,6 @@ class JFormFieldModal_Newsfeed extends JFormField
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
 		// Load the javascript
-		JHtml::_('behavior.framework');
-		JHtml::_('behavior.modal', 'a.modal');
 		JHtml::_('bootstrap.tooltip');
 
 		// Build the script.
@@ -62,7 +60,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jModalClose();';
+		$script[] = '		jQuery("#modalNewsfeed").modal("hide");';
 		$script[] = '	}';
 
 		// Clear button script
@@ -136,10 +134,20 @@ class JFormFieldModal_Newsfeed extends JFormField
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title .
 			'" disabled="disabled" size="35" />';
-		$html[] = '<a class="modal btn hasTooltip" title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED_BUTTON') .
-			'"  href="' . $link . '&amp;' . JSession::getFormToken() .
-			'=1" rel="{handler: \'iframe\', size: {x: 800, y: 450}}"><i class="icon-file"></i> ' .
-			JText::_('JSELECT') . '</a>';
+
+		$html[] = '<a href="#modalNewsfeed"  class="btn hasTooltip" role="button"  data-toggle="modal"'
+			. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED_BUTTON') . '">'
+			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
+			. '</a>';
+
+		$html[] = JHtmlBootstrap::renderModal(
+			'modalNewsfeed', array(
+				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+				'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
+				'width' => '800px',
+				'height' => '300px',
+			), ''
+		);
 
 		// Edit newsfeed button
 		if ($allowEdit)

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -47,7 +47,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectNewsfeed_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
 
 		if ($allowEdit)
@@ -61,6 +61,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 		}
 
 		$script[] = '		jQuery("#modalNewsfeed").modal("hide");';
+
+		if ($this->required)
+		{
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
+			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+		}
+
 		$script[] = '	}';
 
 		// Clear button script
@@ -71,7 +78,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearNewsfeed(id) {';
-			$script[] = '		document.getElementById(id + "_id").value = "";';
+			$script[] = '		document.getElementById(id).value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "' .
 				htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -175,7 +182,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -47,7 +47,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		// Select button script
 		$script[] = '	function jSelectNewsfeed_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '").value = id;';
+		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
 		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
 
 		if ($allowEdit)
@@ -62,12 +62,6 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		$script[] = '		jQuery("#modalNewsfeed").modal("hide");';
 
-		if ($this->required)
-		{
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
-			$script[] = ' 	document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
-		}
-
 		$script[] = '	}';
 
 		// Clear button script
@@ -78,7 +72,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$scriptClear = true;
 
 			$script[] = '	function jClearNewsfeed(id) {';
-			$script[] = '		document.getElementById(id).value = "";';
+			$script[] = '		document.getElementById(id + "_id").value = "";';
 			$script[] = '		document.getElementById(id + "_name").value = "' .
 				htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
@@ -184,7 +178,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -47,6 +47,18 @@
 .collapse.in {
 	height: auto;
 }
+.modal-open .dropdown-menu {
+	z-index: 2050;
+}
+.modal-open .dropdown.open {
+	*z-index: 2050;
+}
+.modal-open .popover {
+	z-index: 2060;
+}
+.modal-open .tooltip {
+	z-index: 2080;
+}
 .modal-backdrop {
 	position: fixed;
 	top: 0;
@@ -64,28 +76,50 @@
 	opacity: 0.8;
 	filter: alpha(opacity=80);
 }
+div.modal {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	z-index: 1050;
+	overflow: auto;
+	width: 80%;
+	margin: -250px 0 0 -40%;
+	background-color: #ffffff;
+	border: 1px solid #999;
+	border: 1px solid rgba(0,0,0,0.3);
+	*border: 1px solid #999;
+	-webkit-border-radius: 6px;
+	-moz-border-radius: 6px;
+	border-radius: 6px;
+	-webkit-box-shadow: 0 3px 7px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 3px 7px rgba(0,0,0,0.3);
+	box-shadow: 0 3px 7px rgba(0,0,0,0.3);
+	-webkit-background-clip: padding-box;
+	-moz-background-clip: padding-box;
+	background-clip: padding-box;
+}
+div.modal.fade {
+	-webkit-transition: opacity .3s linear, top .3s ease-out;
+	-moz-transition: opacity .3s linear, top .3s ease-out;
+	-o-transition: opacity .3s linear, top .3s ease-out;
+	transition: opacity .3s linear, top .3s ease-out;
+	top: -25%;
+}
+div.modal.fade.in {
+	top: 50%;
+}
 .modal-header {
 	padding: 9px 15px;
 	border-bottom: 1px solid #eee;
 }
 .modal-header .close {
+	float: right;
 	margin-top: 2px;
 }
-.modal-header h3 {
-	margin: 0;
-	line-height: 30px;
-}
 .modal-body {
-	width: 98%;
-	position: relative;
 	overflow-y: auto;
 	max-height: 400px;
-	padding: 1%;
-}
-.modal-body iframe {
-	width: 100%;
-	max-height: none;
-	border: 0 !important;
+	padding: 15px;
 }
 .modal-form {
 	margin-bottom: 0;
@@ -119,44 +153,6 @@
 }
 .modal-footer .btn-group .btn + .btn {
 	margin-left: -1px;
-}
-.modal-footer .btn-block + .btn-block {
-	margin-left: 0;
-}
-div.modal {
-	position: fixed;
-	top: 5%;
-	left: 50%;
-	z-index: 1050;
-	width: 80%;
-	margin-left: -40%;
-	background-color: #ffffff;
-	border: 1px solid #999;
-	border: 1px solid rgba(0,0,0,0.3);
-	*border: 1px solid #999;
-	-webkit-border-radius: 6px;
-	-moz-border-radius: 6px;
-	border-radius: 6px;
-	-webkit-box-shadow: 0 3px 7px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0 3px 7px rgba(0,0,0,0.3);
-	box-shadow: 0 3px 7px rgba(0,0,0,0.3);
-	-webkit-background-clip: padding-box;
-	-moz-background-clip: padding-box;
-	background-clip: padding-box;
-	outline: none;
-}
-div.modal.fade {
-	-webkit-transition: opacity .3s linear, top .3s ease-out;
-	-moz-transition: opacity .3s linear, top .3s ease-out;
-	-o-transition: opacity .3s linear, top .3s ease-out;
-	transition: opacity .3s linear, top .3s ease-out;
-	top: -25%;
-}
-div.modal.fade.in {
-	top: 5%;
-}
-.modal-batch {
-	overflow-y: visible;
 }
 @font-face {
 	font-family: 'IcoMoon';

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -157,7 +157,19 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 					<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 						<?php if ($canEdit) : ?>
 							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
-							<?php echo JHtmlBootstrap::renderModal('module' . $module->id . 'Modal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+							<?php echo JHtmlBootstrap::renderModal(
+											'module' . $module->id . 'Modal',
+											array(
+												'url' => $link,
+												'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+												'height' => '300px',
+												'width' => '800px',
+												'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+													. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+													. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+													. JText::_("JSAVE") . '</button>'
+											)
+										); ?>
 						<?php endif; ?>
 					<?php endforeach; ?>
 					<?php elseif ($modMenuId) : ?>

--- a/administrator/templates/hathor/html/com_menus/menutypes/default.php
+++ b/administrator/templates/hathor/html/com_menus/menutypes/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 	setmenutype = function(type)
 	{
 		window.parent.Joomla.submitbutton('item.setType', type);
-		window.parent.jModalClose();
+		window.parent.jQuery("#menuTypeModal").modal("hide");
 	}
 </script>
 

--- a/administrator/templates/hathor/less/modals.less
+++ b/administrator/templates/hathor/less/modals.less
@@ -34,8 +34,8 @@ div.modal {
   left: 50%;
   z-index: @zindexModal;
   overflow: auto;
-  width: 560px;
-  margin: -250px 0 0 -280px;
+  width: 80%;
+  margin: -250px 0 0 -40%;
   background-color: @white;
   border: 1px solid #999;
   border: 1px solid rgba(0,0,0,.3);
@@ -53,7 +53,10 @@ div.modal {
   padding: 9px 15px;
   border-bottom: 1px solid #eee;
   // Close icon
-  .close { margin-top: 2px; }
+  .close {
+	float: right;
+	margin-top: 2px;
+  }
 }
 
 // Body (where all modal content resides)

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -8,8 +8,8 @@
 @import "../../../../media/jui/less/component-animations.less";
 
 // Bootstrap Modals
-@import "../../../../media/jui/less/modals.less";
-@import "../../../../media/jui/less/modals.joomla.less";
+@import "modals.less";
+//@import "../../../../media/jui/less/modals.joomla.less";
 
 // Icon Font
 @import "icomoon.less";


### PR DESCRIPTION
#### This is complimentary to #4661
- Some modals for selecting a single article, contact and newsfeed are still based on mootools code
- Also a disabled="disabled" was added to the menu type input and that prohibits validation to act properly, thus is now removed
- The validation for the modal field wasn’t very descriptive
- Editing a module in `Module Assignment` and then canceling the changes will result in a lock icon appearing in module manager
- All modals have a footer with close button and modules modal also have a save & close button as well.
#### testing
1. Create a menu, add some title and alias and press save you should see:
   ![screen shot 2015-04-19 at 5 26 40](https://cloud.githubusercontent.com/assets/3889375/7219788/5420062c-e6b9-11e4-91db-6fdb50cfad36.png)
2. On the home page menu open module assignment click on a module to bring the modal and the click cancel. Go to module manager and verify that no lock icon exist in front of the module you edit in homepage menu.
3. Create a new menu and select as Menu Item Type  `singe article` then click on select button on the next field `Select Article` respectively you should see a bootstrap modal:
   ![screen shot 2015-04-19 at 5 39 36](https://cloud.githubusercontent.com/assets/3889375/7219822/1e6b87fc-e6bb-11e4-9396-5f523a91ab7a.png)
   Repeat this also for `single contact` `single newsfeed` with a selection on `Select Contact` `Select Newsfeed` respectively.
4. Also Repeat the step 2 insert a title but DON’T select an article, newsfeed and contact and press save you should see a descriptive message about the field that needs input (previously you would only see an error as a message!) Thanks @Erftralle for coding this!
#### Preview

![screen shot 2015-04-29 at 2 15 17](https://cloud.githubusercontent.com/assets/3889375/7382379/d9636fae-ee16-11e4-99fe-d61c2004368e.png)
![screen shot 2015-04-29 at 2 15 40](https://cloud.githubusercontent.com/assets/3889375/7382381/dd0ff3e8-ee16-11e4-8836-0f3c6cdf8a86.png)
![screen shot 2015-04-29 at 2 15 57](https://cloud.githubusercontent.com/assets/3889375/7382384/e16fe858-ee16-11e4-88b6-9bf53c83ccab.png)
![screen shot 2015-04-29 at 2 17 01](https://cloud.githubusercontent.com/assets/3889375/7382386/e5f3926c-ee16-11e4-8d62-d6e22fb4958c.png)
![screen shot 2015-04-29 at 2 17 32](https://cloud.githubusercontent.com/assets/3889375/7382388/e9588796-ee16-11e4-8eec-79248b43bac1.png)
