### PR TITLE
Admin autofocus login

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -25,7 +25,7 @@ JHtml::_('formbehavior.chosen');
 							<?php echo JText::_('JGLOBAL_USERNAME'); ?>
 						</label>
 					</span>
-					<input name="username" tabindex="1" id="mod-login-username" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15"/>
+					<input name="username" tabindex="1" id="mod-login-username" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true" />
 					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_REMIND'); ?>">
 						<span class="icon-help"></span>
 					</a>

--- a/administrator/templates/hathor/html/mod_login/default.php
+++ b/administrator/templates/hathor/html/mod_login/default.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.keepalive');
 	<fieldset class="loginform">
 
 		<label id="mod-login-username-lbl" for="mod-login-username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-		<input name="username" id="mod-login-username" type="text" size="15" />
+		<input name="username" id="mod-login-username" type="text" size="15" autofocus="true" />
 
 		<label id="mod-login-password-lbl" for="mod-login-password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
 		<input name="passwd" id="mod-login-password" type="password" size="15" />

--- a/administrator/templates/hathor/js/template.js
+++ b/administrator/templates/hathor/js/template.js
@@ -9,15 +9,6 @@
  */
 
 /**
- * Set focus to username on the login screen
- */
-function setFocus() {
-	if (jQuery("#login-page").length) {
-		jQuery('#form-login').find('input[name="username"]').focus()
-	}
-}
-
-/**
  * Change the skip nav target to work with webkit browsers (Safari/Chrome) and
  * Opera
  */
@@ -127,7 +118,6 @@ jQuery(function($){
 });
 
 jQuery(function() {
-	setFocus();
 	setSkip();
 	setAriaRoleElementsById();
 	setAriaProperties();

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -58,11 +58,6 @@ function colorIsLight($color)
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<script type="text/javascript">
-        jQuery(function($) {
-            $( "#form-login input[name='username']" ).focus();
-        });
-	</script>
 	<style type="text/css">
 		/* Template color */
 		<?php if ($this->params->get('templateColor')) : ?>


### PR DESCRIPTION
This PR removes the inline javascript from the ISIS  and Hathor templates which adds focus to the username field on the admin login screen and just uses autofocus=true instead
