### PR TITLE
Banners, Changed order of Search Tools - Filter options

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -18,16 +18,6 @@
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>
 		<field
-			name="client_id"
-			type="bannerclient"
-			label="COM_BANNERS_FILTER_CLIENT"
-			extension="com_content"
-			description="COM_BANNERS_FILTER_CLIENT_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">COM_BANNERS_SELECT_CLIENT</option>
-		</field>
-		<field
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
@@ -47,6 +37,16 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
+        <field
+                name="client_id"
+                type="bannerclient"
+                label="COM_BANNERS_FILTER_CLIENT"
+                extension="com_content"
+                description="COM_BANNERS_FILTER_CLIENT_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_BANNERS_SELECT_CLIENT</option>
+        </field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
Patch for #6941 to correct inconsistency with order of Filter options under [Search Tools] button.
## Test instructions

In back-end > Components > Banners > click on [Search Tools] 
The order of the Filter options is currently
**Banner Manager: Banners**
Status | **Client** | Category | Language

![screen shot 2015-05-14 at 08 46 21](http://issues.joomla.org/uploads/1/9aed421b96e0dc2f97050bc5d77e3d17.png)
### This PR changes the order to

**Banner Manager: Banners**
Status | Category | Language | **Client**

![screen shot 2015-05-14 at 08 46 21](http://issues.joomla.org/uploads/1/c2dc46576b618ce4fe62c83a43783c9c.png)
