### PR TITLE
Use correct string in the redirect plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_redirect.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_redirect.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_REDIRECT_XML_DESCRIPTION="The system redirect plugin enables the Joomla Redirect system to catch missing pages and redirect users."
 PLG_SYSTEM_REDIRECT="System - Redirect"
 PLG_SYSTEM_REDIRECT_FIELD_COLLECT_URLS_DESC="This option controls the collection of URLs. This is useful to avoid unnecessary load on the database."
 PLG_SYSTEM_REDIRECT_FIELD_COLLECT_URLS_LABEL="Collect URLs"
+PLG_SYSTEM_REDIRECT_XML_DESCRIPTION="The system redirect plugin enables the Joomla Redirect system to catch missing pages and redirect users."

--- a/plugins/system/redirect/redirect.xml
+++ b/plugins/system/redirect/redirect.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
-	<description>PLG_REDIRECT_XML_DESCRIPTION</description>
+	<description>PLG_SYSTEM_REDIRECT_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="redirect">redirect.php</filename>
 		<filename>index.html</filename>


### PR DESCRIPTION
This is just a PR to let this plugin follow our language string standards.
