### PR TITLE
Allows to specify relative protocol URIs in JHtml()

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -296,7 +296,7 @@ abstract class JHtml
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
 		// If http is present in filename
-		if (strpos($file, 'http') === 0)
+		if (strpos($file, 'http') === 0 || strpos($file, '//') === 0)
 		{
 			$includes = array($file);
 		}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -295,7 +295,7 @@ abstract class JHtml
 	 */
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
-		// If http is present in filename
+		// If http is present in filename or relative protocol URI
 		if (strpos($file, 'http') === 0 || strpos($file, '//') === 0)
 		{
 			$includes = array($file);


### PR DESCRIPTION
# Issue

While working on https://github.com/joomla/joomla-cms/pull/7237 I noticed that you cannot specify relative protocol URIs (description [here](http://tools.ietf.org/html/rfc3986#section-4.2)) when using `JHtml()` to load external scripts or stylesheets.

If you try to use something along the lines of:

``` php
JHtml::_('script', '//www.google.com/recaptcha/api.js');
```

The file will get ignored completely (it won't show up in the `<head>` section).
# Solution

`includeRelativeFiles()` from the `JHtml` class seems to take into account external files only if they begin with `http`. Added another check for `//` and fixed the issue. Or added a new feature, whichever you prefer :)
