### PR TITLE
Define JVersion class vars as constants

### DIFF
--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -16,38 +16,123 @@ defined('JPATH_PLATFORM') or die;
  */
 final class JVersion
 {
-	/** @var  string  Product name. */
-	public $PRODUCT = 'Joomla!';
+	/**
+	 * Product name.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const PRODUCT = 'Joomla!';
 
-	/** @var  string  Release version. */
-	public $RELEASE = '3.4';
+	/**
+	 * Release version.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const RELEASE = '3.4';
 
-	/** @var  string  Maintenance version. */
-	public $DEV_LEVEL = '2-dev';
+	/**
+	 * Maintenance version.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const DEV_LEVEL = '2-dev';
 
-	/** @var  string  Development STATUS. */
-	public $DEV_STATUS = 'Development';
+	/**
+	 * Development status.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const DEV_STATUS = 'Development';
 
-	/** @var  string  Build number. */
-	public $BUILD = '';
+	/**
+	 * Build number.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const BUILD = '';
 
-	/** @var  string  Code name. */
-	public $CODENAME = 'Ember';
+	/**
+	 * Code name.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const CODENAME = 'Ember';
 
-	/** @var  string  Release date. */
-	public $RELDATE = '21-March-2015';
+	/**
+	 * Release date.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const RELDATE = '21-March-2015';
 
-	/** @var  string  Release time. */
-	public $RELTIME = '20:30';
+	/**
+	 * Release time.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const RELTIME = '20:30';
 
-	/** @var  string  Release timezone. */
-	public $RELTZ = 'GMT';
+	/**
+	 * Release timezone.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const RELTZ = 'GMT';
 
-	/** @var  string  Copyright Notice. */
-	public $COPYRIGHT = 'Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.';
+	/**
+	 * Copyright Notice.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const COPYRIGHT = 'Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.';
 
-	/** @var  string  Link text. */
-	public $URL = '<a href="http://www.joomla.org">Joomla!</a> is Free Software released under the GNU General Public License.';
+	/**
+	 * Link text.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	const URL = '<a href="http://www.joomla.org">Joomla!</a> is Free Software released under the GNU General Public License.';
+
+	/**
+	 * Magic getter providing access to constants previously defined as class member vars.
+	 *
+	 * @param   string  $name  The name of the property.
+	 *
+	 * @return  mixed   A value if the property name is valid.
+	 *
+	 * @since   3.5
+	 * @deprecated  4.0  Access the constants directly
+	 */
+	public function __get($name)
+	{
+		if (defined("JVersion::$name"))
+		{
+			JLog::add(
+				'Accessing JVersion data through class member variables is deprecated, use the corresponding constant instead.',
+				JLog::WARNING,
+				'deprecated'
+			);
+
+			return constant("JVersion::$name");
+		}
+
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined constant via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+	}
 
 	/**
 	 * Compares two a "PHP standardized" version number against the current Joomla version.
@@ -73,7 +158,7 @@ final class JVersion
 	 */
 	public function getHelpVersion()
 	{
-		return '.' . str_replace('.', '', $this->RELEASE);
+		return '.' . str_replace('.', '', self::RELEASE);
 	}
 
 	/**
@@ -85,7 +170,7 @@ final class JVersion
 	 */
 	public function getShortVersion()
 	{
-		return $this->RELEASE . '.' . $this->DEV_LEVEL;
+		return self::RELEASE . '.' . self::DEV_LEVEL;
 	}
 
 	/**
@@ -97,9 +182,9 @@ final class JVersion
 	 */
 	public function getLongVersion()
 	{
-		return $this->PRODUCT . ' ' . $this->RELEASE . '.' . $this->DEV_LEVEL . ' '
-			. $this->DEV_STATUS . ' [ ' . $this->CODENAME . ' ] ' . $this->RELDATE . ' '
-			. $this->RELTIME . ' ' . $this->RELTZ;
+		return self::PRODUCT . ' ' . self::RELEASE . '.' . self::DEV_LEVEL . ' '
+			. self::DEV_STATUS . ' [ ' . self::CODENAME . ' ] ' . self::RELDATE . ' '
+			. self::RELTIME . ' ' . self::RELTZ;
 	}
 
 	/**
@@ -122,17 +207,17 @@ final class JVersion
 
 		if ($add_version)
 		{
-			$component .= '/' . $this->RELEASE;
+			$component .= '/' . self::RELEASE;
 		}
 
 		// If masked pretend to look like Mozilla 5.0 but still identify ourselves.
 		if ($mask)
 		{
-			return 'Mozilla/5.0 ' . $this->PRODUCT . '/' . $this->RELEASE . '.' . $this->DEV_LEVEL . ($component ? ' ' . $component : '');
+			return 'Mozilla/5.0 ' . self::PRODUCT . '/' . self::RELEASE . '.' . self::DEV_LEVEL . ($component ? ' ' . $component : '');
 		}
 		else
 		{
-			return $this->PRODUCT . '/' . $this->RELEASE . '.' . $this->DEV_LEVEL . ($component ? ' ' . $component : '');
+			return self::PRODUCT . '/' . self::RELEASE . '.' . self::DEV_LEVEL . ($component ? ' ' . $component : '');
 		}
 	}
 


### PR DESCRIPTION
Joomla's version data is currently manipulable within a JVersion instance since the data is defined as public facing vars.  This PR blocks the ability of developers to be able to manipulate this information by defining the version data as constants instead.
### Backward Compatibility
#### Fetching Data

A magic getter is implemented which will catch any calls which tried to access the previously defined class member variables and will return the corresponding constant instead.  A deprecation log message is added for these cases.  In instances where someone trying to access an undefined class variable occurs, a `E_USER_NOTICE` PHP error is generated (similar to PHP's native handling).
#### Setting Data

With this PR, it's no longer possible.  It should have never been possible.  But, since we are being so strict on B/C, this must be highlighted.  And we should hopefully not use the argument that a developer could previously overwrite the core platform's version data as an excuse to not accept this patch IMO.
### Testing Instructions

Make sure you have the version data displayed in the admin toolbar (default yes), apply the patch, and make sure the page loads without any error messages.
