### PR TITLE
Random Category blog and list order

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -455,6 +455,7 @@ JGLOBAL_PASSWORD_RESET_REQUIRED="You are required to reset your password before 
 JGLOBAL_PERMISSIONS_ANCHOR="Set Permissions"
 JGLOBAL_PREVIEW="Preview"
 JGLOBAL_PUBLISHED_DATE="Published Date"
+JGLOBAL_RANDOM_ORDER="Random Order"
 JGLOBAL_RECORD_NUMBER="Record ID: %d"
 JGLOBAL_REMEMBER_ME="Remember Me"
 JGLOBAL_RIGHT="Right"

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -106,7 +106,7 @@ class ContentHelperQuery
 				break;
 
 			case 'random' :
-				$orderby ='RAND()';
+				$orderby = 'RAND()';
 				break;
 
 			default :

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -106,7 +106,7 @@ class ContentHelperQuery
 				break;
 
 			case 'random' :
-				$orderby = 'RAND()';
+				$orderby = JFactory::getDbo()->getQuery(true)->Rand();
 				break;
 
 			default :

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -104,6 +104,10 @@ class ContentHelperQuery
 			case 'front' :
 				$orderby = 'a.featured DESC, fp.ordering, ' . $queryDate . ' DESC ';
 				break;
+				
+			case 'random' :
+				$orderby ='RAND()';
+				break;
 
 			default :
 				$orderby = 'a.ordering';

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -104,7 +104,7 @@ class ContentHelperQuery
 			case 'front' :
 				$orderby = 'a.featured DESC, fp.ordering, ' . $queryDate . ' DESC ';
 				break;
-				
+
 			case 'random' :
 				$orderby ='RAND()';
 				break;

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -262,8 +262,8 @@
 					<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
 					<option value="hits">JGLOBAL_MOST_HITS</option>
 					<option value="rhits">JGLOBAL_LEAST_HITS</option>
-					<option value="order">JGLOBAL_ORDERING</option>
 					<option value="random">JGLOBAL_RANDOM_ORDER</option>
+					<option value="order">JGLOBAL_ORDERING</option>
 				</field>
 
 				<field

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -263,6 +263,7 @@
 					<option value="hits">JGLOBAL_MOST_HITS</option>
 					<option value="rhits">JGLOBAL_LEAST_HITS</option>
 					<option value="order">JGLOBAL_ORDERING</option>
+					<option value="random">JGLOBAL_RANDOM_ORDER</option>
 				</field>
 
 				<field

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -224,6 +224,7 @@
 				<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
 				<option value="hits">JGLOBAL_MOST_HITS</option>
 				<option value="rhits">JGLOBAL_LEAST_HITS</option>
+				<option value="random">JGLOBAL_RANDOM_ORDER</option>
 				<option value="order">JGLOBAL_ORDERING</option>
 			</field>
 

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -120,6 +120,17 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return ' REGEXP ' . $value;
 	}
+	
+	/**
+	 * Return correct rand() function for Mysql.
+	 *
+	 * Ensure that the rand() function is Mysql compatible.
+	 * 
+	 * Usage:
+	 * $query->Rand();
+	 * 
+	 * @return string the correct rand function.
+	 */
 	public function Rand()
 	{
 		return ' RAND() ';

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -120,7 +120,7 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return ' REGEXP ' . $value;
 	}
-	
+
 	/**
 	 * Return correct rand() function for Mysql.
 	 *

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -120,4 +120,8 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return ' REGEXP ' . $value;
 	}
+	public function Rand()
+	{
+		return ' RAND() ';
+	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -638,4 +638,8 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	{
 		return ' ~* ' . $value;
 	}
+	public function Rand()
+	{
+		return ' RAND() ';
+	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -638,8 +638,19 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	{
 		return ' ~* ' . $value;
 	}
+	
+	/**
+	 * Return correct rand() function for Postgresql.
+	 *
+	 * Ensure that the rand() function is Postgresql compatible.
+	 * 
+	 * Usage:
+	 * $query->Rand();
+	 * 
+	 * @return string the correct rand function.
+	 */
 	public function Rand()
 	{
-		return ' RAND() ';
+		return ' RANDOM() ';
 	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -638,7 +638,7 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	{
 		return ' ~* ' . $value;
 	}
-	
+
 	/**
 	 * Return correct rand() function for Postgresql.
 	 *

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -357,4 +357,8 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 		return $this;
 	}
+	public function Rand()
+	{
+		return ' NEWID() ';
+	}
 }

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -357,7 +357,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 		return $this;
 	}
-	
+
 	/**
 	 * Return correct rand() function for MSSQL.
 	 *

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -357,6 +357,17 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 		return $this;
 	}
+	
+	/**
+	 * Return correct rand() function for MSSQL.
+	 *
+	 * Ensure that the rand() function is MSSQL compatible.
+	 * 
+	 * Usage:
+	 * $query->Rand();
+	 * 
+	 * @return string the correct rand function.
+	 */
 	public function Rand()
 	{
 		return ' NEWID() ';


### PR DESCRIPTION
This PR answers a fairly common request on the forums to add a random ordering option for articles in the blog category and category list view.
### To test
1. create a new category blog menu item and in the blog layout options go to article order and you will see a new option “Random Order”.  Select this option and then check the article order on the front end. Refresh the page and the article order will have changed
2. create a new category list menu item and in the list layout options go to article order and you will see a new option “Random Order".  Select this option and then check the article order on the front end. Refresh the page and the article order will have changed
