### PR TITLE
Regression: module edit pre-select position field does not check for existing module [fix: #7056]

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -593,11 +593,14 @@ class ModulesModelModule extends JModelAdmin
 			$data = $this->getItem();
 
 			// Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
-			$filters = (array) $app->getUserState('com_modules.modules.filter');
-			$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
-			$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
-			$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-			$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+			if ($data->id == null)
+			{
+				$filters = (array) $app->getUserState('com_modules.modules.filter');
+				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
+				$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
+				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+			}
 
 			// This allows us to inject parameter settings into a new module.
 			$params = $app->getUserState('com_modules.add.module.params');

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -593,7 +593,7 @@ class ModulesModelModule extends JModelAdmin
 			$data = $this->getItem();
 
 			// Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
-			if ($data->id == null)
+			if (!$data->id)
 			{
 				$filters = (array) $app->getUserState('com_modules.modules.filter');
 				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));


### PR DESCRIPTION
See
https://github.com/joomla/joomla-cms/issues/7056

When editing an existing module, the fields are set back to Null.
When using filters and the module is new the fields are filled by the filters settings but, once the module is saved once, go back to null.

Checking for an existing id was missing in https://github.com/joomla/joomla-cms/pull/6977
