### PR TITLE
Edit Category - pre-select fields on filters in Manager

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -309,11 +309,25 @@ class CategoriesModelCategory extends JModelAdmin
 	protected function loadFormData()
 	{
 		// Check the session for previously entered form data.
-		$data = JFactory::getApplication()->getUserState('com_categories.edit.' . $this->getName() . '.data', array());
+		$app = JFactory::getApplication();
+		$data = $app->getUserState('com_categories.edit.' . $this->getName() . '.data', array());
 
 		if (empty($data))
 		{
 			$data = $this->getItem();
+
+			// Pre-select some filters (Status, Language, Access) in edit form if those have been selected in Category Manager
+			if ($this->getState('category.id') == 0)
+			{
+				// Check for which extension the Category Manager is used and get selected fields
+				$extension = substr($app->getUserState('com_categories.categories.filter.extension'), 4);
+				$filters = (array) $app->getUserState('com_categories.categories.' . $extension . '.filter');
+
+				$data->set('published', $app->input->getInt('published', (isset($filters['published']) ? $filters['published'] : null)));
+				$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+			}
+
 		}
 
 		$this->preprocessData('com_categories.category', $data);


### PR DESCRIPTION
This PR adds new **pre-selection** feature in the **edit form of the Category Manager**: The form fields **Status**, **Language** and **Access Level** are selected on basis of the [Search Tools] **Set Filters** in the Category Manager. Similar PR as #6966.
## Test instructions

Test in **Category Manager: Articles**, **Category Manager: Banners**, **Category Manager: Contacts**, **Category Manager: News Feeds** if the selected **[Search Tools] > **Filters** (Status, Language and Access Level) are pre-selected in the form when creating a **New** Category
### Category Manager: Articles

Back-end > Content > Category Manager > [Search Tools] > select (Status, Language and Access Level).

![screen shot 2015-05-18 at 04 34 06](http://issues.joomla.org/uploads/1/e1a9d281af69d87bf0db7682e4e4c55a.png)

**Create new Category** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 04 34 07](http://issues.joomla.org/uploads/1/9863c975fcf76ed58142cc73589f0a20.png)
### Category Manager: Banners

Back-end > Components > Banners > Categories > [Search Tools] > select (Status, Language and Access Level).

![screen shot 2015-05-18 at 04 34 06](http://issues.joomla.org/uploads/1/ab37fcab5562d0f1bdef2398df81661a.png)

**Create new Category** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 04 34 07](http://issues.joomla.org/uploads/1/ba5ba300034a132748abe47bdea8d19e.png)
### Category Manager: Contacts

Back-end > Components > Contacts > Categories > [Search Tools] > select (Status, Language and Access Level).

![screen shot 2015-05-18 at 04 34 07](http://issues.joomla.org/uploads/1/aefd29d38b776465a3050e295039b4c0.png)

**Create new Category** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 04 34 07](http://issues.joomla.org/uploads/1/339ece9e3186e4134ec5f36de4c5344c.png)
### Category Manager: News Feeds

Back-end > Components > News Feeds > Categories > [Search Tools] > select (Status, Language and Access Level).

![screen shot 2015-05-18 at 04 34 07](http://issues.joomla.org/uploads/1/c2d5adf74e94f89b47802a24b1aa018f.png)

**Create new Category** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 04 34 06](http://issues.joomla.org/uploads/1/69ed4ed78212cf0f9858a0783c62d7a3.png)
