### PR TITLE
[CODE REVIEW] - Language Switcher

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -79,26 +79,26 @@ abstract class ModLanguagesHelper
 		}
 
 		// For each language...
-		foreach ($languages as $i => &$language)
+		foreach ($languages as $lang_code => $language)
 		{
 			$language->active = false;
 			switch (true)
 			{
 				// Current language link
-				case ($i == $current_lang):
+				case ($lang_code == $current_lang):
 					$language->link = str_replace('&', '&amp;', JUri::getInstance()->toString(array('path', 'query')));
 					$language->active = true;
 					break;
 
 				// Component association
-				case (isset($cassociations[$i])):
-					$language->link = JRoute::_($cassociations[$i]);
+				case (isset($cassociations[$lang_code])):
+					$language->link = JRoute::_($cassociations[$lang_code] . '&lang=' . $language->sef);
 					break;
 
 				// Menu items association
 				// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
-				case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
-					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id);
+				case (isset($associations[$lang_code]) && ($item = $menu->getItem($associations[$lang_code]))):
+					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 					break;
 
 				// No association found, SEF mode

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -80,7 +80,7 @@ abstract class ModLanguagesHelper
 					|| $current_link == $active_link . '/'));
 		}
 
-		// Load component associations.
+		// Load component associations
 		if ($assocs)
 		{
 			$option = $app->input->get('option');

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -56,16 +56,18 @@ abstract class ModLanguagesHelper
 		}
 
 		// Setup menu items associations and check if we are on an home page
-		$is_home = false;
 		$menu = $app->getMenu();
 		$active = $menu->getActive();
+		$assocs = JLanguageAssociations::isEnabled();
+		$is_home = false;
+
 		if ($active)
 		{
 			$active_link = JRoute::_($active->link . '&Itemid=' . $active->id, false);
 			$current_link = JUri::getInstance()->toString(array('path', 'query'));
 
 			// Load menu associations
-			if ($active_link == $current_link)
+			if ($assocs && $active_link == $current_link)
 			{
 				$associations = MenusHelper::getAssociations($active->id);
 			}
@@ -109,13 +111,13 @@ abstract class ModLanguagesHelper
 					break;
 
 				// Component association
-				case (isset($cassociations[$i])):
+				case ($assocs && isset($cassociations[$i])):
 					$language->link = JRoute::_($cassociations[$i] . '&lang=' . $language->sef);
 					break;
 
 				// Menu items association
 				// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
-				case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
+				case ($assocs && isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 					break;
 

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -56,7 +56,7 @@ abstract class ModLanguagesHelper
 			}
 		}
 
-		// Setup menu items associations and check if we are on an home page
+		// Get active menu item and check if we are on an home page
 		$menu = $app->getMenu();
 		$active = $menu->getActive();
 		$is_home = false;
@@ -66,12 +66,6 @@ abstract class ModLanguagesHelper
 			$active_link = JRoute::_($active->link . '&Itemid=' . $active->id, false);
 			$current_link = JUri::getInstance()->toString(array('path', 'query'));
 
-			// Load menu associations
-			if ($assocs && $active_link == $current_link)
-			{
-				$associations = MenusHelper::getAssociations($active->id);
-			}
-
 			// Check if we are on the homepage
 			$is_home = ($active->home
 				&& ($current_link == $active_link
@@ -80,9 +74,16 @@ abstract class ModLanguagesHelper
 					|| $current_link == $active_link . '/'));
 		}
 
-		// Load component associations
-		if ($assocs)
+		// Load associations
+		if ($assocs && !$is_home)
 		{
+			// Load menu associations
+			if ($active)
+			{
+				$associations = MenusHelper::getAssociations($active->id);
+			}
+
+			// Load component associations
 			$option = $app->input->get('option');
 			$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
 			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -33,6 +33,7 @@ abstract class ModLanguagesHelper
 	{
 		// Setup data.
 		$app = JFactory::getApplication();
+		$mode_sef = $app->get('sef', 0);
 		$languages = JLanguageHelper::getLanguages('lang_code');
 		$home_pages = MultilangstatusHelper::getHomepages();
 		$levels = JFactory::getUser()->getAuthorisedViewLevels();
@@ -100,9 +101,14 @@ abstract class ModLanguagesHelper
 					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id);
 					break;
 
-				// No association found
+				// No association found, SEF mode
+				case ($mode_sef):
+					$language->link = '/' . $language->sef . '/';
+					break;
+
+				// No association found, non-SEF mode
 				default:
-					$language->link = JRoute::_('index.php?lang=' . $language->sef);
+					$language->link = '/index.php?lang=' . $language->sef;
 			}
 		}
 		return $languages;

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -97,7 +97,7 @@ abstract class ModLanguagesHelper
 				case ($is_home && $mode_sef):
 					$language->link = '/' . $language->sef . '/';
 					break;
-					
+
 				// Home page, non-SEF URLs
 				case ($is_home && !$mode_sef):
 					$language->link = '/index.php?lang=' . $language->sef;
@@ -118,12 +118,12 @@ abstract class ModLanguagesHelper
 				case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 					break;
-					
+
 				// No association found, SEF mode
 				case ($mode_sef):
 					$language->link = '/' . $language->sef . '/';
 					break;
-					
+
 				// No association found, non-SEF mode
 				default:
 					$language->link = '/index.php?lang=' . $language->sef;

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -110,7 +110,7 @@ abstract class ModLanguagesHelper
 
 				// Current language link
 				case ($i == $current_lang):
-					$language->link = JUri::getInstance()->toString(array('path', 'query'));
+					$language->link = str_replace('&', '&amp;', JUri::getInstance()->toString(array('path', 'query')));
 					break;
 
 				// Component association

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -45,14 +45,14 @@ abstract class ModLanguagesHelper
 		$assocs = JLanguageAssociations::isEnabled();
 
 		// Check language access, language is enabled, language folder exists, and language has an Home Page
-		foreach ($sefs as $sef => $language)
+		foreach ($languages as $lang_code => $language)
 		{
 			if (($language->access && !in_array($language->access, $levels))
-				|| !array_key_exists($language->lang_code, $site_langs)
-				|| !is_dir(JPATH_SITE . '/language/' . $language->lang_code)
-				|| !isset($home_pages[$language->lang_code]))
+				|| !array_key_exists($lang_code, $site_langs)
+				|| !is_dir(JPATH_SITE . '/language/' . $lang_code)
+				|| !isset($home_pages[$lang_code]))
 			{
-				unset($languages[$language->lang_code]);
+				unset($languages[$lang_code]);
 			}
 		}
 

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -19,6 +19,8 @@ JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/co
  * @subpackage  mod_languages
  *
  * @since       1.6.0
+ *
+ * Part of this code is Copyright © 2015 Sergio Manzi - smz@smz.it
  */
 abstract class ModLanguagesHelper
 {

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -31,7 +31,6 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-
 		// Setup data.
 		$app = JFactory::getApplication();
 		$mode_sef = $app->get('sef', 0);
@@ -85,12 +84,12 @@ abstract class ModLanguagesHelper
 
 			// Load component associations
 			$option = $app->input->get('option');
-			$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
-			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
-
-			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
+			$class = ucfirst(str_ireplace('com_', '', $option)) . 'HelperAssociation';
+			$cassoc_func = array($class, 'getAssociations');
+			JLoader::register($class, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+			if (class_exists($class) && is_callable($cassoc_func))
 			{
-				$cassociations = call_user_func(array($cName, 'getAssociations'));
+				$cassociations = call_user_func($cassoc_func);
 			}
 		}
 
@@ -137,7 +136,6 @@ abstract class ModLanguagesHelper
 					$language->link = '/index.php?lang=' . $language->sef;
 			}
 		}
-
 		return $languages;
 	}
 }

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -96,6 +96,7 @@ abstract class ModLanguagesHelper
 		// For each language...
 		foreach ($languages as $i => &$language)
 		{
+			$language->active = false;
 			switch (true)
 			{
 				// Home page, SEF
@@ -111,6 +112,7 @@ abstract class ModLanguagesHelper
 				// Current language link
 				case ($i == $current_lang):
 					$language->link = str_replace('&', '&amp;', JUri::getInstance()->toString(array('path', 'query')));
+					$language->active = true;
 					break;
 
 				// Component association

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -42,6 +42,7 @@ abstract class ModLanguagesHelper
 		$levels = JFactory::getUser()->getAuthorisedViewLevels();
 		$site_langs = MultilangstatusHelper::getSitelangs();
 		$current_lang = JFactory::getLanguage()->getTag();
+		$assocs = JLanguageAssociations::isEnabled();
 
 		// Check language access, language is enabled, language folder exists, and language has an Home Page
 		foreach ($sefs as $sef => $language)
@@ -58,7 +59,6 @@ abstract class ModLanguagesHelper
 		// Setup menu items associations and check if we are on an home page
 		$menu = $app->getMenu();
 		$active = $menu->getActive();
-		$assocs = JLanguageAssociations::isEnabled();
 		$is_home = false;
 
 		if ($active)
@@ -81,13 +81,16 @@ abstract class ModLanguagesHelper
 		}
 
 		// Load component associations.
-		$option = $app->input->get('option');
-		$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
-		JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
-
-		if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
+		if ($assocs)
 		{
-			$cassociations = call_user_func(array($cName, 'getAssociations'));
+			$option = $app->input->get('option');
+			$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
+			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+
+			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
+			{
+				$cassociations = call_user_func(array($cName, 'getAssociations'));
+			}
 		}
 
 		// For each language...

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -55,22 +55,6 @@ abstract class ModLanguagesHelper
 			}
 		}
 
-		// Initialize all links to the home page
-		if ($mode_sef)
-		{
-			foreach ($languages as $i => &$language)
-			{
-				$language->link = '/' . $language->sef . '/';
-			}
-		}
-		else
-		{
-			foreach ($languages as $i => &$language)
-			{
-				$language->link = '/index.php?lang=' . $language->sef;
-			}
-		}
-
 		// Setup menu items associations and check if we are on an home page
 		$is_home = false;
 		$menu = $app->getMenu();
@@ -94,12 +78,6 @@ abstract class ModLanguagesHelper
 					|| $current_link == $active_link . '/'));
 		}
 
-		// If we are on an home page we have nothing more to do!
-		if ($is_home)
-		{
-			return $languages;
-		}
-
 		// Load component associations.
 		$option = $app->input->get('option');
 		$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
@@ -115,6 +93,16 @@ abstract class ModLanguagesHelper
 		{
 			switch (true)
 			{
+				// Home page, SEF
+				case ($is_home && $mode_sef):
+					$language->link = '/' . $language->sef . '/';
+					break;
+					
+				// Home page, non-SEF URLs
+				case ($is_home && !$mode_sef):
+					$language->link = '/index.php?lang=' . $language->sef;
+					break;
+
 				// Current language link
 				case ($i == $current_lang):
 					$language->link = JUri::getInstance()->toString(array('path', 'query'));
@@ -130,6 +118,15 @@ abstract class ModLanguagesHelper
 				case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 					$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 					break;
+					
+				// No association found, SEF mode
+				case ($mode_sef):
+					$language->link = '/' . $language->sef . '/';
+					break;
+					
+				// No association found, non-SEF mode
+				default:
+					$language->link = '/index.php?lang=' . $language->sef;
 			}
 		}
 

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -29,7 +29,7 @@ JHtml::_('stylesheet', 'mod_languages/template.css', array(), true);
 	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block';?>">
 	<?php foreach ($list as $language) : ?>
 		<?php if ($params->get('show_active', 0) || !$language->active):?>
-			<li class="<?php echo $language->active ? 'lang-active' : '';?>" dir="<?php echo JLanguage::getInstance($language->lang_code)->isRTL() ? 'rtl' : 'ltr' ?>">
+			<li <?php echo $language->active ? 'class="lang-active" ' : '';?>dir="<?php echo JLanguage::getInstance($language->lang_code)->isRTL() ? 'rtl' : 'ltr' ?>">
 			<a href="<?php echo $language->link;?>">
 			<?php if ($params->get('image', 1)):?>
 				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true);?>


### PR DESCRIPTION
### Description

This is a code review of the "Language Switcher" module (mod_languages).

The main objective was stricter adherence of the generated links to those generated by the Language Filter for `rel='alternate'` links (_particularly to those generated by my proposed code review in #7271_).

For SEF URL there was no problem, but for non-SEF URL there were some issues with home pages links.

Current implementation generates URLs of this kind (_assuming the default "Featured Articles" home page_): `http://example.com/index.php?option=com_content&view=featured&Itemid=102&lang=en`

The proposed code, instead, generates URLs of this kind (_independently of the referenced menu type_): `http://example.com/index.php?lang=en`. This kind of links is more than enough for menu items flagged as an "Home page".
### Testing instructions
- Have a multilingual site with at least three languages installed and some menu items and some articles/categories associated between themselves
- Test the Language Switcher functionality with all kind of "SEO Settings" (_but particularly with non-SEF URLs_) 
- If possible test this with #7271 too and observe the adherence of the Language Switcher links to those found in the `rel='alternate'` links generated by the Language Filter.
- If possible test it with components other than com_content
- Verify that everything else is OK, and no regression exist.
### Additional comments

Much of the code in the Language Switcher helper class and in the onAfterDispatch() method of the Language Switcher is common and has the function to generate "associated" links between different languages.

I think it would be a good idea to introduce a new public method (e.g.: `getAssociatedLinks()`) to perform that function, use it in both cases and have it publicly available. This should probably go in the JLanguageHelper class...

That method will need a switch (true/false) to choose if a link to the corresponding home page should be generated in case no association is found. 
