### PR TITLE
Fixing issue getting SQL type of a column for compound types

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -401,7 +401,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->Field] = preg_replace("/[(0-9)]/", '', $field->Type);
+				$result[$field->Field] = preg_replace("/[(0-9),?]/", '', $field->Type);
 			}
 		}
 		// If we want the whole field data object add that to the list.

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -235,7 +235,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->Field] = preg_replace("/[(0-9)]/", '', $field->Type);
+				$result[$field->Field] = preg_replace("/[(0-9),?]/", '', $field->Type);
 			}
 		}
 		// If we want the whole field data object add that to the list.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -386,7 +386,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->column_name] = preg_replace("/[(0-9)]/", '', $field->type);
+				$result[$field->column_name] = preg_replace("/[(0-9)],?/", '', $field->type);
 			}
 		}
 		else

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -354,7 +354,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->Field] = preg_replace("/[(0-9)]/", '', $field->Type);
+				$result[$field->Field] = preg_replace("/[(0-9),?]/", '', $field->Type);
 			}
 		}
 		// If we want the whole field data object add that to the list.


### PR DESCRIPTION
Some SQL types have more than 1 parameter such as DECIMAL or FLOAT. These types can be configured specifing the precision and the amount of digits after the decimal point. 
- [Old regular expresion](http://www.regexr.com/3bd3j)
- [New regular expression](http://www.regexr.com/3bd37)

As you can see, the old regular expression left the , on decimal types, but new one makes optional the comma character, what solves the issue for this kind of types.
