### PR TITLE
Fixed primary key null not being respected

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1524,14 +1524,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$userId = (int) $userId;
 		$state  = (int) $state;
 
-		if (!is_array($pks))
-		{
-			$pks = array($pks);
-		}
-
 		if (!is_null($pks))
 		{
-			foreach ($pks AS $key => $pk)
+			if (!is_array($pks))
+			{
+				$pks = array($pks);
+			}
+
+			foreach ($pks as $key => $pk)
 			{
 				if (!is_array($pk))
 				{


### PR DESCRIPTION
## Problem

If no primary key value is passed to the publish method it is now not being respected as it is turned into an array, the loaded state is not being used as should. This PR fixes this issue introduced in #6893
## Test instructions
1. Apply pull request #6900 first
2. Add the code below to the file administrator/component/com_cpanel/cpanel.php after line 10.
   This will show the problem as we first unpublish the record and then publish it.
   
   ``` php
    require_once JPATH_ADMINISTRATOR.'/components/com_contact/tables/contact.php';
    $row = JTable::getInstance('Contact', 'ContactTable');
    $row->load(1);
    $row->publish(1, 0);
    $row->publish();
    echo 'Published: ' . $row->published;
   ```
3. Load the administrator control panel and it shows Published: 0. This is wrong because we just published the record.
4. Apply the patch
5. Load the administrator control panel and it shows Published: 1. This is correct because we just published the record.
6. Testing finished
