### PR TITLE
Fix unescaped ampersand validation error

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -128,7 +128,7 @@ if ($params->get('show_autosuggest', 1))
 
 	$script .= "
 	var suggest = jQuery('#mod-finder-searchword').autocomplete({
-		serviceUrl: '" . JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component', false) . "',
+		serviceUrl: '" . htmlspecialchars(JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component', false)) . "',
 		paramName: 'q',
 		minChars: 1,
 		maxHeight: 400,

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -128,7 +128,7 @@ if ($params->get('show_autosuggest', 1))
 
 	$script .= "
 	var suggest = jQuery('#mod-finder-searchword').autocomplete({
-		serviceUrl: '" . htmlspecialchars(JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component', false)) . "',
+		serviceUrl: '" . JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component') . "',
 		paramName: 'q',
 		minChars: 1,
 		maxHeight: 400,


### PR DESCRIPTION
The W3C validator complains about unescaped ampersand.
