### PR TITLE
Regression. Multilang. Contact and newsfeed associations. Multiple ID conflict in bootstrap modal

### DIFF
--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -60,7 +60,7 @@ class JFormFieldModal_Contact extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jQuery("#modalContact").modal("hide");';
+		$script[] = '		jQuery("#modalContact' . $this->id . '").modal("hide");';
 
 		if ($this->required)
 		{
@@ -141,13 +141,13 @@ class JFormFieldModal_Contact extends JFormField
 		// The current contact display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a href="#modalContact"  class="btn hasTooltip" role="button"  data-toggle="modal"'
+		$html[] = '<a href="#modalContact' . $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"'
 			. ' title="' . JHtml::tooltipText('COM_CONTACT_CHANGE_CONTACT') . '">'
 			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
 			. '</a>';
 
 		$html[] = JHtmlBootstrap::renderModal(
-							'modalContact', array(
+							'modalContact' . $this->id, array(
 							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
 							'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
 							'width' => '800px',

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -60,7 +60,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jQuery("#modalNewsfeed").modal("hide");';
+		$script[] = '		jQuery("#modalNewsfeed' . $this->id . '").modal("hide");';
 
 		if ($this->required)
 		{
@@ -142,13 +142,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title .
 			'" disabled="disabled" size="35" />';
 
-		$html[] = '<a href="#modalNewsfeed"  class="btn hasTooltip" role="button"  data-toggle="modal"'
+		$html[] = '<a href="#modalNewsfeed' . $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"'
 			. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED_BUTTON') . '">'
 			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
 			. '</a>';
 
 		$html[] = JHtmlBootstrap::renderModal(
-						'modalNewsfeed', array(
+						'modalNewsfeed' . $this->id, array(
 							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
 							'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
 							'width' => '800px',


### PR DESCRIPTION
Patch similar to https://github.com/joomla/joomla-cms/pull/6971
for Contacts and Newsfeeds.

Test on a 3 language multilang site. A, B, C
Create a contact and assign a language A to it.
Create a second contact and assign language B, save (do not close) and then click in the associations tab on the select button for each of the 2 languages presented (A and C).
Before patch:
the same first created contact assigned to lang A will be presented to the choice for each language.
After patch
Only the contact assigned to the language A will be presented for the field corresponding to that language. The other one will not present anything until you create a third contact assigned to lang C.

Same test for Newsfeeds.
