### PR TITLE
Correcting comment: do not confuse punycode with percent-encoding

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -78,7 +78,7 @@ class JRouterSite extends JRouter
 		}
 
 		// Get the path
-		// Decode URL to convert punycode to unicode so that strings match when routing.
+		// Decode URL to convert percent-encoding to unicode so that strings match when routing.
 		$path = urldecode($uri->getPath());
 
 		// Remove the base URI path.


### PR DESCRIPTION
As title says. The urldecode() method converts percent-encoded characters ( http://en.wikipedia.org/wiki/Percent-encoding ) to utf8.
Punycode is another type of encoding used for the international domains ( http://fr.wikipedia.org/wiki/Punycode ) which we also support in J grace to a special library (idna_convert).

Simple merge. No need testing.
