### PR TITLE
Use correct element name for file extensions

### DIFF
--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -151,12 +151,10 @@ class JInstallerAdapterFile extends JInstallerAdapter
 	{
 		if (!$element)
 		{
-			// Ensure the element is a string
-			$element = (string) $this->getManifest()->name;
-
-			// Filter the name for illegal characters
-			$element = str_replace('files_', '', JFilterInput::getInstance()->clean($element, 'cmd'));
+			$manifestPath = JPath::clean($this->parent->getPath('manifest'));
+			$element = preg_replace('/\.xml/', '', basename($manifestPath));
 		}
+
 		return $element;
 	}
 


### PR DESCRIPTION
When installing extensions of type `file` their element name (stored in the database) is not chosen correctly. Right now it uses the name of the extension which causes problems when trying to uninstall the extension again.

This pull request changes the installer so that it uses the same approach as for extensions of type `library`: The manifest file name is used for the element name.
#### Test Instructions

Before applying the patch, install the attached test file extension and uninstall it again. This will fail with the message `Files Uninstall: Manifest file invalid or not found.`.
Then, apply the patch and do the same again. This time it will work.

EDIT: Unfortunately, it's not allowed to upload zip archives here, so I'm including the used manifest file here:

```
<?xml version="1.0" encoding="utf-8"?>
<extension type="file" version="3.0" method="upgrade">
  <name>Nice Human Readable Extension 3</name>
  <creationDate>2013/02/11</creationDate>
  <author>JoomGallery::ProjectTeam</author>
  <copyright>This component is released under the GNU/GPL License</copyright>
  <authorEmail>test@test.com</authorEmail>
  <authorUrl>http://test.net</authorUrl>
  <version>1.0 BETA</version>
  <description>Sample description</description>
  <fileset>
    <files target="components/com_content/views">
      <file>test.php</file>
    </files>
  </fileset>
</extension>
```
