### PR TITLE
PHP max_input_vars test plugin

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -273,6 +273,7 @@ class JoomlaInstallerScript
 			array('plugin', 'tags', 'finder', 0),
 			array('plugin', 'totp', 'twofactorauth', 0),
 			array('plugin', 'yubikey', 'twofactorauth', 0),
+			array('plugin', 'maxvars', 'quickicon', 0),
 
 			// Templates
 			array('template', 'beez3', '', 0),

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-17.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-17.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+(453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-07-17.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-07-17.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-07-17.sql
@@ -1,0 +1,2 @@
+INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-07-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-07-17.sql
@@ -1,2 +1,2 @@
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 453, 'PLG_MAXVARS', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_QUICKICON_MAXVARS_WARN="Your PHP configuration has an input limit of %s variables and your website is using approximately <strong>%s</strong>. This <strong>may</strong> create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."
+PLG_QUICKICON_MAXVARS_FAIL="Your PHP configuration has an input limit of %s variables and your website has reached that limit and is using approximately <strong>%s</strong>. <strong> <br />This will create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_MAX_VARS_FAIL="You need to increase the value"
-PLG_MAX_VARS_WARN="You are close to the maximum"
+PLG_MAX_VARS_FAIL="You need to increase the value %s"
+PLG_MAX_VARS_WARN="You are close to the maximum %s"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_MAX_VARS_FAIL="You need to increase the value"
+PLG_MAX_VARS_WARN="You are close to the maximum"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.ini
@@ -1,7 +1,0 @@
-; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
-; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
-; Note : All ini files need to be saved as UTF-8
-
-PLG_MAX_VARS_FAIL="You need to increase the value %s"
-PLG_MAX_VARS_WARN="You are close to the maximum %s"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.sys.ini
@@ -1,0 +1,9 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_FINDER_NEWSFEEDS="Smart Search - News Feeds"
+PLG_FINDER_NEWSFEEDS_ERROR_ACTIVATING_PLUGIN="Could not automatically activate the &quot;Smart Search - Joomla! News Feeds&quot; plugin."
+PLG_FINDER_NEWSFEEDS_XML_DESCRIPTION="This plugin indexes Joomla! News feeds."
+PLG_FINDER_STATISTICS_NEWS_FEED="News Feed"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_maxvars.sys.ini
@@ -3,7 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FINDER_NEWSFEEDS="Smart Search - News Feeds"
-PLG_FINDER_NEWSFEEDS_ERROR_ACTIVATING_PLUGIN="Could not automatically activate the &quot;Smart Search - Joomla! News Feeds&quot; plugin."
-PLG_FINDER_NEWSFEEDS_XML_DESCRIPTION="This plugin indexes Joomla! News feeds."
-PLG_FINDER_STATISTICS_NEWS_FEED="News Feed"
+PLG_QUICKICON_MAXVARS="Quick Icon - Joomla! php max_input_vars check"
+PLG_QUICKICON_MAXVARS_XML_DESCRIPTION="Checks the setting of php max_input_vars and notifies you when you visit the Control Panel page if you have reached the server limit."

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -610,6 +610,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (449, 'plg_authentication_cookie', 'plugin', 'cookie', 'authentication', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (450, 'plg_twofactorauth_yubikey', 'plugin', 'yubikey', 'twofactorauth', 0, 0, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (451, 'plg_search_tags', 'plugin', 'tags', 'search', 0, 1, 1, 0, '', '{"search_limit":"50","show_tagged_items":"1"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 (503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -611,6 +611,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (449, 'plg_authentication_cookie', 'plugin', 'cookie', 'authentication', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (450, 'plg_twofactorauth_yubikey', 'plugin', 'yubikey', 'twofactorauth', 0, 0, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (451, 'plg_search_tags', 'plugin', 'tags', 'search', 0, 1, 1, 0, '', '{"search_limit":"50","show_tagged_items":"1"}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1012,7 +1012,8 @@ UNION ALL
 SELECT 450, 'plg_twofactorauth_yubikey', 'plugin', 'yubikey', 'twofactorauth', 0, 0, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
 SELECT 451, 'plg_search_tags', 'plugin', 'tags', 'search', 0, 1, 1, 0, '', '{"search_limit":"50","show_tagged_items":"1"}', '', '', 0, '1900-01-01 00:00:00', 0, 0;
-
+UNION ALL
+SELECT 453, 'plg_quickicon_maxvars', 'plugin', 'maxvars', 'quickicon', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '1900-01-01 00:00:00', 0, 0

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -76,11 +76,11 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		if ($varcount >= $maxinputvars)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $maxinputvars), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
 		}
 		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $maxinputvars), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package		Joomla.Plugin
+ * @subpackage	Quickicon.Joomla
+ *
+ * @copyright	Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Joomla! php max vars Plugin
+ *
+ * @since       3.5
+ */
+
+class PlgQuickiconMaxvars extends JPlugin
+{
+	/**
+	 * Constructor
+	 *
+	 * @param   object  &$subject  The object to observe
+	 * @param   array   $config    An optional associative array of configuration settings.
+	 *                             Recognized key values include 'name', 'group', 'params', 'language'
+	 *                             (this list is not meant to be comprehensive).
+	 *
+	 * @since   2.5.28
+	 */
+	public function __construct(&$subject, $config = array())
+	{
+		parent::__construct($subject, $config);
+
+		$this->loadLanguage();
+	}
+
+	/**
+	 * This method is called when the Quick Icons module is constructing its set
+	 * of icons. You can return an array which defines a single icon and it will
+	 * be rendered right after the stock Quick Icons.
+	 *
+	 * @param   $context  The calling context
+	 *
+	 * @return  array  A list of icon definition associative arrays, consisting of the
+	 *				   keys link, image, text and access.
+	 *
+	 * @since   2.5.28
+	 */
+public function onGetIcons($context)
+	{
+
+		$text = JText::_('PLG_MAX_VARS');
+		$maxinputvars = ini_get('max_input_vars');
+		$varcount =
+		SELECT SUM(count) FROM (
+			SELECT count(*) as count FROM `#_categories` as a
+			UNION
+			SELECT count(*) as count FROM `#_menu` as b
+			UNION
+			SELECT count(*) as count FROM `#_modules` as c
+			UNION
+			SELECT count(*) as count FROM `#_usergroups` as d	
+			) as varcount;
+	
+	if $varcount >= $maxinputvars	
+		{
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $text), 'error');
+		}
+	// then test if $varcount is within 10% of $maxinputvars and PLG_MAX_VARS_WARN
+		
+		
+	}	
+	
+	
+	
+}

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -59,7 +59,7 @@ class PlgQuickiconMaxvars extends JPlugin
 		);
 
 		// Get a db connection.
-		$db     = JFactory::getDbo();
+		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
 		foreach ($tables as $tableToCheck)

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -77,7 +77,7 @@ class PlgQuickiconMaxvars extends JPlugin
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_FAIL', $maxinputvars, $varcount), 'error');
 		}
 
-		if (($varcount / $maxinputvars) > 0.8)  > 80)
+		if (($varcount / $maxinputvars) > 0.8) > 80)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_WARN', $maxinputvars, $varcount), 'warning');
 		}

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -78,7 +78,9 @@ class PlgQuickiconMaxvars extends JPlugin
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $text), 'error');
 		}
-
-	// then test if $varcount is within 10% of $maxinputvars and PLG_MAX_VARS_WARN
+		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
+		{
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $text), 'error');
+		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -77,7 +77,7 @@ class PlgQuickiconMaxvars extends JPlugin
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_FAIL', $maxinputvars, $varcount), 'error');
 		}
 
-		if (($varcount / $maxinputvars) > 0.8) 
+		if (($varcount / $maxinputvars) > 0.8)  > 80)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_WARN', $maxinputvars, $varcount), 'warning');
 		}

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -80,7 +80,7 @@ class PlgQuickiconMaxvars extends JPlugin
 		}
 		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $text), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $text), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -77,7 +77,7 @@ class PlgQuickiconMaxvars extends JPlugin
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_FAIL', $maxinputvars, $varcount), 'error');
 		}
 
-		if (((($varcount - $maxinputvars) / $maxinputvars) * 100) > 80)
+		if (($varcount / $maxinputvars) > 0.8) 
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_WARN', $maxinputvars, $varcount), 'warning');
 		}

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * @package	Joomla.Plugin
- * @subpackage	Quickicon.Joomla
+ * @package	    Joomla.Plugin
+ * @subpackage  Quickicon.Joomla
  *
- * @copyright	Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
- * @license	GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
@@ -77,9 +77,9 @@ class PlgQuickiconMaxvars extends JPlugin
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_FAIL', $maxinputvars, $varcount), 'error');
 		}
 
-		if (((($varcount- $maxinputvars) / $maxinputvars) * 100) > 80)
+		if (((($varcount - $maxinputvars) / $maxinputvars) * 100) > 80)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_WARN', $maxinputvars, $varcount), 'warning');
 		}
-	}	
+	}
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -76,11 +76,11 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		if ($varcount >= $maxinputvars)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $maxinputvars), 'error');
 		}
 		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $maxinputvars), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -74,12 +74,12 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		if ($varcount >= $maxinputvars)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAXVARS_FAIL', $varcount), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_FAIL', $maxinputvars, $varcount), 'error');
 		}
 
 		if (((($varcount- $maxinputvars) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAXVARS_WARN', $varcount), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_QUICKICON_MAXVARS_WARN', $maxinputvars, $varcount), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -47,7 +47,6 @@ class PlgQuickiconMaxvars extends JPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		$text         = JText::_('PLG_MAX_VARS');
 		$maxinputvars = @ini_get('max_input_vars');
 		$varcount     = 0;
 
@@ -75,12 +74,12 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		if ($varcount >= $maxinputvars)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAXVARS_FAIL', $varcount), 'error');
 		}
 
 		if (((($varcount- $maxinputvars) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAXVARS_WARN', $varcount), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Joomla! php max vars Plugin
  *
- * @since       3.5
+ * @since  3.5
  */
 class PlgQuickiconMaxvars extends JPlugin
 {
@@ -59,7 +59,7 @@ class PlgQuickiconMaxvars extends JPlugin
 		);
 
 		// Get a db connection.
-		$db = JFactory::getDbo();
+		$db     = JFactory::getDbo();
 		$query = $db->getQuery(true);
 
 		foreach ($tables as $tableToCheck)
@@ -72,11 +72,12 @@ class PlgQuickiconMaxvars extends JPlugin
 				$db->setQuery($query);
 				$varcount = $varcount + (int) $db->loadResult();
 		}
-				
+
 		if ($varcount >= $maxinputvars)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
 		}
+
 		if (((($varcount- $maxinputvars) / $maxinputvars) * 100) > 80)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -76,11 +76,11 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		if ($varcount >= $maxinputvars)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $text), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
 		}
 		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $text), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');
 		}
 	}	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package	    Joomla.Plugin
+ * @package     Joomla.Plugin
  * @subpackage  Quickicon.Joomla
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * @package		Joomla.Plugin
+ * @package	Joomla.Plugin
  * @subpackage	Quickicon.Joomla
  *
- * @copyright	Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright	Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license	GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
@@ -14,7 +14,6 @@ defined('_JEXEC') or die;
  *
  * @since       3.5
  */
-
 class PlgQuickiconMaxvars extends JPlugin
 {
 	/**
@@ -25,7 +24,7 @@ class PlgQuickiconMaxvars extends JPlugin
 	 *                             Recognized key values include 'name', 'group', 'params', 'language'
 	 *                             (this list is not meant to be comprehensive).
 	 *
-	 * @since   2.5.28
+	 * @since   3.5
 	 */
 	public function __construct(&$subject, $config = array())
 	{
@@ -44,33 +43,42 @@ class PlgQuickiconMaxvars extends JPlugin
 	 * @return  array  A list of icon definition associative arrays, consisting of the
 	 *				   keys link, image, text and access.
 	 *
-	 * @since   2.5.28
+	 * @since   3.5
 	 */
-public function onGetIcons($context)
+	public function onGetIcons($context)
 	{
-
-		$text = JText::_('PLG_MAX_VARS');
+		$text         = JText::_('PLG_MAX_VARS');
 		$maxinputvars = ini_get('max_input_vars');
-		$varcount =
-		SELECT SUM(count) FROM (
-			SELECT count(*) as count FROM `#_categories` as a
-			UNION
-			SELECT count(*) as count FROM `#_menu` as b
-			UNION
-			SELECT count(*) as count FROM `#_modules` as c
-			UNION
-			SELECT count(*) as count FROM `#_usergroups` as d	
-			) as varcount;
-	
-	if $varcount >= $maxinputvars	
+		$varcount     = 0;
+
+		$tables = array(
+			'#__categories',
+			'#__menu',
+			'#__modules',
+			'#__usergroups',
+		);
+
+		// Get a db connection.
+		$db = JFactory::getDbo();
+
+		foreach ($tables as $tableToCheck)
+		{
+				// Create a new query object.
+				$query = $db->getQuery(true);
+
+				$query->select($db->quoteName('id'));
+				$query->from($db->quoteName($tableToCheck));
+
+				$db->setQuery($query);
+				$db->execute();
+				$varcount = $varcount + $db->getNumRows();
+		}
+
+		if ($varcount >= $maxinputvars)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $text), 'error');
 		}
+
 	// then test if $varcount is within 10% of $maxinputvars and PLG_MAX_VARS_WARN
-		
-		
 	}	
-	
-	
-	
 }

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -48,7 +48,7 @@ class PlgQuickiconMaxvars extends JPlugin
 	public function onGetIcons($context)
 	{
 		$text         = JText::_('PLG_MAX_VARS');
-		$maxinputvars = ini_get('max_input_vars');
+		$maxinputvars = @ini_get('max_input_vars');
 		$varcount     = 0;
 
 		$tables = array(

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -60,25 +60,24 @@ class PlgQuickiconMaxvars extends JPlugin
 
 		// Get a db connection.
 		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
 
 		foreach ($tables as $tableToCheck)
 		{
-				// Create a new query object.
-				$query = $db->getQuery(true);
+				$query->clear();
 
-				$query->select($db->quoteName('id'));
+				$query->select('count(*)');
 				$query->from($db->quoteName($tableToCheck));
 
 				$db->setQuery($query);
-				$db->execute();
-				$varcount = $varcount + $db->getNumRows();
+				$varcount = $varcount + (int) $db->loadResult();
 		}
-
+				
 		if ($varcount >= $maxinputvars)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_FAIL', $varcount), 'error');
 		}
-		if (((($maxinputvars - $varcount) / $maxinputvars) * 100) > 80)
+		if (((($varcount- $maxinputvars) / $maxinputvars) * 100) > 80)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_MAX_VARS_WARN', $varcount), 'warning');
 		}

--- a/plugins/quickicon/maxvars/maxvars.php
+++ b/plugins/quickicon/maxvars/maxvars.php
@@ -38,7 +38,7 @@ class PlgQuickiconMaxvars extends JPlugin
 	 * of icons. You can return an array which defines a single icon and it will
 	 * be rendered right after the stock Quick Icons.
 	 *
-	 * @param   $context  The calling context
+	 * @param   string  $context  The calling context
 	 *
 	 * @return  array  A list of icon definition associative arrays, consisting of the
 	 *				   keys link, image, text and access.

--- a/plugins/quickicon/maxvars/maxvars.xml
+++ b/plugins/quickicon/maxvars/maxvars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.5" type="plugin" group="quickicon">
-	<name>PLG_MAXVARS</name>
+	<name>PLG_QUICKICON_MAXVARS</name>
 	<author>Joomla! Project</author>
 	<creationDate>July 2015</creationDate>
 	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.5.0</version>
-	<description>PLG_MAXVARS_XML_DESCRIPTION</description>
+	<description>PLG_QUICKICON_MAXVARS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="maxvars">maxvars.php</filename>
 	</files>

--- a/plugins/quickicon/maxvars/maxvars.xml
+++ b/plugins/quickicon/maxvars/maxvars.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="23.0" type="plugin" group="quickicon">
-	<name>PLG_MAXVRS</name>
+<extension version="3.5" type="plugin" group="quickicon">
+	<name>PLG_MAXVARS</name>
 	<author>Joomla! Project</author>
-	<creationDate>October 2014</creationDate>
-	<copyright>Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<creationDate>July 2015</creationDate>
+	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>1.0</version>
-	<description>MAx Vars test plugin</description>
+	<version>3.5.0</version>
+	<description>PLG_MAXVARS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="maxvars">maxvars.php</filename>
 	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_quickicon_maxvars.ini</language>
+		<language tag="en-GB">en-GB.plg_quickicon_maxvars.sys.ini</language>
+	</languages>
 </extension>

--- a/plugins/quickicon/maxvars/maxvars.xml
+++ b/plugins/quickicon/maxvars/maxvars.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="23.0" type="plugin" group="quickicon">
+	<name>PLG_MAXVRS</name>
+	<author>Joomla! Project</author>
+	<creationDate>October 2014</creationDate>
+	<copyright>Copyright (C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
+	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>1.0</version>
+	<description>MAx Vars test plugin</description>
+	<files>
+		<filename plugin="maxvars">maxvars.php</filename>
+	</files>
+</extension>


### PR DESCRIPTION
Since php 5.3.9 there is a variable max_input_vars with a default value of 1000.

**_Ever had a large site suddenly stopped saving changes - this is why!!**_

Unfortunately on sites with lots of usergroups, menu items, modules and/or categories this will create issues when saving or making changes. Sadly it is a silent error as it is only a notice in php so depending on your site and server error configuration you might never know about it. All you do know is that you press save and nothing happens.

This plugin works in the same way as the old EOSNOTIFY plugin as a quickicon plugin and is only fired on the admin home screen.

It takes a count of the usergroups, menu items, modules and categories and displays either an error message if the total is greater than the php value for max_input_vars or a warning message if the total is  greater than 80% of the available variables.

This can only be an estimate of the variables in use. The only other way would be to count the ones in use on every page and this would be an unnecessary overhead.

To test - Apply the patch, discover the plugin and enable it and then all I can think of is to add `echo $varcount` and `echo $maxinputvars` to your admin template and check that $varcount is less than 80$ of $maxinputvars.
### Warning Screen

![warning](https://cloud.githubusercontent.com/assets/1296369/8752183/91769036-2caa-11e5-9235-f5c2e419ce6d.png)
### Error Screen

![error](https://cloud.githubusercontent.com/assets/1296369/8752190/9b23448a-2caa-11e5-9fef-185f2782431a.png)

thanks to @zero-24 and @rdeutz who helped me to create this plugin (my first)
