### PR TITLE
There is no var filter in JInput

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -596,7 +596,7 @@ class ModulesModelModule extends JModelAdmin
 			$filters = (array) $app->getUserState('com_modules.modules.filter');
 			$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
 			$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
-			$data->set('language', $app->input->getVar('language', (isset($filters['language']) ? $filters['language'] : null)));
+			$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
 			$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
 
 			// This allows us to inject parameter settings into a new module.


### PR DESCRIPTION
REF: https://github.com/joomla/joomla-cms/pull/7037

There is no var filter in JInput - we should be using a string filter for the language.
## Testing Instructions

Select a language in list view of com_modules. Then create a new module. See the language is preselected in the new module instance (for detailed testing instructions you can look in the screenshots of this issue: https://github.com/joomla/joomla-cms/pull/6977 but note that you only need to test the language field for this PR)
