### PR TITLE
Fixed Issue 7449

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -24,7 +24,7 @@
 			extension="com_content"
 			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
-			published="-2,0,1,2"
+			published="0,1,2"
 			>
 			<option value="">JOPTION_SELECT_CATEGORY</option>
 		</field>


### PR DESCRIPTION
Not displaying trashed categories in drop down filters in Article Manager
#### Steps to reproduce the issue

In  article manager , while using search tools, select "category" field shows trashed category items...
#### Expected result

Need to list out only categories item published....
#### Actual result

select category field displays all category items.......
#### System information (as much as possible)

3.4.3
#### Additional comments

Issue solved on changing filter_articles.xml file

Signed-off-by: Steven Pignataro steven@corephp.com
