### PR TITLE
Code style fixes - Commenting Style

### DIFF
--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -141,7 +141,7 @@ class ContactTableContact extends JTable
 			return false;
 		}
 
-		/** check for valid name */
+		// Check for valid name
 		if (trim($this->name) == '')
 		{
 			$this->setError(JText::_('COM_CONTACT_WARNING_PROVIDE_VALID_NAME'));
@@ -152,14 +152,14 @@ class ContactTableContact extends JTable
 		// Generate a valid alias
 		$this->generateAlias();
 
-		/** check for valid category */
+		// Check for valid category
 		if (trim($this->catid) == '')
 		{
 			$this->setError(JText::_('COM_CONTACT_WARNING_CATEGORY'));
 
 			return false;
 		}
-		/** sanity check for user_id */
+		// Sanity check for user_id */
 		if (!($this->user_id))
 		{
 			$this->user_id = 0;
@@ -177,7 +177,7 @@ class ContactTableContact extends JTable
 		 * Clean up keywords -- eliminate extra spaces between phrases
 		 * and cr (\r) and lf (\n) characters from string.
 		 * Only process if not empty.
- 		 */
+		 */
 		if (!empty($this->metakey))
 		{
 			// Array of characters to remove.


### PR DESCRIPTION
- Single line comments should use `//` rather than the multi-line style `/** ... */`
- Comments must start with a space and a capital letter following `//`
- Tabs not Spaces for indenting
