### PR TITLE
Menu Manager, Changed order of Search Tools - Filter options

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -26,19 +26,6 @@
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>
 		<field
-			name="level"
-			type="integer"
-			first="1"
-			last="10"
-			step="1"
-			label="JOPTION_FILTER_LEVEL"
-			languages="*"
-			description="JOPTION_FILTER_LEVEL_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
-		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
@@ -57,6 +44,19 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
+        <field
+                name="level"
+                type="integer"
+                first="1"
+                last="10"
+                step="1"
+                label="JOPTION_FILTER_LEVEL"
+                languages="*"
+                description="JOPTION_FILTER_LEVEL_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
+        </field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
Patch for #6941 to correct inconsistency with order of Filter options under [Search Tools] button.
## Test instructions

In back-end > Menus > Main Menu > click on [Search Tools] 
The order of the Filter options is currently
**Menu Manager: Menu Items**
Status | **Max Levels** | Access | Language
-> it would me more consistent to move the Max Levels option to the right

![screen shot 2015-05-14 at 08 36 42](http://issues.joomla.org/uploads/1/7ba8a9aba73687f8d4e017715725b1ec.png)
### This PR changes the order to

**Menu Manager: Menu Items**
Status | Access | Language | **Max Levels** 

![screen shot 2015-05-14 at 08 36 42](http://issues.joomla.org/uploads/1/1314e552ddb00716b1874615c664df39.png)
