### PR TITLE
Add test case for JUserHelper::activeUser

### DIFF
--- a/tests/unit/stubs/database/jos_users.csv
+++ b/tests/unit/stubs/database/jos_users.csv
@@ -3,3 +3,4 @@
 '43','Publisher','publisher','publisher@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','0','1','2010-02-13 00:34:42','2010-02-13 00:34:42','0',,'0000-00-00 00:00:00','0'
 '44','Manager','manager','manager@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','0','1','2010-02-13 00:34:42','2010-02-13 00:34:42','0',,'0000-00-00 00:00:00','0'
 '99','Test','test','test@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','0','1','2010-02-13 00:34:42','2010-02-13 00:34:42','0',,'0000-00-00 00:00:00','0'
+'100','Activate','activate','activate@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','1','1','2010-02-13 00:34:42','0000-00-00 00:00:00','30cc6de70fb18231196a28dd83363d57',,'0000-00-00 00:00:00','0'

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -301,10 +301,9 @@ class JUserHelperTest extends TestCaseDatabase
 	 */
 	public function testActivateUser($activation, $expected)
 	{
-		$this->markTestSkipped('Unexpected test failure in CMS environment');
-		$this->assertThat(
+		$this->assertEquals(
 			JUserHelper::activateUser($activation),
-			$this->equalTo($expected)
+			$expected
 		);
 	}
 


### PR DESCRIPTION
The unexpected failure for this unit tests is that a dummy user didn't exist for the user that was supposed to be successfully activated. This adds it. To test check travis passes
