### PR TITLE
Remove <strong>  tag when displaying extension installer message.

### DIFF
--- a/administrator/components/com_installer/views/default/tmpl/default_message.php
+++ b/administrator/components/com_installer/views/default/tmpl/default_message.php
@@ -21,6 +21,6 @@ $message2 = $state->get('extension_message');
 <?php endif; ?> 
 <?php if ($message2) : ?> 
 	<div class="span12"> 
-		<strong><?php echo $message2; ?></strong>
+		<?php echo $message2; ?>
 	</div> 
 <?php endif; ?>


### PR DESCRIPTION
# Issue

During the installation of any extension, the installer script can display its own message, including HTML content (which most extensions do). Since `3.4.0` the contents of this message is forcefully **bold**. I believe that https://github.com/joomla/joomla-cms/pull/5729 introduced this.
# Steps to replicate it

Install any extension that provides a HTML message upon installation. You'll notice that the whole message is wrapped in `<strong>` tags.
# Proposed fix

It's simple: remove the `<strong>` tags that are wrapping the message supplied by the installation script. I have left the `<strong>` tags that show up when displaying the XML `<description>` tag since most people don't use HTML in there so it shouldn't be a problem. The non-bootstrapped version (before the PR) did display the description in `<th>` tags and the message in `<td>` tags, so I'm following what was already in place.
# Before

![bold-forced](https://cloud.githubusercontent.com/assets/1422378/7412418/6ee5cfba-ef4b-11e4-8a1d-5e0adfbeb2b8.jpg)
# After

![no-bold](https://cloud.githubusercontent.com/assets/1422378/7412421/749b3a4e-ef4b-11e4-8ae2-b04b43db04c7.jpg)
