### PR TITLE
[fix] wrong component detection in some Windows servers

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -274,12 +274,7 @@ class JLayoutFile extends JLayoutBase
 				break;
 
 			case 'auto':
-				if (defined('JPATH_COMPONENT'))
-				{
-					$parts = explode('/', JPATH_COMPONENT);
-					$component = end($parts);
-				}
-
+				$component = JApplicationHelper::getComponentName();
 				break;
 
 			default:


### PR DESCRIPTION
## Description

Currently the automatic component detection in `JLayout` is based in the constant `JPATH_COMPONENT` and in explode the path that it contains with:

`$parts = explode('/', JPATH_COMPONENT);`

But actually Windows paths can be something like:

`C:\Xamp\htdocs\joomla-cms\components\com_content`

So the explode will return the full path instead of the expected `com_content` and then the component won't be found enqueuing a system message with something like:

`WARNING: Error component not found: com_content`

Instead of applying a patch based in fixing detection based in `JPATH_COMPONENT` I have opted for using `JApplicationHelper` which I think is more reliable.
## Testing

You need a windows machine for it. I'm not even sure this happens in all the Windows systems (linux user here). Any layout rendered should show the error message.
## B/C issues

This is a bug fix that shouldn't cause any B/C issue.
