### PR TITLE
Add availability to override html markup of calendar field

### DIFF
--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$title = ($displayData['inputvalue'] ? static::_('date', $value, null, null) : '');
+$value = htmlspecialchars($displayData['inputvalue'], ENT_COMPAT, 'UTF-8');
+
+?>
+<div<?php echo $displayData['div_class']; ?>>
+	<input type="text" title="<?php echo $title; ?>" name="<?php echo $displayData['name']; ?>" id="<?php echo $displayData['id']; ?>" value="<?php echo $value; ?>" <?php echo $displayData['attribs']; ?> />
+	<button type="button" class="btn" id="<?php echo $displayData['id']; ?>_img"<?php echo $displayData['btn_style']; ?>>
+		<i class="icon-calendar"></i>
+	</button>
+</div>

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-$title = ($displayData['inputvalue'] ? static::_('date', $value, null, null) : '');
+$title = ($displayData['inputvalue'] ? JHtml::_('date', $displayData['value'], null, null) : '');
 $value = htmlspecialchars($displayData['inputvalue'], ENT_COMPAT, 'UTF-8');
 
 ?>

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1012,15 +1012,22 @@ abstract class JHtml
 			$done[] = $id;
 		}
 
-		// Hide button using inline styles for readonly/disabled fields
-		$btn_style	= ($readonly || $disabled) ? ' style="display:none;"' : '';
-		$div_class	= (!$readonly && !$disabled) ? ' class="input-append"' : '';
+		$data = array();
 
-		return '<div' . $div_class . '>'
-				. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
-				. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
-				. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><i class="icon-calendar"></i></button>'
-			. '</div>';
+		// Hide button using inline styles for readonly/disabled fields
+		$data['btn_style'] = ($readonly || $disabled) ? ' style="display:none;"' : '';
+		$data['div_class'] = (!$readonly && !$disabled) ? ' class="input-append"' : '';
+
+		$data['id'] 			= $id;
+		$data['name'] 			= $name;
+		$data['value'] 			= $value;
+		$data['inputvalue'] 	= $inputvalue;
+		$data['attribs'] 		= $attribs;
+
+		// Instantiate a new JLayoutFile instance and render the layout
+		$layout = new JLayoutFile('joomla.calendar.field');
+
+		return $layout->render($data);
 	}
 
 	/**


### PR DESCRIPTION
Actually there is no way to override the HTML markup for calendar field.

This PR add a layout to be able to override from template.

**How to test**
Try to add or edit an article from the frontend "/index.php?option=com_content&view=form&layout=edit"
-> Field "Start Publishing"
Apply PR
Add an override (copy & edit field.php) : /templates/protostar/html/layouts/joomla/calendar/field.php
-> Field "Start Publishing"
