### PR TITLE
Fix for scrollbar flashing in modals (#7247)

### DIFF
--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -60,7 +60,7 @@ if (isset($params['keyboard']))
  * Specific hack for Bootstrap 2.3.x
  */
 $script[] = "jQuery(document).ready(function($) {";
-$script[] = "   $('#" . $selector . "').on('show', function() {";
+$script[] = "   $('#" . $selector . "').on('shown', function() {";
 $script[] = "       $('body').addClass('modal-open');";
 
 if (isset($params['url']))
@@ -73,7 +73,7 @@ if (isset($params['url']))
 	$script[] = "       modalBody.prepend('" . trim($iframeHtml) . "');";
 }
 
-$script[] = "   }).on('hidden', function () {";
+$script[] = "   }).on('hide', function () {";
 $script[] = "       $('body').removeClass('modal-open');";
 $script[] = "   });";
 $script[] = "});";

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -60,7 +60,7 @@ if (isset($params['keyboard']))
  * Specific hack for Bootstrap 2.3.x
  */
 $script[] = "jQuery(document).ready(function($) {";
-$script[] = "   $('#" . $selector . "').on('shown', function() {";
+$script[] = "   $('#" . $selector . "').on('show', function() {";
 $script[] = "       $('body').addClass('modal-open');";
 
 if (isset($params['url']))


### PR DESCRIPTION
#### Description

In batch modals the main window scrollbar appear/disappear when you move the mouse over a label (_possibly related to tooltips..._).
#### Steps to reproduce the issue
- Open a batch modal (either in article manager or menu manager)
- Move the mouse over a label (e.g.: "Set language" in the Menu manager modal)
- The main window scrollbar, on the right side, will disappear and the modal will snap a little bit to the right (_really annoying_)
### Testing instructions

Apply this patch and the scrollabr will not appear/disappear and the modal will be "steady".
