### PR TITLE
Prevent SQL errors where the UCM type id is not set

### DIFF
--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -323,7 +323,7 @@ class ContenthistoryHelper
 	{
 		$object = static::decodeFields($table->version_data);
 		$typesTable = JTable::getInstance('Contenttype');
-		$typesTable->load(array('type_id' => $table->ucm_type_id));
+		$typesTable->load(array('type_id' => (int) $table->ucm_type_id));
 		$formValues = static::getFormValues($object, $typesTable);
 		$object = static::mergeLabels($object, $formValues);
 		$object = static::hideFields($object, $typesTable);


### PR DESCRIPTION
To fix SQL errors such as:
Save failed with the following error:
You have error in your SQL syntax; check the manual corresponds to your MySQL version for the right syntax use near 'AND sha1_hash = '...' LIMIT 0, 1' at line 3 SQL=SELECT \* FROM dbprefix_ucm_history WHERE ucm_item_id = 1 AND ucm_type_id = AND sha1_hash = '...' LIMIT 0, 1
You are not permitted to use that link to directory access that page (#1).
