### PR TITLE
Fix unit tests failing on windows because of EOL differences

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
@@ -91,7 +91,7 @@ class JHtmlBootstrapTest extends TestCase
 
 		$this->assertEquals(
 			$document->_script['text/javascript'],
-			"(function($){\n\t\t\t\t$('.alert').alert();\n\t\t\t\t})(jQuery);",
+			"(function($){" . PHP_EOL . "\t\t\t\t$('.alert').alert();" . PHP_EOL . "\t\t\t\t})(jQuery);",
 			'Verify that the alert script is initialised'
 		);
 	}
@@ -119,7 +119,7 @@ class JHtmlBootstrapTest extends TestCase
 
 		$this->assertEquals(
 			$document->_script['text/javascript'],
-			"(function($){\n\t\t\t\t$('.button').button();\n\t\t\t\t})(jQuery);",
+			"(function($){" . PHP_EOL . "\t\t\t\t$('.button').button();" . PHP_EOL . "\t\t\t\t})(jQuery);",
 			'Verify that the button script is initialised'
 		);
 	}
@@ -147,7 +147,7 @@ class JHtmlBootstrapTest extends TestCase
 
 		$this->assertEquals(
 			$document->_script['text/javascript'],
-			"(function($){\n\t\t\t\t$('.dropdown-toggle').dropdown();\n\t\t\t\t})(jQuery);",
+			"(function($){" . PHP_EOL . "\t\t\t\t$('.dropdown-toggle').dropdown();" . PHP_EOL . "\t\t\t\t})(jQuery);",
 			'Verify that the dropdown script is initialised'
 		);
 	}
@@ -219,9 +219,9 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndTabSet()
 	{
-		$this->assertThat(
+		$this->assertEquals(
 			JHtml::_('bootstrap.endTabSet'),
-			$this->equalTo("\n</div>")
+			PHP_EOL . "</div>"
 		);
 	}
 
@@ -234,9 +234,9 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndTab()
 	{
-		$this->assertThat(
+		$this->assertEquals(
 			JHtml::_('bootstrap.endTab'),
-			$this->equalTo("\n</div>")
+			PHP_EOL . "</div>"
 		);
 	}
 
@@ -249,9 +249,9 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndPane()
 	{
-		$this->assertThat(
+		$this->assertEquals(
 			JHtml::_('bootstrap.endTabSet'),
-			$this->equalTo("\n</div>")
+			PHP_EOL . "</div>"
 		);
 	}
 
@@ -264,9 +264,9 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndPanel()
 	{
-		$this->assertThat(
+		$this->assertEquals(
 			JHtml::_('bootstrap.endTab'),
-			$this->equalTo("\n</div>")
+			PHP_EOL . "</div>"
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubGistsTest.php
@@ -126,7 +126,7 @@ class JGithubGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . "\n")
+					'gittest' => array('content' => 'GistContent' . PHP_EOL)
 				),
 				'public' => true,
 				'description' => 'This is a gist'

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageGistsTest.php
@@ -123,7 +123,7 @@ class JGithubPackageGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . "\n")
+					'gittest' => array('content' => 'GistContent' . PHP_EOL)
 				),
 				'public' => true,
 				'description' => 'This is a gist'


### PR DESCRIPTION
These functions call a `JLayout` which therefore uses Platform Specific line endings. Therefore we need to use `PHP_EOL` instead of  `\n` in this scenario for unit tests to pass on windows

To test you can run unit tests on windows. Some unit tests will still fail (this fixes 9/15 total failures) - but the ones in `JHtmlBootstrap` and all `JGithub` tests will now pass. You can also observe that travis continue's to pass
