### PR TITLE
Fix: A forgotten call to helper.php in mod_submenu.xml

### DIFF
--- a/administrator/modules/mod_submenu/mod_submenu.xml
+++ b/administrator/modules/mod_submenu/mod_submenu.xml
@@ -11,7 +11,6 @@
 	<description>MOD_SUBMENU_XML_DESCRIPTION</description>
 	<files>
 		<filename module="mod_submenu">mod_submenu.php</filename>
-		<filename>helper.php</filename>
 		<folder>tmpl</folder>
 	</files>
 	<languages>


### PR DESCRIPTION
#### Steps to reproduce the issue

In /administrator/modules/mod_submenu/mod_submenu.xml
line 14
There is still a call to helper.php while the file doesn't exist anymore.

I discovered this while struggling with an update from a 3.2 version to 3.4.3 where : 
/administrator/includes/subtoolbar.php
was not added.
Probably a wrong move from my part.
#### Additional comments

See: https://github.com/joomla/joomla-cms/issues/7409

kudos goes to @ghazal Thanks!

@committer please commit with kundos to @ghazal 
