### PR TITLE
# Output the custom tags - array_unique makes sure that we don't outp…

### DIFF
--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -238,7 +238,8 @@ class JDocumentRendererHead extends JDocumentRenderer
 			$buffer .= $tab . '</script>' . $lnEnd;
 		}
 
-		foreach ($document->_custom as $custom)
+		// Output the custom tags - array_unique makes sure that we don't output the same tags twice
+		foreach (array_unique($document->_custom) as $custom)
 		{
 			$buffer .= $tab . $custom . $lnEnd;
 		}


### PR DESCRIPTION
…ut the same tags twice

In lib_compojoom we have few layouts for social share: 
https://github.com/compojoom/lib_compojoom/tree/master/source/libraries/compojoom/layouts/social/share

I've implemented the open graph requirements to properly share an item in the facebook layout: 
https://github.com/compojoom/lib_compojoom/blob/master/source/libraries/compojoom/layouts/social/share/facebook.php

And I was about the to do the same for the gplus layout as one could use the layouts separately. Google plus is reading open graph data, so basically I could output the same stuff on the page. 

Due to my use of $document->addCustomTag whenever I call 

``` php
$document->addCustomTag('<meta property="og:url" content="' . JURI::current() . '" />');
$document->addCustomTag('<meta property="og:url" content="' . JURI::current() . '" />');
```

This would be added to the head twice. Which I think is not necessary. At the end we don't see the same behavior when we use JHtml::script or stylesheet? That's why I've changed the 
fetchHead function to just output unique values from the custom array:
https://github.com/joomla/joomla-cms/compare/staging...compojoom:addCustomTag?expand=1#diff-ed74c9a4d3ec7e43b62b75c502e3787dL241

How to test?
Let's take a component view. for example:
\components\com_content\views\article\tmpl\default.php right after the defined call add:

``` php
$document = JFactory::getDocument();
$document->addCustomTag('<meta property="og:url" content="' . JURI::current() . '" />');
$document->addCustomTag('<meta property="og:url" content="' . JURI::current() . '" />');
```

without the patch this should output the og:url meta property twice in the head (in single view of article). With the patch you should see the og:url tag just once.
