### PR TITLE
[3.5-dev] Lets the name lowercase as all other core extensions

### DIFF
--- a/plugins/system/updatenotification/updatenotification.xml
+++ b/plugins/system/updatenotification/updatenotification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.5" type="plugin" group="system" method="upgrade">
-	<name>PLG_SYSTEM_UPDATENOTIFICATION</name>
+	<name>plg_system_updatenotification</name>
 	<author>Joomla! Project</author>
 	<creationDate>May 2015</creationDate>
 	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>


### PR DESCRIPTION
This PR only lowercase the name of the new Plugin as we have it for all other extensions in the core too :smile: 
