### PR TITLE
mod_article_news - remove columns specified multiple times

### DIFF
--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -46,12 +46,7 @@ abstract class ModArticlesNewsHelper
 		// Set the filters based on the module params
 		$model->setState('list.start', 0);
 		$model->setState('list.limit', (int) $params->get('count', 5));
-
 		$model->setState('filter.published', 1);
-
-		$model->setState('list.select', 'a.fulltext, a.id, a.title, a.alias, a.introtext, a.state, a.catid, a.created, a.created_by, a.created_by_alias,' .
-			' a.modified, a.modified_by, a.publish_up, a.publish_down, a.images, a.urls, a.attribs, a.metadata, a.metakey, a.metadesc, a.access,' .
-			' a.hits, a.featured, a.language');
 
 		// Access filter
 		$access     = !JComponentHelper::getParams('com_content')->get('show_noauth');


### PR DESCRIPTION
#### Steps to reproduce the issue

install test data and click on left menu item News Flash
#### Expected result

the module works as expected
#### Actual result

DB error on MSSQL `The column 'fulltext' was specified multiple times`
#### System information

MSSQL 2008 R2 10.50.4033
Apache  2.4.7
PHP 5.5.9
Joomla! 3.4.4-dev
#### Additional comments

the helper duplicate already  selected fileds
