### PR TITLE
REGRESSION - Bug in category association (solves #7151 )

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -317,7 +317,7 @@ class CategoriesModelCategory extends JModelAdmin
 			$data = $this->getItem();
 
 			// Pre-select some filters (Status, Language, Access) in edit form if those have been selected in Category Manager
-			if ($this->getState('category.id') == 0)
+			if (!$data->id)
 			{
 				// Check for which extension the Category Manager is used and get selected fields
 				$extension = substr($app->getUserState('com_categories.categories.filter.extension'), 4);


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/7151 for test instructions.
This PR uses the same code as in modules i.e. checking data->id.

The test has to be done on an existing category tagged to one of the content languages.

NOTE: A new category (not yet tagged to a language and saved) will still show all the existing content languages in the associations tab. That is normal until saved.
