### PR TITLE
JForm::filter() make sure that $data is complete

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -242,15 +242,9 @@ class JForm
 			{
 				$output->set($key, $this->filterField($field, $input->get($key, (string) $field['default'])));
 			}
-
-			// Get the JFormField object for this field, only it knows if it is supposed to be multiple.
-			$jfield = $this->getField($name, $group);
-
-			// Fields supporting multiple values must be stored as empty arrays when no values are selected.
-			// If not, they will appear to be unset and then revert to their default value.
-			if ($jfield && $jfield->multiple && !$output->exists($key))
+			else
 			{
-				$output->set($key, array());
+				$output->set($key, null);
 			}
 		}
 


### PR DESCRIPTION
As I have got a "loot positive" feedbacks [there](https://groups.google.com/forum/#!topic/joomla-dev-cms/lwvSE4c6W94) I have decided to make this pull :sweat_smile: 

So, here is revert #2617, and fix for #7316 and #7372, and alternative fix for #2617 

Currently `JForm` do not check when the Browser do not submit the value for some inputs, due specific behavior of these input types (checkbox(es), multiple select) or because field was removed by User by editing HTML.

This patch force `JForm::filter()` to check whether submitted data has all inputs.

**test**
Apply patch.
Add to the `templates/protostar/templateDetails.xml` next fields (after `<fieldset name="advanced">`):

``` xml
<field type="checkbox" name="checkbox" label="Checkbox" />
<field type="checkboxes" name="checkboxes" label="Checkboxes" >
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="text">text</option>
</field>
<field type="list" name="list" label="List" multiple="true" >
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="text">text</option>
</field>
```

Then open `libraries/joomla/form/form.php` and in line 250 (before "return") add:

``` php
$d = $output->toArray();
echo '<pre>';
var_dump($d['params']);
echo '</pre>';
exit;
```

Then go to edit Protostar template parameters, leave all custom fields empty and push save.

**Before patch**
You get:

``` php
array (size=8)
  'checkboxes' => array()
  'list' => array()
  'templateColor' => string '#0088cc' (length=7)
  'templateBackgroundColor' => string '#f4f6f7' (length=7)
  'logoFile' => string '' (length=0)
  'sitetitle' => string '' (length=0)
  'sitedescription' => string '' (length=0)
  'googleFont' => string '1' (length=1)
  'googleFontName' => string 'Open+Sans' (length=9)
  'fluidContainer' => string '0' (length=1)
```

~~Means custom fields was not submitted and so, not available. (Joomla <= 3.4.1)~~
Upd (Joomla >= 3.4.2): Here single `checkbox` is missed, and multiple fields has `array` value that is wrong, because it is cause the validation problem, and the problem with loading the default value when use `Registry`.

**After patch**
You should get:

``` php
array (size=11)
  'checkbox' => null
  'checkboxes' => null
  'list' => null
  'templateColor' => string '#0088cc' (length=7)
  'templateBackgroundColor' => string '#f4f6f7' (length=7)
  'logoFile' => string '' (length=0)
  'sitetitle' => string '' (length=0)
  'sitedescription' => string '' (length=0)
  'googleFont' => string '1' (length=1)
  'googleFontName' => string 'Open+Sans' (length=9)
  'fluidContainer' => string '0' (length=1)
```

Now all fields available in data, and unchecked checkboxes has "empty" values.
