### PR TITLE
Structured data support in Protostar

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -78,7 +78,7 @@ else
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" itemscope itemtype="http://schema.org/WebPage">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />


### PR DESCRIPTION
When an extension enriches it's content with schema.org meta data, then the W3C validator will complain like

`The itemprop attribute was specified, but the element is not a property of any item.`
`<p itemprop="startDate" content="2015-06-18T21:35:00+00:00">`

This situation can easily be solved with the proposed code change.
## Test instructions:
- Download the Free version of DPCalendar from https://joomla.digital-peak.com/download/dpcalendar
- Install it on your test server (preferable accessible from the internet)
- Create some events in the future in DPCalendar
- Publish the DPCalendar upcoming module on all pages
- Open a page on the front
- Copy the url in the browser address bar to https://validator.w3.org and run the validation
- Before the patch is applied tons of the above errors will be shown, after the patch none of the above error should be reported in the validator
