### PR TITLE
$associations was implicitly converted to boolean

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -390,7 +390,7 @@ class ContentModelArticle extends JModelAdmin
 			$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
 
 			// Make fields read only
-			if ($associations)
+			if (!empty($associations))
 			{
 				$form->setFieldAttribute('language', 'readonly', 'true');
 				$form->setFieldAttribute('catid', 'readonly', 'true');


### PR DESCRIPTION
Best Practice fix: The expression $associations of type array is implicitly converted to a boolean; using `!empty($expr)` instead to make it clear that we intend to check for an array without elements.
