### PR TITLE
Refactoring onInit method - reCAPTCHA plugin

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -38,45 +38,35 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 */
 	public function onInit($id = 'dynamic_recaptcha_1')
 	{
-		$document = JFactory::getDocument();
-		$app      = JFactory::getApplication();
-
 		JHtml::_('jquery.framework');
 
-		$lang       = $this->_getLanguage();
-		$version    = $this->params->get('version', '1.0');
-		$pubkey     = $this->params->get('public_key', '');
+		$pubkey = $this->params->get('public_key', '');
 
 		if ($pubkey == null || $pubkey == '')
 		{
 			throw new Exception(JText::_('PLG_RECAPTCHA_ERROR_NO_PUBLIC_KEY'));
 		}
 
-		switch ($version)
+		if ($this->params->get('version', '1.0') == '1.0')
 		{
-			case '1.0':
-				$theme = $this->params->get('theme', 'clean');
-				$file  = 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
+			$theme = $this->params->get('theme', 'clean');
+			$file  = 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
 
-				JHtml::_('script', $file);
-
-				$document->addScriptDeclaration('jQuery( document ).ready(function()
-				{
-					Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $lang . 'tabindex: 0});});'
-				);
-				break;
-			case '2.0':
-				$theme = $this->params->get('theme2', 'light');
-				$file  = 'https://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()->getTag() . '&amp;render=explicit';
-
-				JHtml::_('script', $file, true, true);
-
-				$document->addScriptDeclaration('jQuery(document).ready(function($) {$(window).load(function() {'
-					. 'grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});'
-					. '});});'
-				);
-				break;
+			$document = 'jQuery( document ).ready(function()
+				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $this->_getLanguage() . 'tabindex: 0});});';
 		}
+		else
+		{
+			$theme = $this->params->get('theme2', 'light');
+			$file  = 'https://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()->getTag() . '&amp;render=explicit';
+
+			$document = 'jQuery(document).ready(function($) {$(window).load(function()
+					{grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});
+				});});';
+		}
+
+		JFactory::getDocument()->addScriptDeclaration($document);
+		JHtml::_('script', $file);
 
 		return true;
 	}

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -72,7 +72,7 @@
 		<field
 			name="theme2"
 			type="list"
-			default="dark"
+			default="light"
 			label="PLG_RECAPTCHA_THEME_LABEL"
 			description="PLG_RECAPTCHA_THEME_DESC"
 			required="false"


### PR DESCRIPTION
This PR is based on #6218 but is completely revised. I've refactored the function **onInit** and changed one default value (light theme instead of dark theme for version 2.0).

The main reason for the refactoring is to get rid of the loading of Mootools which is not required.

**How to test?**
1. Go to "Extensions" - "Plugins" - "CAPTCHA - reCAPTCHA"
2. Enter your Public and Private key (get it here: https://www.google.com/recaptcha/intro/index.html)
3. Activate the plugin
4. Set the reCAPTCHA plugin as default captcha in the global configuration
5. Go to a form in the frontend (e.g. registration form - add _index.php?option=com_users&view=registration_ to the URL) and check whether the capchta is loaded properly.

Please test both versions (1.0 and 2.0)!
