### PR TITLE
Undefined $model passed to postDeleteHook

### DIFF
--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -135,9 +135,10 @@ class JControllerAdmin extends JControllerLegacy
 			{
 				$this->setMessage($model->getError(), 'error');
 			}
+
+			// Invoke the postDelete method to allow for the child class to access the model.
+			$this->postDeleteHook($model, $cid);
 		}
-		// Invoke the postDelete method to allow for the child class to access the model.
-		$this->postDeleteHook($model, $cid);
 
 		$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 	}


### PR DESCRIPTION
Post delete hook called with $model not defined in context. Without calling delete method at all, the call to this hook is also pointless.
