### PR TITLE
CSS for addons is in a separate file now. Include it.

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -70,6 +70,7 @@ class PlgEditorCodemirror extends JPlugin
 		JHtml::_('script', $this->basePath . 'lib/codemirror.min.js');
 		JHtml::_('script', $this->basePath . 'lib/addons.min.js');
 		JHtml::_('stylesheet', $this->basePath . 'lib/codemirror.min.css');
+		JHtml::_('stylesheet', $this->basePath . 'lib/addons.min.css');
 
 		JFactory::getDocument()
 			->addScriptDeclaration($this->getInitScript())


### PR DESCRIPTION
I guess I forgot to include the addons css. Maybe I was concatenating all css into one file in the older build process.
