### PR TITLE
Capitalisation

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -968,6 +968,6 @@ SQLITE="SQLite"
 SQLSRV="Microsoft SQL Server"
 
 ; Search tools
-JSEARCH_TOOLS="Search tools"
+JSEARCH_TOOLS="Search Tools"
 JSEARCH_TOOLS_DESC="Filter the list items."
 JSEARCH_TOOLS_ORDERING="Order by:"

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -346,6 +346,6 @@ SQLITE="SQLite"
 SQLSRV="Microsoft SQL Server"
 
 ; Search tools
-JSEARCH_TOOLS="Search tools"
+JSEARCH_TOOLS="Search Tools"
 JSEARCH_TOOLS_DESC="Filter the list items."
 JSEARCH_TOOLS_ORDERING="Order by:"


### PR DESCRIPTION
Simple change to make the two words on the Search Tools button capitalised to be consistent with the rest of the strings

See #5657
