### PR TITLE
[related #6080] Fix startOffset issue when useCookie is true

### DIFF
--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -85,15 +85,8 @@ abstract class JHtmlTabs
 			$opt['titleSelector']       = "dt.tabs";
 			$opt['descriptionSelector'] = "dd.tabs";
 
-			// Initialize value
-			$opt['useStorage'] = false;
-
-			// By default useCookie(this.options.display) is true
-			if (!isset($params['useCookie'])
-				|| (isset($params['useCookie']) && $params['useCookie']))
-			{
-				$opt['useStorage'] = true;
-			}
+			// When use storage is set and value is false - By default we allow to use storage
+			$opt['useStorage'] = (isset($params['useCookie']) && !$params['useCookie']) ? false : true;
 
 			$options = JHtml::getJSObject($opt);
 

--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -82,9 +82,18 @@ abstract class JHtmlTabs
 			$opt['onActive']            = (isset($params['onActive'])) ? '\\' . $params['onActive'] : null;
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
-			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? true : false;
 			$opt['titleSelector']       = "dt.tabs";
 			$opt['descriptionSelector'] = "dd.tabs";
+
+			// Initialize value
+			$opt['useStorage'] = false;
+
+			// By default useCookie(this.options.display) is true
+			if (!isset($params['useCookie'])
+				|| (isset($params['useCookie']) && $params['useCookie']))
+			{
+				$opt['useStorage'] = true;
+			}
 
 			$options = JHtml::getJSObject($opt);
 

--- a/media/system/js/tabs.js
+++ b/media/system/js/tabs.js
@@ -44,9 +44,9 @@ var JTabs = new Class({
 
 		if (this.options.useStorage) {
 			if (Browser.Features.localstorage) {
-				this.options.display = localStorage[this.storageName];
+				this.options.display = this.options.display || localStorage[this.storageName];
 			} else {
-				this.options.display = Cookie.read(this.storageName);
+				this.options.display = this.options.display || Cookie.read(this.storageName);
 			}
 		}
 		if (this.options.display === null || this.options.display === undefined) {


### PR DESCRIPTION
Thanks @Erftralle for reporting issue in https://github.com/joomla/joomla-cms/pull/6080#issuecomment-74376320
#### Testing and Reproduce info

Please follow the instructions given in https://github.com/joomla/joomla-cms/pull/6080 to reproduce the issue. 

You can set `startOffset` and enable `useCookie` by setting options shown as below.

``` php
$options = array(
    'startOffset' => 3, 
    'useCookie'   => true
);

// Using options
echo JHtml::_('tabs.start', 'pane', $options);
```
#### No Backward Compatibility issue

Please also check and confirm that it's not breaking backward compatibility.
