### PR TITLE
Deprecate JPlatform

### DIFF
--- a/libraries/platform.php
+++ b/libraries/platform.php
@@ -11,8 +11,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Version information class for the Joomla Platform.
  *
- * @package  Joomla.Platform
- * @since    11.1
+ * @since       11.1
+ * @deprecated  4.0  Deprecated without replacement
  */
 final class JPlatform
 {
@@ -58,6 +58,7 @@ final class JPlatform
 	 *
 	 * @see     http://www.php.net/version_compare
 	 * @since   11.1
+	 * @deprecated  4.0  Deprecated without replacement
 	 */
 	public static function isCompatible($minimum)
 	{
@@ -70,6 +71,7 @@ final class JPlatform
 	 * @return  string  Version string.
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0  Deprecated without replacement
 	 */
 	public static function getShortVersion()
 	{
@@ -82,6 +84,7 @@ final class JPlatform
 	 * @return  string  Complete version string.
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0  Deprecated without replacement
 	 */
 	public static function getLongVersion()
 	{


### PR DESCRIPTION
Long and short, the Platform is no longer a product.  No need to carry its version info on any longer than necessary.
