### PR TITLE
Remove addLog function that doesn't exist

### DIFF
--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -82,8 +82,12 @@ abstract class JDatabaseImporter
 	 * Logs a message from a import query
 	 *
 	 * @param   string  $message  The message to be logged
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4.4
 	 */
-	private function addLog($message)
+	protected function addLog($message)
 	{
 		JLog::add($message, JLog::DEBUG, 'database');
 	}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -79,20 +79,6 @@ abstract class JDatabaseImporter
 	}
 
 	/**
-	 * Logs a message from a import query
-	 *
-	 * @param   string  $message  The message to be logged
-	 *
-	 * @return  void
-	 *
-	 * @since   3.4.4
-	 */
-	protected function addLog($message)
-	{
-		JLog::add($message, JLog::DEBUG, 'database');
-	}
-
-	/**
 	 * Set the output option for the exporter to XML format.
 	 *
 	 * @return  JDatabaseImporter  Method supports chaining.
@@ -214,11 +200,8 @@ abstract class JDatabaseImporter
 						}
 						catch (RuntimeException $e)
 						{
-							$this->addLog('Fail: ' . $this->db->getQuery());
 							throw $e;
 						}
-
-						$this->addLog('Pass: ' . $this->db->getQuery());
 					}
 				}
 			}
@@ -235,11 +218,8 @@ abstract class JDatabaseImporter
 				}
 				catch (RuntimeException $e)
 				{
-					$this->addLog('Fail: ' . $this->db->getQuery());
 					throw $e;
 				}
-
-				$this->addLog('Pass: ' . $this->db->getQuery());
 			}
 		}
 	}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -79,6 +79,16 @@ abstract class JDatabaseImporter
 	}
 
 	/**
+	 * Logs a message from a import query
+	 *
+	 * @param   string  $message  The message to be logged
+	 */
+	private function addLog($message)
+	{
+		JLog::add($message, JLog::DEBUG, 'database');
+	}
+
+	/**
 	 * Set the output option for the exporter to XML format.
 	 *
 	 * @return  JDatabaseImporter  Method supports chaining.


### PR DESCRIPTION
This is used in various parts of the Database importer classes (e.g. https://github.com/wilsonge/joomla-cms/blob/logging/libraries/joomla/database/importer.php#L217) but isn't actually defined. This just adds the method and proxies it to JLog

Note this class is not used in the CMS and so probably needs a code review
