### PR TITLE
Backport Possible missing break in bin\keychain.php at line 77? to the CMS

### DIFF
--- a/bin/keychain.php
+++ b/bin/keychain.php
@@ -75,6 +75,7 @@ class KeychainManager extends JApplicationCli
 				break;
 			case 'change':
 				$this->change();
+				break;
 			case 'delete':
 				$this->delete();
 				break;


### PR DESCRIPTION
This Backports the fix from the framework into the CMS:
https://github.com/joomla-framework/keychain/commit/7e6488d7e3b395f47e202779f2a247318f5a3bad

Thanks goes to @photodude here: https://github.com/joomla/joomla-cms/issues/6672
