### PR TITLE
Regression: Read More button doesn’t work any more...

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -952,7 +952,10 @@ class PlgEditorTinymce extends JPlugin
 
 			foreach ($buttons as &$button)
 			{
-				$button->onclick = 'IeCursorFix(); return false;';
+				if(empty($button->onclick))
+				{
+					$button->onclick = 'IeCursorFix(); return false;';
+				}
 			}
 
 			$return .= JLayoutHelper::render('joomla.editors.buttons', $buttons);

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -831,32 +831,14 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onGetInsertMethod($name)
 	{
-		$doc = JFactory::getDocument();
-
-		$js = "
-			function isBrowserIE()
-			{
-				return navigator.appName==\"Microsoft Internet Explorer\";
-			}
-
+		JFactory::getDocument()->addScriptDeclaration(
+			"
 			function jInsertEditorText( text, editor )
 			{
 				tinyMCE.execCommand('mceInsertContent', false, text);
 			}
-
-			var global_ie_bookmark = false;
-
-			function IeCursorFix()
-			{
-				if (isBrowserIE())
-				{
-					tinyMCE.execCommand('mceInsertContent', false, '');
-					global_ie_bookmark = tinyMCE.activeEditor.selection.getBookmark(false);
-				}
-				return true;
-			}";
-
-		$doc->addScriptDeclaration($js);
+			"
+		);
 
 		return true;
 	}
@@ -949,14 +931,6 @@ class PlgEditorTinymce extends JPlugin
 		if (is_array($buttons) || (is_bool($buttons) && $buttons))
 		{
 			$buttons = $this->_subject->getButtons($name, $buttons, $asset, $author);
-
-			foreach ($buttons as &$button)
-			{
-				if (empty($button->onclick))
-				{
-					$button->onclick = 'IeCursorFix(); return false;';
-				}
-			}
 
 			$return .= JLayoutHelper::render('joomla.editors.buttons', $buttons);
 		}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -952,7 +952,7 @@ class PlgEditorTinymce extends JPlugin
 
 			foreach ($buttons as &$button)
 			{
-				if(empty($button->onclick))
+				if (empty($button->onclick))
 				{
 					$button->onclick = 'IeCursorFix(); return false;';
 				}


### PR DESCRIPTION
#### Restores read more button functionality

Response to #6909
The problem:

> Create an article, add some text and try to insert a Read More via the Read More button.
> The code <hr id="system-readmore" /> is not inserted.

After some tests with IE 8 & 11 and some reading on what changed in tinyMCE from 3.x to 4.x I removed the function `IeCursorFix`.
#### Test

With latest staging try to insert a read more tag (with the button bellow editor)
Apply patch and retry

This needs to be tested on ALL IE versions Joomla supports, thats 8,9,10 & 11 (and if you have it handy why not with edge). All other browsers are not affected, besides the fact that the code was replacing the `onclick` event of the buttons and therefore made them unusable!
