### PR TITLE
Small UI improvement for mobile

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -93,17 +93,22 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 						<th>
 							<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
-						<th width="10%" class="nowrap center hidden-phone">
-							<?php echo JText::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?>
+						<th width="10%" class="nowrap center">
+							<i class="icon-publish"></i>
+							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?></span>
 						</th>
-						<th width="10%" class="nowrap center hidden-phone">
-							<?php echo JText::_('COM_MENUS_HEADING_UNPUBLISHED_ITEMS'); ?>
+						<th width="10%" class="nowrap center">
+							<i class="icon-unpublish"></i>
+							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_UNPUBLISHED_ITEMS'); ?></span>
 						</th>
-						<th width="10%" class="nowrap center hidden-phone">
-							<?php echo JText::_('COM_MENUS_HEADING_TRASHED_ITEMS'); ?>
+						<th width="10%" class="nowrap center">
+							<i class="icon-trash"></i>
+							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_TRASHED_ITEMS'); ?></span>
 						</th>
-						<th width="20%" class="nowrap hidden-phone">
-							<?php echo JText::_('COM_MENUS_HEADING_LINKED_MODULES'); ?>
+						<th width="20%" class="nowrap center">
+							<i class="icon-cube"></i>
+							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_LINKED_MODULES'); ?></span>
+
 						</th>
 						<th width="1%" class="center nowrap">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
@@ -151,7 +156,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							<a class="badge badge-error" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=-2');?>">
 								<?php echo $item->count_trashed; ?></a>
 						</td>
-						<td class="left">
+						<td class="center">
 							<?php if (isset($this->modules[$item->menutype])) : ?>
 								<div class="btn-group">
 									<a href="#" class="btn btn-small dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
#### Correct the table heading in com_menus - view: menus

The table heading got a hidden class for: Published, Unpublished, Trashed and Linked Modules which breaks the mobile view as the ID is getting in the wrong position. This PR adds some icons and moves the hidden class to a span for the title.
#### Preview

Right now:
Desktop
![screen shot 2015-05-03 at 5 09 20](https://cloud.githubusercontent.com/assets/3889375/7445362/f7dadd56-f1b7-11e4-8d75-d2fb3c80520a.png)

Mobile
![screen shot 2015-05-03 at 5 09 09](https://cloud.githubusercontent.com/assets/3889375/7445364/ffa66c8a-f1b7-11e4-9beb-ebdf9a67416e.png)

After this patch:
Desktop
![screen shot 2015-05-03 at 5 07 14](https://cloud.githubusercontent.com/assets/3889375/7445367/0e6f9de0-f1b8-11e4-992a-dbc5cad82b43.png)

Mobile
![screen shot 2015-05-03 at 5 27 15](https://cloud.githubusercontent.com/assets/3889375/7445397/ad791578-f1b9-11e4-9bd9-d1c2d49d4439.png)
#### Testing

Just confirm that the visual changes are correct ????
