### PR TITLE
Implementing "No Matching Results" in Newsfeed modal

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -71,7 +71,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php endif; ?>
 		</div>
 	</fieldset>
-
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
@@ -154,6 +158,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 		</tbody>
 	</table>
+	<?php endif; ?>
 
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -71,6 +71,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		</div>
 	</fieldset>
 
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
+
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
@@ -145,6 +151,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 		</tbody>
 	</table>
+	<?php endif; ?>
 
 	<div>
 		<input type="hidden" name="task" value="" />


### PR DESCRIPTION
When creating a menu item of type single newsfeed the list of newsfeed is displayed in a modal window.
When filtering and if no results, the display is just empty instead of the usual message "No Matching Results"
This patch is just implementing the message in the modal when necessary.

Thanks to @infograf768 for the code
