### PR TITLE
User Profile: Date of birth should be absolute.

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_profile.php
+++ b/components/com_contact/views/contact/tmpl/default_profile.php
@@ -23,9 +23,9 @@ defined('_JEXEC') or die;
 							$v_http = substr($profile->value, 0, 4);
 
 							if ($v_http == "http") :
-								echo '<dd><a href="' . $profile->text . '">' . $profile->text . '</a></dd>';
+								echo '<dd><a href="' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
 							else :
-								echo '<dd><a href="http://' . $profile->text . '">' . $profile->text . '</a></dd>';
+								echo '<dd><a href="http://' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
 							endif;
 							break;
 

--- a/components/com_contact/views/contact/tmpl/default_profile.php
+++ b/components/com_contact/views/contact/tmpl/default_profile.php
@@ -23,10 +23,14 @@ defined('_JEXEC') or die;
 							$v_http = substr($profile->value, 0, 4);
 
 							if ($v_http == "http") :
-								echo '<dd><a href="' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
+								echo '<dd><a href="' . $profile->text . '">' . $profile->text . '</a></dd>';
 							else :
-								echo '<dd><a href="http://' . $profile->text . '">' . JStringPunycode::urlToUTF8($profile->text) . '</a></dd>';
+								echo '<dd><a href="http://' . $profile->text . '">' . $profile->text . '</a></dd>';
 							endif;
+							break;
+
+						case "profile_dob":
+							echo "<dd>" . JHtml::_('date', $profile->text, JText::_('DATE_FORMAT_LC4')) . "</dd>";
 							break;
 
 						default:

--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -35,6 +35,9 @@ foreach ($fieldsets as $group => $fieldset): // Iterate through the form fieldse
 		if (!$field->hidden && $field->type != 'Spacer') : ?>
 		<dt><?php echo $field->title; ?></dt>
 		<dd>
+			<?php if ($field->type == 'Dob') : ?>
+				<?php $field->value = JHtml::_('date', $field->value, JText::_('DATE_FORMAT_LC4')); ?>
+			<?php endif; ?>
 			<?php if (JHtml::isRegistered('users.' . $field->id)) : ?>
 				<?php echo JHtml::_('users.' . $field->id, $field->value); ?>
 			<?php elseif (JHtml::isRegistered('users.' . $field->fieldname)) : ?>

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -203,6 +203,15 @@ class JFormFieldCalendar extends JFormField
 				}
 
 				break;
+
+			case 'RAW':
+				// Keep the date absolute.
+				if ($this->value && $this->value != JFactory::getDbo()->getNullDate())
+				{
+					$this->value = $this->value->format('Y-m-d H:i:s', true, false);
+				}
+
+				break;
 		}
 
 		// Including fallback code for HTML5 non supported browsers.

--- a/plugins/user/profile/profiles/profile.xml
+++ b/plugins/user/profile/profiles/profile.xml
@@ -107,7 +107,6 @@
 				description="PLG_USER_PROFILE_FIELD_DOB_DESC"
 				info="PLG_USER_PROFILE_SPACER_DOB"
 				format="%Y-%m-%d"
-				filter="server_utc"
 			/>
 			<field
 				name="tos"

--- a/plugins/user/profile/profiles/profile.xml
+++ b/plugins/user/profile/profiles/profile.xml
@@ -107,6 +107,7 @@
 				description="PLG_USER_PROFILE_FIELD_DOB_DESC"
 				info="PLG_USER_PROFILE_SPACER_DOB"
 				format="%Y-%m-%d"
+				filter="raw"
 			/>
 			<field
 				name="tos"


### PR DESCRIPTION
When using the Profile User Plugin, the date of birth entered and displayed should be independent from server or user settings.

Test instructions:

In Global Configuration set the Server Time Zone to Paris (Test done in France, use other values to test)
Enable User - Profile plugin
Edit com_contacts Options =>Contact tab and enable "Show Profile"

In back-end, create a contact and assign it to a user.
Edit the user profile:
1. Set the Time Zone to "Default" in Basic Settings tab
2. Set a Date of birth in "User Profile" tab with the calendar. I have set it to `1948-04-20` below.
3. Create a menu item to display this contact in frontend. Display the Profile tab or slider of that contact.

Before patch, the date of birth is wrong, it displays `1948-04-19`:
![screen shot 2015-07-30 at 13 24 33](https://cloud.githubusercontent.com/assets/869724/8982122/5ca5d3c6-36be-11e5-9d95-62a10421ed0a.png)

After patch, as it takes off the `server-utc` filter, the date is correct.
![screen shot 2015-08-08 at 11 39 07](https://cloud.githubusercontent.com/assets/869724/9149928/4a7fd0b0-3dc2-11e5-996e-c17e090d8163.png)

Will prepare another patch to display the date in the correct language format (DATE_FORMAT_LC4), without the time, i.e. to get for French:
![screen shot 2015-08-08 at 12 06 31](https://cloud.githubusercontent.com/assets/869724/9150027/f1d9bf44-3dc5-11e5-9b51-279d0c62bf03.png)
