### PR TITLE
Freeze parent window whenever bootstrap modal is shown

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -154,6 +154,9 @@ div.modal.fade.in {
 .modal-footer .btn-group .btn + .btn {
 	margin-left: -1px;
 }
+body.modal-open {
+	overflow: hidden;
+}
 @font-face {
 	font-family: 'IcoMoon';
 	src: url('../../../../media/jui/fonts/IcoMoon.eot');

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -156,6 +156,7 @@ div.modal.fade.in {
 }
 body.modal-open {
 	overflow: hidden;
+	-ms-overflow-style: none;
 }
 @font-face {
 	font-family: 'IcoMoon';

--- a/administrator/templates/hathor/less/modals.less
+++ b/administrator/templates/hathor/less/modals.less
@@ -95,4 +95,5 @@ div.modal {
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
   overflow: hidden;
+  -ms-overflow-style: none;
 }

--- a/administrator/templates/hathor/less/modals.less
+++ b/administrator/templates/hathor/less/modals.less
@@ -91,3 +91,8 @@ div.modal {
     margin-left: -1px;
   }
 }
+
+/* Prevent scrolling on the parent window of a modal */
+body.modal-open {
+  overflow: hidden;
+}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8150,6 +8150,7 @@ textarea.noResize {
 }
 body.modal-open {
 	overflow: hidden;
+	-ms-overflow-style: none;
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7021,6 +7021,9 @@ dl.article-info dd.hits span[class*=" icon-"] {
 .icon-pending:before {
 	color: #c67605;
 }
+.icon-back:before {
+	content: "\e008";
+}
 html {
 	height: 100%;
 }
@@ -8144,6 +8147,9 @@ textarea.vert {
 }
 textarea.noResize {
 	resize: none;
+}
+body.modal-open {
+	overflow: hidden;
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8150,4 +8150,5 @@ textarea.noResize {
 }
 body.modal-open {
 	overflow: hidden;
+	-ms-overflow-style: none;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8148,3 +8148,6 @@ textarea.vert {
 textarea.noResize {
 	resize: none;
 }
+body.modal-open {
+	overflow: hidden;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1289,4 +1289,5 @@ textarea.noResize {
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
   overflow: hidden;
+  -ms-overflow-style: none;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1285,3 +1285,8 @@ textarea.vert {
 textarea.noResize {
 	resize: none;
 }
+
+/* Prevent scrolling on the parent window of a modal */
+body.modal-open {
+  overflow: hidden;
+}

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -52,46 +52,33 @@ if (isset($params['keyboard']))
 	$modalAttributes['data-keyboard'] = (is_bool($params['keyboard']) ? ($params['keyboard'] ? 'true' : 'false') : 'true');
 }
 
+/**
+ * These lines below are for disabling scrolling of parent window.
+ * $('body').addClass('modal-open');
+ * $('body').removeClass('modal-open')
+ *
+ * Specific hack for Bootstrap 2.3.x
+ */
+$script[] = "jQuery(document).ready(function($) {";
+$script[] = "   $('#" . $selector . "').on('show', function() {";
+$script[] = "       $('body').addClass('modal-open');";
+
 if (isset($params['url']))
 {
 	$iframeHtml = JLayoutHelper::render('joomla.modal.iframe', $displayData);
 
-	/**
-	 * These three lines below are for disabling scrolling of parent window.
-	 * $('body').addClass('modal-open');
-	 * }).on('hidden', function () {
-	 * $('body').removeClass('modal-open')
-	 *
-	 * Specific hack for Bootstrap 2.3.x
-	 * Remove them for Bootstrap 3.x
-	 */
 	// Script for destroying and reloading the iframe
-	JFactory::getDocument()->addScriptDeclaration("
-		jQuery(document).ready(function($) {
-			$('#" . $selector . "').on('show', function() {
-				$('body').addClass('modal-open');
-				var modalBody = $(this).find('.modal-body');
-				modalBody.find('iframe').remove();
-				modalBody.prepend('" . trim($iframeHtml) . "');
-			}).on('hidden', function () {
-				$('body').removeClass('modal-open')
-			});
-		});
-	");
+	$script[] = "       var modalBody = $(this).find('.modal-body');";
+	$script[] = "       modalBody.find('iframe').remove();";
+	$script[] = "       modalBody.prepend('" . trim($iframeHtml) . "');";
 }
-if (!isset($params['url']))
-{
-	// Same hack as above but for modals without iframe
-	JFactory::getDocument()->addScriptDeclaration("
-		jQuery(document).ready(function($) {
-			$('#" . $selector . "').on('show', function() {
-				$('body').addClass('modal-open');
-			}).on('hidden', function () {
-				$('body').removeClass('modal-open')
-			});
-		});
-	");
-}
+
+$script[] = "   }).on('hidden', function () {";
+$script[] = "       $('body').removeClass('modal-open');";
+$script[] = "   });";
+$script[] = "});";
+
+JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 ?>
 <div id="<?php echo $selector; ?>" <?php echo JArrayHelper::toString($modalAttributes); ?>>
 	<?php

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -56,17 +56,25 @@ if (isset($params['url']))
 {
 	$iframeHtml = JLayoutHelper::render('joomla.modal.iframe', $displayData);
 
+	/*
+	 * These three lines below are for disabling scrolling of parent window.
+	 * $('body').addClass('modal-open');
+	 * }).on('hidden', function () {
+	 * $('body').removeClass('modal-open')
+	 *
+	 * Specific hack for Bootstrap 2.3.x
+	 * Remove them for Bootstrap 3.x
+	 */
+	// Script for destroying and reloading the iframe
 	JFactory::getDocument()->addScriptDeclaration("
 		jQuery(document).ready(function($) {
 			$('#" . $selector . "').on('show', function() {
+				$('body').addClass('modal-open');
 				var modalBody = $(this).find('.modal-body');
-
-				// Destroy previous iframe if loaded
 				modalBody.find('iframe').remove();
-
-				// Load iframe
 				modalBody.prepend('" . trim($iframeHtml) . "');
-
+			}).on('hidden', function () {
+				$('body').removeClass('modal-open')
 			});
 		});
 	");

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -56,7 +56,7 @@ if (isset($params['url']))
 {
 	$iframeHtml = JLayoutHelper::render('joomla.modal.iframe', $displayData);
 
-	/*
+	/**
 	 * These three lines below are for disabling scrolling of parent window.
 	 * $('body').addClass('modal-open');
 	 * }).on('hidden', function () {
@@ -73,6 +73,19 @@ if (isset($params['url']))
 				var modalBody = $(this).find('.modal-body');
 				modalBody.find('iframe').remove();
 				modalBody.prepend('" . trim($iframeHtml) . "');
+			}).on('hidden', function () {
+				$('body').removeClass('modal-open')
+			});
+		});
+	");
+}
+if (!isset($params['url']))
+{
+	// Same hack as above but for modals without iframe
+	JFactory::getDocument()->addScriptDeclaration("
+		jQuery(document).ready(function($) {
+			$('#" . $selector . "').on('show', function() {
+				$('body').addClass('modal-open');
 			}).on('hidden', function () {
 				$('body').removeClass('modal-open')
 			});

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7474,3 +7474,6 @@ code {
 	font-weight: bold;
 	padding: 1px 4px;
 }
+body.modal-open {
+	overflow: hidden;
+}

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7476,4 +7476,5 @@ code {
 }
 body.modal-open {
 	overflow: hidden;
+	-ms-overflow-style: none;
 }

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -600,3 +600,8 @@ code {
 	font-weight:bold;
 	padding:1px 4px;
 }
+
+/* Prevent scrolling on the parent window of a modal */
+body.modal-open {
+  overflow: hidden;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -604,4 +604,5 @@ code {
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
   overflow: hidden;
+  -ms-overflow-style: none;
 }


### PR DESCRIPTION
#### Minor UX/UI for bootstrap modals

Whenever a bootstrap modal is rendered, if you place the cursor outside of the modal you can scroll the page beneath that modal. Which is kinda awkward since the focus is supposed to be on the modal. This PR prevents that behavior by adding a class `modal-open` to the body of the document and removing it when modal closes. This hack is specific to BS 2.3.x, previous and later versions have this as a default behavior. So if you are on BS 3.x edit `/layouts/joomla/modal/main.php` and remove the respective javascript lines.
#### Testing

Apply patch
Create a new menu e.g. Single Article
Place the cursor outside of the modal and try to scroll. (observe that the page is not scrolling)
