### PR TITLE
System - Debug relies on __destruct which is never triggered (Fix #5826)

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -183,9 +183,11 @@ class PlgSystemDebug extends JPlugin
 	/**
 	 * Show the debug info.
 	 *
-	 * @since  1.6
+	 * @return  void
+	 *
+	 * @since   1.6
 	 */
-	public function __destruct()
+	public function onAfterRespond()
 	{
 		// Do not render if debugging or language debug is not enabled.
 		if (!JDEBUG && !$this->debugLang)


### PR DESCRIPTION
This PR addresses #5826 by changing the method that renders the system profiler data to listen to the `onAfterRespond` event, the absolute last thing that Joomla does before PHP should start shutting down the application.
### Testing Instructions

Make sure the profile data still renders correctly.
