### PR TITLE
Remove uneeded ACL checks in template manager

### DIFF
--- a/administrator/components/com_templates/templates.php
+++ b/administrator/components/com_templates/templates.php
@@ -13,11 +13,7 @@ JHtml::_('behavior.tabstate');
 $app  = JFactory::getApplication();
 $user = JFactory::getUser();
 
-// ACL for hardening the access to the template manager.
-if (!$user->authorise('core.manage', 'com_templates')
-	|| !$user->authorise('core.edit', 'com_templates')
-	|| !$user->authorise('core.create', 'com_templates')
-	|| !$user->authorise('core.admin', 'com_templates'))
+if (!$user->authorise('core.manage', 'com_templates'))
 {
 	$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 


### PR DESCRIPTION
### Issue

Currently, the template manager will refuse access if you don't have `core.admin` permissions in the template manager. This is due to some pointless check done in the extension entry point. If any of the checks `core.manager`, `core.edit`, `core.create` or `core.admin` fails, access is refused.
The original plan was probably to fail if all of those checks fail, but it was written wrong.
### Solution

This PR brings the checks in line with other backends where we only check for `core.manage`. Additional checks are performed already in the various tasks to make sure appropriate ACL checks are performed when needed.
### Testing
- Create a user which has access to the template manager but is not able to change the permissions in there.
- Currently access will be refused.
- After applying this PR access will be granted. Depending on the permissions the user will be allowed to create/edit/whatever in the manager.
## Note

Access to any file modification tasks (create overrides, edit files, ...) is restricted to global SuperUsers only. This is expected behavior as you can't really restrict a users permissions if that user has access to the files. 
