### PR TITLE
IIS - Add woff mime type for media folder in web.config.txt

### DIFF
--- a/web.config.txt
+++ b/web.config.txt
@@ -28,4 +28,11 @@
        </rewrite>
    </system.webServer>
    </location>
+   <location path="media">
+        <system.webServer>
+            <staticContent>
+                <mimeMap fileExtension=".woff" mimeType="application/x-woff" />
+            </staticContent>
+        </system.webServer>
+    </location>
 </configuration>


### PR DESCRIPTION
This is a corrected PR for #7168 
## Details copied from original report

This PR add woof mime type for iis web.config because it is not configured by default. This causes 404 errors on files of type ".woff ". Only configure this for media folder.
## Actual result in "Article Manager: Edit Article"

![image](https://cloud.githubusercontent.com/assets/1296369/8387755/2b516734-1c53-11e5-8749-eac271b70795.png)
## Actual result in " Banner Manager Options"

![image](https://cloud.githubusercontent.com/assets/1296369/8387774/4904a746-1c53-11e5-8acd-b7ee3b650b58.png)
## Expected result

No 404 errors
## How to test

You must use IIS for test this PR
1. In administration, edit article,
2. You must see 404 errors,
3. Apply the patch and refesh the page,
4. There are more error.
