### PR TITLE
CS: normalising Authentification Method field tooltip

### DIFF
--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -107,7 +107,7 @@ $fieldsets = $this->form->getFieldsets();
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<strong><?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') ?></strong><br /><?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC') ?>">
+					   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -107,7 +107,7 @@ $fieldsets = $this->form->getFieldsets();
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
+					   title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/administrator/templates/hathor/html/com_users/user/edit.php
+++ b/administrator/templates/hathor/html/com_users/user/edit.php
@@ -92,7 +92,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
+					   title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/administrator/templates/hathor/html/com_users/user/edit.php
+++ b/administrator/templates/hathor/html/com_users/user/edit.php
@@ -92,7 +92,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<strong><?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') ?></strong><br /><?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC') ?>">
+					   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -88,7 +88,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 			<div class="control-group">
 				<div class="control-label">
 					<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-						   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
+						   title="<?php echo '<strong>' . JText::_('COM_USERS_PROFILE_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_PROFILE_TWOFACTOR_DESC'); ?>">
 						<?php echo JText::_('COM_USERS_PROFILE_TWOFACTOR_LABEL'); ?>
 					</label>
 				</div>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -88,7 +88,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 			<div class="control-group">
 				<div class="control-label">
 					<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-						   title="<strong><?php echo JText::_('COM_USERS_PROFILE_TWOFACTOR_LABEL'); ?></strong><br /><?php echo JText::_('COM_USERS_PROFILE_TWOFACTOR_DESC'); ?>">
+						   title="<?php echo JHtml::tooltipText('COM_USERS_USER_FIELD_TWOFACTOR_LABEL', 'COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 						<?php echo JText::_('COM_USERS_PROFILE_TWOFACTOR_LABEL'); ?>
 					</label>
 				</div>


### PR DESCRIPTION
As title says.
To test, enable one (or both) of the Two Factor Authentification plugins, then edit a user (backend) or login and edit the user profile (frontend).

Tooltip should look as before patch, i.e.
![screen shot 2015-08-15 at 08 32 39](https://cloud.githubusercontent.com/assets/869724/9287798/f86082fe-4328-11e5-8c67-d97e46473343.png)

Thanks @nikosdion for testing
