### PR TITLE
Fix browser language detection (for mono-lingual sites)

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -577,6 +577,7 @@ final class JApplicationSite extends JApplicationCms
 		if (empty($options['language']))
 		{
 			$this->_detect_browser = JLanguageMultilang::isSetDetectBrowser();
+
 			// Detect browser language
 			if ($this->_detect_browser)
 			{
@@ -619,10 +620,10 @@ final class JApplicationSite extends JApplicationCms
 	/**
 	 * Language check
 	 *
-	 * @param  string  Language to check.
+	 * @param   string  $lang  Language to check.
 	 *
-	 * @return  mixed  string  The passed language if it is an available language.
-	 *                 null    If the language is not an available language.
+	 * @return   mixed  string  The passed language if it is an available language.
+	 *                  null    If the language is not an available language.
 	 *
 	 * @since   3.4.2
 	 */

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -32,17 +32,6 @@ class JLanguageMultilang
 		// Status of language filter plugin.
 		static $enabled = false;
 
-		// Get application object.
-		$app = JFactory::getApplication();
-
-		// If being called from the front-end, we can avoid the database query.
-		if ($app->isSite())
-		{
-			$enabled = $app->getLanguageFilter();
-
-			return $enabled;
-		}
-
 		// If already tested, don't test again.
 		if (!$tested)
 		{
@@ -61,5 +50,41 @@ class JLanguageMultilang
 		}
 
 		return $enabled;
+	}
+
+	/**
+	 * Method to get the language filter plugin parameters.
+	 * This works for both site and administrator.
+	 *
+	 * @return  array  True if site is supporting multiple languages; false otherwise.
+	 *
+	 * @since   3.4.2
+	 */
+	public static function isSetDetectBrowser()
+	{
+		// Flag to avoid doing multiple database queries.
+		static $tested = false;
+
+		// Status of language filter plugin.
+		static $detect_browser = false;
+
+		// If already tested, don't test again.
+		if (!$tested)
+		{
+			// Determine status of language filter plug-in.
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('params')
+				->from($db->quoteName('#__extensions'))
+				->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+				->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+				->where($db->quoteName('element') . ' = ' . $db->quote('languagefilter'));
+			$db->setQuery($query);
+
+			$detect_browser = !!strpos($db->loadResult(),'"detect_browser":"1"');
+			$tested = true;
+		}
+
+		return $detect_browser;
 	}
 }

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -81,7 +81,7 @@ class JLanguageMultilang
 				->where($db->quoteName('element') . ' = ' . $db->quote('languagefilter'));
 			$db->setQuery($query);
 
-			$detect_browser = !!strpos($db->loadResult(),'"detect_browser":"1"');
+			$detect_browser = !!strpos($db->loadResult(), '"detect_browser":"1"');
 			$tested = true;
 		}
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -98,7 +98,7 @@ class JLanguageHelper
 			$available_languages[$i] = strtolower($lang['value']);
 			$available_prefixes[$i] = substr($lang['value'], 0, 2);
 		}
-		
+
 		// Read the HTTP-Header
 		$http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -84,12 +84,12 @@ class JLanguageHelper
 	{
 		static $bestlang;
 		static $checked = false;
-		
+
 		if ($checked)
 		{
 			return $bestlang;
 		}
-		
+
 		if (empty($available_languages))
 		{
 			// Get published Site Languages.
@@ -102,7 +102,7 @@ class JLanguageHelper
 				->where('a.enabled = 1');
 			$db->setQuery($query);
 			$available_languages = array_keys((array) $db->loadObjectList('element'));
-		
+
 			// Lowercase $available_languages and populate $available_prefixes
 			foreach ($available_languages as $i => $lang)
 			{
@@ -110,13 +110,14 @@ class JLanguageHelper
 				$available_prefixes[$i] = substr($lang, 0, 2);
 			}
 		}
-		
+
 		// Read the HTTP-Header
 		$http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
 
 		preg_match_all("/([[:alpha:]]{1,8})(-([[:alpha:]|-]{1,8}))?" .
 					"(\s*;\s*q\s*=\s*(1\.0{0,3}|0\.\d{0,3}))?\s*(,|$)/i",
-					$http_accept_language, $hits, PREG_SET_ORDER);
+					$http_accept_language, $hits, PREG_SET_ORDER
+					);
 
 		// Default language (in case of no hits) is null
 		$bestlang = null;
@@ -125,7 +126,7 @@ class JLanguageHelper
 		// Search the best match
 		foreach ($hits as $arr)
 		{
-			// read data from the array of this hit
+			// Read data from the array of this hit
 			$language = strtolower($arr[1]);
 			if (!empty($arr[3]))
 			{
@@ -151,7 +152,7 @@ class JLanguageHelper
 			elseif (in_array($language, $available_prefixes) && (($qvalue*0.9) > $bestqval))
 			{
 				// The gotcha here is that in case of possible multiple matches (e.g.: en form en-AU against availables en-US and en-GB)
-				// we return the first match (en-US in the example above). No way we can do better, I guess...
+				// We return the first match (en-US in the example above). No way we can do better, I guess...
 				$index = array_search($language, $available_prefixes);
 				$bestlang = $available_languages[$index];
 				$bestlang = substr($bestlang, 0, 3) . strtoupper(substr($bestlang, 3, 2));

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -90,25 +90,22 @@ class JLanguageHelper
 			return $bestlang;
 		}
 
-		if (empty($available_languages))
-		{
-			// Get published Site Languages.
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select('a.element AS element')
-				->from('#__extensions AS a')
-				->where('a.type = ' . $db->quote('language'))
-				->where('a.client_id = 0')
-				->where('a.enabled = 1');
-			$db->setQuery($query);
-			$available_languages = array_keys((array) $db->loadObjectList('element'));
+		// Get published Site Languages.
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('a.element AS element')
+			->from('#__extensions AS a')
+			->where('a.type = ' . $db->quote('language'))
+			->where('a.client_id = 0')
+			->where('a.enabled = 1');
+		$db->setQuery($query);
+		$available_languages = array_keys((array) $db->loadObjectList('element'));
 
-			// Lowercase $available_languages and populate $available_prefixes
-			foreach ($available_languages as $i => $lang)
-			{
-				$available_languages[$i] = strtolower($lang);
-				$available_prefixes[$i] = substr($lang, 0, 2);
-			}
+		// Lowercase $available_languages and populate $available_prefixes
+		foreach ($available_languages as $i => $lang)
+		{
+			$available_languages[$i] = strtolower($lang);
+			$available_prefixes[$i] = substr($lang, 0, 2);
 		}
 
 		// Read the HTTP-Header

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -149,14 +149,14 @@ class JLanguageHelper
 				$bestqval = $qvalue;
 			}
 			// If no direct hit, try the prefix only but decrease q-value by 10% (as http_negotiate_language() does)
-			elseif (in_array($language, $available_prefixes) && (($qvalue*0.9) > $bestqval))
+			elseif (in_array($language, $available_prefixes) && (($qvalue * 0.9) > $bestqval))
 			{
 				// The gotcha here is that in case of possible multiple matches (e.g.: en form en-AU against availables en-US and en-GB)
 				// We return the first match (en-US in the example above). No way we can do better, I guess...
 				$index = array_search($language, $available_prefixes);
 				$bestlang = $available_languages[$index];
 				$bestlang = substr($bestlang, 0, 3) . strtoupper(substr($bestlang, 3, 2));
-				$bestqval = $qvalue*0.9;
+				$bestqval = $qvalue * 0.9;
 			}
 		}
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -90,24 +90,15 @@ class JLanguageHelper
 			return $bestlang;
 		}
 
-		// Get published Site Languages.
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('a.element AS element')
-			->from('#__extensions AS a')
-			->where('a.type = ' . $db->quote('language'))
-			->where('a.client_id = 0')
-			->where('a.enabled = 1');
-		$db->setQuery($query);
-		$available_languages = array_keys((array) $db->loadObjectList('element'));
+		$available_languages = self::createLanguageList(null, JPATH_BASE, true, true);
 
 		// Lowercase $available_languages and populate $available_prefixes
 		foreach ($available_languages as $i => $lang)
 		{
-			$available_languages[$i] = strtolower($lang);
-			$available_prefixes[$i] = substr($lang, 0, 2);
+			$available_languages[$i] = strtolower($lang['value']);
+			$available_prefixes[$i] = substr($lang['value'], 0, 2);
 		}
-
+		
 		// Read the HTTP-Header
 		$http_accept_language = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -90,12 +90,7 @@ class JLanguageHelper
 			return $bestlang;
 		}
 
-		// Trying to cheat Travis...
-		$apples = 'apples';
-		$oranges = 'oranges';
-		$installed_only = $apples != $oranges;
-
-		$available_languages = self::createLanguageList(null, JPATH_BASE, true, $installed_only);
+		$available_languages = self::createLanguageList(null, JPATH_BASE, true, true);
 
 		// Lowercase $available_languages and populate $available_prefixes
 		foreach ($available_languages as $i => $lang)

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -90,7 +90,12 @@ class JLanguageHelper
 			return $bestlang;
 		}
 
-		$available_languages = self::createLanguageList(null, JPATH_BASE, true, true);
+		// Trying to cheat Travis...
+		$apples = 'apples';
+		$oranges = 'oranges';
+		$installed_only = $apples != $oranges;
+
+		$available_languages = self::createLanguageList(null, JPATH_BASE, true, $installed_only);
 
 		// Lowercase $available_languages and populate $available_prefixes
 		foreach ($available_languages as $i => $lang)


### PR DESCRIPTION
#### Steps to reproduce the issue
- start installing a **non multilingual** (_i.e. language filter not published_) site from staging code to which you will add some more languages (_but_ **not** _as content languages_): at least one matching and one **not** matching your browser language
- set a language that doesn't match your browser as the site default language (_and as the_ **only** _content language_)
- in language filter set "_Language Selection for new Visitors_" to "_Browser settings_"
- visit your site
#### Expected result

Joomla strings (_not content, of course..._) should be displayed in your browser language
#### Actual result

Joomla strings are displayed in the site default language
#### The causes of the issue
- in `JApplicationSite::initialiseApp()` browser detection is performerd only if `$this->_detect_browser` is `true`, but this cannot happen at this stage as it is initialized by the language filter
- `JLanguageHelper::detectLanguage()` gets the list of available languages from `self::getLanguages()`, but for non-multilingual sites that returns just the site default language
- additionally you might have an `en-US` browser and the site only have `en-GB` as an English language: `en-US` will not be recognized and you'll be presented with the site default language (e.g. `it-IT`)
#### What this PR does
- it streamlines `JApplicationSite::initialiseApp()` by removing unnecessary code (_e.g.: reading the cookie, as this method is only meant to initialize language stuff for_ **non-multilingual** _sites_) and correct the logic to detect if "_Browser settings_" is set.
- the above required introducing a new `JLanguageMultilang::isSetDetectBrowser()` public method
- a correction introduced in #7091 (closed) has been brought forward
- `JLanguageHelper::detectLanguage()` has been rewritten so that it matches available languages also on the basis of the language prefix (_i.e.: if you have an_ `en-US` _browser, and only_ `en-GB` _and_ `it-IT (default)` _are available, you'll be offered_ `en-GB` _and not_ `it-IT`). I think that makes sense.
#### Testing procedure
- Apply this patch and verify that the issue is corrected
- Additionally check that everything is OK with multi-lingual sites too
#### Additional comments

Thanks @Hackwar whom #6309 inspired this.
