### PR TITLE
Remove CSS rules for specific icons

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -178,14 +178,6 @@ body.modal-open {
 	margin-right: .25em;
 	line-height: 14px;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
-}
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
 	font-family: 'IcoMoon';

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6266,14 +6266,6 @@ div.modal.fade.in {
 	margin-right: .25em;
 	line-height: 14px;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
-}
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
 	font-family: 'IcoMoon';
@@ -8743,14 +8735,6 @@ input[type="url"] {
 [class^="icon-"],
 [class*=" icon-"] {
 	margin-left: .25em;
-}
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
 }
 .navbar .admin-logo {
 	float: right;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6266,14 +6266,6 @@ div.modal.fade.in {
 	margin-right: .25em;
 	line-height: 14px;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
-}
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
 	font-family: 'IcoMoon';

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -617,11 +617,3 @@ input[type="url"] {
 [class*=" icon-"] {
 	margin-left: .25em;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
-}

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -630,11 +630,3 @@ input[type="url"] {
 [class*=" icon-"] {
 	margin-left: .25em;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time{
-	margin-left: -.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"]{
-	margin-right: 0;
- }

--- a/media/jui/less/icomoon.less
+++ b/media/jui/less/icomoon.less
@@ -29,15 +29,6 @@
 	line-height: 14px;
 }
 
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time{
-	margin-left: -.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"]{
-	margin-right: 0;
- }
- 
 /* Use the following CSS code if you want to have a class per icon */
 [class^="icon-"]:before, [class*=" icon-"]:before {
 	font-family: 'IcoMoon';

--- a/media/jui/less/sprites.less
+++ b/media/jui/less/sprites.less
@@ -28,15 +28,6 @@
 	margin-top: 1px;
 }
 
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time{
-	margin-left: -.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"]{
-	margin-right: 0;
- }
-
 /* White icons with optional class, or on hover/focus/active states of certain elements */
 .icon-white,
 .nav-pills > .active > a > [class^="icon-"],

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6237,14 +6237,6 @@ div.modal.fade.in {
 	margin-right: .25em;
 	line-height: 14px;
 }
-dd > span[class^="icon-"] + time,
-dd > span[class*=" icon-"] + time {
-	margin-left: -0.25em;
-}
-dl.article-info dd.hits span[class^="icon-"],
-dl.article-info dd.hits span[class*=" icon-"] {
-	margin-right: 0;
-}
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
 	font-family: 'IcoMoon';


### PR DESCRIPTION
### Issue

Our icomoon.less file contains some CSS rules which have no business in that file. The same CSS rules also are added to sprites.less where they even make less sense (we don't use that file at all) and in the bootstrap-rtl.less file.
Since we generate our template CSS files based on the LESS files, those rules also are present in Hathor, Isis and Protostar template.css files.

I saw this when I tried to update our media/jui/css/icomoon.css based on its media/jui/less/icomoon.less file as it was badly out of sync.

After investigating I found that it was introduced with #5512 (which is based on #4372). That PR did apply those rules wrongly in the icomoon.less file, when it should have been done in the template.less file for Protostar instead.
Next step was to figure out what the rules are effectively doing, and I found that they can be safely removed. I guess this is something which eventually got fixed elsewhere as well, making those rules unneeded.

This PR proposes to remove the following CSS rules quite specific to certain icon useage from the global LESS files.

```
dd > span[class^="icon-"] + time,
dd > span[class*=" icon-"] + time{
    margin-left: -.25em;
}
dl.article-info dd.hits span[class^="icon-"],
dl.article-info dd.hits span[class*=" icon-"]{
    margin-right: 0;
}
```

There is only a small difference in the spacing however since it's the same space for all icons I don't see an issue.
Currently:
![before](https://cloud.githubusercontent.com/assets/1018684/8283156/c0a33cba-18f5-11e5-9430-db4b6b6095bb.PNG)
After:
![after](https://cloud.githubusercontent.com/assets/1018684/8283165/d587371c-18f5-11e5-8f5d-433871e12c2a.PNG)
That being said, in RTL it looks currently like this:
![rtl-before](https://cloud.githubusercontent.com/assets/1018684/8283169/e26c4d14-18f5-11e5-8158-67786c17275c.PNG)
and with my PR:
![rtl-after](https://cloud.githubusercontent.com/assets/1018684/8283170/e73d20d4-18f5-11e5-980e-d1b130b92026.PNG)
### Testing

The only place where I found this rules being active is the "Article Details" section in frontend. One rule targets the calendar type entries (`<time>` tags) , the other is the hits icon.
I couldn't find any use of it in the backend, so Isis and Hathor should be unaffected..
### Backward Compatibility

As that file is surely is used by some 3rd party templates, it will change the spacing there as well as soon as the template.css is generated again from LESS. Which usually is when the template provided creates a new release. Other than that, nothing will "break".
