### PR TITLE
Double session boot in install application

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -25,32 +25,14 @@ final class InstallationApplicationWeb extends JApplicationCms
 	 */
 	public function __construct()
 	{
+		// Register the application name.
+		$this->_name = 'installation';
+
+		// Register the client ID.
+		$this->_clientId = 2;
+
 		// Run the parent constructor.
 		parent::__construct();
-
-		// Load and set the dispatcher.
-		$this->loadDispatcher();
-
-		// Enable sessions by default.
-		if (is_null($this->config->get('session')))
-		{
-			$this->config->set('session', true);
-		}
-
-		// Set the session default name.
-		if (is_null($this->config->get('session_name')))
-		{
-			$this->config->set('session_name', 'installation');
-		}
-
-		// Create the session if a session name is passed.
-		if ($this->config->get('session') !== false)
-		{
-			$this->loadSession();
-
-			// Register the session with JFactory.
-			JFactory::$session = $this->getSession();
-		}
 
 		// Store the debug value to config based on the JDEBUG flag.
 		$this->config->set('debug', JDEBUG);
@@ -60,12 +42,6 @@ final class InstallationApplicationWeb extends JApplicationCms
 
 		// Register the application to JFactory.
 		JFactory::$application = $this;
-
-		// Register the application name.
-		$this->_name = 'installation';
-
-		// Register the client ID.
-		$this->_clientId = 2;
 
 		// Set the root in the URI one level up.
 		$parts = explode('/', JUri::base(true));
@@ -562,6 +538,9 @@ final class InstallationApplicationWeb extends JApplicationCms
 
 		// Set the session object.
 		$this->session = $session;
+
+		// Register the session with JFactory.
+		JFactory::$session = $session;
 
 		return $this;
 	}


### PR DESCRIPTION
In the install app, the code to boot the session is triggered twice.  This PR fixes that.
### Testing Instructions

So, the easiest way I have to confirm this is fixed is putting a `echo 'loadSession started';` line at the beginning of `InstallationApplicationWeb::loadSession()` as it isn't something you'll notice in normal code execution.  Pre-patch, the message should show twice; post-patch only once.  Otherwise, this is basically just make sure the CMS installs correctly.

Or, you can read through the code and see how the method is called twice.
