### PR TITLE
Remove the doubled closing div in the "Date of Birth" layout

### DIFF
--- a/layouts/plugins/user/profile/fields/dob.php
+++ b/layouts/plugins/user/profile/fields/dob.php
@@ -15,6 +15,6 @@ defined('_JEXEC') or die;
 extract($displayData);
 
 // Closing the opening .control-group and .control-label div so we can add our info text on own line ?>
-</div><div class="controls"><?php echo $text; ?></div></div>
+</div><div class="controls"><?php echo $text; ?></div>
 <?php // Creating new .control-group and .control-label for the actual field ?>
 <div class="control-group"><div class="control-label">


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/7332
### Issue

See the original issue. There are screenshots.
Basically the layout used by the date of birth field has a doubled closing div. Which then breaks the tabs.
