### PR TITLE
[3.5] New Option "Login background Color" cause different default behavior than in <3.5

### DIFF
--- a/administrator/templates/isis/templateDetails.xml
+++ b/administrator/templates/isis/templateDetails.xml
@@ -67,7 +67,7 @@
 				label="TPL_ISIS_COLOR_LINK_LABEL"
 				description="TPL_ISIS_COLOR_LINK_DESC" />
 
-				<field name="loginBackgroundColor" class="" type="color" default="#224C8F"
+				<field name="loginBackgroundColor" class="" type="color" default="#10223E"
 				validate="color"
 				label="TPL_ISIS_COLOR_LOGIN_BACKGROUND_LABEL"
 				description="TPL_ISIS_COLOR_LOGIN_BACKGROUND_DESC" />


### PR DESCRIPTION
### What is changed?

The default value for the `Login background color` is setted to the same as bevor 3.5 ;)
### In 3.4.3

![joomla_343_login](https://cloud.githubusercontent.com/assets/2596554/9046929/929fa754-3a2e-11e5-8084-f88afeec96e2.PNG)
### In 3.5

![joomla_35_login](https://cloud.githubusercontent.com/assets/2596554/9046933/96f01af0-3a2e-11e5-9b05-9c72a67b050b.PNG)
### How to test
- install 3.5
- see the changed background color
- access the template options and change the value for `default background color` from `#224C8F` to `#10223E`
- save and close
- logout
- see the backend login as bevor
