### PR TITLE
Logged in time - admin module

### DIFF
--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -41,7 +41,7 @@ JHtml::_('bootstrap.tooltip');
 			</div>
 			<div class="span3">
 				<span class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
-					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC4')); ?>
+					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC2')); ?>
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
In Joomla 2.5 the admin logged in module displayed the date and time. 
In Joomla 3 it only displays the date which is not as useful.

This simple PR changes it to use the time and date as before
### Before

![](http://i.tee.mn/6FRp%201.png)
### After

![](http://i.tee.mn/6FRp.png)
