### PR TITLE
JPagination link issue href issue in frontend with getListFooter

### DIFF
--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -74,7 +74,7 @@ if ($displayData['active'])
 	// Still using javascript approach in backend
 	if (JFactory::getApplication()->isAdmin())
 	{
-		$onClick = 'document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;';
+		$onClick = 'onclick="document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;"';
 		$href    = '#';
 	}
 }
@@ -86,9 +86,10 @@ else
 <?php if ($displayData['active']) : ?>
 	<li>
 		<a
-			class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?>
+			<?php echo !empty($cssClasses) ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?>
+			<?php echo $title; ?>
+			<?php echo $onClick; ?>
 			href="<?php echo $href; ?>"
-			onclick="<?php echo $onClick; ?>"
 		>
 			<?php echo $display; ?>
 		</a>

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -68,7 +68,15 @@ if ($displayData['active'])
 		$title = ' title="' . $item->text . '" ';
 	}
 
-	$onClick = 'document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;';
+	$onClick = '';
+	$href    = $item->link;
+
+	// Still using javascript approach in backend
+	if (JFactory::getApplication()->isAdmin())
+	{
+		$onClick = 'document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;';
+		$href    = '#';
+	}
 }
 else
 {
@@ -77,7 +85,11 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li>
-		<a class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a
+			class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?>
+			href="<?php echo $href; ?>"
+			onclick="<?php echo $onClick; ?>"
+		>
 			<?php echo $display; ?>
 		</a>
 	</li>


### PR DESCRIPTION
### Problem

When using `getListFooter` in frontend, having issue in pagination link. 
#### For Example:

If we use in `index.php?option=com_content&view=category&id=<category_id>&Itemid=260&limitstart=0`

```
echo $this->pagination->getListFooter();
```

_Note: Layout or pagination file should not be overrided_
### How to reproduce

To reproduce this issue can manually use above function in code or if you are using `JPagination` in your component you may check there. 

_There are many other ways to fix it by overriding `JPagination` class and `JLayout` but I think this should be fix in core too._
