### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the installation folder

### DIFF
--- a/installation/controller/setlanguage.php
+++ b/installation/controller/setlanguage.php
@@ -55,8 +55,8 @@ class InstallationControllerSetlanguage extends JControllerBase
 		$model = new InstallationModelSetup;
 
 		// Get the posted values from the request and validate them.
-		$data = $this->input->post->get('jform', array(), 'array');
-		$return	= $model->validate($data, 'preinstall');
+		$data   = $this->input->post->get('jform', array(), 'array');
+		$return = $model->validate($data, 'preinstall');
 
 		$r = new stdClass;
 

--- a/installation/form/field/prefix.php
+++ b/installation/form/field/prefix.php
@@ -33,11 +33,11 @@ class InstallationFormFieldPrefix extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$size		= $this->element['size'] ? abs((int) $this->element['size']) : 5;
-		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		$class		= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$size      = $this->element['size'] ? abs((int) $this->element['size']) : 5;
+		$maxLength = $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
+		$class     = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$readonly  = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
+		$disabled  = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 
 		// Make sure somebody doesn't put in a too large prefix size value.
 		if ($size > 10)
@@ -51,8 +51,8 @@ class InstallationFormFieldPrefix extends JFormField
 		if (empty($session['db_prefix']))
 		{
 			// Create the random prefix.
-			$prefix = '';
-			$chars = range('a', 'z');
+			$prefix  = '';
+			$chars   = range('a', 'z');
 			$numbers = range(0, 9);
 
 			// We want the fist character to be a random letter.
@@ -77,7 +77,7 @@ class InstallationFormFieldPrefix extends JFormField
 		}
 
 		// Initialize JavaScript field attributes.
-		$onchange	= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' .
 				' value="' . htmlspecialchars($prefix, ENT_COMPAT, 'UTF-8') . '"' .

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -123,7 +123,7 @@ class InstallationModelSetup extends JModelBase
 
 		// Get the posted values from the request and validate them.
 		$data   = $app->input->post->get('jform', array(), 'array');
-		$return	= $this->validate($data, $page);
+		$return = $this->validate($data, $page);
 
 		// Attempt to save the data before validation.
 		$form = $this->getForm();


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the installation folder. The other folders will follow in the next days :smile: 
