### PR TITLE
Remove index.html from install.xml #7155

### DIFF
--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -213,7 +213,6 @@
 		<filename>en-GB.tpl_hathor.sys.ini</filename>
 		<filename>en-GB.tpl_isis.ini</filename>
 		<filename>en-GB.tpl_isis.sys.ini</filename>
-		<filename>index.html</filename> 
 		<filename file="meta">en-GB.xml</filename>	
 		<filename file="meta">install.xml</filename>
 	</files>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -93,7 +93,6 @@
 		<filename>en-GB.tpl_beez3.sys.ini</filename>
 		<filename>en-GB.tpl_protostar.ini</filename>
 		<filename>en-GB.tpl_protostar.sys.ini</filename>
-		<filename>index.html</filename>
 		<filename file="meta">install.xml</filename>
 		<filename file="meta">en-GB.xml</filename>
 	</files>


### PR DESCRIPTION
Fix for

In Joomla, the file index.html is no longer used in the directories.

However, in the file install.xml the following line of code is there.
< filename>index.html</ filename>

The file install.xml is available in both the directories \administrator\language\en-GB and \language\en-GB.

Since en-GB is native to Joomla and not getting installed just like any other language pack, the issue is not seen. If someone copies thse file to create a language pack, the language pack installation will fail as there would not be any file named index.html.
