### PR TITLE
Create article - pre-select language & access level

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -426,6 +426,14 @@ class ContentModelArticle extends JModelAdmin
 				$filterCatId = isset($filters['category_id']) ? $filters['category_id'] : null;
 
 				$data->set('catid', $app->input->getInt('catid', $filterCatId));
+
+				// Pre-select language if set in Article Manager: Articles > Search Tools > Set Language
+				$filterLanguage = isset($filters['language']) ? $filters['language'] : null;
+				$data->set('language', $app->input->getVar('language', $filterLanguage));
+
+				// Pre-select Access Level if set in Article Manager: Articles > Search Tools > Set Access
+				$filterLanguage = isset($filters['access']) ? $filters['access'] : null;
+				$data->set('access', $app->input->getInt('access', $filterLanguage));
 			}
 		}
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -419,21 +419,13 @@ class ContentModelArticle extends JModelAdmin
 		{
 			$data = $this->getItem();
 
-			// Prime some default values.
+			// Pre-select some filters (Category, Language, Access) in edit form if those have been selected in Article Manager: Articles
 			if ($this->getState('article.id') == 0)
 			{
 				$filters = (array) $app->getUserState('com_content.articles.filter');
-				$filterCatId = isset($filters['category_id']) ? $filters['category_id'] : null;
-
-				$data->set('catid', $app->input->getInt('catid', $filterCatId));
-
-				// Pre-select language if set in Article Manager: Articles > Search Tools > Set Language
-				$filterLanguage = isset($filters['language']) ? $filters['language'] : null;
-				$data->set('language', $app->input->getVar('language', $filterLanguage));
-
-				// Pre-select Access Level if set in Article Manager: Articles > Search Tools > Set Access
-				$filterAccess = isset($filters['access']) ? $filters['access'] : null;
-				$data->set('access', $app->input->getInt('access', $filterAccess));
+				$data->set('catid', $app->input->getInt('catid', (isset($filters['category_id']) ? $filters['category_id'] : null)));
+				$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
 			}
 		}
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -419,10 +419,11 @@ class ContentModelArticle extends JModelAdmin
 		{
 			$data = $this->getItem();
 
-			// Pre-select some filters (Category, Language, Access) in edit form if those have been selected in Article Manager: Articles
+			// Pre-select some filters (Status, Category, Language, Access) in edit form if those have been selected in Article Manager: Articles
 			if ($this->getState('article.id') == 0)
 			{
 				$filters = (array) $app->getUserState('com_content.articles.filter');
+				$data->set('state', $app->input->getInt('state', (isset($filters['published']) ? $filters['published'] : null)));
 				$data->set('catid', $app->input->getInt('catid', (isset($filters['category_id']) ? $filters['category_id'] : null)));
 				$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -432,8 +432,8 @@ class ContentModelArticle extends JModelAdmin
 				$data->set('language', $app->input->getVar('language', $filterLanguage));
 
 				// Pre-select Access Level if set in Article Manager: Articles > Search Tools > Set Access
-				$filterLanguage = isset($filters['access']) ? $filters['access'] : null;
-				$data->set('access', $app->input->getInt('access', $filterLanguage));
+				$filterAccess = isset($filters['access']) ? $filters['access'] : null;
+				$data->set('access', $app->input->getInt('access', $filterAccess));
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the **Article Edit form** with **pre-selection** of **Language** and **Access Level**.
Issue: if you want to add a lot of new articles and assign them to other Languages or Access Levels,
you've to select those manually in each new article. 
## Test instructions

Go to Article Manager
In back-end > Content > Articles > [Search Tools]
**Set Filters** for **Select Category**, **Select Language** (to something different than "All") and **Select Access** (to something different than "Public").

![screen shot 2015-05-17 at 09 48 27](http://issues.joomla.org/uploads/1/7c46214732996e045273e8b206fdb5fa.png)

Create a **New Article**
Look on the right:
- Category -> the Category that you've filtered on in the Article Manager
- Access -> **always "Public"**
- Language -> **always "All"**

![screen shot 2015-05-17 at 09 48 27](http://issues.joomla.org/uploads/1/6a03175829c8040b13de4f20fd43d974.png)
### This PR fixes the "pre-selection"

on basis of Access Level & Language filters. 
After the PR the parameters on the right should show:
- Category -> the Category that you've filtered on in the Article Manager
- Access -> the Access Level that you've filtered on in the Article Manager
- Language -> the Language that you've filtered on in the Article Manager

![screen shot 2015-05-17 at 09 48 27](http://issues.joomla.org/uploads/1/f22f66853ba38a75bde1f488163bdbe1.png)
