### PR TITLE
Read More and login Redirect for single registered article display

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -131,11 +131,18 @@ JHtml::_('behavior.caption');
 	<?php elseif ($params->get('show_noauth') == true && $user->get('guest')) : ?>
 	<?php echo $this->item->introtext; ?>
 	<?php //Optional link to let them register to see the whole article. ?>
-	<?php if ($params->get('show_readmore') && $this->item->fulltext != null) :
-		$link1 = JRoute::_('index.php?option=com_users&view=login');
-		$link = new JUri($link1);?>
+	<?php
+	if ($params->get('show_readmore') && $this->item->fulltext != null) :
+		$menu	= JFactory::getApplication()->getMenu();
+		$active		= $menu->getActive();
+		$itemId		= $active->id;
+		$link = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
+		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
+		$fullURL = new JUri($link);
+		$fullURL->setVar('return', base64_encode($returnURL));
+	?>
 	<p class="readmore">
-		<a href="<?php echo $link; ?>">
+		<a href="<?php echo $fullURL; ?>" class="register">
 		<?php $attribs = json_decode($this->item->attribs); ?>
 		<?php
 		if ($attribs->alternative_readmore == null) :
@@ -162,4 +169,3 @@ JHtml::_('behavior.caption');
 	<?php endif; ?>
 	<?php echo $this->item->event->afterDisplayContent; ?>
 </div>
-

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -131,16 +131,14 @@ JHtml::_('behavior.caption');
 	<?php elseif ($params->get('show_noauth') == true && $user->get('guest')) : ?>
 	<?php echo $this->item->introtext; ?>
 	<?php //Optional link to let them register to see the whole article. ?>
-	<?php
-	if ($params->get('show_readmore') && $this->item->fulltext != null) :
-		$menu	= JFactory::getApplication()->getMenu();
-		$active		= $menu->getActive();
-		$itemId		= $active->id;
-		$link = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId);
-		$returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
-		$fullURL = new JUri($link);
-		$fullURL->setVar('return', base64_encode($returnURL));
-	?>
+	<?php if ($params->get('show_readmore') && $this->item->fulltext != null) : ?>
+	<?php $menu = JFactory::getApplication()->getMenu(); ?>
+	<?php $active = $menu->getActive(); ?>
+	<?php $itemId = $active->id; ?>
+	<?php $link = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId); ?>
+	<?php $returnURL = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>
+	<?php $fullURL = new JUri($link); ?>
+	<?php $fullURL->setVar('return', base64_encode($returnURL)); ?>
 	<p class="readmore">
 		<a href="<?php echo $fullURL; ?>" class="register">
 		<?php $attribs = json_decode($this->item->attribs); ?>


### PR DESCRIPTION
Testing instructions using staging:
Create an article with Access set to Registered.
Toggle editor and paste this in the text area (as it seems the Read More button is broken here, separate bug)

```
<p>some text before read more</p>
<hr id="system-readmore" />
<p>some other text</p>
```

Then create a single article menu item set to Public Access to display the single article above.
Make sure that Options->Show Unauthorised Links is set to Yes.

In Frontend, click on the menu item.
=> The article will display with a "Register to Read More" button.
Click on the button
=> the login fields are displayed
Login
=> the redirect is to the Profile edit and NOT to the registered article.

Logout.
Patch.
Redo the Frontend steps
Now the registered article displays in full. 

The code used here is similar to the one used in category blogs or featured.
