### PR TITLE
Remove bootstrap.modal call in multilang status module

### DIFF
--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -9,15 +9,13 @@
 
 defined('_JEXEC') or die;
 
-	// Include jQuery
-	JHtml::_('jquery.framework');
-	JHtml::_('bootstrap.modal');
+// Include jQuery
+JHtml::_('jquery.framework');
 
-	JFactory::getDocument()->addStyleDeclaration('.navbar-fixed-bottom {z-index:1050;}');
+JFactory::getDocument()->addStyleDeclaration('.navbar-fixed-bottom {z-index:1050;}');
 
-	$link = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
-	$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-		. JText::_('JTOOLBAR_CLOSE') . '</a>';
+$link = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
+$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JTOOLBAR_CLOSE') . '</a>';
 ?>
 <div class="btn-group multilanguage">
 	<a href="#multiLangModal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('MOD_MULTILANGSTATUS'); ?>">
@@ -26,8 +24,10 @@ defined('_JEXEC') or die;
 	</a>
 </div>
 
-<?php echo JHtmlBootstrap::renderModal(
-	'multiLangModal', array(
+<?php echo JHtml::_(
+	'bootstrap.renderModal',
+	'multiLangModal',
+	array(
 		'title' => JText::_('MOD_MULTILANGSTATUS'),
 		'backdrop' => 'static',
 		'keyboard' => true,


### PR DESCRIPTION
There is a condition where the multilingual status module and patch tester conflict for reasons I've not been able to debug (see https://github.com/joomla-extensions/patchtester/issues/92 for more info), but the solution for this issue seems to be in the status module.

JHtmlBootstrap::modal is documented as broken [since 3.4.0](https://github.com/joomla/joomla-cms/blob/3.4.0/libraries/cms/html/bootstrap.php#L261) yet is still used in the module.  Removing the call to the broken method seems to fix the conflict I'm hitting without breaking the module.
### Testing Instructions
1. Install the latest [com_patchtester build](https://github.com/joomla-extensions/patchtester/releases/tag/2.0.0.beta3)
2. Enable the Multilanguage status module for the admin side
3. With your browser's debug console enabled, navigate to the patch tester
4. Notice there's a `Uncaught TypeError: Cannot read property 'options' of null` message  The component's "Fetch Data" modal nor the modal for the module will work correctly either.
5. Apply the patch and repeat, there should be no JavaScript issues and both modals should work correctly.
### Added Bonus

Codestyle fixes in the module's layout and correctly calling the JHtmlBootstrap::renderModal() method through the JHtml::_ loader.
