### PR TITLE
Disable sudo in Travis to use the new enviroment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
   - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: php
+# Forces new Travis-CI Infrastructure
 sudo: false
+
+language: php
 
 php:
   - 5.3


### PR DESCRIPTION
According to http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade we can migrate to the new Travis infrastructure by just adding `sudo: false` to our `.travis.yml` file.

This PR does this and it indeed run a bit faster.
