### PR TITLE
Fixing default values for article/module/category creation

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -323,7 +323,7 @@ class CategoriesModelCategory extends JModelAdmin
 				$extension = substr($app->getUserState('com_categories.categories.filter.extension'), 4);
 				$filters = (array) $app->getUserState('com_categories.categories.' . $extension . '.filter');
 
-				$data->set('published', $app->input->getInt('published', (!empty($filters['published']) ? $filters['published'] : null)));
+				$data->set('published', $app->input->getInt('published', ((isset($filters['published']) && $filters['published'] !== '') ? $filters['published'] : null)));
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -423,7 +423,7 @@ class ContentModelArticle extends JModelAdmin
 			if ($this->getState('article.id') == 0)
 			{
 				$filters = (array) $app->getUserState('com_content.articles.filter');
-				$data->set('state', $app->input->getInt('state', (!empty($filters['published']) ? $filters['published'] : null)));
+				$data->set('state', $app->input->getInt('state', ((isset($filters['published']) && $filters['published'] !== '') ? $filters['published'] : null)));
 				$data->set('catid', $app->input->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -596,7 +596,7 @@ class ModulesModelModule extends JModelAdmin
 			if (!$data->id)
 			{
 				$filters = (array) $app->getUserState('com_modules.modules.filter');
-				$data->set('published', $app->input->getInt('published', (!empty($filters['state']) ? $filters['state'] : null)));
+				$data->set('published', $app->input->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
 				$data->set('position', $app->input->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));


### PR DESCRIPTION
This is a fix for the previous fix https://github.com/joomla/joomla-cms/pull/7313
I'm getting better at fixing my own fixes :smile: 
### Issue

When having the "state"/"published" filter in the article/module/category manager set to "unpublished", that state should be used as default value when creating a new item. However in this specific case it didn't work.
### Solution

My code was only checking if a (boolean) value is present. That works fine for most filters since zero is never a valid case for eg a category or access level. However for the state it is a valid case and thus it failed.
The solution is to use explicite checks instead of the generic boolean check.
### Testing

Test creating new articles/categories/modules while you have active filters in Search Tools. The active filters should be preselected in the respective field in the form.
Especially the published/state filter is interesting as that is where it was broken before and now should be fixed.
