### PR TITLE
mod_related_items - query portability

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -88,7 +88,7 @@ abstract class ModRelatedItemsHelper
 				$query->clear()
 					->select('a.id')
 					->select('a.title')
-					->select('DATE(a.created) as created')
+					->select('CAST(a.created AS DATE) as created')
 					->select('a.catid')
 					->select('a.language')
 					->select('cc.access AS cat_access')


### PR DESCRIPTION
#### Steps to reproduce the issue

install test data and click on left menu item Related Items
#### Expected result

the module works as expected
#### Actual result

DB error on MSSQL `DATE() is not a recognized built-in function name.`

System information

MSSQL 2008 R2 10.50.4033
Apache 2.4.7
PHP 5.5.9
Joomla! 3.4.4-dev

Additional comments
DATE() is not a recognized built-in function in MSSQL used CAST instead
