### PR TITLE
Backend dropdown fix

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7470,6 +7470,9 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 .chzn-drop {
 	max-width: 100% !important;
 }
+.control-group:last-of-type .chzn-container-active .chzn-drop {
+	position: static !important;
+}
 @media (max-width: 979px) {
 	.navbar .nav {
 		font-size: 13px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6100,6 +6100,12 @@ fieldset.radio.btn-group {
 	-moz-border-radius: 0;
 	border-radius: 0;
 }
+
+.control-group:last-of-type .chzn-container-active .chzn-drop  {
+    position:static!important;
+
+}
+
 .element-invisible {
 	position: absolute;
 	padding: 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6100,12 +6100,6 @@ fieldset.radio.btn-group {
 	-moz-border-radius: 0;
 	border-radius: 0;
 }
-
-.control-group:last-of-type .chzn-container-active .chzn-drop  {
-    position:static!important;
-
-}
-
 .element-invisible {
 	position: absolute;
 	padding: 0;
@@ -7475,6 +7469,9 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 .chzn-container,
 .chzn-drop {
 	max-width: 100% !important;
+}
+.control-group:last-of-type .chzn-container-active .chzn-drop {
+	position: static !important;
 }
 @media (max-width: 979px) {
 	.navbar .nav {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -584,6 +584,12 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 .chzn-drop {
 	max-width: 100% !important;
 }
+/*Fix for last dropdown */
+.control-group:last-of-type .chzn-container-active .chzn-drop  {
+  position:static!important;
+
+}
+
 @media (max-width: 979px) {
 	.navbar {
 		.nav {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -586,8 +586,7 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 }
 /*Fix for last dropdown */
 .control-group:last-of-type .chzn-container-active .chzn-drop  {
-  position:static!important;
-
+  position:static!important
 }
 
 @media (max-width: 979px) {

--- a/media/com_finder/css/finder.css
+++ b/media/com_finder/css/finder.css
@@ -127,3 +127,16 @@ ul.autocompleter-choices li.autocompleter-selected span.autocompleter-queried {
 ul#finder-filter-select-list {
 	top: 4em !important;
 }
+
+#mod-finder-advanced select, #mod-finder-advanced .form-horizontal .control-label  {
+    max-width:100%;
+}
+
+#mod-finder-advanced .form-horizontal .control-label
+{
+    text-align: left;
+}
+
+#mod-finder-advanced .form-horizontal .controls {
+    margin-left: 0;
+}


### PR DESCRIPTION
The dropdowns are cut off at the bottom of page when appearing on the end of the site. 
Example: mod_smart_search

![bildschirmfoto 2015-06-16 um 11 57 05](https://cloud.githubusercontent.com/assets/828371/8180710/37920cf0-1420-11e5-897d-ff40fbb606e0.png)

To test please apply this patch an test if it works in different browsers and the other dropdowns work as expected.

Thanks!
