### PR TITLE
Template discover install does not load language files

### DIFF
--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -188,10 +188,11 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 			$client = 'ADMINISTRATOR';
 		}
 
+		$base = constant('JPATH_' . strtoupper($client));
 		$extension = 'tpl_' . $this->getName();
-		$source    = $path ? $path : ($client) . '/templates/' . $this->getName();
+		$source    = $path ? $path : $base . '/templates/' . $this->getName();
 
-		$this->doLoadLanguage($extension, $source, constant('JPATH_' . strtoupper($client)));
+		$this->doLoadLanguage($extension, $source, $base);
 	}
 
 	/**


### PR DESCRIPTION
When using discover install, path to the template is wrong when loading the language.

Old code pointed to `site/templates/{$template}` or `ADMINISTRATOR/templates/{$template}` where it should point to the real directory, either in administration or site.

This pull request will fix the lookup path to point to `{$base}/templates/{$template}` where base is either JPATH_SITE or JPATH_ADMINISTRATOR.
