### PR TITLE
Remove images from breadcrumbs

### DIFF
--- a/media/jui/less/breadcrumbs.less
+++ b/media/jui/less/breadcrumbs.less
@@ -1,24 +1,27 @@
 //
 // Breadcrumbs
 // --------------------------------------------------
-
-
 .breadcrumb {
-  padding: 8px 15px;
-  margin: 0 0 @baseLineHeight;
-  list-style: none;
-  background-color: #f5f5f5;
-  .border-radius(@baseBorderRadius);
-  > li {
-    display: inline-block;
-    .ie7-inline-block();
-    text-shadow: 0 1px 0 @white;
-    > .divider {
-      padding: 0 5px;
-      color: #ccc;
-    }
-  }
-  > .active {
-    color: @grayLight;
-  }
+	padding: 8px 15px;
+	margin: 0 0 @baseLineHeight;
+	list-style: none;
+	background-color: #f5f5f5;
+	.border-radius(@baseBorderRadius);
+	
+	> li {
+		display: inline-block;
+		.ie7-inline-block();
+		text-shadow: 0 1px 0 @white;
+		
+		> .divider {
+			padding: 0 5px;
+			margin-right: 0;
+			vertical-align: middle;
+			color: #ccc;
+		}
+	}
+	
+	> .active {
+		color: @grayLight;
+	}
 }

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -87,11 +87,11 @@ class ModBreadCrumbsHelper
 		{
 			if ($lang->isRTL())
 			{
-				$_separator = JHtml::_('image', 'system/arrow_rtl.png', null, null, true);
+				$_separator = '&#60;';
 			}
 			else
 			{
-				$_separator = JHtml::_('image', 'system/arrow.png', null, null, true);
+				$_separator = '&#62';
 			}
 		}
 		else

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3698,6 +3698,8 @@ input[type="submit"].btn.btn-mini {
 }
 .breadcrumb > li > .divider {
 	padding: 0 5px;
+	margin-right: 0;
+	vertical-align: middle;
 	color: #ccc;
 }
 .breadcrumb > .active {


### PR DESCRIPTION
## Changes in this PR

This PR removes the orange arrows (dividers) from the breadcrumbs and replace them with `>` for LTR languages and `<` for RTL languages. I also add code style to the breadcrumb.less file.
## Background information

I made this PR because the current image where not good aligned in the first place. Also, I think you can better use text instead of images. The used images where old and ugly in my opinion.
My first thought was using the Bootstrap icons, like `icon-arrow-left`, but that will break backward compatibility. Because (unfortunately) not every template supports an icon set.
