### PR TITLE
removeField and removeGroup were always returning true, no matter if …

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -882,7 +882,7 @@ class JForm
 	 * @param   string  $name   The name of the form field for which remove.
 	 * @param   string  $group  The optional dot-separated form group path on which to find the field.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  boolean  True on success, false otherwise.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
@@ -903,9 +903,11 @@ class JForm
 		{
 			$dom = dom_import_simplexml($element);
 			$dom->parentNode->removeChild($dom);
+
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	/**
@@ -913,7 +915,7 @@ class JForm
 	 *
 	 * @param   string  $group  The dot-separated form group path for the group to remove.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  boolean  True on success, false otherwise.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
@@ -933,9 +935,11 @@ class JForm
 		{
 			$dom = dom_import_simplexml($element);
 			$dom->parentNode->removeChild($dom);
+
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
…they deleted the field or group

To test go to administrator\components\com_content\models\article.php in the getForm function right before the return $form do:

``` php
        var_dump($form->removeField('blabla')); // without patch true, with patch false
        var_dump($form->removeGroup('blabla')); // without patch true, with patch false
        var_dump($form->removeField('language')); // without patch true, with patch true
        var_dump($form->removeGroup('images')); // without patch true, with patch true
```
