### PR TITLE
Increase session lifetime to 24h

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -717,7 +717,7 @@
 		<field
 			name="lifetime"
 			type="text"
-			default="15"
+			default="1440"
 			label="COM_CONFIG_FIELD_SESSION_TIME_LABEL"
 			description="COM_CONFIG_FIELD_SESSION_TIME_DESC"
 			required="true"


### PR DESCRIPTION
## Description

The default session timeout is way too low (15min). This patch increases the default to 24h (24*60=1440).

For comparison, these are the default values of other CMS:
Wordpress: 48 hours
Typo3: 1 hour
Drupal: ~23days
## How to test:

Go to "Global Configuration" -> "System" and check that "Session lifetime" is set to "1440" on a new installation.
Screenshot:
![bildschirmfoto vom 2015-07-03 17-08-50](https://cloud.githubusercontent.com/assets/3502738/8501493/4935d1d8-21a6-11e5-93d2-dce566620f93.png)
