### PR TITLE
Fixed tabs ignoring useCookie param

### DIFF
--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -82,7 +82,7 @@ abstract class JHtmlTabs
 			$opt['onActive']            = (isset($params['onActive'])) ? '\\' . $params['onActive'] : null;
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
-			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
+			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? true : false;
 			$opt['titleSelector']       = "dt.tabs";
 			$opt['descriptionSelector'] = "dd.tabs";
 


### PR DESCRIPTION
Not sure why they were strings before. They're assumed to be booleans later on when they're used in JS at this line: https://github.com/joomla/joomla-cms/blob/staging/media/system/js/tabs.js#L45

Reason for not removing the `true` and `false` values since they're redundant: https://github.com/joomla/coding-standards/issues/88
#### Steps to reproduce
1. Create tabs using something like this `echo JHtml::_('tabs.start', 'signInPane', array('startOffset' => 2, 'useCookie' => false));` and anything else that's necessary to create the rest of the tabs pane.
2. Visit the tabs on the frontend.
#### Expected result

Have the 3rd tab (because of zero indexing) be open. And upon selecting another tab and refreshing, have the 3rd tab still open, and not the last active tab.
