### PR TITLE
Profile plugin: Display Date of Birth TIP only when editing + correcting alignment of display

### DIFF
--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -45,9 +45,17 @@ class JFormFieldDob extends JFormFieldCalendar
 
 		if ($text)
 		{
-			$layout = new JLayoutFile('plugins.user.profile.fields.dob');
-			$info   = $layout->render(array('text' => $text));
-			$label  = $info . $label;
+			$app	= JFactory::getApplication();
+			$layout	= new JLayoutFile('plugins.user.profile.fields.dob');
+			$view	= $app->input->getString('view', '');
+
+			// Only display the tip when editing profile
+			if (!$app->isSite() || $view == 'profile' || $view == 'registration')
+			{
+				$layout	= new JLayoutFile('plugins.user.profile.fields.dob');
+				$info	= $layout->render(array('text' => $text));
+				$label	= $info . $label;
+			}
 		}
 
 		return $label;

--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -50,7 +50,7 @@ class JFormFieldDob extends JFormFieldCalendar
 			$view	= $app->input->getString('view', '');
 
 			// Only display the tip when editing profile
-			if (!$app->isSite() || $view == 'profile' || $view == 'registration')
+			if ($app->isAdmin() || $view == 'profile' || $view == 'registration')
 			{
 				$layout	= new JLayoutFile('plugins.user.profile.fields.dob');
 				$info	= $layout->render(array('text' => $text));

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7477,3 +7477,6 @@ body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;
 }
+#users-profile-custom label {
+	display: inline;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -606,3 +606,8 @@ body.modal-open {
   overflow: hidden;
   -ms-overflow-style: none;
 }
+
+/* Align fields for the profile display */
+#users-profile-custom label {
+	display: inline;
+}


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/7340 solves only one aspect of the Date of Birth issue.
It is advised to first merge #7340 before testing this PR.

This PR lets display the Date of Birth TIP ("The date of birth entered should use the format Year-Month-Day, ie 0000-00-00") ONLY when editing the profile.
It also solves a long standing issue of a bad alignment of the profile content in Protostar.
<b>Before patch:</b>

![screen shot 2015-07-04 at 10 53 30](https://cloud.githubusercontent.com/assets/869724/8507276/2a1c68ee-223b-11e5-8f11-5e6993e76afc.png)

<b>After patch:</b>
![screen shot 2015-07-05 at 09 04 12](https://cloud.githubusercontent.com/assets/869724/8510665/edc0315e-22f4-11e5-8d68-40606d09563b.png)

To test, enable the User - Profile plugin.
Set "Date of Birth" parameter to Optional or Required.
Create a user and fill out his profile with the Date of Birth.
Create a contact for this user and a menu item to display this contact in front-end.
