### PR TITLE
Added countItems to com_contact helper file

### DIFF
--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -39,4 +39,35 @@ class ContactHelper extends JHelperContent
 			$vName == 'categories'
 		);
 	}
+
+	/**
+	 * Adds Count Items for Category Manager.
+	 *
+	 * @param   object $query The query object of com_categories
+	 *
+	 * @return  object
+	 *
+	 * @since   3.4
+	 */
+	public static function countItems(&$query)
+	{
+		// Join articles to categories and count published items
+		$query->select('COUNT(DISTINCT cp.id) AS count_published');
+		$query->join('LEFT', '#__contact_details AS cp ON cp.catid = a.id AND cp.published = 1');
+
+		// Count unpublished items
+		$query->select('COUNT(DISTINCT cu.id) AS count_unpublished');
+		$query->join('LEFT', '#__contact_details AS cu ON cu.catid = a.id AND cu.published = 0');
+
+		// Count archived items
+		$query->select('COUNT(DISTINCT ca.id) AS count_archived');
+		$query->join('LEFT', '#__contact_details AS ca ON ca.catid = a.id AND ca.published = 2');
+
+		// Count trashed items
+		$query->select('COUNT(DISTINCT ct.id) AS count_trashed');
+		$query->join('LEFT', '#__contact_details AS ct ON ct.catid = a.id AND ct.published = -2');
+
+		return $query;
+	}
+
 }


### PR DESCRIPTION
This patch creates in "Category Manager: Contacts" 4 new columns with the number of contacts per category. It contains a helper file for com_contacts that is used in com_categories to calculate the number of contact items (published, unpublished, archived, and trashed) in each category. **Note** This patch **works only in combination with** #6916. 
## Test instructions:

The Category Manager: Contacts (Components > Contacts > Categories) does not display the number of Contacts in each category.

![screen shot 2015-05-14 at 06 03 38](http://issues.joomla.org/uploads/1/00a751de553bd35d2c33b178372192cd.png)

Create some new Contacts that are unpublished, trashed & archived.
**Install both #6916 and this patch** (the order of installation does not matter, you just need both).
After installing the patch, The Category Manager: Contacts (Components > Contacts > Categories) should displays 4 new columns.

![screen shot 2015-05-14 at 06 03 38](http://issues.joomla.org/uploads/1/761c41c17245f0fdaf6ebe833be5e361.png)

Please also check this patch with the Hathor admin template.
