### PR TITLE
Code style fixes - control structure spacing

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -327,7 +327,6 @@ class CategoriesModelCategory extends JModelAdmin
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
-
 		}
 
 		$this->preprocessData('com_categories.category', $data);
@@ -510,6 +509,7 @@ class CategoriesModelCategory extends JModelAdmin
 					$data['alias'] = '';
 				}
 			}
+
 			$data['published'] = 0;
 		}
 
@@ -937,7 +937,7 @@ class CategoriesModelCategory extends JModelAdmin
 			// Set the new location in the tree for the node.
 			$this->table->setLocation($this->table->parent_id, 'last-child');
 
-			// TODO: Deal with ordering?
+			// @TODO: Deal with ordering?
 			// $this->table->ordering	= 1;
 			$this->table->level = null;
 			$this->table->asset_id = null;


### PR DESCRIPTION
- 329 Blank line found after control structure. A blank line is not needed after a control structure when the next line is just a closing brace of the parent control structure
- 512 No blank line found after control structure, A blank line is needed after a control structure when the next line is code.
- 940 missing `@` from TODO
