### PR TITLE
Fix: User Admin with editstate permission cannot block/unblock users

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -91,7 +91,7 @@ $loggeduser = JFactory::getUser();
 				?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center">
-							<?php if ($canEdit) : ?>
+							<?php if ($canEdit || $canChange) : ?>
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 							<?php endif; ?>
 						</td>


### PR DESCRIPTION
this pull request replaces http://issues.joomla.org/tracker/joomla-cms/7131

Problem: 

It is not possible to create admin groups which have the ability to deactivate / activate other users, but not change any other user rights. An administrator/user with only EditState permission for the Administration User component cannot deactivate / activate other users. When clicking on block/unblock in the userlist, the status of the user doesnt change.

The problem occurs because the tick-boxes in the userlist are not shown when the administrator has only EditState permission. The tickbox is only shown when the administrator has also Edit permission.

Solution: 
administrator/components/com_users/views/users/tmpl/default.php
must be patched in line 94:
old code in Joomla 3.4.1: <?php if ($canEdit) : ?>
New: <?php if ($canEdit || $canChange) : ?>
#### Steps to reproduce the issue

Create a user / group so that the user has the following calculated settings in the user com_user administration component. 

Configure ACL & Options: Not Allowed
Access Administration Interface: Allowed
Create: Allowed
Delete: Not Allowed.
Edit: Not Allowed.
Edit: State Allowed

Log into the administrator backend with that user and access the user administration.
#### Expected result

The user should be able to block/unblock other users with the switches in the "enabled" column 
#### Actual result

The user can see the block/unblock switches in the "Enabled" column but when clicking the status of the user is not changing.

The problem occurs because the tick-boxes in the userlist are not shown when the administrator has only EditState permission. 
#### System information (as much as possible)

Any Joomla version from Joomla 2.5.28 until 3.4.1

Solution: 
patch administrator/components/com_users/views/users/tmpl/default.php
in line 94:
old code in Joomla 3.4.1: <?php if ($canEdit) : ?>
New: <?php if ($canEdit || $canChange) : ?>
