### PR TITLE
MSSQL - fix typo error on getTableColumns()

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -362,7 +362,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->type), "nvarchar"))
+				if (stristr(strtolower($field->Type), "nvarchar"))
 				{
 					$field->Default = "";
 				}


### PR DESCRIPTION
#### Steps to reproduce the issue

install current staging on MSSQL
#### Expected result

The installation goes well
#### Actual result

the installation process don't end
#### System information

Windows 2008 R2 10.50.4033
Apache 2.4.7
PHP 5.5.9
Joomla! 3.4.4-dev
#### Additional comments

this error was introduced by this commit https://github.com/joomla/joomla-cms/commit/2f76e54df9f76b2cfd2cae71edc0184b75a1a149 #6314

there was a typo on function    getTableColumns()
accordingly to query

```
'SELECT column_name as Field, data_type as Type, is_nullable as \'Null\', column_default as \'Default\'' .
            ' FROM information_schema.columns WHERE table_name = ' . $this->quote($table_temp)
```

should be `$field->Type` instead of  `$field->type`

sorry for this :innocent:
