### PR TITLE
[Fix #6876] Regression: Routing errors when "Remove URL Language Code" is set in "Language filter"

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -244,7 +244,16 @@ class PlgSystemLanguageFilter extends JPlugin
 			// that we have in our system, its the default language and we "found" the right language
 			if ($this->params->get('remove_default_prefix', 0) && !isset($this->sefs[$sef]))
 			{
-				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+				if ($parts[0])
+				{
+					// We load a default site language page
+					$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+				}
+				else
+				{
+					// We check for an existing language cookie
+					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+				}
 
 				if (!$lang_code && $this->params->get('detect_browser', 0) == 1)
 				{


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/6876 for testing instructions.

Looking for a cookie should be done only when loading the pure tld.
This checks if we have anything after the tld before looking for an existing cookie.

Thank you for testing.
