### PR TITLE
Missing </div> into com_installer default.html

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -174,6 +174,8 @@ JHtml::_('bootstrap.tooltip');
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
+		</div>
+
 	<input type="hidden" name="type" value="" />
 	<input type="hidden" name="installtype" value="upload" />
 	<input type="hidden" name="task" value="install.install" />


### PR DESCRIPTION
Missing /div into file administrator/components/com_installer/views/install/tmpl/default.html

**Step to reproduce**

Go to the extension manager and check if with https://validator.w3.org/nu/

You will have a message such:
There is a missing html tag line 183 which produce error during W3C validation using https://validator.w3.org/nu/
Error: Unclosed element div.
From line 583, column 3; to line 583, column 44
/div> div id="j-main-container" class="span10">

The proposal is to add the missing <div> on line 177

**Expected result**

No more error

**Actual result**

Error: Unclosed element div.

**System information**

Joomla 3.4.1
