### PR TITLE
Fix error in ConfigControllerModulesSave

### DIFF
--- a/administrator/components/com_modules/controllers/module.php
+++ b/administrator/components/com_modules/controllers/module.php
@@ -220,7 +220,7 @@ class ModulesControllerModule extends JControllerForm
 
 		}
 
-		parent::save($key, $urlVar);
+		return parent::save($key, $urlVar);
 
 	}
 

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -80,7 +80,7 @@ class ConfigControllerModulesSave extends JControllerBase
 		if ($return === false)
 		{
 			// Save the data in the session.
-			$data  = $this->input->post->get('jform', array(), 'array');
+			$data = $this->input->post->get('jform', array(), 'array');
 			$this->app->setUserState('com_config.modules.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -84,7 +84,7 @@ class ConfigControllerModulesSave extends JControllerBase
 			$this->app->setUserState('com_config.modules.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
-			$this->app->enqueueMessage(JText::_('JERROR_SAVE_FAILED'));
+			$this->app->enqueueMessage($controllerClass->getError(), 'error');
 			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.modules' . $moduleId . $redirect, false));
 		}
 

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  * @package     Joomla.Site
  * @subpackage  com_config
  * @since       3.2
-*/
+ */
 class ConfigControllerModulesSave extends JControllerBase
 {
 	/**
@@ -80,7 +80,8 @@ class ConfigControllerModulesSave extends JControllerBase
 		if ($return === false)
 		{
 			// Save the data in the session.
-			$app->setUserState('com_config.modules.global.data', $data);
+			$data  = $this->input->post->get('jform', array(), 'array');
+			$this->app->setUserState('com_config.modules.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
 			$this->app->enqueueMessage(JText::_('JERROR_SAVE_FAILED'));


### PR DESCRIPTION
## PR summary

In this line of of code https://github.com/joomla/joomla-cms/blob/staging/components/com_config/controller/modules/save.php#L83, the $app and $data variables are not defined and it can cause fatal error if saving a module in frontend (using frontend module editing) return false for some reasons. This PR fixes that mistake
## Testing instructions

I think this PR just need a quick review from CMS maintainers to get it merged. If you want to test, just try to edit a module from frontend and make sure it is still saved properly.  
