### PR TITLE
Filter by client_id prevents duplicates

### DIFF
--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -123,7 +123,7 @@ class TemplatesModelStyles extends JModelList
 
 		// Filter by extension enabled
 		$query->select('extension_id AS e_id')
-			->join('LEFT', '#__extensions AS e ON e.element = a.template')
+			->join('LEFT', '#__extensions AS e ON e.element = a.template AND e.client_id = a.client_id')
 			->where('e.enabled = 1')
 			->where('e.type=' . $db->quote('template'));
 


### PR DESCRIPTION
If a template has an admin and a site version and both are named the same, both the admin and the site template will appear twice in the list (so essentially the template will appear 4 times in the list).
Adding the client_id in the left join for the extensions table ensures that templates with the same name but with different client_ids will not be displayed multiple times.
