### PR TITLE
Prevent SQL errors where the UCM type and content id is not set

### DIFF
--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -269,8 +269,8 @@ class ContenthistoryModelHistory extends JModelList
 			)
 		)
 		->from($db->quoteName('#__ucm_history') . ' AS h')
-		->where($db->quoteName('h.ucm_item_id') . ' = ' . $this->getState('item_id'))
-		->where($db->quoteName('h.ucm_type_id') . ' = ' . $this->getState('type_id'))
+		->where($db->quoteName('h.ucm_item_id') . ' = ' . (int) $this->getState('item_id'))
+		->where($db->quoteName('h.ucm_type_id') . ' = ' . (int) $this->getState('type_id'))
 
 		// Join over the users for the editor
 		->select('uc.name AS editor')


### PR DESCRIPTION
To fix SQL errors such as:
Save failed with the following error:
You have error in your SQL syntax; check the manual corresponds to your MySQL version for the right syntax use near 'AND sha1_hash = '...' LIMIT 0, 1' at line 3 SQL=SELECT \* FROM dbprefix_ucm_history WHERE ucm_item_id = 1 AND ucm_type_id = AND sha1_hash = '...' LIMIT 0, 1
You are not permitted to use that link to directory access that page (#1).
