### PR TITLE
Make sure only a valid template can be loaded

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -511,7 +511,7 @@ final class JApplicationSite extends JApplicationCms
 		// Allows for overriding the active template from the request
 		$template_override = $this->input->getCmd('template', '');
 
-		// If the template is still empty, then set our default value again
+		// Only set template override if it is a valid template
 		if (!empty($template_override))
 		{
 			if (file_exists(JPATH_THEMES . '/' . $template_override . '/index.php'))

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -509,7 +509,23 @@ final class JApplicationSite extends JApplicationCms
 		}
 
 		// Allows for overriding the active template from the request
-		$template->template = $this->input->getCmd('template', $template->template);
+		$template_override = $this->input->getCmd('template', '');
+
+		// If the template is still empty, then set our default value again
+		if (!empty($template_override))
+		{
+			if (file_exists(JPATH_THEMES . '/' . $template_override . '/index.php'))
+			{
+				foreach ($templates as $tmpl)
+				{
+					if ($tmpl->template == $template_override)
+					{
+						$template->template = $template_override;
+						break;
+					}
+				}
+			}
+		}
 
 		// Need to filter the default value as well
 		$template->template = JFilterInput::getInstance()->clean($template->template, 'cmd');

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -511,7 +511,7 @@ final class JApplicationSite extends JApplicationCms
 		// Allows for overriding the active template from the request
 		$template_override = $this->input->getCmd('template', '');
 
-		// Only set template override if it is a valid template
+		// Only set template override if it is a valid template (= it exists and is enabled)
 		if (!empty($template_override))
 		{
 			if (file_exists(JPATH_THEMES . '/' . $template_override . '/index.php'))


### PR DESCRIPTION
This is my approach to fix the problem described here: https://github.com/joomla/joomla-cms/issues/7227 
This patch also avoids the problem with not valid templates from this pull request: https://github.com/joomla/joomla-cms/pull/7228

This PR will only load a template if it is a valid template (-> it exists and is enabled) else the specified template is loaded.

**How to test**

1.) Add _?template=_ and then _?template=xyz_ (not valid template name) to the end of the frontpage (this should load the default Beez3 template, IMHO not a good fallback solution...)
2.) Deactivate the template Beez3 (Extensions - Extensions - Manage - Status) and try it again, both tries will result in an error message on blank page
3.) Apply this PR (with Patchtester component) and try it again. The correct (selected) template will be loaded on both tries!
