### PR TITLE
Pagination user manager when Search Tools present

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -80,7 +80,7 @@ class UsersModelUsers extends JModelList
 		$state = $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state');
 		$this->setState('filter.state', $state);
 
-		$groupId = $this->getUserStateFromRequest($this->context . '.filter.group', 'filter_group_id', null, 'int');
+		$groupId = $this->getUserStateFromRequest($this->context . '.filter.group_id', 'filter_group_id', null, 'int');
 		$this->setState('filter.group_id', $groupId);
 
 		$range = $this->getUserStateFromRequest($this->context . '.filter.range', 'filter_range');

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -666,7 +666,7 @@ class JModelList extends JModelLegacy
 			$name    = substr($request, 7);
 			$filters = $app->input->get('filter', array(), 'array');
 
-			if (!empty($filters[$name]))
+			if (isset($filters[$name]) && $filters[$name] !== '')
 			{
 				$new_state = $filters[$name];
 			}


### PR DESCRIPTION
### Issue

Pagination doesn't work when you select a "0" value in the SearchTools. In the user manager this is for example "Activated" or the state "Enabled". In the Article Manager this would be the state "Disabled" (btw consistency ftw!).
See https://github.com/joomla/joomla-cms/issues/7486 for the original issue
### Solution

I tried to fix that originally with https://github.com/joomla/joomla-cms/pull/7194 but did a stupid mistake. Of course "0" is a valid filter value, but my boolean check would take that as an invalid value.
This PR fixes it by only threating an empty string (nothing selected) as invalid.
### Testing

Test that the pagination the managers with Search Tools work with any values. Also test that it still works in Hathor and modal layouts.

~~Known issue so far~~
~~The "Groups" filter in the user manager still acts wrong. I haven't found yet why that is. maybe someone has an idea.~~
