### PR TITLE
Disable the new `view admin` option per default

### DIFF
--- a/administrator/modules/mod_status/mod_status.xml
+++ b/administrator/modules/mod_status/mod_status.xml
@@ -35,7 +35,7 @@
 					name="show_viewadmin"
 					type="radio"
 					class="btn-group btn-group-yesno"
-					default="1"
+					default="0"
 					label="MOD_STATUS_FIELD_SHOW_VIEWADMIN_LABEL"
 					description="MOD_STATUS_FIELD_SHOW_VIEWADMIN_DESC">
 					<option value="1">JYES</option>

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -25,7 +25,7 @@ if ($params->get('show_viewsite', 1))
 }
 
 // Print the link to open a new Administrator window.
-if ($params->get('show_viewadmin', 1))
+if ($params->get('show_viewadmin', 0))
 {
 	$output[] = '<div class="btn-group viewsite">'
 		. '<a href="' . JURI::base() . '" target="_blank">'
@@ -56,7 +56,7 @@ if ($params->get('show_loggedin_users_admin', 1))
 //  Print the inbox message.
 if ($params->get('show_messages', 1))
 {
-	$active = $unread ? ' badge-warning' : '';
+	$active   = $unread ? ' badge-warning' : '';
 	$output[] = '<div class="btn-group hasTooltip ' . $inboxClass . '"'
 		. ' title="' . JText::plural('MOD_STATUS_MESSAGES', $unread) . '">'
 		. ($hideLinks ? '' : '<a href="' . $inboxLink . '">')


### PR DESCRIPTION
This Disable the new `view admin` option per default that was introduced here: https://github.com/joomla/joomla-cms/pull/7174/files
### How to test
- install this repo: https://github.com/zero-24/joomla-cms/archive/disable_new_option.zip
- make sure that the `View Administrator` link is not shown per default
- go to the mod_status module
- check that the option there is disabled.
