### PR TITLE
Allow HTTP transports to have adapter options injected

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -178,6 +178,12 @@ class JHttpTransportCurl implements JHttpTransport
 			}
 		}
 
+		// Set any custom transport options
+		foreach ($this->options->get('transport.curl', array()) as $key => $value)
+		{
+			$options[$key] = $value;
+		}
+
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);
 

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -124,6 +124,12 @@ class JHttpTransportSocket implements JHttpTransport
 			}
 		}
 
+		// Set any custom transport options
+		foreach ($this->options->get('transport.socket', array()) as $value)
+		{
+			$request[] = $value;
+		}
+
 		// If we have data to send add it to the request payload.
 		if (!empty($data))
 		{

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -124,13 +124,19 @@ class JHttpTransportStream implements JHttpTransport
 		// Follow redirects.
 		$options['follow_location'] = (int) $this->options->get('follow_location', 1);
 
+		// Set any custom transport options
+		foreach ($this->options->get('transport.stream', array()) as $key => $value)
+		{
+			$options[$key] = $value;
+		}
+
 		// Create the stream context for the request.
 		$context = stream_context_create(
 			array(
 				'http' => $options,
 				'ssl' => array(
 					'verify_peer'   => true,
-					'cafile'        => __DIR__ . '/cacert.pem',
+					'cafile'        => $this->options->get('stream.certpath', __DIR__ . '/cacert.pem'),
 					'verify_depth'  => 5,
 				)
 			)


### PR DESCRIPTION
This is a backport of https://github.com/joomla-framework/http/pull/12 which enables developers to inject additional adapter specific options into our `JHttpTransport` interface implementations.  This enables developers to set additional options for the transport that are otherwise unable to be set through the API and potentially override some settings depending on how the transport config is assembled.

Also changed with this PR is adding an option to the stream transport to override the path for the cacert.pam file (similar to the curl adapter).
### Developer Info

For developers using `JHttp` there are three new "reserved" keys for the options array; `transport.curl`, `transport.socket`, and `transport.stream`.  If using `JHttpFactory::getHttp()` to build your objects (the preferred method), simply add an array for each of these keys with the transport specific options to inject (examples can be found in the `JHttpTransportTest::$options`).
### Testing Instructions

You can place the below text snippet anywhere which will build a `JHttp` object with the extra context options added.

``` php
$extraOptions = array(
    'transport.curl'   => array(CURLOPT_SSL_VERIFYPEER => false),
    'transport.socket' => array('X-Joomla-Test: true'),
    'transport.stream' => array('ignore_errors' => true)
);

$transportOptions = new \Joomla\Registry\Registry($extraOptions);
$transport = JHttpFactory::getHttp($transportOptions);
$transport->get('http://localhost');
```

Since the transport connection options aren't retrievable via a public API, you'll need to do a `var_dump()` on the object the options are being added to before the connection is initiated (this is going to be environment dependent, usually it will be `JHttpTransportCurl` if your environment supports it).  You should verify the extra option is included in the options array.  Note for curl that the options array's keys will be integers that match the constant's value, `CURLOPT_SSL_VERIFYPEER` has a value of 64.
