### PR TITLE
Added a class "current-trail" to the menu module

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -41,7 +41,7 @@ foreach ($list as $i => &$item)
 		$class .= ' current';
 	}
 
-	if (in_array ($item->id, $trail))
+	if (in_array($item->id, $trail))
 	{
 		$class .= ' current-trail';
 	}

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -22,6 +22,16 @@ defined('_JEXEC') or die;
 	}
 ?>>
 <?php
+
+foreach ($list as &$item)
+{
+	if ($item->id == $active_id)
+	{
+		$trail = $item->tree;
+		break;
+	}
+}
+
 foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;
@@ -29,6 +39,11 @@ foreach ($list as $i => &$item)
 	if (($item->id == $active_id) OR ($item->type == 'alias' AND $item->params->get('aliasoptions') == $active_id))
 	{
 		$class .= ' current';
+	}
+
+	if (in_array ($item->id, $trail))
+	{
+		$class .= ' current-trail';
 	}
 
 	if (in_array($item->id, $path))


### PR DESCRIPTION
Much like in Drupal (where the class is called "active-trail"), this marks each displayed menu item in the menu tree towards the active item with a specific class "current-trail". This unleashes a lot of easy CSS possibilities for menu styling that were previously not possible.
