### PR TITLE
Add (array) to JRouter::_rules return value

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -590,7 +590,7 @@ class JRouter
 
 		foreach ($this->_rules['parse' . $stage] as $rule)
 		{
-			$vars += call_user_func_array($rule, array(&$this, &$uri));
+			$vars += (array) call_user_func_array($rule, array(&$this, &$uri));
 		}
 
 		return $vars;


### PR DESCRIPTION
Currently our router rules should return array, otherwise will return this error

```
Fatal error: Unsupported operand types in /path/to/joomla/libraries/cms/router/router.php on line 593
```

There are two choice:
- Throw Exception to notice developer that they return wrong type.
- Just force all value to array to ignore error.

I try to force return value to array that will prevent fatal error.
## How to Test

Add a custom plugin or in any plugin `onAfterInitialise` event, add this code:

``` php
$closure = function(\JRouterSite $router, \JUri $uri)
{
    return;
};

$app = JFactory::getApplication();
$router = $app::getRouter();

$router->attachParseRule($closure, $router::PROCESS_BEFORE);
```

Then it will raise fatal error in frontend.
