### PR TITLE
Fix title in com_installer

### DIFF
--- a/administrator/components/com_installer/views/default/view.php
+++ b/administrator/components/com_installer/views/default/view.php
@@ -80,10 +80,6 @@ class InstallerViewDefault extends JViewLegacy
 			JToolbarHelper::divider();
 		}
 
-		// Document.
-		$document = JFactory::getDocument();
-		$document->setTitle(JText::_('COM_INSTALLER_TITLE_' . $this->getName()));
-
 		// Render side bar.
 		$this->sidebar = JHtmlSidebar::render();
 	}


### PR DESCRIPTION
All administrator components have the `<title>` set to sitename - component etc
eg
`<title>SiteName - Administration - Contacts</title>`

Except for com_installer which is just displaying
`<title>Extension manager - Install</title>`

After this PR the com_installer titles will be consistent with all the others and will look like
`<title>SiteName - Administration - Extensions: Install</title>`

You can obviously see the title tag in the source but it is also displayed as the browser tab title
