### PR TITLE
Isolate JGoogleAuthOauth2Test from JOAuth2ClientTest

### DIFF
--- a/tests/unit/suites/libraries/joomla/google/JGoogleAuthOauth2Test.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleAuthOauth2Test.php
@@ -89,7 +89,7 @@ class JGoogleAuthOauth2Test extends TestCase
 
 		$this->object->setOption('clientsecret', 'jeDs8rKw_jDJW8MMf-ff8ejs');
 		$this->input->set('code', '4/wEr_dK8SDkjfpwmc98KejfiwJP-f4wm.kdowmnr82jvmeisjw94mKFIJE48mcEM');
-		$this->http->expects($this->once())->method('post')->will($this->returnCallback('jsonGrantOauthCallback'));
+		$this->http->expects($this->once())->method('post')->willReturnCallback(array($this, 'jsonGrantOauthCallback'));
 		$result = $this->object->authenticate();
 		$this->assertEquals('accessvalue', $result['access_token']);
 		$this->assertEquals('refreshvalue', $result['refresh_token']);
@@ -136,12 +136,12 @@ class JGoogleAuthOauth2Test extends TestCase
 		$token['expires_in'] = 3600;
 		$this->oauth->setToken($token);
 
-		$this->http->expects($this->once())->method('get')->will($this->returnCallback('getOauthCallback'));
+		$this->http->expects($this->once())->method('get')->willReturnCallback(array($this, 'getOauthCallback'));
 		$result = $this->object->query('https://www.googleapis.com/auth/calendar', array('param' => 'value'), array(), 'get');
 		$this->assertEquals($result->body, 'Lorem ipsum dolor sit amet.');
 		$this->assertEquals(200, $result->code);
 
-		$this->http->expects($this->once())->method('post')->will($this->returnCallback('queryOauthCallback'));
+		$this->http->expects($this->once())->method('post')->willReturnCallback(array($this, 'queryOauthCallback'));
 		$result = $this->object->query('https://www.googleapis.com/auth/calendar', array('param' => 'value'), array(), 'post');
 		$this->assertEquals($result->body, 'Lorem ipsum dolor sit amet.');
 		$this->assertEquals(200, $result->code);
@@ -164,7 +164,7 @@ class JGoogleAuthOauth2Test extends TestCase
 		$token['expires_in'] = 3600;
 		$this->oauth->setToken($token);
 
-		$this->http->expects($this->once())->method('get')->will($this->returnCallback('getOauthCallback'));
+		$this->http->expects($this->once())->method('get')->willReturnCallback(array($this, 'getOauthCallback'));
 		$result = $this->object->query('https://www.googleapis.com/auth/calendar', array('param' => 'value'), array(), 'get');
 
 		$this->assertEquals('https://accounts.google.com/o/oauth2/auth', $this->object->getOption('authurl'));
@@ -201,5 +201,73 @@ class JGoogleAuthOauth2Test extends TestCase
 			$this->object->getOption('key'),
 			$this->equalTo('value')
 		);
+	}
+
+	/**
+	 * Dummy
+	 *
+	 * @param   string   $url      Path to the resource.
+	 * @param   mixed    $data     Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers  An array of name-value pairs to include in the header of the request
+	 * @param   integer  $timeout  Read timeout in seconds.
+	 *
+	 * @return  JHttpResponse
+	 *
+	 * @since   12.3
+	 */
+	public static function jsonGrantOauthCallback($url, $data, array $headers = null, $timeout = null)
+	{
+		$response = new stdClass;
+
+		$response->code = 200;
+		$response->headers = array('Content-Type' => 'application/json');
+		$response->body = '{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}';
+
+		return $response;
+	}
+
+	/**
+	 * Dummy
+	 *
+	 * @param   string   $url      Path to the resource.
+	 * @param   mixed    $data     Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers  An array of name-value pairs to include in the header of the request
+	 * @param   integer  $timeout  Read timeout in seconds.
+	 *
+	 * @return  JHttpResponse
+	 *
+	 * @since   12.3
+	 */
+	public static function queryOauthCallback($url, $data, array $headers = null, $timeout = null)
+	{
+		$response = new stdClass;
+
+		$response->code = 200;
+		$response->headers = array('Content-Type' => 'text/html');
+		$response->body = 'Lorem ipsum dolor sit amet.';
+
+		return $response;
+	}
+
+	/**
+	 * Dummy
+	 *
+	 * @param   string   $url      Path to the resource.
+	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout  Read timeout in seconds.
+	 *
+	 * @return  JHttpResponse
+	 *
+	 * @since   12.3
+	 */
+	public static function getOauthCallback($url, array $headers = null, $timeout = null)
+	{
+		$response = new stdClass;
+
+		$response->code = 200;
+		$response->headers = array('Content-Type' => 'text/html');
+		$response->body = 'Lorem ipsum dolor sit amet.';
+
+		return $response;
 	}
 }


### PR DESCRIPTION
The static functions added currently belong to JOAuth2ClientTest. This means that whilst the unit tests pass as a group if you run this class isolated then it fails because none of the functions exist.

The entire JGoogleAuthOauth2Test class needs a bigger overhaul to mock more of the functionality - but this at least isolates the test class

You can test by running the JGoogleAuthOauth2Test on it's own. Before this change it will fail - after it will pass
