### PR TITLE
Prevent SQL errors where the UCM type and content id is not set

### DIFF
--- a/libraries/cms/table/contenthistory.php
+++ b/libraries/cms/table/contenthistory.php
@@ -162,8 +162,8 @@ class JTableContenthistory extends JTable
 		$query = $db->getQuery(true);
 		$query->select('*')
 			->from($db->quoteName('#__ucm_history'))
-			->where($db->quoteName('ucm_item_id') . ' = ' . $this->get('ucm_item_id'))
-			->where($db->quoteName('ucm_type_id') . ' = ' . $this->get('ucm_type_id'))
+			->where($db->quoteName('ucm_item_id') . ' = ' . (int) $this->get('ucm_item_id'))
+			->where($db->quoteName('ucm_type_id') . ' = ' . (int) $this->get('ucm_type_id'))
 			->where($db->quoteName('sha1_hash') . ' = ' . $db->quote($this->get('sha1_hash')));
 		$db->setQuery($query, 0, 1);
 


### PR DESCRIPTION
To fix SQL errors such as:
Save failed with the following error:
You have error in your SQL syntax; check the manual corresponds to your MySQL version for the right syntax use near 'AND sha1_hash = '...' LIMIT 0, 1' at line 3 SQL=SELECT \* FROM dbprefix_ucm_history WHERE ucm_item_id = 1 AND ucm_type_id = AND sha1_hash = '...' LIMIT 0, 1
You are not permitted to use that link to directory access that page (#1).
