### PR TITLE
Added "getVar" method to JInput phpdoc

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -35,6 +35,9 @@ defined('JPATH_PLATFORM') or die;
  * @method      string   getHtml()      getHtml($name, $default = null)
  * @method      string   getPath()      getPath($name, $default = null)
  * @method      string   getUsername()  getUsername($name, $default = null)
+ * @method      string   getVar()       getVar($name, $default = null)       This method will act like getString. If the
+ *                                                                           input is an array it will return an array
+ *                                                                           of fully decoded and sanitised strings.
  */
 class JInput implements Serializable, Countable
 {


### PR DESCRIPTION
`JInput::getVar` method is using in two places.

See the search result here:
https://github.com/joomla/joomla-cms/search?utf8=%E2%9C%93&q=%22input-%3EgetVar%22&type=Code

But there is no document related to `JInput::getVar` method. I think it is good to place the document in `JInput`.
