### PR TITLE
Prevents the plugin parameters are destroyed if the captcha plugin is loaded more than once

### DIFF
--- a/libraries/cms/captcha/captcha.php
+++ b/libraries/cms/captcha/captcha.php
@@ -230,8 +230,12 @@ class JCaptcha extends JObject
 			throw new RuntimeException(JText::sprintf('JLIB_CAPTCHA_ERROR_PLUGIN_NOT_FOUND', $name));
 		}
 
-		$params = new Registry($plugin->params);
-		$plugin->params = $params;
+		// Check for already loaded params
+		if (!($plugin->params instanceof Registry))
+		{
+			$params = new Registry($plugin->params);
+			$plugin->params = $params;
+		}
 
 		// Build captcha plugin classname
 		$name = 'plgCaptcha' . $this->_name;


### PR DESCRIPTION
This change prevents the plugin parameters are destroyed if the captcha plugin is loaded more than once on the same page.
https://github.com/joomla/joomla-cms/issues/6674

---
#### Steps to reproduce the issue

Create two captcha fields in the same page through a form with type="captcha" (I use different "namespace" for each field)
#### Expected result

Two captcha in the same page.
#### Actual result

Error: reCAPTCHA plugin needs a site key to be set in its parameters. Please contact a site administrator.
#### System information (as much as possible)

Joomla 3.4.1
#### Additional comments

The fist time the captcha plugin is loaded, the _load function in the captcha library convert the plugin params from string to a Registry object, this is correct, but the second time the plugin is loaded, the library put the already converted params inside a new Registry object and the plugin params can't be used anymore.

File: libraries/cms/captcha/captcha.php
Line: 233

This issue can be fixed by checking if the plugin params is already a JRegistry object.

if (!($plugin->params instanceof JRegistry))
{
  $params = new Registry($plugin->params);
  $plugin->params = $params;
}

Please note. With the current version of Recaptcha (reCAPTCHA API version 2.0), you can have multiple recaptchas on one page, and this is the first step to achieve this feature.
