### PR TITLE
Add microdata to breadcrumbs

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -10,20 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
-
 ?>
 
-<ul class="breadcrumb<?php echo $moduleclass_sfx; ?>">
-	<?php
-	if ($params->get('showHere', 1))
-	{
-		echo '<li class="active">' . JText::_('MOD_BREADCRUMBS_HERE') . '&#160;</li>';
-	}
-	else
-	{
-		echo '<li class="active"><span class="divider icon-location"></span></li>';
-	}
+<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
+	<?php if ($params->get('showHere', 1)) : ?>
+		<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="active">
+			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
+		</li>
+	<?php else : ?>
+		<li class="active">
+			<span class="divider icon-location"></span>
+		</li>
+	<?php endif; ?>
 
+	<?php
 	// Get rid of duplicated entries on trail including home page when using multilanguage
 	for ($i = 0; $i < $count; $i++)
 	{
@@ -44,32 +44,34 @@ JHtml::_('bootstrap.tooltip');
 
 	// Generate the trail
 	foreach ($list as $key => $item) :
-	if ($key != $last_item_key)
-	{
-		// Render all but last item - along with separator
-		echo '<li>';
-		if (!empty($item->link))
-		{
-			echo '<a href="' . $item->link . '" class="pathway">' . $item->name . '</a>';
-		}
-		else
-		{
-			echo '<span>' . $item->name . '</span>';
-		}
+		if ($key != $last_item_key) :
+			// Render all but last item - along with separator ?>
+			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+				<?php if (!empty($item->link)) : ?>
+					<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway">
+						<span itemprop="name">
+							<?php echo $item->name; ?>
+						</span>
+					</a>
+				<?php else : ?>
+					<span itemprop="name">
+						<?php $item->name; ?>
+					</span>
+				<?php endif; ?>
 
-		if (($key != $penult_item_key) || $show_last)
-		{
-			echo '<span class="divider">' . $separator . '</span>';
-		}
-
-		echo '</li>';
-	}
-	elseif ($show_last)
-	{
-		// Render last item if reqd.
-		echo '<li class="active">';
-		echo '<span>' . $item->name . '</span>';
-		echo '</li>';
-	}
+				<?php if (($key != $penult_item_key) || $show_last) : ?>
+					<span class="divider">
+						<?php echo $separator; ?>
+					</span>
+				<?php endif; ?>
+			</li>
+		<?php elseif ($show_last) :
+			// Render last item if reqd. ?>
+			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="active">
+				<span itemprop="name">
+					<?php echo $item->name; ?>
+				</span>
+			</li>
+		<?php endif;
 	endforeach; ?>
-</ul>
+</ol>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -64,7 +64,7 @@ JHtml::_('bootstrap.tooltip');
 						<?php echo $separator; ?>
 					</span>
 				<?php endif; ?>
-				<meta property="position" content="<?php echo $key + 1; ?>">
+				<meta itemprop="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php elseif ($show_last) :
 			// Render last item if reqd. ?>
@@ -72,7 +72,7 @@ JHtml::_('bootstrap.tooltip');
 				<span itemprop="name">
 					<?php echo $item->name; ?>
 				</span>
-				<meta property="position" content="<?php echo $key + 1; ?>">
+				<meta itemprop="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php endif;
 	endforeach; ?>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 ?>
 
-<ol itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
+<ul itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 	<?php if ($params->get('showHere', 1)) : ?>
 		<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="active">
 			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
@@ -64,6 +64,7 @@ JHtml::_('bootstrap.tooltip');
 						<?php echo $separator; ?>
 					</span>
 				<?php endif; ?>
+				<meta property="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php elseif ($show_last) :
 			// Render last item if reqd. ?>
@@ -71,7 +72,8 @@ JHtml::_('bootstrap.tooltip');
 				<span itemprop="name">
 					<?php echo $item->name; ?>
 				</span>
+				<meta property="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php endif;
 	endforeach; ?>
-</ol>
+</ul>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 
 <ul itemscope itemtype="http://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 	<?php if ($params->get('showHere', 1)) : ?>
-		<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="active">
+		<li class="active">
 			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
 		</li>
 	<?php else : ?>


### PR DESCRIPTION
This PR add Micro Structured Data to the Joomla! breadcrumbs. I followed this guide lines: https://developers.google.com/structured-data/breadcrumbs

Also add some code style and change some `if ($condition) {` to `if ($condition) :` to make the code more readable.
## Test instructions

Confirm that all parameters are working correct like they used do
