### PR TITLE
setRedirect does not exist in InstallationControllerDefault

### DIFF
--- a/installation/controller/default.php
+++ b/installation/controller/default.php
@@ -90,7 +90,7 @@ class InstallationControllerDefault extends JControllerBase
 
 		if ($vName != $default_view && ($checkOptions && empty($options)))
 		{
-			$this->setRedirect('index.php');
+			$app->redirect('index.php');
 		}
 
 		// Include the component HTML helpers.


### PR DESCRIPTION
There's a method call that doesn't exist in the InstallationControllerDefault class.  This PR adjusts it to something that does.
