### PR TITLE
Remove Temporary PHPCS Exclusion

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/modal_options.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal_options.php
@@ -16,7 +16,7 @@ $i = 0;
 <?php foreach ($fieldSets as $name => $fieldSet) : ?>
 	<?php
 	$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CATEGORIES_' . $name . '_FIELDSET_LABEL';
-	echo JHtml::_('bootstrap.addSlide', 'categoryOptions', JText::_($label), 'collapse' . $i++);
+	echo JHtml::_('bootstrap.addSlide', 'categoryOptions', JText::_($label), 'collapse' . ($i++));
 	if (isset($fieldSet->description) && trim($fieldSet->description))
 	{
 		echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';

--- a/administrator/components/com_menus/views/item/tmpl/edit_options.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_options.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 		if (!(($this->item->link == 'index.php?option=com_wrapper&view=wrapper') && $fieldSet->name == 'request')
 				&& !($this->item->link == 'index.php?Itemid=' && $fieldSet->name == 'aliasoptions')) :
 			$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_MENUS_' . $name . '_FIELDSET_LABEL';
-			echo JHtml::_('bootstrap.addSlide', 'menuOptions', JText::_($label), 'collapse' . $i++);
+			echo JHtml::_('bootstrap.addSlide', 'menuOptions', JText::_($label), 'collapse' . ($i++));
 				if (isset($fieldSet->description) && trim($fieldSet->description)) :
 					echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
 				endif;

--- a/administrator/components/com_modules/views/module/tmpl/edit_options.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_options.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_MODULES_' . $name . '_FIELDSET_LABEL';
 		$class = isset($fieldSet->class) && !empty($fieldSet->class) ? $fieldSet->class : '';
 
-		echo JHtml::_('bootstrap.addSlide', 'moduleOptions', JText::_($label), 'collapse' . $i++, $class);
+		echo JHtml::_('bootstrap.addSlide', 'moduleOptions', JText::_($label), 'collapse' . ($i++), $class);
 			if (isset($fieldSet->description) && trim($fieldSet->description)) :
 				echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
 			endif;

--- a/administrator/components/com_tags/views/tag/tmpl/edit_options.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit_options.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
 
 	foreach ($fieldSets as $name => $fieldSet) :
 		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_TAGS_' . $name . '_FIELDSET_LABEL';
-		echo JHtml::_('bootstrap.addSlide', 'categoryOptions', JText::_($label), 'collapse' . $i++);
+		echo JHtml::_('bootstrap.addSlide', 'categoryOptions', JText::_($label), 'collapse' . ($i++));
 			if (isset($fieldSet->description) && trim($fieldSet->description)) :
 				echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
 			endif;

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -76,8 +76,6 @@
 
  <rule ref="Squiz.Operators.IncrementDecrementUsage">
   <exclude name="Squiz.Operators.IncrementDecrementUsage.processAssignment"/>
-  <!-- These exceptions are temporary -->
-  <exclude-pattern type="relative">administrator/components/*</exclude-pattern>
  </rule>
 
  <rule ref="Squiz.Scope.StaticThisUsage"/>


### PR DESCRIPTION
Removes a temporary code style excemption on increment and decrement (`$i++` and `$i--`)
