### PR TITLE
Multilanguage: deleting an associated item does not delete it in the _associations table

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -33,6 +33,14 @@ class CategoriesModelCategory extends JModelAdmin
 	public $typeAlias = null;
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var      string
+	 * @since    3.4.4
+	 */
+	protected $associationsContext = 'com_categories.item';
+
+	/**
 	 * Override parent constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -29,6 +29,14 @@ class ContactModelContact extends JModelAdmin
 	public $typeAlias = 'com_contact.contact';
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var      string
+	 * @since    3.4.4
+	 */
+	protected $associationsContext = 'com_contact.item';
+
+	/**
 	 * Batch copy/move command. If set to false, 
 	 * the batch copy/move command is not supported
 	 *

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -35,6 +35,14 @@ class ContentModelArticle extends JModelAdmin
 	public $typeAlias = 'com_content.article';
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var      string
+	 * @since    3.4.4
+	 */
+	protected $associationsContext = 'com_content.item';
+
+	/**
 	 * Batch copy items to a new category or current.
 	 *
 	 * @param   integer  $value     The new category.

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -30,6 +30,14 @@ class MenusModelItem extends JModelAdmin
 	public $typeAlias = 'com_menus.item';
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var      string
+	 * @since    3.4.4
+	 */
+	protected $associationsContext = 'com_menus.item';
+
+	/**
 	 * @var        string    The prefix to use with controller messages.
 	 * @since   1.6
 	 */

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -30,6 +30,14 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	public $typeAlias = 'com_newsfeeds.newsfeed';
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var string
+	 * @since    3.4.4
+	 */
+	protected $associationsContext = 'com_newsfeeds.item';
+
+	/**
 	 * @var     string    The prefix to use with controller messages.
 	 * @since   1.6
 	 */

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -810,7 +810,7 @@ abstract class JModelAdmin extends JModelForm
 							{
 								$query->clear()
 									->delete($db->quoteName('#__associations'))
-									->where($db->quoteName('key') . ' = ' .  $db->quote($key))
+									->where($db->quoteName('key') . ' = ' . $db->quote($key))
 									->where($db->quoteName('context') . ' = ' . $db->quote($assoc_context));
 
 								$db->setQuery($query);

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -93,6 +93,14 @@ abstract class JModelAdmin extends JModelForm
 	);
 
 	/**
+	 * The context used for the associations table
+	 *
+	 * @var     string
+	 * @since   3.4.4
+	 */
+	protected $associationsContext = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -773,16 +781,15 @@ abstract class JModelAdmin extends JModelForm
 					}
 
 					// Multilanguage: if associated, delete the item in the _associations table
-					if (JLanguageAssociations::isEnabled())
+					if ($this->associationsContext && JLanguageAssociations::isEnabled())
 					{
-						$assoc_context = $this->option . '.item';
 
 						$db = JFactory::getDbo();
 						$query = $db->getQuery(true)
 							->select('COUNT(*) as count, ' . $db->quoteName('as1.key'))
 							->from($db->quoteName('#__associations') . ' AS as1')
 							->join('LEFT', $db->quoteName('#__associations') . ' AS as2 ON ' . $db->quoteName('as1.key') . ' =  ' . $db->quoteName('as2.key'))
-							->where($db->quoteName('as1.context') . ' = ' . $db->quote($assoc_context))
+							->where($db->quoteName('as1.context') . ' = ' . $db->quote($this->associationsContext))
 							->where($db->quoteName('as1.id') . ' = ' . (int) $pk);
 
 						$db->setQuery($query);
@@ -792,7 +799,7 @@ abstract class JModelAdmin extends JModelForm
 						{
 							$query = $db->getQuery(true)
 								->delete($db->quoteName('#__associations'))
-								->where($db->quoteName('context') . ' = ' . $db->quote($assoc_context))
+								->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext))
 								->where($db->quoteName('key') . ' = ' . $db->quote($row['key']));
 
 							if ($row['count'] > 2)


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/7127

As title says.
The _associations row should be deleted for the item as well as for the associated item if we have only 2 associated items.

To test:
Create a multilingual site and set associations to Yes in the Languagefilter plugin.

Create an article for each language (first with 2 languages) and associate them.
Note their id.
Send to trash. Don't empty trash yet.

With phpMyadmin look at the _associations table for rows with the id and the context "com_content.item"

Empty trash.
Reload the phpmyAdmin page: the 2 items are still there.

Recreate 2 articles and Patch.
re-test. Both rows are now deleted from the _associations table.

Then test with 3 languages, associating 3 articles.
Now, only the article deleted will be deleted from the associations table, letting the 2 others associated as should.

This is also working for menu items, categories, contacts, newsfeeds.
