### PR TITLE
Having a multilang-site should not override the options of JCategories

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -261,7 +261,7 @@ class JCategories
 			->where('badcats.id is null');
 
 		// Note: i for item
-		if ($this->_options['currentlang'] !== 0 || $this->_options['countItems'] == 1)
+		if ($this->_options['countItems'] == 1)
 		{
 			$queryjoin = $db->quoteName($this->_table) . ' AS i ON i.' . $db->quoteName($this->_field) . ' = c.id';
 


### PR DESCRIPTION
With the changes in #5416, the option to disable the count-join in JCategories is permanently enabled, making extensions that don't use this feature and for example don't have a catid field in their table, fail. Just because you have a multilang-site, the option to disable the counting should NOT be overriden.
