### PR TITLE
Implementing "No Matching Results" in Users modal

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -39,13 +39,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 		</div>
 	</fieldset>
-		<?php if (empty($this->items)) : ?>
-			<div class="alert alert-no-items">
-				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-			</div>
-		<?php else : ?>
-	<table class="table table-striped table-condensed">
-		<thead>
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
+		<table class="table table-striped table-condensed">
+			<thead>
 			<tr>
 				<th class="left">
 					<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
@@ -58,14 +58,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
+			<tfoot>
 			<tr>
 				<td colspan="15">
 					<?php echo $this->pagination->getListFooter(); ?>
 				</td>
 			</tr>
 		</tfoot>
-		<tbody>
+			<tbody>
 		<?php
 			$i = 0;
 
@@ -84,7 +84,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</tr>
 		<?php endforeach; ?>
 		</tbody>
-	</table>
+		</table>
 	<?php endif; ?>
 
 	<div>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -39,7 +39,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 		</div>
 	</fieldset>
-
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
@@ -81,6 +85,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php endforeach; ?>
 		</tbody>
 	</table>
+	<?php endif; ?>
+
 	<div>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>" />

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -46,47 +46,47 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php else : ?>
 		<table class="table table-striped table-condensed">
 			<thead>
-			<tr>
-				<th class="left">
-					<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
-				</th>
-				<th class="nowrap" width="25%">
-					<?php echo JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
-				</th>
-				<th class="nowrap" width="25%">
-					<?php echo JText::_('COM_USERS_HEADING_GROUPS'); ?>
-				</th>
-			</tr>
-		</thead>
+				<tr>
+					<th class="left">
+						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
+					</th>
+					<th class="nowrap" width="25%">
+						<?php echo JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
+					</th>
+					<th class="nowrap" width="25%">
+						<?php echo JText::_('COM_USERS_HEADING_GROUPS'); ?>
+					</th>
+				</tr>
+			</thead>
 			<tfoot>
-			<tr>
-				<td colspan="15">
-					<?php echo $this->pagination->getListFooter(); ?>
-				</td>
-			</tr>
-		</tfoot>
+				<tr>
+					<td colspan="15">
+						<?php echo $this->pagination->getListFooter(); ?>
+					</td>
+				</tr>
+			</tfoot>
 			<tbody>
-		<?php
-			$i = 0;
+				<?php
+				$i = 0;
 
-			foreach ($this->items as $item) : ?>
-			<tr class="row<?php echo $i % 2; ?>">
-				<td>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>');">
-						<?php echo $item->name; ?></a>
-				</td>
-				<td align="center">
-					<?php echo $item->username; ?>
-				</td>
-				<td align="left">
-					<?php echo nl2br($item->group_names); ?>
-				</td>
-			</tr>
-		<?php endforeach; ?>
-		</tbody>
+				foreach ($this->items as $item) : ?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td>
+							<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>');">
+								<?php echo $item->name; ?>
+							</a>
+						</td>
+						<td align="center">
+							<?php echo $item->username; ?>
+						</td>
+						<td align="left">
+							<?php echo nl2br($item->group_names); ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
 		</table>
 	<?php endif; ?>
-
 	<div>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>" />

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -39,11 +39,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</div>
 		</div>
 	</fieldset>
-	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
-	<?php else : ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>


### PR DESCRIPTION
In the article manage when selecting a User in the publishing tab  the list of users is displayed in a modal window.
When filtering and if no results, the display is just empty instead of the usual message "No Matching Results"
This patch is just implementing the message in the modal when necessary.

Thanks to @infograf768 for the code idea
