### PR TITLE
New 'behavior.inputLimitTest' for checks the setting of php max_input_vars

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'item-form');
+JHtml::_('behavior.inputlimittest', 'item-form', array('category.apply', 'category.save', 'category.save2new', 'category.save2copy'));
 
 $app = JFactory::getApplication();
 $input = $app->input;

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -15,6 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'item-form');
 
 $app = JFactory::getApplication();
 $input = $app->input;

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -15,7 +15,7 @@ use Joomla\Registry\Registry;
 JHtml::_('behavior.formvalidator');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'application-form');
+JHtml::_('behavior.inputlimittest', 'application-form', array('config.save.application.apply', 'config.save.application.save'));
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -15,6 +15,7 @@ use Joomla\Registry\Registry;
 JHtml::_('behavior.formvalidator');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'application-form');
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -16,6 +16,7 @@ $template = $app->getTemplate();
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'component-form', array('config.save.component.apply', 'config.save.component.save'));
 
 JFactory::getDocument()->addScriptDeclaration(
 	'

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -15,6 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'item-form');
 
 $this->configFieldsets  = array('editorConfig');
 $this->hiddenFieldsets  = array('basic-limited');

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'item-form');
+JHtml::_('behavior.inputlimittest', 'item-form', array('article.apply', 'article.save', 'article.save2new', 'article.save2copy'));
 
 $this->configFieldsets  = array('editorConfig');
 $this->hiddenFieldsets  = array('basic-limited');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -16,6 +16,7 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'item-form');
 
 JText::script('ERROR');
 JText::script('JGLOBAL_VALIDATION_FORM_FAILED');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -16,7 +16,7 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'item-form');
+JHtml::_('behavior.inputlimittest', 'item-form', array('item.apply', 'item.save', 'item.save2new', 'item.save2copy'));
 
 JText::script('ERROR');
 JText::script('JGLOBAL_VALIDATION_FORM_FAILED');

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.combobox');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'module-form');
+JHtml::_('behavior.inputlimittest', 'module-form', array('module.apply', 'module.save', 'module.save2new', 'module.save2copy'));
 
 $hasContent = empty($this->item->module) ||  isset($this->item->xml->customContent);
 $hasContentFieldName = "content";

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -14,6 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.combobox');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'module-form');
 
 $hasContent = empty($this->item->module) ||  isset($this->item->xml->customContent);
 $hasContentFieldName = "content";

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -13,7 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'style-form');
+JHtml::_('behavior.inputlimittest', 'style-form', array('plugin.apply', 'plugin.save'));
 
 $this->fieldsets = $this->form->getFieldsets('params');
 

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -13,6 +13,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'style-form');
+
 $this->fieldsets = $this->form->getFieldsets('params');
 
 JFactory::getDocument()->addScriptDeclaration("

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -14,6 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.inputlimittest', 'user-form');
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.inputlimittest', 'user-form');
+JHtml::_('behavior.inputlimittest', 'user-form', array('user.apply', 'user.save', 'user.save2new'));
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -167,6 +167,7 @@ JERROR_NOLOGIN_BLOCKED="Login denied! Your account has either been blocked or yo
 JERROR_SENDING_EMAIL="Email could not be sent."
 JERROR_SESSION_STARTUP="Error initialising the session."
 JERROR_SAVE_FAILED="Could not save data. Error: %s"
+JERROR_MAXVARS_REACHED="Your PHP configuration has an input limit of %s variables and your website close to that limit or has reached that limit and is using approximately <strong>%s</strong>. <strong> <br />This will create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."
 
 JFIELD_ACCESS_DESC="The access level group that is allowed to view this item."
 JFIELD_ACCESS_LABEL="Access"

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -167,7 +167,7 @@ JERROR_NOLOGIN_BLOCKED="Login denied! Your account has either been blocked or yo
 JERROR_SENDING_EMAIL="Email could not be sent."
 JERROR_SESSION_STARTUP="Error initialising the session."
 JERROR_SAVE_FAILED="Could not save data. Error: %s"
-JERROR_MAXVARS_REACHED="Your PHP configuration has an input limit of %s variables and your website close to that limit or has reached that limit and is using approximately <strong>%s</strong>. <strong> <br />This will create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."
+JERROR_MAXVARS_REACHED="Your PHP configuration has an input limit of %s variables and your website is close to that limit or has reached that limit and is using approximately <strong>%s</strong>. <strong> <br />This will create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."
 
 JFIELD_ACCESS_DESC="The access level group that is allowed to view this item."
 JFIELD_ACCESS_LABEL="Access"

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -168,6 +168,7 @@ JERROR_SENDING_EMAIL="Email could not be sent."
 JERROR_SESSION_STARTUP="Error initialising the session."
 JERROR_SAVE_FAILED="Could not save data. Error: %s"
 JERROR_MAXVARS_REACHED="Your PHP configuration has an input limit of %s variables and your website is close to that limit or has reached that limit and is using approximately <strong>%s</strong>. <strong> <br />This will create issues making changes to your website.</strong> <br />Please contact your hosting provider and ask them to increase the limit of the PHP setting <strong>max_input_vars</strong>."
+JERROR_MAXVARS_NOSUBMIT="You cannot submit the form until the limit is changed."
 
 JFIELD_ACCESS_DESC="The access level group that is allowed to view this item."
 JFIELD_ACCESS_LABEL="Access"

--- a/administrator/templates/hathor/html/com_categories/category/edit.php
+++ b/administrator/templates/hathor/html/com_categories/category/edit.php
@@ -18,6 +18,7 @@ $saveHistory = $this->state->get('params')->get('save_history', 0);
 
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
+JHtml::_('behavior.inputlimittest', 'item-form', array('category.apply', 'category.save', 'category.save2new', 'category.save2copy'));
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/administrator/templates/hathor/html/com_config/application/default.php
+++ b/administrator/templates/hathor/html/com_config/application/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.switcher');
+JHtml::_('behavior.inputlimittest', 'application-form', array('config.save.application.apply', 'config.save.application.save'));
 
 // Load submenu template, using element id 'submenu' as needed by behavior.switcher
 $this->document->setBuffer($this->loadTemplate('navigation'), 'modules', 'submenu');

--- a/administrator/templates/hathor/html/com_config/component/default.php
+++ b/administrator/templates/hathor/html/com_config/component/default.php
@@ -14,6 +14,7 @@ $template = $app->getTemplate();
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('bootstrap.framework');
+JHtml::_('behavior.inputlimittest', 'component-form', array('config.save.component.apply', 'config.save.component.save'));
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/administrator/templates/hathor/html/com_content/article/edit.php
+++ b/administrator/templates/hathor/html/com_content/article/edit.php
@@ -14,6 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
+JHtml::_('behavior.inputlimittest', 'item-form', array('article.apply', 'article.save', 'article.save2new', 'article.save2copy'));
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');

--- a/administrator/templates/hathor/html/com_menus/item/edit.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit.php
@@ -15,6 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.framework');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.modal');
+JHtml::_('behavior.inputlimittest', 'item-form', array('item.apply', 'item.save', 'item.save2new', 'item.save2copy'));
 
 $assoc = JLanguageAssociations::isEnabled();
 

--- a/administrator/templates/hathor/html/com_modules/module/edit.php
+++ b/administrator/templates/hathor/html/com_modules/module/edit.php
@@ -13,6 +13,8 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.combobox');
+JHtml::_('behavior.inputlimittest', 'module-form', array('module.apply', 'module.save', 'module.save2new', 'module.save2copy'));
+
 $hasContent = empty($this->item->module) || $this->item->module == 'custom' || $this->item->module == 'mod_custom';
 
 $script = "Joomla.submitbutton = function(task)

--- a/administrator/templates/hathor/html/com_plugins/plugin/edit.php
+++ b/administrator/templates/hathor/html/com_plugins/plugin/edit.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.formvalidator');
+JHtml::_('behavior.inputlimittest', 'style-form', array('plugin.apply', 'plugin.save'));
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/administrator/templates/hathor/html/com_users/user/edit.php
+++ b/administrator/templates/hathor/html/com_users/user/edit.php
@@ -14,6 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
+JHtml::_('behavior.inputlimittest', 'user-form', array('user.apply', 'user.save', 'user.save2new'));
 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -918,7 +918,21 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		$maxinputvars = (int) ini_get('max_input_vars');
+		// Get the request limit from the PHP configiration
+		$suhosinPostVars = (int) ini_get('suhosin.post.max_vars');
+		$suhosinReqVars  = (int) ini_get('suhosin.request.max_vars');
+		$maxinputvars    = (int) ini_get('max_input_vars');
+
+		if ($suhosinPostVars || $suhosinReqVars)
+		{
+			// Take the minimum value but not a zero
+			$maxinputvars = min(array_filter(array($suhosinPostVars, $suhosinReqVars)));
+		}
+		elseif (!$maxinputvars)
+		{
+			// Server do not tell us his secrets
+			return;
+		}
 
 		static::core();
 		JHtml::_('jquery.framework');

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -942,7 +942,7 @@ abstract class JHtmlBehavior
 		JFactory::getDocument()->addScriptDeclaration('
 			jQuery(window).load(function(){
 				var form = document.getElementById("' . $formid . '"),
-					tasks = ' . json_encode($preventTasks) . ',
+					tasks = ' . json_encode($preventTasks) . ', msgs = {},
 					limit = ' . $maxinputvars . ', msg, type, reached, near;
 				if (!form) return;
 				reached = form.length >= limit;
@@ -950,10 +950,11 @@ abstract class JHtmlBehavior
 				if (!reached && !near) return;
 				type = reached ? "error" : "warning";
 				msg  = Joomla.JText._("JERROR_MAXVARS_REACHED");
-				msg  = msg.replace("%s", limit).replace("%s", form.length)
-				Joomla.renderMessages({[type]:[msg]});
+				msg  = msg.replace("%s", limit).replace("%s", form.length);
+				msgs[type] = [msg];
+				Joomla.renderMessages(msgs);
 				if (reached) {
-					jQuery(form).on("submit", function(e){
+					jQuery(form).on("submit", function(){
 						if (tasks.indexOf(this.task.value) !== -1) {
 							Joomla.renderMessages({"error":[msg, Joomla.JText._("JERROR_MAXVARS_NOSUBMIT")]});
 							return false;

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -933,7 +933,7 @@ abstract class JHtmlBehavior
 			// Server do not tell us his secrets
 			return;
 		}
-
+		$maxinputvars = 5;
 		static::core();
 		JHtml::_('jquery.framework');
 		JText::script('JERROR_MAXVARS_REACHED');

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -904,7 +904,7 @@ abstract class JHtmlBehavior
 	/**
 	 * Add script for checks the setting of php max_input_vars and notifies user
 	 *
-	 * @param   string   $formid
+	 * @param   string   $formid  The id of the form, that will be used for test
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -900,4 +900,41 @@ abstract class JHtmlBehavior
 		JHtml::_('script', 'system/tabs-state.js', false, true);
 		self::$loaded[__METHOD__] = true;
 	}
+
+	/**
+	 * Add script for checks the setting of php max_input_vars and notifies user
+	 *
+	 * @param   string   $formid
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	public static function inputLimitTest($formid = 'adminForm')
+	{
+		if (isset(self::$loaded[__METHOD__][$formid]))
+		{
+			return;
+		}
+
+		$maxinputvars = (int) ini_get('max_input_vars');
+
+		static::core();
+		JHtml::_('jquery.framework');
+		JText::script('JERROR_MAXVARS_REACHED');
+
+		JFactory::getDocument()->addScriptDeclaration('
+			jQuery(window).load(function(){
+				var form = document.getElementById("' . $formid . '"),
+					limit = ' . $maxinputvars . ', warning;
+				if (form && (form.length >= limit || form.length/limit > 0.8)) {
+					warning = Joomla.JText._("JERROR_MAXVARS_REACHED");
+					warning = warning.replace("%s", limit).replace("%s", form.length)
+					Joomla.renderMessages({"warning":[warning]});
+				}
+			});
+		');
+
+		self::$loaded[__METHOD__][$formid] = true;
+	}
 }

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -933,7 +933,7 @@ abstract class JHtmlBehavior
 			// Server do not tell us his secrets
 			return;
 		}
-		$maxinputvars = 5;
+
 		static::core();
 		JHtml::_('jquery.framework');
 		JText::script('JERROR_MAXVARS_REACHED');

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -904,7 +904,7 @@ abstract class JHtmlBehavior
 	/**
 	 * Add script for checks the setting of php max_input_vars and notifies user
 	 *
-	 * @param   string   $formid  The id of the form, that will be used for test
+	 * @param   string  $formid  The id of the form, that will be used for test
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
Here is another way to check `max_input_vars` with better precision, at least in theory :smile: 
The script compare amount of form inputs with server limit.

Currently I added it to the form: article, category, module, menu item, global configuration, plugin, user.

**test**
Simplest way to test is to create the hundred(or two) `usergroup`s and try open one of mentioned above form.

Original idea by @brianteeman #7456
The text for Warning I copied from that pull, with small modification ... @brianteeman please check :wink: 
I think, in the warning message instead of `your website` need something more precision , like `current form` (because script do test per the form) ... but not sure how to make it correct.
