### PR TITLE
Fix shebangs to improve portability

### DIFF
--- a/build/indexmaker.php
+++ b/build/indexmaker.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /**

--- a/libraries/vendor/leafo/lessphp/lessify
+++ b/libraries/vendor/leafo/lessphp/lessify
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if (php_sapi_name() != "cli") { 


### PR DESCRIPTION
Replace `#!/usr/bin/php` with `#!/usr/bin/env php` to make these scripts [more portable](https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability).
