### PR TITLE
Pagination layout. Missing icons and weird display (redo of #6633)

### DIFF
--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -43,7 +43,7 @@ switch ((string) $item->text)
 
 if ($icon !== null)
 {
-	$display = '<i class="' . $icon . '"></i>';
+	$display = '<span class="' . $icon . '"></span>';
 }
 
 if ($displayData['active'])

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -17,23 +17,23 @@ switch ((string) $item->text)
 {
 	// Check for "Start" item
 	case JText::_('JLIB_HTML_START') :
-		$icon = "icon-backward";
+		$icon = "icon-backward icon-first";
 		break;
 
 	// Check for "Prev" item
 	case $item->text == JText::_('JPREV') :
 		$item->text = JText::_('JPREVIOUS');
-		$icon = "icon-step-backward";
+		$icon = "icon-step-backward icon-previous";
 		break;
 
 	// Check for "Next" item
 	case JText::_('JNEXT') :
-		$icon = "icon-step-forward";
+		$icon = "icon-step-forward icon-next";
 		break;
 
 	// Check for "End" item
 	case JText::_('JLIB_HTML_END') :
-		$icon = "icon-forward";
+		$icon = "icon-forward icon-last";
 		break;
 
 	default:
@@ -43,7 +43,7 @@ switch ((string) $item->text)
 
 if ($icon !== null)
 {
-	$display = '<span class="' . $icon . '"></span>';
+	$display = '<i class="' . $icon . '"></i>';
 }
 
 if ($displayData['active'])


### PR DESCRIPTION
Take over the fix by @bertmert from https://github.com/joomla/joomla-cms/pull/6633

---

Test:
- Rename /administrator/templates/isis/html/pagination.php
  to
  paginationxxxxxxxxxxxxxx.php
- Thus, Isis uses pagination from
  layouts/joomla/pagination/link.php
- Now, see backend list views, e.g. article manager:

Pagination in Joomla staging

![pagination-staging](https://cloud.githubusercontent.com/assets/11038612/6958609/adb63250-d90e-11e4-9391-1caff383dfd9.jpg)

Pagination in Joomla Staging after patch
![pagination-staging-after](https://cloud.githubusercontent.com/assets/11038612/6958626/f48e7a5c-d90e-11e4-8025-026f49db86d9.jpg)
