### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the admin folder without components

### DIFF
--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -50,7 +50,7 @@ else
 
 	if ($feed != false) :
 		// Image handling
-		$iUrl	= isset($feed->image)	? $feed->image	: null;
+		$iUrl   = isset($feed->image) ? $feed->image : null;
 		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
 		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> ! important"  class="feed<?php echo $moduleclass_sfx; ?>">

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -26,7 +26,7 @@ abstract class ModMenuHelper
 	public static function getMenus()
 	{
 		$db     = JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$query = $db->getQuery(true)
 			->select('a.*, SUM(b.home) AS home')
 			->from('#__menu_types AS a')
 			->join('LEFT', '#__menu AS b ON b.menutype = a.menutype AND b.home != 0')

--- a/administrator/modules/mod_status/mod_status.php
+++ b/administrator/modules/mod_status/mod_status.php
@@ -9,14 +9,14 @@
 
 defined('_JEXEC') or die;
 
-$config	= JFactory::getConfig();
+$config = JFactory::getConfig();
 $user   = JFactory::getUser();
 $db     = JFactory::getDbo();
 $lang   = JFactory::getLanguage();
 $input  = JFactory::getApplication()->input;
 
 // Get the number of unread messages in your inbox.
-$query	= $db->getQuery(true)
+$query = $db->getQuery(true)
 	->select('COUNT(*)')
 	->from('#__messages')
 	->where('state = 0 AND user_id_to = ' . (int) $user->get('id'));

--- a/administrator/templates/hathor/html/com_banners/clients/default.php
+++ b/administrator/templates/hathor/html/com_banners/clients/default.php
@@ -13,10 +13,10 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=clients'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_banners/tracks/default.php
+++ b/administrator/templates/hathor/html/com_banners/tracks/default.php
@@ -14,10 +14,10 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.modal', 'a.modal');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=tracks'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/templates/hathor/html/com_cache/cache/default.php
+++ b/administrator/templates/hathor/html/com_cache/cache/default.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_cache'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -14,15 +14,16 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$extension	= $this->escape($this->state->get('filter.extension'));
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$ordering 	= ($listOrder == 'a.lft');
-$saveOrder 	= ($listOrder == 'a.lft' && $listDirn == 'asc');
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$extension = $this->escape($this->state->get('filter.extension'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$ordering  = ($listOrder == 'a.lft');
+$saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 ?>
+
 <div class="categories">
 	<form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories'); ?>" method="post" name="adminForm" id="adminForm">
 		<?php if (!empty($this->sidebar)) : ?>

--- a/administrator/templates/hathor/html/com_contact/contacts/default.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/default.php
@@ -13,15 +13,14 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_contact.category');
-$saveOrder	= $listOrder == 'a.ordering';
-$assoc		= JLanguageAssociations::isEnabled();
-
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_contact.category');
+$saveOrder = $listOrder == 'a.ordering';
+$assoc     = JLanguageAssociations::isEnabled();
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_contact'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_content/articles/default.php
+++ b/administrator/templates/hathor/html/com_content/articles/default.php
@@ -13,15 +13,16 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$saveOrder	= $listOrder == 'a.ordering';
-$assoc		= JLanguageAssociations::isEnabled();
-$n			= count($this->items);
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$saveOrder = $listOrder == 'a.ordering';
+$assoc     = JLanguageAssociations::isEnabled();
+$n         = count($this->items);
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_content/featured/default.php
+++ b/administrator/templates/hathor/html/com_content/featured/default.php
@@ -14,13 +14,14 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_content.article');
-$saveOrder	= $listOrder == 'fp.ordering';
-$n			= count($this->items);
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_content.article');
+$saveOrder = $listOrder == 'fp.ordering';
+$n         = count($this->items);
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=featured'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_finder/filters/default.php
+++ b/administrator/templates/hathor/html/com_finder/filters/default.php
@@ -9,10 +9,10 @@
 
 defined('_JEXEC') or die;
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 
 JText::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
 

--- a/administrator/templates/hathor/html/com_finder/index/default.php
+++ b/administrator/templates/hathor/html/com_finder/index/default.php
@@ -11,10 +11,10 @@ defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$lang      = JFactory::getLanguage();
 
-$lang = JFactory::getLanguage();
 JText::script('COM_FINDER_INDEX_CONFIRM_PURGE_PROMPT');
 JText::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
 
@@ -124,7 +124,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				</td>
 			</tr>
 		<?php endif; ?>
-		<?php $canChange	= JFactory::getUser()->authorise('core.manage',	'com_finder'); ?>
+		<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th class="center">

--- a/administrator/templates/hathor/html/com_finder/maps/default.php
+++ b/administrator/templates/hathor/html/com_finder/maps/default.php
@@ -11,10 +11,10 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$lang      = JFactory::getLanguage();
 
-$lang = JFactory::getLanguage();
 JText::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');
 
 JFactory::getDocument()->addScriptDeclaration("
@@ -105,7 +105,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</tr>
 		<?php endif; ?>
 
-		<?php $canChange	= JFactory::getUser()->authorise('core.manage',	'com_finder'); ?>
+		<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 		<?php foreach ($this->items as $i => $item) :?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th class="center">

--- a/administrator/templates/hathor/html/com_installer/discover/default.php
+++ b/administrator/templates/hathor/html/com_installer/discover/default.php
@@ -12,9 +12,10 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 ?>
+
 <div id="installer-discover">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=discover');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/templates/hathor/html/com_installer/manage/default.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default.php
@@ -12,9 +12,10 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.multiselect');
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 ?>
+
 <div id="installer-manage">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=manage');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/templates/hathor/html/com_installer/update/default.php
+++ b/administrator/templates/hathor/html/com_installer/update/default.php
@@ -12,9 +12,10 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.multiselect');
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 ?>
+
 <div id="installer-update">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=update');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
@@ -49,9 +50,8 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 		</thead>
 
 		<tbody>
-		<?php foreach ($this->items as $i => $item):
-			$client	= $item->client_id ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
-		?>
+		<?php foreach ($this->items as $i => $item) : ?>
+			<?php $client = $item->client_id ? JText::_('JADMINISTRATOR') : JText::_('JSITE'); ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td><?php echo JHtml::_('grid.id', $i, $item->update_id); ?></td>
 				<td>

--- a/administrator/templates/hathor/html/com_languages/installed/default.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default.php
@@ -12,11 +12,12 @@ defined('_JEXEC') or die;
 JHtmlBehavior::core();
 // Add specific helper files for html generation
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$client		= $this->state->get('filter.client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
-$clientId	= $this->state->get('filter.client_id', 0);
+$user     = JFactory::getUser();
+$userId   = $user->get('id');
+$client   = $this->state->get('filter.client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
+$clientId = $this->state->get('filter.client_id', 0);
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client='.$clientId); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -14,13 +14,13 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$n			= count($this->items);
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_languages');
-$saveOrder	= $listOrder == 'a.ordering';
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$n         = count($this->items);
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_languages');
+$saveOrder = $listOrder == 'a.ordering';
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=languages'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_languages/overrides/default.php
+++ b/administrator/templates/hathor/html/com_languages/overrides/default.php
@@ -10,10 +10,12 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
-$client			= $this->state->get('filter.client') == 'site' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
-$language		= $this->state->get('filter.language');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn		= $this->escape($this->state->get('list.direction')); ?>
+$client    = $this->state->get('filter.client') == 'site' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
+$language  = $this->state->get('filter.language');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=overrides'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -14,17 +14,18 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$app		= JFactory::getApplication();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$ordering 	= ($listOrder == 'a.lft');
-$canOrder	= $user->authorise('core.edit.state',	'com_menus');
-$saveOrder 	= ($listOrder == 'a.lft' && $listDirn == 'asc');
-$assoc		= JLanguageAssociations::isEnabled();
+$user      = JFactory::getUser();
+$app       = JFactory::getApplication();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state',	'com_menus');
+$saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
+$assoc     = JLanguageAssociations::isEnabled();
 ?>
-<?php //Set up the filter bar. ?>
+
+<?php // Set up the filter bar. ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -14,12 +14,12 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$uri		= JUri::getInstance();
-$return		= base64_encode($uri);
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$uri       = JUri::getInstance();
+$return    = base64_encode($uri);
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 $modMenuId = (int) $this->get('ModMenuId');
 
 JFactory::getDocument()->addScriptDeclaration("

--- a/administrator/templates/hathor/html/com_messages/messages/default.php
+++ b/administrator/templates/hathor/html/com_messages/messages/default.php
@@ -14,9 +14,9 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_messages&view=messages'); ?>" method="post" name="adminForm" id="adminForm">
@@ -75,7 +75,7 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 
 		<tbody>
 		<?php foreach ($this->items as $i => $item) :
-			$canChange	= $user->authorise('core.edit.state', 'com_messages');
+			$canChange = $user->authorise('core.edit.state', 'com_messages');
 			?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td>

--- a/administrator/templates/hathor/html/com_modules/module/edit_assignment.php
+++ b/administrator/templates/hathor/html/com_modules/module/edit_assignment.php
@@ -19,8 +19,8 @@ JFactory::getDocument()->addScriptDeclaration("
 		document.getElements('select').addEvent('change', function(e){validate();});
 	});
 	function validate(){
-		var value	= document.id('jform_assignment').value;
-		var list	= document.id('menu-assignment');
+		var value = document.id('jform_assignment').value;
+		var list  = document.id('menu-assignment');
 		if (value == '-' || value == '0'){
 			$$('.jform-assignments-button').each(function(el) {el.setProperty('disabled', true); });
 			list.getElements('input').each(function(el){
@@ -91,19 +91,17 @@ JFactory::getDocument()->addScriptDeclaration("
 
 				<div class="clr"></div>
 
-				<?php
-				$count 	= count($type->links);
-				$i		= 0;
-				if ($count) :
-				?>
+				<?php $count = count($type->links); ?>
+				<?php $i     = 0; ?>
+				<?php if ($count) : ?>
 				<ul class="menu-links">
 					<?php
 					foreach ($type->links as $link) :
-						if (trim($this->item->assignment) == '-'):
+						if (trim($this->item->assignment) == '-') :
 							$checked = '';
-						elseif ($this->item->assignment == 0):
+						elseif ($this->item->assignment == 0) :
 							$checked = ' checked="checked"';
-						elseif ($this->item->assignment < 0):
+						elseif ($this->item->assignment < 0) :
 							$checked = in_array(-$link->value, $this->item->assigned) ? ' checked="checked"' : '';
 						elseif ($this->item->assignment > 0) :
 							$checked = in_array($link->value, $this->item->assigned) ? ' checked="checked"' : '';

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -15,13 +15,14 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.modal');
 
-$client 	= $this->state->get('filter.client_id') ? 'administrator' : 'site';
-$user 		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_modules');
-$saveOrder	= $listOrder == 'ordering';
+$client    = $this->state->get('filter.client_id') ? 'administrator' : 'site';
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_modules');
+$saveOrder = $listOrder == 'ordering';
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -14,14 +14,14 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_newsfeeds.category');
-$saveOrder	= $listOrder == 'a.ordering';
-$assoc		= JLanguageAssociations::isEnabled();
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
+$saveOrder = $listOrder == 'a.ordering';
+$assoc     = JLanguageAssociations::isEnabled();
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -14,11 +14,11 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state',	'com_plugins');
-$saveOrder	= $listOrder == 'ordering';
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_plugins');
+$saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/templates/hathor/html/com_redirect/links/default.php
+++ b/administrator/templates/hathor/html/com_redirect/links/default.php
@@ -14,9 +14,9 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_redirect&view=links'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_search/searches/default.php
+++ b/administrator/templates/hathor/html/com_search/searches/default.php
@@ -14,9 +14,10 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_search&view=searches'); ?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>

--- a/administrator/templates/hathor/html/com_tags/tags/default.php
+++ b/administrator/templates/hathor/html/com_tags/tags/default.php
@@ -13,14 +13,15 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$saveOrder	= $listOrder == 'a.ordering';
-$n			= count($this->items);
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$saveOrder = $listOrder == 'a.ordering';
+$n         = count($this->items);
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_tags&view=tags');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_templates/styles/default.php
+++ b/administrator/templates/hathor/html/com_templates/styles/default.php
@@ -15,10 +15,11 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('script', 'system/multiselect.js', false, true);
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_templates&view=styles'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_templates/templates/default.php
+++ b/administrator/templates/hathor/html/com_templates/templates/default.php
@@ -15,9 +15,9 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_templates&view=templates'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_users/debuggroup/default.php
+++ b/administrator/templates/hathor/html/com_users/debuggroup/default.php
@@ -14,8 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=debuggroup&user_id='.(int) $this->state->get('filter.user_id'));?>" method="post" name="adminForm" id="adminForm">
@@ -107,20 +107,20 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				</td>
 				<?php foreach ($this->actions as $action) : ?>
 					<?php
-					$name	= $action[0];
-					$check	= $item->checks[$name];
+					$name  = $action[0];
+					$check = $item->checks[$name];
 					if ($check === true) :
-						$class	= 'check-a';
-						$text	= '&#10003;';
+						$class = 'check-a';
+						$text  = '&#10003;';
 					elseif ($check === false) :
-						$class	= 'check-d';
-						$text	= '&#10007;';
+						$class = 'check-d';
+						$text  = '&#10007;';
 					elseif ($check === null) :
-						$class	= 'check-0';
-						$text	= '-';
+						$class = 'check-0';
+						$text  = '-';
 					else :
-						$class	= '';
-						$text	= '&#160;';
+						$class = '';
+						$text  = '&#160;';
 					endif;
 					?>
 				<td class="center <?php echo $class;?>">

--- a/administrator/templates/hathor/html/com_users/debuguser/default.php
+++ b/administrator/templates/hathor/html/com_users/debuguser/default.php
@@ -14,8 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=debuguser&user_id='.(int) $this->state->get('filter.user_id'));?>" method="post" name="adminForm" id="adminForm">
@@ -107,20 +107,20 @@ $listDirn	= $this->escape($this->state->get('list.direction'));
 				</td>
 				<?php foreach ($this->actions as $action) : ?>
 					<?php
-					$name	= $action[0];
-					$check	= $item->checks[$name];
+					$name  = $action[0];
+					$check = $item->checks[$name];
 					if ($check === true) :
-						$class	= 'check-a';
-						$text	= '&#10003;';
+						$class = 'check-a';
+						$text  = '&#10003;';
 					elseif ($check === false) :
-						$class	= 'check-d';
-						$text	= '&#10007;';
+						$class = 'check-d';
+						$text  = '&#10007;';
 					elseif ($check === null) :
-						$class	= 'check-0';
-						$text	= '-';
+						$class = 'check-0';
+						$text  = '-';
 					else :
-						$class	= '';
-						$text	= '&#160;';
+						$class = '';
+						$text  = '&#160;';
 					endif;
 					?>
 				<td class="center <?php echo $class;?>">

--- a/administrator/templates/hathor/html/com_users/groups/default.php
+++ b/administrator/templates/hathor/html/com_users/groups/default.php
@@ -14,9 +14,9 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
 
@@ -96,7 +96,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			{
 				$canEdit = false;
 			}
-			$canChange	= $user->authorise('core.edit.state',	'com_users');
+			$canChange = $user->authorise('core.edit.state',	'com_users');
 		?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td>

--- a/administrator/templates/hathor/html/com_users/levels/default.php
+++ b/administrator/templates/hathor/html/com_users/levels/default.php
@@ -14,12 +14,13 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_users');
-$saveOrder	= $listOrder == 'a.ordering';
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_users');
+$saveOrder = $listOrder == 'a.ordering';
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/templates/hathor/html/com_users/notes/default.php
+++ b/administrator/templates/hathor/html/com_users/notes/default.php
@@ -92,7 +92,7 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 		</thead>
 		<tbody>
 		<?php foreach ($this->items as $i => $item) : ?>
-			<?php $canChange	= $user->authorise('core.edit.state',	'com_users'); ?>
+			<?php $canChange = $user->authorise('core.edit.state',	'com_users'); ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td class="center checklist">
 					<?php echo JHtml::_('grid.id', $i, $item->id); ?>

--- a/administrator/templates/hathor/html/com_users/user/edit.php
+++ b/administrator/templates/hathor/html/com_users/user/edit.php
@@ -92,7 +92,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
+						title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/administrator/templates/hathor/html/com_users/users/default.php
+++ b/administrator/templates/hathor/html/com_users/users/default.php
@@ -117,13 +117,14 @@ $loggeduser = JFactory::getUser();
 
 		<tbody>
 		<?php foreach ($this->items as $i => $item) :
-			$canEdit	= $this->canDo->get('core.edit');
-			$canChange	= $loggeduser->authorise('core.edit.state',	'com_users');
+			$canEdit   = $this->canDo->get('core.edit');
+			$canChange = $loggeduser->authorise('core.edit.state',	'com_users');
+
 			// If this group is super admin and this user is not super admin, $canEdit is false
 			if ((!$loggeduser->authorise('core.admin')) && JAccess::check($item->id, 'core.admin'))
 			{
-				$canEdit	= false;
-				$canChange	= false;
+				$canEdit   = false;
+				$canChange = false;
 			}
 		?>
 			<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -14,12 +14,12 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.modal');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_weblinks.category');
-$saveOrder	= $listOrder == 'a.ordering';
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_weblinks.category');
+$saveOrder = $listOrder == 'a.ordering';
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_weblinks&view=weblinks'); ?>" method="post" name="adminForm" id="adminForm">
@@ -125,12 +125,12 @@ $saveOrder	= $listOrder == 'a.ordering';
 
 		<tbody>
 		<?php foreach ($this->items as $i => $item) :
-			$ordering   = ($listOrder == 'a.ordering');
-			$item->cat_link	= JRoute::_('index.php?option=com_categories&extension=com_weblinks&task=edit&type=other&cid[]=' . $item->catid);
-			$canCreate  = $user->authorise('core.create',     'com_weblinks.category.' . $item->catid);
-			$canEdit    = $user->authorise('core.edit',       'com_weblinks.category.' . $item->catid);
-			$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
-			$canChange  = $user->authorise('core.edit.state', 'com_weblinks.category.' . $item->catid) && $canCheckin;
+			$ordering       = ($listOrder == 'a.ordering');
+			$item->cat_link = JRoute::_('index.php?option=com_categories&extension=com_weblinks&task=edit&type=other&cid[]=' . $item->catid);
+			$canCreate      = $user->authorise('core.create',     'com_weblinks.category.' . $item->catid);
+			$canEdit        = $user->authorise('core.edit',       'com_weblinks.category.' . $item->catid);
+			$canCheckin     = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
+			$canChange      = $user->authorise('core.edit.state', 'com_weblinks.category.' . $item->catid) && $canCheckin;
 			?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td>


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the admin folder but withour  the admin component folder
