### PR TITLE
Isis fix for safari bug #5970

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8158,17 +8158,21 @@ body.modal-open {
 	width: 100%;
 	z-index: 1028;
 }
-@media (max-width: 440px) {
+#j-sidebar-container.affix {
+	position: fixed;
+	top: 85px;
+}
+@media (max-width: 748px) {
 	#second-nav.affix {
 		position: static;
 		width: auto;
 		top: 0;
 		z-index: -100;
 	}
-}
-#j-sidebar-container.affix {
-	position: fixed;
-	top: 85px;
+	#j-sidebar-container.affix {
+		position: static;
+		top: 0;
+	}
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8152,6 +8152,20 @@ body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;
 }
+#second-nav.affix {
+	position: fixed;
+	top: 30px;
+	width: 100%;
+	z-index: 1028;
+}
+@media (max-width: 440px) {
+	#second-nav.affix {
+		position: static;
+		width: auto;
+		top: 0;
+		z-index: -100;
+	}
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8157,6 +8157,10 @@ body.modal-open {
 	top: 30px;
 	width: 100%;
 	z-index: 1028;
+	-webkit-transition: top 0.4s ease-out;
+	-moz-transition: top 0.4s ease-out;
+	-o-transition: top 0.4s ease-out;
+	transition: top 0.4s ease-out;
 }
 @media (max-width: 748px) {
 	#second-nav.affix {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8158,20 +8158,12 @@ body.modal-open {
 	width: 100%;
 	z-index: 1028;
 }
-#j-sidebar-container.affix {
-	position: fixed;
-	top: 85px;
-}
 @media (max-width: 748px) {
 	#second-nav.affix {
 		position: static;
 		width: auto;
 		top: 0;
 		z-index: -100;
-	}
-	#j-sidebar-container.affix {
-		position: static;
-		top: 0;
 	}
 }
 .pull-right {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8166,6 +8166,10 @@ body.modal-open {
 		z-index: -100;
 	}
 }
+#j-sidebar-container.affix {
+	position: fixed;
+	top: 85px;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8157,10 +8157,10 @@ body.modal-open {
 	top: 30px;
 	width: 100%;
 	z-index: 1028;
-	-webkit-transition: top 0.4s ease-out;
-	-moz-transition: top 0.4s ease-out;
-	-o-transition: top 0.4s ease-out;
-	transition: top 0.4s ease-out;
+	-webkit-transition: all 0.4s ease;
+	-moz-transition: all 0.4s ease;
+	-o-transition: all 0.4s ease;
+	transition: all 0.4s ease;
 }
 @media (max-width: 748px) {
 	#second-nav.affix {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8158,15 +8158,19 @@ body.modal-open {
 	width: 100%;
 	z-index: 1028;
 }
-@media (max-width: 440px) {
+#j-sidebar-container.affix {
+	position: fixed;
+	top: 85px;
+}
+@media (max-width: 748px) {
 	#second-nav.affix {
 		position: static;
 		width: auto;
 		top: 0;
 		z-index: -100;
 	}
-}
-#j-sidebar-container.affix {
-	position: fixed;
-	top: 85px;
+	#j-sidebar-container.affix {
+		position: static;
+		top: 0;
+	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8157,6 +8157,10 @@ body.modal-open {
 	top: 30px;
 	width: 100%;
 	z-index: 1028;
+	-webkit-transition: top 0.4s ease-out;
+	-moz-transition: top 0.4s ease-out;
+	-o-transition: top 0.4s ease-out;
+	transition: top 0.4s ease-out;
 }
 @media (max-width: 748px) {
 	#second-nav.affix {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8152,3 +8152,17 @@ body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;
 }
+#second-nav.affix {
+	position: fixed;
+	top: 30px;
+	width: 100%;
+	z-index: 1028;
+}
+@media (max-width: 440px) {
+	#second-nav.affix {
+		position: static;
+		width: auto;
+		top: 0;
+		z-index: -100;
+	}
+}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8166,3 +8166,7 @@ body.modal-open {
 		z-index: -100;
 	}
 }
+#j-sidebar-container.affix {
+	position: fixed;
+	top: 85px;
+}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8158,19 +8158,11 @@ body.modal-open {
 	width: 100%;
 	z-index: 1028;
 }
-#j-sidebar-container.affix {
-	position: fixed;
-	top: 85px;
-}
 @media (max-width: 748px) {
 	#second-nav.affix {
 		position: static;
 		width: auto;
 		top: 0;
 		z-index: -100;
-	}
-	#j-sidebar-container.affix {
-		position: static;
-		top: 0;
 	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8157,10 +8157,10 @@ body.modal-open {
 	top: 30px;
 	width: 100%;
 	z-index: 1028;
-	-webkit-transition: top 0.4s ease-out;
-	-moz-transition: top 0.4s ease-out;
-	-o-transition: top 0.4s ease-out;
-	transition: top 0.4s ease-out;
+	-webkit-transition: all 0.4s ease;
+	-moz-transition: all 0.4s ease;
+	-o-transition: all 0.4s ease;
+	transition: all 0.4s ease;
 }
 @media (max-width: 748px) {
 	#second-nav.affix {

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -293,8 +293,8 @@ function colorIsLight($color)
 <?php if ($displayHeader && $stickyToolbar) : ?>
 	<script type="text/javascript">
 		jQuery(document).ready(function($){
-				$("#second-nav").affix();
-				$("#j-sidebar-container").affix();
+			$("#second-nav").affix();
+			$("#j-sidebar-container").affix();
 		});
 	</script>
 <?php endif; ?>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -222,7 +222,7 @@ function colorIsLight($color)
 	<a class="btn btn-subhead" data-toggle="collapse" data-target=".subhead-collapse"><?php echo JText::_('TPL_ISIS_TOOLBAR'); ?>
 		<span class="icon-wrench"></span></a>
 	<div class="subhead-collapse collapse">
-		<div class="subhead">
+		<div class="subhead" id="second-nav" data-spy="affix-top">
 			<div class="container-fluid">
 				<div id="container-collapse" class="container-collapse"></div>
 				<div class="row-fluid">
@@ -290,47 +290,10 @@ function colorIsLight($color)
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
-<?php if ($stickyToolbar) : ?>
-	<script>
-		jQuery(function($)
-		{
-
-			var navTop;
-			var isFixed = false;
-
-			processScrollInit();
-			processScroll();
-
-			$(window).on('resize', processScrollInit);
-			$(window).on('scroll', processScroll);
-
-			function processScrollInit()
-			{
-				if ($('.subhead').length) {
-					navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
-
-					// Only apply the scrollspy when the toolbar is not collapsed
-					if (document.body.clientWidth > 480)
-					{
-						$('.subhead-collapse').height($('.subhead').height());
-						$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
-					}
-				}
-			}
-
-			function processScroll()
-			{
-				if ($('.subhead').length) {
-					var scrollTop = $(window).scrollTop();
-					if (scrollTop >= navTop && !isFixed) {
-						isFixed = true;
-						$('.subhead').addClass('subhead-fixed');
-					} else if (scrollTop <= navTop && isFixed) {
-						isFixed = false;
-						$('.subhead').removeClass('subhead-fixed');
-					}
-				}
-			}
+<?php if ($displayHeader && $stickyToolbar) : ?>
+	<script type="text/javascript">
+		jQuery(document).ready(function($){
+				$("#second-nav").affix();
 		});
 	</script>
 <?php endif; ?>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -151,6 +151,15 @@ function colorIsLight($color)
 		</style>
 	<?php endif; ?>
 
+	<?php if ($displayHeader) : ?>
+		<style type="text/css">
+			#second-nav {
+				top: 78px;
+				width: 100%;
+			}
+		</style>
+	<?php endif; ?>
+
 	<!--[if lt IE 9]>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -254,7 +254,7 @@ function colorIsLight($color)
 		<jdoc:include type="modules" name="top" style="xhtml" />
 		<div class="row-fluid">
 			<?php if ($showSubmenu) : ?>
-			<div class="span2" id="sidebar-affix" data-spy="affix-top">
+			<div class="span2">
 				<jdoc:include type="modules" name="submenu" style="none" />
 			</div>
 			<div class="span10">

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -70,7 +70,7 @@ $displayHeader = $this->params->get('displayHeader', '1');
 $statusFixed   = $this->params->get('statusFixed', '1');
 $stickyToolbar = $this->params->get('stickyToolbar', '1');
 
-if ($displayHeader && $stickyToolbar)
+if ($stickyToolbar)
 {
 	$doc->addScriptDeclaration(
 		'

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -243,7 +243,7 @@ function colorIsLight($color)
 		<jdoc:include type="modules" name="top" style="xhtml" />
 		<div class="row-fluid">
 			<?php if ($showSubmenu) : ?>
-			<div class="span2">
+			<div class="span2" id="sidebar-affix" data-spy="affix-top">
 				<jdoc:include type="modules" name="submenu" style="none" />
 			</div>
 			<div class="span10">
@@ -294,6 +294,7 @@ function colorIsLight($color)
 	<script type="text/javascript">
 		jQuery(document).ready(function($){
 				$("#second-nav").affix();
+				$("#j-sidebar-container").affix();
 		});
 	</script>
 <?php endif; ?>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -76,7 +76,6 @@ if ($stickyToolbar)
 		'
 		jQuery(document).ready(function($){
 			$("#second-nav").affix();
-			$("#j-sidebar-container").affix();
 		});
 		'
 	);

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -70,6 +70,18 @@ $displayHeader = $this->params->get('displayHeader', '1');
 $statusFixed   = $this->params->get('statusFixed', '1');
 $stickyToolbar = $this->params->get('stickyToolbar', '1');
 
+if ($displayHeader && $stickyToolbar)
+{
+	$doc->addScriptDeclaration(
+		'
+		jQuery(document).ready(function($){
+			$("#second-nav").affix();
+			$("#j-sidebar-container").affix();
+		});
+		'
+	);
+}
+
 // Header classes
 $template_is_light = ($this->params->get('templateColor') && colorIsLight($this->params->get('templateColor')));
 $header_is_light = ($displayHeader && $this->params->get('headerColor') && colorIsLight($this->params->get('headerColor')));
@@ -290,13 +302,5 @@ function colorIsLight($color)
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
-<?php if ($displayHeader && $stickyToolbar) : ?>
-	<script type="text/javascript">
-		jQuery(document).ready(function($){
-			$("#second-nav").affix();
-			$("#j-sidebar-container").affix();
-		});
-	</script>
-<?php endif; ?>
 </body>
 </html>

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -91,9 +91,7 @@
 				$debug.addClass('j-toggle-main');
 			}
 
-			var mainHeight = $main.outerHeight()+30,
-				sidebarHeight = $sidebar.outerHeight(),
-				bodyWidth = $('body').outerWidth(),
+			var bodyWidth = $('body').outerWidth(),
 				sidebarWidth = $sidebar.outerWidth(),
 				contentWidth = $('#content').outerWidth(),
 				contentWidthRelative = contentWidth / bodyWidth * 100,
@@ -159,7 +157,7 @@
 				$sidebar.find('a').removeAttr('tabindex');
 				$sidebar.find(':input').removeAttr('tabindex');
 
-				if (!isComponent && bodyWidth > 768 && mainHeight < sidebarHeight)
+				if (!isComponent && bodyWidth > 768)
 				{
 					$debug.css( 'width', mainWidthRelative + '%' );
 				}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1308,3 +1308,8 @@ body.modal-open {
 	z-index : -100;
   }
 }
+#j-sidebar-container.affix {
+  position: fixed;
+  top: 85px;
+}
+

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1298,6 +1298,7 @@ body.modal-open {
   top: 30px;
   width:100%;
   z-index : 1028;
+  .transition(top 0.4s ease-out);
 }
 @media (max-width: 748px) {
   #second-nav.affix {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1299,17 +1299,20 @@ body.modal-open {
   width:100%;
   z-index : 1028;
 }
+#j-sidebar-container.affix {
+  position: fixed;
+  top: 85px;
+}
 
-@media (max-width: 440px) {
+@media (max-width: 748px) {
   #second-nav.affix {
 	position: static;
 	width: auto;
 	top: 0;
 	z-index : -100;
   }
+  #j-sidebar-container.affix {
+	position: static;
+	top: 0;
+  }
 }
-#j-sidebar-container.affix {
-  position: fixed;
-  top: 85px;
-}
-

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1291,3 +1291,20 @@ body.modal-open {
   overflow: hidden;
   -ms-overflow-style: none;
 }
+
+/* Use bootstrap affix for the second navigation trick to stick on top */
+#second-nav.affix {
+  position: fixed;
+  top: 30px;
+  width:100%;
+  z-index : 1028;
+}
+
+@media (max-width: 440px) {
+  #second-nav.affix {
+	position: static;
+	width: auto;
+	top: 0;
+	z-index : -100;
+  }
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1299,20 +1299,11 @@ body.modal-open {
   width:100%;
   z-index : 1028;
 }
-#j-sidebar-container.affix {
-  position: fixed;
-  top: 85px;
-}
-
 @media (max-width: 748px) {
   #second-nav.affix {
 	position: static;
 	width: auto;
 	top: 0;
 	z-index : -100;
-  }
-  #j-sidebar-container.affix {
-	position: static;
-	top: 0;
   }
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1298,7 +1298,7 @@ body.modal-open {
   top: 30px;
   width:100%;
   z-index : 1028;
-  .transition(top 0.4s ease-out);
+  .transition(all 0.4s ease);
 }
 @media (max-width: 748px) {
   #second-nav.affix {


### PR DESCRIPTION
This PR drops the current custom code for sticking the two top toolbars together and instead use the already loaded bootstrap script!

Should work with all browsers but the idea was to fix #5970 and safari!

@wilsonge If this gets merged you got a nice conflict with 3.5-dev ???? Sorry!

@losedk @JoomliC and anyone with safari ever experienced this glitch can you give this a test?
