### PR TITLE
Reset factory DBO in languages install steps (Fix #7620)

### DIFF
--- a/installation/controller/install/languages.php
+++ b/installation/controller/install/languages.php
@@ -28,7 +28,6 @@ class InstallationControllerInstallLanguages extends JControllerBase
 		// Overrides application config and set the configuration.php file so tokens and database works
 		JFactory::$config = null;
 		JFactory::getConfig(JPATH_SITE . '/configuration.php');
-		JFactory::$session = null;
 	}
 
 	/**

--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -28,7 +28,6 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		// Overrides application config and set the configuration.php file so tokens and database works
 		JFactory::$config = null;
 		JFactory::getConfig(JPATH_SITE . '/configuration.php');
-		JFactory::$session = null;
 	}
 
 	/**

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -58,7 +58,13 @@ class InstallationModelLanguages extends JModelBase
 		// Overrides application config and set the configuration.php file so tokens and database works.
 		JFactory::$config = null;
 		JFactory::getConfig(JPATH_SITE . '/configuration.php');
-		JFactory::$session = null;
+
+		/*
+		 * JFactory::getDbo() gets called during app bootup, and because of the "uniqueness" of the install app, the config doesn't get read
+		 * correctly at that point.  So, we have to reset the factory database object here so that we can get a valid database configuration.
+		 * The day we have proper dependency injection will be a glorious one.
+		 */
+		JFactory::$database = null;
 
 		parent::__construct();
 	}


### PR DESCRIPTION
This fixes #7620.  Read on to see why no developer should ever debug configuration issues while sober in Joomla.
### Summary

With the changes from #7173 `JFactory::getDbo()` is now called from the application constructor.  In the install application, the configuration is not yet loaded into `JFactory::$config` so when this call is made, Joomla attempts to populate that too.  The default path in `JFactory::getConfig()` doesn't align to the path that the CMS writes its configuration to, so the real configuration (which is available at the point the installer is at now) doesn't get loaded.  Because of a string of very inconsistent and borderline crazy behaviors, this actually works OK in the site/admin apps because they [preload `JConfig`](https://github.com/joomla/joomla-cms/blob/staging/includes/framework.php#L46) so the class exists in the filesystem and JFactory is able to load it when the time comes.  Hat tip to @wilsonge and his lost sanity chasing that one down.  Since `JFactory::getDbo()` has been called and a default configuration object is now persisted into the factory, the factory now also includes a database object that can't connect to the database because it wasn't loaded with the right configuration.
### The Fix

We have to reset the configuration and database objects in the factory to force it to recreate them with the correct data to get past this error, and that is changed in `InstallationModelLanguages`.
### Other Changes

Because of #5088 being merged and it bringing a bit more strictness with session bootup, errors were getting tossed out because we were previously resetting `JFactory::$session` which is causing the session to be booted twice.  I wish I could remember why that was happening, all I know is it was needed at some point.  After fixing the database error, the language install UI appeared to be "hanging", but inspecting requests with the Chrome Dev Tools showed that PHP errors were getting thrown because we were basically booting the session twice and setting config values after a session had been started, a big no-no.  So, unsetting the session from the factory is no longer performed too.
### How to Test

Just run through the installer and make sure the darn thing works.
