### PR TITLE
Fix for  #6904 --> Fixed the check on published content languages.

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -519,7 +519,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (!$lang_code
 				|| !array_key_exists($lang_code, $this->lang_codes)
-				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages())
+				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages()))
 			{
 				$lang_code = $this->current_lang;
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -518,7 +518,6 @@ class PlgSystemLanguageFilter extends JPlugin
 			$lang_code = $user['language'];
 
 			// If no language is specified for this user, we set it to the site default language
-			// This is deliberate: see PR #7130
 			if (empty($lang_code))
 			{
 				$lang_code = $this->default_lang;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -517,7 +517,9 @@ class PlgSystemLanguageFilter extends JPlugin
 			$assoc = JLanguageAssociations::isEnabled();
 			$lang_code = $user['language'];
 
-			if (!$lang_code || !array_key_exists($lang_code, $this->lang_codes))
+			if (!$lang_code
+				|| !array_key_exists($lang_code, $this->lang_codes)
+				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages())
 			{
 				$lang_code = $this->current_lang;
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -519,7 +519,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if (!$lang_code
 				|| !array_key_exists($lang_code, $this->lang_codes)
-				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages()))
+				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages())
+				|| !JFolder::exists(JPATH_SITE . '/language/' . $lang_code))
 			{
 				$lang_code = $this->current_lang;
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -34,14 +34,6 @@ class PlgSystemLanguageFilter extends JPlugin
 	private $user_lang_code;
 
 	/**
-	 * JDatabaseDriver instance
-	 *
-	 * @var    JDatabaseDriver
-	 * @since  3.4.2
-	 */
-	protected $db = null;
-
-	/**
 	 * Application object.
 	 *
 	 * @var    JApplicationCms
@@ -525,24 +517,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			$assoc = JLanguageAssociations::isEnabled();
 			$lang_code = $user['language'];
 
-			if (empty($lang_code))
-			{
-				$lang_code = $this->default_lang;
-			}
-
-			// Get a 1-dimensional array of published language codes
-			$query = $this->db->getQuery(true)
-				->select($this->db->quoteName('a.lang_code'))
-				->from($this->db->quoteName('#__languages', 'a'))
-				->where($this->db->quoteName('published') . ' = 1');
-			$this->db->setQuery($query);
-			$lang_codes = $this->db->loadColumn();
-
-			// The user language has been deleted/disabled or the related content language does not exist/has been unpublished
-			// or the related home page does not exist/has been unpublished
-			if (!array_key_exists($lang_code, MultilangstatusHelper::getSitelangs())
-				|| !in_array($lang_code, $lang_codes)
-				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages()))
+			if (!$lang_code || !array_key_exists($lang_code, $this->lang_codes))
 			{
 				$lang_code = $this->current_lang;
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -524,6 +524,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				$lang_code = $this->default_lang;
 			}
 
+			// The language has been deleted/disabled or the related content language does not exist/has been unpublished
+			// or the related home page does not exist/has been unpublished
 			if (!array_key_exists($lang_code, $this->lang_codes)
 				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages())
 				|| !JFolder::exists(JPATH_SITE . '/language/' . $lang_code))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -517,8 +517,14 @@ class PlgSystemLanguageFilter extends JPlugin
 			$assoc = JLanguageAssociations::isEnabled();
 			$lang_code = $user['language'];
 
-			if (!$lang_code
-				|| !array_key_exists($lang_code, $this->lang_codes)
+			// If no language is specified for this user, we set it to the site default language
+			// This is deliberate: see PR #7130
+			if (empty($lang_code))
+			{
+				$lang_code = $this->default_lang;
+			}
+
+			if (!array_key_exists($lang_code, $this->lang_codes)
 				|| !array_key_exists($lang_code, MultilangstatusHelper::getHomepages())
 				|| !JFolder::exists(JPATH_SITE . '/language/' . $lang_code))
 			{


### PR DESCRIPTION
There is no need to go to the database: we already have $this->lang_codes setup to perform this check...

This also remove the newly introduced `protected $db = null`, so that we do not create B/C legacy.
