### PR TITLE
Featured Items view - added Alias + Hits

### DIFF
--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -74,13 +74,16 @@ $saveOrder	= $listOrder == 'fp.ordering';
 							<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
+						</th>
+						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
 					</tr>
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="8">
+						<td colspan="10">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>
@@ -133,6 +136,9 @@ $saveOrder	= $listOrder == 'fp.ordering';
 								<?php else : ?>
 									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 								<?php endif; ?>
+								<span class="small break-word">
+									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
 								</div>
@@ -174,6 +180,9 @@ $saveOrder	= $listOrder == 'fp.ordering';
 						</td>
 						<td class="nowrap small hidden-phone">
 							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+						</td>
+						<td class="center hidden-phone">
+							<?php echo (int) $item->hits; ?>
 						</td>
 						<td class="center hidden-phone">
 							<?php echo (int) $item->id; ?>


### PR DESCRIPTION
This PR changes view of **Featured Articles** with 1 extra 'hits' column, and 'article alias' behind the article title.
## Test instructions

Compare the **Articles** view with **Featured Articles** view.
In back-end > Content > **Articles**

![screen shot 2015-05-14 at 11 17 05](http://issues.joomla.org/uploads/1/3bdddaf3147fb3ea9ce8064f65bc922a.png)

In back-end > Content > **Featured Articles**

![screen shot 2015-05-14 at 11 17 05](http://issues.joomla.org/uploads/1/3cf6e72ca978942f4c282b72a1833f8a.png)
## This PR will add

extra 'hits' column, and 'article alias' behind the article title:

![screen shot 2015-05-14 at 11 17 05](http://issues.joomla.org/uploads/1/f9e68eb97b709cc54465ba9c2e99ee76.png)
