### PR TITLE
Make JToolbarHelper::custom calls consistent

### DIFF
--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -72,7 +72,7 @@ class InstallerViewDatabase extends InstallerViewDefault
 		/*
 		 * Set toolbar items for the page.
 		 */
-		JToolbarHelper::custom('database.fix', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DATABASE_FIX', false, false);
+		JToolbarHelper::custom('database.fix', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DATABASE_FIX', false);
 		JToolbarHelper::divider();
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_DATABASE');

--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -49,8 +49,8 @@ class InstallerViewDiscover extends InstallerViewDefault
 		/*
 		 * Set toolbar items for the page.
 		 */
-		JToolbarHelper::custom('discover.install', 'upload', 'upload', 'JTOOLBAR_INSTALL', true, false);
-		JToolbarHelper::custom('discover.refresh', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DISCOVER', false, false);
+		JToolbarHelper::custom('discover.install', 'upload', 'upload', 'JTOOLBAR_INSTALL', true);
+		JToolbarHelper::custom('discover.refresh', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DISCOVER', false);
 		JToolbarHelper::divider();
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=discover');

--- a/administrator/components/com_installer/views/languages/view.html.php
+++ b/administrator/components/com_installer/views/languages/view.html.php
@@ -74,8 +74,8 @@ class InstallerViewLanguages extends InstallerViewDefault
 
 		if ($canDo->get('core.admin'))
 		{
-			JToolBarHelper::custom('languages.install', 'upload', 'upload', 'COM_INSTALLER_TOOLBAR_INSTALL', true, false);
-			JToolBarHelper::custom('languages.find', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_FIND_LANGUAGES', false, false);
+			JToolBarHelper::custom('languages.install', 'upload', 'upload', 'COM_INSTALLER_TOOLBAR_INSTALL', true);
+			JToolBarHelper::custom('languages.find', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_FIND_LANGUAGES', false);
 			JToolBarHelper::divider();
 			parent::addToolbar();
 

--- a/administrator/components/com_installer/views/update/view.html.php
+++ b/administrator/components/com_installer/views/update/view.html.php
@@ -78,9 +78,9 @@ class InstallerViewUpdate extends InstallerViewDefault
 	 */
 	protected function addToolbar()
 	{
-		JToolbarHelper::custom('update.update', 'upload', 'upload', 'COM_INSTALLER_TOOLBAR_UPDATE', true, false);
-		JToolbarHelper::custom('update.find', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_FIND_UPDATES', false, false);
-		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'COM_INSTALLER_TOOLBAR_PURGE', false, false);
+		JToolbarHelper::custom('update.update', 'upload', 'upload', 'COM_INSTALLER_TOOLBAR_UPDATE', true);
+		JToolbarHelper::custom('update.find', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_FIND_UPDATES', false);
+		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'COM_INSTALLER_TOOLBAR_PURGE', false);
 		JToolbarHelper::divider();
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=manage');

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -41,7 +41,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 
 		// Set the toolbar information.
 		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'arrow-up-2 install');
-		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'JTOOLBAR_PURGE_CACHE', false, false);
+		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'JTOOLBAR_PURGE_CACHE', false);
 
 		// Add toolbar buttons.
 		$user = JFactory::getUser();

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -194,13 +194,13 @@ class TemplatesViewTemplate extends JViewLegacy
 			// Add a Crop and Resize button
 			elseif ($this->type == 'image')
 			{
-				JToolbarHelper::custom('template.cropImage', 'move', 'move', 'COM_TEMPLATES_BUTTON_CROP', false, false);
+				JToolbarHelper::custom('template.cropImage', 'move', 'move', 'COM_TEMPLATES_BUTTON_CROP', false);
 				JToolbarHelper::modal('resizeModal', 'icon-refresh', 'COM_TEMPLATES_BUTTON_RESIZE');
 			}
 			// Add an extract button
 			elseif ($this->type == 'archive')
 			{
-				JToolbarHelper::custom('template.extractArchive', 'arrow-down', 'arrow-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false, false);
+				JToolbarHelper::custom('template.extractArchive', 'arrow-down', 'arrow-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false);
 			}
 
 			// Add a copy template button (Hathor override doesn't need the button)
@@ -240,7 +240,7 @@ class TemplatesViewTemplate extends JViewLegacy
 			// Add a Compile Button
 			if ($ext == 'less')
 			{
-				JToolbarHelper::custom('template.less', 'play', 'play', 'COM_TEMPLATES_BUTTON_LESS', false, false);
+				JToolbarHelper::custom('template.less', 'play', 'play', 'COM_TEMPLATES_BUTTON_LESS', false);
 			}
 		}
 


### PR DESCRIPTION
# Executive summary

In some part of the code the JToolbarHelper::custom method was called with 6 parameters but the method has only 5 parameters.
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Testing instructions

Because the parameter was ignored before there isn’t so much to test. Just make sure the following backend views are still working and the buttons are doing what they did before

I have changed the custom Buttons in this views:
- Extensions/Manage/Update ->Update, Find Updates, Clear Cache
- Extensions/Manage/Discover -> Install, Discover
- Extensions/Manage/Database -> Fix
- Extensions/Manage/Install Languages -> Install, Find Languages
- Components/Joomla! Update -> Clear Cache
- Extensions/Templates -> open a Template:
  *\* Select an Image -> Crop
  *\* Select a Zip Archive (maybe copy a zip into the template Dir) -> Extract Here
  *\* Select a less file -> Compile Less

Thanks to @brianteeman for finding the inconsistency
