### PR TITLE
Properly output unicode characters.

### DIFF
--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -115,6 +115,9 @@ class JResponseJson
 	 */
 	public function __toString()
 	{
+		if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+			return json_encode($this, JSON_UNESCAPED_UNICODE);
+		}
 		return json_encode($this);
 	}
 }

--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -119,7 +119,6 @@ class JResponseJson
 		{
 			return json_encode($this, JSON_UNESCAPED_UNICODE);
 		}
-		
 		return json_encode($this);
 	}
 }

--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -115,7 +115,7 @@ class JResponseJson
 	 */
 	public function __toString()
 	{
-		if (version_compare(PHP_VERSION, '5.4.0', '>=')) 
+		if (version_compare(PHP_VERSION, '5.4.0', '>='))
 		{
 			return json_encode($this, JSON_UNESCAPED_UNICODE);
 		}

--- a/libraries/cms/response/json.php
+++ b/libraries/cms/response/json.php
@@ -115,9 +115,11 @@ class JResponseJson
 	 */
 	public function __toString()
 	{
-		if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+		if (version_compare(PHP_VERSION, '5.4.0', '>=')) 
+		{
 			return json_encode($this, JSON_UNESCAPED_UNICODE);
 		}
+		
 		return json_encode($this);
 	}
 }


### PR DESCRIPTION
Added a check for the PHP (>= 5.4) version and `JSON_UNESCAPED_UNICODE` to the `return json_encode` statement of the`__toString` method to display the unicode characters properly.

This addition is mostly suggested for the sake of convenience when the output is read by a **human** to check the `json` formatting and see how the data is displayed. 

It's not only about strings containing a few instances of unicode characters; the "real issue" occurs when the response contains _mostly_ unicode characters like cyrillic or greek. 
For example the following is a nightmare to be read by a human and check the data:

```
json_encode('йцукенгшщзхъ');
// "\u0439\u0446\u0443\u043a\u0435\u043d\u0433\u0448\u0449\u0437\u0445\u044a"

json_encode('ασδφγηξκλμνψω');
// "\u03b1\u03c3\u03b4\u03c6\u03b3\u03b7\u03be\u03ba\u03bb\u03bc\u03bd\u03c8\u03c9"
```

After the addition suggested the characters are displayed in a human friendly form and it is easier to read them.
