### PR TITLE
Override module chrome with a plugin

### DIFF
--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -79,7 +79,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 		$templates = array_merge($templates, $this->getTemplates());
 		$plugins = $app->triggerEvent('onGetModuleStyles');
 
-		foreach($templates as $template)
+		foreach ($templates as $template)
 		{
 			$moduleFilePaths[$template->element] = JPATH_SITE . '/templates/' . $template->element . '/html/modules.php';
 		}
@@ -94,7 +94,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 				}
 				elseif (is_array($plugin))
 				{
-					foreach($plugin as $p)
+					foreach ($plugin as $p)
 					{
 						$moduleFilePaths[$p->element] = $p->path;
 					}

--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -77,26 +77,23 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 
 		$templates = array($this->getSystemTemplate());
 		$templates = array_merge($templates, $this->getTemplates());
-		$plugins = $app->triggerEvent('onGetModuleStyles');
+		$events = $app->triggerEvent('onGetModuleChromes');
 
 		foreach ($templates as $template)
 		{
 			$moduleFilePaths[$template->element] = JPATH_SITE . '/templates/' . $template->element . '/html/modules.php';
 		}
 
-		if (!empty($plugins))
+		if (!empty($events))
 		{
-			foreach ($plugins as $plugin)
+			foreach ($events as $event)
 			{
-				if (is_object($plugin))
+				// Returned a keyed array with "element" and "path"
+				if (is_array($event) && array_key_exists('element', $event) && array_key_exists('path', $event))
 				{
-					$moduleFilePaths[$plugin->element] = $plugin->path;
-				}
-				elseif (is_array($plugin))
-				{
-					foreach ($plugin as $p)
+					if (is_string($event['path']))
 					{
-						$moduleFilePaths[$p->element] = $p->path;
+						$moduleFilePaths[$event['element']] = $event['path'];
 					}
 				}
 			}
@@ -104,12 +101,11 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 
 		foreach ($moduleFilePaths as $key => $moduleFilePath)
 		{
-			// Is there modules.php for that template?
-			if (file_exists($modulesFilePath))
+			if (file_exists($moduleFilePath))
 			{
-				$modulesFileData = file_get_contents($modulesFilePath);
+				$moduleFileData = file_get_contents($moduleFilePath);
 
-				preg_match_all('/function[\s\t]*modChrome\_([a-z0-9\-\_]*)[\s\t]*\(/i', $modulesFileData, $styles);
+				preg_match_all('/function[\s\t]*modChrome\_([a-z0-9\-\_]*)[\s\t]*\(/i', $moduleFileData, $styles);
 
 				if (!array_key_exists($key, $moduleStyles))
 				{

--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -71,15 +71,39 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 	 */
 	protected function getTemplateModuleStyles()
 	{
+		$app = JFactory::getApplication();
 		$moduleStyles = array();
+		$moduleFilePaths = array();
 
 		$templates = array($this->getSystemTemplate());
 		$templates = array_merge($templates, $this->getTemplates());
+		$plugins = $app->triggerEvent('onGetModuleStyles');
 
-		foreach ($templates as $template)
+		foreach($templates as $template)
 		{
-			$modulesFilePath = JPATH_SITE . '/templates/' . $template->element . '/html/modules.php';
+			$moduleFilePaths[$template->element] = JPATH_SITE . '/templates/' . $template->element . '/html/modules.php';
+		}
 
+		if (!empty($plugins))
+		{
+			foreach ($plugins as $plugin)
+			{
+				if (is_object($plugin))
+				{
+					$moduleFilePaths[$plugin->element] = $plugin->path;
+				}
+				elseif (is_array($plugin))
+				{
+					foreach($plugin as $p)
+					{
+						$moduleFilePaths[$p->element] = $p->path;
+					}
+				}
+			}
+		}
+
+		foreach ($moduleFilePaths as $key => $moduleFilePath)
+		{
 			// Is there modules.php for that template?
 			if (file_exists($modulesFilePath))
 			{
@@ -87,12 +111,12 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 
 				preg_match_all('/function[\s\t]*modChrome\_([a-z0-9\-\_]*)[\s\t]*\(/i', $modulesFileData, $styles);
 
-				if (!array_key_exists($template->element, $moduleStyles))
+				if (!array_key_exists($key, $moduleStyles))
 				{
-					$moduleStyles[$template->element] = array();
+					$moduleStyles[$key] = array();
 				}
 
-				$moduleStyles[$template->element] = $styles[1];
+				$moduleStyles[$key] = $styles[1];
 			}
 		}
 

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -308,12 +308,12 @@ abstract class JModuleHelper
 		{
 			return $pPath;
 		}
-		
+
 		if (file_exists($bPath))
 		{
 			return $bPath;
 		}
-		
+
 		return $dPath;
 	}
 

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -297,13 +297,13 @@ abstract class JModuleHelper
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
-		// If a plugin has a layout override use it
-		// ElseIf the template has a layout override use it
+		// If a template has a layout override use it
 		if (file_exists($tPath))
 		{
 			return $tPath;
 		}
-		
+
+		// If the plugin has a layout override use it
 		if (file_exists($pPath))
 		{
 			return $pPath;

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -291,12 +291,18 @@ abstract class JModuleHelper
 		}
 
 		// Build the template and base path for the layout
+		$pPath = $app->triggerEvent('onGetModuleLayoutPath', array($module, $layout));
 		$tPath = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
-		// If the template has a layout override use it
-		if (file_exists($tPath))
+		// If a plugin has a layout override use it
+		// ElseIf the template has a layout override use it
+		if(file_exists($pPath))
+		{
+			return $pPath;
+		}
+		elseif(file_exists($tPath))
 		{
 			return $tPath;
 		}

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -278,42 +278,43 @@ abstract class JModuleHelper
 	 */
 	public static function getLayoutPath($module, $layout = 'default')
 	{
-		$template = JFactory::getApplication()->getTemplate();
+		$app           = JFactory::getApplication();
+		$template      = $app->getTemplate();
 		$defaultLayout = $layout;
 
 		if (strpos($layout, ':') !== false)
 		{
 			// Get the template and file name from the string
-			$temp = explode(':', $layout);
-			$template = ($temp[0] == '_') ? $template : $temp[0];
-			$layout = $temp[1];
+			$temp          = explode(':', $layout);
+			$template      = ($temp[0] == '_') ? $template : $temp[0];
+			$layout        = $temp[1];
 			$defaultLayout = ($temp[1]) ? $temp[1] : 'default';
 		}
 
 		// Build the template and base path for the layout
-		$pPath = $app->triggerEvent('onGetModuleLayoutPath', array($module, $layout));
 		$tPath = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
+		$pPath = $app->triggerEvent('onGetModuleLayoutPath', array($module, $layout));
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
 		// If a plugin has a layout override use it
 		// ElseIf the template has a layout override use it
-		if(file_exists($pPath))
-		{
-			return $pPath;
-		}
-		elseif(file_exists($tPath))
+		if (file_exists($tPath))
 		{
 			return $tPath;
 		}
-		elseif (file_exists($bPath))
+		
+		if (file_exists($pPath))
+		{
+			return $pPath;
+		}
+		
+		if (file_exists($bPath))
 		{
 			return $bPath;
 		}
-		else
-		{
-			return $dPath;
-		}
+		
+		return $dPath;
 	}
 
 	/**

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -284,8 +284,7 @@ abstract class JModuleHelper
 	 */
 	public static function getLayoutPath($module, $layout = 'default')
 	{
-		$app           = JFactory::getApplication();
-		$template      = $app->getTemplate();
+		$template      = JFactory::getApplication()->getTemplate();
 		$defaultLayout = $layout;
 		$layoutPaths   = array();
 

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -200,9 +200,26 @@ abstract class JModuleHelper
 
 		// Load system chromes and active template chromes
 		$chromePaths = array(JPATH_THEMES . '/system/html/modules.php', JPATH_THEMES . '/' . $template . '/html/modules.php');
+		$elements = array('system', $template);
 
 		// Load chromes from plugins
-		$chromePaths = array_merge($chromePaths, $app->triggerEvent('onGetModuleChromePaths'));
+		$events = $app->triggerEvent('onGetModuleChromes');
+
+		if (!empty($events))
+		{
+			foreach ($events as $event)
+			{
+				// Returned a keyed array with "element" and "path"
+				if (is_array($event) && array_key_exists('element', $event) && array_key_exists('path', $event))
+				{
+					if (is_string($event['path']))
+					{
+							$chromePaths[] = $event['path'];
+							$elements[] = $event['element'];
+					}
+				}
+			}
+		}
 
 		foreach ($chromePaths as $chromePath)
 		{
@@ -222,7 +239,8 @@ abstract class JModuleHelper
 
 		if ($paramsChromeStyle)
 		{
-			$attribs['style'] = preg_replace('/^(system|' . $template . ')\-/i', '', $paramsChromeStyle);
+			$elements = implode('|', $elements);
+			$attribs['style'] = preg_replace('/^(' . $elements . ')\-/i', '', $paramsChromeStyle);
 		}
 
 		// Make sure a style is set

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -202,7 +202,7 @@ abstract class JModuleHelper
 		$chromePaths = array(JPATH_THEMES . '/system/html/modules.php', JPATH_THEMES . '/' . $template . '/html/modules.php');
 
 		// Load chromes from plugins
-		$chromePaths = array_merge($chromePaths, $app->triggerEvent('onGetModuleChromes'));
+		$chromePaths = array_merge($chromePaths, $app->triggerEvent('onGetModuleChromePaths'));
 
 		foreach ($chromePaths as $chromePath)
 		{
@@ -302,7 +302,7 @@ abstract class JModuleHelper
 		$layoutPaths[] = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
 
 		// Add plugin layout
-		$layoutPaths[] = $app->triggerEvent('onGetModuleLayoutPath', array($module, $layout));
+		$layoutPaths[] = $app->triggerEvent('onGetModuleLayoutPaths', array($module, $layout));
 
 		// Add standard layouts
 		$layoutPaths[] = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -298,13 +298,8 @@ abstract class JModuleHelper
 			$defaultLayout = ($temp[1]) ? $temp[1] : 'default';
 		}
 
-		// Add template layout - highest priority
+		// Add layout paths in priority order
 		$layoutPaths[] = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
-
-		// Add plugin layout
-		$layoutPaths[] = $app->triggerEvent('onGetModuleLayoutPaths', array($module, $layout));
-
-		// Add standard layouts
 		$layoutPaths[] = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$layoutPaths[] = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 


### PR DESCRIPTION
#### Purpose

Template providers often ship the same module chromes with every template. It is much more convenient to manage one file and ship a plugin or a plugin + library that could register these module chromes.

Unfortunately a popular template framework provider already implements this concept by overriding
the core file /libraries/cms/module/helper.php with their framework initialization plugin for the purposes of adding their own triggerEvent.
#### How it works

A plugin that executes on the **onGetModuleChromes** must return an array with keys **element** (friendly name for their list of module chromes) and **path** (path to file containing module chrome definitions)
#### Testing
1. Install Joomla (sample data not necessary)
2. [Upload plugin folders to /plugins/system](https://github.com/jrseliga/module-chrome-plugins) 
3. Discover / Enable plugins **modulechromesone** and **modulechromestwo**
4. Navigate to front-end notice the "Login Form" module
   ![default-install](https://cloud.githubusercontent.com/assets/3277067/8049245/bc724da0-0e2a-11e5-966c-2700b522c0d0.png)
5. Module Manager
   - Login Form
     1. Advanced tab
     2. Module Style
        - Scroll to bottom, will see two new grouped lists **Plugin One** and **Plugin Two**
          ![module-style](https://cloud.githubusercontent.com/assets/3277067/8049249/c522ed10-0e2a-11e5-8b4f-0a4e052cc833.png)
   - Choose any from either of these groups
   - Refresh front-end, the name of the module chrome function used will be displayed in place of the log in form.![one](https://cloud.githubusercontent.com/assets/3277067/8049264/f90ebaf0-0e2a-11e5-915a-0175693a933f.png)
   - Repeat last two steps to see different chromes rendered. ![four](https://cloud.githubusercontent.com/assets/3277067/8049255/dcae7daa-0e2a-11e5-944a-d0ed79fc135a.png)
