### PR TITLE
Fix: jQuery Tooltip script error TypeError: JQuery(...).tooltip is not a function #4719

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -377,7 +377,7 @@ abstract class JHtmlBootstrap
 		JFactory::getDocument()->addScriptDeclaration(
 			"jQuery(document).ready(function()
 			{
-				jQuery('" . $selector . "').popover(" . $options . ");
+				if ( jQuery.isFunction(jQuery.fn.popover) ) jQuery('" . $selector . "').popover(" . $options . ");
 			});"
 		);
 
@@ -478,7 +478,7 @@ abstract class JHtmlBootstrap
 			// Build the script.
 			$script = array();
 			$script[] = "jQuery(document).ready(function(){";
-			$script[] = "\tjQuery('" . $selector . "').tooltip(" . $options . ");";
+			$script[] = "\tif ( jQuery.isFunction(jQuery.fn.tooltip) ) jQuery('" . $selector . "').tooltip(" . $options . ");";
 
 			if ($onShow)
 			{


### PR DESCRIPTION
Fix to remove error TypeError: JQuery(...).tooltip is not a function, issue #4719
https://github.com/joomla/joomla-cms/issues/4719

---
#### Steps to reproduce the issue

Installed Joomla v3.3.6 in localhost using XAMPP 1.8.2-5 and without any other component installed you can see an inline javascript file loaded in the head that is calling jQuery tooltip and popover. And that was causing the Error in Firebug Console.

I installed SmartSlider 2 component from http://www.nextendweb.com. I was wondering why their module disappears when I add a new module in any position. When I look at firebug console, I am getting "TypeError: JQuery(...).tooltip is not a function". That error stopped javascript to make nextendweb.com slider module to work.
#### Expected result

jQuery tooltip and popover shouldn't be loaded or called when there is no use for it. 
#### Actual result

![screen shot 2014-10-16 at 22 41 30](http://issues.joomla.org/uploads/1/97c3500f12b1d3558abae3ff7cae9b41.png)
#### System information (as much as possible)
#### Additional comments

Fix is from nextendweb.com support (Gabor Racz):

This error is probably coming from this file: libraries/cms/html/bootstrap.php

Look for this code, it's probably at line 481.:
$script[] = "\t jQuery('" . $selector . "').tooltip(" . $options . ");";

change it to this:
$script[] = "\t if ( jQuery.isFunction(jQuery.fn.tooltip) ) jQuery('" . $selector . "').tooltip(" . $options . ");";

After changing line 481, I then got an error on popover, then around line 380.:
jQuery('" . $selector . "').popover(" . $options . ");

Change like 380 to:
if ( jQuery.isFunction(jQuery.fn.popover) ) jQuery('" . $selector . "').popover(" . $options . ");

The hack nextendweb.com provided worked, their slider module worked fine and I'm not seeing the javascript error anymore.
