### PR TITLE
Load mootools modal in layouts only if needed

### DIFF
--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 $buttons = $displayData;
 
-// Load modal popup behavior
-JHtml::_('behavior.modal', 'a.modal-button');
 ?>
 <div id="editor-xtd-buttons" class="btn-toolbar pull-left">
 	<?php if ($buttons) : ?>

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -19,6 +19,12 @@ $button = $displayData;
 		$href     = ($button->get('link')) ? ' href="' . JUri::base() . $button->get('link') . '"' : null;
 		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+	// Load modal popup behavior
+	if ($button->get('modal'))
+	{
+		JHtml::_('behavior.modal', 'a.modal-button');
+	}
 	?>
 	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href, $onclick; ?> rel="<?php echo $button->get('options'); ?>">
 		<span class="icon-<?php echo $button->get('name'); ?>"></span> <?php echo $button->get('text'); ?>

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -55,8 +55,6 @@ class PlgButtonArticle extends JPlugin
 		$doc = JFactory::getDocument();
 		$doc->addScriptDeclaration($js);
 
-		JHtml::_('behavior.modal');
-
 		/*
 		 * Use the built-in element view to select the article.
 		 * Currently uses blank class.

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -52,7 +52,7 @@ class PlgButtonImage extends JPlugin
 			||	(count($user->getAuthorisedCategories($extension, 'core.edit.own')) > 0 && $author == $user->id))
 		{
 			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset=' . $asset . '&amp;author=' . $author;
-			JHtml::_('behavior.modal');
+
 			$button = new JObject;
 			$button->modal = true;
 			$button->class = 'btn';

--- a/plugins/editors-xtd/pagebreak/pagebreak.php
+++ b/plugins/editors-xtd/pagebreak/pagebreak.php
@@ -33,7 +33,6 @@ class PlgButtonPagebreak extends JPlugin
 	 */
 	public function onDisplay($name)
 	{
-		JHtml::_('behavior.modal');
 
 		$link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
 


### PR DESCRIPTION
#### Conservative loading of mootools modal

Core editor xtd plugins call mootools modal way to early in the process, but we can differ this to layout and actually load it only if the plugin is actually a modal!
This should be 100% B/C
#### TESTING

Apply this patch and create a new Article. Observe any console error and that functionality of all buttons remains the same!

Apply also #7152, #5871, #5655, #5654 and try to create a new article. Observe that no mootools is loaded! Test functionality

Install some 3rd party dev xtd plugins and try their functionality and look for console logged errors
