### PR TITLE
Fix for "Googlebot cannot access CSS and JS files"

### DIFF
--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -27,6 +27,5 @@ Disallow: /modules/
 Disallow: /plugins/
 Disallow: /tmp/
 
-User-Agent: Googlebot
 Allow: .js
 Allow: .css

--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -27,3 +27,6 @@ Disallow: /modules/
 Disallow: /plugins/
 Disallow: /tmp/
 
+User-Agent: Googlebot
+Allow: .js
+Allow: .css


### PR DESCRIPTION
In July 2015 a lot of people got "Googlebot cannot access CSS and JS files" notifications from Google.
This PR implements the fix described here:
http://upcity.com/blog/how-to-fix-googlebot-cannot-access-css-and-js-files-error-in-google-search-console/
