### PR TITLE
Some headers were missing when serving from cache

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -79,7 +79,7 @@ class PlgSystemCache extends JPlugin
 			// Set cached body.
 			$app->setBody($data);
 
-			echo $app->toString($app->get('gzip'));
+			echo $app->toString();
 
 			if (JDEBUG)
 			{
@@ -97,7 +97,7 @@ class PlgSystemCache extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	public function onAfterRender()
+	public function onAfterRespond()
 	{
 		$app = JFactory::getApplication();
 


### PR DESCRIPTION
The setting of headers like 'Content-Type' is currently happening in method `respond` of class `JApplicationWeb`.

Unfortunately, the system cache plugin stores contents at event `onAfterRender` which is triggered before `respond` is executed. Therefore, certain headers are missing when serving from the cache.
This creates problems especially if we are serving content that is not of Content-Type `text/html`.

This pull request changes the plugin so that the cache is created only after these headers are set by using event `onAfterRespond` instead of `onAfterRender`.

Since gzip compression already happened at this point, the compressed contents are stored in the cache and therefore no further compression is necessary when serving cached contents. Thus, the second change in the plugin file.

For testing please make sure that everything works as before and check that the `Content-Type` header is also cached now.
### Testing Instructions
1. Install attached cache test component and access it in frontend (there's no backend part).
2. Click on the presented link which takes you to an image which should be displayed fine (even after refreshing the page).
3. Enable the cache plugin of Joomla! and ensure that debug mode is disabled and you aren't logged in in frontend.
4. Refresh the page of the image a few times. => It won't be displayed correctly anymore.
5. Apply the patch, clear the cache and do the same again => the image will be displayed even after refreshing.
