### PR TITLE
RFC: Remove components, modules, & plugins from robots.txt

### DIFF
--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -16,14 +16,11 @@ Disallow: /administrator/
 Disallow: /bin/
 Disallow: /cache/
 Disallow: /cli/
-Disallow: /components/
 Disallow: /includes/
 Disallow: /installation/
 Disallow: /language/
 Disallow: /layouts/
 Disallow: /libraries/
 Disallow: /logs/
-Disallow: /modules/
-Disallow: /plugins/
 Disallow: /tmp/
 


### PR DESCRIPTION
Many extensions still don't use best practice to store their resources in the media folder, as a result users could be penalized by Google's new algorithm changes for mobile.

In the attached PR, I've proposed some changes that could improve this.

See https://www.ostraining.com/blog/general/google-mobile-robots for more information.
