### PR TITLE
Protostar: Missing slash in logo url for monolanguage sites (corrects #7394)

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -85,7 +85,7 @@ if (JLanguageMultilang::isEnabled())
 }
 else
 {
-	$logo_link = $this->baseurl;
+	$logo_link = $this->baseurl . '/';
 }
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
$this->baseurl was missing a slash. Thanks @smz
Please merge. 
#7417 can be discussed further
