### PR TITLE
Removed Disallow: /cache/

### DIFF
--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -14,7 +14,6 @@
 User-agent: *
 Disallow: /administrator/
 Disallow: /bin/
-Disallow: /cache/
 Disallow: /cli/
 Disallow: /components/
 Disallow: /includes/


### PR DESCRIPTION
This PR is to fix #6939
I removed "Disallow: /cache/" so that Google will be able to index CSS & JS files stored in /cache/
