### PR TITLE
Fix colspan for com_content

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -23,6 +23,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 $archived	= $this->state->get('filter.published') == 2 ? true : false;
 $trashed	= $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder	= $listOrder == 'a.ordering';
+$columns	= 10;
 
 if ($saveOrder)
 {
@@ -70,6 +71,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
 					<?php if ($assoc) : ?>
+						<?php $columns++; ?>
 						<th width="5%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 						</th>
@@ -93,7 +95,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="11">
+						<td colspan="<?php echo $columns; ?>">
 						</td>
 					</tr>
 				</tfoot>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -91,6 +91,12 @@ $assoc		= JLanguageAssociations::isEnabled();
 						</th>
 					</tr>
 				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="10">
+						</td>
+					</tr>
+				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$item->max_ordering = 0;

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -93,7 +93,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="10">
+						<td colspan="11">
 						</td>
 					</tr>
 				</tfoot>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -80,7 +80,7 @@ $saveOrder	= $listOrder == 'fp.ordering';
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="8">
+						<td colspan="9">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>


### PR DESCRIPTION
This PR fixes the colspan for com_content Thanks goes to @pe7er for show here the way to fix such issue https://github.com/pe7er/joomla-cms/commit/d173053e77049081db56430e19ed9462470a46dc :+1: 
### How to test
- login into the backend
- access com_content
- switch to the `featured` view
- make sure that the colspan is not to the end see

![bevor_content_featured](https://cloud.githubusercontent.com/assets/2596554/7629941/5f2cbf16-fa31-11e4-9a43-ff00b355a43e.PNG)
- apply the patch
- make sure the line is not to the end of the screen like:

![fixed_content_featured](https://cloud.githubusercontent.com/assets/2596554/7629962/957e381a-fa31-11e4-9e4f-78485a49d681.PNG)
- similiar fix for com_content `articles` there this PR add the complete missing line there :smile: 
- success test.
