### PR TITLE
Adding maxlength parameter to version_note field

### DIFF
--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -45,6 +45,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			maxlength="255"
 			class="span12" size="45"
 			labelclass="control-label"
 		/>

--- a/administrator/components/com_banners/models/forms/client.xml
+++ b/administrator/components/com_banners/models/forms/client.xml
@@ -36,6 +36,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			maxlength="255"
 			size="45"
 			labelclass="control-label"
 		/>

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -79,6 +79,7 @@
 		type="text"
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 		description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+		maxlength="255"
 		class="span12"
 		size="45" />
 

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -88,6 +88,7 @@
 		type="text"
 		label="COM_CATEGORIES_FIELD_NOTE_LABEL"
 		description="COM_CATEGORIES_FIELD_NOTE_DESC"
+		maxlength="255"
 		class="span12"
 		size="40"/>
 

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -32,6 +32,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			maxlength="255"
 			class="span12" size="45"
 			labelclass="control-label"
 		/>

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -21,6 +21,7 @@
 		<field name="version_note" type="text" label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
 			class="span12"
+			maxlength="255"
 			size="45" />
 
 		<field name="articletext" type="editor"

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -37,6 +37,7 @@
 			type="text"
 			label="JFIELD_NOTE_LABEL"
 			description="COM_MENUS_ITEM_FIELD_NOTE_DESC"
+			maxlength="255"
 			class="span12"
 			size="40"/>
 

--- a/administrator/components/com_modules/models/forms/module.xml
+++ b/administrator/components/com_modules/models/forms/module.xml
@@ -20,7 +20,7 @@
 		<field name="note" type="text"
 			description="COM_MODULES_FIELD_NOTE_DESC"
 			label="COM_MODULES_FIELD_NOTE_LABEL"
-			maxlength="100"
+			maxlength="255"
 			size="40"
 			class="span12"
 		/>

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -55,6 +55,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			maxlength="255"
 			class="span12" size="45"
 			labelclass="control-label"
 		/>

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -217,6 +217,7 @@
 		type="text"
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 		description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+		maxlength="255"
 		class="span12" size="45"
 		labelclass="control-label"
 	/>

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -84,6 +84,7 @@
 	<field
 		name="note"
 		type="text"
+		maxlength="255"
 		class="span12"
 		label="COM_TAGS_FIELD_NOTE_LABEL"
 		description="COM_TAGS_FIELD_NOTE_DESC"

--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -127,6 +127,7 @@
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
+			maxlength="255"
 			size="45"
 			labelclass="control-label"
 			/>	

--- a/components/com_config/model/form/modules.xml
+++ b/components/com_config/model/form/modules.xml
@@ -19,7 +19,7 @@
 		<field name="note" type="text"
 			description="COM_MODULES_FIELD_NOTE_DESC"
 			label="COM_MODULES_FIELD_NOTE_LABEL"
-			maxlength="100"
+			maxlength="255"
 			size="35"
 		/>
 

--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -128,6 +128,7 @@
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
 			class="inputbox"
+			maxlength="255"
 			size="45"
 			labelclass="control-label" />
 


### PR DESCRIPTION
### Issue

As explained in #7539 the version note will be truncated without notice if it is longer than 255 characters. That is because the database field is no bigger. See https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1724
### Solution

Add the HTML `maxlength` attribute so the user isn't able to enter more than 255 characters into the version note field
### Testing
- Add a long string (more than 255 characters) into the version note field in any of the forms supporting it. Eg article, banner, contact. Check after saving and see that the string was truncated.
  You can use this string:

```
abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10
```
- Apply patch and try to enter the string again. See that it is truncated before saving already. You will not be able to paste the full string.
