### PR TITLE
Make sure template value is not empty

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -508,8 +508,16 @@ final class JApplicationSite extends JApplicationCms
 			$template = $templates[0];
 		}
 
+		$oldTemplate = $template->template;
+
 		// Allows for overriding the active template from the request
-		$template->template = $this->input->getCmd('template', $template->template);
+		$template->template = $this->input->getCmd('template', $oldTemplate);
+
+		// If the template is still empty, then set our default value again
+		if (!$template->template)
+		{
+			$template->template = $oldTemplate;
+		}
 
 		// Need to filter the default value as well
 		$template->template = JFilterInput::getInstance()->clean($template->template, 'cmd');


### PR DESCRIPTION
See #7227 for details.

This catches if the value ends up being empty and restores the value returned from the lookup a few lines above this.

---

Hi there. Check this [http://www.joomla.org/?template=](http://www.joomla.org/?template=) 
It looking not good in main Joomla site.
I have checked this at my projects - yea, looks like bad bug, when you add ?template after joomlasiteurl/
