### PR TITLE
Backport Messages modal converted to bootstrap

### DIFF
--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -14,7 +14,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.modal');
 
 JFactory::getDocument()->addScriptDeclaration("
 		Joomla.submitbutton = function(task)
@@ -24,49 +23,17 @@ JFactory::getDocument()->addScriptDeclaration("
 				Joomla.submitform(task, document.getElementById('config-form'));
 			}
 		};
+
 ");
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
+<form action="<?php echo JRoute::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
 	<fieldset>
-		<div>
-			<div class="modal-header">
-				<h3><?php echo JText::_('COM_MESSAGES_MY_SETTINGS');?></h3>
-			</div>
-			<div class="modal-body">
-				<button class="btn btn-primary" type="submit" onclick="Joomla.submitform('config.save', this.form);window.top.setTimeout('window.parent.jModalClose()', 700);">
-					<?php echo JText::_('JSAVE');?></button>
-				<button class="btn" type="button" onclick="window.parent.jModalClose();">
-					<?php echo JText::_('JCANCEL');?></button>
-				<hr />
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('lock'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('lock'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('mail_on_new'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('mail_on_new'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('auto_purge'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('auto_purge'); ?>
-					</div>
-				</div>
+		<?php echo $this->form->renderField('lock'); ?>
+		<?php echo $this->form->renderField('mail_on_new'); ?>
+		<?php echo $this->form->renderField('auto_purge'); ?>
+	</fieldset>
+	<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
 
-			</div>
-		</div>
-		</fieldset>
-		<input type="hidden" name="task" value="" />
-		<?php echo JHtml::_('form.token'); ?>
-
+	<input type="hidden" name="task" value="" />
+	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_messages/views/message/tmpl/default.php
+++ b/administrator/components/com_messages/views/message/tmpl/default.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.framework');
+JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -16,9 +16,21 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+
+JFactory::getDocument()->addStyleDeclaration(
+	"
+	@media (min-width: 768px) {
+		div.modal {
+			left: none;
+			width: 500px;
+			margin-left: -250px;
+		}
+	}
+	"
+);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_messages&view=messages'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -8,7 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.modal');
 
 /**
  * View class for a list of messages.
@@ -34,9 +33,9 @@ class MessagesViewMessages extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -60,8 +59,8 @@ class MessagesViewMessages extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_messages');
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_messages');
 
 		JToolbarHelper::title(JText::_('COM_MESSAGES_MANAGER_MESSAGES'), 'envelope inbox');
 
@@ -79,12 +78,23 @@ class MessagesViewMessages extends JViewLegacy
 
 		JToolbarHelper::divider();
 		$bar = JToolBar::getInstance('toolbar');
-
-		// Instantiate a new JLayoutFile instance and render the layout
-		JHtml::_('behavior.modal', 'a.messagesSettings');
-		$layout = new JLayoutFile('toolbar.mysettings');
-
-		$bar->appendButton('Custom', $layout->render(array()), 'upload');
+		$bar->appendButton(
+			'Popup',
+			'cog',
+			'COM_MESSAGES_TOOLBAR_MY_SETTINGS',
+			'index.php?option=com_messages&amp;view=config&amp;tmpl=component',
+			500,
+			250,
+			0,
+			0,
+			'',
+			'',
+			'<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
+				. JText::_('JCANCEL') 
+				. '</button><button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true"onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">' 
+				. JText::_('JSAVE') 
+				. '</button>'
+		);
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))
 		{

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -11,6 +11,9 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
+// Only required for legacy captions. This should be removed in j4.
+JHtml::_('behavior.caption');
+
 // Create shortcuts to some parameters.
 $params  = $this->item->params;
 $images  = json_decode($this->item->images);
@@ -18,7 +21,7 @@ $urls    = json_decode($this->item->urls);
 $canEdit = $params->get('access-edit');
 $user    = JFactory::getUser();
 $info    = $params->get('info_block_position', 0);
-JHtml::_('behavior.caption');
+
 ?>
 <div class="item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="http://schema.org/Article">
 	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? JFactory::getConfig()->get('language') : $this->item->language; ?>" />
@@ -93,11 +96,16 @@ JHtml::_('behavior.caption');
 	<?php if ($params->get('access-view')):?>
 	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
 	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_fulltext_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
+	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
+		<img
+		<?php if ($images->image_fulltext_caption) :  ?>
+		<?php echo 'title="' .htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+		<?php if ($images->image_fulltext_caption) : ?>
+			<figcaption><?php echo htmlspecialchars($images->image_fulltext_caption); ?></figcaption>
+		<?php endif; ?>
+	</figure>
 	<?php endif; ?>
 	<?php
 	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -94,6 +94,7 @@ $info    = $params->get('info_block_position', 0);
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 	<?php if ($params->get('access-view')) : ?>
+	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
 	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
 		<img
 		<?php if ($images->image_fulltext_caption) : ?>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -94,7 +94,16 @@ $info    = $params->get('info_block_position', 0);
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 	<?php if ($params->get('access-view')) : ?>
-	<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
+	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
+		<img
+		<?php if ($images->image_fulltext_caption) : ?>
+			echo 'title="' .htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+		<?php if ($images->image_fulltext_caption) : ?>
+			<figcaption><?php echo htmlspecialchars($images->image_fulltext_caption); ?></figcaption>
+		<?php endif; ?>
+	</figure>
 	<?php
 	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
 		echo $this->item->pagination;

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -98,7 +98,7 @@ $info    = $params->get('info_block_position', 0);
 	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
 		<img
 		<?php if ($images->image_fulltext_caption) : ?>
-			echo 'title="' .htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
+			<?php echo 'title="' .htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
 		<?php endif; ?>
 		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
 		<?php if ($images->image_fulltext_caption) : ?>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -93,28 +93,14 @@ $info    = $params->get('info_block_position', 0);
 		|| (empty($urls->urls_position) && (!$params->get('urls_position')))) : ?>
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
-	<?php if ($params->get('access-view')):?>
-	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
-	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
-		<img
-		<?php if ($images->image_fulltext_caption) :  ?>
-		<?php echo 'title="' .htmlspecialchars($images->image_fulltext_caption) . '"'; ?>
-		<?php endif; ?>
-		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
-		<?php if ($images->image_fulltext_caption) : ?>
-			<figcaption><?php echo htmlspecialchars($images->image_fulltext_caption); ?></figcaption>
-		<?php endif; ?>
-	</figure>
+	<?php if ($params->get('access-view')) : ?>
+	<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
+	<?php if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative) : ?>
+		<?php echo $this->item->pagination; ?>
 	<?php endif; ?>
-	<?php
-	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
-		echo $this->item->pagination;
-	endif;
-	?>
-	<?php if (isset ($this->item->toc)) :
-		echo $this->item->toc;
-	endif; ?>
+	<?php if (isset ($this->item->toc)) : ?>
+		<?php echo $this->item->toc; ?>
+	<?php endif; ?>
 	<div itemprop="articleBody">
 		<?php echo $this->item->text; ?>
 	</div>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -95,12 +95,14 @@ $info    = $params->get('info_block_position', 0);
 	<?php endif; ?>
 	<?php if ($params->get('access-view')) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
-	<?php if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative) : ?>
-		<?php echo $this->item->pagination; ?>
-	<?php endif; ?>
-	<?php if (isset ($this->item->toc)) : ?>
-		<?php echo $this->item->toc; ?>
-	<?php endif; ?>
+	<?php
+	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
+		echo $this->item->pagination;
+	endif;
+	?>
+	<?php if (isset ($this->item->toc)) :
+		echo $this->item->toc;
+	endif; ?>
 	<div itemprop="articleBody">
 		<?php echo $this->item->text; ?>
 	</div>

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -11,7 +11,9 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
+// Only required for legacy captions. This should be removed in j4.
 JHtml::_('behavior.caption');
+
 ?>
 <div class="blog<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="http://schema.org/Blog">
 	<?php if ($this->params->get('show_page_heading')) : ?>

--- a/components/com_content/views/featured/tmpl/default.php
+++ b/components/com_content/views/featured/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
+// Only required for legacy captions. This should be removed in j4.
 JHtml::_('behavior.caption');
 
 // If the page class is defined, add to class as suffix.

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -56,14 +56,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 	<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'above')); ?>
 <?php endif; ?>
 
-<?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
-	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/> </div>
-<?php endif; ?>
+<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
 
 <?php if (!$params->get('show_intro')) : ?>
 	<?php echo $this->item->event->afterDisplayTitle; ?>

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -8,23 +8,21 @@
  */
 
 defined('_JEXEC') or die;
-$params  = $displayData->params;
+
+$params = $displayData->params;
+$images = json_decode($displayData->images);
+
 ?>
-<?php $images = json_decode($displayData->images); ?>
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> 
-	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-	<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"><img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="thumbnailUrl"/></a>
-	<?php else : ?><img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="thumbnailUrl"/>
-	<?php endif; ?> 
-</div>
+	<figure class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
+		<img
+		<?php if ($images->image_intro_caption) : ?>
+			<?php echo 'title="' .htmlspecialchars($images->image_intro_caption) .'"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
+		<?php if ($images->image_intro_caption) : ?>
+			<figcaption><?php echo htmlspecialchars($images->image_intro_caption); ?></figcaption>
+		<?php endif; ?>
+	</figure>
 <?php endif; ?>

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -99,9 +99,13 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated 4.0 Use the layout (layouts/joomla/content/intro_image.php) instead
 	 */
 	public static function caption($selector = 'img.caption')
 	{
+		JLog::add('The use of caption is deprecated use the layout (layouts/joomla/content/intro_image.php) instead.', JLog::WARNING, 'deprecated');
+
 		// Only load once
 		if (isset(static::$loaded[__METHOD__][$selector]))
 		{
@@ -136,7 +140,7 @@ abstract class JHtmlBehavior
 	 *
 	 * @since   1.5
 	 *
-	 * @Deprecated 3.4 Use formvalidator instead
+	 * @deprecated 4.0 Use formvalidator instead
 	 */
 	public static function formvalidation()
 	{


### PR DESCRIPTION
see: https://github.com/joomla-extensions/messages/pull/7 and https://github.com/joomla/joomla-cms/pull/4563 we initial move that code to the messages repo but is should be also in the main repo.

All the work is done by @dgt41 and this change is allready tested see: http://issues.joomla.org/tracker/joomla-cms/4563

(Restored initial PR comment on #4563)

---
#### Move modals from mootools to Bootstrap

Testing:
NOW this IS the last PR to get all back end using bootstrap modals. The rest are: #4513 #4514 #4561 and #4562

Try the my settings button on Components->Messaging
On administrator/index.php?option=com_messages the settings button on the toolbar uses modal

![screenshot 2014-10-12 09 07 49](https://cloud.githubusercontent.com/assets/3889375/4605258/7ef8c596-51d6-11e4-921c-445687d7a165.png)

![screenshot 2014-10-12 09 08 03](https://cloud.githubusercontent.com/assets/3889375/4605259/8146172c-51d6-11e4-889d-e650feb042f2.png)
