### PR TITLE
Fixed the check on published content languages.

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
+JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
 
 /**
  * Helper for mod_languages
@@ -77,8 +78,6 @@ abstract class ModLanguagesHelper
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)
 		{
-			JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
-
 			// Do not display language without frontend UI
 			if (!array_key_exists($language->lang_code, MultilangstatusHelper::getSitelangs()))
 			{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -35,7 +35,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 * JDatabaseDriver instance
 	 *
 	 * @var    JDatabaseDriver
-	 * @since  4.2.2
+	 * @since  3.4.2
 	 */
 	protected $db = null;
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -32,6 +32,14 @@ class PlgSystemLanguageFilter extends JPlugin
 	private $user_lang_code;
 
 	/**
+	 * JDatabaseDriver instance
+	 *
+	 * @var    JDatabaseDriver
+	 * @since  4.2.2
+	 */
+	protected $db = null;
+
+	/**
 	 * Application object.
 	 *
 	 * @var    JApplicationCms
@@ -537,10 +545,18 @@ class PlgSystemLanguageFilter extends JPlugin
 				$lang_code = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 			}
 
+			// Get a 1-dimensional array of published language codes
+			$query = $this->db->getQuery(true)
+				->select($this->db->quoteName('a.lang_code'))
+				->from($this->db->quoteName('#__languages', 'a'))
+				->where($this->db->quoteName('published') . ' = 1');
+			$this->db->setQuery($query);
+			$lang_codes = $this->db->loadColumn();
+
 			// The user language has been deleted/disabled or the related content language does not exist/has been unpublished
 			// or the related home page does not exist/has been unpublished
 			if (!array_key_exists($lang_code, MultilangstatusHelper::getSitelangs())
-				|| !array_key_exists($lang_code, MultilangstatusHelper::getContentlangs())
+				|| !in_array($lang_code, $lang_codes)
 				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages()))
 			{
 				$lang_code = $this->default_lang;


### PR DESCRIPTION
The languagefilter plugin was not checking for the correct list of published content languages. This PR fixes that by querying the correct published content languages. In addition there is a small cleanup of the language module helper file.

@infograf768: Please add test instructions.
