### PR TITLE
Module list

### DIFF
--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -241,7 +241,7 @@ class ModulesModelModules extends JModelList
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.note, a.position, a.module, a.language,' .
-					'a.checked_out, a.checked_out_time, a.published+2*(e.enabled-1) as published, a.access, a.ordering, a.publish_up, a.publish_down'
+					'a.checked_out, a.checked_out_time, a.published as published, e.enabled as enabled, a.access, a.ordering, a.publish_up, a.publish_down'
 			)
 		);
 		$query->from($db->quoteName('#__modules') . ' AS a');

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -161,20 +161,34 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php endif; ?>
 						</td>
 						<td class="center">
-							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
+							<?php
+                            if ($item->enabled>0)
+                            {
+                                echo JHtml::_('grid.id', $i, $item->id);
+                            } ?>
 						</td>
 						<td class="center">
 							<div class="btn-group">
-								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php
-									// Create dropdown items
-									JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');
+                                //Check if extension is enabled
+                                if ($item->enabled>0)
+                                {
+                                    echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down);
+                                }else{
+                                    //Extension is not enabled, show a message that indicates this.
+                                }
+                                ?>
+								<?php
+                                if ($item->enabled>0) {
+                                    // Create dropdown items
+                                    JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');
 
-									$action = $trashed ? 'untrash' : 'trash';
-									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'modules');
+                                    $action = $trashed ? 'untrash' : 'trash';
+                                    JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'modules');
 
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+                                    // Render dropdown list
+                                    echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+                                }
 								?>
 							</div>
 						</td>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -20,6 +20,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 $trashed	= $this->state->get('filter.state') == -2 ? true : false;
 $canOrder	= $user->authorise('core.edit.state', 'com_modules');
 $saveOrder	= $listOrder == 'ordering';
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_modules&task=modules.saveOrderAjax&tmpl=component';
@@ -54,7 +55,6 @@ JFactory::getDocument()->addScriptDeclaration('
 <?php else : ?>
 	<div id="j-main-container">
 <?php endif;?>
-
 		<div id="filter-bar" class="btn-toolbar">
 			<div class="filter-search btn-group pull-left">
 				<label for="filter_search" class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL');?></label>
@@ -161,35 +161,25 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php endif; ?>
 						</td>
 						<td class="center">
-							<?php
-                            if ($item->enabled>0)
-                            {
-                                echo JHtml::_('grid.id', $i, $item->id);
-                            } ?>
+						<?php if ($item->enabled > 0) : ?>
+							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
+						<?php endif; ?>
 						</td>
 						<td class="center">
 							<div class="btn-group">
-								<?php
-                                //Check if extension is enabled
-                                if ($item->enabled>0)
-                                {
-                                    echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down);
-                                }else{
-                                    //Extension is not enabled, show a message that indicates this.
-                                }
-                                ?>
-								<?php
-                                if ($item->enabled>0) {
-                                    // Create dropdown items
-                                    JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');
-
-                                    $action = $trashed ? 'untrash' : 'trash';
-                                    JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'modules');
-
-                                    // Render dropdown list
-                                    echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
-                                }
-								?>
+							<?php // Check if extension is enabled ?>
+							<?php if ($item->enabled > 0) : ?>
+								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+								<?php// Create dropdown items ?>
+								<?php JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules'); ?>
+								<?php $action = $trashed ? 'untrash' : 'trash'; ?>
+								<?php JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'modules'); ?>
+								<?php // Render dropdown list ?>
+								<?php echo JHtml::_('actionsdropdown.render', $this->escape($item->title)); ?>
+							<?php else : ?>
+								<?php // Extension is not enabled, show a message that indicates this. ?>
+							<?php endif; ?>
+								
 							</div>
 						</td>
 						<td class="has-context">


### PR DESCRIPTION
See the failure
1.  Go to the Extensions | Module Manager and ensure, that you have at least two modules of the type banners for the location site. One is published and another is unpublished.
2.  Switch to Extension Manager|Manage and disable the Modul “Banners” for the location site.
3.  Go back to Extensions | Module Manager and see, that the Status show wrong values. The published Module looks like unpublished and the unpublished value looks like trashed.

Apply my patch
1.  Go to the Extensions | Module Manager and ensure, that you have at least two modules of the type banners for the location site. One is published and another is unpublished.
2.  Switch to Extension Manager|Manage and disable the Module “Banners” for the location site.
3.  Go back to Extensions | Module Manager and see, that the Status did not show the wrong values any more. The Module with disabled extensions has no status. 
