### PR TITLE
Removes the duplicated update message in the quickicon

### DIFF
--- a/media/plg_quickicon_joomlaupdate/js/jupdatecheck.js
+++ b/media/plg_quickicon_joomlaupdate/js/jupdatecheck.js
@@ -25,7 +25,7 @@ jQuery(document).ready(function() {
 					var updateInfo = updateInfoList.shift();
 					if (updateInfo.version != plg_quickicon_jupdatecheck_jversion) {
 						var updateString = plg_quickicon_joomlaupdate_text.UPDATEFOUND.replace("%s", updateInfo.version + "");
-						jQuery('#plg_quickicon_joomlaupdate').find('span').html(updateString);
+						jQuery('#plg_quickicon_joomlaupdate').find('.j-links-link').html(updateString);
 						var updateString = plg_quickicon_joomlaupdate_text.UPDATEFOUND_MESSAGE.replace("%s", updateInfo.version + "");
 						if (jQuery('.alert-joomlaupdate').length == 0) {
 							jQuery('#system-message-container').prepend(


### PR DESCRIPTION
### Issue

The quickicon plugin which checks for Joomla Updates shows the message twice.

**Expected**
![expected](https://cloud.githubusercontent.com/assets/1018684/8483941/b08bcfa2-20f4-11e5-900a-416930bfa77b.PNG)
**Actual**
![actual](https://cloud.githubusercontent.com/assets/1018684/8483943/b46a6624-20f4-11e5-8c31-44374e093876.PNG)
### Solution and Background

The JavaScript code which adds this message checks for a `<span>` in the specific ID of that plugin output and adds the message there. This worked fine as long as there was only one `<span>` there. Now we changed the icons to use the `<span>` tag instead of `<i>` and guess what, now there are two `<span>` tags in there. You don't need to be a JavaScript guru to understand what now happens :smile: 
The solution is to not target the `<span>` tag itself but the specific class of that `<span>`
### Testing

Best test with a Joomla 3.4.2 before updating to 3.4.3.
