### PR TITLE
[FIX] Permissions settings is not saved for new article

### DIFF
--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -228,7 +228,7 @@ class JTableContent extends JTable
 			}
 
 			// If we don't have any access rules set at this point just use an empty JAccessRules class
-			if (!isset($this->_rules))
+			if (!$this->getRules())
 			{
 				$rules = $this->getDefaultAssetValues('com_content');
 				$this->setRules($rules);

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -228,7 +228,7 @@ class JTableContent extends JTable
 			}
 
 			// If we don't have any access rules set at this point just use an empty JAccessRules class
-			if (!isset($this->rules))
+			if (!isset($this->_rules))
 			{
 				$rules = $this->getDefaultAssetValues('com_content');
 				$this->setRules($rules);


### PR DESCRIPTION
## PR Summary

This PR fixes the issue reported at https://github.com/joomla/joomla-cms/issues/7205. When you create a new article and change permission settings for that new article tab, that change is not saved. This happens because a typo in JTableContent class. Because of that typo, the permission settings of the new article which you created is always the same with the default permission settings of com_content component, not depend on the settings you set for that article.

Please note that this issue only happen when you create a new article, not when you edit an article
## Testing instructions:
- Create a new article, look at Permissions tab, try to change some permission settings. Save it. You will see that the permission settings you change is not being saved.
- Apply this patch
- Test again. The permission settings you set for the new article will be saved properly.
