### PR TITLE
Declare visibility for method _getUserDisplayedGroups

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -423,7 +423,7 @@ class UsersModelUsers extends JModelList
 	 *
 	 * @return  string   Groups titles imploded :$
 	 */
-	function _getUserDisplayedGroups($user_id)
+	public function _getUserDisplayedGroups($user_id)
 	{
 		$db    = JFactory::getDbo();
 		$query = "SELECT title FROM " . $db->quoteName('#__usergroups') . " ug left join " .

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -423,7 +423,7 @@ class UsersModelUsers extends JModelList
 	 *
 	 * @return  string   Groups titles imploded :$
 	 */
-	public function _getUserDisplayedGroups($user_id)
+	protected function _getUserDisplayedGroups($user_id)
 	{
 		$db    = JFactory::getDbo();
 		$query = "SELECT title FROM " . $db->quoteName('#__usergroups') . " ug left join " .


### PR DESCRIPTION
Best Practices fix: It is generally recommended to explicitly declare the visibility for methods.
Assuming public for method `_getUserDisplayedGroups`
