### PR TITLE
Add closing div for all contact page formats in beez

### DIFF
--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -193,6 +193,4 @@ $cparams = JComponentHelper::getParams('com_media');
 			</div>
 		<?php endif; ?>
 	<?php endif; ?>
-	<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-		</div>
-	<?php endif; ?>
+</div>


### PR DESCRIPTION
At the moment, the outer div ([com_contact/contact/default.php, line 14](https://github.com/joomla/joomla-cms/blob/staging/templates/beez3/html/com_contact/contact/default.php#L14)) for a single contact page in the Beez override is opened in all display formats, but closed only for sliders.

 This enables the closing div tag for all styles of the contact page in beez.
## Testing instructions
1. Create a contact linked to a user and enter some information (address, social media, misc. information).
2. Create a menu item for the contact:
   - Type: Single Contact
   - Contact Display Options - Display Format: Tabs or Plain
3. Set Beez3 as the template for this menu item (or as the default template for the whole site).
4. View the menu item in front end. In the unlikely case that nothing looks broken, take a look at the HTML output with focus on opening and closing tags. You may test the page on https://validator.w3.org/, too.
5. Apply the patch.
6. Repeat step 4 for all three display formats (Sliders, Tabs, Plain). Make sure that all elements are closed correctly.
