### PR TITLE
com_categories - remove duplicate ordering option

### DIFF
--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -62,29 +62,6 @@
 	</fields>
 	<fields name="list">
 		<field
-			name="fullordering"
-			type="list"
-			label="JGLOBAL_SORT_BY"
-			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
-			onchange="this.form.submit();"
-			default="a.lft ASC"
-			>
-			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.published ASC">JSTATUS_ASC</option>
-			<option value="a.published DESC">JSTATUS_DESC</option>
-			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
-			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-		</field>
-		<field
 			name="limit"
 			type="limitbox"
 			class="input-mini"


### PR DESCRIPTION
This PR is similar to PR #7712

The **Categories** list view has two ordering options:
1. You can **order the list** of Article or Featured Article items on any column **by clicking on the column heading** (Status, Title, Access, Author, Language, Date, Hits, ID). You can reverse the order direction by clicking a second time on the same column heading.
2. Another way to **order the list** is to click the **Sort Table By: dropdown option**. However that name is never visible there. The list is already ordered by default and the default ordering option is: "**Ordering ascending**". 

IMHO option 2 **Sort Table By: dropdown option is not very user friendly** for new users. The "**Ordering ascending**" option is confusing. And for experienced users it's another option to focus on. And because **all ordering options** are already **available via column headers** (option 1), I decided to create this PR **to remove the duplicate ordering dropdown option**
# Testing instructions
## Before the PR
### Content > **Categories**

The list of Articles can be ordered by clicking on column headers, 
and by clicking on the "Sort Table By" dropdown option on the top right.

![categories-remove-duplicate-ordering](https://cloud.githubusercontent.com/assets/1217850/9301561/a8f76d88-44cf-11e5-81ef-9f7902d4baf2.png)
## After the PR
### Content > **Categories**

The list of Articles can be ordered by clicking on column headers. The duplicate "Sort Table By" dropdown has been removed and the user has one option less too focus on.

![categories-remove-duplicate-ordering-after](https://cloud.githubusercontent.com/assets/1217850/9301560/a8f6dd6e-44cf-11e5-99c6-e6f48a6d2108.png)
### Note that com_categories is used by other components!

Banners, Contacts, Newsfeeds (and the removed component Weblinks) all use com_categories to manage the categories for their items. After installing this PR the duplicate option should be removed for those components as well.
For example the Category view of the Banners Component:
### Components > Banners > Categories
#### Before PR

![categories-banners-remove-duplicate-ordering](https://cloud.githubusercontent.com/assets/1217850/9301562/a8f9f58a-44cf-11e5-8bad-a2b85c27f40b.png)
#### After PR

![categories-banners-remove-duplicate-ordering-after](https://cloud.githubusercontent.com/assets/1217850/9301559/a8f584aa-44cf-11e5-96b1-408717600166.png)
