### PR TITLE
[CODE REVIEW] - languagefilter.php

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -304,8 +304,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			}
 		}
 
-		// We are called via POST. We don't care about the language
-		// and simply set the default language as our current language.
+		// We are called via POST. We don't care about the language and simply set the default language as our current language.
 		// [Errr... this is not exactly what happens here below!!! TBD verify...]
 		if ($this->app->input->getMethod() == "POST"
 			|| count($this->app->input->post) > 0
@@ -478,9 +477,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				$lang_code = $this->default_lang;
 			}
 
-			// The language has been deleted/disabled/unpublished
-			// or the related home page does not exist
-			// or the related content language does not exist
+			// The language has been deleted/disabled/unpublished, or the related home page does not exist,
+			// or the related content language folder does not exist
 			if (!array_key_exists($lang_code, $this->lang_codes)
 				|| !array_key_exists($lang_code, $this->home_pages)
 				|| !is_dir(JPATH_SITE . '/language/' . $lang_code))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -48,6 +48,8 @@ class PlgSystemLanguageFilter extends JPlugin
 	 * @param   array   $config    An optional associative array of configuration settings.
 	 *
 	 * @since   1.6
+	 *
+	 * Part of this code is Copyright © 2015 Sergio Manzi - smz@smz.it
 	 */
 	public function __construct(&$subject, $config)
 	{
@@ -235,6 +237,8 @@ class PlgSystemLanguageFilter extends JPlugin
 	 * @return  array
 	 *
 	 * @since   1.6
+	 *
+	 * Part of this code is Copyright © 2015 Sergio Manzi - smz@smz.it
 	 */
 	public function parseRule(&$router, &$uri)
 	{
@@ -535,6 +539,8 @@ class PlgSystemLanguageFilter extends JPlugin
 	 * @return  void
 	 *
 	 * @since   1.7
+	 *
+	 * Part of this code is Copyright © 2015 Sergio Manzi - smz@smz.it
 	 */
 	public function onAfterDispatch()
 	{
@@ -668,6 +674,8 @@ class PlgSystemLanguageFilter extends JPlugin
 	 * @return  string
 	 *
 	 * @since   3.5
+	 *
+	 * Part of this code is Copyright © 2015 Sergio Manzi - smz@smz.it
 	 */
 	private function getClientLanguage()
 	{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -561,7 +561,10 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				// Check if we are on the homepage
 				$is_home = ($active->home
-					&& ($active_link == $current_link || $active_link == $current_link . 'index.php' || $active_link . '/' == $current_link));
+					&& ($current_link == $active_link
+						|| $current_link == '/index.php?lang=' . $languages[$this->current_lang]->sef
+						|| $current_link . 'index.php' == $active_link
+						|| $current_link == $active_link . '/'));
 			}
 
 			// Load component associations.
@@ -584,9 +587,14 @@ class PlgSystemLanguageFilter extends JPlugin
 						unset($languages[$i]);
 						break;
 
-					// Home page
-					case ($is_home):
+					// Home page SEF
+					case ($is_home && $this->mode_sef):
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $this->home_pages[$i]->id);
+						break;
+
+					// Home page non SEF
+					case ($is_home && !$this->mode_sef):
+						$language->link = '/index.php?lang=' . $language->sef;
 						break;
 
 					// Current language link

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -69,10 +69,10 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($this->sefs as $sef => $language)
 			{
+				// Check access and if frontend language exists and is enabled
 				// @todo: In Joomla 2.5.4 and earlier access wasn't set. Non modified Content Languages got 0 as access value
-				// we also check if frontend language exists and is enabled
 				if (($language->access && !in_array($language->access, $levels))
-					|| (!array_key_exists($language->lang_code, $site_langs))
+					|| !array_key_exists($language->lang_code, $site_langs)
 					|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code))
 				{
 					unset($this->lang_codes[$language->lang_code]);
@@ -544,7 +544,6 @@ class PlgSystemLanguageFilter extends JPlugin
 			$languages = $this->lang_codes;
 			$menu = $this->app->getMenu();
 			$active = $menu->getActive();
-			$levels = JFactory::getUser()->getAuthorisedViewLevels();
 			$remove_default_prefix = $this->params->get('remove_default_prefix', 0);
 			$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
 			$is_home = false;
@@ -580,9 +579,8 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				switch (true)
 				{
-					// Language without specific home menu || Language without authorized access level
+					// Language without specific home menu
 					case (!isset($this->home_pages[$i])):
-					case (isset($language->access) && $language->access && !in_array($language->access, $levels)):
 						unset($languages[$i]);
 						break;
 
@@ -668,19 +666,19 @@ class PlgSystemLanguageFilter extends JPlugin
 		$cookie = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
 		$lang_code = $cookie;
 
-		// Let's be sure we got a valid language code. Fallback to null (so that in case we try the browser)
+		// If the cookie is not for a valid language code, fallback to null (so that in case we try the browser)
 		if (!$this->checkLanguage($lang_code))
 		{
 			$lang_code = null;
 		}
 
-		// No valid cookie, try browser
+		// If we have an invalid cookie and the "Detect browser language" param is set, we try the browser language
 		if (!$lang_code && $this->params->get('detect_browser', 0))
 		{
 			$lang_code = JLanguageHelper::detectLanguage();
 		}
 
-		// Nor the cookie, nor the browser language are valid: fallback to default
+		// If we still have an invalid language we fallback to default
 		if (!$this->checkLanguage($lang_code))
 		{
 			$lang_code = $this->default_lang;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -67,16 +67,16 @@ class PlgSystemLanguageFilter extends JPlugin
 			$levels = JFactory::getUser()->getAuthorisedViewLevels();
 			$site_langs = MultilangstatusHelper::getSitelangs();
 
-			foreach ($this->sefs as $sef => $language)
+			foreach ($this->lang_codes as $lang_code => $language)
 			{
 				// Check language access, language is enabled, language folder exists, and language has an Home Page
 				// @todo: In Joomla 2.5.4 and earlier access wasn't set. Non modified Content Languages got 0 as access value
 				if (($language->access && !in_array($language->access, $levels))
-					|| !array_key_exists($language->lang_code, $site_langs)
-					|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code)
-					|| !isset($this->home_pages[$language->lang_code]))
+					|| !array_key_exists($lang_code, $site_langs)
+					|| !is_dir(JPATH_SITE . '/language/' . $lang_code)
+					|| !isset($this->home_pages[$lang_code]))
 				{
-					unset($this->lang_codes[$language->lang_code]);
+					unset($this->lang_codes[$lang_code]);
 					unset($this->sefs[$language->sef]);
 				}
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -74,7 +74,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				if (($language->access && !in_array($language->access, $levels))
 					|| !array_key_exists($language->lang_code, $site_langs)
 					|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code)
-					|| !isset($this->home_pages[$i]))
+					|| !isset($this->home_pages[$language->lang_code]))
 				{
 					unset($this->lang_codes[$language->lang_code]);
 					unset($this->sefs[$language->sef]);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -595,7 +595,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Current language
 					case ($i == $this->current_lang):
-						$language->link = JUri::getInstance()->toString(array('path', 'query'));
+						$language->link = str_replace('&', '&amp;', JUri::getInstance()->toString(array('path', 'query')));
 						break;
 
 					// Component association

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -69,11 +69,12 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($this->sefs as $sef => $language)
 			{
-				// Check access and if frontend language exists and is enabled
+				// Check language access, language is enabled, language folder exists, and language has an Home Page
 				// @todo: In Joomla 2.5.4 and earlier access wasn't set. Non modified Content Languages got 0 as access value
 				if (($language->access && !in_array($language->access, $levels))
 					|| !array_key_exists($language->lang_code, $site_langs)
-					|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code))
+					|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code)
+					|| !isset($this->home_pages[$i]))
 				{
 					unset($this->lang_codes[$language->lang_code]);
 					unset($this->sefs[$language->sef]);
@@ -582,22 +583,17 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				switch (true)
 				{
-					// Language without specific home menu
-					case (!isset($this->home_pages[$i])):
-						unset($languages[$i]);
-						break;
-
-					// Home page SEF
+					// Home page, SEF mode
 					case ($is_home && $this->mode_sef):
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $this->home_pages[$i]->id);
 						break;
 
-					// Home page non SEF
+					// Home page, non-SEF mode
 					case ($is_home && !$this->mode_sef):
 						$language->link = '/index.php?lang=' . $language->sef;
 						break;
 
-					// Current language link
+					// Current language
 					case ($i == $this->current_lang):
 						$language->link = JUri::getInstance()->toString(array('path', 'query'));
 						break;
@@ -613,7 +609,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 						break;
 
-					// Too bad...
+					// No association found
 					default:
 						unset($languages[$i]);
 				}
@@ -712,7 +708,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	private function checkLanguage($lang_code)
 	{
-		return (isset($lang_code) && array_key_exists($lang_code, $this->lang_codes) && array_key_exists($lang_code, $this->home_pages));
+		return (isset($lang_code) && array_key_exists($lang_code, $this->lang_codes));
 	}
 
 }

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -572,7 +572,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 
 				// Load component associations
-				$option = $this->$app->input->get('option');
+				$option = $this->app->input->get('option');
 				$class = ucfirst(str_ireplace('com_', '', $option)) . 'HelperAssociation';
 				$cassoc_func = array($class, 'getAssociations');
 				JLoader::register($class, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));


### PR DESCRIPTION
### Description

This is a code review of the "Language Filter" system plugin.

The main objective was code simplification and optimization.
At the same time some small issues/bugs have been solved.

The major differences can be found in the `parseRule()` method where, I think, the logic is also better documented. `getLanguageCookie()` too has some major mods.

Less important modifications have been introduced in `onUserBeforeSave()`, `onUserAfterSave()`, `onUserLogin()` and `onAfterDispatch()`
### Testing instructions
- Have a multilingual site with at least three languages installed
- Test front-end multilingual functionalities (_including logging in with users that have a specific language assigned_)
- Verify correct browser language detection
- Verify correct menu items and component association
- Verify that everything else is OK, no regression exist and some small glitches are gone
### Potentially solved issues (_please test..._)
- #7047 Cookie-based Redirect to 404s in language filter
- #7419 Wrong language prefix automatically added
