### PR TITLE
Make it easier for Varnish (and similar caching proxies) to work just fine with the "remember me" functionality for user logins

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -54,7 +54,7 @@ class PlgAuthenticationCookie extends JPlugin
 		}
 
 		// Get cookie
-		$cookieName  = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+		$cookieName  = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 		$cookieValue = $this->app->input->cookie->get($cookieName);
 
 		if (!$cookieValue)
@@ -220,7 +220,7 @@ class PlgAuthenticationCookie extends JPlugin
 		if (isset($options['responseType']) && $options['responseType'] == 'Cookie')
 		{
 			// Logged in using a cookie
-			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 
 			// We need the old data to get the existing series
 			$cookieValue = $this->app->input->cookie->get($cookieName);
@@ -233,7 +233,7 @@ class PlgAuthenticationCookie extends JPlugin
 		elseif (!empty($options['remember']))
 		{
 			// Remember checkbox is set
-			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 
 			// Create an unique series which will be used over the lifespan of the cookie
 			$unique     = false;
@@ -346,7 +346,7 @@ class PlgAuthenticationCookie extends JPlugin
 			return false;
 		}
 
-		$cookieName  = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+		$cookieName  = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 		$cookieValue = $this->app->input->cookie->get($cookieName);
 
 		// There are no cookies to delete.

--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -54,7 +54,7 @@ class PlgAuthenticationCookie extends JPlugin
 		}
 
 		// Get cookie
-		$cookieName  = JUserHelper::getShortHashedUserAgent();
+		$cookieName  = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 		$cookieValue = $this->app->input->cookie->get($cookieName);
 
 		if (!$cookieValue)
@@ -220,7 +220,7 @@ class PlgAuthenticationCookie extends JPlugin
 		if (isset($options['responseType']) && $options['responseType'] == 'Cookie')
 		{
 			// Logged in using a cookie
-			$cookieName = JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 
 			// We need the old data to get the existing series
 			$cookieValue = $this->app->input->cookie->get($cookieName);
@@ -233,7 +233,7 @@ class PlgAuthenticationCookie extends JPlugin
 		elseif (!empty($options['remember']))
 		{
 			// Remember checkbox is set
-			$cookieName		= JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 
 			// Create an unique series which will be used over the lifespan of the cookie
 			$unique     = false;
@@ -346,7 +346,7 @@ class PlgAuthenticationCookie extends JPlugin
 			return false;
 		}
 
-		$cookieName  = JUserHelper::getShortHashedUserAgent();
+		$cookieName  = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 		$cookieValue = $this->app->input->cookie->get($cookieName);
 
 		// There are no cookies to delete.

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -51,7 +51,7 @@ class PlgSystemRemember extends JPlugin
 		// Check for a cookie if user is not logged in
 		if (JFactory::getUser()->get('guest'))
 		{
-			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 
 			// Check for the cookie
 			if ($this->app->input->cookie->get($cookieName))
@@ -77,7 +77,7 @@ class PlgSystemRemember extends JPlugin
 			return true;
 		}
 
-		$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
+		$cookieName = 'JRememberMe_' . JUserHelper::getShortHashedUserAgent();
 
 		// Check for the cookie
 		if ($this->app->input->cookie->get($cookieName))

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -51,7 +51,7 @@ class PlgSystemRemember extends JPlugin
 		// Check for a cookie if user is not logged in
 		if (JFactory::getUser()->get('guest'))
 		{
-			$cookieName = JUserHelper::getShortHashedUserAgent();
+			$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 
 			// Check for the cookie
 			if ($this->app->input->cookie->get($cookieName))
@@ -77,7 +77,7 @@ class PlgSystemRemember extends JPlugin
 			return true;
 		}
 
-		$cookieName = JUserHelper::getShortHashedUserAgent();
+		$cookieName = 'JRememberMe_'.JUserHelper::getShortHashedUserAgent();
 
 		// Check for the cookie
 		if ($this->app->input->cookie->get($cookieName))


### PR DESCRIPTION
This is a performance related improvement for Joomla. It also makes Joomla more compatible with Varnish and similar caching proxies in the sense that it allows the "remember me" feature for user logins to work out of the box with only typical configuration on Varnish's part.

Why, you may ask. Well, in order for software like Varnish to provide the best possible caching for Joomla (or any other CMS), it's highly recommended to strip all CMS generated cookies in order to normalize generated web content, minimize the caching "effort" on behalf of the CMS and thus boost the actual performance of the site.

Since Joomla by default uses session cookies even for guest users, we use Varnish to strip these cookies on any page that does not require user interaction (= where session cookies are not really needed). If we didn't and say we had 100 guest users visiting the exact same page, Varnish would have to generate 100 different cache objects because it considers the combination of HTML output and cookies unique. If however we strip the session cookies, Varnish generates just 1 cache object and relieves Joomla from regenerating that page even for a million guest users with insignificant server resources occupied.

We can obviously exclude cookie stripping from a login page but if we want to have the "remember me" functionality work flawlessly, we need to be able to detect the "remember me" cookie on any page in Joomla, whether it has session cookies stripped or not. The only way to do this is by simply adding a prefix to the "remember me" cookie. 

Using a prefix in that cookie name instead of just a hashed UA string (as it's currently done), we can configure Varnish to detect that particular cookie and (as expected) log a user in the site, regardless of what page the user opened the site to.

It's a very simple patch that has no security impact and I hope the core team will consider this addition.

Thank you.

P.S. This is the configuration for Varnish to detect the "remember me" cookie properly (it's really typical cookie detection in Varnish):

sub vcl_recv {
    [...other rules...]
    if (req.http.Cookie ~ "JRememberMe") {
        return (pass);
    }
    [...other rules...]
}

sub vcl_fetch {
    [...other rules...]
    if (bereq.http.Cookie ~ "JRememberMe") {
        return (hit_for_pass);
    }
    [...other rules...]
}
