### PR TITLE
[New feature] Version History limit context

### DIFF
--- a/libraries/cms/helper/contenthistory.php
+++ b/libraries/cms/helper/contenthistory.php
@@ -147,7 +147,7 @@ class JHelperContenthistory extends JHelper
 
 		$context = (isset($aliasParts[1])) ? $aliasParts[1] : '';
 
-		$maxVersionsContext = JComponentHelper::getParams($aliasParts[0])->get('history_limit' . '_' . $context, null);
+		$maxVersionsContext = JComponentHelper::getParams($aliasParts[0])->get('history_limit' . '_' . $context, 0);
 
 		if ($maxVersionsContext)
 		{

--- a/libraries/cms/helper/contenthistory.php
+++ b/libraries/cms/helper/contenthistory.php
@@ -145,7 +145,15 @@ class JHelperContenthistory extends JHelper
 		// Load history_limit config from extension.
 		$aliasParts = explode('.', $this->typeAlias);
 
-		if ($maxVersions = JComponentHelper::getParams($aliasParts[0])->get('history_limit', 0))
+		$context = (isset($aliasParts[1])) ? $aliasParts[1] : '';
+
+		$maxVersionsContext = JComponentHelper::getParams($aliasParts[0])->get('history_limit' . '_' . $context, null);
+
+		if ($maxVersionsContext)
+		{
+			$historyTable->deleteOldVersions($maxVersionsContext);
+		}
+		elseif ($maxVersions = JComponentHelper::getParams($aliasParts[0])->get('history_limit', 0))
 		{
 			$historyTable->deleteOldVersions($maxVersions);
 		}


### PR DESCRIPTION
## Context

When using Joomla! versioning feature, we are able to fix a number of history limit in configuration.
[Follow of #7191](https://github.com/joomla/joomla-cms/issues/7191)
## Actual limitation

This history limit is only applied of the whole component context eg: com_banners.
If you want to got (wanna keep using banners component for exemple) only 10 history limit for banner and 5 for client (dunno if this could be real) this is actually not possible.
## How to test
### Part1
- Create 1 banner, save and edit multiple time (you need versioning history ON and history limitation setup)
- Then create 1 client, save and edit multiple time.
- Both got same history limitation
- Erase all
### Part2

Apply patch.

Go to `administrator\components\com_banners` and edit `config.xml` and add after

``` xml
<field
    name="history_limit"
    type="text"
    filter="integer"
    label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
    description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
    default="5"
/>
```

this

``` xml
<field
    name="history_limit_client"
    type="text"
    filter="integer"
    label="COM_BANNERS_CLIENT_HISTORY_LIMIT_OPTIONS_LABEL"
    description="COM_BANNERS_CLIENT_HISTORY_LIMIT_OPTIONS_DESC"
    default="5"
/>
<field
    name="history_limit_banner"
    type="text"
    filter="integer"
    label="COM_BANNERS_BANNER_HISTORY_LIMIT_OPTIONS_LABEL"
    description="COM_BANNERS_BANNER_HISTORY_LIMIT_OPTIONS_DESC"
    default="5"
/>
```

OR
Use [this repo / ZIP](https://github.com/Devportobello/joomla-attach-PR-7206).

Repeat the part1 after having different setup for history limitation using 2 new context (banner / client) eg: 3 for maximum version client, 4 for maximum version banner and 5 for the base maximum version
You would be able to got different number of history limit.
