### PR TITLE
Fixed JMailHelper::isEmailAddress to validate IPv4 addresses

### DIFF
--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -140,7 +140,8 @@ abstract class JMailHelper
 
 		if (preg_match($regex, $domain))
 		{
-			return true;
+			$regex = '/^(?:[01]?\d\d?|2[0-4]\d|25[0-5])\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])$/';
+			return preg_match($regex, $domain) === 1;
 		}
 
 		// Check Lengths


### PR DESCRIPTION
Fixed JMailHelper::isEmailAddress to validate IPv4 addresses. Previously any numeric values were treated as valid domains for emails.

---
#### Steps to reproduce the issue

JMailHelper::isEmailAddress('q@7');
#### Expected result

false
#### Actual result

true
#### System information (as much as possible)

Joomla 3.4.1, OpenServer (Apache 2.2, PHP 5.3), MS Windows 7
#### Additional comments

The problem piece of code is (/libraries/joomla/mail/helper.php):

// No problem if the domain looks like an IP address, ish
$regex = '/^[0-9.]+$/';

if (preg_match($regex, $domain))
{
    return true;
}

A bit better solution:

$regex = '^([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])\.
([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])$';

Source: http://www.mkyong.com/regular-expressions/how-to-validate-ip-address-with-regular-expression/
