### PR TITLE
$data in JModelForm::preprocessData need to be linked

### DIFF
--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -240,7 +240,7 @@ abstract class JModelForm extends JModelLegacy
 		JPluginHelper::importPlugin('content');
 
 		// Trigger the data preparation event.
-		$results = $dispatcher->trigger('onContentPrepareData', array($context, $data));
+		$results = $dispatcher->trigger('onContentPrepareData', array($context, &$data));
 
 		// Check for errors encountered while preparing the data.
 		if (count($results) > 0 && in_array(false, $results, true))


### PR DESCRIPTION
$data in JModelForm::preprocessData need to be linked, otherwise any changes made by plugin on `onContentPrepareData` have no effect when $data is array

**test**
add event `onContentPrepareData` into the content plugin:

``` php
public function onContentPrepareData($context, &$data)
{
    if ($context !== 'com_menus.item')
    {
        return true;
    }
        $data['title'] = 'My custom title';
}
```

Then go to menu manager and try make new menu item.

**expected result**
you get predefined title "My custom title"

**actual result**
nothing changed
