### PR TITLE
Fix for: zero or negative values on session lifetime.

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -650,7 +650,8 @@
 		label="CONFIG_SESSION_SETTINGS_LABEL">
 		<field
 			name="lifetime"
-			type="text"
+			type="number"
+			min="1"
 			default="15"
 			label="COM_CONFIG_FIELD_SESSION_TIME_LABEL"
 			description="COM_CONFIG_FIELD_SESSION_TIME_DESC"

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -26,12 +26,14 @@
 
 		<field
 			name="cachetime"
-			type="text"
+			type="number"
+			min="1"
 			default="15"
 			label="COM_CONFIG_FIELD_CACHE_TIME_LABEL"
 			description="COM_CONFIG_FIELD_CACHE_TIME_DESC"
 			required="true"
 			filter="integer"
+			validate="number"
 			size="6" />
 
 		<field
@@ -657,6 +659,7 @@
 			description="COM_CONFIG_FIELD_SESSION_TIME_DESC"
 			required="true"
 			filter="integer"
+			validate="number"
 			size="6" />
 
 		<field

--- a/libraries/joomla/form/rule/number.php
+++ b/libraries/joomla/form/rule/number.php
@@ -11,6 +11,10 @@ defined('JPATH_PLATFORM') or die;
 
 /**
  * Form Rule class for the Joomla Platform.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ * @since       xx.x
  */
 class JFormRuleNumber extends JFormRule
 {
@@ -26,14 +30,16 @@ class JFormRuleNumber extends JFormRule
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   xx.x
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{
-		$float_value = (float)$value;
+		$float_value = (float) $value;
 
 		if (isset($element['min']))
 		{
-			$min = (float)$element['min'];
+			$min = (float) $element['min'];
 
 			if ($min > $float_value)
 			{
@@ -43,7 +49,7 @@ class JFormRuleNumber extends JFormRule
 
 		if (isset($element['max']))
 		{
-			$max = (float)$element['max'];
+			$max = (float) $element['max'];
 
 			if ($max < $float_value)
 			{

--- a/libraries/joomla/form/rule/number.php
+++ b/libraries/joomla/form/rule/number.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ */
+class JFormRuleNumber extends JFormRule
+{
+	/**
+	 * Method to test the range for a number value using min and max attributes.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 */
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+	{
+		$float_value = (float)$value;
+
+		if (isset($element['min']))
+		{
+			$min = (float)$element['min'];
+
+			if ($min > $float_value)
+			{
+				return false;
+			}
+		}
+
+		if (isset($element['max']))
+		{
+			$max = (float)$element['max'];
+
+			if ($max < $float_value)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
### Zero or negative values on session lifetime

Session lifetime is an integer value and should be setted to a positive value greater than zero.
- Negative value cause that the session to be always "expired".
- Zero behavior is equals to the default value of 15 minute, this behavior is not explict and can be obtained setting 15 minutes of lifetime, so i remove zero from the valid range.
