### PR TITLE
Fix: Regression Notice: Undefined variable: link com_menus in 3.4.3

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -200,6 +200,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							<?php elseif ($modMenuId) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
 								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
+								<?php $link = JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>
 								<?php echo JHtml::_(
 										'bootstrap.renderModal',
 										'moduleModal',

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -198,8 +198,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>
-							<?php $link = JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>
-							<a href="<?php echo $link; ?>"><?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
+								<?php $link = JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>
+								<a href="<?php echo $link; ?>"><?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
 								<?php echo JHtml::_(
 										'bootstrap.renderModal',
 										'moduleModal',

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -198,9 +198,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<?php endif; ?>
 								<?php endforeach; ?>
 							<?php elseif ($modMenuId) : ?>
-							<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>">
-								<?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
-								<?php $link = JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>
+							<?php $link = JRoute::_('index.php?option=com_modules&task=module.add&eid=' . $modMenuId . '&params[menutype]=' . $item->menutype); ?>
+							<a href="<?php echo $link; ?>"><?php echo JText::_('COM_MENUS_ADD_MENU_MODULE'); ?></a>
 								<?php echo JHtml::_(
 										'bootstrap.renderModal',
 										'moduleModal',


### PR DESCRIPTION
This fixes the issue reported here: https://github.com/joomla/jissues/issues/674 by @minonario

Notice: Undefined variable: link in .... /administrator/components/com_menus/views/menus/tmpl/default.php on line 207
### how to reproduce
- install 3.4.3 (error reporting maximum)
- create a new menu (without module)
- create a new admin account
- don't allow the admin group edit on `com_menus`
- add a new user with admin group
- login as admin
- access com_menus menus view.
- see the error
- apply the patch
- confirm issue is fixed
