### PR TITLE
Batch modals changes

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -192,8 +192,6 @@ if ($saveOrder)
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_BANNERS_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -190,9 +190,9 @@ if ($saveOrder)
 				</tbody>
 			</table>
 			<?php //Load the batch processing form. ?>
-			<?php if ($user->authorise('core.create', 'com_categories')
-				&& $user->authorise('core.edit', 'com_categories')
-				&& $user->authorise('core.edit.state', 'com_categories')) : ?>
+			<?php if ($user->authorise('core.create', $extension)
+				&& $user->authorise('core.edit', $extension)
+				&& $user->authorise('core.edit.state', $extension)) : ?>
 				<?php echo JHtml::_(
 						'bootstrap.renderModal',
 						'collapseModal',

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -189,9 +189,23 @@ if ($saveOrder)
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<?php //Load the batch processing form. ?>
+			<?php if ($user->authorise('core.create', 'com_categories')
+				&& $user->authorise('core.edit', 'com_categories')
+				&& $user->authorise('core.edit.state', 'com_categories')) : ?>
+				<?php echo JHtml::_(
+						'bootstrap.renderModal',
+						'collapseModal',
+						array(
+							'title' => JText::_('COM_CATEGORIES_BATCH_OPTIONS'),
+							'width' => '800px',
+							'height' => '300px',
+							'footer' => $this->loadTemplate('batch_footer')
+						),
+						$this->loadTemplate('batch_body')
+					); ?>
+			<?php endif; ?>
 		<?php endif; ?>
-		<?php //Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
 		<input type="hidden" name="task" value="" />

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -198,8 +198,6 @@ if ($saveOrder)
 						'collapseModal',
 						array(
 							'title' => JText::_('COM_CATEGORIES_BATCH_OPTIONS'),
-							'width' => '800px',
-							'height' => '300px',
 							'footer' => $this->loadTemplate('batch_footer')
 						),
 						$this->loadTemplate('batch_body')

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_categories
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+JHtml::_('formbehavior.chosen', 'select');
+
+$options = array(
+	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
+	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
+);
+$published = $this->state->get('filter.published');
+$extension = $this->escape($this->state->get('filter.extension'));
+?>
+
+<p><?php echo JText::_('COM_CATEGORIES_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div class="span6">
+			<div class="control-group">
+				<label id="batch-choose-action-lbl" for="batch-category-id" class="control-label">
+					<?php echo JText::_('COM_CATEGORIES_BATCH_CATEGORY_LABEL'); ?>
+				</label>
+				<div id="batch-choose-action" class="combo controls">
+					<select name="batch[category_id]" id="batch-category-id">
+						<option value=""><?php echo JText::_('JSELECT') ?></option>
+						<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
+					</select>
+				</div>
+			</div>
+			<div class="control-group radio">
+				<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.tag'); ?>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_footer.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_categories
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('category.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -152,9 +152,10 @@ class CategoriesViewCategories extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', $extension) & $user->authorise('core.edit', $extension) && $user->authorise('core.edit.state', $extension))
+		if ($user->authorise('core.create', $extension)
+			&& $user->authorise('core.edit', $extension)
+			&& $user->authorise('core.edit.state', $extension))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -246,10 +246,23 @@ JFactory::getDocument()->addScriptDeclaration('
 					</tr>
 				</tfoot>
 			</table>
+			<?php //Load the batch processing form. ?>
+			<?php if ($user->authorise('core.create', 'com_contact')
+				&& $user->authorise('core.edit', 'com_contact')
+				&& $user->authorise('core.edit.state', 'com_contact')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_CONTACT_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif; ?>
 		<?php endif;?>
-
-		<?php //Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -255,8 +255,6 @@ JFactory::getDocument()->addScriptDeclaration('
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_CONTACT_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
@@ -36,11 +36,9 @@ $published = $this->state->get('filter.published');
 			<?php echo JHtml::_('batch.tag'); ?>
 		</div>
 	</div>
-	<div class="row-fluid">
-		<div class="control-group">
-			<div class="controls">
-				<?php echo JHtml::_('batch.user'); ?>
-			</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.user'); ?>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_contact
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_CONTACT_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.item', 'com_contact'); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.tag'); ?>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<div class="control-group">
+			<div class="controls">
+				<?php echo JHtml::_('batch.user'); ?>
+			</div>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch_footer.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_contact
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('contact.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -98,7 +98,6 @@ class ContactViewContacts extends JViewLegacy
 			&& $user->authorise('core.edit', 'com_contacts')
 			&& $user->authorise('core.edit.state', 'com_contacts'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -222,8 +222,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_CONTENT_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -213,11 +213,25 @@ $assoc		= JLanguageAssociations::isEnabled();
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif; ?>
+			<?php //Load the batch processing form. ?>
+			<?php if ($user->authorise('core.create', 'com_content')
+				&& $user->authorise('core.edit', 'com_content')
+				&& $user->authorise('core.edit.state', 'com_content')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_CONTENT_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif; ?>
+		<?php endif;?>
 
 		<?php echo $this->pagination->getListFooter(); ?>
-		<?php // Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_content/views/articles/tmpl/default_batch.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_CONTENT_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.item', 'com_content'); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.tag'); ?>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_content/views/articles/tmpl/default_batch_footer.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('contact.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -114,9 +114,11 @@ class ContentViewArticles extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_content') && $user->authorise('core.edit', 'com_content') && $user->authorise('core.edit.state', 'com_content'))
+		if ($user->authorise('core.create', 'com_content')
+			&& $user->authorise('core.edit', 'com_content')
+			&& $user->authorise('core.edit.state', 'com_content'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
+
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -226,11 +226,21 @@ $assoc		= JLanguageAssociations::isEnabled();
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<?php //Load the batch processing form.is user is allowed ?>
+			<?php if ($user->authorise('core.create', 'com_menus') || $user->authorise('core.edit', 'com_menus')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_MENUS_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif;?>
 		<?php endif; ?>
-		<?php //Load the batch processing form.is user is allowed ?>
-		<?php if ($user->authorise('core.create', 'com_menus') || $user->authorise('core.edit', 'com_menus')) : ?>
-			<?php echo $this->loadTemplate('batch'); ?>
-		<?php endif;?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -233,8 +233,6 @@ $assoc		= JLanguageAssociations::isEnabled();
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_MENUS_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_menus
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+$options = array(
+	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
+	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
+);
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_MENUS_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div id="batch-choose-action" class="combo control-group">
+			<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
+				<?php echo JText::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
+			</label>
+			<div class="controls">
+				<select name="batch[menu_id]" id="batch-menu-id">
+					<option value=""><?php echo JText::_('JSELECT') ?></option>
+					<?php echo JHtml::_('select.options', JHtml::_('menu.menuitems', array('published' => $published))); ?>
+				</select>
+			</div>
+		</div>
+		<div id="batch-copy-move" class="control-group radio">
+			<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+		</div>
+	<?php endif; ?>
+</div>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_menus
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -263,9 +263,10 @@ class MenusViewItems extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_menus') && $user->authorise('core.edit', 'com_menus') && $user->authorise('core.edit.state', 'com_menus'))
+		if ($user->authorise('core.create', 'com_menus')
+			&& $user->authorise('core.edit', 'com_menus')
+			&& $user->authorise('core.edit.state', 'com_menus'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -244,8 +244,6 @@ JFactory::getDocument()->addScriptDeclaration('
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_NEWSFEEDS_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -235,10 +235,23 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
-
-		<?php // Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
+			<?php //Load the batch processing form if user is allowed ?>
+			<?php if ($user->authorise('core.create', 'com_newsfeeds')
+				&& $user->authorise('core.edit', 'com_newsfeeds')
+				&& $user->authorise('core.edit.state', 'com_newsfeeds')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_NEWSFEEDS_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_newsfeed
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_NEWSFEEDS_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.item', 'com_newsfeeds'); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.tag'); ?>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_footer.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_newsfeed
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('newsfeed.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -113,7 +113,6 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 			&& $user->authorise('core.edit', 'com_newsfeeds')
 			&& $user->authorise('core.edit.state', 'com_newsfeeds'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -141,13 +141,27 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<?php //Load the batch processing form if user is allowed ?>
+			<?php if ($user->authorise('core.create', 'com_redirect')
+				&& $user->authorise('core.edit', 'com_redirect')
+				&& $user->authorise('core.edit.state', 'com_redirect')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_REDIRECT_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif;?>
 		<?php endif; ?>
 
 		<?php if (!empty($this->items)) : ?>
 			<?php echo $this->loadTemplate('addform'); ?>
 		<?php endif; ?>
-
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -150,8 +150,6 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_REDIRECT_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_redirect
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span12">
+		<div class="controls">
+			<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_redirect
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.id('batch_urls').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('links.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -109,7 +109,6 @@ class RedirectViewLinks extends JViewLegacy
 			// Get the toolbar object instance
 			$bar = JToolBar::getInstance('toolbar');
 
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -227,9 +227,23 @@ JFactory::getDocument()->addScriptDeclaration('
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+			<?php //Load the batch processing form if user is allowed ?>
+			<?php if ($user->authorise('core.create', 'com_tags')
+				&& $user->authorise('core.edit', 'com_tags')
+				&& $user->authorise('core.edit.state', 'com_tags')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_TAGS_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif;?>
 		<?php endif; ?>
-		<?php //Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -236,8 +236,6 @@ JFactory::getDocument()->addScriptDeclaration('
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_TAGS_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch_body.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch_body.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_tags
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+?>
+
+<p><?php echo JText::_('COM_TAGS_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch_footer.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_tags
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('tag.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -110,9 +110,10 @@ class TagsViewTags extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_tags') && $user->authorise('core.edit', 'com_tags') && $user->authorise('core.edit.state', 'com_tags'))
+		if ($user->authorise('core.create', 'com_tags')
+			&& $user->authorise('core.edit', 'com_tags')
+			&& $user->authorise('core.edit.state', 'com_tags'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -164,10 +164,23 @@ $loggeduser = JFactory::getUser();
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<?php //Load the batch processing form if user is allowed ?>
+			<?php if ($loggeduser->authorise('core.create', 'com_users')
+				&& $loggeduser->authorise('core.edit', 'com_users')
+				&& $loggeduser->authorise('core.edit.state', 'com_users')) : ?>
+				<?php echo JHtml::_(
+					'bootstrap.renderModal',
+					'collapseModal',
+					array(
+						'title' => JText::_('COM_USERS_BATCH_OPTIONS'),
+						'width' => '800px',
+						'height' => '300px',
+						'footer' => $this->loadTemplate('batch_footer')
+					),
+					$this->loadTemplate('batch_body')
+				); ?>
+			<?php endif;?>
 		<?php endif; ?>
-
-		<?php //Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -173,8 +173,6 @@ $loggeduser = JFactory::getUser();
 					'collapseModal',
 					array(
 						'title' => JText::_('COM_USERS_BATCH_OPTIONS'),
-						'width' => '800px',
-						'height' => '300px',
 						'footer' => $this->loadTemplate('batch_footer')
 					),
 					$this->loadTemplate('batch_body')

--- a/administrator/components/com_users/views/users/tmpl/default_batch.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_users/views/users/tmpl/default_batch_body.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_body.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+// Create the copy/move options.
+$options = array(
+	JHtml::_('select.option', 'add', JText::_('COM_USERS_BATCH_ADD')),
+	JHtml::_('select.option', 'del', JText::_('COM_USERS_BATCH_DELETE')),
+	JHtml::_('select.option', 'set', JText::_('COM_USERS_BATCH_SET'))
+);
+
+// Create the reset password options.
+$resetOptions = array(
+	JHtml::_('select.option', '', JText::_('COM_USERS_NO_ACTION')),
+	JHtml::_('select.option', 'yes', JText::_('JYES')),
+	JHtml::_('select.option', 'no', JText::_('JNO'))
+);
+JHtml::_('formbehavior.chosen', 'select');
+?>
+
+<div class="row-fluid">
+	<div id="batch-choose-action" class="combo control-group">
+		<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
+			<?php echo JText::_('COM_USERS_BATCH_GROUP') ?>
+		</label>
+	</div>
+	<div id="batch-choose-action" class="combo controls">
+		<div class="control-group">
+			<select name="batch[group_id]" id="batch-group-id">
+				<option value=""><?php echo JText::_('JSELECT') ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
+			</select>
+		</div>
+	</div>
+	<div class="control-group radio">
+		<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add') ?>
+	</div>
+</div>
+<label><?php echo JText::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>
+<div class="control-group radio">
+	<?php echo JHtml::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', '') ?>
+</div>

--- a/administrator/components/com_users/views/users/tmpl/default_batch_footer.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-group-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('user.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -118,9 +118,10 @@ class UsersViewUsers extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_users') && $user->authorise('core.edit', 'com_users') && $user->authorise('core.edit.state', 'com_users'))
+		if ($user->authorise('core.create', 'com_users')
+			&& $user->authorise('core.edit', 'com_users')
+			&& $user->authorise('core.edit.state', 'com_users'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button


### PR DESCRIPTION
#### This is the rest of #7000

What is changed:
1. modals are properly rendered through the API
2. overrides have only the actual content (no hard coded structure)
3. obey to ACL
4. modal is rendered only if items exist
5. process button class from primary to success (color change from blue to green)
#### testing

You need to test the batch functionality for these urls
administrator/index.php?option=com_users&view=users
administrator/index.php?option=com_categories&extension=com_content
administrator/index.php?option=com_content&view=articles
administrator/index.php?option=com_menus&view=items&menutype=mainmenu
administrator/index.php?option=com_contact
administrator/index.php?option=com_newsfeeds
administrator/index.php?option=com_redirect
administrator/index.php?option=com_tags
#### Preview

![screen shot 2015-05-21 at 2 31 47](https://cloud.githubusercontent.com/assets/3889375/7747834/3efcfa1c-ffc7-11e4-90c7-fdab14950c39.png)
![screen shot 2015-05-21 at 2 33 24](https://cloud.githubusercontent.com/assets/3889375/7747835/424974f2-ffc7-11e4-98af-0e2417c8aad8.png)
![screen shot 2015-05-21 at 2 34 16](https://cloud.githubusercontent.com/assets/3889375/7747837/45922bea-ffc7-11e4-9807-e9cace240c74.png)
![screen shot 2015-05-21 at 2 35 02](https://cloud.githubusercontent.com/assets/3889375/7747839/48718fae-ffc7-11e4-9cc7-5e1346a8f8b4.png)
![screen shot 2015-05-21 at 2 36 25](https://cloud.githubusercontent.com/assets/3889375/7747840/4b829f12-ffc7-11e4-99b6-23b6abaeea6e.png)
![screen shot 2015-05-21 at 2 37 07](https://cloud.githubusercontent.com/assets/3889375/7747842/4e375d1a-ffc7-11e4-84ee-1b9184194ff6.png)
![screen shot 2015-05-21 at 2 37 50](https://cloud.githubusercontent.com/assets/3889375/7747843/50e0b05c-ffc7-11e4-9b3b-16ec2144711c.png)
![screen shot 2015-05-21 at 2 38 58](https://cloud.githubusercontent.com/assets/3889375/7747845/541aba9c-ffc7-11e4-94de-7df00f5ef8e4.png)
