### PR TITLE
Stop allowing failures on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ php:
   - 5.6
   - 7.0
 
-matrix:
-  allow_failures:
-    - php: 7.0
-
 services:
   - memcached
   - redis-server


### PR DESCRIPTION
PHP 7 has had its third beta release and the CMS' unit test suite has been running without issue since the first beta's release.  To me this indicates that the CMS and PHP 7 are stable enough to stop allowing unit test failures on this PHP version.
### Implications

All PRs to the `3.5-dev` branch and all merges from `staging` to `3.5-dev` must not introduce test failures on PHP 7.
