### PR TITLE
com_installer Manage - Moved sidebar Filters to Search Tools

### DIFF
--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -144,13 +144,15 @@ class InstallerHelper
 	 * Get a list of filter options for the application clients.
 	 *
 	 * @return  array  An array of JHtmlOption elements.
+	 *
+	 * @since   3.5
 	 */
 	public static function getClientOptions()
 	{
 		// Build the filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '0', JText::_('JSITE'));
-		$options[]	= JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '0', JText::_('JSITE'));
+		$options[] = JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
 
 		return $options;
 	}
@@ -159,15 +161,17 @@ class InstallerHelper
 	 * Get a list of filter options for the application statuses.
 	 *
 	 * @return  array  An array of JHtmlOption elements.
+	 *
+	 * @since   3.5
 	 */
 	public static function getStateOptions()
 	{
 		// Build the filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '0', JText::_('JDISABLED'));
-		$options[]	= JHtml::_('select.option', '1', JText::_('JENABLED'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('JPROTECTED'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('JUNPROTECTED'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '0', JText::_('JDISABLED'));
+		$options[] = JHtml::_('select.option', '1', JText::_('JENABLED'));
+		$options[] = JHtml::_('select.option', '2', JText::_('JPROTECTED'));
+		$options[] = JHtml::_('select.option', '3', JText::_('JUNPROTECTED'));
 
 		return $options;
 	}

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -87,7 +87,7 @@ class InstallerHelper
 
 		foreach ($types as $type)
 		{
-			$options[] = JHtml::_('select.option', $type, 'COM_INSTALLER_TYPE_' . strtoupper($type));
+			$options[] = JHtml::_('select.option', $type, JText::_('COM_INSTALLER_TYPE_' . strtoupper($type)));
 		}
 
 		return $options;
@@ -138,5 +138,37 @@ class InstallerHelper
 		$result = JHelperContent::getActions('com_installer');
 
 		return $result;
+	}
+
+	/**
+	 * Get a list of filter options for the application clients.
+	 *
+	 * @return  array  An array of JHtmlOption elements.
+	 */
+	public static function getClientOptions()
+	{
+		// Build the filter options.
+		$options	= array();
+		$options[]	= JHtml::_('select.option', '0', JText::_('JSITE'));
+		$options[]	= JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
+
+		return $options;
+	}
+
+	/**
+	 * Get a list of filter options for the application statuses.
+	 *
+	 * @return  array  An array of JHtmlOption elements.
+	 */
+	public static function getStateOptions()
+	{
+		// Build the filter options.
+		$options	= array();
+		$options[]	= JHtml::_('select.option', '0', JText::_('JDISABLED'));
+		$options[]	= JHtml::_('select.option', '1', JText::_('JENABLED'));
+		$options[]	= JHtml::_('select.option', '2', JText::_('JPROTECTED'));
+		$options[]	= JHtml::_('select.option', '3', JText::_('JUNPROTECTED'));
+
+		return $options;
 	}
 }

--- a/administrator/components/com_installer/models/fields/extensionstatus.php
+++ b/administrator/components/com_installer/models/fields/extensionstatus.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('JPATH_BASE') or die;
+defined('_JEXEC') or die;
 
 JFormHelper::loadFieldClass('list');
 
@@ -23,20 +23,22 @@ class JFormFieldExtensionStatus extends JFormFieldList
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
-	 * @since   1.6
+	 * @var    string
+	 * @since  3.5
 	 */
 	protected $type = 'ExtensionStatus';
+
 	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   1.6
+	 * @since   3.5
 	 */
 	public function getOptions()
 	{
 		$options2 = InstallerHelper::getStateOptions();
+
 		return array_merge(parent::getOptions(), $options2);
 	}
 }

--- a/administrator/components/com_installer/models/fields/extensionstatus.php
+++ b/administrator/components/com_installer/models/fields/extensionstatus.php
@@ -37,8 +37,8 @@ class JFormFieldExtensionStatus extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options2 = InstallerHelper::getStateOptions();
+		$options = InstallerHelper::getStateOptions();
 
-		return array_merge(parent::getOptions(), $options2);
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_installer/models/fields/extensionstatus.php
+++ b/administrator/components/com_installer/models/fields/extensionstatus.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_installer
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+JFormHelper::loadFieldClass('list');
+
+require_once __DIR__ . '/../../helpers/installer.php';
+
+/**
+ * Status Field class for the Joomla Framework.
+ *
+ * @since  3.5
+ */
+class JFormFieldExtensionStatus extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var		string
+	 * @since   1.6
+	 */
+	protected $type = 'ExtensionStatus';
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   1.6
+	 */
+	public function getOptions()
+	{
+		$options2 = InstallerHelper::getStateOptions();
+		return array_merge(parent::getOptions(), $options2);
+	}
+}

--- a/administrator/components/com_installer/models/fields/folder.php
+++ b/administrator/components/com_installer/models/fields/folder.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('JPATH_BASE') or die;
+defined('_JEXEC') or die;
 
 JFormHelper::loadFieldClass('list');
 

--- a/administrator/components/com_installer/models/fields/folder.php
+++ b/administrator/components/com_installer/models/fields/folder.php
@@ -23,20 +23,22 @@ class JFormFieldFolder extends JFormFieldList
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
-	 * @since   1.6
+	 * @var    string
+	 * @since  3.5
 	 */
 	protected $type = 'Folder';
+
 	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   1.6
+	 * @since   3.5
 	 */
 	public function getOptions()
 	{
-		$options2 = InstallerHelper::getExtensionGroupes();
-		return array_merge(parent::getOptions(), $options2);
+		$options = InstallerHelper::getExtensionGroupes();
+
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_installer/models/fields/folder.php
+++ b/administrator/components/com_installer/models/fields/folder.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_installer
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+JFormHelper::loadFieldClass('list');
+
+require_once __DIR__ . '/../../helpers/installer.php';
+
+/**
+ * Folder Field class for the Joomla Framework.
+ *
+ * @since  3.5
+ */
+class JFormFieldFolder extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var		string
+	 * @since   1.6
+	 */
+	protected $type = 'Folder';
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   1.6
+	 */
+	public function getOptions()
+	{
+		$options2 = InstallerHelper::getExtensionGroupes();
+		return array_merge(parent::getOptions(), $options2);
+	}
+}

--- a/administrator/components/com_installer/models/fields/location.php
+++ b/administrator/components/com_installer/models/fields/location.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('JPATH_BASE') or die;
+defined('_JEXEC') or die;
 
 JFormHelper::loadFieldClass('list');
 

--- a/administrator/components/com_installer/models/fields/location.php
+++ b/administrator/components/com_installer/models/fields/location.php
@@ -23,20 +23,22 @@ class JFormFieldLocation extends JFormFieldList
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
-	 * @since   1.6
+	 * @var	   string
+	 * @since  3.5
 	 */
 	protected $type = 'Location';
+
 	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   1.6
+	 * @since   3.5
 	 */
 	public function getOptions()
 	{
 		$options = InstallerHelper::getClientOptions();
+
 		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_installer/models/fields/location.php
+++ b/administrator/components/com_installer/models/fields/location.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_installer
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+JFormHelper::loadFieldClass('list');
+
+require_once __DIR__ . '/../../helpers/installer.php';
+
+/**
+ * Location Field class for the Joomla Framework.
+ *
+ * @since  3.5
+ */
+class JFormFieldLocation extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var		string
+	 * @since   1.6
+	 */
+	protected $type = 'Location';
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   1.6
+	 */
+	public function getOptions()
+	{
+		$options = InstallerHelper::getClientOptions();
+		return array_merge(parent::getOptions(), $options);
+	}
+}

--- a/administrator/components/com_installer/models/fields/type.php
+++ b/administrator/components/com_installer/models/fields/type.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('JPATH_BASE') or die;
+defined('_JEXEC') or die;
 
 JFormHelper::loadFieldClass('list');
 
@@ -23,20 +23,22 @@ class JFormFieldType extends JFormFieldList
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
-	 * @since   1.6
+	 * @var	   string
+	 * @since  3.5
 	 */
 	protected $type = 'Type';
+
 	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   1.6
+	 * @since   3.5
 	 */
 	public function getOptions()
 	{
 		$options = InstallerHelper::getExtensionTypes();
+
 		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_installer/models/fields/type.php
+++ b/administrator/components/com_installer/models/fields/type.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_installer
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+JFormHelper::loadFieldClass('list');
+
+require_once __DIR__ . '/../../helpers/installer.php';
+
+/**
+ * Type Field class for the Joomla Framework.
+ *
+ * @since  3.5
+ */
+class JFormFieldType extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var		string
+	 * @since   1.6
+	 */
+	protected $type = 'Type';
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   1.6
+	 */
+	public function getOptions()
+	{
+		$options = InstallerHelper::getExtensionTypes();
+		return array_merge(parent::getOptions(), $options);
+	}
+}

--- a/administrator/components/com_installer/models/forms/filter_manage.xml
+++ b/administrator/components/com_installer/models/forms/filter_manage.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset addfieldpath="/administrator/components/com_installer/models/fields" />
+
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                hint="JSEARCH_FILTER"
+                />
+
+        <field
+                name="client_id"
+                type="location"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
+        </field>
+
+        <field
+                name="status"
+                type="extensionstatus"
+                label="COM_PLUGINS_FILTER_PUBLISHED"
+                description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_PUBLISHED</option>
+        </field>
+
+        <field
+                name="type"
+                type="type"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_TYPE_SELECT</option>
+        </field>
+
+        <field
+                name="group"
+                type="folder"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_FOLDER_SELECT</option>
+        </field>
+
+    </fields>
+    <fields name="list">
+        <field
+                name="limit"
+                type="limitbox"
+                class="input-mini"
+                default="25"
+                onchange="this.form.submit();"
+                />
+    </fields>
+</form>

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -73,6 +73,8 @@ class InstallerModelManage extends InstallerModel
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
 
+		$this->setState('list.ordering', 'name');
+
 		parent::populateState('name', 'asc');
 	}
 

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -34,19 +34,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 	<?php if ($this->ftp) : ?>
 		<?php echo $this->loadTemplate('ftp'); ?>
 	<?php endif; ?>
-		<div id="filter-bar" class="btn-toolbar">
-			<div class="btn-group pull-right hidden-phone">
-				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-			<div class="filter-search btn-group pull-left">
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_INSTALLER_FILTER_LABEL'); ?>" />
-			</div>
-			<div class="btn-group pull-left">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-			</div>
-		</div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -38,11 +38,11 @@ class InstallerViewManage extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state 			= $this->get('State');
-		$this->items 			= $this->get('Items');
-		$this->pagination 		= $this->get('Pagination');
-		$this->filterForm		= $this->get('FilterForm');
-		$this->activeFilters	= $this->get('ActiveFilters');
+		$this->state         = $this->get('State');
+		$this->items         = $this->get('Items');
+		$this->pagination    = $this->get('Pagination');
+		$this->filterForm    = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -68,7 +68,7 @@ class InstallerViewManage extends InstallerViewDefault
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_installer');
+		$canDo = JHelperContent::getActions('com_installer');
 
 		if ($canDo->get('core.edit.state'))
 		{

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -38,9 +38,11 @@ class InstallerViewManage extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state      = $this->get('State');
-		$this->items      = $this->get('Items');
-		$this->pagination = $this->get('Pagination');
+		$this->state 			= $this->get('State');
+		$this->items 			= $this->get('Items');
+		$this->pagination 		= $this->get('Pagination');
+		$this->filterForm		= $this->get('FilterForm');
+		$this->activeFilters	= $this->get('ActiveFilters');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -85,58 +87,6 @@ class InstallerViewManage extends InstallerViewDefault
 		}
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=manage');
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'),
-			'filter_client_id',
-			JHtml::_(
-				'select.options',
-				array('0' => 'JSITE', '1' => 'JADMINISTRATOR'),
-				'value',
-				'text',
-				$this->state->get('filter.client_id'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_STATE_SELECT'),
-			'filter_status',
-			JHtml::_(
-				'select.options',
-				array('0' => 'JDISABLED', '1' => 'JENABLED', '2' => 'JPROTECTED', '3' => 'JUNPROTECTED'),
-				'value',
-				'text',
-				$this->state->get('filter.status'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'),
-			'filter_type',
-			JHtml::_(
-				'select.options',
-				InstallerHelper::getExtensionTypes(),
-				'value',
-				'text',
-				$this->state->get('filter.type'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'),
-			'filter_group',
-			JHtml::_(
-				'select.options',
-				array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))),
-				'value',
-				'text',
-				$this->state->get('filter.group'),
-				true
-			)
-		);
 
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_MANAGE');


### PR DESCRIPTION
This PR moves Filters from left sidebar to Search Tools.
# Testing instructions
## Before this PR

Extensions > Manage > **Manage**
1. Left sidebar has 4 filter options (Select: Location, Status, Type, Folder) that cannot be reset easily to original state with one button.

![extension-manage-before](https://cloud.githubusercontent.com/assets/1217850/9295876/43ceb9b8-447d-11e5-8123-5beba59e6ad9.png)
## After this PR

Extensions > Manage > **Manage**
1. The Filters have been moved from sidebar to Search Tools in middle column. All filters can be reset with the "Clear" button.

![extension-manage-after](https://cloud.githubusercontent.com/assets/1217850/9295875/43b81ef6-447d-11e5-9eb1-c4c33c9c6459.png)
## Technical notes
1. During development I got the following SQL error:
   Error - Unknown column "Array" in "order clause" SQL=SELECT _,2_protected+(1-protected)*enabled as status FROM test_extensions WHERE state=0 ORDER BY Array ASC LIMIT 0, 20
   I fixed it in administrator/components/com_installer/models/manage.php in the method 
   protected function populateState($ordering = null, $direction = null)
   I added this line: $this->setState('list.ordering', 'name');
2. To get the correct list of installer types, I had to add JText to the helper file administrator/components/com_installer/helpers/installer.php in the method 
   public static function getExtensionTypes()

**Please triple double check if these two changes did not break anything anywhere else**
