### PR TITLE
Add ability to override html markup of calendar field

### DIFF
--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -12,18 +12,18 @@ defined('_JEXEC') or die;
 // Load the calendar behavior
 JHtml::_('behavior.calendar');
 
-if ($done)
+if ($displayData['done'])
 {
 	$document 	= JFactory::getDocument();
 	$js 		= array();
 
 	$js[] = 'jQuery(document).ready(function($) {Calendar.setup({';
 	// Id of the input field
-	$js[] = 'inputField: "' . $id . '",';
+	$js[] = 'inputField: "' . $displayData['id'] . '",';
 	// Format of the input field
-	$js[] = 'ifFormat: "' . $format . '",';
+	$js[] = 'ifFormat: "' . $displayData['format'] . '",';
 	// Trigger for the calendar (button ID)
-	$js[] = 'button: "' . $id . '_img",';
+	$js[] = 'button: "' . $displayData['id'] . '_img",';
 	// Alignment (defaults to "Bl")
 	$js[] = 'align: "Tl",';
 	$js[] = 'singleClick: true,';

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Load the calendar behavior
 JHtml::_('behavior.calendar');
 
-if ($displayData['done'])
+if (!$displayData['done'])
 {
 	$document 	= JFactory::getDocument();
 	$js 		= array();

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -9,6 +9,29 @@
 
 defined('_JEXEC') or die;
 
+// Load the calendar behavior
+JHtml::_('behavior.calendar');
+
+if ($done)
+{
+	$document 	= JFactory::getDocument();
+	$js 		= array();
+
+	$js[] = 'jQuery(document).ready(function($) {Calendar.setup({';
+	// Id of the input field
+	$js[] = 'inputField: "' . $id . '",';
+	// Format of the input field
+	$js[] = 'ifFormat: "' . $format . '",';
+	// Trigger for the calendar (button ID)
+	$js[] = 'button: "' . $id . '_img",';
+	// Alignment (defaults to "Bl")
+	$js[] = 'align: "Tl",';
+	$js[] = 'singleClick: true,';
+	$js[] = 'firstDay: ' . JFactory::getLanguage()->getFirstDay();
+	$js[] = '});});';
+	$document->addScriptDeclaration( implode($js) );
+}
+
 $title = ($displayData['inputvalue'] ? JHtml::_('date', $displayData['value'], null, null) : '');
 $value = htmlspecialchars($displayData['inputvalue'], ENT_COMPAT, 'UTF-8');
 

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Load the calendar behavior
 JHtml::_('behavior.calendar');
 
-if (!$displayData['done'])
+if ($displayData['done'])
 {
 	$document 	= JFactory::getDocument();
 	$js 		= array();

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$title = ($displayData['inputvalue'] ? static::_('date', $value, null, null) : '');
+$value = htmlspecialchars($displayData['inputvalue'], ENT_COMPAT, 'UTF-8');
+
+?>
+<div<?php echo $displayData['div_class']; ?>>
+	<input type="text" title="<?php echo $title; ?>" name="<?php echo $displayData['name']; ?>" id="<?php echo $displayData['id']; ?>" value="<?php echo $value; ?>" <?php echo $displayData['attribs']; ?> />
+	<button type="button" class="btn" id="<?php echo $displayData['id']; ?>_img"<?php echo $displayData['btn_style']; ?>>
+		<i class="icon-calendar"></i>
+	</button>
+</div>

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -14,8 +14,8 @@ JHtml::_('behavior.calendar');
 
 if ($displayData['done'])
 {
-	$document 	= JFactory::getDocument();
-	$js 		= array();
+	$document = JFactory::getDocument();
+	$js       = array();
 
 	$js[] = 'jQuery(document).ready(function($) {Calendar.setup({';
 	// Id of the input field

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-$title = ($displayData['inputvalue'] ? static::_('date', $value, null, null) : '');
+$title = ($displayData['inputvalue'] ? JHtml::_('date', $displayData['value'], null, null) : '');
 $value = htmlspecialchars($displayData['inputvalue'], ENT_COMPAT, 'UTF-8');
 
 ?>

--- a/layouts/joomla/calendar/field.php
+++ b/layouts/joomla/calendar/field.php
@@ -29,7 +29,7 @@ if (!$displayData['done'])
 	$js[] = 'singleClick: true,';
 	$js[] = 'firstDay: ' . JFactory::getLanguage()->getFirstDay();
 	$js[] = '});});';
-	$document->addScriptDeclaration( implode($js) );
+	$document->addScriptDeclaration(implode($js));
 }
 
 $title = ($displayData['inputvalue'] ? JHtml::_('date', $displayData['value'], null, null) : '');

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1012,15 +1012,22 @@ abstract class JHtml
 			$done[] = $id;
 		}
 
-		// Hide button using inline styles for readonly/disabled fields
-		$btn_style	= ($readonly || $disabled) ? ' style="display:none;"' : '';
-		$div_class	= (!$readonly && !$disabled) ? ' class="input-append"' : '';
+		$data = array();
 
-		return '<div' . $div_class . '>'
-				. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
-				. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
-				. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><i class="icon-calendar"></i></button>'
-			. '</div>';
+		// Hide button using inline styles for readonly/disabled fields
+		$data['btn_style'] = ($readonly || $disabled) ? ' style="display:none;"' : '';
+		$data['div_class'] = (!$readonly && !$disabled) ? ' class="input-append"' : '';
+
+		$data['id'] 			= $id;
+		$data['name'] 			= $name;
+		$data['value'] 			= $value;
+		$data['inputvalue'] 	= $inputvalue;
+		$data['attribs'] 		= $attribs;
+
+		// Instantiate a new JLayoutFile instance and render the layout
+		$layout = new JLayoutFile('joomla.calendar.field');
+
+		return $layout->render($data);
 	}
 
 	/**

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -987,32 +987,16 @@ abstract class JHtml
 			$inputvalue = '';
 		}
 
-		// Load the calendar behavior
-		static::_('behavior.calendar');
+		$data = array(
+			'done' => false
+		);
 
 		// Only display the triggers once for each control.
 		if (!in_array($id, $done))
 		{
-			$document = JFactory::getDocument();
-			$document
-				->addScriptDeclaration(
-				'jQuery(document).ready(function($) {Calendar.setup({
-			// Id of the input field
-			inputField: "' . $id . '",
-			// Format of the input field
-			ifFormat: "' . $format . '",
-			// Trigger for the calendar (button ID)
-			button: "' . $id . '_img",
-			// Alignment (defaults to "Bl")
-			align: "Tl",
-			singleClick: true,
-			firstDay: ' . JFactory::getLanguage()->getFirstDay() . '
-			});});'
-			);
 			$done[] = $id;
+			$data['done'] = true;
 		}
-
-		$data = array();
 
 		// Hide button using inline styles for readonly/disabled fields
 		$data['btn_style'] = ($readonly || $disabled) ? ' style="display:none;"' : '';

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1005,6 +1005,7 @@ abstract class JHtml
 		$data['id'] 			= $id;
 		$data['name'] 			= $name;
 		$data['value'] 			= $value;
+		$data['format'] 		= $format;
 		$data['inputvalue'] 	= $inputvalue;
 		$data['attribs'] 		= $attribs;
 

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -994,7 +994,7 @@ abstract class JHtml
 		// Only display the triggers once for each control.
 		if (!in_array($id, $done))
 		{
-			$done[] = $id;
+			$done[]       = $id;
 			$data['done'] = true;
 		}
 
@@ -1002,12 +1002,12 @@ abstract class JHtml
 		$data['btn_style'] = ($readonly || $disabled) ? ' style="display:none;"' : '';
 		$data['div_class'] = (!$readonly && !$disabled) ? ' class="input-append"' : '';
 
-		$data['id'] 			= $id;
-		$data['name'] 			= $name;
-		$data['value'] 			= $value;
-		$data['format'] 		= $format;
-		$data['inputvalue'] 	= $inputvalue;
-		$data['attribs'] 		= $attribs;
+		$data['id']         = $id;
+		$data['name']       = $name;
+		$data['value']      = $value;
+		$data['format']     = $format;
+		$data['inputvalue'] = $inputvalue;
+		$data['attribs']    = $attribs;
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('joomla.calendar.field');


### PR DESCRIPTION
Actually there is no way to override the HTML markup for calendar field.

This PR add a layout to be able to override from template.
I also moved import of js behavior.calendar + init in layout to give ability to edit the calendar setup.

**How to test**
Try to add or edit an article from the frontend "/index.php?option=com_content&view=form&layout=edit"
-> Field "Start Publishing"
Apply PR
Add an override (copy & edit field.php) : /templates/protostar/html/layouts/joomla/calendar/field.php
-> Field "Start Publishing"
