### PR TITLE
Always log database errors.

### DIFF
--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -89,6 +89,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$users = false;
 			}
 
@@ -103,6 +104,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$items = false;
 			}
 
@@ -137,6 +139,7 @@ class ModStatsHelper
 				}
 				catch (RuntimeException $e)
 				{
+					JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 					$links = false;
 				}
 
@@ -164,6 +167,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$hits = false;
 			}
 

--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -83,6 +83,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$users = false;
 			}
 
@@ -97,6 +98,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$items = false;
 			}
 
@@ -129,6 +131,7 @@ class ModStatsHelper
 				}
 				catch (RuntimeException $e)
 				{
+					JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 					$links = false;
 				}
 
@@ -156,6 +159,7 @@ class ModStatsHelper
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				$hits = false;
 			}
 

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -100,7 +100,8 @@ abstract class ModTagsPopularHelper
 		catch (RuntimeException $e)
 		{
 			$results = array();
-			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 		}
 
 		return $results;

--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -28,7 +28,7 @@ class ModWhosonlineHelper
 		$db = JFactory::getDbo();
 
 		// Calculate number of guests and users
-		$result	     = array();
+		$result      = array();
 		$user_array  = 0;
 		$guest_array = 0;
 
@@ -44,7 +44,7 @@ class ModWhosonlineHelper
 		}
 		catch (RuntimeException $e)
 		{
-			// Don't worry be happy
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 			$sessions = array();
 		}
 
@@ -116,6 +116,7 @@ class ModWhosonlineHelper
 		}
 		catch (RuntimeException $e)
 		{
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 			return array();
 		}
 	}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -64,6 +64,7 @@ class PlgUserJoomla extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 			return false;
 		}
 
@@ -228,6 +229,7 @@ class PlgUserJoomla extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
+			JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 			return false;
 		}
 
@@ -283,6 +285,7 @@ class PlgUserJoomla extends JPlugin
 			}
 			catch (RuntimeException $e)
 			{
+				JLog::add($e->getMessage(), JLog::ERROR, 'controller');
 				return false;
 			}
 		}


### PR DESCRIPTION
As a followup to the "Handle DB errors" by @alikon. As requested by @wilsonge :smile: 

I just added logging to the catches where they were missing.
And I changed one place where the error message still was shown to use the new way of showing a generic message and logging the error.

Should be simple to review.
