### PR TITLE
Fix JToolbar unit tests in windows

### DIFF
--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -121,11 +121,11 @@ class JToolbarButtonTest extends TestCaseDatabase
 	{
 		$type = array('Standard', 'test');
 
-		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">\n"
-			. "\t<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{ Joomla.submitbutton('')}\" class=\"btn btn-small\">\n"
-			. "\t<span class=\"icon-test\"></span>\n"
-			. "\t</button>\n"
-			. "</div>\n";
+		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">" . PHP_EOL
+			. "\t<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{ Joomla.submitbutton('')}\" class=\"btn btn-small\">" . PHP_EOL
+			. "\t<span class=\"icon-test\"></span>" . PHP_EOL
+			. "\t</button>" . PHP_EOL
+			. "</div>" . PHP_EOL;
 
 		$this->assertEquals(
 			$expected,

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -89,9 +89,9 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{if (confirm('Confirm action?')){Joomla.submitbutton('article.save');}}\" class=\"btn btn-small\">\n"
-			. "\t<span class=\"icon-confirm-test\"></span>\n"
-			. "\tConfirm?</button>\n";
+		$html = "<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{if (confirm('Confirm action?')){Joomla.submitbutton('article.save');}}\" class=\"btn btn-small\">" . PHP_EOL
+			. "\t<span class=\"icon-confirm-test\"></span>" . PHP_EOL
+			. "\tConfirm?</button>" . PHP_EOL;
 
 		$this->assertEquals(
 			$this->object->fetchButton('Confirm', 'Confirm action?', 'confirm-test', 'Confirm?', 'article.save'),

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
@@ -92,9 +92,9 @@ class JToolbarButtonHelpTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-small\">\n"
-			. "\t<span class=\"icon-question-sign\"></span>\n"
-			. "\tJTOOLBAR_HELP</button>\n";
+		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-small\">" . PHP_EOL
+			. "\t<span class=\"icon-question-sign\"></span>" . PHP_EOL
+			. "\tJTOOLBAR_HELP</button>" . PHP_EOL;
 
 		$this->assertEquals(
 			$this->object->fetchButton('Help', 'JHELP_CONTENT_ARTICLE_MANAGER'),


### PR DESCRIPTION
These are loaded in a `JLayout` and therefore use device specific end of lines. This causes the tests to fail currently in windows
