### PR TITLE
Fixed wrong lft/rgt values after uninstalling a component with categories

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -802,6 +802,10 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		$db->setQuery($query);
 		$db->execute();
 
+		// Rebuild the categories for correct lft/rgt
+		$category = JTable::getInstance('category');
+		$category->rebuild();
+
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
 		$uid = $update->find(


### PR DESCRIPTION
If you uninstall a component with categories, the categories will be deleted by the component. But the deletion just removes the entries without proper nested sets handling. So the rgt/lft values are wrong.

This patch fixes this issue.

How to test:
1. Look into #__categories for the entry "root.1" and remember the "rgt" value
2. Uninstall a component which uses categories
3. Look into the table again => the rgt value did not change (although we have a lower number of categories)
4. Apply patch
5. Try again

=> the rgt value is now correct
