### PR TITLE
Fix case with string value

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -975,7 +975,7 @@ abstract class JHtml
 		static::_('bootstrap.tooltip');
 
 		// Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
-		if ((int) $value && $value != JFactory::getDbo()->getNullDate())
+		if ($value && $value != JFactory::getDbo()->getNullDate())
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -177,7 +177,7 @@ class JFormFieldCalendar extends JFormField
 		{
 			case 'SERVER_UTC':
 				// Convert a date to UTC based on the server timezone.
-				if ((int) $this->value && $this->value != JFactory::getDbo()->getNullDate())
+				if ($this->value && $this->value != JFactory::getDbo()->getNullDate())
 				{
 					// Get a date object based on the correct timezone.
 					$date = JFactory::getDate($this->value, 'UTC');
@@ -191,7 +191,7 @@ class JFormFieldCalendar extends JFormField
 
 			case 'USER_UTC':
 				// Convert a date to UTC based on the user timezone.
-				if ((int) $this->value && $this->value != JFactory::getDbo()->getNullDate())
+				if ($this->value && $this->value != JFactory::getDbo()->getNullDate())
 				{
 					// Get a date object based on the correct timezone.
 					$date = JFactory::getDate($this->value, 'UTC');

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCalendarTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCalendarTest.php
@@ -16,7 +16,7 @@ JFormHelper::loadFieldClass('calendar');
  * @subpackage  Form
  * @since       11.1
  */
-class JFormFieldCalendarTest extends TestCase
+class JFormFieldCalendarTest extends TestCaseDatabase
 {
 	/**
 	 * Backup of the SERVER superglobal
@@ -501,7 +501,7 @@ class JFormFieldCalendarTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testGetInput()
+	public function testGetInputWithNullDatabase()
 	{
 		$form = new JForm('form1');
 
@@ -514,7 +514,49 @@ class JFormFieldCalendarTest extends TestCase
 		$field = new JFormFieldCalendar($form);
 
 		$this->assertThat(
-			$field->setup($form->getXml()->field, 'value'),
+			$field->setup($form->getXml()->field, '0000-00-00 00:00:00'),
+			$this->isTrue(),
+			'Line:' . __LINE__ . ' The setup method should return true.'
+		);
+
+		$this->assertThat(
+			strlen($field->input),
+			$this->greaterThan(0),
+			'Line:' . __LINE__ . ' The getInput method should return something without error.'
+		);
+
+		// TODO: Should check all the attributes have come in properly.
+	}
+
+	/**
+	 * Test the getInput method.
+	 *
+	 * @return void
+	 */
+	public function testGetInputWithStringValue()
+	{
+		$form = new JForm('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="calendar" type="calendar" /></form>'),
+			$this->isTrue(),
+			'Line:' . __LINE__ . ' XML string should load successfully.'
+		);
+
+		// The calendar form field depends on having the time zone available. Easiest way is to
+		// mock it in the config
+		$testConfig = $this->getMockConfig();
+		$testConfig->expects(
+			$this->any()
+		)
+			->method('get')
+			->will($this->returnValue('Europe/London'));
+		JFactory::$config = $testConfig;
+
+		$field = new JFormFieldCalendar($form);
+
+		$this->assertThat(
+			$field->setup($form->getXml()->field, 'June 2015'),
 			$this->isTrue(),
 			'Line:' . __LINE__ . ' The setup method should return true.'
 		);


### PR DESCRIPTION
This PR is an updated version of https://github.com/joomla/joomla-cms/pull/5763

I finally figured out the reason that the test failed in 5763 was because we were inputting a value for the field as value. This isn't a valid date format for the PHP Datetime class (which JDate extends from), therefore we got an exception.

I've replaced it with two tests - one tests when there is a database null value, and the other for when there is a valid string value (this currently fails)
