### PR TITLE
Articles + Featured, Changed order of Search Tools - Filter options

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -27,19 +27,6 @@
 			<option value="">JOPTION_SELECT_CATEGORY</option>
 		</field>
 		<field
-			name="level"
-			type="integer"
-			first="1"
-			last="10"
-			step="1"
-			label="JOPTION_FILTER_LEVEL"
-			languages="*"
-			description="JOPTION_FILTER_LEVEL_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
-		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
@@ -47,15 +34,6 @@
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
-		</field>
-		<field
-			name="author_id"
-			type="author"
-			label="COM_CONTENT_FILTER_AUTHOR"
-			description="COM_CONTENT_FILTER_AUTHOR_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_AUTHOR</option>
 		</field>
 		<field
 			name="language"
@@ -77,6 +55,28 @@
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
+        <field
+                name="author_id"
+                type="author"
+                label="COM_CONTENT_FILTER_AUTHOR"
+                description="COM_CONTENT_FILTER_AUTHOR_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_AUTHOR</option>
+        </field>
+        <field
+                name="level"
+                type="integer"
+                first="1"
+                last="10"
+                step="1"
+                label="JOPTION_FILTER_LEVEL"
+                languages="*"
+                description="JOPTION_FILTER_LEVEL_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
+        </field>
 	</fields>
 	<fields name="list">
 		<field

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -28,28 +28,6 @@
 			<option value="">JOPTION_SELECT_CATEGORY</option>
 		</field>
 		<field
-			name="level"
-			type="integer"
-			first="1"
-			last="10"
-			step="1"
-			label="JOPTION_FILTER_LEVEL"
-			languages="*"
-			description="JOPTION_FILTER_LEVEL_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
-		<field
-			name="author_id"
-			type="author"
-			label="COM_CONTENT_FILTER_AUTHOR"
-			description="COM_CONTENT_FILTER_AUTHOR_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_AUTHOR</option>
-		</field>
-		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
@@ -78,6 +56,28 @@
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
+        <field
+                name="author_id"
+                type="author"
+                label="COM_CONTENT_FILTER_AUTHOR"
+                description="COM_CONTENT_FILTER_AUTHOR_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_AUTHOR</option>
+        </field>
+        <field
+                name="level"
+                type="integer"
+                first="1"
+                last="10"
+                step="1"
+                label="JOPTION_FILTER_LEVEL"
+                languages="*"
+                description="JOPTION_FILTER_LEVEL_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
+        </field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
Patch for #6941 to correct inconsistency with order of Filter options under [Search Tools] button.
## Test instructions

In back-end > Content > Articles, click on [Search Tools] 
The order of the Filter options is currently
**Article Manager: Articles**
Status | Category | Max Levels | Access | Author | Language | Tag

![screen shot 2015-05-14 at 08 16 19](http://issues.joomla.org/uploads/1/4fcfa5de5ee27081aeb20fe32f3b4790.png)

In back-end > Content > Featured Articles, click on [Search Tools] 
The order of the Filter options is currently
**Article Manager: Featured Articles**
Status | Category | Max Levels | Author | Access | Language | Tag

![screen shot 2015-05-14 at 08 16 19](http://issues.joomla.org/uploads/1/c4c93d5bc192df3356ee1ac532e40fb7.png)
### This PR changes the order to

Status | Category | Access | Language | Tag |  Author | Max Levels

**Article Manager: Articles**

![screen shot 2015-05-14 at 08 16 19](http://issues.joomla.org/uploads/1/c2f8aa6f32f6110e96ccab4e692358d4.png)

**Article Manager: Featured Articles**

![screen shot 2015-05-14 at 08 16 19](http://issues.joomla.org/uploads/1/c03bf4dbee739f1402a283170e6c35f6.png)
