### PR TITLE
[Fix] Correct possible error when using TRIM with UTF8 hex (solves #6803 )

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -257,8 +257,8 @@ class JFilterInput
 
 			case 'TRIM':
 				$result = (string) trim($source);
-				$result = trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = trim($result, chr(0xC2) . chr(0xA0));
+				$result = JString::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
+				$result = JString::trim($result, chr(0xC2) . chr(0xA0));
 				break;
 
 			case 'USERNAME':

--- a/libraries/vendor/joomla/filter/src/InputFilter.php
+++ b/libraries/vendor/joomla/filter/src/InputFilter.php
@@ -231,8 +231,8 @@ class InputFilter
 
 			case 'TRIM':
 				$result = (string) trim($source);
-				$result = trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = trim($result, chr(0xC2) . chr(0xA0));
+				$result = JString::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
+				$result = JString::trim($result, chr(0xC2) . chr(0xA0));
 				break;
 
 			case 'USERNAME':

--- a/libraries/vendor/joomla/filter/src/InputFilter.php
+++ b/libraries/vendor/joomla/filter/src/InputFilter.php
@@ -231,8 +231,8 @@ class InputFilter
 
 			case 'TRIM':
 				$result = (string) trim($source);
-				$result = JString::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = JString::trim($result, chr(0xC2) . chr(0xA0));
+				$result = trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
+				$result = trim($result, chr(0xC2) . chr(0xA0));
 				break;
 
 			case 'USERNAME':


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/6803
The `à` character has a UTF8 hex value of `0xA0`
The non breaking space has a value of `0xC2 0xA0`

The normal trim() php method trims the characters `chr()` in the charlist one by one.
Therefore when `JFilterInput::getInstance->clean($data['created_by_alias'], 'TRIM')` is used, (here for the created by alias field in article edit->publishing) and the alias entered ends with an `à`, that character is deleted by the method.

The solution is to use our custom utf8 method JString::trim() instead of trim.

Test before patch by entering `Saccà` in the field and saving.

Test after patch.
Also, after patch, make sure it works fine to trim
multibyte space:
「　」

non-breaking space:
「 」

normal space
「 」

by entering one OR the other spaces above before and after the desired word.
