### PR TITLE
JFormFieldEditor does not pass columns value (Fix #5209)

### DIFF
--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -244,7 +244,7 @@ class JFormFieldEditor extends JFormFieldTextarea
 		$editor = $this->getEditor();
 
 		return $editor->display(
-			$this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $this->width, $this->height, $this->cols, $this->rows,
+			$this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $this->width, $this->height, $this->columns, $this->rows,
 			$this->buttons ? (is_array($this->buttons) ? array_merge($this->buttons, $this->hide) : $this->hide) : false, $this->id, $this->asset,
 			$this->form->getValue($this->authorField), array('syntax' => (string) $this->element['syntax'])
 		);


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/5209 for issue details.

---
#### Steps to reproduce the issue

Create form with 

```
  <field name='description'
  type="editor" 
  cols="5"
  rows="5"
  label='COM_NKCOMP_FIELD_GROUPTARGET_LABEL'
  description='COM_NKCOMP_FIELD_DESC'
  required="true"
  buttons="false"
  filter="JComponentHelper::filterText"
/>
```

When rendered in components administration view, the value for the attribute "cols" is not shown in the HTML output for the according textarea element. 
#### Expected result

Value for cols should be passed to HTML-Element.
#### Actual result

Empty attribute in HTML-Element textarea: cols=""
#### System information (as much as possible)

Linux, Apache2, php 5.4
#### Additional comments

traced it down to libraries/cms/form/field/editor/editor.php line 249:

```
249c249
< $this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $this->width, $this->height, $this->cols, $this->rows,

---
> $this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $this->width, $this->height, $this->columns, $this->rows,
```

In JFormFieldTextarea is no class variable "cols" but a class variable "columns". 
