### PR TITLE
Unterminated statement

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -232,7 +232,7 @@ class JFormFieldMedia extends JFormField
 			$script[] = '				$("#" + id + "_preview_empty").hide();';
 			$script[] = '				$("#" + id + "_preview_img").show()';
 			$script[] = '			} else { ';
-			$script[] = '				$img.attr("src", "")';
+			$script[] = '				$img.attr("src", "");';
 			$script[] = '				$("#" + id + "_preview_empty").show();';
 			$script[] = '				$("#" + id + "_preview_img").hide();';
 			$script[] = '			} ';


### PR DESCRIPTION
While line-breaks may be used instead of semicolons to terminate JavaScript statements, some coding styles prefer the semicolon for consistency with the other languages.
