### PR TITLE
Safari glitch correction on sidebar

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -131,6 +131,12 @@
 				$main.removeClass('span10').addClass('span12 expanded');
 				$toggleSidebarIcon.removeClass(openIcon).addClass(closedIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );
+				// Re initiate tooltip for Safari bad rendering
+				$("#j-toggle-sidebar-button").tooltip('destroy').tooltip({
+					"placement": "top",
+					"title": Joomla.JText._('JTOGGLE_SHOW_SIDEBAR'),
+					"container": "body"
+				});
 				if (!isComponent) {
 					$debug.css( 'width', contentWidthRelative + '%' );
 				}
@@ -151,6 +157,12 @@
 				$main.removeClass('span12 expanded').addClass('span10');
 				$toggleSidebarIcon.removeClass(closedIcon).addClass(openIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );
+				// Re initiate tooltip for Safari bad rendering
+				$("#j-toggle-sidebar-button").tooltip('destroy').tooltip({
+					"placement": "top",
+					"title": Joomla.JText._('JTOGGLE_SHOW_SIDEBAR'),
+					"container": "body"
+				});
 
 				if (!isComponent && bodyWidth > 768 && mainHeight < sidebarHeight)
 				{


### PR DESCRIPTION
#### Correct a visual glitch

This is a response to #5970

To cut the long story sort, sometimes you might end up with a screen like this:
![screen shot 2015-05-05 at 11 47 04](https://cloud.githubusercontent.com/assets/3889375/7482735/41673c28-f382-11e4-9e8e-ab1c643aed58.png)

The problem seems to be an interference between tooltips and collapse. What this PR does is resetting the tooltip on every change of the sidebar status.
#### B/C

Shouldn’t be any problems
#### Testing

Apply patch
verify that glitch is eliminated, (without introducing another error)
