### PR TITLE
Contact profile displays idna url as punycode encoded

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_profile.php
+++ b/components/com_contact/views/contact/tmpl/default_profile.php
@@ -23,9 +23,9 @@ defined('_JEXEC') or die;
 							$v_http = substr($profile->value, 0, 4);
 
 							if ($v_http == "http") :
-								echo '<dd><a href="' . $profile->text . '">' . $profile->text . '</a></dd>';
+								echo '<dd><a href="' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
 							else :
-								echo '<dd><a href="http://' . $profile->text . '">' . $profile->text . '</a></dd>';
+								echo '<dd><a href="http://' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
 							endif;
 							break;
 


### PR DESCRIPTION
Test:
Enable User - Profile plugin
Edit com_contacts Options =>Contact tab and enable "Show Profile"

In back-end, create a contact and assign it to a user.
Edit the user account/profile and add in the Website field this idna url:
`http://www.джумла-тест.рф/index.php`

Create a menu item to display this contact in front-end.

Before patch, you will get:
![screen shot 2015-07-30 at 13 25 51](https://cloud.githubusercontent.com/assets/869724/8982139/8994a9c0-36be-11e5-957e-31428e061f48.png)

After patch, the url is displayed as utf8:
![screen shot 2015-07-30 at 13 24 33](https://cloud.githubusercontent.com/assets/869724/8982122/5ca5d3c6-36be-11e5-9d95-62a10421ed0a.png)

Source will rightfully display:
`Website:</label></dt><dd><a href="http://www.xn----7sblgc4ag8bhcd.xn--p1ai/index.php">http://www.джумла-тест.рф/index.php</a></dd><dt>`
