### PR TITLE
Remove @author tag

### DIFF
--- a/libraries/classloader.php
+++ b/libraries/classloader.php
@@ -16,7 +16,6 @@ use Composer\Autoload\ClassLoader;
  * For backward compatibility due to class aliasing in the CMS, the loadClass() method was modified to call
  * the JLoader::applyAliasFor() method.
  *
- * @author  Johan Janssens
  * @since   3.4
  */
 class JClassLoader


### PR DESCRIPTION
I believe (although google fails me) that a decision was made in the past to remove @author tags from Joomla methods/classes source code. 

This PR removes one that was recently changed from Nicholas Dionysopoulos to Johan Janssens in https://github.com/joomla/joomla-cms/commit/e1cfdc0bf85a9905adb7a7627f76af42e788cd44
