### PR TITLE
Set default RSS setting to display email address to OFF

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -907,7 +907,7 @@
 		<field
 			name="feed_email"
 			type="list"
-			default="author"
+			default="none"
 			label="COM_CONFIG_FIELD_FEED_EMAIL_LABEL"
 			description="COM_CONFIG_FIELD_FEED_EMAIL_DESC"
 			filter="word">

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -29,7 +29,7 @@ class ContentViewFeatured extends JViewLegacy
 		$app       = JFactory::getApplication();
 		$doc       = JFactory::getDocument();
 		$params    = $app->getParams();
-		$feedEmail = $app->get('feed_email', 'author');
+		$feedEmail = $app->get('feed_email', 'none');
 		$siteEmail = $app->get('mailfrom');
 		$doc->link = JRoute::_('index.php?option=com_content&view=featured');
 

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -32,7 +32,7 @@ class TagsViewTag extends JViewLegacy
 		$app->input->set('limit', $app->get('feed_limit'));
 		$siteEmail        = $app->get('mailfrom');
 		$fromName         = $app->get('fromname');
-		$feedEmail        = $app->get('feed_email', 'author');
+		$feedEmail        = $app->get('feed_email', 'none');
 		$document->editor = $fromName;
 
 		if ($feedEmail != "none")

--- a/components/com_tags/views/tags/view.feed.php
+++ b/components/com_tags/views/tags/view.feed.php
@@ -32,7 +32,7 @@ class TagsViewTags extends JViewLegacy
 		$app->input->set('limit', $app->get('feed_limit'));
 		$siteEmail        = $app->get('mailfrom');
 		$fromName         = $app->get('fromname');
-		$feedEmail        = $app->get('feed_email', 'author');
+		$feedEmail        = $app->get('feed_email', 'none');
 		$document->editor = $fromName;
 
 		if ($feedEmail != "none")

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -94,5 +94,5 @@ class JConfig {
 
 	/* Feed Settings */
 	public $feed_limit = 10;
-	public $feed_email = 'author';
+	public $feed_email = 'none';
 }

--- a/libraries/legacy/view/categoryfeed.php
+++ b/libraries/legacy/view/categoryfeed.php
@@ -55,7 +55,7 @@ class JViewCategoryfeed extends JViewLegacy
 		$app->input->set('limit', $app->get('feed_limit'));
 		$siteEmail        = $app->get('mailfrom');
 		$fromName         = $app->get('fromname');
-		$feedEmail        = $app->get('feed_email', 'author');
+		$feedEmail        = $app->get('feed_email', 'none');
 		$document->editor = $fromName;
 
 		if ($feedEmail != 'none')


### PR DESCRIPTION
A default installation of Joomla leaks email addresses of the website & authors via RSS & ATOM feeds.
Even when you have RSS not enabled (via Content > Article Manager > [Options] button (on the right) > "Integration" tab > Show Feed Link: set to Hide) visitors can see the RSS/ATOM feeds of Category Blog items & Contact items by adding ?format=feed&type=rss or ?format=feed&type=atom behind the URL. 

The default setting of Joomla is to show the "Author" email address in <author> tag for every RSS feed 
and the general site admin address in <managingEditor> tag.
(via System > Global Configuration > Feed Email Address > default = Author Email)

This PR sets the default to "No Email".
