### PR TITLE
Revert #7093, introduce activeEditor for tinyMCE

### DIFF
--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -37,7 +37,7 @@ class PlgButtonReadmore extends JPlugin
 
 		// Button is not active in specific content components
 
-		$getContent = $this->_subject->getContent("'+editor+'");
+		$getContent = $this->_subject->getContent($name);
 		$present = JText::_('PLG_READMORE_ALREADY_EXISTS', true);
 		$js = "
 			function insertReadmore(editor)

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -801,9 +801,9 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return  string
 	 */
-	public function onGetContent($editor)
+	public function onGetContent()
 	{
-		return 'tinyMCE.get(\'' . $editor . '\').getContent();';
+		return 'tinyMCE.activeEditor.getContent();';
 	}
 
 	/**
@@ -814,9 +814,9 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return  string
 	 */
-	public function onSetContent($editor, $html)
+	public function onSetContent($html)
 	{
-		return 'tinyMCE.get(\'' . $editor . '\').setContent(' . $html . ');';
+		return 'tinyMCE.activeEditor.setContent(' . $html . ');';
 	}
 
 	/**
@@ -828,7 +828,7 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onSave($editor)
 	{
-		return 'if (tinyMCE.get("' . $editor . '").isHidden()) {tinyMCE.get("' . $editor . '").show()}; tinyMCE.get("' . $editor . '").save();';
+		return 'if (tinyMCE.get("' . $editor . '").isHidden()) {tinyMCE.get("' . $editor . '").show()};';
 	}
 
 	/**

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -801,7 +801,7 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return  string
 	 */
-	public function onGetContent()
+	public function onGetContent($editor)
 	{
 		return 'tinyMCE.activeEditor.getContent();';
 	}
@@ -814,7 +814,7 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return  string
 	 */
-	public function onSetContent($html)
+	public function onSetContent($editor, $html)
 	{
 		return 'tinyMCE.activeEditor.setContent(' . $html . ');';
 	}


### PR DESCRIPTION
#### This solves regression #7260
### Testing

edit administrator/modules/custom/mod_custom.xml and insert after line 36:

```
                <field name="articletext1" type="editor"
                       label="test" description="test"
                       filter="JComponentHelper::filterText" buttons="true" />
                <field name="articletext2" type="editor"
                       label="test" description="test"
                       filter="JComponentHelper::filterText" buttons="true" />
                <field name="articletext3" type="editor"
                       label="test" description="test"
                       filter="JComponentHelper::filterText" buttons="true" />
```

Set editor to tiny. And try to create a new custom HTML module for the ADMINISTRATOR area!!!
Try before applying this patch to insert a read more tag in every editor
Apply patch, retry

Switch editors none, tiny, code mirror and this everything works for all of them

This is what you should been looking for, the read dotted line in tinyMCE
![screenshot 2015-06-25 16 28 10](https://cloud.githubusercontent.com/assets/3889375/8355313/37c573ae-1b57-11e5-8f8b-9659876d25b8.png)

and as a tag for none and code mirror
![screenshot 2015-06-25 16 38 02](https://cloud.githubusercontent.com/assets/3889375/8355565/afaac9c2-1b58-11e5-894d-2fc822367e34.png)
