### PR TITLE
Fix behavior keepalive - Revert

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -634,7 +634,16 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		$url = JUri::base(true) . '/index.php?option=com_ajax&format=json';
+		$life_time    = JFactory::getConfig()->get('lifetime') * 60000;
+		$refresh_time = ($life_time <= 60000) ? 45000 : $life_time - 60000;
+
+		// The longest refresh period is one hour to prevent integer overflow.
+		if ($refresh_time > 3600000 || $refresh_time <= 0)
+		{
+			$refresh_time = 3600000;
+		}
+
+		$url = JUri::root(true) . '/index.php?option=com_ajax&format=json';
 
 		$script = 'window.setInterval(function(){';
 		$script .= 'var r;';
@@ -642,7 +651,7 @@ abstract class JHtmlBehavior
 		$script .= 'r=window.XMLHttpRequest?new XMLHttpRequest():new ActiveXObject("Microsoft.XMLHTTP")';
 		$script .= '}catch(e){}';
 		$script .= 'if(r){r.open("GET","' . $url . '",true);r.send(null)}';
-		$script .= '},45000);';
+		$script .= '},' . $refresh_time . ');';
 
 		JFactory::getDocument()->addScriptDeclaration($script);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -634,16 +634,32 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		$life_time    = JFactory::getConfig()->get('lifetime') * 60000;
-		$refresh_time = ($life_time <= 60000) ? 45000 : $life_time - 60000;
-
-		// The longest refresh period is one hour to prevent integer overflow.
-		if ($refresh_time > 3600000 || $refresh_time <= 0)
+		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
+		if (JFactory::getConfig()->get('session_handler') != 'database')
 		{
-			$refresh_time = 3600000;
+			$refresh_time = 300000;
+		}
+		else
+		{
+			$life_time    = JFactory::getConfig()->get('lifetime') * 60000;
+			$refresh_time = ($life_time <= 60000) ? 45000 : $life_time - 60000;
+
+			// The longest refresh period is one hour to prevent integer overflow.
+			if ($refresh_time > 3600000 || $refresh_time <= 0)
+			{
+				$refresh_time = 3600000;
+			}
 		}
 
-		$url = JUri::root(true) . '/index.php?option=com_ajax&format=json';
+		// If we are in the frontend or logged in as a user, we can use the ajax component to reduce the load
+		if (JFactory::getApplication()->isSite() || !JFactory::getUser()->guest)
+		{
+			$url = JUri::base(true) . '/index.php?option=com_ajax&format=json';
+		}
+		else
+		{
+			$url = JUri::base(true) . '/index.php';
+		}
 
 		$script = 'window.setInterval(function(){';
 		$script .= 'var r;';

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -630,17 +630,10 @@ class JHtmlBehaviorTest extends TestCase
 		// We generate a random template name so that we don't collide or hit anything//
 		$template = 'mytemplate' . rand(1, 10000);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
+		// We create a stub (not a mock because we don't enforce whether it is called or not) to return a value from getTemplate
+		JFactory::$application->expects($this->any())
 			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
+			->willReturn($template);
 
 		JHtmlBehaviorInspector::keepalive();
 		$this->assertEquals(


### PR DESCRIPTION
This is an improvement (some kind of revert) of the PR that I've merged yesterday. After a discussion with @wilsonge and @mbabker we decided to restore some parts of the code. There is no need to refresh the session independent of the set session time. In the previous PR the refresh period was set to a fixed value (45 seconds), so if the session time was set ,for example, to 30 minutes there would be a lot of unnecessary requests.

Now the refresh time is always one minute less than the session time except if the session time is set to one minute, then the fresh time is 45 seconds.

Another important change is to use _root_ instead of _base_ for the request URL because the request created a _500 Internal Error_ on the login page of the administrator area. I've just found this bug while testing my own PR...

**How to test**

Since we restore the functionality to the default behavior, you won't see a "before / after" change. But you can test the keepalive behavior in general (here backend, also applies to the frontend):
1. Set the session time to 1 minute in the global configuration.
2. Open the console of the browser, then the tab "Network"
3. Open an existing article in the edit mode or click on the button "New"
4. Wait for 45 seconds, then you should see an Ajax request to the server which refreshes the session
5. Do the same with another time value (e.g. 5 minutes), then the refresh request will be triggered one minute before the ssessions ends.

@wilsonge or @mbabker Please check and commit the PR. Thanks!
