### PR TITLE
Tag edit form cleanup

### DIFF
--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fields name="urls">
-		<!-- This fieldset is needed to stop the URLs column being null which throws errors in postgres -->
-		<fieldset name="urls">
-			<field
-				name="urla"
-				type="hidden"
-			/>
-		</fieldset>
-	</fields>
-
 	<field
 		name="id"
 		type="text"

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -13,10 +13,6 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
-// Create shortcut to parameters.
-$params = $this->state->get('params');
-$params = $params->toArray();
-
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)
 	{

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -24,7 +24,7 @@ JFactory::getDocument()->addScriptDeclaration("
 ");
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
-$this->ignore_fieldsets = array('jmetadata', 'urls');
+$this->ignore_fieldsets = array('jmetadata');
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_tags&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
@@ -63,7 +63,6 @@ $this->ignore_fieldsets = array('jmetadata', 'urls');
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS', true)); ?>
 		<?php echo $this->form->renderFieldset('images'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php echo $this->form->renderFieldset('urls'); ?>
 	</div>
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -59,10 +59,6 @@ $this->ignore_fieldsets = array('jmetadata');
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS', true)); ?>
-		<?php echo $this->form->renderFieldset('images'); ?>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	</div>
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-// Include the component HTML helpers.
-JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');


### PR DESCRIPTION
### Issue

The tag edit view currently shows the "images" tab twice.
### This PR

While trying to fix the doubled tab, I suprisingly stumbled over a few other funny things in that form. So I fixed those as well. This PR now
- Removes the doubled "images" tab, leaving it to the JLayout to render it.
- Removes a workaround for the "urls" columng in the #__tags table. The underlying issue has been fixed with #6314. The column isn't used anywhere and could most likely be removed from the database. I just leave it there for B/C reasons.
- Removes a `JHtml::addIncludePath()` call since the added path doesn't even exist.
- Removes `$params` "shortcut". We're not using params anywhere in the layout.
### Testing

Make sure you can create and edit tags.
