### PR TITLE
Yet another modal from mootools to bootstrap

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -48,9 +48,6 @@ class JFormFieldModal_Category extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
 
-		// Load the modal behavior script.
-		JHtml::_('behavior.modal', 'a.modal');
-
 		// Build the script.
 		$script = array();
 
@@ -69,7 +66,7 @@ class JFormFieldModal_Category extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jModalClose();';
+		$script[] = '		jQuery("#modalCategory-' . $this->id . '").modal("hide");';
 		$script[] = '	}';
 
 		// Clear button script
@@ -143,11 +140,9 @@ class JFormFieldModal_Category extends JFormField
 		// The current category display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a'
-			. ' class="modal btn hasTooltip"'
-			. ' title="' . JHtml::tooltipText('COM_CATEGORIES_CHANGE_CATEGORY') . '"'
-			. ' href="' . $link . '&amp;' . JSession::getFormToken() . '=1"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
+		$html[] = '<a href="#modalCategory-'
+			. $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"'
+			. ' title="' . JHtml::tooltipText('COM_CATEGORIES_CHANGE_CATEGORY') . '">'
 			. '<i class="icon-file"></i> ' . JText::_('JSELECT')
 			. '</a>';
 
@@ -161,6 +156,16 @@ class JFormFieldModal_Category extends JFormField
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
 				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
+
+			$html[] = JHtml::_('bootstrap.renderModal', 'modalCategory-' . $this->id, array(
+								'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+								'title' => JText::_('COM_CATEGORIES_CHANGE_CATEGORY'),
+								'width' => '800px',
+								'height' => '300px',
+								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								)
+							);
 		}
 
 		// Clear category button

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -157,15 +157,18 @@ class JFormFieldModal_Category extends JFormField
 				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
 
-			$html[] = JHtml::_('bootstrap.renderModal', 'modalCategory-' . $this->id, array(
-								'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-								'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
-								'width' => '800px',
-								'height' => '300px',
-								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-								)
-							);
+			$html[] = JHtml::_(
+				'bootstrap.renderModal',
+				'modalCategory-' . $this->id,
+				array(
+					'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+					'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
+					'width' => '800px',
+					'height' => '300px',
+					'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				)
+			);
 		}
 
 		// Clear category button

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -159,7 +159,7 @@ class JFormFieldModal_Category extends JFormField
 
 			$html[] = JHtml::_('bootstrap.renderModal', 'modalCategory-' . $this->id, array(
 								'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-								'title' => JText::_('COM_CATEGORIES_CHANGE_CATEGORY'),
+								'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
 								'width' => '800px',
 								'height' => '300px',
 								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'


### PR DESCRIPTION
#### Convert a mootool modal in category associations to bootstrap

This seems to be a non ending story with the modals that needs to be converted from mootools to bootstrap!
#### Testing - Preview

You need multilingual setup, latest staging and enabled the Language Filter plugin
Testing: 
Go to Content->Category Manager and select a category (or create a new one)
Got to the 3rd tab `Associations`
There are as many fields as the languages you have installed
Pressing the button `Select` will bring a modal to select any categories you already have from that specific language
Make sure that selecting a category is possible!
Something like this should be the result:

![screen shot 2015-05-18 at 11 13 16](https://cloud.githubusercontent.com/assets/3889375/7689527/a5fc26fc-fdb5-11e4-9edf-9ca8e05d66b5.png)
![screen shot 2015-05-18 at 11 13 24](https://cloud.githubusercontent.com/assets/3889375/7689529/a8dd323a-fdb5-11e4-82cb-5814d84e8111.png)
