### PR TITLE
Prevent SQL errors where the UCM type id is not set

### DIFF
--- a/libraries/cms/ucm/base.php
+++ b/libraries/cms/ucm/base.php
@@ -126,7 +126,7 @@ class JUcmBase implements JUcm
 		$type = $type ? $type : $this->type;
 
 		$data = array(
-			'ucm_type_id' => $type->id,
+			'ucm_type_id' => (int) $type->id,
 			'ucm_item_id' => $original[$type->primary_key],
 			'ucm_language_id' => JHelperContent::getLanguageId($original['language'])
 		);


### PR DESCRIPTION
To fix SQL errors such as:
Save failed with the following error:
You have error in your SQL syntax; check the manual corresponds to your MySQL version for the right syntax use near 'AND `sha1_hash` = '...' LIMIT 0, 1' at line 3 SQL=SELECT \* FROM `dbprefix_ucm_history` WHERE `ucm_item_id` = 1 AND `ucm_type_id` = AND `sha1_hash` = '...' LIMIT 0, 1
You are not permitted to use that link to directory access that page (#1).
