### PR TITLE
com_content - duplicate ordering articles + featured

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -82,40 +82,6 @@
 	</fields>
 	<fields name="list">
 		<field
-			name="fullordering"
-			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
-			onchange="this.form.submit();"
-			default="a.id DESC"
-			>
-			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.state ASC">JSTATUS_ASC</option>
-			<option value="a.state DESC">JSTATUS_DESC</option>
-			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="category_title ASC">JCATEGORY_ASC</option>
-			<option value="category_title DESC">JCATEGORY_DESC</option>
-			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
-			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
-			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.created_by ASC">JAUTHOR_ASC</option>
-			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
-			<option value="a.created ASC">JDATE_ASC</option>
-			<option value="a.created DESC">JDATE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-			<option value="a.featured ASC">JFEATURED_ASC</option>
-			<option value="a.featured DESC">JFEATURED_DESC</option>
-			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>
-			<option value="a.hits DESC">JGLOBAL_HITS_DESC</option>
-		</field>
-		<field
 			name="limit"
 			type="limitbox"
 			class="input-mini"

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -82,36 +82,6 @@
 	</fields>
 	<fields name="list">
 		<field
-			name="fullordering"
-			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
-			onchange="this.form.submit();"
-			default="a.title ASC"
-			>
-			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="fp.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="fp.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.state ASC">JSTATUS_ASC</option>
-			<option value="a.state DESC">JSTATUS_DESC</option>
-			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="category_title ASC">JCATEGORY_ASC</option>
-			<option value="category_title DESC">JCATEGORY_DESC</option>
-			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
-			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.created_by ASC">JAUTHOR_ASC</option>
-			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
-			<option value="a.created ASC">JDATE_ASC</option>
-			<option value="a.created DESC">JDATE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>
-			<option value="a.hits DESC">JGLOBAL_HITS_DESC</option>
-		</field>
-		<field
 			name="limit"
 			type="limitbox"
 			class="input-mini"


### PR DESCRIPTION
The **Articles** and **Featured Articles** list view both have two ordering options:
1. You can **order the list** of Article or Featured Article items on any column **by clicking on the column heading** (Ordering, Status, Title, Access, Author, Language, Date, Hits, ID). You can reverse the order direction by clicking a second time on the same column heading.
2. Another way to **order the list** is to click the **Sort Table By: dropdown option**. However that name is never listed there. The list is already ordered by default and the default ordering option is: "ID descending". 

IMHO option 2 **Sort Table By: dropdown option is not very user friendly** for new users: they don't understand what the "ID descending" button means. And for experienced users it's another extra button / option to focus on. And because **all ordering options** are already **available via column headers** (option 1), I decided to create this PR **to remove the duplicate ordering dropdown option**
# Testing instructions
## Before the PR
### Content > **Articles**

The list of Articles can be ordered by clicking on column headers, 
and by clicking on the "Sort Table By" dropdown option on the top right.

![articles-remove-duplicate-ordering](https://cloud.githubusercontent.com/assets/1217850/9301212/27095554-44cd-11e5-958b-86d19e483666.png)
### Content > Articles > **Featured Articles**

The list of Featured Articles can be ordered by clicking on column headers, 
and by clicking on the "Sort Table By" dropdown option on the top right.

![featuredarticles-remove-duplicate-ordering](https://cloud.githubusercontent.com/assets/1217850/9301210/2708eb3c-44cd-11e5-9a36-49f6136a4f6e.png)
## After the PR
### Content > **Articles**

The list of Articles can be ordered by clicking on column headers. The duplicate "Sort Table By" dropdown has been removed and the user has one option less too focus on.

![articles-remove-duplicate-ordering-after](https://cloud.githubusercontent.com/assets/1217850/9301211/2708fa00-44cd-11e5-8dbc-82bf1a12e20f.png)
### Content > Articles > **Featured Articles**

The list of Featured Articles can be ordered by clicking on column headers. The duplicate "Sort Table By" dropdown has been removed and the user has one option less too focus on.

![featuredarticles-remove-duplicate-ordering-after](https://cloud.githubusercontent.com/assets/1217850/9301213/270c112c-44cd-11e5-9b19-a4f9b4263086.png)
