### PR TITLE
TOC links not shown as active

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -309,16 +309,9 @@ class PlgContentPagebreak extends JPlugin
 				$title	= JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
 			}
 
-			$class = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
-			$row->toc .= '
-				<li>
-
-					<a href="' . $link . '" class="' . $class . '">'
-					. $title .
-					'</a>
-
-				</li>
-				';
+			$liClass = ($limitstart == $i - 1) ? ' class="active"' : '';
+			$class   = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
+			$row->toc .= '<li' . $liClass . '><a href="' . $link . '" class="' . $class . '">' . $title . '</a></li>';
 			$i++;
 		}
 

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -317,17 +317,11 @@ class PlgContentPagebreak extends JPlugin
 
 		if ($this->params->get('showall'))
 		{
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
-			$class = ($showall == 1) ? 'toclink active' : 'toclink';
-			$row->toc .= '
-			<li>
-
-					<a href="' . $link . '" class="' . $class . '">'
-					. JText::_('PLG_CONTENT_PAGEBREAK_ALL_PAGES') .
-					'</a>
-
-			</li>
-			';
+			$link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
+			$liClass = ($limitstart == $i - 1) ? ' class="active"' : '';
+			$class   = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
+			$row->toc .= '<li' . $liClass . '><a href="' . $link . '" class="' . $class . '">'
+				. JText::_('PLG_CONTENT_PAGEBREAK_ALL_PAGES') . '</a></li>';
 		}
 
 		$row->toc .= '</ul></div>';


### PR DESCRIPTION
In articles with a TOC and pagebreaks, the 2nd or later page may not be displayed as active because the `active` class is not applied to the `<li>` element as demonstrated in Bootstrap's documentation.
### Testing Instructions

Create an article that uses page breaks; this snippet can be pasted into an editor in HTML mode to accomplish the test:

``` html
<p>Page 1</p>
<hr title="Second Page" alt="second-page" class="system-pagebreak" />
<p>Page 2</p>
```

Pre-test, when you navigate pages, the 2nd page will never highlight as active.  Post patch, it does.
