### PR TITLE
Clean up the published method.

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -441,7 +441,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 			$pk = (object) $pk;
 
-			foreach ($this->_tbl_keys AS $k)
+			foreach ($this->_tbl_keys as $k)
 			{
 				$query->where($this->_db->quoteName($k) . ' = ' . $this->_db->quote($pk->$k));
 			}
@@ -1563,11 +1563,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			$pks = array($pk);
 		}
 
-		foreach ($pks AS $pk)
+		foreach ($pks as $pk)
 		{
-			// Sanitize the input
-			$pk = Joomla\Utilities\ArrayHelper::toInteger($pk);
-
 			// Update the publishing state for rows with the given primary keys.
 			$query = $this->_db->getQuery(true)
 				->update($this->_tbl)

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1521,7 +1521,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{
 		// Sanitize input
-		$pks = Joomla\Utilities\ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
 		$state  = (int) $state;
 
@@ -1561,6 +1560,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		foreach ($pks AS $pk)
 		{
+			// Sanitize the input
+			$pk = Joomla\Utilities\ArrayHelper::toInteger($pk);
+
 			// Update the publishing state for rows with the given primary keys.
 			$query = $this->_db->getQuery(true)
 				->update($this->_tbl)

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1524,6 +1524,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$userId = (int) $userId;
 		$state  = (int) $state;
 
+		if (!is_array($pks))
+		{
+			$pks = array($pks);
+		}
+
 		if (!is_null($pks))
 		{
 			foreach ($pks AS $key => $pk)

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -32,6 +32,9 @@ class JTableContent extends JTable
 
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_content.article'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_content.article'));
+
+		// Set the alias since the column is called state
+		$this->setColumnAlias('published', 'state');
 	}
 
 	/**
@@ -341,95 +344,5 @@ class JTableContent extends JTable
 		}
 
 		return parent::store($updateNulls);
-	}
-
-	/**
-	 * Method to set the publishing state for a row or list of rows in the database
-	 * table. The method respects checked out rows by other users and will attempt
-	 * to checkin rows that it can after adjustments are made.
-	 *
-	 * @param   mixed    $pks     An optional array of primary key values to update.  If not set the instance property value is used.
-	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published]
-	 * @param   integer  $userId  The user id of the user performing the operation.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   11.1
-	 */
-	public function publish($pks = null, $state = 1, $userId = 0)
-	{
-		$k = $this->_tbl_key;
-
-		// Sanitize input.
-		JArrayHelper::toInteger($pks);
-		$userId = (int) $userId;
-		$state = (int) $state;
-
-		// If there are no primary keys set check to see if the instance key is set.
-		if (empty($pks))
-		{
-			if ($this->$k)
-			{
-				$pks = array($this->$k);
-			}
-			// Nothing to set publishing state on, return false.
-			else
-			{
-				$this->setError(JText::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
-
-				return false;
-			}
-		}
-
-		// Build the WHERE clause for the primary keys.
-		$where = $k . '=' . implode(' OR ' . $k . '=', $pks);
-
-		// Determine if there is checkin support for the table.
-		if (!property_exists($this, 'checked_out') || !property_exists($this, 'checked_out_time'))
-		{
-			$checkin = '';
-		}
-		else
-		{
-			$checkin = ' AND (checked_out = 0 OR checked_out = ' . (int) $userId . ')';
-		}
-
-		// Update the publishing state for rows with the given primary keys.
-		$query = $this->_db->getQuery(true)
-			->update($this->_db->quoteName($this->_tbl))
-			->set($this->_db->quoteName('state') . ' = ' . (int) $state)
-			->where('(' . $where . ')' . $checkin);
-		$this->_db->setQuery($query);
-
-		try
-		{
-			$this->_db->execute();
-		}
-		catch (RuntimeException $e)
-		{
-			$this->setError($e->getMessage());
-
-			return false;
-		}
-
-		// If checkin is supported and all rows were adjusted, check them in.
-		if ($checkin && (count($pks) == $this->_db->getAffectedRows()))
-		{
-			// Checkin the rows.
-			foreach ($pks as $pk)
-			{
-				$this->checkin($pk);
-			}
-		}
-
-		// If the JTable instance value is in the list of primary keys that were set, set the instance.
-		if (in_array($this->$k, $pks))
-		{
-			$this->state = $state;
-		}
-
-		$this->setError('');
-
-		return true;
 	}
 }


### PR DESCRIPTION
## Goal

The goal of this pull request is to clean up some code that I found is duplicate and could be improved after checking #3189. This completely removes the publish() override for the JTableContent class as it is obsolete with the update.
## How to test
1. Go to the article manager:
   administrator/index.php?option=com_content&view=articles
2. Unpublish an article and check that it works
3. Publish an article and check that it works
4. Apply this pull request
5. Unpublish an article and check that it works
6. Publish an article and check that it works
