### PR TITLE
Reression Smart search menu item cannot been saved

### DIFF
--- a/components/com_finder/views/search/tmpl/default.xml
+++ b/components/com_finder/views/search/tmpl/default.xml
@@ -30,7 +30,6 @@
 			<field name="show_date_filters"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_DATE_FILTERS_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_DATE_FILTERS_DESC">
 				<option value="1">JSHOW</option>
@@ -40,7 +39,6 @@
 			<field name="show_advanced"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_ADVANCED_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_ADVANCED_DESC">
 				<option value="1">JSHOW</option>
@@ -50,7 +48,6 @@
 			<field name="expand_advanced"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_EXPAND_ADVANCED_LABEL"
 				description="COM_FINDER_CONFIG_EXPAND_ADVANCED_DESC">
 				<option value="1">JSHOW</option>
@@ -61,7 +58,6 @@
 			<field name="show_description"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_DESCRIPTION_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_DESCRIPTION_DESC">
 				<option value="1">JSHOW</option>
@@ -79,7 +75,6 @@
 			<field name="show_url"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_URL_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_URL_DESC">
 				<option value="1">JSHOW</option>
@@ -91,7 +86,6 @@
 		<fieldset name="advanced">
 			<field name="show_pagination_limit" type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
-				validate="options"
 				description="JGLOBAL_DISPLAY_SELECT_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
@@ -99,7 +93,6 @@
 			</field>
 			<field name="show_pagination" type="list"
 				description="JGLOBAL_PAGINATION_DESC"
-				validate="options"
 				label="JGLOBAL_PAGINATION_LABEL" >
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
@@ -108,7 +101,6 @@
 			</field>
 			<field name="show_pagination_results" type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				validate="options"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC" >
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
@@ -118,7 +110,6 @@
 				type="radio"
 				class="btn-group btn-group-yesno"
 				default="0"
-				validate="options"
 				label="COM_FINDER_ALLOW_EMPTY_QUERY_LABEL"
 				description="COM_FINDER_ALLOW_EMPTY_QUERY_DESC">
 				<option value="1">JYES</option>
@@ -127,7 +118,6 @@
 			<field name="show_suggested_query"
 				type="list"
 				default="1"
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -137,7 +127,6 @@
 			<field name="show_explained_query"
 				type="list"
 				default="1"
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -147,7 +136,6 @@
 			<field name="sort_order"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SORT_ORDER_LABEL"
 				description="COM_FINDER_CONFIG_SORT_ORDER_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -158,7 +146,6 @@
 			<field name="sort_direction"
 				type="list"
 				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SORT_DIRECTION_LABEL"
 				description="COM_FINDER_CONFIG_SORT_DIRECTION_DESC">
 				<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -170,7 +157,6 @@
 				type="radio"
 				class="btn-group btn-group-yesno"
 				default="0"
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_FEED_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_FEED_DESC">
 				<option value="1">JSHOW</option>
@@ -180,7 +166,6 @@
 				type="radio"
 				class="btn-group btn-group-yesno"
 				default="0"
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_FEED_TEXT_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_FEED_TEXT_DESC">
 				<option value="1">JYES</option>
@@ -190,7 +175,6 @@
 		<fieldset name="integration">
 			<field name="show_feed_link" type="list"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				validate="options"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL" >
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>


### PR DESCRIPTION
#### This fixes #7309
#### Steps to reproduce the issue

Create a new menu item for Smart Search
#### Expected result

Menu link created
#### Actual result

Invalid field: Date Filters
Invalid field: Advanced Search
Invalid field: Expand Advanced Search
#### Testing

Apply patch and follow the instructions above. Menu item should be saved without any errors
