### PR TITLE
Fixes #6461 | Adding custom position of the module in the position dr…

### DIFF
--- a/components/com_config/model/modules.php
+++ b/components/com_config/model/modules.php
@@ -131,7 +131,7 @@ class ConfigModelModules extends ConfigModelForm
 
 		// Load templateDetails.xml file
 		$path = JPath::clean(JPATH_BASE . '/templates/' . $templateName . '/templateDetails.xml');
-		$currentPositions = array();
+		$currentTemplatePositions = array();
 
 		if (file_exists($path))
 		{
@@ -139,21 +139,129 @@ class ConfigModelModules extends ConfigModelForm
 
 			if (isset($xml->positions[0]))
 			{
+				// Load language files
+				$lang->load('tpl_' . $templateName . '.sys', JPATH_BASE, null, false, true)
+				||	$lang->load('tpl_' . $templateName . '.sys', JPATH_BASE . '/templates/' . $templateName, null, false, true);
+
 				foreach ($xml->positions[0] as $position)
 				{
-					// Load language files
-					$lang->load('tpl_' . $templateName . '.sys', JPATH_BASE, null, false, true)
-					||	$lang->load('tpl_' . $templateName . '.sys', JPATH_BASE . '/templates/' . $templateName, null, false, true);
-
-					$key = (string) $position;
-					$value = preg_replace('/[^a-zA-Z0-9_\-]/', '_', 'TPL_' . strtoupper($templateName) . '_POSITION_' . strtoupper($key));
+					$value = (string) $position;
+					$text = preg_replace('/[^a-zA-Z0-9_\-]/', '_', 'TPL_' . strtoupper($templateName) . '_POSITION_' . strtoupper($value));
 
 					// Construct list of positions
-					$currentPositions[$key] = JText::_($value) . ' [' . $key . ']';
+					$currentTemplatePositions[] = self::createOption($value, JText::_($text) . ' [' . $value . ']');
 				}
 			}
 		}
 
-		return $currentPositions;
+		$templateGroups = array();
+
+		// Add an empty value to be able to deselect a module position
+		$option = self::createOption();
+		$templateGroups[''] = self::createOptionGroup('', array($option));
+
+		$templateGroups[$templateName] = self::createOptionGroup($templateName, $currentTemplatePositions);
+
+		// Add custom position to options
+		$customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
+
+		$editPositions = true;
+		$customPositions = self::getActivePositions(0, $editPositions);
+		$templateGroups[$customGroupText] = self::createOptionGroup($customGroupText, $customPositions);
+
+		return $templateGroups;
+	}
+
+	/**
+	 * Get a list of modules positions
+	 *
+	 * @param   integer  $clientId       Client ID
+	 * @param   boolean  $editPositions  Allow to edit the positions
+	 *
+	 * @return  array  A list of positions
+	 */
+	public static function getActivePositions($clientId, $editPositions = false)
+	{
+		$db		= JFactory::getDbo();
+		$query	= $db->getQuery(true)
+			->select('DISTINCT(position)')
+			->from('#__modules')
+			->where($db->quoteName('client_id') . ' = ' . (int) $clientId)
+			->order('position');
+
+		$db->setQuery($query);
+
+		try
+		{
+			$positions = $db->loadColumn();
+			$positions = is_array($positions) ? $positions : array();
+		}
+		catch (RuntimeException $e)
+		{
+			JError::raiseWarning(500, $e->getMessage());
+
+			return;
+		}
+
+		// Build the list
+		$options = array();
+
+		foreach ($positions as $position)
+		{
+			if (!$position && !$editPositions)
+			{
+				$options[]	= JHtml::_('select.option', 'none', ':: ' . JText::_('JNONE') . ' ::');
+			}
+			else
+			{
+				$options[]	= JHtml::_('select.option', $position, $position);
+			}
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Create and return a new Option
+	 *
+	 * @param   string  $value  The option value [optional]
+	 * @param   string  $text   The option text [optional]
+	 *
+	 * @return  object  The option as an object (stdClass instance)
+	 *
+	 * @since   3.0
+	 */
+	private static function createOption($value = '', $text = '')
+	{
+		if (empty($text))
+		{
+			$text = $value;
+		}
+
+		$option = new stdClass;
+		$option->value = $value;
+		$option->text  = $text;
+
+		return $option;
+	}
+
+	/**
+	 * Create and return a new Option Group
+	 *
+	 * @param   string  $label    Value and label for group [optional]
+	 * @param   array   $options  Array of options to insert into group [optional]
+	 *
+	 * @return  array  Return the new group as an array
+	 *
+	 * @since   3.0
+	 */
+	private static function createOptionGroup($label = '', $options = array())
+	{
+		$group = array();
+		$group['value'] = $label;
+		$group['text']  = $label;
+		$group['items'] = $options;
+
+		return $group;
 	}
 }

--- a/components/com_config/view/modules/tmpl/default_positions.php
+++ b/components/com_config/view/modules/tmpl/default_positions.php
@@ -8,13 +8,19 @@
  */
 
 defined('_JEXEC') or die;
-
 $positions = $this->model->getPositions();
 
-$currentPosition = $this->item['position'];
+// Add custom position to options
+$customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 
-if (in_array($currentPosition, $positions) == false){
-	$positions[$currentPosition] = $currentPosition;
-}
+// Build field
+$attr = array(
+	'id'          => 'jform_position',
+	'list.select' => $this->item['position'],
+	'list.attr'   => 'class="chzn-custom-value" '
+		. 'data-custom_group_text="' . $customGroupText . '" '
+		. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
+		. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '
+);
 
-echo JHtml::_('select.genericlist', $positions, 'jform[position]', '', '', '', $currentPosition);
+echo JHtml::_('select.groupedlist', $positions, 'jform[position]', $attr);

--- a/components/com_config/view/modules/tmpl/default_positions.php
+++ b/components/com_config/view/modules/tmpl/default_positions.php
@@ -11,4 +11,10 @@ defined('_JEXEC') or die;
 
 $positions = $this->model->getPositions();
 
-echo JHtml::_('select.genericlist', $positions, 'jform[position]', '', '', '', $this->item['position']);
+$currentPosition = $this->item['position'];
+
+if (in_array($currentPosition, $positions) == false){
+	$positions[$currentPosition] = $currentPosition;
+}
+
+echo JHtml::_('select.genericlist', $positions, 'jform[position]', '', '', '', $currentPosition);


### PR DESCRIPTION
…opdown while editing module on frontend.

http://issues.joomla.org/tracker/joomla-cms/6461
## Test instructions
#### Added by @brianteeman 25 Aug

Edit the index.php of the protostar template and rename the module position in line 177 from
`<jdoc:include type="modules" name="position-8" style="xhtml" />`

to

`<jdoc:include type="modules" name="test123" style="xhtml" />`

Now go to the module and create a new custom module and place it in position test123 (it wont be on the list you have to manually enter it)

Go to global configuration and make sure that you have "Mouse-over Edit Icons for" set for modules

Go to the front end of the site and check the new module is displayed and then log in

Hover over the module and you get an icon to let you open the module for editing. Change the module title and press save. The module will have been saved in a different position.

Now apply the patch. Go to module manager and put the module back into test123 and repeat

You will now see that when you edit the module you will see at the bottom of the list of module positions a section "Active positions" and test123 is there. Dont change the position. Edit the title and sabe the module. The module will have been saved in the same position
