### PR TITLE
Do not unset db connection

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -119,7 +119,8 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	{
 		// Close the connection.
 		$this->freeResult();
-		unset($this->connection);
+
+		$this->connection = null;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -311,7 +311,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		}
 
 		$this->freeResult();
-		unset($this->connection);
+
+		$this->connection = null;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -57,7 +57,8 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	public function disconnect()
 	{
 		$this->freeResult();
-		unset($this->connection);
+
+		$this->connection = null;
 	}
 
 	/**


### PR DESCRIPTION
## What Happened?

The Pdomysql / Pdo / Oracle and Sqlite driver will unset `connection` property when disconnect.

But if we reconnect to DB, the `connect()` method will tell us this error:

```
 Notice: Undefined property: JDatabaseDriverPdomysql::$connection 
```

![p-2015-08-03-002](https://cloud.githubusercontent.com/assets/1639206/9027063/bf4dd2a0-3978-11e5-8622-d80c01d3cfbf.jpg)
## How to Resolve?

Set `$this->connection = null` instead unset it.
## How to Test

In any plugin or everywhere, use this code

``` php
$db = \JFactory::getDbo();

$db->disconnect();

$db->setQuery('select * from #__content limit 1')->execute();
```

The PHP will raise Notice message to page.

And it will disappear if apply this patch.
