### PR TITLE
RTL, protostar: correcting sub-menu alignment

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -160,6 +160,18 @@ textarea {
 		page-break-after: avoid;
 	}
 }
+.rtl .navigation .nav-child {
+	left: auto;
+	right: 0;
+}
+.rtl .navigation .nav > li > .nav-child:before {
+	left: auto;
+	right: 12px;
+}
+.rtl .navigation .nav > li > .nav-child:after {
+	left: auto;
+	right: 13px;
+}
 .clearfix {
 	*zoom: 1;
 }

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -127,6 +127,7 @@ else
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
 	. ($params->get('fluidContainer') ? ' fluid' : '');
+	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 
 	<!-- Body -->

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -3,6 +3,7 @@
 
 // Core variables and mixins
 @import "variables.less"; // Custom for this template
+@import "template_rtl.less"; // Specific for rtl
 @import "../../../media/jui/less/mixins.less";
 
 // Grid system and page structure

--- a/templates/protostar/less/template_rtl.less
+++ b/templates/protostar/less/template_rtl.less
@@ -1,0 +1,15 @@
+// Specific RTL. rtl class is added to body tag
+
+// Fix for sub menu alignment
+.rtl .navigation .nav-child {
+	left: auto;
+	right:0;
+}
+.rtl .navigation .nav > li > .nav-child:before {
+	left: auto;
+	right:12px;
+}
+.rtl .navigation .nav > li > .nav-child:after {
+	left: auto;
+	right:13px;
+}


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/6740 (See test instructions there) by implementing @phproberto suggestion.

@oc666
Thanks for the css.

Any future RTL improvement would now be easily done in template_rtl.less by adding .rtl to the styles concerned.
