### PR TITLE
Move form field moduleposition to layouts and use Bootstrap modal

### DIFF
--- a/administrator/templates/hathor/html/layouts/joomla/form/field/moduleposition.php
+++ b/administrator/templates/hathor/html/layouts/joomla/form/field/moduleposition.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $id The module id number
+ * @var  string   $clientId The Client id (site/admin)
+ * @var  string   $inputTag The input field
+ */
+extract($displayData);
+
+// Add the script to the document head.
+JFactory::getDocument()->addScriptDeclaration(
+	'
+	function jSelectPosition_' . $id . '(name) {
+		document.getElementById("' . $id . '").value = name;
+		jQuery("#module' . $id . 'PositionModal").modal("hide");
+	}
+	'
+);
+
+$link = 'index.php?option=com_modules&view=positions&layout=modal&tmpl=component&function=jSelectPosition_'
+	. $id . '&amp;client_id=' . $clientId;
+
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'module' . $id . 'PositionModal',
+	array(
+		'url' => $link,
+		'title' => JText::_('COM_MODULES_CHANGE_POSITION_TITLE'),
+		'height' => '300px',
+		'width' => '800px'
+	)
+);
+?>
+<div class="input-append">
+	<?php echo $inputTag; ?>
+	<button onclick="jQuery('#module<?php echo $id; ?>PositionModal').modal('show')" class="btn" data-toggle="modal" title="<?php echo JText::_('COM_MODULES_CHANGE_POSITION_BUTTON'); ?>">
+		<span><?php echo JText::_('COM_MODULES_CHANGE_POSITION_BUTTON'); ?></span>
+	</button>
+</div>

--- a/administrator/templates/hathor/html/layouts/joomla/form/field/moduleposition.php
+++ b/administrator/templates/hathor/html/layouts/joomla/form/field/moduleposition.php
@@ -39,7 +39,7 @@ echo JHtml::_(
 		'url' => $link,
 		'title' => JText::_('COM_MODULES_CHANGE_POSITION_TITLE'),
 		'height' => '300px',
-		'width' => '800px'
+		'width' => '100%'
 	)
 );
 ?>

--- a/layouts/joomla/form/field/moduleposition.php
+++ b/layouts/joomla/form/field/moduleposition.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $id The module id number
+ * @var  string   $clientId The Client id (site/admin)
+ * @var  string   $inputTag The input field
+ */
+extract($displayData);
+
+// Load the modal behavior script.
+JHtml::_('behavior.modal', 'a.modal');
+
+// Add the script to the document head.
+JFactory::getDocument()->addScriptDeclaration(
+	'
+	function jSelectPosition_' . $id . '(name) {
+		document.getElementById("' . $id . '").value = name;
+		jModalClose();
+	}
+	'
+);
+
+$link = 'index.php?option=com_modules&view=positions&layout=modal&tmpl=component&function=jSelectPosition_'
+	. $id . '&amp;client_id=' . $clientId;
+?>
+<div class="input-append">
+	<?php echo $inputTag; ?>
+	<a class="btn modal" title="<?php echo JText::_('COM_MODULES_CHANGE_POSITION_TITLE'); ?>"  href="<?php echo $link; ?>" rel="{handler: 'iframe', size: {x: 800, y: 450}}">
+		<?php echo JText::_('COM_MODULES_CHANGE_POSITION_BUTTON'); ?></a>
+</div>

--- a/libraries/cms/form/field/moduleposition.php
+++ b/libraries/cms/form/field/moduleposition.php
@@ -138,12 +138,26 @@ class JFormFieldModulePosition extends JFormFieldText
 	 */
 	protected function getInput()
 	{
-		$displayData = array(
-			'id'       => $this->id,
-			'clientId' => $this->clientId,
-			'inputTag'    => parent::getInput()
+		return JLayoutHelper::render($this->layout, $this->getLayoutData());
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.5
+	 */
+	protected function getLayoutData()
+	{
+		// Get the basic field data
+		$data = parent::getLayoutData();
+
+		$extraData = array(
+				'clientId' => $this->clientId,
+				'inputTag' => parent::getInput()
 		);
 
-		return JLayoutHelper::render($this->layout, $displayData);
+		return array_merge($data, $extraData);
 	}
 }

--- a/libraries/cms/form/field/moduleposition.php
+++ b/libraries/cms/form/field/moduleposition.php
@@ -35,6 +35,13 @@ class JFormFieldModulePosition extends JFormFieldText
 	protected $clientId;
 
 	/**
+	* Layout to render the label
+	*
+	* @var  string
+	*/
+	protected $layout = 'joomla.form.field.moduleposition';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to the the value.
@@ -131,32 +138,12 @@ class JFormFieldModulePosition extends JFormFieldText
 	 */
 	protected function getInput()
 	{
-		// Load the modal behavior script.
-		JHtml::_('behavior.modal', 'a.modal');
+		$displayData = array(
+			'id'       => $this->id,
+			'clientId' => $this->clientId,
+			'inputTag'    => parent::getInput()
+		);
 
-		// Build the script.
-		$script = array();
-		$script[] = '	function jSelectPosition_' . $this->id . '(name) {';
-		$script[] = '		document.getElementById("' . $this->id . '").value = name;';
-		$script[] = '		jModalClose();';
-		$script[] = '	}';
-
-		// Add the script to the document head.
-		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
-
-		// Setup variables for display.
-		$html = array();
-		$link = 'index.php?option=com_modules&view=positions&layout=modal&tmpl=component&function=jSelectPosition_' . $this->id
-			. '&amp;client_id=' . $this->clientId;
-
-		// The current user display field.
-		$html[] = '<div class="input-append">';
-		$html[] = parent::getInput()
-			. '<a class="btn modal" title="' . JText::_('COM_MODULES_CHANGE_POSITION_TITLE') . '"  href="' . $link
-			. '" rel="{handler: \'iframe\', size: {x: 800, y: 450}}">'
-			. JText::_('COM_MODULES_CHANGE_POSITION_BUTTON') . '</a>';
-		$html[] = '</div>';
-
-		return implode("\n", $html);
+		return JLayoutHelper::render($this->layout, $displayData);
 	}
 }

--- a/libraries/cms/form/field/moduleposition.php
+++ b/libraries/cms/form/field/moduleposition.php
@@ -138,7 +138,12 @@ class JFormFieldModulePosition extends JFormFieldText
 	 */
 	protected function getInput()
 	{
-		return JLayoutHelper::render($this->layout, $this->getLayoutData());
+		if (empty($this->layout))
+		{
+			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+		}
+
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
 	}
 
 	/**


### PR DESCRIPTION
## Move form field moduleposition to layouts and use Bootstrap modal

Moduleposition is yet another form field that uses mootools modal. Now it uses JLayout.
## B/C

None as the default behavior remains the mootools modal, but overriding with Bootstrap modal (or any other modal) is now possible and easy.
### Testing

Apply patch.
Select Hathor as the admin template.
Try to edit any module in the module manager and select another position.
You should see a Bootstrap modal and the functionality should be the same.
Now delete /hathor/html/layouts/joomla/form/field/moduleposition.php
Repeat the testing procedure, but now you should see a mootools modal.
