### PR TITLE
Added possibility to get help remotely in com_config component view

### DIFF
--- a/administrator/components/com_config/view/component/html.php
+++ b/administrator/components/com_config/view/component/html.php
@@ -92,7 +92,7 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 		JToolbarHelper::divider();
 		JToolbarHelper::cancel('config.cancel.component');
 		JToolbarHelper::divider();
-		
+
 		/*
 		 * Get help for the component by
 		 * -remotely searching in a language defined dedicated URL: *component*_HELP_URL
@@ -100,11 +100,11 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 		 * -remotely searching in a component URL if helpURL param exists in the component and is NOT set to ''
 		 */
 		$component	= JFactory::getApplication()->input->get('component');
-		
+
 		$lang = JFactory::getLanguage();
 		$lang->load($component, JPATH_BASE, null, false, true)
 		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
-		
+
 		$ref_key = 'JHELP_COMPONENTS_' . strtoupper($component) . '_OPTIONS';
 		if ($lang->hasKey($lang_help_url = strtoupper($component) . '_HELP_URL'))
 		{

--- a/administrator/components/com_config/view/component/html.php
+++ b/administrator/components/com_config/view/component/html.php
@@ -92,6 +92,31 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 		JToolbarHelper::divider();
 		JToolbarHelper::cancel('config.cancel.component');
 		JToolbarHelper::divider();
-		JToolbarHelper::help('JHELP_COMPONENTS_' . $this->currentComponent . '_OPTIONS');
+		
+		/*
+		 * Get help for the component by
+		 * -remotely searching in a language defined dedicated URL: *component*_HELP_URL
+		 * -locally  searching in a component help file if helpURL param exists in the component and is set to ''
+		 * -remotely searching in a component URL if helpURL param exists in the component and is NOT set to ''
+		 */
+		$component	= JFactory::getApplication()->input->get('component');
+		
+		$lang = JFactory::getLanguage();
+		$lang->load($component, JPATH_BASE, null, false, true)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
+		
+		$ref_key = 'JHELP_COMPONENTS_' . strtoupper($component) . '_OPTIONS';
+		if ($lang->hasKey($lang_help_url = strtoupper($component) . '_HELP_URL'))
+		{
+			$debug = $lang->setDebug(false);
+			$url = JText::_($lang_help_url);
+			$lang->setDebug($debug);
+		}
+		else
+		{
+			$url = null;
+		}
+
+		JToolbarHelper::help($ref_key, JComponentHelper::getParams($component)->exists('helpURL'), $url);
 	}
 }

--- a/administrator/components/com_config/view/component/html.php
+++ b/administrator/components/com_config/view/component/html.php
@@ -117,6 +117,6 @@ class ConfigViewComponentHtml extends ConfigViewCmsHtml
 			$url = null;
 		}
 
-		JToolbarHelper::help($ref_key, JComponentHelper::getParams($component)->exists('helpURL'), $url);
+		JToolbarHelper::help($ref_key, JComponentHelper::getParams($component)->exists('helpURL'), $url, $component);
 	}
 }


### PR DESCRIPTION
Previously com_config was getting help only from local file by reference key.
This PR added possibility to get help remotely by URL from language file, locally by key, remotely by URL provided in component settings and key.
Idea taken from com_categories code.
### How to test

1) Install you component
2) Go to config page of you component
3) Try to press "Help" button. You will arrive to Joomla help server
4) Apply the patch
5) Add to lang file constant:
COM_COMPONENTNAME_HELP_URL="https://example/{keyref}.html"
6) Try to press "Help" and you will arrive to page like:
https://example/JHELP_COMPONENTS_COM_COMPONENTNAME_OPTIONS.html
You can use lang file to override JHELP_COMPONENTS_COM_COMPONENTNAME_OPTIONS with something user friendly.
7) Remove COM_COMPONENTNAME_HELP_URL from lang file.
8) Add field "helpURL" to your component config.xml and insert there same url (https://example/{keyref}.html)
9) Try to press "Help" button. Result should be the same as in point 6.
10) Clean helpURL field and save configs.
11) Try to press "Help" button. You should get local help page.
