### PR TITLE
Add some more JEditor Unit tests

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -127,7 +127,7 @@ class JEditor extends JObject
 	/**
 	 * Attach an observer object
 	 *
-	 * @param   object  $observer  An observer object to attach
+	 * @param   array|object  $observer  An observer object to attach or an array with handler and event keys
 	 *
 	 * @return  void
 	 *
@@ -174,6 +174,8 @@ class JEditor extends JObject
 			}
 
 			$this->_observers[] = $observer;
+
+			// @todo We require a JEditor object above but get the methods from JPlugin - something isn't right here!
 			$methods = array_diff(get_class_methods($observer), get_class_methods('JPlugin'));
 		}
 

--- a/tests/unit/suites/libraries/cms/editor/JEditorTest.php
+++ b/tests/unit/suites/libraries/cms/editor/JEditorTest.php
@@ -61,7 +61,7 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 	 * @return  void
 	 *
 	 * @since   3.0
-	 * @covers JEditor::getInstance
+	 * @covers JEditor::getState
 	 */
 	public function testGetState()
 	{
@@ -89,19 +89,21 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 		);
 		$this->object->attach($testObserver);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array($testObserver),
-			TestReflection::getValue($this->object, '_observers'),
+			'_observers',
+			$this->object,
 			'Observer was not attached to the editor'
 		);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array(
 				'oninit' => array(
 					0 => 0
 				)
 			),
-			TestReflection::getValue($this->object, '_methods'),
+			'_methods',
+			$this->object,
 			'The method for the test observer was not stored correctly'
 		);
 	}
@@ -128,20 +130,22 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 		$this->object->attach($testObserver);
 		$this->object->attach($testObserver2);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array($testObserver, $testObserver2),
-			TestReflection::getValue($this->object, '_observers'),
+			'_observers',
+			$this->object,
 			'Observers were not attached to the editor'
 		);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array(
 				'oninit' => array(
 					0 => 0,
 					1 => 1,
 				)
 			),
-			TestReflection::getValue($this->object, '_methods'),
+			'_methods',
+			$this->object,
 			'The methods for the test observers were not stored correctly'
 		);
 	}
@@ -168,13 +172,14 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 		$this->object->attach($testObserver);
 		$this->object->attach($testObserver2);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array($testObserver, $testObserver2),
-			TestReflection::getValue($this->object, '_observers'),
+			'_observers',
+			$this->object,
 			'Observers were not attached to the editor'
 		);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array(
 				'oninit' => array(
 					0 => 0,
@@ -183,7 +188,8 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 					0 => 1
 				)
 			),
-			TestReflection::getValue($this->object, '_methods'),
+			'_methods',
+			$this->object,
 			'The methods for the test observers were not stored correctly'
 		);
 	}
@@ -198,10 +204,11 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 		$testObserver = new EditorObserver;
 		$this->object->attach($testObserver);
 
-		$this->assertEquals(
+		$this->assertAttributeSame(
 			array($testObserver),
-			TestReflection::getValue($this->object, '_observers'),
-			'The observer as a class was not attached to the editor'
+			'_observers',
+			$this->object,
+			'Observer was not attached to the editor'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/editor/JEditorTest.php
+++ b/tests/unit/suites/libraries/cms/editor/JEditorTest.php
@@ -7,6 +7,8 @@
  * @license	    GNU General Public License version 2 or later; see LICENSE
  */
 
+require_once __DIR__ . '/stubs/EditorObserver.php';
+
 /**
  * Test class for JEditor.
  *
@@ -43,12 +45,13 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers JEditor::getInstance
 	 */
 	public function testGetInstance()
 	{
-		$this->assertThat(
-			JEditor::getInstance('none'),
-			$this->isInstanceOf('JEditor')
+		$this->assertInstanceOf(
+			'JEditor',
+			JEditor::getInstance('none')
 		);
 	}
 
@@ -58,15 +61,147 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers JEditor::getInstance
 	 */
 	public function testGetState()
 	{
 		// Preload the state to test it
 		TestReflection::setValue($this->object, '_state', 'JEditor::getState()');
 
-		$this->assertThat(
-			$this->object->getState(),
-			$this->equalTo('JEditor::getState()')
+		$this->assertEquals(
+			'JEditor::getState()',
+			$this->object->getState()
+		);
+	}
+
+	/**
+	 * @testdox Test attaching a single closure as an observer in the JEditor class
+	 *
+	 * @since  3.4.4
+	 */
+	public function testAttachWithClosure()
+	{
+		$testObserver = array(
+			'event' => 'onInit',
+			'handler' => function () {
+				return 'teststring';
+			}
+		);
+		$this->object->attach($testObserver);
+
+		$this->assertEquals(
+			array($testObserver),
+			TestReflection::getValue($this->object, '_observers'),
+			'Observer was not attached to the editor'
+		);
+
+		$this->assertEquals(
+			array(
+				'oninit' => array(
+					0 => 0
+				)
+			),
+			TestReflection::getValue($this->object, '_methods'),
+			'The method for the test observer was not stored correctly'
+		);
+	}
+
+	/**
+	 * @testdox Test attaching multiple closures as observers in the JEditor class using the same event names
+	 *
+	 * @since  3.4.4
+	 */
+	public function testAttachWithMultipleClosuresForSameEvent()
+	{
+		$testObserver = array(
+			'event' => 'onInit',
+			'handler' => function () {
+				return 'teststring';
+			}
+		);
+		$testObserver2 = array(
+			'event' => 'onInit',
+			'handler' => function () {
+				return 'secondTestString';
+			}
+		);
+		$this->object->attach($testObserver);
+		$this->object->attach($testObserver2);
+
+		$this->assertEquals(
+			array($testObserver, $testObserver2),
+			TestReflection::getValue($this->object, '_observers'),
+			'Observers were not attached to the editor'
+		);
+
+		$this->assertEquals(
+			array(
+				'oninit' => array(
+					0 => 0,
+					1 => 1,
+				)
+			),
+			TestReflection::getValue($this->object, '_methods'),
+			'The methods for the test observers were not stored correctly'
+		);
+	}
+
+	/**
+	 * @testdox Test attaching multiple closures as observers in the JEditor class with different event names
+	 *
+	 * @since  3.4.4
+	 */
+	public function testAttachWithMultipleClosuresForDifferentEvents()
+	{
+		$testObserver = array(
+			'event' => 'onInit',
+			'handler' => function () {
+				return 'teststring';
+			}
+		);
+		$testObserver2 = array(
+			'event' => 'onAfterStuff',
+			'handler' => function () {
+				return 'secondTestString';
+			}
+		);
+		$this->object->attach($testObserver);
+		$this->object->attach($testObserver2);
+
+		$this->assertEquals(
+			array($testObserver, $testObserver2),
+			TestReflection::getValue($this->object, '_observers'),
+			'Observers were not attached to the editor'
+		);
+
+		$this->assertEquals(
+			array(
+				'oninit' => array(
+					0 => 0,
+				),
+				'onafterstuff' => array(
+					0 => 1
+				)
+			),
+			TestReflection::getValue($this->object, '_methods'),
+			'The methods for the test observers were not stored correctly'
+		);
+	}
+
+	/**
+	 * @testdox Test an observer object is correctly stored in the JEditor class
+	 *
+	 * @since  3.4.4
+	 */
+	public function testAttachWithClass()
+	{
+		$testObserver = new EditorObserver;
+		$this->object->attach($testObserver);
+
+		$this->assertEquals(
+			array($testObserver),
+			TestReflection::getValue($this->object, '_observers'),
+			'The observer as a class was not attached to the editor'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/editor/stubs/EditorObserver.php
+++ b/tests/unit/suites/libraries/cms/editor/stubs/EditorObserver.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Editor
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Stub observer for the editor class
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Plugin
+ * @since       3.4.4
+ */
+class EditorObserver extends JEditor
+{
+	/**
+	 * Dummy public method for testing
+	 *
+	 * @return  string
+	 *
+	 * @since   3.4.4
+	 */
+	public function onInit()
+	{
+		return 'someString';
+	}
+}


### PR DESCRIPTION
This adds some unit tests for the attach method in JEditor. Note there is something hugely wrong with adding a class - we require a `JEditor` object for the class here https://github.com/joomla/joomla-cms/blob/3.4.3/libraries/cms/editor/editor.php#L160 but then grab the methods in that class from `JPlugin` https://github.com/joomla/joomla-cms/blob/3.4.3/libraries/cms/editor/editor.php#L177

I've added a todo note - but fixing it is outside the scope of these unit tests
