### PR TITLE
# fix for #7178 - JFile::move() returns a string

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -249,7 +249,9 @@ class JFile
 		// Check src path
 		if (!is_readable($src))
 		{
-			return JText::_('JLIB_FILESYSTEM_CANNOT_FIND_SOURCE_FILE');
+			JLog::add(JText::_('JLIB_FILESYSTEM_CANNOT_FIND_SOURCE_FILE'), JLog::WARNING, 'jerror');
+
+			return false;
 		}
 
 		if ($use_streams)


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/issues/7178

Test by Using JFile::move with invalid $src parameter. Without the patch the function returns a string. With the patch it returns a boolean false. And the error is logged.
