### PR TITLE
Multilanguage: making Protostar logo link multilang aware

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -80,27 +80,8 @@ else
 // Get the correct logo link in multilingual
 if (JLanguageMultilang::isEnabled())
 {
-	$this->lang_codes	= JLanguageHelper::getLanguages('lang_code');
-	$this->current_lang = JFactory::getLanguage()->getTag();
-	$this->sef			= $this->lang_codes[$this->current_lang]->sef;
-	$homemenu			= $app->getMenu()->getDefault($this->current_lang);
-	$this->mode_sef		= $app->get('sef', 0);
-
-	if ($this->mode_sef)
-	{
-		if ($app->get('sef_rewrite'))
-		{
-			$logo_link = $this->baseurl . '/' . $this->sef . '/';
-		}
-		else
-		{
-			$logo_link = $this->baseurl . '/index.php/' . $this->sef . '/';
-		}
-	}
-	else
-	{
-		$logo_link = $this->baseurl . '/index.php?lang=' . $this->sef;
-	}
+	$homemenu	= $app->getMenu()->getDefault(JFactory::getLanguage()->getTag());
+	$logo_link	= JRoute::_('index.php?Itemid=' . $homemenu->id);
 }
 else
 {

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -76,6 +76,36 @@ else
 {
 	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
 }
+
+// Get the correct logo link in multilingual
+if (JLanguageMultilang::isEnabled())
+{
+	$this->lang_codes	= JLanguageHelper::getLanguages('lang_code');
+	$this->current_lang = JFactory::getLanguage()->getTag();
+	$this->sef			= $this->lang_codes[$this->current_lang]->sef;
+	$homemenu			= $app->getMenu()->getDefault($this->current_lang);
+	$this->mode_sef		= $app->get('sef', 0);
+
+	if ($this->mode_sef)
+	{
+		if ($app->get('sef_rewrite'))
+		{
+			$logo_link = $this->baseurl . '/' . $this->sef . '/';
+		}
+		else
+		{
+			$logo_link = $this->baseurl . '/index.php/' . $this->sef . '/';
+		}
+	}
+	else
+	{
+		$logo_link = $this->baseurl . '/index.php?lang=' . $this->sef;
+	}
+}
+else
+{
+	$logo_link = $this->baseurl;
+}
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -136,7 +166,7 @@ else
 			<!-- Header -->
 			<header class="header" role="banner">
 				<div class="header-inner clearfix">
-					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>/">
+					<a class="brand pull-left" href="<?php echo $logo_link; ?>">
 						<?php echo $logo; ?>
 						<?php if ($this->params->get('sitedescription')) : ?>
 							<?php echo '<div class="site-description">' . htmlspecialchars($this->params->get('sitedescription')) . '</div>'; ?>


### PR DESCRIPTION
In Protostar, the link used for the logo header is always a direct link to the home page.
Code is 

```
<a class="brand pull-left" href="<?php echo $this->baseurl; ?>/">
```

This means that we get an url of the type `http://mysite.com/`

In a multilanguage site it means the url will display the site default language or browser default language home page (depending on "Language Selection for new visitors") when sef is off 

This patch, depending if sef is on or off, creates the good url.
1. Test sef on, "Remove URL Language code" set to Yes and with "Use URL Rewriting" set to Yes or No
2. Test sef on, "Remove URL Language code" set to No and with "Use URL Rewriting" set to Yes or No 
3. Test with sef off 

In each case, clicking on the logo will display the site home page in the language in use.
