### PR TITLE
installation folder comment

### DIFF
--- a/installation/language/en-AU/en-AU.ini
+++ b/installation/language/en-AU/en-AU.ini
@@ -118,13 +118,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder successfully removed"
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"

--- a/installation/language/en-CA/en-CA.ini
+++ b/installation/language/en-CA/en-CA.ini
@@ -118,13 +118,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder successfully removed"
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -116,13 +116,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder successfully removed."
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application select the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla! to download and install the new languages. <br />Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! Administrator."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla!"
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -118,13 +118,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder successfully removed"
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application click the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need Internet access for Joomla! to download and install the new languages. <br/>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! administrator."
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla!."
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"


### PR DESCRIPTION
It has become apparent that in some translations the word "installation" has been translated when it refers to the folder named "installation" and should not have been translated.

This PR add a line comment for translators to inform them not to translate this word on the specific lines in the installation language files 

This should be displayed when using com_localise to create joomla translation packages as stated by @infograf768 

I have updated all the en-\* installation languages and the string added is

> ; The word 'installation' should not be translated as it is a physical folder.
