### PR TITLE
[imp]Client side validation for menu type single contact

### DIFF
--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -62,6 +62,12 @@ class JFormFieldModal_Contact extends JFormField
 
 		$script[] = '		jQuery("#modalContact").modal("hide");';
 
+		if ($this->required)
+		{
+			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_id"));';
+			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+		}
+
 		$script[] = '	}';
 
 		// Clear button script
@@ -187,5 +193,17 @@ class JFormFieldModal_Contact extends JFormField
 		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
+	}
+
+	/**
+	 * Method to get the field label markup.
+	 *
+	 * @return  string  The field label markup.
+	 *
+	 * @since   3.4
+	 */
+	protected function getLabel()
+	{
+		return str_replace($this->id, $this->id . '_id', parent::getLabel());
 	}
 }


### PR DESCRIPTION
#### Test instructions
- Go to Menu Manager: New Menu Item
- Enter a menu title
- Select **Single Contact** for **Menu Item Type** 
- Do not select any contact
- Click on Save or Save & Close

You will recognize:
- The system message container just displays the message **Error** without any hint to the field concerned
- The field label will not be coloured red
- If you select a contact now the red colouring is not removed

After applaying the patch:
- The system message container now displays the additional message **Invalid field: Select Contact**
- The field label will be coloured red
- After selecting a contact the red colouring is removed now
#### System information

Latest Joomla! staging
