### PR TITLE
Multilanguage: Propose current language as default when creating new article in frontend

### DIFF
--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -102,7 +102,7 @@ class ContentViewForm extends JViewLegacy
 		}
 
 		// Propose current language as default when creating new article
-		if (JLanguageMultilang::isEnabled())
+		if (JLanguageMultilang::isEnabled() && empty($this->item->id))
 		{
 			$lang = JFactory::getLanguage()->getTag();
 			$this->form->setFieldAttribute('language', 'default', $lang);

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -101,6 +101,13 @@ class ContentViewForm extends JViewLegacy
 			$this->form->setFieldAttribute('catid', 'readonly', 'true');
 		}
 
+		// Propose current language as default when creating new article
+		if (JLanguageMultilang::isEnabled())
+		{
+			$lang = JFactory::getLanguage()->getTag();
+			$this->form->setFieldAttribute('language', 'default', $lang);
+		}
+
 		$this->_prepareDocument();
 		parent::display($tpl);
 	}


### PR DESCRIPTION
As title says.
See: http://forum.joomla.org/viewtopic.php?f=711&t=887853

To test, add a "Create Article" menu item in each mainmenu of a multilanguage site.
Create a new article in different languages in front-end, it will propose as default in the dropdown the current language.
