### PR TITLE
com_menus Menu Items - remove duplicate ordering

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -61,33 +61,6 @@
 	</fields>
 	<fields name="list">
 		<field
-			name="fullordering"
-			type="list"
-			label="JGLOBAL_SORT_BY"
-			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
-			onchange="this.form.submit();"
-			default="a.lft ASC"
-			>
-			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.published ASC">JSTATUS_ASC</option>
-			<option value="a.published DESC">JSTATUS_DESC</option>
-			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="a.home ASC">COM_MENUS_HEADING_HOME_ASC</option>
-			<option value="a.home DESC">COM_MENUS_HEADING_HOME_DESC</option>
-			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
-			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
-			<option value="association DESC" requries="associations">JASSOCIATIONS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-		</field>
-		<field
 			name="limit"
 			type="limitbox"
 			class="input-mini"


### PR DESCRIPTION
This PR is similar to PR #7712 + #7713 + #7714

The list of Menu Items has two ordering options:
1. You can **order the list** on any column **by clicking on the column heading** (Ordering, Status, Title, Home, Access, Language and ID). You can reverse the order direction by clicking a second time on the same column heading.
2. Another way to **order the list** is to click the **Sort Table By: dropdown option**. 

This PR **removes the duplicate ordering dropdown option** like with the PRs mentioned above.
# Testing instructions
## Before the PR

The lists can be ordered by clicking on column headers, 
and by clicking on the "Sort Table By" dropdown option on the top right.
### Menus > [click a menu] e.g. **Main Menu** > the left sidebar displays **Menu Items**

![menu-items](https://cloud.githubusercontent.com/assets/1217850/9316497/a67d1a6a-4535-11e5-9453-351aea0c270f.png)
## After the PR

The lists can be ordered by clicking on column headers. The duplicate "Sort Table By" dropdown has been removed and the user has one option less too focus on.

![menu-items-after](https://cloud.githubusercontent.com/assets/1217850/9316498/a67ff334-4535-11e5-8bce-70235fae3978.png)
