### PR TITLE
Use the Joomla way for bootstrap modals

### DIFF
--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -146,16 +146,18 @@ class JFormFieldModal_Contact extends JFormField
 			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
 			. '</a>';
 
-		$html[] = JHtmlBootstrap::renderModal(
-							'modalContact' . $this->id, array(
-							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-							'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
-							'width' => '800px',
-							'height' => '300px',
-							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						)
-					);
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'modalContact' . $this->id,
+			array(
+				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+				'title' => JText::_('COM_CONTACT_CHANGE_CONTACT'),
+				'width' => '800px',
+				'height' => '300px',
+				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
 
 		// Edit contact button.
 		if ($allowEdit)

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -167,8 +167,10 @@ class JFormFieldModal_Article extends JFormField
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
-		$html[] = JHtmlBootstrap::renderModal(
-			'modalArticle' . $this->id, array(
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'modalArticle' . $this->id,
+			array(
 				'url' => $url,
 				'title' => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
 				'width' => '800px',

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -86,7 +86,7 @@ class JFormFieldMenutype extends JFormFieldList
 			. '<span class="icon-list icon-white"></span> '
 			. JText::_('JSELECT') . '</a></span>';
 		$html[] = JHtml::_(
-			'bootstrap.renderModal'
+			'bootstrap.renderModal',
 			'menuTypeModal',
 			array(
 				'url' => $link,

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -85,17 +85,18 @@ class JFormFieldMenutype extends JFormFieldList
 		$html[] = '<a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="' . JText::_('JSELECT') . '">'
 			. '<span class="icon-list icon-white"></span> '
 			. JText::_('JSELECT') . '</a></span>';
-		$html[] = JHtml::_('bootstrap.renderModal'
-						'menuTypeModal',
-						array(
-							'url' => $link,
-							'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
-							'width' => '800px',
-							'height' => '300px',
-							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						)
-					);
+		$html[] = JHtml::_(
+			'bootstrap.renderModal'
+			'menuTypeModal',
+			array(
+				'url' => $link,
+				'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+				'width' => '800px',
+				'height' => '300px',
+				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
 
 		return implode("\n", $html);

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -85,8 +85,9 @@ class JFormFieldMenutype extends JFormFieldList
 		$html[] = '<a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="' . JText::_('JSELECT') . '">'
 			. '<span class="icon-list icon-white"></span> '
 			. JText::_('JSELECT') . '</a></span>';
-		$html[] = JHtmlBootstrap::renderModal(
-						'menuTypeModal', array(
+		$html[] = JHtml::_('bootstrap.renderModal'
+						'menuTypeModal',
+						array(
 							'url' => $link,
 							'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
 							'width' => '800px',

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -100,19 +100,19 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 					<?php endif; ?>
 				</td>
 			<?php echo JHtml::_(
-							'bootstrap.renderModal',
-							'module' . $module->id . 'Modal',
-							array(
-								'url' => $link,
-								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-								'height' => '300px',
-								'width' => '800px',
-								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-									. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-									. JText::_("JSAVE") . '</button>'
-							)
-						); ?>
+					'bootstrap.renderModal',
+					'module' . $module->id . 'Modal',
+					array(
+						'url' => $link,
+						'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+						'height' => '300px',
+						'width' => '800px',
+						'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+							. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+							. JText::_("JSAVE") . '</button>'
+					)
+				); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -99,7 +99,10 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 						</span>
 					<?php endif; ?>
 				</td>
-			<?php echo JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
+			<?php echo JHtml::_(
+							'bootstrap.renderModal',
+							'module' . $module->id . 'Modal',
+							array(
 								'url' => $link,
 								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 								'height' => '300px',
@@ -108,8 +111,8 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 									. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 									. JText::_("JSAVE") . '</button>'
-								)
-							); ?>
+							)
+						); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -99,9 +99,7 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 						</span>
 					<?php endif; ?>
 				</td>
-			<?php echo JHtmlBootstrap::renderModal(
-							'module' . $module->id . 'Modal',
-							array(
+			<?php echo JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
 								'url' => $link,
 								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 								'height' => '300px',
@@ -110,8 +108,8 @@ echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 									. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 									. JText::_("JSAVE") . '</button>'
-							)
-						); ?>
+								)
+							); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -180,19 +180,21 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 									<?php if ($canEdit) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
-										<?php echo
-							JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
-									'url' => $link,
-									'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-									'height' => '300px',
-									'width' => '800px',
-									'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-										. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-										. JText::_("JSAVE") . '</button>'
-									)
-								);
-										?>
+										<?php echo JHtml::_(
+														'bootstrap.renderModal',
+														'module' . $module->id . 'Modal',
+														array(
+															'url' => $link,
+															'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+															'height' => '300px',
+															'width' => '800px',
+															'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+																. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+																. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
+																. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+																. JText::_("JSAVE") . '</button>'
+														)
+													); ?>
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -181,37 +181,37 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<?php if ($canEdit) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 										<?php echo JHtml::_(
-														'bootstrap.renderModal',
-														'module' . $module->id . 'Modal',
-														array(
-															'url' => $link,
-															'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-															'height' => '300px',
-															'width' => '800px',
-															'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-																. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-																. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
-																. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-																. JText::_("JSAVE") . '</button>'
-														)
-													); ?>
+												'bootstrap.renderModal',
+												'module' . $module->id . 'Modal',
+												array(
+													'url' => $link,
+													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+													'height' => '300px',
+													'width' => '800px',
+													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+														. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
+														. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+														. JText::_("JSAVE") . '</button>'
+												)
+											); ?>
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
 								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
 								<?php echo JHtml::_(
-												'bootstrap.renderModal',
-												'moduleModal',
-												array(
-													'url' => $link,
-													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-													'height' => '500px',
-													'width' => '800px',
-													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-												)
-											); ?>
+										'bootstrap.renderModal',
+										'moduleModal',
+										array(
+											'url' => $link,
+											'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+											'height' => '500px',
+											'width' => '800px',
+											'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+												. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+										)
+									); ?>
 							<?php endif; ?>
 						</td>
 						<td class="center">

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -200,15 +200,18 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							<?php elseif ($modMenuId) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
 								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
-								<?php echo JHtml::_('bootstrap.renderModal', 'moduleModal', array(
+								<?php echo JHtml::_(
+												'bootstrap.renderModal',
+												'moduleModal',
+												array(
 													'url' => $link,
 													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 													'height' => '500px',
 													'width' => '800px',
 													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-														)
-													); ?>
+												)
+											); ?>
 							<?php endif; ?>
 						</td>
 						<td class="center">

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -181,9 +181,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<?php if ($canEdit) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 										<?php echo
-							JHtmlBootstrap::renderModal(
-								'module' . $module->id . 'Modal',
-								array(
+							JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
 									'url' => $link,
 									'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 									'height' => '300px',
@@ -192,15 +190,23 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 										. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 										. JText::_("JSAVE") . '</button>'
-								)
-							);
+									)
+								);
 										?>
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
 								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
-								<?php echo JHtmlBootstrap::renderModal('moduleModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+								<?php echo JHtml::_('bootstrap.renderModal', 'moduleModal', array(
+													'url' => $link,
+													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+													'height' => '500px',
+													'width' => '800px',
+													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+														)
+													); ?>
 							<?php endif; ?>
 						</td>
 						<td class="center">

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -147,16 +147,15 @@ class JFormFieldModal_Newsfeed extends JFormField
 			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
 			. '</a>';
 
-		$html[] = JHtmlBootstrap::renderModal(
-						'modalNewsfeed' . $this->id, array(
+		$html[] = JHtml::_('bootstrap.renderModal', 'modalNewsfeed' . $this->id, array(
 							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
 							'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
 							'width' => '800px',
 							'height' => '300px',
 							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						)
-					);
+								)
+							);
 
 		// Edit newsfeed button
 		if ($allowEdit)

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -147,15 +147,18 @@ class JFormFieldModal_Newsfeed extends JFormField
 			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
 			. '</a>';
 
-		$html[] = JHtml::_('bootstrap.renderModal', 'modalNewsfeed' . $this->id, array(
-							'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-							'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
-							'width' => '800px',
-							'height' => '300px',
-							'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-								)
-							);
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'modalNewsfeed' . $this->id,
+			array(
+				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+				'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
+				'width' => '800px',
+				'height' => '300px',
+				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
 
 		// Edit newsfeed button
 		if ($allowEdit)

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -79,14 +79,17 @@ class JHtmlTemplates
 				$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 					. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
-				$html .= JHtml::_('bootstrap.renderModal', $template . '-Modal', array(
-									'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-									'height' => '500px',
-									'width' => '800px',
-									'footer' => $footer
-									),
-								$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
-							);
+				$html .= JHtml::_(
+					'bootstrap.renderModal',
+					$template . '-Modal',
+					array(
+						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+						'height' => '500px',
+						'width' => '800px',
+						'footer' => $footer
+					),
+					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
+				);
 			}
 		}
 

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -79,15 +79,14 @@ class JHtmlTemplates
 				$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 					. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
-				$html .= JHtmlBootstrap::renderModal(
-					$template . '-Modal', array(
-						'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
-						'height' => '500px',
-						'width' => '800px',
-						'footer' => $footer
-					),
-					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
-				);
+				$html .= JHtml::_('bootstrap.renderModal', $template . '-Modal', array(
+									'title' => JText::_('COM_TEMPLATES_BUTTON_PREVIEW'),
+									'height' => '500px',
+									'width' => '800px',
+									'footer' => $footer
+									),
+								$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
+							);
 			}
 		}
 

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -125,17 +125,20 @@ class JHtmlUsers
 		$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 			. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
-		return JHtml::_('bootstrap.renderModal', 'userModal_' . (int) $userId, array(
-							'title' => $title,
-							'backdrop' => 'static',
-							'keyboard' => true,
-							'closeButton' => true,
-							'footer' => $footer,
-							'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
-							'height' => '300px',
-							'width' => '800px'
-							)
-						);
+		return JHtml::_(
+			'bootstrap.renderModal',
+			'userModal_' . (int) $userId,
+			array(
+				'title' => $title,
+				'backdrop' => 'static',
+				'keyboard' => true,
+				'closeButton' => true,
+				'footer' => $footer,
+				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
+				'height' => '300px',
+				'width' => '800px'
+			)
+		);
 
 	}
 

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -125,18 +125,17 @@ class JHtmlUsers
 		$footer = '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 			. JText::_('JTOOLBAR_CLOSE') . '</a>';
 
-		return JHtmlBootstrap::renderModal(
-			'userModal_' . (int) $userId, array(
-				'title' => $title,
-				'backdrop' => 'static',
-				'keyboard' => true,
-				'closeButton' => true,
-				'footer' => $footer,
-				'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
-				'height' => '300px',
-				'width' => '800px'
-				)
-		);
+		return JHtml::_('bootstrap.renderModal', 'userModal_' . (int) $userId, array(
+							'title' => $title,
+							'backdrop' => 'static',
+							'keyboard' => true,
+							'closeButton' => true,
+							'footer' => $footer,
+							'url' => JRoute::_('index.php?option=com_users&view=notes&tmpl=component&layout=modal&u_id=' . (int) $userId),
+							'height' => '300px',
+							'width' => '800px'
+							)
+						);
 
 	}
 

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -158,34 +158,37 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 						<?php if ($canEdit) : ?>
 							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
 							<?php echo JHtml::_(
-								'bootstrap.renderModal',
-								'module' . $module->id . 'Modal',
-								array(
-									'url' => $link,
-									'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-									'height' => '300px',
-									'width' => '800px',
-									'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-										. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
-										. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-										. JText::_("JSAVE") . '</button>'
-								)
-							); ?>
+									'bootstrap.renderModal',
+									'module' . $module->id . 'Modal',
+									array(
+										'url' => $link,
+										'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+										'height' => '300px',
+										'width' => '800px',
+										'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+											. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+											. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
+											. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+											. JText::_("JSAVE") . '</button>'
+									)
+								); ?>
 						<?php endif; ?>
 					<?php endforeach; ?>
 					<?php elseif ($modMenuId) : ?>
 					<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]='.$item->menutype); ?>">
 						<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
-					<?php echo JHtml::_('bootstrap.renderModal', 'moduleModal', array(
-											'url' => $link,
-											'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-											'height' => '500px',
-											'width' => '800px',
-											'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-												. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-											)
-										); ?>
+					<?php echo JHtml::_(
+							'bootstrap.renderModal',
+							'moduleModal',
+							array(
+								'url' => $link,
+								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+								'height' => '500px',
+								'width' => '800px',
+								'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								)
+						); ?>
 					<?php endif; ?>
 				</td>
 				<td class="center">

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -157,17 +157,21 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 					<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 						<?php if ($canEdit) : ?>
 							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
-							<?php echo JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
-													'url' => $link,
-													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-													'height' => '300px',
-													'width' => '800px',
-													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-														. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-														. JText::_("JSAVE") . '</button>'
-													)
-												); ?>
+							<?php echo JHtml::_(
+								'bootstrap.renderModal',
+								'module' . $module->id . 'Modal',
+								array(
+									'url' => $link,
+									'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+									'height' => '300px',
+									'width' => '800px',
+									'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+										. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+										. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
+										. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+										. JText::_("JSAVE") . '</button>'
+								)
+							); ?>
 						<?php endif; ?>
 					<?php endforeach; ?>
 					<?php elseif ($modMenuId) : ?>

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -157,25 +157,31 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 					<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 						<?php if ($canEdit) : ?>
 							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
-							<?php echo JHtmlBootstrap::renderModal(
-											'module' . $module->id . 'Modal',
-											array(
-												'url' => $link,
-												'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-												'height' => '300px',
-												'width' => '800px',
-												'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-													. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-													. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-													. JText::_("JSAVE") . '</button>'
-											)
-										); ?>
+							<?php echo JHtml::_('bootstrap.renderModal', 'module' . $module->id . 'Modal', array(
+													'url' => $link,
+													'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+													'height' => '300px',
+													'width' => '800px',
+													'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+														. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+														. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+														. JText::_("JSAVE") . '</button>'
+													)
+												); ?>
 						<?php endif; ?>
 					<?php endforeach; ?>
 					<?php elseif ($modMenuId) : ?>
 					<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]='.$item->menutype); ?>">
 						<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
-					<?php echo JHtmlBootstrap::renderModal('moduleModal', array( 'url' => $link, 'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),'height' => '500px', 'width' => '800px'), ''); ?>
+					<?php echo JHtml::_('bootstrap.renderModal', 'moduleModal', array(
+											'url' => $link,
+											'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+											'height' => '500px',
+											'width' => '800px',
+											'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+												. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+											)
+										); ?>
 					<?php endif; ?>
 				</td>
 				<td class="center">


### PR DESCRIPTION
#### Exchange some class names

Most of the PRs that convert the mootools modals to bootstrap use `JHtmlBootstrap::renderModal(etc)`
but they should actually use `JHtml::_('bootstrap.renderModal', etc)`.
And here is how I found out:
Me: JHtmlBootstrap::renderModal( vs JHtml::_('bootstrap.renderModal'
The first one on my IDE with cmd + click on JHtmlBootstrap takes me to the correct file/class but the other takes me to JHtml and cmd + click on 'bootstrap.renderModal' isn’t really helpful as well. So I am a little bit confused here…
@mbabker: JHtml has some code that can let you override the various methods if called via JHtml::_. Direct calling of JHtml (and its subclasses) methods break that functionality. The downside is just as you pointed out, IDE autocompletion is out the window.

So in order to prevent any future conflicts with this code is better to change it ASAP!

Because this is only a rename and some CS work I would like to ask the maintainers to just review and commit. @wilsonge @roland-d ? 
To save other people and not to spent their time here, I provide a proof that all the relative modals still work as before. So:
administrator/components/com_contact/models/fields/modal/contact.php
![screen shot 2015-05-20 at 3 46 56](https://cloud.githubusercontent.com/assets/3889375/7725928/8277e45c-ff07-11e4-94ba-350b120b1f7c.png)

administrator/components/com_content/models/fields/modal/article.php
![screen shot 2015-05-20 at 3 48 26](https://cloud.githubusercontent.com/assets/3889375/7725961/b3cc78a6-ff07-11e4-8909-52d54e6e5fcd.png)

administrator/components/com_menus/models/fields/menutype.php
![screen shot 2015-05-20 at 3 49 12](https://cloud.githubusercontent.com/assets/3889375/7725985/d788e1da-ff07-11e4-8713-c33814f9484f.png)

administrator/components/com_menus/views/item/tmpl/edit_modules.php
![screen shot 2015-05-20 at 3 50 24](https://cloud.githubusercontent.com/assets/3889375/7726024/09eba82e-ff08-11e4-8a79-0360be55a8eb.png)

administrator/templates/hathor/html/com_menus/menus/default.php
![screen shot 2015-05-20 at 3 52 04](https://cloud.githubusercontent.com/assets/3889375/7726069/4501cd4e-ff08-11e4-9cfe-7b3cc20cac50.png)

administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
![screen shot 2015-05-20 at 3 53 37](https://cloud.githubusercontent.com/assets/3889375/7726094/6ebcf762-ff08-11e4-947f-da1e9106676e.png)

administrator/components/com_templates/helpers/html/templates.php
![screen shot 2015-05-20 at 3 55 10](https://cloud.githubusercontent.com/assets/3889375/7726134/ac60c0ee-ff08-11e4-8ffe-b80a34473369.png)

administrator/components/com_users/helpers/html/users.php
![screen shot 2015-05-20 at 3 57 04](https://cloud.githubusercontent.com/assets/3889375/7726183/ef61193e-ff08-11e4-9d88-c54f4a6b8abc.png)

administrator/templates/hathor/html/com_menus/menus/default.php
![screen shot 2015-05-20 at 3 59 04](https://cloud.githubusercontent.com/assets/3889375/7726230/396f07a2-ff09-11e4-8d85-cf0c78a88df5.png)
