### PR TITLE
Remove to-do comment

### DIFF
--- a/layouts/joomla/content/info_block/block.php
+++ b/layouts/joomla/content/info_block/block.php
@@ -19,7 +19,6 @@ $blockPosition = $displayData['params']->get('info_block_position', 0);
 				) : ?>
 
 			<dt class="article-info-term">
-				<?php // TODO: implement info_block_show_title param to hide article info title ?>
 				<?php if ($displayData['params']->get('info_block_show_title', 1)) : ?>
 					<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
 				<?php endif; ?>


### PR DESCRIPTION
Remove the `// TODO: implement info_block_show_title param to hide article info title` comment. Discussion about it can be found in #7379
