### PR TITLE
Prevent SQL errors where the UCM type id is not set

### DIFF
--- a/libraries/cms/helper/contenthistory.php
+++ b/libraries/cms/helper/contenthistory.php
@@ -102,7 +102,7 @@ class JHelperContenthistory extends JHelper
 		$historyTable = JTable::getInstance('Contenthistory', 'JTable');
 		$typeTable = JTable::getInstance('Contenttype', 'JTable');
 		$typeTable->load(array('type_alias' => $this->typeAlias));
-		$historyTable->set('ucm_type_id', $typeTable->type_id);
+		$historyTable->set('ucm_type_id', (int) $typeTable->type_id);
 
 		$key = $table->getKeyName();
 		$historyTable->set('ucm_item_id', $table->$key);


### PR DESCRIPTION
To fix SQL errors such as:
Save failed with the following error:
You have error in your SQL syntax; check the manual corresponds to your MySQL version for the right syntax use near 'AND sha1_hash = '...' LIMIT 0, 1' at line 3 SQL=SELECT \* FROM dbprefix_ucm_history WHERE ucm_item_id = 1 AND ucm_type_id = AND sha1_hash = '...' LIMIT 0, 1
You are not permitted to use that link to directory access that page (#1).
