### PR TITLE
Fix for #7044: use secure cookie on HTTPS servers

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -709,16 +709,17 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 
 		// Get the cookie lifetime we want.
-		$cookie_time = 0;
+		$cookie_expire = 0;
 		if ($this->params->get('lang_cookie', 1) == 1)
 		{
-			$cookie_time = time() + 365 * 86400;
+			$cookie_expire = time() + 365 * 86400;
 		}
 
 		// Create a cookie.
 		$cookie_domain = $this->app->get('cookie_domain');
 		$cookie_path   = $this->app->get('cookie_path', '/');
-		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_time, $cookie_path, $cookie_domain, $this->app->isSSLConnection());
+		$cookie_secure = $this->app->isSSLConnection();
+		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_expire, $cookie_path, $cookie_domain, $cookie_secure);
 	}
 
 	/**

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -718,7 +718,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		// Create a cookie.
 		$cookie_domain = $this->app->get('cookie_domain');
 		$cookie_path   = $this->app->get('cookie_path', '/');
-		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_time, $cookie_path, $cookie_domain);
+		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_time, $cookie_path, $cookie_domain, $this->app->isSSLConnection());
 	}
 
 	/**


### PR DESCRIPTION
#### Description

This should fix #7044 by using a secure cookie when the server is an HTTPS server.
#### Test instructions
- verify that there is no regression on normal servers by using  a multilingual site, switchnig to a non-default language, exiting the browser, re-visiting the test site with the naked domain and observing that you are redirected to the non-default language you had previously selected.
- observe how the language cookie is delivered on HTTPS servers
