### PR TITLE
Change PHP 7 Exception handling to catch Throwable

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -19,7 +19,7 @@ class JErrorPage
 	/**
 	 * Render the error page based on an exception.
 	 *
-	 * @param   object  $error  An Exception or BaseException (PHP 7+) object for which to render the error page.
+	 * @param   object  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.
 	 *
 	 * @return  void
 	 *
@@ -27,10 +27,10 @@ class JErrorPage
 	 */
 	public static function render($error)
 	{
-		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'BaseException' : 'Exception';
+		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'Throwable' : 'Exception';
 		$isException   = $error instanceof $expectedClass;
 
-		// In PHP 5, the $error object should be an instance of Exception; PHP 7 should be a BaseException
+		// In PHP 5, the $error object should be an instance of Exception; PHP 7 should be a Throwable implementation
 		if ($isException)
 		{
 			try

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -53,7 +53,7 @@ class JDocumentError extends JDocument
 	 */
 	public function setError($error)
 	{
-		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'BaseException' : 'Exception';
+		$expectedClass = PHP_MAJOR_VERSION >= 7 ? 'Throwable' : 'Exception';
 
 		if ($error instanceof $expectedClass)
 		{

--- a/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
+++ b/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
@@ -64,8 +64,8 @@ class JErrorPageTest extends TestCaseDatabase
 			$this->markTestSkipped('Test only applies to PHP 7+');
 		}
 
-		// Create an Exception to inject into the method
-		$exception = new EngineException('Testing JErrorPage::render()', 500);
+		// Create an Error to inject into the method
+		$exception = new Error('Testing JErrorPage::render()', 500);
 
 		// The render method echoes the output, so catch it in a buffer
 		ob_start();


### PR DESCRIPTION
Per PHP's [Throwable RFC](https://wiki.php.net/rfc/throwable-interface), a change has been made in PHP 7's error handling.  Long and short, the `BaseException` class is gone and the two error branches (`Exception` and `Error` (previously `EngineException`)) now implement the `Throwable` interface.  This PR updates our adoption of the previous exception objects to follow the newly implemented interfaces.

Note that this change is now implemented in the PHP 7 branch.  Travis-CI (as of the time this was opened) may not yet be updated with this change.
