### PR TITLE
Regression: remaining code from #5140 breaks multilanguage

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -370,9 +370,6 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$lang_code = $this->default_lang;
 				}
-				// Either we detected the language via the browser or we got it from the cookie. In worst case
-				// we fall back to the application setting
-				$lang_code = $this->getLanguageCookie();
 			}
 
 			if ($this->mode_sef)


### PR DESCRIPTION
To test, just install a new staging/master Joomla as a multilingual site.
Load frontend.
You will get and undefined index error because no cookie is set at that time.
Also, on an updated formally existing multilang site, any link to another language item which is not a direct menu link will get a wrong sef (and therefore 404) as the code fetches the cookie lang_code.

Patch and retest
