### PR TITLE
Fixed required multiple field which is empty

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1958,8 +1958,9 @@ class JForm
 
 		if ($required)
 		{
-			// If the field is required and the value is empty return an error message.
-			if (($value === '') || ($value === null))
+			// If the field is required and the value is empty return an error message. Special handling
+			// For multiple fields, because the filter method sets empty fields to array()
+			if (($value === '') || ($value === null) || (in_array($element['multiple'], array('true', 'multiple')) && !count($value)))
 			{
 				if ($element['label'])
 				{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1958,9 +1958,9 @@ class JForm
 
 		if ($required)
 		{
-			$multiple = ((string) $element['multiple'] == 'true' || (string) $element['required'] == 'multiple');
+			$multiple = ((string) $element['multiple'] == 'true' || (string) $element['multiple'] == 'multiple');
 
-			// Prepare multiple fields: check if we have at least one valid value
+			// Prepare multiple fields: throw away all invalid values, so we can check, if we have at least one valid
 			if ($multiple && is_array($value))
 			{
 				// Filter all invalid values
@@ -1971,8 +1971,9 @@ class JForm
 						);
 			}
 
-			// If the field is required and the value is empty return an error message.
-			if ($value === '' || $value === null || ($multiple && !count($value)))
+			// If the field is required and the value is empty return an error message. Special handling
+			// For multiple fields, because the filter method sets empty fields to array()
+			if ($value === '' || $value === null || ($multiple && is_array($value) && !count($value)))
 			{
 				if ($element['label'])
 				{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1958,18 +1958,21 @@ class JForm
 
 		if ($required)
 		{
-			$multiple = ((string) $element['multiple'] == 'true' || (string) $element['multiple'] == 'multiple');
+			$multiple = ((string) $element['multiple'] == 'true' || (string) $element['required'] == 'multiple');
 
 			// Prepare multiple fields: check if we have at least one valid value
 			if ($multiple && is_array($value))
 			{
 				// Filter all invalid values
-				$value = array_filter($value, function($val) { return !($val === '' || $val === null); });
+				$value = array_filter(
+							$value, function($val) {
+								return !($val === '' || $val === null);
+							}
+						);
 			}
 
-			// If the field is required and the value is empty return an error message. Special handling
-			// For multiple fields, because the filter method sets empty fields to array()
-			if ($value === '' || $value === null || ($multiple && is_array($value) && !count($value)))
+			// If the field is required and the value is empty return an error message.
+			if ($value === '' || $value === null || ($multiple && !count($value)))
 			{
 				if ($element['label'])
 				{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1958,9 +1958,18 @@ class JForm
 
 		if ($required)
 		{
+			$multiple = ((string) $element['multiple'] == 'true' || (string) $element['multiple'] == 'multiple');
+
+			// Prepare multiple fields: check if we have at least one valid value
+			if ($multiple && is_array($value))
+			{
+				// Filter all invalid values
+				$value = array_filter($value, function($val) { return !($val === '' || $val === null); });
+			}
+
 			// If the field is required and the value is empty return an error message. Special handling
 			// For multiple fields, because the filter method sets empty fields to array()
-			if (($value === '') || ($value === null) || (in_array($element['multiple'], array('true', 'multiple')) && !count($value)))
+			if ($value === '' || $value === null || ($multiple && is_array($value) && !count($value)))
 			{
 				if ($element['label'])
 				{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1964,11 +1964,7 @@ class JForm
 			if ($multiple && is_array($value))
 			{
 				// Filter all invalid values
-				$value = array_filter(
-							$value, function($val) {
-								return !($val === '' || $val === null);
-							}
-						);
+				$value = array_filter($value, 'strlen');
 			}
 
 			// If the field is required and the value is empty return an error message. Special handling


### PR DESCRIPTION
If you submit an empty multiple field, the JForm::filter method set's the value to an array:
https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/form/form.php#L251
And now the JForm::validateField doesn't recognize it as empty:
https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/form/form.php#L1962

The patch will fix that

How to test:
- open the XML file administrator/components/com_content/models/forms/article.xml
- add the following field: `<field name="foobar" multiple="true" required="true" />`
- Create an article, add an title and try to save

Expected result: Joomla! complains about the required field "foobar" (because we didn't send it)
Current result: article could be saved
- Apply path
- try again
