### PR TITLE
Update punycode.php - change JPATH_ROOT to JPATH_LIBRARIES

### DIFF
--- a/libraries/joomla/string/punycode.php
+++ b/libraries/joomla/string/punycode.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLoader::register('idna_convert', JPATH_ROOT . '/libraries/idna_convert/idna_convert.class.php');
+JLoader::register('idna_convert', JPATH_LIBRARIES . '/idna_convert/idna_convert.class.php');
 
 /**
  * Joomla Platform String Punycode Class


### PR DESCRIPTION
When use JPATH_ROOT we get "Fatal error: Class 'idna_convert' not found in /var/www/test/.protect/.libraries/joomla/string/punycode.php on line 52" if move and rename libraries directory in own custom defines.php

Bug in files:
/libraries/joomla/string/wrapper/punycode.php
/libraries/joomla/string/punycode.php
