### PR TITLE
Fixes duplicate queries from MenusHelper::getAssociations()

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -267,11 +267,11 @@ class MenusHelper
 	 */
 	public static function getAssociations($pk)
 	{
-		static $associations = array();
-		static $unchecked = true;
+		static $cache = array();
 
-		if ($unchecked)
+		if (!isset($cache[$pk]))
 		{
+			$associations = array();
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->from('#__menu as m')
@@ -282,14 +282,7 @@ class MenusHelper
 				->select('m2.language, m2.id');
 			$db->setQuery($query);
 
-			try
-			{
-				$menuitems = $db->loadObjectList('language');
-			}
-			catch (RuntimeException $e)
-			{
-				throw new Exception($e->getMessage(), 500);
-			}
+			$menuitems = $db->loadObjectList('language');
 
 			foreach ($menuitems as $tag => $item)
 			{
@@ -300,9 +293,9 @@ class MenusHelper
 				}
 			}
 
-			$unchecked = false;
+			$cache[$pk] = $associations;
 		}
 
-		return $associations;
+		return $cache[$pk];
 	}
 }

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -267,33 +267,40 @@ class MenusHelper
 	 */
 	public static function getAssociations($pk)
 	{
-		$associations = array();
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->from('#__menu as m')
-			->join('INNER', '#__associations as a ON a.id=m.id AND a.context=' . $db->quote('com_menus.item'))
-			->join('INNER', '#__associations as a2 ON a.key=a2.key')
-			->join('INNER', '#__menu as m2 ON a2.id=m2.id')
-			->where('m.id=' . (int) $pk)
-			->select('m2.language, m2.id');
-		$db->setQuery($query);
+		static $associations = array();
+		static $unchecked = true;
 
-		try
+		if ($unchecked)
 		{
-			$menuitems = $db->loadObjectList('language');
-		}
-		catch (RuntimeException $e)
-		{
-			throw new Exception($e->getMessage(), 500);
-		}
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->from('#__menu as m')
+				->join('INNER', '#__associations as a ON a.id=m.id AND a.context=' . $db->quote('com_menus.item'))
+				->join('INNER', '#__associations as a2 ON a.key=a2.key')
+				->join('INNER', '#__menu as m2 ON a2.id=m2.id')
+				->where('m.id=' . (int) $pk)
+				->select('m2.language, m2.id');
+			$db->setQuery($query);
 
-		foreach ($menuitems as $tag => $item)
-		{
-			// Do not return itself as result
-			if ((int) $item->id != $pk)
+			try
 			{
-				$associations[$tag] = $item->id;
+				$menuitems = $db->loadObjectList('language');
 			}
+			catch (RuntimeException $e)
+			{
+				throw new Exception($e->getMessage(), 500);
+			}
+
+			foreach ($menuitems as $tag => $item)
+			{
+				// Do not return itself as result
+				if ((int) $item->id != $pk)
+				{
+					$associations[$tag] = $item->id;
+				}
+			}
+
+			$unchecked = false;
 		}
 
 		return $associations;


### PR DESCRIPTION
#### Description

getAssociations() is called several times in the life of a Joomla! process.
This PR optimize it by locally caching the result
#### Testing procedure
- Use a multilingual site with at least some menu items associated between themselves (menu item association) and with the "_Add Alternate Meta Tags_" set to "Yes" in the language filter
- Navigate to a menu item associated to another menu item in a different language.
- Switch back and forth from one language to another using the language switcher and verify that menu items association is respected
- Verify in the generated HTML that the "rel="alternate" tags are present and correct
- Turn on Joomla Debug in global configuration and verify that at least a couple of duplicated queries are now gone.

Even better: apply this together with #7136. If OK, you can give "@test OK" to both PRs
