### PR TITLE
Better external resource detection in JHtml::includeRelativeFiles()

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -296,7 +296,7 @@ abstract class JHtml
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
 		// If http is present in filename
-		if (strpos($file, 'http') === 0)
+		if (strpos($file, 'http') === 0 || strpos($file, '//') === 0)
 		{
 			$includes = array($file);
 		}


### PR DESCRIPTION
Better external resource detection in `JHtml::includeRelativeFiles()`

**Test**
Add in template index.php:
 `JHtml::_('script', '//maps.googleapis.com/maps/api/js?v=3&sensor=false');`
Open site in browser and check the page source.

**Actual result**
JHtml does not add `//maps.googleapis.com/maps/api/js` to the page `<head>`

**Expected**
Somewhere between `<head>` tags you should be able to see: 

``` html
<script src="//maps.googleapis.com/maps/api/js?v=3&sensor=false" type="text/javascript"></script>
```
