### PR TITLE
Add Bootstrap Styling to Joomla Update Confirmation Message

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<legend>
 		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING') ?>
 	</legend>
-	<p>
+	<p class="alert alert-success">
 		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE', JVERSION); ?>
 	</p>
 </fieldset>


### PR DESCRIPTION
This is to add Bootstrap styling to the "successfully updated" confirmation message after updating Joomla via com_joomlaupdate.
### Before Change

![jupdate-confirm-original](https://cloud.githubusercontent.com/assets/13225615/8910575/9bc6f2f8-3455-11e5-923a-88310e0fa586.png)
### After Change

![jupdate-confirm-new](https://cloud.githubusercontent.com/assets/13225615/8910581/a2d79872-3455-11e5-967a-4150b31b73fd.png)
### How to Test
1. Implement the `class="alert alert-success"` addition.
2. Visit administrator/index.php?option=com_joomlaupdate&layout=complete in your browser.
