### PR TITLE
Allows visible text fields within JSortableList

### DIFF
--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -217,36 +217,36 @@
 				if (ui.originalPosition.top > ui.position.top) //if item moved up
 				{						
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[type=text]', ui.item).attr('value', parseInt($('[type=text]', ui.item.next()).attr('value')));
+						$('[type=text]:hidden', ui.item).attr('value', parseInt($('[type=text]:hidden', ui.item.next()).attr('value')));
 					}
 					$(range).each(function () {
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){	
 							if (_top > ui.item.position().top && _top <= ui.originalPosition.top) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[type=text]', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[type=text]:hidden', $(this)).attr('value')) + 1;
 								} else {
-									var newValue = parseInt($('[type=text]', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[type=text]:hidden', $(this)).attr('value')) - 1;
 								}
 	
-								$('[type=text]', $(this)).attr('value', newValue);
+								$('[type=text]:hidden', $(this)).attr('value', newValue);
 							}
 						}
 					});
 				} else if (ui.originalPosition.top < ui.position.top) {
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[type=text]', ui.item).attr('value', parseInt($('[type=text]', ui.item.prev()).attr('value')));
+						$('[type=text]:hidden', ui.item).attr('value', parseInt($('[type=text]:hidden', ui.item.prev()).attr('value')));
 					}					
 					$(range).each(function () {												
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){						
 							if (_top < ui.item.position().top && _top >= ui.originalPosition.top) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[type=text]', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[type=text]:hidden', $(this)).attr('value')) - 1;
 								} else {
-									var newValue = parseInt($('[type=text]', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[type=text]:hidden', $(this)).attr('value')) + 1;
 								}
-								$('[type=text]', $(this)).attr('value', newValue);
+								$('[type=text]:hidden', $(this)).attr('value', newValue);
 							}
 						}
 						


### PR DESCRIPTION
JSortableList is altering all text fields found in the table.. which is
unnecessary and quite restrictive.
Of course it would be better to use the following selector
".text-area-order" but as there are some locations (ie. com_menus,
com_categories, ..) without the class, and maybe others in 3rd party
components, the easiet way is maybe to search for: [type=text]:hidden
At least, this allows us to have "visible" text fields without
alteration of their value.
Thanks,
Sebastien
