### PR TITLE
Edit Menu Item - pre-select fields on filters in Manager

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -532,6 +532,16 @@ class MenusModelItem extends JModelAdmin
 		// Check the session for previously entered form data.
 		$data = array_merge((array) $this->getItem(), (array) JFactory::getApplication()->getUserState('com_menus.edit.item.data', array()));
 
+		// For a new menu item, pre-select some filters (Status, Language, Access) in edit form if those have been selected in Menu Manager
+		if ($this->getItem()->id == 0)
+		{
+			// Get selected fields
+			$filters = JFactory::getApplication()->getUserState('com_menus.items.filter');
+			$data['published'] = (isset($filters['published']) ? $filters['published'] : null);
+			$data['language'] = (isset($filters['language']) ? $filters['language'] : null);
+			$data['access'] = (isset($filters['access']) ? $filters['access'] : null);
+		}
+
 		$this->preprocessData('com_menus.item', $data);
 
 		return $data;


### PR DESCRIPTION
This PR adds new **pre-selection** feature in the **edit form of the Menu Item Manager**: The form fields **Status**, **Language** and **Access Level** are selected on basis of the [Search Tools] **Set Filters** in the Menu Item Manager. Similar PR as #6966 + #6973.

**Please triple check my code** for this PR: In the menu item model the $data is an array and not an object (like with articles (#6966) and categories (#6973)), so I could not use $data->set and used $data['some-field'] instead.
## Test instructions

Test in **Menu Manager: Menu Items** if the selected **[Search Tools] > **Filters** (Status, Language and Access Level) are pre-selected in the form when creating a **New** Menu Item.
### Menu Manager: Menu Items

Back-end > Menus > select a Menu (eg Main Menu) > [Search Tools] > select (Status, Language and Access Level).

![screen shot 2015-05-18 at 05 38 51](http://issues.joomla.org/uploads/1/34ca6c8165ccf2216e0e286bf2761f47.png)

**Create new Menu Item** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 05 38 51](http://issues.joomla.org/uploads/1/a7d4d4dbc24e2687018dfca292bd6dc8.png)
