### PR TITLE
Fixing content search plugin in PostgreSQL

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -178,7 +178,7 @@ class PlgSearchContent extends JPlugin
 						. 'AND (a.publish_up = ' . $db->quote($nullDate) . ' OR a.publish_up <= ' . $db->quote($now) . ') '
 						. 'AND (a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')'
 				)
-				->group('a.id, a.title, a.metadesc, a.metakey, a.created, a.introtext, a.fulltext, c.title, a.alias, c.alias, c.id')
+				->group('a.id, a.title, a.metadesc, a.metakey, a.created, a.introtext, a.fulltext, c.title, a.alias, c.alias, c.id, a.language, a.catid')
 				->order($order);
 
 			// Filter by language.


### PR DESCRIPTION
Change to bring search plugin back to work in Postgres SQL as the last to terms are missing in the group by clause.

PostgreSQL. 9.0
