### PR TITLE
access.xml - Add support default value for permission

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -555,7 +555,8 @@ class JAccess
 				$actions[] = (object) array(
 					'name' => (string) $action['name'],
 					'title' => (string) $action['title'],
-					'description' => (string) $action['description']
+					'description' => (string) $action['description'],
+					'default' => isset($action['default']) ? (int) $action['default'] : null
 				);
 			}
 		}

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -549,15 +549,20 @@ class JAccess
 		// If there some elements, analyse them
 		if (!empty($elements))
 		{
-			foreach ($elements as $action)
+			foreach ($elements as $element)
 			{
 				// Add the action to the actions array
-				$actions[] = (object) array(
-					'name' => (string) $action['name'],
-					'title' => (string) $action['title'],
-					'description' => (string) $action['description'],
-					'default' => isset($action['default']) ? (int) $action['default'] : null
-				);
+				$action = new StdClass;
+				$action->name = (string) $element['name'];
+				$action->title = (string) $element['title'];
+				$action->description = (string) $element['description'];
+
+				if (isset($element['default']))
+				{
+					$action->default = (int) $element['default'];
+				}
+
+				$actions[] = $action;
 			}
 		}
 

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -280,11 +280,11 @@ class JFormFieldRules extends JFormField
 				if ($assetRule === null)
 				{
 					// If asset Rule is not exist yet. Use default option in action if available
-					$html[] = '<option value=""' . ($action->default === null ? ' selected="selected"' : '') . '>'
+					$html[] = '<option value=""' . (!isset($action->default) ? ' selected="selected"' : '') . '>'
 						. JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
-					$html[] = '<option value="1"' . (is_int($action->default) && ($action->default == 1) ? ' selected="selected"' : '') . '>'
+					$html[] = '<option value="1"' . (isset($action->default) && ($action->default == 1) ? ' selected="selected"' : '') . '>'
 						. JText::_('JLIB_RULES_ALLOWED') . '</option>';
-					$html[] = '<option value="0"' . (is_int($action->default) && ($action->default == 0) ? ' selected="selected"' : '') . '>'
+					$html[] = '<option value="0"' . (isset($action->default) && ($action->default == 0) ? ' selected="selected"' : '') . '>'
 						. JText::_('JLIB_RULES_DENIED') . '</option>';
 				}
 				else

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -277,14 +277,26 @@ class JFormFieldRules extends JFormField
 				$assetRule = $assetRules->allow($action->name, $group->value);
 
 				// Build the dropdowns for the permissions sliders
-
-				// The parent group has "Not Set", all children can rightly "Inherit" from that.
-				$html[] = '<option value=""' . ($assetRule === null ? ' selected="selected"' : '') . '>'
-					. JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
-				$html[] = '<option value="1"' . ($assetRule === true ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_ALLOWED')
-					. '</option>';
-				$html[] = '<option value="0"' . ($assetRule === false ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_DENIED')
-					. '</option>';
+				if ($assetRule === null)
+				{
+					// If asset Rule is not exist yet. Use default option in action if available
+					$html[] = '<option value=""' . ($action->default === null ? ' selected="selected"' : '') . '>'
+						. JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
+					$html[] = '<option value="1"' . (is_int($action->default) && ($action->default == 1) ? ' selected="selected"' : '') . '>'
+						. JText::_('JLIB_RULES_ALLOWED') . '</option>';
+					$html[] = '<option value="0"' . (is_int($action->default) && ($action->default == 0) ? ' selected="selected"' : '') . '>'
+						. JText::_('JLIB_RULES_DENIED') . '</option>';
+				}
+				else
+				{
+					// The parent group has "Not Set", all children can rightly "Inherit" from that.
+					$html[] = '<option value="">'
+						. JText::_(empty($group->parent_id) && empty($component) ? 'JLIB_RULES_NOT_SET' : 'JLIB_RULES_INHERITED') . '</option>';
+					$html[] = '<option value="1"' . ($assetRule === true ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_ALLOWED')
+						. '</option>';
+					$html[] = '<option value="0"' . ($assetRule === false ? ' selected="selected"' : '') . '>' . JText::_('JLIB_RULES_DENIED')
+						. '</option>';
+				}
 
 				$html[] = '</select>&#160; ';
 


### PR DESCRIPTION
For now, when use ACL permission (by access.xml file for define rule), it's not support to set an default value for permission.

This PR for add an attribute "default" into an rule in access.xml file to set it default is "allow" or "denied", if default not specific, default rule will be "Inherit" as normal use.
