### PR TITLE
Issue when a content language is unpublished/deleted

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -266,7 +266,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				else
 				{
 					// We check for an existing language cookie
-					$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+					$lang_code = $this->getLanguageCookie();
 				}
 
 				if (!$lang_code && $this->params->get('detect_browser', 0) == 1)
@@ -300,9 +300,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					&& $lang_code == $this->default_lang)
 				{
 					// Create a cookie.
-					$cookie_domain = $this->app->get('cookie_domain');
-					$cookie_path   = $this->app->get('cookie_path', '/');
-					$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					$this->setLanguageCookie($lang_code);
 
 					$found = false;
 					array_shift($parts);
@@ -337,7 +335,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (!isset($lang_code))
 			{
-				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+				$lang_code = $this->getLanguageCookie();
 			}
 
 			if ($this->params->get('detect_browser', 1) && !$lang_code)
@@ -374,7 +372,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 				// Either we detected the language via the browser or we got it from the cookie. In worst case
 				// we fall back to the application setting
-				$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'), $lang_code);
+				$lang_code = $this->getLanguageCookie();
 			}
 
 			if ($this->mode_sef)
@@ -423,11 +421,9 @@ class PlgSystemLanguageFilter extends JPlugin
 		}
 
 		// Create a cookie.
-		if ($this->app->input->cookie->getString(JApplicationHelper::getHash('language')) != $lang_code)
+		if ($this->getLanguageCookie() != $lang_code)
 		{
-			$cookie_domain = $this->app->get('cookie_domain');
-			$cookie_path   = $this->app->get('cookie_path', '/');
-			$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+			$this->setLanguageCookie($lang_code);
 		}
 
 		return $array;
@@ -504,9 +500,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					);
 
 					// Create a cookie.
-					$cookie_domain 	= $this->app->get('cookie_domain', '');
-					$cookie_path 	= $this->app->get('cookie_path', '/');
-					setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+					$this->setLanguageCookie($lang_code);
 				}
 			}
 		}
@@ -589,9 +583,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				$this->current_lang = $lang_code;
 
 				// Create a cookie.
-				$cookie_domain	= $this->app->get('cookie_domain', '');
-				$cookie_path	= $this->app->get('cookie_path', '/');
-				setcookie(JApplicationHelper::getHash('language'), $lang_code, $this->getLangCookieTime(), $cookie_path, $cookie_domain);
+				$this->setLanguageCookie($lang_code);
 
 				// Change the language code.
 				JFactory::getLanguage()->setLanguage($lang_code);
@@ -705,23 +697,53 @@ class PlgSystemLanguageFilter extends JPlugin
 	}
 
 	/**
-	 * Get the language cookie settings.
+	 * Set the language cookie
 	 *
-	 * @return  string  The cookie time.
+	 * @param   string   $lang_code   The language code for which we want to set the cookie
 	 *
-	 * @since   3.0.4
+	 * @return  void
+	 *
+	 * @since   3.4.2
 	 */
-	private function getLangCookieTime()
+	public function setLanguageCookie($lang_code)
 	{
+
+		// Get the cookie lifetime we want.
+		$cookie_time = 0;
 		if ($this->params->get('lang_cookie', 1) == 1)
 		{
-			$lang_cookie = time() + 365 * 86400;
-		}
-		else
-		{
-			$lang_cookie = 0;
+			$cookie_time = time() + 365 * 86400;
 		}
 
-		return $lang_cookie;
+		// Let's be sure we set a valid language cookie. Falls back setting the cookie for the default language.
+		if (!array_key_exists($lang_code, $this->lang_codes))
+		{
+			$lang_code = $this->default_lang;
+		}
+
+		// Create a cookie.
+		$cookie_domain = $this->app->get('cookie_domain');
+		$cookie_path   = $this->app->get('cookie_path', '/');
+		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_time, $cookie_path, $cookie_domain);
 	}
+
+	/**
+	 * Get the language cookie
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4.2
+	 */
+	public function getLanguageCookie()
+	{
+		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+		// Let's be sure we got a valid language code. Falls back returning the default language.
+		if (!array_key_exists($lang_code, $this->lang_codes))
+		{
+			$lang_code = $this->default_lang;
+		}
+		return $lang_code;
+	}
+
 }

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -699,13 +699,13 @@ class PlgSystemLanguageFilter extends JPlugin
 	/**
 	 * Set the language cookie
 	 *
-	 * @param   string   $lang_code   The language code for which we want to set the cookie
+	 * @param   string  $lang_code  The language code for which we want to set the cookie
 	 *
 	 * @return  void
 	 *
 	 * @since   3.4.2
 	 */
-	public function setLanguageCookie($lang_code)
+	private function setLanguageCookie($lang_code)
 	{
 
 		// Get the cookie lifetime we want.
@@ -713,12 +713,6 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->params->get('lang_cookie', 1) == 1)
 		{
 			$cookie_time = time() + 365 * 86400;
-		}
-
-		// Let's be sure we set a valid language cookie. Falls back setting the cookie for the default language.
-		if (!array_key_exists($lang_code, $this->lang_codes))
-		{
-			$lang_code = $this->default_lang;
 		}
 
 		// Create a cookie.
@@ -734,7 +728,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @since   3.4.2
 	 */
-	public function getLanguageCookie()
+	private function getLanguageCookie()
 	{
 		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 


### PR DESCRIPTION
#### Steps to reproduce the issue
- have a site with at least three content languages published (eg. en-GB, fr-FR, it-IT)
- in Language filter have the cookie lifetime set to one year
- in front-end switch to one of the two non-default languages (e.g., it-IT)
- exit the browser
- unpublish the content language to which you had previously switched (e.g. it-IT)
- visit the naked domain (i.e: no language code specified)
#### Expected result

As you have a language cookie for a now unpublished language you should be routed to the default language
#### Actual result

an invalid redirection occours
![cookie issue](https://cloud.githubusercontent.com/assets/552475/7861139/8ffe88a4-054e-11e5-95fa-920a4a8bc058.PNG)
#### Additional comments

Apply this patch and the behavior will be as expected

I took the occasion to factor-in some code and create two new ~~public~~ private methods: `setLanguageCookie()` and `getLanguageCookie()`
