### PR TITLE
Adding core.options to remaining extensions

### DIFF
--- a/administrator/components/com_banners/access.xml
+++ b/administrator/components/com_banners/access.xml
@@ -2,6 +2,7 @@
 <access component="com_banners">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_banners/views/banners/view.html.php
+++ b/administrator/components/com_banners/views/banners/view.html.php
@@ -141,7 +141,7 @@ class BannersViewBanners extends JViewLegacy
 			JToolbarHelper::trash('banners.trash');
 		}
 
-		if ($user->authorise('core.admin', 'com_banners'))
+		if ($user->authorise('core.admin', 'com_banners') || $user->authorise('core.options', 'com_banners'))
 		{
 			JToolbarHelper::preferences('com_banners');
 		}

--- a/administrator/components/com_banners/views/clients/view.html.php
+++ b/administrator/components/com_banners/views/clients/view.html.php
@@ -94,7 +94,7 @@ class BannersViewClients extends JViewLegacy
 			JToolbarHelper::trash('clients.trash');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_banners');
 		}

--- a/administrator/components/com_banners/views/tracks/view.html.php
+++ b/administrator/components/com_banners/views/tracks/view.html.php
@@ -78,7 +78,7 @@ class BannersViewTracks extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_banners');
 			JToolbarHelper::divider();

--- a/administrator/components/com_contact/access.xml
+++ b/administrator/components/com_contact/access.xml
@@ -2,6 +2,7 @@
 <access component="com_contact">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -117,7 +117,7 @@ class ContactViewContacts extends JViewLegacy
 			JToolbarHelper::trash('contacts.trash');
 		}
 
-		if ($user->authorise('core.admin', 'com_contact'))
+		if ($user->authorise('core.admin', 'com_contact') || $user->authorise('core.options', 'com_contact'))
 		{
 			JToolbarHelper::preferences('com_contact');
 		}

--- a/administrator/components/com_finder/access.xml
+++ b/administrator/components/com_finder/access.xml
@@ -2,6 +2,7 @@
 <access component="com_finder">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_finder/views/filters/view.html.php
+++ b/administrator/components/com_finder/views/filters/view.html.php
@@ -79,7 +79,7 @@ class FinderViewFilters extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_finder');
 		}

--- a/administrator/components/com_finder/views/index/view.html.php
+++ b/administrator/components/com_finder/views/index/view.html.php
@@ -81,7 +81,7 @@ class FinderViewIndex extends JViewLegacy
 			JToolbarHelper::unpublishList('index.unpublish');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_finder');
 		}

--- a/administrator/components/com_finder/views/maps/view.html.php
+++ b/administrator/components/com_finder/views/maps/view.html.php
@@ -77,7 +77,7 @@ class FinderViewMaps extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_finder');
 		}

--- a/administrator/components/com_installer/access.xml
+++ b/administrator/components/com_installer/access.xml
@@ -2,6 +2,7 @@
 <access component="com_installer">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />

--- a/administrator/components/com_installer/views/default/view.php
+++ b/administrator/components/com_installer/views/default/view.php
@@ -74,7 +74,7 @@ class InstallerViewDefault extends JViewLegacy
 		$canDo	= JHelperContent::getActions('com_installer');
 		JToolbarHelper::title(JText::_('COM_INSTALLER_HEADER_' . $this->getName()), 'puzzle install');
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_installer');
 			JToolbarHelper::divider();

--- a/administrator/components/com_joomlaupdate/access.xml
+++ b/administrator/components/com_joomlaupdate/access.xml
@@ -2,6 +2,7 @@
 <access component="com_joomlaupdate">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -44,7 +44,9 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'JTOOLBAR_PURGE_CACHE', false, false);
 
 		// Add toolbar buttons.
-		if (JFactory::getUser()->authorise('core.admin', 'com_joomlaupdate'))
+		$user = JFactory::getUser();
+
+		if ($user->authorise('core.admin', 'com_joomlaupdate') || $user->authorise('core.options', 'com_joomlaupdate'))
 		{
 			JToolbarHelper::preferences('com_joomlaupdate');
 		}

--- a/administrator/components/com_joomlaupdate/views/update/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/update/view.html.php
@@ -36,7 +36,9 @@ class JoomlaupdateViewUpdate extends JViewLegacy
 		JToolBarHelper::help('JHELP_COMPONENTS_JOOMLA_UPDATE');
 
 		// Add toolbar buttons.
-		if (JFactory::getUser()->authorise('core.admin', 'com_joomlaupdate'))
+		$user = JFactory::getUser();
+
+		if ($user->authorise('core.admin', 'com_joomlaupdate') || $user->authorise('core.options', 'com_joomlaupdate'))
 		{
 			JToolbarHelper::preferences('com_joomlaupdate');
 		}

--- a/administrator/components/com_media/access.xml
+++ b/administrator/components/com_media/access.xml
@@ -2,6 +2,7 @@
 <access component="com_media">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_media/views/media/view.html.php
+++ b/administrator/components/com_media/views/media/view.html.php
@@ -149,7 +149,7 @@ class MediaViewMedia extends JViewLegacy
 		}
 
 		// Add a preferences button
-		if ($user->authorise('core.admin', 'com_media'))
+		if ($user->authorise('core.admin', 'com_media') || $user->authorise('core.options', 'com_media'))
 		{
 			JToolbarHelper::preferences('com_media');
 			JToolbarHelper::divider();

--- a/administrator/components/com_menus/access.xml
+++ b/administrator/components/com_menus/access.xml
@@ -2,6 +2,7 @@
 <access component="com_menus">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_menus/views/menus/view.html.php
+++ b/administrator/components/com_menus/views/menus/view.html.php
@@ -98,7 +98,7 @@ class MenusViewMenus extends JViewLegacy
 
 		JToolbarHelper::custom('menus.rebuild', 'refresh.png', 'refresh_f2.png', 'JTOOLBAR_REBUILD', false);
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::divider();
 			JToolbarHelper::preferences('com_menus');

--- a/administrator/components/com_newsfeeds/access.xml
+++ b/administrator/components/com_newsfeeds/access.xml
@@ -2,6 +2,7 @@
 <access component="com_newsfeeds">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -132,7 +132,7 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 			JToolbarHelper::trash('newsfeeds.trash');
 		}
 
-		if ($user->authorise('core.admin', 'com_newsfeeds'))
+		if ($user->authorise('core.admin', 'com_newsfeeds') || $user->authorise('core.options', 'com_newsfeeds'))
 		{
 			JToolbarHelper::preferences('com_newsfeeds');
 		}

--- a/administrator/components/com_redirect/access.xml
+++ b/administrator/components/com_redirect/access.xml
@@ -2,6 +2,7 @@
 <access component="com_redirect">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -130,7 +130,7 @@ class RedirectViewLinks extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_redirect');
 			JToolbarHelper::divider();

--- a/administrator/components/com_search/access.xml
+++ b/administrator/components/com_search/access.xml
@@ -2,6 +2,7 @@
 <access component="com_search">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />
 	</section>

--- a/administrator/components/com_search/views/searches/view.html.php
+++ b/administrator/components/com_search/views/searches/view.html.php
@@ -71,7 +71,7 @@ class SearchViewSearches extends JViewLegacy
 
 		JToolbarHelper::divider();
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_search');
 		}

--- a/administrator/components/com_tags/access.xml
+++ b/administrator/components/com_tags/access.xml
@@ -2,6 +2,7 @@
 <access component="com_tags">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -131,7 +131,7 @@ class TagsViewTags extends JViewLegacy
 			JToolbarHelper::trash('tags.trash');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_tags');
 		}

--- a/administrator/components/com_templates/access.xml
+++ b/administrator/components/com_templates/access.xml
@@ -2,6 +2,7 @@
 <access component="com_templates">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_templates/views/styles/view.html.php
+++ b/administrator/components/com_templates/views/styles/view.html.php
@@ -88,7 +88,7 @@ class TemplatesViewStyles extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_templates');
 			JToolbarHelper::divider();

--- a/administrator/components/com_templates/views/templates/view.html.php
+++ b/administrator/components/com_templates/views/templates/view.html.php
@@ -85,7 +85,7 @@ class TemplatesViewTemplates extends JViewLegacy
 
 		JToolbarHelper::title(JText::_('COM_TEMPLATES_MANAGER_TEMPLATES'), 'eye thememanager');
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_templates');
 			JToolbarHelper::divider();

--- a/administrator/components/com_users/access.xml
+++ b/administrator/components/com_users/access.xml
@@ -2,6 +2,7 @@
 <access component="com_users">
 	<section name="component">
 		<action name="core.admin" title="JACTION_ADMIN" description="JACTION_ADMIN_COMPONENT_DESC" />
+		<action name="core.options" title="JACTION_OPTIONS" description="JACTION_OPTIONS_COMPONENT_DESC" />
 		<action name="core.manage" title="JACTION_MANAGE" description="JACTION_MANAGE_COMPONENT_DESC" />
 		<action name="core.create" title="JACTION_CREATE" description="JACTION_CREATE_COMPONENT_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />

--- a/administrator/components/com_users/views/groups/view.html.php
+++ b/administrator/components/com_users/views/groups/view.html.php
@@ -98,7 +98,7 @@ class UsersViewGroups extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_users');
 			JToolbarHelper::divider();

--- a/administrator/components/com_users/views/levels/view.html.php
+++ b/administrator/components/com_users/views/levels/view.html.php
@@ -98,7 +98,7 @@ class UsersViewLevels extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_users');
 			JToolbarHelper::divider();

--- a/administrator/components/com_users/views/notes/view.html.php
+++ b/administrator/components/com_users/views/notes/view.html.php
@@ -135,7 +135,7 @@ class UsersViewNotes extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_users');
 			JToolbarHelper::divider();

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -130,7 +130,7 @@ class UsersViewUsers extends JViewLegacy
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if ($canDo->get('core.admin'))
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
 			JToolbarHelper::preferences('com_users');
 			JToolbarHelper::divider();


### PR DESCRIPTION
With #4975, we added a new ACL rule `core.option` to the article manager which allows to access the options, but without the "Permissions" tab. Previously, you had to give that user basically SuperAdmin permissions (at least for that component).

This PR adds that new rule to the other core extensions.
### Testing
- Create a second user and adjust the permissions in the various components so he can access the options ("Configure Options Only") but doesn't have "Configure ACL & Options" permissions.
- Check with SuperUser and this new user if the options work as expected. SuperUser should be able to save the permissions. The new user should not see them and not be able to save them (even if he fakes the form).

The components to check are:
- [ ] Banners
- [ ] Contacts
- [ ] Smart Search (Finder)
- [ ] Search
- [ ] Extension Installer
- [ ] Joomla Update
- [ ] Media
- [ ] Menu
- [ ] Newsfeed
- [ ] Redirect
- [ ] Tags
- [ ] User
- [ ] Template Manager
### Known Issue

The Template Manager is a bit special as you currently need SuperUser permissions anyway to even access the whole thing. I still added the new rule but it's pointless atm like all the other ones there. That's will be improved with another PR I already prepared, but it's out of scope for this PR.
