### PR TITLE
Fixing JToolbarHelper::back()-Button

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7021,6 +7021,9 @@ dl.article-info dd.hits span[class*=" icon-"] {
 .icon-pending:before {
 	color: #c67605;
 }
+.icon-back:before {
+	content: "\e008";
+}
 html {
 	height: 100%;
 }

--- a/administrator/templates/isis/less/icomoon.less
+++ b/administrator/templates/isis/less/icomoon.less
@@ -34,3 +34,6 @@
 .icon-pending:before {
 	color: @btnWarningBackgroundHighlight;
 }
+.icon-back:before {
+	content: "\e008";
+}


### PR DESCRIPTION
The JToolbarHelper::back() button currently does not display an icon, because it expects the class to be .icon-back, but it would have to be .icon-chevron-left. Theoretically, this could be solved with .icon-back:before:extend(.icon-chevron-left:before), but since our LESS compiler version in Joomla is ancient, we gotta basically hardcode this in here.

How to test? Add JToolbarHelper::back() somewhere in a view.html.php file in the backend. See that it has no icon. Apply the patch and see that it has an arrow.
