### PR TITLE
Fixes duplicate queries from MultilangstatusHelper

### DIFF
--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -83,22 +83,21 @@ abstract class MultilangstatusHelper
 	{
 		static $sitelangs = null;
 
-		if (!empty($sitelangs))
+		if (empty($sitelangs))
 		{
-			return $sitelangs;
+			// Check for published Site Languages.
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('a.element AS element')
+				->from('#__extensions AS a')
+				->where('a.type = ' . $db->quote('language'))
+				->where('a.client_id = 0')
+				->where('a.enabled = 1');
+			$db->setQuery($query);
+
+			$sitelangs = $db->loadObjectList('element');
 		}
 
-		// Check for published Site Languages.
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('a.element AS element')
-			->from('#__extensions AS a')
-			->where('a.type = ' . $db->quote('language'))
-			->where('a.client_id = 0')
-			->where('a.enabled = 1');
-		$db->setQuery($query);
-
-		$sitelangs = $db->loadObjectList('element');
 		return $sitelangs;
 	}
 

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -130,7 +130,7 @@ abstract class MultilangstatusHelper
 			}
 		}
 
-		return homepages;
+		return $homepages;
 	}
 
 	/**

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -95,7 +95,14 @@ abstract class MultilangstatusHelper
 				->where('a.enabled = 1');
 			$db->setQuery($query);
 
-			$sitelangs = $db->loadObjectList('element');
+			try
+			{
+				$sitelangs = $db->loadObjectList('element');
+			}
+			catch (RuntimeException $e)
+			{
+				throw new Exception($e->getMessage(), 500);
+			}
 		}
 
 		return $sitelangs;

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -81,6 +81,13 @@ abstract class MultilangstatusHelper
 	 */
 	public static function getSitelangs()
 	{
+		static $sitelangs = null;
+
+		if (!empty($sitelangs))
+		{
+			return $sitelangs;
+		}
+		
 		// Check for published Site Languages.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -91,7 +98,8 @@ abstract class MultilangstatusHelper
 			->where('a.enabled = 1');
 		$db->setQuery($query);
 
-		return $db->loadObjectList('element');
+		$sitelangs = $db->loadObjectList('element');
+		return $sitelangs;
 	}
 
 	/**

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -87,7 +87,7 @@ abstract class MultilangstatusHelper
 		{
 			return $sitelangs;
 		}
-		
+
 		// Check for published Site Languages.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -85,14 +85,7 @@ abstract class MultilangstatusHelper
 				->where('a.enabled = 1');
 			$db->setQuery($query);
 
-			try
-			{
-				$sitelangs = $db->loadObjectList('element');
-			}
-			catch (RuntimeException $e)
-			{
-				throw new Exception($e->getMessage(), 500);
-			}
+			$sitelangs = $db->loadObjectList('element');
 		}
 
 		return $sitelangs;
@@ -120,14 +113,7 @@ abstract class MultilangstatusHelper
 				->where('client_id = 0');
 			$db->setQuery($query);
 
-			try
-			{
-				$homepages = $db->loadObjectList('language');
-			}
-			catch (RuntimeException $e)
-			{
-				throw new Exception($e->getMessage(), 500);
-			}
+			$homepages = $db->loadObjectList('language');
 		}
 
 		return $homepages;

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -23,17 +23,7 @@ abstract class MultilangstatusHelper
 	 */
 	public static function getHomes()
 	{
-		// Check for multiple Home pages.
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('COUNT(*)')
-			->from($db->quoteName('#__menu'))
-			->where('home = 1')
-			->where('published = 1')
-			->where('client_id = 0');
-		$db->setQuery($query);
-
-		return $db->loadResult();
+		return count(self::getHomepages());
 	}
 
 	/**
@@ -115,18 +105,32 @@ abstract class MultilangstatusHelper
 	 */
 	public static function getHomepages()
 	{
-		// Check for Home pages languages.
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('language')
-			->select('id')
-			->from($db->quoteName('#__menu'))
-			->where('home = 1')
-			->where('published = 1')
-			->where('client_id = 0');
-		$db->setQuery($query);
+		static $homepages = null;
 
-		return $db->loadObjectList('language');
+		if (empty($homepages))
+		{
+			// Check for Home pages languages.
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('language')
+				->select('id')
+				->from($db->quoteName('#__menu'))
+				->where('home = 1')
+				->where('published = 1')
+				->where('client_id = 0');
+			$db->setQuery($query);
+
+			try
+			{
+				$homepages = $db->loadObjectList('language');
+			}
+			catch (RuntimeException $e)
+			{
+				throw new Exception($e->getMessage(), 500);
+			}
+		}
+
+		return homepages;
 	}
 
 	/**


### PR DESCRIPTION
#### Description

several methods from MultilangstatusHelper are called multiple times in the life of a Joomla! process.
This PR optimize this by locally caching the results
#### Testing procedure
- Use a multilingual site
- Verify that everything is "_business as usual_" (a.k.a: _SNAFU_... :smile: ) with and without this PR, both in the front-end and in the back-end.
- Turn on Joomla Debug in global configuration and verify that several duplicated queries are now gone.

Even better: apply this together with #7137 and follow testing instruction there. If OK, you can give "@test OK" to both PRs
#### Additional comments

Thanks to "Viper" and "Robert G Mears" that have brought duplicate queries to my attention.
_This might be a first in a series..._
