### PR TITLE
Using of an absolute image path

### DIFF
--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -20,7 +20,7 @@ $params = JComponentHelper::getParams('com_media');
 
 JFactory::getDocument()->addScriptDeclaration(
 	"
-	var image_base_path = '" . $params->get('image_path', 'images') . "/';
+	var image_base_path = '/" . $params->get('image_path', 'images') . "/';
 	"
 );
 ?>


### PR DESCRIPTION
I think, it would be reasonable to start an image path with a slash. When I developed an extension, I found that the links which had been added in the frontend declaration from the media manager were interpreted by JavaScript as relative. As a result, I got 404 errors, because the paths to the files were incorrect.
