### PR TITLE
content plugins not able to insert custom fieldsets into core forms

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -32,6 +32,9 @@ JFactory::getDocument()->addScriptDeclaration('
 	};
 ');
 
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('jmetadata', 'item_associations');
+
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/administrator/components/com_categories/views/category/tmpl/modal.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal.php
@@ -38,6 +38,9 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 ");
+
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('jmetadata', 'item_associations');
 ?>
 <div class="container-popup">
 

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -28,6 +28,9 @@ JFactory::getDocument()->addScriptDeclaration('
 		}
 	};
 ');
+
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('details', 'item_associations', 'jmetadata');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_contact&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="contact-form" class="form-validate">

--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -37,6 +37,9 @@ JFactory::getDocument()->addScriptDeclaration('
 		}
 	};
 ');
+
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('details', 'display', 'email', 'item_associations');
 ?>
 <div class="container-popup">
 

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -16,10 +16,9 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
-$this->hiddenFieldsets = array();
-$this->hiddenFieldsets[0] = 'basic-limited';
-$this->configFieldsets = array();
-$this->configFieldsets[0] = 'editorConfig';
+$this->configFieldsets  = array('editorConfig');
+$this->hiddenFieldsets  = array('basic-limited');
+$this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');

--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -17,10 +17,9 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
-$this->hiddenFieldsets = array();
-$this->hiddenFieldsets[0] = 'basic-limited';
-$this->configFieldsets = array();
-$this->configFieldsets[0] = 'editorConfig';
+$this->configFieldsets  = array('editorConfig');
+$this->hiddenFieldsets  = array('basic-limited');
+$this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -78,6 +78,8 @@ Joomla.submitbutton = function(task, type){
 // Add the script to the document head.
 JFactory::getDocument()->addScriptDeclaration($script);
 
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('item_associations');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -28,6 +28,10 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 ");
+
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('images', 'jbasic', 'jmetadata', 'item_associations');
+
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="newsfeed-form" class="form-validate">
 
@@ -77,7 +81,6 @@ JFactory::getDocument()->addScriptDeclaration("
 		<?php echo $this->loadTemplate('display'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php $this->set('ignore_fieldsets', array('jbasic')); ?>
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
 

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -35,6 +35,8 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 ");
+
+$this->ignore_fieldsets = array('jbasic', 'item_associations');
 ?>
 <div class="container-popup">
 
@@ -93,7 +95,6 @@ JFactory::getDocument()->addScriptDeclaration("
 		<?php echo $this->loadTemplate('display'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php $this->set('ignore_fieldsets', array('jbasic')); ?>
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
 		<?php if ($assoc) : ?>

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -31,7 +31,7 @@ JFactory::getDocument()->addScriptDeclaration("
 ");
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
-$this->ignore_fieldsets = array('jmetadata');
+$this->ignore_fieldsets = array('jmetadata', 'urls');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_tags&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -29,6 +29,9 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 ");
+
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->ignore_fieldsets = array('jmetadata');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_tags&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -9,15 +9,9 @@
 
 defined('_JEXEC') or die;
 
-$app = JFactory::getApplication();
-$form = $displayData->getForm();
-
-$fieldSets = $form->getFieldsets('params');
-
-// For BC with versions < 3.2 we need to render the attribs too
-$attribsFieldSet = $form->getFieldsets('attribs');
-
-$fieldSets = array_merge($fieldSets, $attribsFieldSet);
+$app       = JFactory::getApplication();
+$form      = $displayData->getForm();
+$fieldSets = $form->getFieldsets();
 
 if (empty($fieldSets))
 {
@@ -25,8 +19,8 @@ if (empty($fieldSets))
 }
 
 $ignoreFieldsets = $displayData->get('ignore_fieldsets') ?: array();
-$ignoreFields = $displayData->get('ignore_fields') ?: array();
-$extraFields = $displayData->get('extra_fields') ?: array();
+$ignoreFields    = $displayData->get('ignore_fields') ?: array();
+$extraFields     = $displayData->get('extra_fields') ?: array();
 
 if (!empty($displayData->hiddenFieldsets))
 {
@@ -46,8 +40,9 @@ if ($displayData->get('show_options', 1))
 	{
 		// Ensure any fieldsets we don't want to show are skipped (including repeating formfield fieldsets)
 		if (in_array($name, $ignoreFieldsets) || (!empty($configFieldsets) && in_array($name, $configFieldsets))
-				|| !empty($hiddenFieldsets) && in_array($name, $hiddenFieldsets)
-				|| (isset($fieldSet->repeat) && $fieldSet->repeat == true))
+			|| !empty($hiddenFieldsets) && in_array($name, $hiddenFieldsets)
+			|| (isset($fieldSet->repeat) && $fieldSet->repeat == true)
+		)
 		{
 			continue;
 		}
@@ -81,7 +76,7 @@ if ($displayData->get('show_options', 1))
 }
 else
 {
-	$html = array();
+	$html   = array();
 	$html[] = '<div style="display:none;">';
 	foreach ($fieldSets as $name => $fieldSet)
 	{


### PR DESCRIPTION
This is basically the work done in this previous PR
https://github.com/joomla/joomla-cms/pull/4284
With the additions that Jean Marie asked for regarding multi lingual sites and the associations tab that is added.
The test instructions are the same as #4284

---
## Background

With the implementation of using JLayout to render parameters (https://github.com/joomla/joomla-cms/pull/2162) support for rendering custom named fieldsets ceased to be supported. This is a documented feature since at least Joomla 2.5 http://docs.joomla.org/Adding_custom_fields_to_the_article_component and is also documented to be suported in 3.1 at http://docs.joomla.org/Adding_custom_fields_to_core_components_using_a_plugin. In fact, the current core user profile plugin would break if JLayout 'joomla.edit.params' was implemented for com_users.user due to the plugin using custom named fieldsets (https://github.com/joomla/joomla-cms/blob/staging/plugins/user/profile/profiles/profile.xml#L3-L4) and the current implementation of JLayout 'joomla.edit.params' being effectively hardcoded to only render fieldsets named `params` and `attribs` (https://github.com/joomla/joomla-cms/blob/staging/layouts/joomla/edit/params.php#L15-L18). 
## Changes

This PR changes the behavior of JLayout 'joomla.edit.params' to render all fieldsets of the form, except those designated with the `ignore_fieldsets` property.

Affected by this PR are the following backend edit views:
- com_categories.category
- com_contact.contact
- com_content.article
- com_finder.filter
- com_menus.item
- com_modules.module
- com_newsfeeds.newsfeed
- com_plugins.plugin
- com_tags.tag
- com_templates.style
## Backwards Compatibility

This PR should be 100% backwards compatible while restoring this functionality.
## Testing

Apply the patch associated with this PR and review the above views to ensure that all of the currently rendered fieldsets (as tabs in Isis) remain to be rendered. Then, install and plugin that uses a custom named fieldset and ensure that it is rendered at all of the above views as described in Joomla's documentation.

A test plugin can be downloaded from https://github.com/betweenbrain/Joomla-Custom-Field-Plugin-Example/archive/test.zip
