### PR TITLE
value is null so it doesn't match to the empty option

### DIFF
--- a/libraries/joomla/form/rule/options.php
+++ b/libraries/joomla/form/rule/options.php
@@ -53,7 +53,9 @@ class JFormRuleOptions extends JFormRule
 		}
 		else
 		{
-			return in_array($value, $options);
+			// In this case value must be a string
+
+			return in_array((string) $value, $options);
 		}
 	}
 }


### PR DESCRIPTION
### This is a fix for #7309, #7308
#### Steps to reproduce the issue

Create a new menu item for Smart Search
#### Expected result

Menu link created
#### Actual result

Invalid field: Date Filters
Invalid field: Advanced Search
Invalid field: Expand Advanced Search
#### Testing

Apply patch and follow the instructions above. Menu item should be saved without any errors
#### Background

The problem here is that the validation get's as value null and this is never part of the options array.
