### PR TITLE
Password: Fix for Firefox as autocomplete=off does not work [fix for #7054]

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -38,7 +38,7 @@ $fieldsets = $this->form->getFieldsets();
 		<div class="control-group">
 			<div class="control-label"><?php echo $field->label; ?></div>
 			<div class="controls">
-				<?php if ($field->name = 'password') : ?>
+				<?php if ($field->getAttribute('name') == 'password2') : ?>
 					<!-- disables autocomplete --><input type="text" style="display:none">
 				<?php endif; ?>
 				<?php echo $field->input; ?>

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -38,8 +38,8 @@ $fieldsets = $this->form->getFieldsets();
 		<div class="control-group">
 			<div class="control-label"><?php echo $field->label; ?></div>
 			<div class="controls">
-				<?php if ($field->getAttribute('name') == 'password2') : ?>
-					<!-- disables autocomplete --><input type="text" style="display:none">
+				<?php if ($field->fieldname == 'password2') : ?>
+					<?php // Disables autocomplete ?> <input type="text" style="display:none">
 				<?php endif; ?>
 				<?php echo $field->input; ?>
 			</div>

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -37,7 +37,12 @@ $fieldsets = $this->form->getFieldsets();
 	<?php foreach ($this->form->getFieldset('user_details') as $field) : ?>
 		<div class="control-group">
 			<div class="control-label"><?php echo $field->label; ?></div>
-			<div class="controls"><?php echo $field->input; ?></div>
+			<div class="controls">
+				<?php if ($field->name = 'password') : ?>
+					<!-- disables autocomplete --><input type="text" style="display:none">
+				<?php endif; ?>
+				<?php echo $field->input; ?>
+			</div>
 		</div>
 	<?php endforeach; ?>
 	<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -59,8 +59,8 @@ $fieldsets = $this->form->getFieldsets();
 							<?php echo $field->label; ?>
 						</div>
 						<div class="controls">
-							<?php if ($field->getAttribute('name') == 'password') : ?>
-								<!-- disables autocomplete --><input type="text" style="display:none">
+							<?php if ($field->fieldname == 'password') : ?>
+								<?php // Disables autocomplete ?> <input type="text" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -59,7 +59,7 @@ $fieldsets = $this->form->getFieldsets();
 							<?php echo $field->label; ?>
 						</div>
 						<div class="controls">
-							<?php if ($field->name = 'password') : ?>
+							<?php if ($field->getAttribute('name') == 'password') : ?>
 								<!-- disables autocomplete --><input type="text" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -59,6 +59,9 @@ $fieldsets = $this->form->getFieldsets();
 							<?php echo $field->label; ?>
 						</div>
 						<div class="controls">
+							<?php if ($field->name = 'password') : ?>
+								<!-- disables autocomplete --><input type="text" style="display:none">
+							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>
 					</div>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -69,7 +69,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 							<?php endif; ?>
 						</div>
 						<div class="controls">
-							<?php if ($field->name = 'password1') : ?>
+							<?php if ($field->getAttribute('name') == 'password1') : ?>
 								<!-- disables autocomplete --><input type="text" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -69,6 +69,9 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 							<?php endif; ?>
 						</div>
 						<div class="controls">
+							<?php if ($field->name = 'password1') : ?>
+								<!-- disables autocomplete --><input type="text" style="display:none">
+							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>
 					</div>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -69,8 +69,8 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 							<?php endif; ?>
 						</div>
 						<div class="controls">
-							<?php if ($field->getAttribute('name') == 'password1') : ?>
-								<!-- disables autocomplete --><input type="text" style="display:none">
+							<?php if ($field->fieldname == 'password1') : ?>
+								<?php // Disables autocomplete ?> <input type="text" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>


### PR DESCRIPTION
This fixes https://github.com/joomla/joomla-cms/issues/7054

The password field is filled even when it is only optional thus forcing to enter a value in the Confirm Password field. As this is not expected by the user, the error "Invalid field: Confirm Password" displays.

To test:
3 instances:
1. Edit a user (editing yourself as superuser) through User Manager.
2. Editing your own profile in back-end
3.Editing your own profile in front-end

In these 3 cases, you will see that the password field contains a value.

Patch and retest, then save any user parameter without touching at the passwords fields. Now should be OK.
