### PR TITLE
Fixing Pagination when Search Tools are present

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -660,6 +660,18 @@ class JModelList extends JModelLegacy
 		$cur_state = (!is_null($old_state)) ? $old_state : $default;
 		$new_state = $input->get($request, null, $type);
 
+		// BC for Search Tools which uses different naming
+		if ($new_state === null && strpos($request, 'filter_') === 0)
+		{
+			$name    = substr($request, 7);
+			$filters = $app->input->get('filter', array(), 'array');
+
+			if (!empty($filters[$name]))
+			{
+				$new_state = $filters[$name];
+			}
+		}
+
 		if (($cur_state != $new_state) && ($resetPage))
 		{
 			$input->set('limitstart', 0);


### PR DESCRIPTION
### Issue

As raised in #6677, #7052 and some other issues we currently have an issue with pagination in views where Search Tools are implemented.
That is, you can't change to page 2, you're stuck on page 1.
### Background

The issue is that the Search Tools uses different names for the filter inputs as they are generated using JForm. Without Search Tools, the name was for example `filter_published`, which became `filter[published]` with Search Tools.
Now the model still checks for the old name since we still have layouts without Search Tools (Hathor overrides and modal layouts). However because the inputs aren't present in the case of Search Tools, the `getUserStateFromRequest` doesn't find anything (`null`). This method however also compares the old value to the new one and if it changed it resets the pagination. Which is what we experience.
The whole thing apparently only surfaced in Joomla 3.4.1 due to a bug fixed elsewhere in JRegistry.
### Proposes solution

This PR uses a bit of a hackish workaround which will try to retrieve the value from the Search Tools field in case the requested field starts with `filter_` and contains no value.
This way, everything should work as expected and nothing should break.
### Testing
- Use for example the article manager to reproduce the issue: Apply a filter and try to go to the second page. You will be stuck on page 1.
- Apply patch and try again, now it should work.
- Try also with Hathor (uses Overrides) and the modal layout which is used when you try to insert an article into an article using the editor button.
- Check also frontend lists.
