### PR TITLE
Minor fixes in "Install localised content"

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1097,8 +1097,8 @@ class InstallationModelLanguages extends JModelBase
 		$db = JFactory::getDbo();
 
 		$newlanguage = new JLanguage($itemLanguage->language, false);
-		$newlanguage->load('plg_editors-xtd_article', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
-		$title = $newlanguage->_('PLG_ARTICLE_BUTTON_ARTICLE');
+		$newlanguage->load('com_content.sys', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
+		$title = $newlanguage->_('COM_CONTENT_CONTENT_TYPE_ARTICLE');
 
 		$article                   = JTable::getInstance('Content');
 
@@ -1124,7 +1124,7 @@ class InstallationModelLanguages extends JModelBase
 			'catid'            => $categoryId,
 			'metadata'         => '{"robots":"","author":"","rights":"","xreference":"","tags":null}',
 			'metakey'          => '',
-			'metadesc'         => '{"robots":"","author":"","rights":"","xreference":""}',
+			'metadesc'         => '',
 			'language'         => $itemLanguage->language,
 			'featured'         => 1,
 			'attribs'          => array(),


### PR DESCRIPTION
### Description

This fixes a couple of minor issues in the localised content installation
### Steps to reproduce the issue
- Perform Joomla! installation
- Select "Extra steps: Install languages"
- In "Install Language Packages" select one or more additional language
- Set "Activate the multilingual feature:" to "Yes"
- Select "Install localised content"
- When installation has completed login in the backend and examine the automatically installed articles
### Expected result
- Articles titles should be "Article" (or the corresponding translation) + Language code
- Articles should have empty metadata
### Actual result
- In some language (_e.g. Italian_) the translation of the word "Article" might be incorrect.
- In the "Meta Description:" you'll find a JSON encoded string: `{"robots":"","author":"","rights":"","xreference":""}`
### Testing instructions

Apply this patch and perform a new installation, as above: actual result should match expected result
### Additional comments

Fixes #7280
