### PR TITLE
Show tooltip for search in Search Tools

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -5,6 +5,7 @@
 			name="search"
 			type="text"
 			label="COM_CONTENT_FILTER_SEARCH_DESC"
+			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -12,6 +12,7 @@
 			name="search"
 			type="text"
 			label="COM_MENUS_FILTER_SEARCH_DESC"
+			description="COM_MENUS_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -35,6 +35,9 @@ $filters = $data['view']->filterForm->getGroup('filter');
 		</label>
 		<div class="btn-wrapper input-append">
 			<?php echo $filters['filter_search']->input; ?>
+			<?php if ($filters['filter_search']->description) : ?>
+				<?php JHtmlBootstrap::tooltip('#filter_search', array('title' => JText::_($filters['filter_search']->description))); ?>
+			<?php endif; ?>
 			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>">
 				<span class="icon-search"></span>
 			</button>


### PR DESCRIPTION
Originated and discussed in #7146 

This PR adds back the tooltip for the search input element in views featuring Search Tools. It takes the value for the tooltip from the XML file specifying the filters.

To test just hover over the search input element and see that there is now a tooltip in articles and menuitems view. The other views remain unchanged.
