### PR TITLE
Remove redundant formbehavior chosen call

### DIFF
--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('formbehavior.chosen', 'select');
 
 $user = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -12,11 +12,11 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user = JFactory::getUser();
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn = $this->escape($this->state->get('list.direction'));
-$canEdit = $user->authorise('core.edit', 'com_users');
-$sortFields = $this->getSortFields();
+$user		= JFactory::getUser();
+$listOrder	= $this->escape($this->state->get('list.ordering'));
+$listDirn	= $this->escape($this->state->get('list.direction'));
+$canEdit	= $user->authorise('core.edit', 'com_users');
+$sortFields	= $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()


### PR DESCRIPTION
Two `JHtml::_('formbehavior.chosen', 'select');` calls

+some CS
