### PR TITLE
Implementing "No Matching Results" in Contacts modal

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -76,88 +76,88 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 		</div>
 	<?php else : ?>
-	<table class="table table-striped table-condensed">
-		<thead>
-			<tr>
-				<th class="title">
-					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
-				</th>
-				<th class="center nowrap">
-					<?php echo JHtml::_('grid.sort', 'COM_CONTACT_FIELD_LINKED_USER_LABEL', 'ul.name', $listDirn, $listOrder); ?>
-				</th>
-				<th width="15%" class="center nowrap">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
-				</th>
-				<th width="15%" class="center nowrap">
-					<?php echo JHtml::_('grid.sort', 'JCATEGORY', 'a.catid', $listDirn, $listOrder); ?>
-				</th>
-				<th width="5%" class="center nowrap">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-				</th>
-				<th width="1%" class="center nowrap">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-				</th>
-			</tr>
-		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="6">
-					<?php echo $this->pagination->getListFooter(); ?>
-				</td>
-			</tr>
-		</tfoot>
-		<tbody>
-		<?php foreach ($this->items as $i => $item) : ?>
-			<?php if ($item->language && JLanguageMultilang::isEnabled())
-			{
-				$tag = strlen($item->language);
-				if ($tag == 5)
+		<table class="table table-striped table-condensed">
+			<thead>
+				<tr>
+					<th class="title">
+						<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
+					</th>
+					<th class="center nowrap">
+						<?php echo JHtml::_('grid.sort', 'COM_CONTACT_FIELD_LINKED_USER_LABEL', 'ul.name', $listDirn, $listOrder); ?>
+					</th>
+					<th width="15%" class="center nowrap">
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
+					</th>
+					<th width="15%" class="center nowrap">
+						<?php echo JHtml::_('grid.sort', 'JCATEGORY', 'a.catid', $listDirn, $listOrder); ?>
+					</th>
+					<th width="5%" class="center nowrap">
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+					</th>
+					<th width="1%" class="center nowrap">
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+					</th>
+				</tr>
+			</thead>
+			<tfoot>
+				<tr>
+					<td colspan="6">
+						<?php echo $this->pagination->getListFooter(); ?>
+					</td>
+				</tr>
+			</tfoot>
+			<tbody>
+			<?php foreach ($this->items as $i => $item) : ?>
+				<?php if ($item->language && JLanguageMultilang::isEnabled())
 				{
-					$lang = substr($item->language, 0, 2);
+					$tag = strlen($item->language);
+					if ($tag == 5)
+					{
+						$lang = substr($item->language, 0, 2);
+					}
+					elseif ($tag == 6)
+					{
+						$lang = substr($item->language, 0, 3);
+					}
+					else {
+						$lang = "";
+					}
 				}
-				elseif ($tag == 6)
+				elseif (!JLanguageMultilang::isEnabled())
 				{
-					$lang = substr($item->language, 0, 3);
-				}
-				else {
 					$lang = "";
 				}
-			}
-			elseif (!JLanguageMultilang::isEnabled())
-			{
-				$lang = "";
-			}
-			?>
-			<tr class="row<?php echo $i % 2; ?>">
-				<td>
-					<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-					<?php echo $this->escape($item->name); ?></a>
-				</td>
-				<td align="center">
-					<?php if (!empty($item->linked_user)) : ?>
-						<?php echo $item->linked_user;?>
-					<?php endif; ?>
-				</td>
-				<td class="center">
-					<?php echo $this->escape($item->access_level); ?>
-				</td>
-				<td class="center">
-					<?php echo $this->escape($item->category_title); ?>
-				</td>
-				<td class="center">
-					<?php if ($item->language == '*'):?>
-						<?php echo JText::alt('JALL', 'language'); ?>
-					<?php else:?>
-						<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-					<?php endif;?>
-				</td>
-				<td align="center">
-					<?php echo (int) $item->id; ?>
-				</td>
-			</tr>
+				?>
+				<tr class="row<?php echo $i % 2; ?>">
+					<td>
+						<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+						<?php echo $this->escape($item->name); ?></a>
+					</td>
+					<td align="center">
+						<?php if (!empty($item->linked_user)) : ?>
+							<?php echo $item->linked_user;?>
+						<?php endif; ?>
+					</td>
+					<td class="center">
+						<?php echo $this->escape($item->access_level); ?>
+					</td>
+					<td class="center">
+						<?php echo $this->escape($item->category_title); ?>
+					</td>
+					<td class="center">
+						<?php if ($item->language == '*'):?>
+							<?php echo JText::alt('JALL', 'language'); ?>
+						<?php else:?>
+							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+						<?php endif;?>
+					</td>
+					<td align="center">
+						<?php echo (int) $item->id; ?>
+					</td>
+				</tr>
 			<?php endforeach; ?>
-		</tbody>
-	</table>
+			</tbody>
+		</table>
 	<?php endif; ?>
 
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -71,7 +71,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php endif; ?>
 		</div>
 	</fieldset>
-
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
@@ -154,6 +158,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 		</tbody>
 	</table>
+	<?php endif; ?>
 
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />


### PR DESCRIPTION
When creating a menu item of type single contact  the list of contacts is displayed in a modal window.
When filtering and if no results, the display is just empty instead of the usual message "No Matching Results"
This patch is just implementing the message in the modal when necessary.

Thanks t0 @infograf768 for the code
