### PR TITLE
Fix Array to string conversion using Menu item Compact list of tagged items

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -212,7 +212,7 @@ class JFilterInput
 				}
 				else
 				{
-					$result = (string) preg_replace('/[^A-Z0-9_\.-]/i', '', $source);
+					$result = (string) preg_replace('/-?[0-9]+/', '', $source);
 					$result = ltrim($result, '.');
 				}
  				break;

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -198,9 +198,24 @@ class JFilterInput
 			case 'INT':
 			case 'INTEGER':
 				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
-				$result = @ (int) $matches[0];
-				break;
+				if (is_array($source))
+				{
+					foreach ($source as $key => $value)
+					{
+						if (is_string($value))
+						{
+							$source[$key] = preg_match('/-?[0-9]+/', (string) '', $value);
+							$source[$key] = ltrim($source[$key], '.');
+						}
+					}
+					$result = $source;
+				}
+				else
+				{
+					$result = (string) preg_replace('/[^A-Z0-9_\.-]/i', '', $source);
+					$result = ltrim($result, '.');
+				}
+ 				break;
 
 			case 'UINT':
 				// Only use the first integer value


### PR DESCRIPTION
#### Steps to reproduce the issue

Create 3 articles (Test article 1, Test article 2, Test article 3)
Create 3 Tags in the Tags Component (Tag 1, Tag 2, Tag 3)
Add to all the three articles all three  tags
Create a menu item of the type "Compact list of tagged items"
Select in the menu item all the three tags in the Tag field
Select content type Article.

Access the menu item and the warning "Notice: Array to string conversion in C:\xampp\htdocs\joomla\libraries\joomla\filter\input.php on line 201" should be there.
#### Expected result

There should be no Notice warning
#### Actual result

A warning "Notice: Array to string conversion in C:\xampp\htdocs\joomla\libraries\joomla\filter\input.php on line 201"
The list of the articles which have the corresponding tags
#### System information (as much as possible)

PHP versie 5.6.9
Webserver Apache
WebServer naar PHP interface litespeed
Joomla! versie  Joomla! 3.4.3 Stable [ Ember ] 2-July-2015 16:00 GMT
Joomla! Platform versie Joomla Platform 13.1.0 Stable [ Curiosity ] 24-Apr-2013 00:00 GMT
Gebruikersagent Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36
#### Additional comments

Please check the code an I hope it does not break anything...
