### PR TITLE
Added method getGroupTitle

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -282,7 +282,7 @@ class JAccess
         $query
             ->select('title')
             ->from('#__usergroups')
-            ->where('id = ' . $db->quote($groupid));
+            ->where('id = ' . $db->quote($groupId));
         $db->setQuery($query);
 
         return $db->loadResult();

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -266,28 +266,27 @@ class JAccess
 		return $rules;
 	}
 
-
 	/**
 	 * Method to return the title of a user group
 	 *
-	 * @param   integer  $groupId     Id of the group for which to get the title of.
+	 * @param   integer  $groupId  Id of the group for which to get the title of.
 	 *
-	 * @return  string    the title of the group
+	 * @return  string  Tthe title of the group
+	 *
+	 * @since   3.5
 	 */
 	public static function getGroupTitle($groupId)
 	{
 		// Fetch the group title from the database
-        $db = JFactory::getDbo();
-        $query = $db->getQuery(true);
-        $query
-            ->select('title')
-            ->from('#__usergroups')
-            ->where('id = ' . $db->quote($groupId));
-        $db->setQuery($query);
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true);
+		$query->select('title')
+			->from('#__usergroups')
+			->where('id = ' . $db->quote($groupId));
+		$db->setQuery($query);
 
-        return $db->loadResult();
+		return $db->loadResult();
 	}
-
 
 	/**
 	 * Method to return a list of user groups mapped to a user. The returned list can optionally hold

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -266,6 +266,29 @@ class JAccess
 		return $rules;
 	}
 
+
+	/**
+	 * Method to return the title of a user group
+	 *
+	 * @param   integer  $groupId     Id of the group for which to get the title of.
+	 *
+	 * @return  string    the title of the group
+	 */
+	public static function getGroupTitle($groupId)
+	{
+		// Fetch the group title from the database
+        $db = JFactory::getDbo();
+        $query = $db->getQuery(true);
+        $query
+            ->select('title')
+            ->from('#__usergroups')
+            ->where('id = ' . $db->quote($groupid));
+        $db->setQuery($query);
+
+        return $db->loadResult();
+	}
+
+
 	/**
 	 * Method to return a list of user groups mapped to a user. The returned list can optionally hold
 	 * only the groups explicitly mapped to the user or all groups both explicitly mapped and inherited


### PR DESCRIPTION
Added a helper method for getting the title of a group by its id.

I've not found any method to do this in the Joomla documentation so i put it it.

This example will echo out the title of every group that a user is in:
### Example

``` php
// Get the JUser object of the current user
$user   = JFactory::getUser();

// Get an array of the group id's that the current user is in.
$groups = JAccess::getGroupsByUser($user->id);

// Loop through each group id
foreach ($groups as $groupId) {
    // Print out the title of that group
    echo JAccess::getGroupTitle($groupId);
}

```
