### PR TITLE
Setting proper default values for access level

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -325,7 +325,7 @@ class CategoriesModelCategory extends JModelAdmin
 
 				$data->set('published', $app->input->getInt('published', (isset($filters['published']) ? $filters['published'] : null)));
 				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 
 		}

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -323,9 +323,9 @@ class CategoriesModelCategory extends JModelAdmin
 				$extension = substr($app->getUserState('com_categories.categories.filter.extension'), 4);
 				$filters = (array) $app->getUserState('com_categories.categories.' . $extension . '.filter');
 
-				$data->set('published', $app->input->getInt('published', (isset($filters['published']) ? $filters['published'] : null)));
-				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
+				$data->set('published', $app->input->getInt('published', (!empty($filters['published']) ? $filters['published'] : null)));
+				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 
 		}

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -423,10 +423,10 @@ class ContentModelArticle extends JModelAdmin
 			if ($this->getState('article.id') == 0)
 			{
 				$filters = (array) $app->getUserState('com_content.articles.filter');
-				$data->set('state', $app->input->getInt('state', (isset($filters['published']) ? $filters['published'] : null)));
-				$data->set('catid', $app->input->getInt('catid', (isset($filters['category_id']) ? $filters['category_id'] : null)));
-				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
+				$data->set('state', $app->input->getInt('state', (!empty($filters['published']) ? $filters['published'] : null)));
+				$data->set('catid', $app->input->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
+				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 		}
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -426,7 +426,7 @@ class ContentModelArticle extends JModelAdmin
 				$data->set('state', $app->input->getInt('state', (isset($filters['published']) ? $filters['published'] : null)));
 				$data->set('catid', $app->input->getInt('catid', (isset($filters['category_id']) ? $filters['category_id'] : null)));
 				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 		}
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -599,7 +599,7 @@ class ModulesModelModule extends JModelAdmin
 				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
 				$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
 				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : null)));
+				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 
 			// This allows us to inject parameter settings into a new module.

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -596,10 +596,10 @@ class ModulesModelModule extends JModelAdmin
 			if (!$data->id)
 			{
 				$filters = (array) $app->getUserState('com_modules.modules.filter');
-				$data->set('published', $app->input->getInt('published', (isset($filters['state']) ? $filters['state'] : null)));
-				$data->set('position', $app->input->getInt('position', (isset($filters['position']) ? $filters['position'] : null)));
-				$data->set('language', $app->input->getString('language', (isset($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
+				$data->set('published', $app->input->getInt('published', (!empty($filters['state']) ? $filters['state'] : null)));
+				$data->set('position', $app->input->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
+				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 
 			// This allows us to inject parameter settings into a new module.


### PR DESCRIPTION
Fixes #7311 
### Issue

Module, Article and Category creation applies a wrong default values for the access level. Instead of the one from the global config it just takes none, and thus the first in the list is selected.
This is a regression introduced with #6966 and some similar PRs.
### Solution

Set the correct default value.
### Testing
- Create an article/module/category and see the preselected access level. If your default one is the first in the list, change it to something else first.
- Before patch, always the first access level is selected. After patch the default one from the config is preselected.
