### PR TITLE
Check if $instance is a JUser object

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -243,7 +243,7 @@ abstract class JFactory
 			}
 		}
 		// Check if we have a string as the id or if the numeric id is the current instance
-		elseif (is_string($id) || $instance->id !== $id)
+		elseif (!($instance instanceof JUser) || is_string($id) || $instance->id !== $id)
 		{
 			$instance = JUser::getInstance($id);
 		}


### PR DESCRIPTION
Update of PR #4675 to resolve merge conflict.
### Original Description

public static function getUser($id = null)
{
$instance = self::getSession()->get('user');
if (is_null($id))
{
if (!($instance instanceof JUser))
{
$instance = JUser::getInstance();
}
}
elseif ($instance->id != $id)
{
$instance = JUser::getInstance($id);
}
return $instance;
}

When I write a unit test case for a function, which has the code JFactory::getUser(); inside, then I need to set user in session. Otherwise session does not contain anything, and return NULL on first line of function. If $instance is null then it gets an error for "Accessing undefined property on on non-object" ($instance->id ).

There should be a check before using "elseif ($instance->id != $id)"
### Test Instructions
- Download this test CLI script to your CMS install - https://gist.github.com/mbabker/37600809b162b17de2d4
- Run this script from command line (in order to better represent the issue being addressed, a command line environment is preferred as web requests do not seem to hit this issue)
- Pre-patch, you should get a `Notice: Trying to get property of non-object in libraries/joomla/factory.php on line 246` message
- Apply the patch
- Post patch, the message should not appear
