### PR TITLE
Rename the install app JHtml helper

### DIFF
--- a/installation/controller/default.php
+++ b/installation/controller/default.php
@@ -93,9 +93,6 @@ class InstallationControllerDefault extends JControllerBase
 			$this->setRedirect('index.php');
 		}
 
-		// Include the component HTML helpers.
-		JHtml::addIncludePath(JPATH_COMPONENT . '/helper/html');
-
 		// Register the layout paths for the view
 		$paths = new SplPriorityQueue;
 		$paths->insert(JPATH_INSTALLATION . '/view/' . $vName . '/tmpl', 'normal');

--- a/installation/html/helper.php
+++ b/installation/html/helper.php
@@ -11,10 +11,9 @@ defined('_JEXEC') or die;
 /**
  * HTML utility class for the installation application
  *
- * @package  Joomla.Installation
- * @since    1.6
+ * @since  1.6
  */
-class JHtmlInstallation
+class InstallationHtmlHelper
 {
 	/**
 	 * Method to generate the side bar.

--- a/installation/view/database/tmpl/default.php
+++ b/installation/view/database/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('installation.stepbar'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
 	<div class="btn-toolbar">
 		<div class="btn-group pull-right">

--- a/installation/view/defaultlanguage/tmpl/default.php
+++ b/installation/view/defaultlanguage/tmpl/default.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<?php echo JHtml::_('installation.stepbarlanguages'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbarlanguages'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
 	<div class="btn-toolbar">
 		<div class="btn-group pull-right">

--- a/installation/view/ftp/tmpl/default.php
+++ b/installation/view/ftp/tmpl/default.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('installation.stepbar'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
 	<div class="btn-toolbar">
 		<div class="btn-group pull-right">

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -23,7 +23,7 @@ $version = new JVersion;
 	}
 </script>
 
-<?php echo JHtml::_('installation.stepbarlanguages'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbarlanguages'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
 	<div class="btn-toolbar">
 		<div class="btn-group pull-right">

--- a/installation/view/site/tmpl/default.php
+++ b/installation/view/site/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('installation.stepbar'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
 <div class="btn-toolbar">
 	<div class="btn-group pull-right">
 		<a href="#" class="btn btn-primary" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNext'); ?>"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('JNext'); ?></a>

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -16,7 +16,7 @@ $path = JPATH_CONFIGURATION . '/configuration.php';
 $useftp = (file_exists($path)) ? !is_writable($path) : !is_writable(JPATH_CONFIGURATION . '/');
 $prev = $useftp ? 'ftp' : 'database';
 ?>
-<?php echo JHtml::_('installation.stepbar'); ?>
+<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
 	<div class="btn-toolbar">
 		<div class="btn-group pull-right">


### PR DESCRIPTION
### The Proposal

To demonstrate a feature of `JHtml::_()`, I'm suggesting to rename the JHtml helper class in the install app to demonstrate how that method can use a three part key.
### Details

`JHtml::_()` calls `JHtml::extract()` to turn the key supplied in the `_` method's first argument into a class and method name.  A standard two part key like `bootstrap.modal` will try to locate and call `JHtmlBootstrap::modal()`.  A three part key like my proposed `installationhtml.helper.stepbar` will try to locate and call `InstallationHtmlHelper::stepbar()`.  When three keys exist, the first key is used as the class name prefix (defaults to `JHtml` if not provided).
### Why Make This Change?

There are a lot of features in JHtml that aren't well documented or used.  By trying to demonstrate some of those features in the core code, we can show developers the advanced use cases of its internal API.
### How to Test

Apply the patch and run the installer.  Should still have a stepbar and no errors.
