### PR TITLE
ArrayHelper::getColumn to allow use one of the columns as key for returned array

### DIFF
--- a/libraries/vendor/joomla/utilities/src/ArrayHelper.php
+++ b/libraries/vendor/joomla/utilities/src/ArrayHelper.php
@@ -201,26 +201,38 @@ final class ArrayHelper
 	/**
 	 * Extracts a column from an array of arrays or objects
 	 *
-	 * @param   array   $array  The source array
-	 * @param   string  $index  The index of the column or name of object property
+	 * @param   array   $array      The source array
+	 * @param   string  $value_col  The index of the column or name of object property to be used as value
+	 * @param   string  $key_col    The index of the column or name of object property to be used as key
 	 *
 	 * @return  array  Column of values from the source array
 	 *
 	 * @since   1.0
+	 * @see     http://php.net/manual/en/language.types.array.php
 	 */
-	public static function getColumn(array $array, $index)
+	public static function getColumn(array $array, $value_col, $key_col = null)
 	{
 		$result = array();
 
 		foreach ($array as $item)
 		{
-			if (is_array($item) && isset($item[$index]))
+			// Convert object to array
+			$subject = is_object($item) ? static::fromObject($item) : $item;
+
+			// We process array (and object already converted to array) only.
+			// Only if the value column exists in this item
+			if (is_array($subject) && isset($subject[$value_col]))
 			{
-				$result[] = $item[$index];
-			}
-			elseif (is_object($item) && isset($item->$index))
-			{
-				$result[] = $item->$index;
+				// Array keys can only be integer or string. Casting will occur as per the PHP Manual.
+				if ($key_col && isset($subject[$key_col]) && is_scalar($subject[$key_col]))
+				{
+					$key          = $subject[$key_col];
+					$result[$key] = $subject[$value_col];
+				}
+				else
+				{
+					$result[] = $subject[$value_col];
+				}
 			}
 		}
 


### PR DESCRIPTION
Adding feature to `ArrayHelper::getColumn()` that allows us to (optionally) use one of the columns as `key` for the returned array.
Currently this returns an indexed array always with auto indexes. This PR is made backward compatible with the previous implementation.
