### PR TITLE
Fix Feed-reader crashes site if source is not a newsfeed

### DIFF
--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -64,12 +64,13 @@ class JFeedFactory
 		try
 		{
 			// Skip ahead to the root node.
-			do
+			while ($reader->read())
 			{
-				$reader->read();
+				if ($reader->nodeType == XMLReader::ELEMENT)
+				{
+					break;
+				}
 			}
-
-			while ($reader->nodeType !== XMLReader::ELEMENT);
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
Change initial XMLReader loop to properly handle bad RSS feeds.  Current loop will loop indefinitely until memory is exhausted.
http://issues.joomla.org/tracker/joomla-cms/5939

---
#### Steps to reproduce the issue

Ad a new "Module Feed Display" and set as Feed URL: http://www.google.com/robots.txt
#### Expected result

Message "Feed not available" in module position
#### Actual result

Site crash

Warning: XMLReader::read(): An Error Occurred while reading in \libraries\joomla\feed\factory.php on line 71
#### System information (as much as possible)

Joomla 3.3.6 / Apache 2.4.4 / PHP 5.5.3 / MySQL 5.6.11
#### Additional comments

We include a newsfeed which is sometimes down. In this case the feed-server returns a page with text/plain content - and our site crashes.
It makes no difference to include feed via module or via News Feed Manager.
