### PR TITLE
Implementing "No Matching Results" in Categories modal

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -72,6 +72,11 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</div>
 	</fieldset>
 
+	<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+	<?php else : ?>
 	<table class="table table-striped" id="categoryList">
 		<thead>
 			<tr>
@@ -151,6 +156,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 		</tbody>
 	</table>
+	<?php endif; ?>
 
 	<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -77,85 +77,85 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 		</div>
 	<?php else : ?>
-	<table class="table table-striped" id="categoryList">
-		<thead>
-			<tr>
-				<th>
-					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
-				</th>
-				<th width="10%" class="nowrap hidden-phone">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
-				</th>
-				<th width="5%" class="nowrap hidden-phone">
-					<?php
-					echo JHtml::_(
-						'grid.sort',
-						'JGRID_HEADING_LANGUAGE',
-						'language',
-						$this->state->get('list.direction'),
-						$this->state->get('list.ordering')
-					);
-					?>
-				</th>
-				<th width="1%" class="nowrap hidden-phone">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-				</th>
-			</tr>
-		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="15">
-					<?php echo $this->pagination->getListFooter(); ?>
-				</td>
-			</tr>
-		</tfoot>
-		<tbody>
-			<?php foreach ($this->items as $i => $item) : ?>
-				<?php if ($item->language && JLanguageMultilang::isEnabled())
-				{
-					$tag = strlen($item->language);
-					if ($tag == 5)
+		<table class="table table-striped" id="categoryList">
+			<thead>
+				<tr>
+					<th>
+						<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+					</th>
+					<th width="10%" class="nowrap hidden-phone">
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+					</th>
+					<th width="5%" class="nowrap hidden-phone">
+						<?php
+						echo JHtml::_(
+							'grid.sort',
+							'JGRID_HEADING_LANGUAGE',
+							'language',
+							$this->state->get('list.direction'),
+							$this->state->get('list.ordering')
+						);
+						?>
+					</th>
+					<th width="1%" class="nowrap hidden-phone">
+						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+					</th>
+				</tr>
+			</thead>
+			<tfoot>
+				<tr>
+					<td colspan="15">
+						<?php echo $this->pagination->getListFooter(); ?>
+					</td>
+				</tr>
+			</tfoot>
+			<tbody>
+				<?php foreach ($this->items as $i => $item) : ?>
+					<?php if ($item->language && JLanguageMultilang::isEnabled())
 					{
-						$lang = substr($item->language, 0, 2);
+						$tag = strlen($item->language);
+						if ($tag == 5)
+						{
+							$lang = substr($item->language, 0, 2);
+						}
+						elseif ($tag == 6)
+						{
+							$lang = substr($item->language, 0, 3);
+						}
+						else
+						{
+							$lang = "";
+						}
 					}
-					elseif ($tag == 6)
-					{
-						$lang = substr($item->language, 0, 3);
-					}
-					else
+					elseif (!JLanguageMultilang::isEnabled())
 					{
 						$lang = "";
 					}
-				}
-				elseif (!JLanguageMultilang::isEnabled())
-				{
-					$lang = "";
-				}
-				?>
-				<tr class="row<?php echo $i % 2; ?>">
-					<td>
-						<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>
-						<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-							<?php echo $this->escape($item->title); ?>
-						</a>
-					</td>
-					<td class="small hidden-phone">
-						<?php echo $this->escape($item->access_level); ?>
-					</td>
-					<td class="center nowrap">
-						<?php if ($item->language == '*'): ?>
-							<?php echo JText::alt('JALL', 'language'); ?>
-						<?php else: ?>
-							<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-						<?php endif; ?>
-					</td>
-					<td class="center hidden-phone">
-						<?php echo (int) $item->id; ?>
-					</td>
-				</tr>
-			<?php endforeach; ?>
-		</tbody>
-	</table>
+					?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td>
+							<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>
+							<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+								<?php echo $this->escape($item->title); ?>
+							</a>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="center nowrap">
+							<?php if ($item->language == '*'): ?>
+								<?php echo JText::alt('JALL', 'language'); ?>
+							<?php else: ?>
+								<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+							<?php endif; ?>
+						</td>
+						<td class="center hidden-phone">
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
 	<?php endif; ?>
 
 	<input type="hidden" name="extension" value="<?php echo $extension; ?>" />


### PR DESCRIPTION
Similar patch as #7232, #7236, #7234, #7231 for Categories.
To test, install a basic multilingual site and set associations in the language filter plugin. Create at least one article category for each language (2 languages are enough).
Edit a category. Click on the Associations Tab. Select a category. The list of categories associated to that peculiar language display in a modal.

![screen shot 2015-06-22 at 17 50 47](https://cloud.githubusercontent.com/assets/869724/8286213/8d09cea6-1908-11e5-9184-4c3c21c00ec4.png)

When filtering and if no results, the display is just empty instead of the usual message "No Matching Results"
