### PR TITLE
[#33445] RTL Chosen Select causes the page to disappear

### DIFF
--- a/media/jui/css/chosen.css
+++ b/media/jui/css/chosen.css
@@ -379,7 +379,6 @@
   right: auto;
   left: 4px;
 }
-.chzn-rtl.chzn-container-single-nosearch .chzn-search,
 .chzn-rtl .chzn-drop {
   left: 9999px;
 }
@@ -409,6 +408,14 @@
 }
 .chzn-rtl.chzn-container-single.chzn-with-drop .chzn-single div b {
   background-position: -12px 2px;
+}
+[dir="rtl"] .chzn-container .chzn-drop,
+[dir="rtl"] .chzn-container-single.chzn-container-single-nosearch .chzn-search {
+  left: auto;
+  right: -9999px;
+}
+[dir="rtl"] .chzn-container.chzn-with-drop .chzn-drop {
+  right: 0;
 }
 
 /* @end */


### PR DESCRIPTION
This PR fixes a long time [known problem](http://code.joomla.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=33445) already confirmed, but still present.
## How to reproduce

The bug affects Google Chrome, Firefox and Internet Explorer. Opera browser is not affected.
- On "Template Manager", set Beez3 as default front-end template, which makes easier to reproduce the problem. **Edit:** This does not only affect Beez3, but a lot of third party templates as well.
- On "Language Manager", set an RTL language as default front-end language, such as "Arabic", or "Hebrew". **Edit:** As per Brian's suggestion, it is not necessary to actually use Arabic language, you can just set `<rtl>1</rtl>` in language/en-GB/en-GB.xml to get English behave RTL.
- Browse a page on your site containing at least one "select" component, the Archived Articles view is perfect for this purpose. `index.php?option=com_content&view=archive`
- Open the "Select Month" dropdown. It is the rightmost. As soon as you choose an item, the most of the page elements disappear.
- Reload the page.
- Now open the pagination dropdown, which is the leftmost. Here the bug appears as soon as you open the dropdown. The problem is slightly different since it doesn't contain the search input-box.

When testing this patch, ensure to clear the cache of your browser and load the fixed css.
