### PR TITLE
namespace mismatch in doc

### DIFF
--- a/libraries/vendor/joomla/utilities/src/ArrayHelper.php
+++ b/libraries/vendor/joomla/utilities/src/ArrayHelper.php
@@ -237,7 +237,7 @@ final class ArrayHelper
 	 *
 	 * @return  mixed  The value from the source array
 	 *
-	 * @throws  InvalidArgumentException
+	 * @throws  \InvalidArgumentException
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Fixed namespace mismatch in return type doc for InvalidArgumentException in ArrayHelper::getValue()
