### PR TITLE
Change MySQL checks to work with PDO driver

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -47,7 +47,7 @@ class JoomlaInstallerScript
 	{
 		$db = JFactory::getDbo();
 
-		if (substr($db->name, 0, 5) == 'mysql')
+		if (strpos($db->name, 'mysql') !== false)
 		{
 			$this->updateDatabaseMySQL();
 		}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1372,7 +1372,7 @@ class PlgSystemDebug extends JPlugin
 
 		$this->totalQueries = $db->getCount();
 
-		$dbVersion5037 = (strncmp($db->name, 'mysql', 5) == 0) && version_compare($db->getVersion(), '5.0.37', '>=');
+		$dbVersion5037 = (strpos($db->name, 'mysql') !== false) && version_compare($db->getVersion(), '5.0.37', '>=');
 
 		if ($dbVersion5037)
 		{
@@ -1415,7 +1415,7 @@ class PlgSystemDebug extends JPlugin
 
 			foreach ($log as $k => $query)
 			{
-				$dbVersion56 = (strncmp($db->name, 'mysql', 5) == 0) && version_compare($db->getVersion(), '5.6', '>=');
+				$dbVersion56 = (strpos($db->name, 'mysql') !== false) && version_compare($db->getVersion(), '5.6', '>=');
 
 				if ((stripos($query, 'select') === 0) || ($dbVersion56 && ((stripos($query, 'delete') === 0) || (stripos($query, 'update') === 0))))
 				{


### PR DESCRIPTION
There are a few checks in the code that check the database name property to determine if `mysql` is the first 5 characters.  These checks exclude supporting the PDO MySQL driver since its internal name is `pdomysql`.  This PR changes the checks to determine if `mysql` is contained in the name or not.
