### PR TITLE
Rapid Repair Fix: Restore browser detection

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -733,11 +733,12 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 
-		// Let's be sure we got a valid language code. Falls back returning the default language.
+		// Let's be sure we got a valid language code. Fallback to null.
 		if (!array_key_exists($lang_code, $this->lang_codes))
 		{
-			$lang_code = $this->default_lang;
+			$lang_code = null;
 		}
+
 		return $lang_code;
 	}
 


### PR DESCRIPTION
#### Description

This fixes a stupid, idiotic, moronic and whatever else mistake **I** introduced in #7055: browser detection was broken because in case of missing/wrong language cookie I'd set it to the default language instead of setting it to null and then let browser detection do its duty...
