### PR TITLE
Makes the Protostar menu responsive

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -146,11 +146,19 @@ else
 					</div>
 				</div>
 			</header>
-			<?php if ($this->countModules('position-1')) : ?>
-				<nav class="navigation" role="navigation">
-					<jdoc:include type="modules" name="position-1" style="none" />
-				</nav>
-			<?php endif; ?>
+         <?php if ($this->countModules('position-1')) : ?>
+            <nav class="navigation" role="navigation">
+                                      <div class="navbar pull-left">
+                              <a class="btn btn-navbar collapsed" data-toggle="collapse" data-target=".nav-collapse">
+                              <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                                <span class="icon-bar"></span>
+                              </a>
+                       </div>
+ 
+           <div class="nav-collapse">   <jdoc:include type="modules" name="position-1" style="none" /> </div>
+            </nav>
+         <?php endif; ?>
 			<jdoc:include type="modules" name="banner" style="xhtml" />
 			<div class="row-fluid">
 				<?php if ($this->countModules('position-8')) : ?>


### PR DESCRIPTION
Makes the Protostar menu responsive
### Steps to reproduce the issue

View with mobile device or shrink the browser
### Expected result

Menu should collapse
### Actual result

Menu does not collapse

Apply patch and the menu collapses on mobile devices
