### PR TITLE
Missing grouping label on mod_articles_category

### DIFF
--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 	<?php if ($grouped) : ?>
 		<?php foreach ($list as $group_name => $group) : ?>
 		<li>
+			<div class="mod-articles-category-group"><?php echo $group_name;?></div>
 			<ul>
 				<?php foreach ($group as $item) : ?>
 					<li>


### PR DESCRIPTION
This PR fixes a bug reported by @Nzara in https://github.com/joomla/joomla-cms/issues/7169. Detailed description and testing instructions can be found in that issue.
