### PR TITLE
Module Manager - pre-select fields on filters in Manager

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -592,6 +592,16 @@ class ModulesModelModule extends JModelAdmin
 		{
 			$data = $this->getItem();
 
+			// Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
+			if ($this->getItem == 0)
+			{
+				$filters = (array) $app->getUserState('com_modules.modules.filter');
+				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
+				$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
+				$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+			}
+
 			// This allows us to inject parameter settings into a new module.
 			$params = $app->getUserState('com_modules.add.module.params');
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -593,14 +593,11 @@ class ModulesModelModule extends JModelAdmin
 			$data = $this->getItem();
 
 			// Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
-			if ($this->getItem == 0)
-			{
-				$filters = (array) $app->getUserState('com_modules.modules.filter');
-				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
-				$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
-				$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
-			}
+			$filters = (array) $app->getUserState('com_modules.modules.filter');
+			$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
+			$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
+			$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
+			$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
 
 			// This allows us to inject parameter settings into a new module.
 			$params = $app->getUserState('com_modules.add.module.params');


### PR DESCRIPTION
This PR adds new **pre-selection** feature in the **edit form of the Module Manager**: The form fields **Status**, **Position**, **Language** and **Access Level** are pre-selected on basis of the [Search Tools] **Set Filters** in the Module Manager. Similar PR as #6966, #6973 & #6976.
## Test instructions

Test in **Module Manager: Modules** if the selected **[Search Tools] > **Filters** (Status, Position, Language and Access Level) are pre-selected in the form when creating a **New** Module instance.
### Module Manager: Modules

Back-end > Extensions > Module Manager > [Search Tools] > select (Status, Position, Language and Access Level).

![screen shot 2015-05-18 at 06 06 27](http://issues.joomla.org/uploads/1/668191cfa7df6c1995d1455866640ce1.png)

**Create new Module**, e.g. **Banner Module** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 06 06 27](http://issues.joomla.org/uploads/1/85a4d4ef436a55ad4d551cb4810fdfe3.png)

**Create new Module**, e.g. **Custom HTML Module** and check if the parameters on the left are "pre-selected".

![screen shot 2015-05-18 at 06 06 27](http://issues.joomla.org/uploads/1/a0804c61ee3a0b289e54297f36410435.png)
