### PR TITLE
Regression multilanguage: double associations tab when editing menu item

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -78,8 +78,6 @@ Joomla.submitbutton = function(task, type){
 // Add the script to the document head.
 JFactory::getDocument()->addScriptDeclaration($script);
 
-// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
-$this->ignore_fieldsets = array('item_associations');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
@@ -146,7 +144,7 @@ $this->ignore_fieldsets = array('item_associations');
 
 		<?php
 		$this->fieldsets = array();
-		$this->ignore_fieldsets = array('aliasoptions', 'request');
+		$this->ignore_fieldsets = array('aliasoptions', 'request', 'item_associations');
 		echo JLayoutHelper::render('joomla.edit.params', $this);
 		?>
 


### PR DESCRIPTION
Test: create a multilingual site, set Associations to Yes in the language filter plugin. Edit a menu item.

This comes from https://github.com/joomla/joomla-cms/pull/7126.
We get now
![tabbefore](https://cloud.githubusercontent.com/assets/869724/8978406/4be8d270-36a2-11e5-8d45-3f3cdf8bccf1.png)

After patch we get
![tabafter](https://cloud.githubusercontent.com/assets/869724/8978408/58a09af2-36a2-11e5-9a63-ab1486e52f21.png)
