### PR TITLE
postStoreProcess tag method replaces all tags when false is set

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -805,7 +805,7 @@ class JHelperTags extends JHelper
 		// Process ucm_content and ucm_base if either tags have changed or we have some tags.
 		if ($this->tagsChanged || (!empty($newTags) && $newTags[0] != ''))
 		{
-			if (!$newTags && $replace = true)
+			if (!$newTags && $replace == true)
 			{
 				// Delete all tags data
 				$key = $table->getKeyName();


### PR DESCRIPTION
Caused by improper operator in /libraries/cms/helper/tags line 807, which should read:

`if (!$newTags && $replace == true)`

Fixes #7635
