### PR TITLE
Wrong loadRowList param description in driver.php

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1407,14 +1407,17 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * Method to get an array of the result set rows from the database query where each row is an array.  The array
 	 * of objects can optionally be keyed by a field offset, but defaults to a sequential numeric array.
 	 *
-	 * @param   integer  $key  The index of a field on which to key the result array.
+	 * NOTE: Choosing to key the result array by a non-unique field can result in unwanted
+	 * behavior and should be avoided.
+	 *
+	 * @param   integer  $index  The index of a field on which to key the result array.
 	 *
 	 * @return  mixed   The return value or null if the query failed.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException
 	 */
-	public function loadRowList($key = null)
+	public function loadRowList($index = null)
 	{
 		$this->connect();
 
@@ -1429,9 +1432,9 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		// Get all of the rows from the result set as arrays.
 		while ($row = $this->fetchArray($cursor))
 		{
-			if ($key !== null)
+			if ($index !== null)
 			{
-				$array[$row[$key]] = $row;
+				$array[$row[$index]] = $row;
 			}
 			else
 			{

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1407,10 +1407,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * Method to get an array of the result set rows from the database query where each row is an array.  The array
 	 * of objects can optionally be keyed by a field offset, but defaults to a sequential numeric array.
 	 *
-	 * NOTE: Choosing to key the result array by a non-unique field can result in unwanted
-	 * behavior and should be avoided.
-	 *
-	 * @param   string  $key  The name of a field on which to key the result array.
+	 * @param   integer  $key  The index of a field on which to key the result array.
 	 *
 	 * @return  mixed   The return value or null if the query failed.
 	 *


### PR DESCRIPTION
`$key` is a numeric index of a field in $row array not a field/column name. `$row` variable is an array indexed starting from zero. So `$key` is unique . Using column name in this param can result in unexpected results.

Here is a test (put it for example in template's index.php):

``` php
$db = JFactory::getDbo();
$query = $db->getQuery(true);
$query->select('title,id')->from('#__menu');
$db->setQuery($query);
$results = $db->loadRowList('id');
var_dump($results);die;
```

This test should return all menu items indexed by item id. But what it does is returning first item in rows list.

``` php
The correct code should be a follows:
Here is test:
$db = JFactory::getDbo();
$query = $db->getQuery(true);
$query->select('title,id')->from('#__menu');
$db->setQuery($query);
$results = $db->loadRowList(1);
var_dump($results);die;
```

So as you can see description is wrong.
