### PR TITLE
[imp] Adding manifest xml link to Update Sites Manager page

### DIFF
--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -93,6 +93,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td>
 							<label for="cb<?php echo $i; ?>">
 								<?php echo $item->update_site_name; ?>
+								<br /><span class="small"><a href="<?php echo $item->location; ?>"><?php echo $item->location; ?></a></span>
 							</label>
 						</td>
 						<td class="hidden-phone">

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -93,7 +93,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td>
 							<label for="cb<?php echo $i; ?>">
 								<?php echo $item->update_site_name; ?>
-								<br /><span class="small"><a href="<?php echo $item->location; ?>"><?php echo $item->location; ?></a></span>
+								<br /><span class="small"><a href="<?php echo $item->location; ?>" target="_blank"><?php echo $item->location; ?></a></span>
 							</label>
 						</td>
 						<td class="hidden-phone">

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -93,7 +93,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td>
 							<label for="cb<?php echo $i; ?>">
 								<?php echo $item->update_site_name; ?>
-								<br /><span class="small"><a href="<?php echo $item->location; ?>" target="_blank"><?php echo $item->location; ?></a></span>
+								<br />
+								<span class="small">
+									<a href="<?php echo $item->location; ?>" target="_blank"><?php echo $this->escape($item->location); ?></a>
+								</span>
 							</label>
 						</td>
 						<td class="hidden-phone">


### PR DESCRIPTION
This improvement lets check easily if the xml is correct by displaying a link to its location under the site name.

After patch one should get:
![screen shot 2015-07-23 at 17 29 08](https://cloud.githubusercontent.com/assets/869724/8854657/404f17a8-3161-11e5-9341-616c8e8b038b.png)

@nikosdion 
