### PR TITLE
Display Captcha using HTTPS only + URL encode & sign

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -57,7 +57,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 			case '1.0':
 				$theme = $this->params->get('theme', 'clean');
 				$file  = 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
-				
+
 				JHtml::_('script', $file);
 
 				$document->addScriptDeclaration('jQuery( document ).ready(function()

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -56,9 +56,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			case '1.0':
 				$theme = $this->params->get('theme', 'clean');
-
-				$file = $app->isSSLConnection() ? 'https' : 'http';
-				$file .= '://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
+				$file  = 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
+				
 				JHtml::_('script', $file);
 
 				$document->addScriptDeclaration('jQuery( document ).ready(function()
@@ -68,10 +67,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 				break;
 			case '2.0':
 				$theme = $this->params->get('theme2', 'light');
-
-				$file = $app->isSSLConnection() ? 'https' : 'http';
-				$file .= '://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()
-						->getTag() . '&render=explicit';
+				$file  = 'https://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()->getTag() . '&amp;render=explicit';
 
 				JHtml::_('script', $file, true, true);
 


### PR DESCRIPTION
# Issue

Described in #6807 - script is loaded based on current protocol causing issues when caching is enabled (if you switch from http to https the cached page still uses http for script inclusion and thus the browser is blocking it).
# Solution

I see no problem in loading it using https all the time. I've also found that `&render=explicit` is not properly URL encoded and fixed that as well.
