### PR TITLE
Deprecate getCurrentLanguage() methods

### DIFF
--- a/components/com_tags/models/tags.php
+++ b/components/com_tags/models/tags.php
@@ -148,7 +148,7 @@ class TagsModelTags extends JModelList
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JFactory::getLanguage()->getTag();
 			}
 
 			$query->where($db->quoteName('language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -128,6 +128,7 @@ class JHelperContent
 	 * Gets the current language
 	 *
 	 * @param   boolean  $detectBrowser  Flag indicating whether to use the browser language as a fallback.
+	 *                                   Starting with Joomla! 3.4.2 this parameter is ignored.
 	 *
 	 * @return  string  The language string
 	 *
@@ -136,23 +137,7 @@ class JHelperContent
 	 */
 	public static function getCurrentLanguage($detectBrowser = true)
 	{
-		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
-
-		// No cookie - let's try to detect browser language or use site default
-		if (!$langCode)
-		{
-			if ($detectBrowser)
-			{
-				$langCode = JLanguageHelper::detectLanguage();
-			}
-			else
-			{
-				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
-			}
-		}
-
-		return $langCode;
+		return JFactory::getLanguage()->getTag();
 	}
 
 	/**

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -136,7 +136,7 @@ class JHelperContent
 	 *
 	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
-	public static function getCurrentLanguage($detectBrowser = true)
+	public static function getCurrentLanguage($detectBrowser)
 	{
 		return JFactory::getLanguage()->getTag();
 	}

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -133,7 +133,8 @@ class JHelperContent
 	 * @return  string  The language string
 	 *
 	 * @since   3.1
-	 * @note    JHelper::getCurrentLanguage is the preferred method
+	 *
+	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
 	public static function getCurrentLanguage($detectBrowser = true)
 	{

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -136,7 +136,7 @@ class JHelperContent
 	 *
 	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
-	public static function getCurrentLanguage($detectBrowser)
+	public static function getCurrentLanguage($detectBrowser = null)
 	{
 		return JFactory::getLanguage()->getTag();
 	}

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -25,6 +25,8 @@ class JHelper
 	 * @return  string  The language string
 	 *
 	 * @since   3.2
+	 *
+	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
 	public function getCurrentLanguage($detectBrowser = true)
 	{

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -28,7 +28,7 @@ class JHelper
 	 *
 	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
-	public function getCurrentLanguage($detectBrowser = true)
+	public function getCurrentLanguage($detectBrowser)
 	{
 		return JFactory::getLanguage()->getTag();
 	}

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -20,6 +20,7 @@ class JHelper
 	 * Gets the current language
 	 *
 	 * @param   boolean  $detectBrowser  Flag indicating whether to use the browser language as a fallback.
+	 *                                   Starting with Joomla! 3.4.2 this parameter is ignored.
 	 *
 	 * @return  string  The language string
 	 *
@@ -27,23 +28,7 @@ class JHelper
 	 */
 	public function getCurrentLanguage($detectBrowser = true)
 	{
-		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
-
-		// No cookie - let's try to detect browser language or use site default
-		if (!$langCode)
-		{
-			if ($detectBrowser)
-			{
-				$langCode = JLanguageHelper::detectLanguage();
-			}
-			else
-			{
-				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
-			}
-		}
-
-		return $langCode;
+		return JFactory::getLanguage()->getTag();
 	}
 
 	/**

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -28,7 +28,7 @@ class JHelper
 	 *
 	 * @deprecated  4.0  Use JFactory::getLanguage()->getTag() instead
 	 */
-	public function getCurrentLanguage($detectBrowser)
+	public function getCurrentLanguage($detectBrowser = null)
 	{
 		return JFactory::getLanguage()->getTag();
 	}

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -409,7 +409,7 @@ class JHelperTags extends JHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = $this->getCurrentLanguage();
+				$language = JFactory::getLanguage()->getTag();
 			}
 
 			$query->where($db->quoteName('language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');
@@ -586,7 +586,7 @@ class JHelperTags extends JHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = $this->getCurrentLanguage();
+				$language = JFactory::getLanguage()->getTag();
 			}
 
 			$query->where($db->quoteName('c.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -69,7 +69,7 @@ abstract class ModTagsPopularHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JFactory::getLanguage()->getTag();
 			}
 
 			$query->where($db->quoteName('t.language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -105,7 +105,7 @@ abstract class ModTagssimilarHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JFactory::getLanguage()->getTag();
 			}
 
 			$query->where($db->quoteName('cc.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');


### PR DESCRIPTION
#### Description

There is no apparent issue involved, but two getCurrentLanguage() methods were using _questionable_ code.

This PR greatly simplify that code (by making the two methods proxies to the _official_ way to get the currently active language) and make it more robust

The methods are deprecated too, and any reference to them has been substituted with the correct (already existing) method.
#### Steps to test

To test that there is no regression:
- have a multilingual site
- create some tags and assign them to the different languages and to the "All" languages
- assign those tags to some different articles in different languages (consistently and also inconsistently to the article's language)
- publish a "Tags - Popular" module on "All pages" and for all languages. Set the "Display Number of Items" option to "Yes"
- in Tags component options, under "Item Selection Options" select "Language filter: Current"

The reason to use "Tags" to test this PR is that the two involved methods are used by com_tags only (AFAIK...)
#### Expected result

With or without this patch the displayed tags, the number of items for each tag, and the available items under each tag should be the same
#### Additional comments

If you assigned tags in an inconsistent way (i.e. a "French" tag to an "English" article) and also if you assigned tags flagged as "All languages" to specific language articles, the displayed **number** of items for each tag will not match the number of items available under that tag for a particular language, **but this is a separate issue** and that behavior too will not be affected by this patch.

_Thanks @bakual for suggesting the usage of `JFactory::getLanguage()->getTag()` to get the currently active language._
