### PR TITLE
Code review: JLanguageMultilang::isEnabled()

### DIFF
--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -32,17 +32,6 @@ class JLanguageMultilang
 		// Status of language filter plugin.
 		static $enabled = false;
 
-		// Get application object.
-		$app = JFactory::getApplication();
-
-		// If being called from the front-end, we can avoid the database query.
-		if ($app->isSite())
-		{
-			$enabled = $app->getLanguageFilter();
-
-			return $enabled;
-		}
-
 		// If already tested, don't test again.
 		if (!$tested)
 		{


### PR DESCRIPTION
#### Description

By removing the dependency on `JFactory::getApplication()` we will be able to efficiently use this method in the application initialization phase (e.g. see #6309)

After all, at least one hit on the database will always be required, directly or indirectly, so I think it is just better to do it here and then rely on the `static $enabled` variable.
#### Test instructions

Multilingual and non-multilingual sites should behave as before.
