### PR TITLE
Restructure JErrorPage to support PHP 7 exceptions

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -19,69 +19,89 @@ class JErrorPage
 	/**
 	 * Render the error page based on an exception.
 	 *
-	 * @param   Exception  $error  The exception for which to render the error page.
+	 * @param   object  $error  An Exception or BaseException (PHP 7+) object for which to render the error page.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public static function render(Exception $error)
+	public static function render($error)
 	{
-		try
+		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'BaseException' : 'Exception';
+		$isException   = $error instanceof $expectedClass;
+
+		// In PHP 5, the $error object should be an instance of Exception; PHP 7 should be a BaseException
+		if ($isException)
 		{
-			$app      = JFactory::getApplication();
-			$document = JDocument::getInstance('error');
-
-			if (!$document)
+			try
 			{
-				// We're probably in an CLI environment
-				jexit($error->getMessage());
+				$app      = JFactory::getApplication();
+				$document = JDocument::getInstance('error');
+
+				if (!$document)
+				{
+					// We're probably in an CLI environment
+					jexit($error->getMessage());
+				}
+
+				// Get the current template from the application
+				$template = $app->getTemplate();
+
+				// Push the error object into the document
+				$document->setError($error);
+
+				if (ob_get_contents())
+				{
+					ob_end_clean();
+				}
+
+				$document->setTitle(JText::_('Error') . ': ' . $error->getCode());
+
+				$data = $document->render(
+					false,
+					array(
+						'template'  => $template,
+						'directory' => JPATH_THEMES,
+						'debug'     => JDEBUG
+					)
+				);
+
+				// Do not allow cache
+				$app->allowCache(false);
+
+				// If nothing was rendered, just use the message from the Exception
+				if (empty($data))
+				{
+					$data = $error->getMessage();
+				}
+
+				$app->setBody($data);
+
+				echo $app->toString();
+
+				return;
 			}
-
-			// Get the current template from the application
-			$template = $app->getTemplate();
-
-			// Push the error object into the document
-			$document->setError($error);
-
-			if (ob_get_contents())
+			catch (Exception $e)
 			{
-				ob_end_clean();
+				// Pass the error down
 			}
-
-			$document->setTitle(JText::_('Error') . ': ' . $error->getCode());
-
-			$data = $document->render(
-				false,
-				array(
-					'template'  => $template,
-					'directory' => JPATH_THEMES,
-					'debug'     => JDEBUG
-				)
-			);
-
-			// Do not allow cache
-			$app->allowCache(false);
-
-			// If nothing was rendered, just use the message from the Exception
-			if (empty($data))
-			{
-				$data = $error->getMessage();
-			}
-
-			$app->setBody($data);
-
-			echo $app->toString();
 		}
-		catch (Exception $e)
+
+		// This isn't an Exception, we can't handle it.
+		if (!headers_sent())
 		{
-			// Try to set a 500 header if they haven't already been sent
-			if (!headers_sent())
-			{
-				header('HTTP/1.1 500 Internal Server Error');
-			}
-
-			jexit('Error displaying the error page: ' . $e->getMessage() . ': ' . $error->getMessage());
+			header('HTTP/1.1 500 Internal Server Error');
 		}
+
+		$message = 'Error displaying the error page';
+
+		if ($isException)
+		{
+			$message .= ': ' . $e->getMessage() . ': ' . $error->getMessage();
+		}
+
+		echo $message;
+
+		jexit(1);
 	}
 }

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -53,16 +53,16 @@ class JDocumentError extends JDocument
 	 */
 	public function setError($error)
 	{
-		if ($error instanceof Exception)
+		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'BaseException' : 'Exception';
+
+		if ($error instanceof $expectedClass)
 		{
 			$this->_error = & $error;
 
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -606,21 +606,25 @@ abstract class JLoader
 	}
 }
 
-/**
- * Global application exit.
- *
- * This function provides a single exit point for the platform.
- *
- * @param   mixed  $message  Exit code or string. Defaults to zero.
- *
- * @return  void
- *
- * @codeCoverageIgnore
- * @since   11.1
- */
-function jexit($message = 0)
+// Check if jexit is defined first (our unit tests mock this)
+if (!function_exists('jexit'))
 {
-	exit($message);
+	/**
+	 * Global application exit.
+	 *
+	 * This function provides a single exit point for the platform.
+	 *
+	 * @param   mixed  $message  Exit code or string. Defaults to zero.
+	 *
+	 * @return  void
+	 *
+	 * @codeCoverageIgnore
+	 * @since   11.1
+	 */
+	function jexit($message = 0)
+	{
+		exit($message);
+	}
 }
 
 /**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -12,6 +12,18 @@
  * @link        http://www.phpunit.de/manual/current/en/installation.html
  */
 
+/**
+ * Mock for the global application exit.
+ *
+ * @param   mixed  $message  Exit code or string. Defaults to zero.
+ *
+ * @return  void
+ */
+function jexit($message = 0)
+{
+	return;
+}
+
 define('_JEXEC', 1);
 
 // Fix magic quotes.
@@ -99,12 +111,6 @@ require_once JPATH_PLATFORM . '/import.legacy.php';
 
 // Bootstrap the CMS libraries.
 require_once JPATH_LIBRARIES . '/cms.php';
-
-// For PHP 7, unset the exception handler
-if (PHP_MAJOR_VERSION >= 7)
-{
-	restore_exception_handler();
-}
 
 // Register the core Joomla test classes.
 JLoader::registerPrefix('Test', __DIR__ . '/core');

--- a/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
+++ b/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
@@ -52,4 +52,44 @@ class JErrorPageTest extends TestCaseDatabase
 		// Validate the <title> element was set correctly
 		$this->assertContains('<title>500 - Testing JErrorPage::render()</title>', $output);
 	}
+
+	/**
+	 * @covers  JErrorPage::render
+	 */
+	public function testEnsureTheErrorPageIsCorrectlyRenderedWithEngineExceptions()
+	{
+		// Only test for PHP 7+
+		if (PHP_MAJOR_VERSION < 7)
+		{
+			$this->markTestSkipped('Test only applies to PHP 7+');
+		}
+
+		// Create an Exception to inject into the method
+		$exception = new EngineException('Testing JErrorPage::render()', 500);
+
+		// The render method echoes the output, so catch it in a buffer
+		ob_start();
+		JErrorPage::render($exception);
+		$output = ob_get_clean();
+
+		// Validate the <title> element was set correctly
+		$this->assertContains('Testing JErrorPage::render()', $output);
+	}
+
+	/**
+	 * @covers  JErrorPage::render
+	 */
+	public function testEnsureTheRenderMethodCorrectlyHandlesNonExceptionClasses()
+	{
+		// Create an object to inject into the method
+		$object = new stdClass;
+
+		// The render method echoes the output, so catch it in a buffer
+		ob_start();
+		JErrorPage::render($object);
+		$output = ob_get_clean();
+
+		// Validate the <title> element was set correctly
+		$this->assertContains('Error displaying the error page', $output);
+	}
 }


### PR DESCRIPTION
This PR restructures JErrorPage, the class that is used as our global Exception handler, to support PHP 7.  Specific changes:
- Remove the typehinting for the render method
- Test internal to the method for an Exception (PHP 5) or BaseException (PHP 7)
- Add support to JDocumentError for the same
- Wrap jexit in a function_exists check so that it can be mocked in our PHPUnit suite
- Add unit tests to verify the PHP 7 behavior and the method's functionality when a non-Exception object is passed in

//cc @wilsonge
