### PR TITLE
Incorrect check for response header Oauth2 Client

### DIFF
--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -80,7 +80,7 @@ class JOAuth2Client
 
 			if ($response->code >= 200 && $response->code < 400)
 			{
-				if ($response->headers['Content-Type'] == 'application/json')
+				if (strpos($response->headers['Content-Type'],'application/json') === 0)
 				{
 					$token = array_merge(json_decode($response->body, true), array('created' => time()));
 				}

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -80,7 +80,7 @@ class JOAuth2Client
 
 			if ($response->code >= 200 && $response->code < 400)
 			{
-				if (strpos($response->headers['Content-Type'],'application/json') === 0)
+				if (strpos($response->headers['Content-Type'], 'application/json') === 0)
 				{
 					$token = array_merge(json_decode($response->body, true), array('created' => time()));
 				}

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -192,7 +192,7 @@ class JOAuth2Client
 	/**
 	 * Send a signed Oauth request.
 	 *
-	 * @param   string  $url      The URL forf the request.
+	 * @param   string  $url      The URL for the request.
 	 * @param   mixed   $data     The data to include in the request
 	 * @param   array   $headers  The headers to send with the request
 	 * @param   string  $method   The method with which to send the request
@@ -365,7 +365,7 @@ class JOAuth2Client
 
 		if ($response->code >= 200 || $response->code < 400)
 		{
-			if ($response->headers['Content-Type'] == 'application/json')
+			if (strpos($response->headers['Content-Type'], 'application/json') === 0)
 			{
 				$token = array_merge(json_decode($response->body, true), array('created' => time()));
 			}


### PR DESCRIPTION
In Oauth2 Client, there is an incorrect check when we want to get access token back from http post.
Some time (maybe all time) there is charset added in the content-type contained in reponse header.
## How to test

You can download and install this component [here](https://github.com/AteDev/joomla-components-test/tree/PR-7110)
You need to edit this file: [controller](https://github.com/AteDev/joomla-components-test/blob/PR-7110/site/controllers/test.php#L64-L67) to add your client ID/Secret from your linkedin app
If you dont use localhost remove/comment [this line](https://github.com/AteDev/joomla-components-test/blob/PR-7110/site/controllers/test.php#L75)
- Go to yourdomain/index.php/test
- Click "Sign in with Linkedin", apply app, you will see the return token from linkedin (incorrect array)
- Apply patch, repeat steps and you will see perfect array.
## PS

I tested whith the Linkedin api, this add in content-type "application/json;charset:utf8"
