### PR TITLE
Use pk ci tag map

### DIFF
--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -16,6 +16,13 @@ defined('_JEXEC') or die;
  */
 class ContactModelContacts extends JModelList
 {
+	/** The content type _id
+	*
+	* @var	integer
+	* @since 3.4
+	*/
+	protected $type_id = 2;
+
 	/**
 	 * Constructor.
 	 *
@@ -270,7 +277,7 @@ class ContactModelContacts extends JModelList
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_contact.contact')
+					. ' AND ' . $db->quoteName('tagmap.type_id') . ' = ' . $this->type_id
 				);
 		}
 

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -17,6 +17,14 @@ defined('_JEXEC') or die;
 class ContentModelArticles extends JModelList
 {
 	/**
+	 * The content type _id
+	 *
+	 * @var	integer
+	 * @since 3.4
+	 */
+	protected $type_id = 1;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -299,7 +307,7 @@ class ContentModelArticles extends JModelList
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
+					. ' AND ' . $db->quoteName('tagmap.type_id') . ' = ' . $this->type_id
 				);
 		}
 

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -19,6 +19,14 @@ require_once __DIR__ . '/articles.php';
 class ContentModelFeatured extends ContentModelArticles
 {
 	/**
+	* The content type _id
+	*
+	* @var	integer
+	* @since 3.4
+	*/
+	protected $type_id = 3;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -193,7 +201,7 @@ class ContentModelFeatured extends ContentModelArticles
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
+					. ' AND ' . $db->quoteName('tagmap.type_id') . ' = ' . $this->type_id
 				);
 		}
 

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -24,7 +24,7 @@ class ContentModelFeatured extends ContentModelArticles
 	* @var	integer
 	* @since 3.4
 	*/
-	protected $type_id = 3;
+	protected $type_id = 1;
 
 	/**
 	 * Constructor.

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -17,6 +17,14 @@ defined('_JEXEC') or die;
 class NewsfeedsModelNewsfeeds extends JModelList
 {
 	/**
+	* The content type _id
+	*
+	* @var	integer
+	* @since 3.4
+	*/
+	protected $type_id = 3;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -247,7 +255,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_newsfeeds.newsfeed')
+					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $this->type_id
 				);
 		}
 

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -255,7 +255,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 				->join(
 					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $this->type_id
+					. ' AND ' . $db->quoteName('tagmap.type_id') . ' = ' . $this->type_id
 				);
 		}
 


### PR DESCRIPTION
Performance improvement by accessing #_contentitem_tag_map via PK.
Instead of using the type_alias it uses the type_id which allows access through PK.

Testinstruction:
Filter on a tag in the backend
