### PR TITLE
Allowing readmore in each editor on the same page

### DIFF
--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -37,7 +37,7 @@ class PlgButtonReadmore extends JPlugin
 
 		// Button is not active in specific content components
 
-		$getContent = $this->_subject->getContent($name);
+		$getContent = $this->_subject->getContent("'+editor+'");
 		$present = JText::_('PLG_READMORE_ALREADY_EXISTS', true);
 		$js = "
 			function insertReadmore(editor)


### PR DESCRIPTION
Quick workaround to allow multiple editor instances on the same page to have a readmore break.
Without this workaround, only one of the editors was allowed to have a readmore break.
