### PR TITLE
Isis template tooltip mismatch

### DIFF
--- a/administrator/language/en-GB/en-GB.tpl_isis.ini
+++ b/administrator/language/en-GB/en-GB.tpl_isis.ini
@@ -5,8 +5,8 @@
 
 ISIS="Isis Administrator template"
 TPL_ISIS_CLEAR_CACHE="Clear Cache"
-TPL_ISIS_COLOR_DESC="Choose a colour for the navigation bar. If left blank the Default (#13294a) is used."
-TPL_ISIS_COLOR_HEADER_DESC="Choose a colour for the header. If left blank the Default (#184a7d) is used."
+TPL_ISIS_COLOR_DESC="Choose a colour for the navigation bar. If left blank the Default (#10223e) is used."
+TPL_ISIS_COLOR_HEADER_DESC="Choose a colour for the header. If left blank the Default (#1a3867) is used."
 TPL_ISIS_COLOR_HEADER_LABEL="Header Colour"
 TPL_ISIS_COLOR_LABEL="Nav Bar Colour"
 TPL_ISIS_COLOR_SIDEBAR_DESC="Choose a colour for the Sidebar Background. If left blank the Default (#0088cc) is used."

--- a/administrator/templates/isis/language/en-GB/en-GB.tpl_isis.ini
+++ b/administrator/templates/isis/language/en-GB/en-GB.tpl_isis.ini
@@ -5,8 +5,8 @@
 
 ISIS="Isis Administrator template"
 TPL_ISIS_CLEAR_CACHE="Clear Cache"
-TPL_ISIS_COLOR_DESC="Choose a colour for the navigation bar. If left blank the Default (#13294a) is used."
-TPL_ISIS_COLOR_HEADER_DESC="Choose a colour for the header. If left blank the Default (#184a7d) is used."
+TPL_ISIS_COLOR_DESC="Choose a colour for the navigation bar. If left blank the Default (#10223e) is used."
+TPL_ISIS_COLOR_HEADER_DESC="Choose a colour for the header. If left blank the Default (#1a3867) is used."
 TPL_ISIS_COLOR_HEADER_LABEL="Header Colour"
 TPL_ISIS_COLOR_LABEL="Nav Bar Colour"
 TPL_ISIS_COLOR_SIDEBAR_DESC="Choose a colour for the Sidebar Background. If left blank the Default (#0088cc) is used."


### PR DESCRIPTION
There was a mismatch between the default value for the colour in the xml file and the value displayed in the tooltip.

This small PR corrects the tooltip so that it displays the correct value
