### PR TITLE
Fix PHP Notice in Smart Search adapter (#6842)

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -790,7 +790,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 		$params = json_decode($params);
 
 		// Get the page title if it is set.
-		if ($params->page_title)
+		if (isset($params->page_title) && $params->page_title)
 		{
 			$return = $params->page_title;
 		}


### PR DESCRIPTION
Fix for #6842.

If a menu item exists but there is no page_title parameter set, then indexing will throw a PHP notice.  This PR suppresses the notice by first checking that the parameter exists.
