### PR TITLE
Mootools too hard to die?

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -13,9 +13,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.modal');
 JHtml::_('formbehavior.chosen', 'select');
-
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.tabstate');

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -223,7 +223,7 @@ class TemplatesViewTemplate extends JViewLegacy
 		// Add a Template preview button
 		if ($this->preview->client_id == 0)
 		{
-			$bar->appendButton('Link', 'picture', 'COM_TEMPLATES_BUTTON_PREVIEW', JUri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id);
+			$bar->appendButton('Popup', 'picture', 'COM_TEMPLATES_BUTTON_PREVIEW', JUri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id, 800, 520);
 		}
 
 		// Add Manage folders button

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -627,6 +627,8 @@ abstract class JToolbarHelper
 	 */
 	public static function modal($targetModalId, $icon, $alt)
 	{
+		JHtml::_('bootstrap.modal');
+
 		$title = JText::_($alt);
 		$dhtml = "<button data-toggle='modal' data-target='#" . $targetModalId . "' class='btn btn-small'>
 			<i class='" . $icon . "' title='" . $title . "'></i> " . $title . "</button>";

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -627,7 +627,7 @@ abstract class JToolbarHelper
 	 */
 	public static function modal($targetModalId, $icon, $alt)
 	{
-		JHtml::_('bootstrap.modal');
+		JHtml::_('bootstrap.framework');
 
 		$title = JText::_($alt);
 		$dhtml = "<button data-toggle='modal' data-target='#" . $targetModalId . "' class='btn btn-small'>

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -627,7 +627,6 @@ abstract class JToolbarHelper
 	 */
 	public static function modal($targetModalId, $icon, $alt)
 	{
-		JHtml::_('behavior.modal');
 		$title = JText::_($alt);
 		$dhtml = "<button data-toggle='modal' data-target='#" . $targetModalId . "' class='btn btn-small'>
 			<i class='" . $icon . "' title='" . $title . "'></i> " . $title . "</button>";


### PR DESCRIPTION
#### Mootools still loading where it shouldn’t

On latest stagging try to access `administrator/index.php?option=com_templates&view=template&id=507&file=aG9tZQ==`

In this view there is no need for mootools to be loaded but the library still loads. Apply this patch and mootools will be history. 

Also the preview button is kinda awkward: if you press it instead of a preview in modal or a new window the actual result is a redirect IN THE CURRENT WINDOW to the front end of the site with the selected template. Of course no back button exists to return to the previous screen. From a UX point of view this is very bad! Apply this patch and then by pressing the preview you get the rendered preview in a modal!
#### Testing

Apply this patch and verify that all the buttons and links in this view behave as expected, and that preview of a front end site opens on a modal window. Also observe the browsers console that no mootools javascript is loaded! The result should be something like this:

![screen shot 2015-05-05 at 12 58 20](https://cloud.githubusercontent.com/assets/3889375/7470572/e224346a-f326-11e4-9b79-c1ed4c80b43f.png)

And this:

![screen shot 2015-05-05 at 12 57 43](https://cloud.githubusercontent.com/assets/3889375/7470579/eee0d01e-f326-11e4-9e3f-e577cb83c17a.png)
