### PR TITLE
Regression: Multilanguage: cookie is not checked when sef is off and when sef is on and URL Language Code always present

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -246,21 +246,29 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			$sef = $parts[0];
 
-			// If the default prefix should be removed and the SEF prefix is not among those
-			// that we have in our system, its the default language and we "found" the right language
-			if ($this->params->get('remove_default_prefix', 0) && !isset($this->sefs[$sef]))
+			// Do we have a URL Language Code ?
+			if (!isset($this->sefs[$sef]))
 			{
-				if ($parts[0])
+				// Check if remove default url language code is set
+				if ($this->params->get('remove_default_prefix', 0))
 				{
-					// We load a default site language page
-					$lang_code = $this->default_lang;
+					if ($parts[0])
+					{
+						// We load a default site language page
+						$lang_code = $this->default_lang;
+					}
+					else
+					{
+						// We check for an existing language cookie
+						$lang_code = $this->getLanguageCookie();
+					}
 				}
 				else
 				{
-					// We check for an existing language cookie
 					$lang_code = $this->getLanguageCookie();
 				}
 
+				// No language code. Try using browser settings or default site language
 				if (!$lang_code && $this->params->get('detect_browser', 0) == 1)
 				{
 					$lang_code = JLanguageHelper::detectLanguage();
@@ -271,20 +279,16 @@ class PlgSystemLanguageFilter extends JPlugin
 					$lang_code = $this->default_lang;
 				}
 
-				if ($lang_code == $this->default_lang)
+				if ($this->params->get('remove_default_prefix', 0) && $lang_code == $this->default_lang)
 				{
 					$found = true;
 				}
 			}
 			else
 			{
-				// If the language prefix should always be present or it is indeed , we can now look it up in our array
-				if (isset($this->sefs[$sef]))
-				{
-					// We found our language
-					$found = true;
-					$lang_code = $this->sefs[$sef]->lang_code;
-				}
+				// We found our language
+				$found = true;
+				$lang_code = $this->sefs[$sef]->lang_code;
 
 				// If we found our language, but its the default language and we don't want a prefix for that, we are on a wrong URL.
 				// Or we try to change the language back to the default language. We need a redirect to the proper URL for the default language.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -308,6 +308,21 @@ class PlgSystemLanguageFilter extends JPlugin
 			}
 		}
 		// We are not in SEF mode
+		else
+		{
+			$lang_code = $this->getLanguageCookie();
+
+			if ($this->params->get('detect_browser', 1) && !$lang_code)
+			{
+				$lang_code = JLanguageHelper::detectLanguage();
+			}
+
+			if (!isset($this->lang_codes[$lang_code]))
+			{
+				$lang_code = $this->default_lang;
+			}
+		}
+
 		$lang = $uri->getVar('lang', $lang_code);
 
 		if (isset($this->sefs[$lang]))

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -76,17 +76,6 @@ else
 {
 	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
 }
-
-// Get the correct logo link in multilingual
-if (JLanguageMultilang::isEnabled())
-{
-	$homemenu	= $app->getMenu()->getDefault(JFactory::getLanguage()->getTag());
-	$logo_link	= JRoute::_('index.php?Itemid=' . $homemenu->id);
-}
-else
-{
-	$logo_link = $this->baseurl . '/';
-}
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -147,7 +136,7 @@ else
 			<!-- Header -->
 			<header class="header" role="banner">
 				<div class="header-inner clearfix">
-					<a class="brand pull-left" href="<?php echo $logo_link; ?>">
+					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>/">
 						<?php echo $logo; ?>
 						<?php if ($this->params->get('sitedescription')) : ?>
 							<?php echo '<div class="site-description">' . htmlspecialchars($this->params->get('sitedescription')) . '</div>'; ?>


### PR DESCRIPTION
See: https://github.com/joomla/joomla-cms/issues/7417#issuecomment-120837824 and https://github.com/joomla/joomla-cms/pull/7394

The problem was that the lang cookie was never checked when sef was off.

To test:
Create a simple multilanguage site with 3 languages. Make sure the default site language and the browser preferred language are different.
Set SEF to off in Global Configuration.
Display any site page which is not using the default site language or the browser preferred language.
Let's call it lang3

Open a new window in the same browser and enter the pure domain url, i.e. of the type `http://mysite.com`

Before patch, you will be redirected to the default site language or to the preferred browser language (depending on the language filter settings).
After patch, it will display lang3 language home page and the protostar logo link will too.
