### PR TITLE
com_users - remove duplicate ordering option

### DIFF
--- a/administrator/components/com_users/models/forms/filter_users.xml
+++ b/administrator/components/com_users/models/forms/filter_users.xml
@@ -48,32 +48,6 @@
 	</fields>
 	<fields name="list">
 		<field
-			name="fullordering"
-			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
-			onchange="this.form.submit();"
-			default="a.title ASC"
-			>
-			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="a.name ASC">COM_USERS_HEADING_NAME_ASC</option>
-			<option value="a.name DESC">COM_USERS_HEADING_NAME_DESC</option>
-			<option value="a.username ASC">COM_USERS_HEADING_USERNAME_ASC</option>
-			<option value="a.username DESC">COM_USERS_HEADING_USERNAME_DESC</option>
-			<option value="a.block ASC">COM_USERS_HEADING_ENABLED_ASC</option>
-			<option value="a.block DESC">COM_USERS_HEADING_ENABLED_DESC</option>
-			<option value="a.activation ASC">COM_USERS_HEADING_ACTIVATED_ASC</option>
-			<option value="a.activation DESC">COM_USERS_HEADING_ACTIVATED_DESC</option>
-			<option value="a.email ASC">COM_USERS_HEADING_EMAIL_ASC</option>
-			<option value="a.email DESC">COM_USERS_HEADING_EMAIL_DESC</option>
-			<option value="a.lastvisitDate ASC">COM_USERS_HEADING_LAST_VISIT_DATE_ASC</option>
-			<option value="a.lastvisitDate DESC">COM_USERS_HEADING_LAST_VISIT_DATE_DESC</option>
-			<option value="a.registerDate ASC">COM_USERS_HEADING_REGISTRATION_DATE_ASC</option>
-			<option value="a.registerDate DESC">COM_USERS_HEADING_REGISTRATION_DATE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-		</field>
-		<field
 			name="limit"
 			type="limitbox"
 			class="input-mini"

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -94,21 +94,6 @@ JFactory::getDocument()->addScriptDeclaration('
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 				<?php echo $this->pagination->getLimitBox(); ?>
 			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
-				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php if ($listDirn == 'asc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php if ($listDirn == 'desc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING');  ?></option>
-				</select>
-			</div>
-			<div class="btn-group pull-right">
-				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
-				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY');?></option>
-					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
-				</select>
-			</div>
 		</div>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -68,21 +68,6 @@ JFactory::getDocument()->addScriptDeclaration('
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 				<?php echo $this->pagination->getLimitBox(); ?>
 			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
-				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php if ($listDirn == 'asc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php if ($listDirn == 'desc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING');  ?></option>
-				</select>
-			</div>
-			<div class="btn-group pull-right">
-				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
-				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY');?></option>
-					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
-				</select>
-			</div>
 		</div>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -57,21 +57,6 @@ JFactory::getDocument()->addScriptDeclaration('
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 				<?php echo $this->pagination->getLimitBox(); ?>
 			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
-				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php if ($listDirn == 'asc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php if ($listDirn == 'desc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING');  ?></option>
-				</select>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
-				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY');?></option>
-					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
-				</select>
-			</div>
 		</div>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>


### PR DESCRIPTION
This PR is similar to PR #7712 + #7713

The list views of the Users Back-end Component all have two ordering options:
1. You can **order the list** on any column **by clicking on the column heading** (Status, Title, Access, Author, Language, Date, Hits, ID). You can reverse the order direction by clicking a second time on the same column heading.
2. Another way to **order the list** is to click the **Sort Table By: dropdown option**. 

IMHO option 2 **Sort Table By: dropdown option is not very user friendly** for new users and for experienced users it's another option to focus on. Because **all ordering options** are already **available via column headers** (option 1), I decided to create this PR **to remove the duplicate ordering dropdown option**
# Testing instructions
## Before the PR

The lists can be ordered by clicking on column headers, 
and by clicking on the "Sort Table By" dropdown option on the top right.
### Users > Manage > **Users**

![users-users](https://cloud.githubusercontent.com/assets/1217850/9301928/969c9228-44d2-11e5-824b-6aca0fa042c8.png)
### Users > Manage > **User Groups**

![users-usergroups](https://cloud.githubusercontent.com/assets/1217850/9301925/9692dae4-44d2-11e5-9f67-00815045d15f.png)
### Users > Manage > **Viewing Access Levels**

![users-viewaccesslevels](https://cloud.githubusercontent.com/assets/1217850/9301926/96950be8-44d2-11e5-815f-1097333ac09e.png)
### Users > Manage > **User Notes**

![users-usernotes](https://cloud.githubusercontent.com/assets/1217850/9301927/96952312-44d2-11e5-943f-09d77ca60eb0.png)
### Users > Manage > **Note Categories**

This view won't be affected by this PR, but PR #7713 will remove the extra ordering option.
![users-notescategories](https://cloud.githubusercontent.com/assets/1217850/9301923/968ffda6-44d2-11e5-9605-5de2ee305a78.png)
## After the PR

The lists can be ordered by clicking on column headers. The duplicate "Sort Table By" dropdown has been removed and the user has one option less too focus on.
### Users > Manage > **Users**

![users-users-after](https://cloud.githubusercontent.com/assets/1217850/9301924/96905968-44d2-11e5-8c4c-03b63bea0c95.png)
### Users > Manage > **User Groups**

![users-usergroups-after](https://cloud.githubusercontent.com/assets/1217850/9301922/9686fc88-44d2-11e5-81f9-dd497b06c36b.png)
### Users > Manage > **Viewing Access Levels**

![users-viewaccesslevels-after](https://cloud.githubusercontent.com/assets/1217850/9301921/966fdd14-44d2-11e5-830c-7ed5528dfaaf.png)
### Users > Manage > **User Notes**

![users-usernotes-after](https://cloud.githubusercontent.com/assets/1217850/9301929/96a67d9c-44d2-11e5-87b6-5c9334a006f4.png)
### Users > Manage > **Note Categories**

This view won't be affected by this PR, but PR #7713 will remove the extra ordering option.
![users-notescategories](https://cloud.githubusercontent.com/assets/1217850/9301923/968ffda6-44d2-11e5-9605-5de2ee305a78.png)
