### PR TITLE
Add tooltip to search input in com_banners, com_content and com_users

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -5,6 +5,7 @@
 			name="search"
 			type="text"
 			label="COM_BANNERS_SEARCH_IN_TITLE"
+			description="COM_BANNERS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>

--- a/administrator/components/com_banners/models/forms/filter_clients.xml
+++ b/administrator/components/com_banners/models/forms/filter_clients.xml
@@ -5,6 +5,7 @@
 			name="search"
 			type="text"
 			label="COM_BANNERS_SEARCH_IN_TITLE"
+			description="COM_BANNERS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -5,6 +5,7 @@
 			name="search"
 			type="text"
 			label="COM_CONTENT_FILTER_SEARCH_DESC"
+			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>

--- a/administrator/components/com_users/models/forms/filter_users.xml
+++ b/administrator/components/com_users/models/forms/filter_users.xml
@@ -4,7 +4,8 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_USERS_FILTER_SEARCH_DESC"
+			label="COM_USERS_SEARCH_USERS"
+			description="COM_USERS_SEARCH_IN_NAME"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>


### PR DESCRIPTION
This PR adds tooltips to four more views. Similar to what is done in https://github.com/joomla/joomla-cms/pull/7150.
### Testing

Please note that this PR needs #7150 applied as well.
Check the search input field in the following manager views and verify that there is now a tooltip after the PR is applied. Before there was none.
- Banners -> Banners
- Banners -> Clients
- Content -> Featured Articles
- Users -> User Manager

If you find other views where there are Search Tools and the search field doesn't show anything, feel free to note.
The only one I found is the category manager, but there I didn't found the correct string. So either I'm blind or there is none.
