### PR TITLE
Undefined variable $accept

### DIFF
--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -69,7 +69,7 @@ class JFormFieldFile extends JFormField
 		switch ($name)
 		{
 			case 'accept':
-				$this->$accept = (string) $value;
+				$this->$name = (string) $value;
 				break;
 
 			default:


### PR DESCRIPTION
The key usage was like `$this->$accept` instead of   `$this->accept` causing error undefined variable `$accept`.  
I know this is a part of `Joomla-framework/Form` package, but that repo has changed drastically as compared to the current CMS copy. If this still not ok to PR here, please advise.
