### PR TITLE
contact list acl fix

### DIFF
--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -283,10 +283,6 @@ class ContactModelCategory extends JModelList
 			// Filter by start and end dates.
 			$this->setState('filter.publish_date', true);
 		}
-		else
-		{
-			$this->setState('filter.published', array(0, 1, 2));
-		}
 
 		$this->setState('filter.language', JLanguageMultilang::isEnabled());
 

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -287,7 +287,7 @@ class ContactModelCategory extends JModelList
 		{
 			$this->setState('filter.published', array(0, 1, 2));
 		}
-		
+
 		$this->setState('filter.language', JLanguageMultilang::isEnabled());
 
 		// Load the parameters.

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -168,6 +168,10 @@ class ContactModelCategory extends JModelList
 		{
 			$query->where('a.published = ' . (int) $state);
 		}
+		else
+		{
+			$query->where('(a.published IN (0,1,2))');
+		}
 		// Filter by start and end dates.
 		$nullDate = $db->quote($db->getNullDate());
 		$nowDate = $db->quote(JFactory::getDate()->toSql());
@@ -279,7 +283,11 @@ class ContactModelCategory extends JModelList
 			// Filter by start and end dates.
 			$this->setState('filter.publish_date', true);
 		}
-
+		else
+		{
+			$this->setState('filter.published', array(0, 1, 2));
+		}
+		
 		$this->setState('filter.language', JLanguageMultilang::isEnabled());
 
 		// Load the parameters.


### PR DESCRIPTION
Contact list displays trashed items - this PR fixes it
### Trashed

Create multiple articles and contacts. 
Create two menu items for "Articles » Category List" and "Contacts » List Contacts in a Category"
Trash one article and one contact
Check the menus - the trashed items do not appear
Login to the frontend as admin (or anyone with Special access)
Check the article menu - the trashed article does not appear
Check the contact menu - the trashed contact does appear
### Unpublished

Create multiple articles and contacts. 
Create two menu items for "Articles » Category List" and "Contacts » List Contacts in a Category"
Unpublish one article and one contact
Check the menus - the unpublished items do not appear
Login to the frontend as admin (or anyone with Special access)
Check the article menu - the unpublished article does appear with a flag saying unpublished
Check the contact menu - the unpublished contact does appear with a flag saying unpublished
### Before

![screen shot 2015-07-23 at 09 14 53](http://issues.joomla.org/uploads/1/fd5291781910182f9e49df5470e565ef.png)
