### PR TITLE
Make the link input field large

### DIFF
--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -47,7 +47,7 @@
 			description="COM_MENUS_ITEM_FIELD_LINK_DESC"
 			readonly="true"
 			class="input-xxlarge"
-			space="50"/>
+			size="50"/>
 
 		<field
 			name="menutype"

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -46,7 +46,8 @@
 			label="COM_MENUS_ITEM_FIELD_LINK_LABEL"
 			description="COM_MENUS_ITEM_FIELD_LINK_DESC"
 			readonly="true"
-			class="input-xxlarge"/>
+			class="input-xxlarge"
+			space="50"/>
 
 		<field
 			name="menutype"

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -46,7 +46,7 @@
 			label="COM_MENUS_ITEM_FIELD_LINK_LABEL"
 			description="COM_MENUS_ITEM_FIELD_LINK_DESC"
 			readonly="true"
-			size="50"/>
+			class="input-xxlarge"/>
 
 		<field
 			name="menutype"


### PR DESCRIPTION
When I want to know which is the link behind a menu item, I have to inspect the code because the field shows only the first and uninteresting part of the link. This small change makes ist possible to see the whole link.
![menu-item](https://cloud.githubusercontent.com/assets/1035262/8055852/e6964500-0ea2-11e5-934b-d2a78e7d79c0.PNG)
