### PR TITLE
Use correct string in the redirect plugin also the sys ini file. See #7089

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_redirect.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_redirect.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_REDIRECT_XML_DESCRIPTION="The system redirect plugin enables the Joomla Redirect system to catch missing pages and redirect users."
 PLG_SYSTEM_REDIRECT="System - Redirect"
+PLG_SYSTEM_REDIRECT_XML_DESCRIPTION="The system redirect plugin enables the Joomla Redirect system to catch missing pages and redirect users."


### PR DESCRIPTION
See: https://github.com/joomla/joomla-cms/commit/1f68dd3fe39910612cf0c0a52a4a36870cef49fd there I just missed the sys.ini file. @Bakual 
