### PR TITLE
# JImage: fixing error when ftp mode is on Folder does not exist and cannot be cr...

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -243,6 +243,8 @@ class JImage
 	 */
 	public function createThumbs($thumbSizes, $creationMethod = self::SCALE_INSIDE, $thumbsFolder = null)
 	{
+		jimport('joomla.filesystem.folder');
+
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
@@ -256,7 +258,7 @@ class JImage
 		}
 
 		// Check destination
-		if (!is_dir($thumbsFolder) && (!is_dir(dirname($thumbsFolder)) || !@mkdir($thumbsFolder)))
+		if (!is_dir($thumbsFolder) && (!is_dir(dirname($thumbsFolder)) || !@JFolder::create($thumbsFolder)))
 		{
 			throw new InvalidArgumentException('Folder does not exist and cannot be created: ' . $thumbsFolder);
 		}


### PR DESCRIPTION
...eated

I had a customer who uses FTP mode on his installation. When my code tried to create a thumb we got a fatal error:
Folder does not exist and cannot be created: 

The reason for this was line 261 in JImage:
if (!is_dir($thumbsFolder) && (!is_dir(dirname($thumbsFolder)) || !@mkdir($thumbsFolder)))

Mkdir can't create the folder when the user is using ftp mode, that's why changing this line to use JFolder::create instead fixes the issue.

Testing this is easy, but you need 2 things.
1. A site that uses ftp mode
2. A script that uses JImage->createThumbs. 
