### PR TITLE
newsfeed acl list

### DIFF
--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -234,10 +234,6 @@ class NewsfeedsModelCategory extends JModelList
 			// Filter by start and end dates.
 			$this->setState('filter.publish_date', true);
 		}
-		else
-		{
-			$this->setState('filter.published', array(0, 1, 2));
-		}
 
 		$this->setState('filter.language', JLanguageMultilang::isEnabled());
 

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -137,6 +137,10 @@ class NewsfeedsModelCategory extends JModelList
 		{
 			$query->where('a.published = ' . (int) $state);
 		}
+		else
+		{
+			$query->where('(a.published IN (0,1,2))');
+		}
 
 		// Filter by start and end dates.
 		$nullDate = $db->quote($db->getNullDate());
@@ -229,6 +233,10 @@ class NewsfeedsModelCategory extends JModelList
 
 			// Filter by start and end dates.
 			$this->setState('filter.publish_date', true);
+		}
+		else
+		{
+			$this->setState('filter.published', array(0, 1, 2));
 		}
 
 		$this->setState('filter.language', JLanguageMultilang::isEnabled());


### PR DESCRIPTION
****Same issue as #7535 

Contact list displays trashed items - this PR fixes it
### Before

Create multiple newsfeeds
Create menu items for "News Feeds » List News Feeds in a Category"
Trash one feed and unpublish one feed
Check the menu without being logged in - the trashed and unpublished items do not appear
Login to the frontend as admin (or anyone with Special access)
The trashed and unpublished newsfeed is present

![lwma](https://cloud.githubusercontent.com/assets/1296369/8855859/4f704236-315f-11e5-9474-718c0b8fe370.png)
### After

Apply the patch
Check the menu without being logged in - the trashed and unpublished items do not appear
Login to the frontend as admin (or anyone with Special access)
The  unpublished newsfeed is present and the trashed one is not

![lwma 1](https://cloud.githubusercontent.com/assets/1296369/8855892/8100d900-315f-11e5-9851-6cfccbfd9592.png)
