### PR TITLE
com_config - prevent wrong database settings

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -97,6 +97,21 @@ class ConfigModelApplication extends ConfigModelForm
 	{
 		$app = JFactory::getApplication();
 
+		// Check that we aren't setting wrong database configuration
+		$options = array(
+			'driver'   => $data['dbtype'],
+			'host'     => $data['host'],
+			'user'     => $data['user'],
+			'password' => JFactory::getConfig()->get('password'),
+			'database' => $data['db'],
+			'prefix'   => $data['dbprefix']
+		);
+		$dbc = JDatabaseDriver::getInstance($options)->getConnection();
+		if (!$dbc)
+		{
+			$app->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_CONNECT'), 'error');
+			return false;
+		}
 		// Save the rules
 		if (isset($data['rules']))
 		{


### PR DESCRIPTION
#### Steps to reproduce the issue

in Administration : System -> Global configuration - Database setting
accidentally change  for example  the hostname from localhost to localost  and save

![j35dev administration global configuration](https://cloud.githubusercontent.com/assets/181681/9316637/7cb681a2-4536-11e5-8b11-ab63e2ee3be8.png)
#### Expected result

Some warning message
#### Actual result

Error displaying the error page: Application Instantiation Error: Could not connect to MySQL.
#### After apply the pr

you got an error message and wrong data are not saved
