### PR TITLE
Format Date of Birth and adjust timezone correctly.

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_profile.php
+++ b/components/com_contact/views/contact/tmpl/default_profile.php
@@ -29,6 +29,10 @@ defined('_JEXEC') or die;
 							endif;
 							break;
 
+						case "profile_dob":
+							echo '<dd>' . JHtml::_('date', $profile->text, JText::_('DATE_FORMAT_LC4'), false) . '</dd>';
+						break;
+
 						default:
 							echo '<dd>' . $profile->text . '</dd>';
 							break;

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -129,7 +129,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * returns a anchor tag generated from a given value
+	 * Returns a anchor tag generated from a given value
 	 *
 	 * @param   string  $value  url to use
 	 *
@@ -158,7 +158,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * returns html markup showing a date picker
+	 * Returns html markup showing a date picker
 	 *
 	 * @param   string  $value  valid date string
 	 *
@@ -177,7 +177,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * returns the date of birth formatted and calculated using server timezone.
+	 * Returns the date of birth formatted and calculated using server timezone.
 	 *
 	 * @param   string  $value  valid date string
 	 *
@@ -194,7 +194,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * return the translated strings yes or no depending on the value
+	 * Return the translated strings yes or no depending on the value
 	 *
 	 * @param   boolean  $value  input value
 	 *
@@ -213,7 +213,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * adds additional fields to the user editing form
+	 * Adds additional fields to the user editing form
 	 *
 	 * @param   JForm  $form  The form to be altered.
 	 * @param   mixed  $data  The associated data for the form.
@@ -368,7 +368,7 @@ class PlgUserProfile extends JPlugin
 	}
 
 	/**
-	 * saves user profile data
+	 * Saves user profile data
 	 *
 	 * @param   array    $data    entered user data
 	 * @param   boolean  $isNew   true if this is a new user

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -118,6 +118,11 @@ class PlgUserProfile extends JPlugin
 			{
 				JHtml::register('users.tos', array(__CLASS__, 'tos'));
 			}
+
+			if (!JHtml::isRegistered('users.dob'))
+			{
+				JHtml::register('users.dob', array(__CLASS__, 'dob'));
+			}
 		}
 
 		return true;
@@ -169,6 +174,23 @@ class PlgUserProfile extends JPlugin
 		{
 			return JHtml::_('date', $value, null, null);
 		}
+	}
+
+	/**
+	 * returns the date of birth formatted and calculated using server timezone.
+	 *
+	 * @param   string  $value  valid date string
+	 *
+	 * @return  mixed
+	 */
+	public static function dob($value)
+	{
+		if (!$value)
+		{
+			return '';
+		}
+
+		return JHtml::_('date', $value, JText::_('DATE_FORMAT_LC1'), false);
 	}
 
 	/**


### PR DESCRIPTION
### Issue

As explained in #7657 we have an issue with the date of birth being shown as the wrong day if the timezone of the server is set to a positive value (eg Moscow).
### Background

Joomla always stores the dates in UTC and calculates them back when showing. Meaning when you set your server timezone to Moscow, it will subtract 3 hours from the date when saving, storing it as the day before at 9pm. When showing again, it should add those three hours again which brings us back to the day we saved.
### Solution

This PR fixes the part when showing the date and applies the correct timezone there. Currently the value is just shown as it was stored in the database.
As an additional advantage we can now specify the format of the date, which usually for date of births is only the date part. Usually nobody is interested in the actual time of birth. :smile: 
### Testing

Test with entering the date of birth while the timezone is on a positive or on a negative timezone. Both should work. Also test with changing the user timezone, that one should have no impact at all.
You will probably notice that the date of birth may change when you change the server timezone. That is expected as all already stored values will be wrong if you change the server timezone after the data is saved.
