### PR TITLE
Add Autofocus to Frontend Login Component Form

### DIFF
--- a/components/com_users/models/forms/login.xml
+++ b/components/com_users/models/forms/login.xml
@@ -10,6 +10,7 @@
 			size="25"
 			required="true"
 			validate="username"
+			autofocus="true"
 		/>
 
 		<field


### PR DESCRIPTION
Just like the /administrator login screen, this will make the Username field be autofocus and ready to type in to.

This is the better/simpler/easier way to accomplish this idea compared to my previous PR #7601.
### To Test

Create a frontend menu item that points to the Users Login view. You should notice that the username field is autofocused on and ready for you to type into.
