### PR TITLE
com_finder.ini wrong comment

### DIFF
--- a/administrator/language/en-GB/en-GB.com_finder.ini
+++ b/administrator/language/en-GB/en-GB.com_finder.ini
@@ -136,7 +136,7 @@ COM_FINDER_INDEX_HEADING_INDEX_TYPE="Type"
 COM_FINDER_INDEX_HEADING_LINK_URL="Raw URL"
 COM_FINDER_INDEX_NO_CONTENT="No content matches your search criteria."
 COM_FINDER_INDEX_NO_DATA="No content has been indexed."
-; Change 'Content%20-%20Smart%20Search' to the value in plg_finder_categories.sys.ini for your language
+; Change 'Content%20-%20Smart%20Search' to the value for PLG_CONTENT_FINDER in plg_content_finder.sys.ini for your language
 COM_FINDER_INDEX_PLUGIN_CONTENT_NOT_ENABLED="Smart Search content plugin is not enabled. Changes to content will not update the Smart Search index if you do not <a href="_QQ_"index.php?option=com_plugins&view=plugins&filter[search]=Content%20-%20Smart%20Search"_QQ_">enable this plugin</a>."
 COM_FINDER_INDEX_PURGE_SUCCESS="All items have been successfully purged."
 COM_FINDER_INDEX_TIP="Start the indexer by pressing the Index button in the toolbar."


### PR DESCRIPTION
Correcting the value to change.
From
`; Change 'Content%20-%20Smart%20Search' to the value in plg_finder_categories.sys.ini for your language`
to the correct one
`; Change 'Content%20-%20Smart%20Search' to the value for PLG_CONTENT_FINDER in plg_content_finder.sys.ini for your language`

Simple merge please. NOT a real language change as it only concerns the comment.
