### PR TITLE
Strip tags for administrator page title

### DIFF
--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -37,7 +37,7 @@ abstract class JToolbarHelper
 
 		$app = JFactory::getApplication();
 		$app->JComponentTitle = $html;
-		JFactory::getDocument()->setTitle($app->get('sitename') . ' - ' . JText::_('JADMINISTRATION') . ' - ' . $title);
+		JFactory::getDocument()->setTitle($app->get('sitename') . ' - ' . JText::_('JADMINISTRATION') . ' - ' . strip_tags($title));
 	}
 
 	/**


### PR DESCRIPTION
`JToolbarHelper::title` allow to add HTML markup for toolbar, however it also add the HTML for browser title. 
This pull fix it.

**test**
into Isis template file `index.php` add next: `JToolbarHelper::title('<b>Test</b>');`
and check the browser title
**actual result**
`Site Name - Administration - <b>Test</b>`
**expected**
`Site Name - Administration - Test`
