### PR TITLE
RSS, ATOM fix publish date. Pull to #7392.

### DIFF
--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -337,7 +337,7 @@ class JFeedItem
 	public $guid;
 
 	/**
-	 * Published date
+	 * Update date (Alternative publish date)
 	 *
 	 * optional
 	 *
@@ -357,6 +357,28 @@ class JFeedItem
 	 * @since  11.1
 	 */
 	public $date;
+        
+	/**
+	 * Published date
+	 *
+	 * optional
+	 *
+	 * May be in one of the following formats:
+	 *
+	 * RFC 822:
+	 * "Mon, 20 Jan 03 18:05:41 +0400"
+	 * "20 Jan 03 18:05:41 +0000"
+	 *
+	 * ISO 8601:
+	 * "2003-01-20T18:05:41+04:00"
+	 *
+	 * Unix:
+	 * 1043082341
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	public $pubDate;
 
 	/**
 	 * Source element

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -150,8 +150,15 @@ class JDocumentRendererAtom extends JDocumentRenderer
 
 			$itemDate = JFactory::getDate($data->items[$i]->date);
 			$itemDate->setTimeZone($tz);
-			$feed .= "		<published>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</published>\n";
-			$feed .= "		<updated>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
+			if(empty($data->items[$i]->pubDate)) {
+				$feed .= "		<updated>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
+				$feed .= "		<published>" . htmlspecialchars($itemDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</published>\n";
+			} else {
+				$pubDate = JFactory::getDate($data->items[$i]->pubDate);
+				$pubDate->setTimezone($tz);
+				$feed .= "		<updated>" . htmlspecialchars($pubDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
+				$feed .= "		<published>" . htmlspecialchars($pubDate->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</published>\n";
+			}
 
 			if (empty($data->items[$i]->guid) === true)
 			{

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -244,7 +244,11 @@ class JDocumentRendererRSS extends JDocumentRenderer
 
 			if ($data->items[$i]->date != "")
 			{
-				$itemDate = JFactory::getDate($data->items[$i]->date);
+				if(empty($data->items[$i]->pubDate)) {
+					$itemDate = JFactory::getDate($data->items[$i]->date);
+				} else {
+					$itemDate = JFactory::getDate($data->items[$i]->pubDate);
+				}
 				$itemDate->setTimeZone($tz);
 				$feed .= "			<pubDate>" . htmlspecialchars($itemDate->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</pubDate>\n";
 			}

--- a/libraries/legacy/view/categoryfeed.php
+++ b/libraries/legacy/view/categoryfeed.php
@@ -38,16 +38,19 @@ class JViewCategoryfeed extends JViewLegacy
 		$ucmMapCommon = json_decode($ucmRow->field_mappings)->common;
 		$createdField = null;
 		$titleField = null;
+		$publishField = null;
 
 		if (is_object($ucmMapCommon))
 		{
 			$createdField = $ucmMapCommon->core_created_time;
 			$titleField = $ucmMapCommon->core_title;
+			$publishField = $ucmMapCommon->core_publish_up;
 		}
 		elseif (is_array($ucmMapCommon))
 		{
 			$createdField = $ucmMapCommon[0]->core_created_time;
 			$titleField = $ucmMapCommon[0]->core_title;
+			$publishField = $ucmMapCommon[0]->core_publish_up;
 		}
 
 		$document->link = JRoute::_(JHelperRoute::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
@@ -98,6 +101,12 @@ class JViewCategoryfeed extends JViewLegacy
 			{
 				$date = '';
 			}
+			
+			if($publishField) {
+				$pubDate = isset($item->$publishField) ? date('r', strtotime($item->$publishField)) : '';
+			} else {
+				$pubDate = '';
+			}
 
 			// Load individual item creator class.
 			$feeditem              = new JFeedItem;
@@ -105,6 +114,7 @@ class JViewCategoryfeed extends JViewLegacy
 			$feeditem->link        = $link;
 			$feeditem->description = $description;
 			$feeditem->date        = $date;
+			$feeditem->pubDate     = $pubDate;
 			$feeditem->category    = $category->title;
 			$feeditem->author      = $author;
 


### PR DESCRIPTION
It's pull to my issue
https://github.com/joomla/joomla-cms/issues/7392

---

Hello.

RSS and ATOM generate problem

"pubDate" is same as "update"

I fixed some files. It's code. My fix mark as ARTUR FIX

Sorry I cant any time for pull.

---

It's fix need for right publish date.
I'm using hootsuite.com for RSS feed for all social accounts from http://goingrus.com/info/en/russia-photo to https://www.facebook.com/goingrus https://plus.google.com/+GoingrusService/posts https://www.facebook.com/palytratravel and other accounts.
Sevice work not correct because update date NOT publish date. I'm using system pulush date and if publish date not set i'm using update date.
