### PR TITLE
Remove Gitter webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,3 @@ script:
 branches:
   except:
     - 2.5.x
-
-notifications:
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/18687d008d633d02aa84
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
-


### PR DESCRIPTION
We don't use Gitter anymore and the `on_start` command was wrong anyway.

If Travis passes, this can be merged on review :smile: 
