### PR TITLE
Category Manager, Changed order of Search Tools - Filter options

### DIFF
--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -9,19 +9,6 @@
 			class="js-stools-search-string"
 		/>
 		<field
-			name="level"
-			type="integer"
-			first="1"
-			last="10"
-			step="1"
-			label="JOPTION_FILTER_LEVEL"
-			languages="*"
-			description="JOPTION_FILTER_LEVEL_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
-		<field
 			name="published"
 			type="status"
 			label="COM_CATEGORIES_FILTER_PUBLISHED"
@@ -59,6 +46,19 @@
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
+        <field
+                name="level"
+                type="integer"
+                first="1"
+                last="10"
+                step="1"
+                label="JOPTION_FILTER_LEVEL"
+                languages="*"
+                description="JOPTION_FILTER_LEVEL_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
+        </field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
Patch for #6941 to correct inconsistency with order of Filter options under [Search Tools] button.
## Test instructions

In back-end > Content > Categories, click on [Search Tools] 
The order of the Filter options is currently
**Category Manager: Articles** (and Banners, Contacts, Newsfeeds, User Notes Categories)
**Max Levels** | Status | Access | Language | Tag
-> all other Components start with the filter option "Status"

![screen shot 2015-05-14 at 08 25 34](http://issues.joomla.org/uploads/1/f6dde61aa15efe2a75266c69dc935c8a.png)
### This PR changes the order to

**Category Manager: Articles** (and Banners, Contacts, Newsfeeds, User Notes Categories)
Status | Access | Language | Tag | Max Levels

![screen shot 2015-05-14 at 08 25 34](http://issues.joomla.org/uploads/1/6ddf5f0ad839d978406435bf9c278562.png)
