### PR TITLE
Regression buttons on the com_banner export track modal doesn't work

### DIFF
--- a/administrator/components/com_banners/views/download/tmpl/default.php
+++ b/administrator/components/com_banners/views/download/tmpl/default.php
@@ -25,8 +25,8 @@ defined('_JEXEC') or die;
 			<?php echo $field->input; ?>
 		<?php endforeach; ?>
 		<div class="clr"></div>
-		<button type="button" class="btn" onclick="this.form.submit();window.top.setTimeout('window.parent.jModalClose()', 700);"><?php echo JText::_('COM_BANNERS_TRACKS_EXPORT'); ?></button>
-		<button type="button" class="btn" onclick="window.parent.jModalClose();"><?php echo JText::_('COM_BANNERS_CANCEL'); ?></button>
+		<button type="button" class="btn" onclick="this.form.submit();window.top.setTimeout('window.parent.jQuery(\'#modal-download\').modal(\'hide\')', 700);"><?php echo JText::_('COM_BANNERS_TRACKS_EXPORT'); ?></button>
+		<button type="button" class="btn" onclick="window.parent.jQuery('#modal-download').modal('hide');"><?php echo JText::_('COM_BANNERS_CANCEL'); ?></button>
 
 	</fieldset>
 </form>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.multiselect');
-JHtml::_('behavior.modal', 'a.modal');
 JHtml::_('formbehavior.chosen', 'select');
 
 $user       = JFactory::getUser();


### PR DESCRIPTION
#### The buttons doesn’t close the modal!

This PR does two things:
1. Remove an unneeded mootools modal call
2. Restores the functionality on the buttons inside the modal
#### Testing

Apply this PR
Goto `administrator/index.php?option=com_banners&view=tracks`
Observe that no mootools are loaded
Press the button export on the toolbar (top right)
press the Export button 
repeat and press the cancel button
Everything should be fine!
