### PR TITLE
Simplification for the release process

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -11,9 +11,23 @@ defined('_JEXEC') or die;
 // Joomla system checks.
 @ini_set('magic_quotes_runtime', 0);
 
+// System includes
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Set system error handling
+JError::setErrorHandling(E_NOTICE, 'message');
+JError::setErrorHandling(E_WARNING, 'message');
+JError::setErrorHandling(E_ERROR, 'message', array('JError', 'customErrorPage'));
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+$version = new JVersion;
+
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
-	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10) /* || file_exists(JPATH_INSTALLATION . '/index.php')*/)
+	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10)
+	|| (file_exists(JPATH_INSTALLATION . '/index.php') && ! $version->isInDevelopmentState()))
 {
 	if (file_exists(JPATH_INSTALLATION . '/index.php'))
 	{
@@ -28,17 +42,6 @@ if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
 		exit;
 	}
 }
-
-// System includes
-require_once JPATH_LIBRARIES . '/import.legacy.php';
-
-// Set system error handling
-JError::setErrorHandling(E_NOTICE, 'message');
-JError::setErrorHandling(E_WARNING, 'message');
-JError::setErrorHandling(E_ERROR, 'message', array('JError', 'customErrorPage'));
-
-// Bootstrap the CMS libraries.
-require_once JPATH_LIBRARIES . '/cms.php';
 
 // Pre-Load configuration. Don't remove the Output Buffering due to BOM issues, see JCode 26026
 ob_start();

--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -27,7 +27,7 @@ $version = new JVersion;
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
 	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10)
-	|| (file_exists(JPATH_INSTALLATION . '/index.php') && ! $version->isInDevelopmentState()))
+	|| (file_exists(JPATH_INSTALLATION . '/index.php') && (false === $version->isInDevelopmentState())))
 {
 	if (file_exists(JPATH_INSTALLATION . '/index.php'))
 	{

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -11,9 +11,23 @@ defined('_JEXEC') or die;
 // Joomla system checks.
 @ini_set('magic_quotes_runtime', 0);
 
+// System includes
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Set system error handling
+JError::setErrorHandling(E_NOTICE, 'message');
+JError::setErrorHandling(E_WARNING, 'message');
+JError::setErrorHandling(E_ERROR, 'callback', array('JError', 'customErrorPage'));
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+$version = new JVersion;
+
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
-	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10) /*|| file_exists(JPATH_INSTALLATION . '/index.php')*/)
+	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10)
+	|| (file_exists(JPATH_INSTALLATION . '/index.php') && ! $version->isInDevelopmentState()))
 {
 	if (file_exists(JPATH_INSTALLATION . '/index.php'))
 	{
@@ -28,17 +42,6 @@ if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
 		exit;
 	}
 }
-
-// System includes
-require_once JPATH_LIBRARIES . '/import.legacy.php';
-
-// Set system error handling
-JError::setErrorHandling(E_NOTICE, 'message');
-JError::setErrorHandling(E_WARNING, 'message');
-JError::setErrorHandling(E_ERROR, 'callback', array('JError', 'customErrorPage'));
-
-// Bootstrap the CMS libraries.
-require_once JPATH_LIBRARIES . '/cms.php';
 
 // Pre-Load configuration. Don't remove the Output Buffering due to BOM issues, see JCode 26026
 ob_start();

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -27,7 +27,7 @@ $version = new JVersion;
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
 	|| (filesize(JPATH_CONFIGURATION . '/configuration.php') < 10)
-	|| (file_exists(JPATH_INSTALLATION . '/index.php') && ! $version->isInDevelopmentState()))
+	|| (file_exists(JPATH_INSTALLATION . '/index.php') && (false === $version->isInDevelopmentState())))
 {
 	if (file_exists(JPATH_INSTALLATION . '/index.php'))
 	{

--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -52,7 +52,9 @@ final class JVersion
 	/**
 	 * Check if we are in development mode
 	 *
-	 * @return bool
+	 * @return  boolean
+	 *
+	 * @since   3.4.3
 	 */
 	public function isInDevelopmentState()
 	{
@@ -64,7 +66,7 @@ final class JVersion
 	 *
 	 * @param   string  $minimum  The minimum version of the Joomla which is compatible.
 	 *
-	 * @return  bool    True if the version is compatible.
+	 * @return  boolean True if the version is compatible.
 	 *
 	 * @see     http://www.php.net/version_compare
 	 * @since   1.0

--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -50,6 +50,16 @@ final class JVersion
 	public $URL = '<a href="http://www.joomla.org">Joomla!</a> is Free Software released under the GNU General Public License.';
 
 	/**
+	 * Check if we are in development mode
+	 *
+	 * @return bool
+	 */
+	public function isInDevelopmentState()
+	{
+		return strtolower($this->DEV_STATUS) != 'stable';
+	}
+
+	/**
 	 * Compares two a "PHP standardized" version number against the current Joomla version.
 	 *
 	 * @param   string  $minimum  The minimum version of the Joomla which is compatible.


### PR DESCRIPTION
Simplification for the release process
# Executive summary

This PR simplifies the process of packing a release. We always comment out the installer check when we are in development. This needs so far a manuell change of two files. When we are doing a stable release we also set the variable DEV_STATUS = Stable. So we have the information at one place, but we don’t use it.
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Testing instructions

Clone the joomla-cms repro and apply the patch. Do an installation. You should be able to login into the backend without removing the installation folder. Now go to /libraries/cms/version/version.php and set the DEV_STATUS variable to Stable. If you now try to access the site the system tells you that you have to remove the installation folder. You can also delete the configuration.php in the root of the Joomla install and do an install, at the end it forces you to remove the installation folder.
