### PR TITLE
Add "btn-group-yesno" class for show title field on frontend module editing

### DIFF
--- a/components/com_config/model/form/modules.xml
+++ b/components/com_config/model/form/modules.xml
@@ -31,7 +31,7 @@
 		/>
 
 		<field name="showtitle" type="radio"
-			class="btn-group"
+			class="btn-group btn-group-yesno"
 			default="1"
 			description="COM_MODULES_FIELD_SHOWTITLE_DESC"
 			label="COM_MODULES_FIELD_SHOWTITLE_LABEL"


### PR DESCRIPTION
The group btn class for "yes/no" buttons should be:
`btn-group btn-group-yesno`

**Right now we have**
Backend Module Editing:
Show Title field class: `btn-group btn-group-yesno`
All other "yes/no" fields class:  `btn-group btn-group-yesno`

Frontend Module Editing:
Show Title field class: `btn-group`
All other "yes/no" fields class:  `btn-group btn-group-yesno`

Apply PR then all grouped buttons should be displayed consistently.
