### PR TITLE
HTTP status response not rendered correctly

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -691,7 +691,7 @@ class JApplicationWeb extends JApplicationBase
 				if ('status' == strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header(ucfirst(strtolower($header['name'])) . ': ' . $header['value'], null, (int) $header['value']);
+					$this->header('HTTP/1.1 ' . $header['value'], null, (int) $header['value']);
 				}
 				else
 				{

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1246,7 +1246,7 @@ class JApplicationWebTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				array('Status: 200', null, 200),
+				array('HTTP/1.1 200', null, 200),
 				array('X-JWeb-SendHeaders: foo', true, null),
 			),
 			$this->class->headers


### PR DESCRIPTION
The 'status' headers need to be handled differently, but the code was adding a new 'status' header field rather than altering the HTTP response code.  Unit test has also been fixed.

See: http://php.net/manual/en/function.header.php

This is a backport of this fix in the Framework: https://github.com/joomla-framework/application/pull/49
