### PR TITLE
Multilanguage: When the user logs in from a "Register to Read More" link, the language should not change

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -185,8 +185,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($this->mode_sef
 			&& (!$this->params->get('remove_default_prefix', 0)
-				|| $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
-				|| $lang != $this->default_lang))
+			|| $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+			|| $lang != $this->default_lang))
 		{
 			$uri->setPath($uri->getPath() . '/' . $sef . '/');
 		}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -542,7 +542,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// When the user logs in from a "Register to Read More" link,
 			// the language should not change
-			if (strpos($url, 'return') !== false && strpos($url, 'view=login') !== false)
+			if (strpos($url, 'return') !== false)
 			{
 				$lang_code = $this->default_lang;
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -538,7 +538,18 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 
-			$lang_code = $user['language'];
+			$url = $_SERVER['HTTP_REFERER'];
+
+			// When the user logs in from a "Register to Read More" link,
+			// the language should not change
+			if (strpos($url, 'return') !== false && strpos($url, 'view=login') !== false)
+			{
+				$lang_code = $this->default_lang;
+			}
+			else
+			{
+				$lang_code = $user['language'];
+			}
 
 			if (empty($lang_code))
 			{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -185,8 +185,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($this->mode_sef
 			&& (!$this->params->get('remove_default_prefix', 0)
-			|| $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
-			|| $lang != $this->default_lang))
+				|| $lang != JComponentHelper::getParams('com_languages')->get('site', 'en-GB')
+				|| $lang != $this->default_lang))
 		{
 			$uri->setPath($uri->getPath() . '/' . $sef . '/');
 		}
@@ -525,31 +525,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($this->app->isSite() && $this->params->get('automatic_change', 1))
 		{
-			// Load associations.
 			$assoc = JLanguageAssociations::isEnabled();
-
-			if ($assoc)
-			{
-				$active = $menu->getActive();
-
-				if ($active)
-				{
-					$associations = MenusHelper::getAssociations($active->id);
-				}
-			}
-
-			$url = $_SERVER['HTTP_REFERER'];
-
-			// When the user logs in from a "Register to Read More" link,
-			// the language should not change
-			if (strpos($url, 'return') !== false)
-			{
-				$lang_code = $this->default_lang;
-			}
-			else
-			{
-				$lang_code = $user['language'];
-			}
+			$lang_code = $user['language'];
 
 			if (empty($lang_code))
 			{
@@ -573,7 +550,37 @@ class PlgSystemLanguageFilter extends JPlugin
 				$lang_code = $this->default_lang;
 			}
 
-			if ($lang_code != $this->default_lang)
+			// Try to get association from the current active menu item
+			$active = $menu->getActive();
+			$foundAssociation	= false;
+
+			if ($active)
+			{
+				if ($assoc)
+				{
+					$associations = MenusHelper::getAssociations($active->id);
+				}
+
+				if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
+				{
+					$associationItemid = $associations[$lang_code];
+					$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+					$foundAssociation  = true;
+				}
+				elseif ($active->home)
+				{
+					// We are on a Home page, we redirect to the user site language home page
+					$item = $menu->getDefault($lang_code);
+
+					if ($item && $item->language != $active->language && $item->language != '*')
+					{
+						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $item->id);
+						$foundAssociation = true;
+					}
+				}
+			}
+
+			if ($foundAssociation && $lang_code != $this->default_lang)
 			{
 				// Change language.
 				$this->default_lang = $lang_code;
@@ -585,19 +592,6 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				// Change the language code.
 				JFactory::getLanguage()->setLanguage($lang_code);
-
-				// Change the redirect (language has changed).
-				if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
-				{
-					$itemid = $associations[$lang_code];
-					$this->app->setUserState('users.login.form.return', 'index.php?&Itemid=' . $itemid);
-				}
-				else
-				{
-					$homes  = MultilangstatusHelper::getHomepages();
-					$itemid = isset($homes[$lang_code]) ? $homes[$lang_code]->id : $homes['*']->id;
-					$this->app->setUserState('users.login.form.return', 'index.php?&Itemid=' . $itemid);
-				}
 			}
 		}
 	}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -552,7 +552,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// Try to get association from the current active menu item
 			$active = $menu->getActive();
-			$foundAssociation	= false;
+			$foundAssociation = false;
 
 			if ($active)
 			{
@@ -565,7 +565,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$associationItemid = $associations[$lang_code];
 					$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
-					$foundAssociation  = true;
+					$foundAssociation = true;
 				}
 				elseif ($active->home)
 				{


### PR DESCRIPTION
On a multilanguage site, if "Automatic Language Change" is set to Yes and the user logs in on a page which is not using his default site language, the redirect is always to the Home page of the language set for the user, even when it is a Register to Read More link which is displayed in another language than the user site language.
This patch solves this issue by checking which language is used in the page proposing the Register to Read More link, and change the redirection to that language (and article) in case it is necessary.

Test:
Set "Automatic Language Change" to "Yes" in the languagefilter system plugin parameter.
Set the registered user site language to another language than the global site default language.

Create an article with Access set to Registered tagged to a <b>different language than the user default site language</b>
Toggle editor and paste this in the text area (as it the Read More button is broken for now in staging)

```
<p>some text before read more</p>
<hr id="system-readmore" />
<p>some other text</p>
```

Create a category blog menu item displaying the category of that article and make sure the article is displayed on the first page (that is just to make it easier to check) in a <b>different language than the user default site language</b>
Make sure that Options->Show Unauthorised Links is set to Yes.

Load the page containing the menu item (it is a  <b>different language than the user default site language</b>
Click on the menu item
=> The article will display with a "Register to Read More" button.
Click on the button
=> the login fields are displayed
Login
=> The user is redirected to the home page for his site language.

Logout, patch and retest;
The user is now correctly redirected to the article in full in language of the article.
