### PR TITLE
Removed item checked_out status

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -36,7 +36,7 @@ class ModArchiveHelper
 			->select('MIN(' . $db->quoteName('created') . ') AS created')
 			->select($query->year($db->quoteName('created')) . ' AS created_year')
 			->from('#__content')
-			->where('state = 2 AND checked_out = 0')
+			->where('state = 2')
 			->group($query->year($db->quoteName('created')) . ', ' . $query->month($db->quoteName('created')))
 			->order($query->year($db->quoteName('created')) . ' DESC, ' . $query->month($db->quoteName('created')) . ' DESC');
 


### PR DESCRIPTION
Removed checked_out = 0 from WHERE clause that prevented items not being shown in archived articles module if the item is checked out.
