### PR TITLE
[3.5] [imp] Add the ability to use a custom CSS file with beez3 & make the other similiar checks consistend see #4211

### DIFF
--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -39,22 +39,6 @@ else
 
 $doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
-// Load custom.css
-$file = 'templates/' . $this->template . '/css/custom.css';
-
-if (file_exists($file) && filesize($file) > 0)
-{
-	$doc->addStyleSheetVersion($file);
-}
-
-// Load specific language related CSS
-$file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
-
-if (is_file($file))
-{
-	$doc->addStyleSheetVersion($file);
-}
-
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
@@ -62,18 +46,26 @@ if ($this->direction == 'rtl')
 	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
-// Load specific language related CSS
-$file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
-
-if (is_file($file))
-{
-	$doc->addStyleSheetVersion($file);
-}
-
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
 	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
+}
+
+// Load specific language related CSS
+$languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
+
+if (file_exists($languageCss) && filesize($languageCss) > 0)
+{
+	$doc->addStyleSheetVersion($languageCss);
+}
+
+// Load custom.css
+$customCss = 'templates/' . $this->template . '/css/custom.css';
+
+if (file_exists($customCss) && filesize($customCss) > 0)
+{
+	$doc->addStyleSheetVersion($customCss);
 }
 
 // Load template javascript
@@ -170,7 +162,7 @@ else
 	<p class="copyright">
 		<?php
 		// Fix wrong display of Joomla!® in RTL language
-		if (JFactory::getLanguage()->isRtl())
+		if (JFactory::getLanguage()->isRTL())
 		{
 			$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
 		}

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -42,7 +42,7 @@ $doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/
 // Load custom.css
 $file = 'templates/' . $this->template . '/css/custom.css';
 
-if (is_file($file))
+if (file_exists($file) && filesize($file) > 0)
 {
 	$doc->addStyleSheetVersion($file);
 }
@@ -170,7 +170,7 @@ else
 	<p class="copyright">
 		<?php
 		// Fix wrong display of Joomla!® in RTL language
-		if (JFactory::getLanguage()->isRTL())
+		if (JFactory::getLanguage()->isRtl())
 		{
 			$joomla = '<a href="http://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
 		}

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -24,16 +24,16 @@ $doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/t
 // Add Stylesheets
 $doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
-// Load specific language related CSS
-$file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
+// Load custom.css
+$file = 'templates/' . $this->template . '/css/custom.css';
 
-if (is_file($file))
+if (file_exists($file) && filesize($file) > 0)
 {
 	$doc->addStyleSheetVersion($file);
 }
 
-// Load custom.css
-$file = 'templates/' . $this->template . '/css/custom.css';
+// Load specific language related CSS
+$file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
@@ -71,10 +71,8 @@ $statusFixed   = $this->params->get('statusFixed', '1');
 $stickyToolbar = $this->params->get('stickyToolbar', '1');
 
 // Header classes
-$navbar_color = $this->params->get('templateColor') ? $this->params->get('templateColor') : '';
-$header_color = ($displayHeader && $this->params->get('headerColor')) ? $this->params->get('headerColor') : '';
-$navbar_is_light = ($navbar_color && colorIsLight($navbar_color));
-$header_is_light = ($header_color && colorIsLight($header_color));
+$template_is_light = ($this->params->get('templateColor') && colorIsLight($this->params->get('templateColor')));
+$header_is_light = ($displayHeader && $this->params->get('headerColor') && colorIsLight($this->params->get('headerColor')));
 
 if ($displayHeader)
 {
@@ -98,28 +96,6 @@ function colorIsLight($color)
 
 	return $yiq >= 200;
 }
-
-// Pass some values to javascript
-$offset = 20;
-
-if ($displayHeader || !$statusFixed)
-{
-	$offset = 30;
-}
-
-$stickyBar = 0;
-
-if ($stickyToolbar)
-{
-	$stickyBar = 1;
-}
-
-$doc->addScriptDeclaration(
-	"
-	window.isisStickyToolbar = $stickyBar;
-	window.isisOffsetTop = $offset;
-	"
-);
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -129,18 +105,18 @@ $doc->addScriptDeclaration(
 	<jdoc:include type="head" />
 
 	<!-- Template color -->
-	<?php if ($navbar_color) : ?>
+	<?php if ($this->params->get('templateColor')) : ?>
 		<style type="text/css">
 			.navbar-inner, .navbar-inverse .navbar-inner, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle, #status.status-top {
-				background: <?php echo $navbar_color; ?>;
+				background: <?php echo $this->params->get('templateColor'); ?>;
 			}
 		</style>
 	<?php endif; ?>
 	<!-- Template header color -->
-	<?php if ($header_color) : ?>
+	<?php if ($displayHeader && $this->params->get('headerColor')) : ?>
 		<style type="text/css">
 			.header {
-				background: <?php echo $header_color; ?>;
+				background: <?php echo $this->params->get('headerColor'); ?>;
 			}
 		</style>
 	<?php endif; ?>
@@ -171,7 +147,7 @@ $doc->addScriptDeclaration(
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>">
 <!-- Top Navigation -->
-<nav class="navbar<?php echo $navbar_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">
+<nav class="navbar<?php echo $template_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">
 	<div class="navbar-inner">
 		<div class="container-fluid">
 			<?php if ($this->params->get('admin_menus') != '0') : ?>
@@ -314,5 +290,55 @@ $doc->addScriptDeclaration(
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
+<?php if ($stickyToolbar) : ?>
+	<script>
+		jQuery(function($)
+		{
+
+			var navTop;
+			var isFixed = false;
+
+			processScrollInit();
+			processScroll();
+
+			$(window).on('resize', processScrollInit);
+			$(window).on('scroll', processScroll);
+
+			function processScrollInit()
+			{
+				if ($('.subhead').length) {
+					navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
+
+					// Fix the container top
+					$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
+
+					// Only apply the scrollspy when the toolbar is not collapsed
+					if (document.body.clientWidth > 480)
+					{
+						$('.subhead-collapse').height($('.subhead').height());
+						$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
+					}
+				}
+			}
+
+			function processScroll()
+			{
+				if ($('.subhead').length) {
+					var scrollTop = $(window).scrollTop();
+					if (scrollTop >= navTop && !isFixed) {
+						isFixed = true;
+						$('.subhead').addClass('subhead-fixed');
+
+						// Fix the container top
+						$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
+					} else if (scrollTop <= navTop && isFixed) {
+						isFixed = false;
+						$('.subhead').removeClass('subhead-fixed');
+					}
+				}
+			}
+		});
+	</script>
+<?php endif; ?>
 </body>
 </html>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -19,25 +19,26 @@ $user            = JFactory::getUser();
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
+
 $doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
 $doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
-// Load custom.css
-$file = 'templates/' . $this->template . '/css/custom.css';
+// Load specific language related CSS
+$languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
-if (file_exists($file) && filesize($file) > 0)
+if (file_exists($languageCss) && filesize($languageCss) > 0)
 {
-	$doc->addStyleSheetVersion($file);
+	$doc->addStyleSheetVersion($languageCss);
 }
 
-// Load specific language related CSS
-$file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
+// Load custom.css
+$customCss = 'templates/' . $this->template . '/css/custom.css';
 
-if (is_file($file))
+if (file_exists($customCss) && filesize($customCss) > 0)
 {
-	$doc->addStyleSheetVersion($file);
+	$doc->addStyleSheetVersion($customCss);
 }
 
 // Detecting Active Variables
@@ -71,8 +72,10 @@ $statusFixed   = $this->params->get('statusFixed', '1');
 $stickyToolbar = $this->params->get('stickyToolbar', '1');
 
 // Header classes
-$template_is_light = ($this->params->get('templateColor') && colorIsLight($this->params->get('templateColor')));
-$header_is_light = ($displayHeader && $this->params->get('headerColor') && colorIsLight($this->params->get('headerColor')));
+$navbar_color = $this->params->get('templateColor') ? $this->params->get('templateColor') : '';
+$header_color = ($displayHeader && $this->params->get('headerColor')) ? $this->params->get('headerColor') : '';
+$navbar_is_light = ($navbar_color && colorIsLight($navbar_color));
+$header_is_light = ($header_color && colorIsLight($header_color));
 
 if ($displayHeader)
 {
@@ -96,6 +99,28 @@ function colorIsLight($color)
 
 	return $yiq >= 200;
 }
+
+// Pass some values to javascript
+$offset = 20;
+
+if ($displayHeader || !$statusFixed)
+{
+	$offset = 30;
+}
+
+$stickyBar = 0;
+
+if ($stickyToolbar)
+{
+	$stickyBar = 1;
+}
+
+$doc->addScriptDeclaration(
+	"
+	window.isisStickyToolbar = $stickyBar;
+	window.isisOffsetTop = $offset;
+	"
+);
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -105,18 +130,18 @@ function colorIsLight($color)
 	<jdoc:include type="head" />
 
 	<!-- Template color -->
-	<?php if ($this->params->get('templateColor')) : ?>
+	<?php if ($navbar_color) : ?>
 		<style type="text/css">
 			.navbar-inner, .navbar-inverse .navbar-inner, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle, #status.status-top {
-				background: <?php echo $this->params->get('templateColor'); ?>;
+				background: <?php echo $navbar_color; ?>;
 			}
 		</style>
 	<?php endif; ?>
 	<!-- Template header color -->
-	<?php if ($displayHeader && $this->params->get('headerColor')) : ?>
+	<?php if ($header_color) : ?>
 		<style type="text/css">
 			.header {
-				background: <?php echo $this->params->get('headerColor'); ?>;
+				background: <?php echo $header_color; ?>;
 			}
 		</style>
 	<?php endif; ?>
@@ -147,7 +172,7 @@ function colorIsLight($color)
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>">
 <!-- Top Navigation -->
-<nav class="navbar<?php echo $template_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">
+<nav class="navbar<?php echo $navbar_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">
 	<div class="navbar-inner">
 		<div class="container-fluid">
 			<?php if ($this->params->get('admin_menus') != '0') : ?>
@@ -290,55 +315,5 @@ function colorIsLight($color)
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
-<?php if ($stickyToolbar) : ?>
-	<script>
-		jQuery(function($)
-		{
-
-			var navTop;
-			var isFixed = false;
-
-			processScrollInit();
-			processScroll();
-
-			$(window).on('resize', processScrollInit);
-			$(window).on('scroll', processScroll);
-
-			function processScrollInit()
-			{
-				if ($('.subhead').length) {
-					navTop = $('.subhead').length && $('.subhead').offset().top - <?php echo ($displayHeader || !$statusFixed) ? 30 : 20;?>;
-
-					// Fix the container top
-					$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
-
-					// Only apply the scrollspy when the toolbar is not collapsed
-					if (document.body.clientWidth > 480)
-					{
-						$('.subhead-collapse').height($('.subhead').height());
-						$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
-					}
-				}
-			}
-
-			function processScroll()
-			{
-				if ($('.subhead').length) {
-					var scrollTop = $(window).scrollTop();
-					if (scrollTop >= navTop && !isFixed) {
-						isFixed = true;
-						$('.subhead').addClass('subhead-fixed');
-
-						// Fix the container top
-						$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
-					} else if (scrollTop <= navTop && isFixed) {
-						isFixed = false;
-						$('.subhead').removeClass('subhead-fixed');
-					}
-				}
-			}
-		});
-	</script>
-<?php endif; ?>
 </body>
 </html>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -70,7 +70,7 @@ $userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
 
 if (file_exists($userCss) && filesize($userCss) > 0)
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/user.css');
+	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
 }
 
 ?>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -65,6 +65,14 @@ $doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/
 $doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/respond.src.js', 'text/javascript');
 $doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js', 'text/javascript');
 
+// Check for a custom CSS file
+$userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
+
+if (file_exists($userCss) && filesize($userCss) > 0)
+{
+	$doc->addStyleSheet('templates/' . $this->template . '/css/user.css');
+}
+
 ?>
 
 <!DOCTYPE html>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -47,7 +47,7 @@ $userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
 
 if (file_exists($userCss) && filesize($userCss) > 0)
 {
-	$doc->addStyleSheet('templates/' . $this->template . '/css/user.css');
+	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
 }
 
 // Load optional RTL Bootstrap CSS


### PR DESCRIPTION
This backports the `user.css` that we have in protostar back to beez3. For the backed we can use a custom.css file.
#### How to test
- set beez3 as default template
- access the frontend
- see all is good.
- apply the patch
- add a user.css with custom styling to this folder `/templates/bezz3/css/user.css`
- reload the page
- see that the file gets loaded.
#### Other changes

Make the checks consistent and use `if (file_exists($file) && filesize($file) > 0)` and `$doc->addStyleSheetVersion($file);`
