### PR TITLE
Problem with edit.state when creating new articles

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -193,10 +193,12 @@ class ContentModelArticle extends JModelAdmin
 		{
 			return $user->authorise('core.edit.state', 'com_content.category.' . (int) $record->catid);
 		}
-		// Default to component settings if neither article nor category known.
 		else
 		{
-			return parent::canEditState('com_content');
+			// If catid is 0 we are displaying the form for a new article.
+			// Changing the state fields shall be possible for that (while saving
+			// the article later on, the correct permissions will be checked again).
+			return true;
 		}
 	}
 
@@ -359,10 +361,8 @@ class ContentModelArticle extends JModelAdmin
 
 		$user = JFactory::getUser();
 
-		// Check for existing article.
 		// Modify the form based on Edit State access controls.
-		if ($id != 0 && (!$user->authorise('core.edit.state', 'com_content.article.' . (int) $id))
-			|| ($id == 0 && !$user->authorise('core.edit.state', 'com_content')))
+		if (!$this->canEditState((object) $data))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('featured', 'disabled', 'true');
@@ -447,6 +447,11 @@ class ContentModelArticle extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 		$filter  = JFilterInput::getInstance();
+
+		if(!isset($data['catid']) || !$data['catid'])
+		{
+			throw new RuntimeException('Category ID not found');
+		}
 
 		if (isset($data['metadata']) && isset($data['metadata']['author']))
 		{

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -448,7 +448,7 @@ class ContentModelArticle extends JModelAdmin
 		$input = JFactory::getApplication()->input;
 		$filter  = JFilterInput::getInstance();
 
-		if(!isset($data['catid']) || !$data['catid'])
+		if (!isset($data['catid']) || !$data['catid'])
 		{
 			throw new RuntimeException('Category ID not found');
 		}

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -127,7 +127,7 @@ JFactory::getDocument()->addScriptDeclaration("
 						<?php echo $this->form->renderField('version_note'); ?>
 					<?php endif; ?>
 					<?php echo $this->form->renderField('created_by_alias'); ?>
-					<?php if ($this->item->params->get('access-change')) : ?>
+					<?php if (!$this->item->id || $this->item->params->get('access-change')) : ?>
 						<?php echo $this->form->renderField('state'); ?>
 						<?php echo $this->form->renderField('featured'); ?>
 						<?php echo $this->form->renderField('publish_up'); ?>


### PR DESCRIPTION
#### Steps to reproduce the issue
1. Create a new user group independent from the others
2. Give this user group login permissions to the frontend
3. Create a new user and assign it to the new user group
4. For one content category assign 'create' and 'edit.state' permissions to the new user group
5. With the new user log into the frontend and create a new article in the category you gave the 'create' and 'edit.state' permissions to.
#### Expected result

The new article is saved and already published because the user has 'edit.state' permissions for the selected category.
#### Actual result

The article is created but it's unpublished.

(That's due to the fact that for new articles Joomla is consulting the root permissions of com_content).
#### System information (as much as possible)

Joomla! 3.4.1
#### Solution

The attached pull request fixes this problem by always displaying the 'state' fields if a new article is created, even though Joomla might later detect that 'edit.state' is not allowed. In the latter case JForm will reset the 'state' fields before saving.

Since this approach assumes that valid articles that are going to be saved always have a category ID, this pull request also fixes the bug of being able to submit an article without a category (by tampering with the HTML in the edit form).
