### PR TITLE
Prevent notice with unset timezone while formatting a date

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -284,7 +284,7 @@ class JDate extends DateTime
 		}
 
 		// If the returned time should not be local use GMT.
-		if ($local == false)
+		if ($local == false && !empty(self::$gmt))
 		{
 			parent::setTimezone(self::$gmt);
 		}
@@ -316,7 +316,7 @@ class JDate extends DateTime
 			}
 		}
 
-		if ($local == false)
+		if ($local == false && !empty($this->tz))
 		{
 			parent::setTimezone($this->tz);
 		}


### PR DESCRIPTION
If you call JDate->format and no timezone is set, you'll get the error:
Warning: DateTime::setTimezone() expects parameter 1 to be DateTimeZone, null given‏
