### PR TITLE
Fix JTable publish method error

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1545,7 +1545,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			{
 				if ($this->$key)
 				{
-					$pk[$this->$key] = $this->$key;
+					$pk[$key] = $this->$key;
 				}
 				// We don't have a full primary key - return false
 				else


### PR DESCRIPTION
### Issue description

While reviewing the PR https://github.com/joomla/joomla-cms/pull/6893, I see that JTable publish method has a bug. If you create a JTable object, load a record from using load() method, then call publish() method, you will see some notices and the record won't be published.

To see it, try to run this code somewhere on your Joomla site:

``` php
require_once JPATH_ADMINISTRATOR.'/components/com_contact/tables/contact.php';
$row = JTable::getInstance('Contact', 'ContactTable');
$row->load(1);
$row->publish();
```

After running the code above, we should have contact with ID = 1 published. However, the published status of the record not changed and you will see notices like this:

```
Notice: Undefined property: stdClass::$id in E:\www\joomla\libraries\joomla\table\table.php on line 446
Notice: Undefined index: id in E:\www\joomla\libraries\joomla\table\table.php on line 1594
```

It causes by a typo in the code, I think. And this PR fix it.
### Testing instruction
- For none developers: This PR makes change to publish method of JTable class, so you just need to go to backend of your site, try to publish , unpublish records (articles, categories for example) and make sure it is still working as expected.
- For developers: Try to run the code above (need to change 1 to ID of an unpublished contact, run the code I mentioned some where (even in your own component), see the error. Apply the patch, the error is gone, the contact is published.
