### PR TITLE
Smart Search module messed up when Parameters are on

### DIFF
--- a/media/com_finder/css/finder.css
+++ b/media/com_finder/css/finder.css
@@ -127,3 +127,16 @@ ul.autocompleter-choices li.autocompleter-selected span.autocompleter-queried {
 ul#finder-filter-select-list {
 	top: 4em !important;
 }
+
+#mod-finder-advanced select, #mod-finder-advanced .form-horizontal .control-label  {
+    max-width:100%;
+}
+
+#mod-finder-advanced .form-horizontal .control-label
+{
+    text-align: left;
+}
+
+#mod-finder-advanced .form-horizontal .controls {
+    margin-left: 0;
+}


### PR DESCRIPTION
http://issues.joomla.org/tracker/joomla-cms/7132
Added css to fix overflowing input and select in modules. (Safari, Os X)

![bildschirmfoto 2015-06-06 um 10 34 16](https://cloud.githubusercontent.com/assets/828371/8044386/8217cf70-0e2c-11e5-9ad5-a57a18ecd758.png)

Test instructions:
1) Create a Smart Search Module (don´t forget to publish the smart search plugin first and index your content in smart search component)
2) turn filter on
3) check if select and labels are now shown right without overflowing.

// Need some help on fixing the alignment of label, input and button at the top
