### PR TITLE
Modules batch modals changes

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -237,7 +237,19 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php endif;?>
 
 		<?php //Load the batch processing form. ?>
-		<?php echo $this->loadTemplate('batch'); ?>
+		<?php if ($user->authorise('core.create', 'com_modules')
+			&& $user->authorise('core.edit', 'com_modules')
+			&& $user->authorise('core.edit.state', 'com_modules')) : ?>
+			<?php echo JHtml::_(
+				'bootstrap.renderModal',
+				'collapseModal',
+				array(
+					'title' => JText::_('COM_MODULES_BATCH_OPTIONS'),
+					'footer' => $this->loadTemplate('batch_footer')
+				),
+				$this->loadTemplate('batch_body')
+			); ?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -5,6 +5,8 @@
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  3.4 Use default_batch_body and default_batch_footer
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -72,7 +72,7 @@ $attr = array(
 		<button class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
-		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('module.batch');">
+		<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('module.batch');">
 			<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 		</button>
 	</div>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_modules
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$clientId  = $this->state->get('filter.client_id');
+// show only Module Positions of published Templates
+$published = 1;
+$positions = JHtml::_('modules.positions', $clientId, $published);
+$positions['']['items'][] = ModulesHelper::createOption('nochange', JText::_('COM_MODULES_BATCH_POSITION_NOCHANGE'));
+$positions['']['items'][] = ModulesHelper::createOption('noposition', JText::_('COM_MODULES_BATCH_POSITION_NOPOSITION'));
+
+// Add custom position to options
+$customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
+
+// Build field
+$attr = array(
+	'id'		=> 'batch-position-id',
+	'list.attr'	=> 'class="chzn-custom-value input-xlarge" '
+		. 'data-custom_group_text="' . $customGroupText . '" '
+		. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
+		. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '
+);
+
+?>
+
+<p><?php echo JText::_('COM_MODULES_BATCH_TIP'); ?></p>
+<div class="row-fluid">
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.language'); ?>
+		</div>
+	</div>
+	<div class="control-group span6">
+		<div class="controls">
+			<?php echo JHtml::_('batch.access'); ?>
+		</div>
+	</div>
+</div>
+<div class="row-fluid">
+	<?php if ($published >= 0) : ?>
+		<div class="span6">
+			<div class="controls">
+				<label id="batch-choose-action-lbl" for="batch-choose-action">
+					<?php echo JText::_('COM_MODULES_BATCH_POSITION_LABEL'); ?>
+				</label>
+				<div id="batch-choose-action" class="control-group">
+					<?php echo JHtml::_('select.groupedlist', $positions, 'batch[position_id]', $attr) ?>
+					<div id="batch-copy-move" class="control-group radio">
+						<?php echo JHtml::_('modules.batchOptions'); ?>
+					</div>
+				</div>
+			</div>
+		</div>
+	<?php endif; ?>
+</div>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_modules
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+?>
+<button class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+	<?php echo JText::_('JCANCEL'); ?>
+</button>
+<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('module.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
@@ -12,6 +12,6 @@ defined('_JEXEC') or die;
 <button class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </button>
-<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('module.batch');">
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('module.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>


### PR DESCRIPTION
#### This is complimentary to #7000 and #7003

What is changed:
1. modals are properly rendered through the API
2. overrides have only the actual content (no hard coded structure)
3. obey to ACL
4. modal is rendered only if items exist
5. process button class from primary to success (color change from blue to green)
#### testing

You need to test the batch functionality for this url: administrator/index.php?option=com_modules&view=modules
