### PR TITLE
Fixing Search Filter Changes in System Tests

### DIFF
--- a/tests/system/webdriver/Pages/System/AdminManagerPage.php
+++ b/tests/system/webdriver/Pages/System/AdminManagerPage.php
@@ -202,6 +202,18 @@ abstract class AdminManagerPage extends AdminPage
 
 	public function setFilter($idOrLabel, $value)
 	{
+		$el = $this->driver->findElements(By::xPath("//button"));
+		foreach($el as $element)
+		{
+			if ($element->getAttribute('data-original-title') == 'Filter the list items.')
+			{
+				$element->click();
+				if($value == 'Select Status')
+				{
+					$element->click();
+				}
+			}
+		}
 		$filters = array_change_key_case($this->filters, CASE_LOWER);
 		$idOrLabel = strtolower($idOrLabel);
 		$filterId = '';


### PR DESCRIPTION
@javigomez Before merging https://github.com/joomla/joomla-cms/pull/6764 Please merge this PR, I have made changes in the setFilter function to fix the failure in our test.

Now Filters appear when we click on Search Tool button, hence modified the function to work accordingly. 
