### PR TITLE
[imp]Client side validation for menu type single article

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -59,6 +59,12 @@ class JFormFieldModal_Article extends JFormField
 
 		$script[] = '		jQuery("#modalArticle").modal("hide");';
 
+		if ($this->required)
+		{
+			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_id"));';
+			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+		}
+
 		$script[] = '	}';
 
 		// Clear button script
@@ -172,5 +178,17 @@ class JFormFieldModal_Article extends JFormField
 			)
 		);
 		return implode("\n", $html);
+	}
+
+	/**
+	 * Method to get the field label markup.
+	 *
+	 * @return  string  The field label markup.
+	 *
+	 * @since   3.4
+	 */
+	protected function getLabel()
+	{
+		return str_replace($this->id, $this->id . '_id', parent::getLabel());
 	}
 }


### PR DESCRIPTION
#### Test instructions
- Go to Menu Manager: New Menu Item
- Enter a menu title
- Select **Single article** for **Menu Item Type** 
- Do not select any article
- Click on Save or Save & Close

You will recognize:
- The system message container just displays the message **Error** without any hint to the field concerned
- The field label will not be coloured red
- If you select an article now the red colouring is not removed

After applaying the patch:
- The system message container now displays the additional message **Invalid field: Select Article**
- The field label will be coloured red
- After selecting an article the red colouring is removed now
#### System information

Latest Joomla! staging

If this amendment is agreed I would provide similar changes for the menu types **Single contact** and **Single newsfeed**. See also #6654 and #6761 dealing with the same problem.
