### PR TITLE
Fix line ending issues when running tests in windows

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
@@ -95,21 +95,17 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 			// Function parameters array($expected, $data, $name, $attribs = null, $optKey = 'value', $optText = 'text', $selected = null, $idtag = false,
 			// 						$translate = false)
 			array(
-				"<div class=\"controls\">
-	<label for=\"yesId\" id=\"yesId-lbl\" class=\"radio\">
-\t
-	<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\"  >Yes
-	</label>
-	<label for=\"myRadioListName0\" id=\"myRadioListName0-lbl\" class=\"radio\">
-\t
-	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\"  >No
-	</label>
-	<label for=\"myRadioListName-1\" id=\"myRadioListName-1-lbl\" class=\"radio\">
-\t
-	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\"  >Maybe
-	</label>
-</div>
-",
+				"<div class=\"controls\">\n\t" .
+				"<label for=\"yesId\" id=\"yesId-lbl\" class=\"radio\">\n\t\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\"  >Yes\n\t" .
+				"</label>\n\t" .
+				"<label for=\"myRadioListName0\" id=\"myRadioListName0-lbl\" class=\"radio\">\n\t\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\"  >No\n\t" .
+				"</label>\n\t" .
+				"<label for=\"myRadioListName-1\" id=\"myRadioListName-1-lbl\" class=\"radio\">\n\t\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\"  >Maybe\n\t" .
+				"</label>\n" .
+				"</div>\n",
 				array(
 					array(
 						'value' => '1',
@@ -128,17 +124,14 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 				"myRadioListName"
 			),
 			array(
-				"<div class=\"controls\">
-	<label for=\"fooId\" id=\"fooId-lbl\" class=\"radio\">
-\t
-	<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\" >FOO
-	</label>
-	<label for=\"myFooBarListNamebar\" id=\"myFooBarListNamebar-lbl\" class=\"radio\">
-\t
-	<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\" >BAR
-	</label>
-</div>
-",
+				"<div class=\"controls\">\n\t" .
+				"<label for=\"fooId\" id=\"fooId-lbl\" class=\"radio\">\n\t\n\t" .
+				"<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\" >FOO\n\t" .
+				"</label>\n\t" .
+				"<label for=\"myFooBarListNamebar\" id=\"myFooBarListNamebar-lbl\" class=\"radio\">\n\t\n\t" .
+				"<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\" >BAR\n\t" .
+				"</label>\n" .
+				"</div>\n",
 				array(
 					array(
 						'key' => 'foo',


### PR DESCRIPTION
In `JHtmlSelect::radioSelect()` we are using `\n` to represent a new line. However in our unit tests we are actually creating a new line (i.e. using `PHP_EOL`). This gives errors on a windows system. So I have explicitly new line instances with `\n`

With this fix I now have all unit tests passing on Windows 8.1
