### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the admin components folder

### DIFF
--- a/administrator/components/com_admin/views/help/view.html.php
+++ b/administrator/components/com_admin/views/help/view.html.php
@@ -55,11 +55,11 @@ class AdminViewHelp extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->help_search			= $this->get('HelpSearch');
-		$this->page					= $this->get('Page');
-		$this->toc					= $this->get('Toc');
-		$this->lang_tag				= $this->get('LangTag');
-		$this->latest_version_check	= $this->get('LatestVersionCheck');
+		$this->help_search          = $this->get('HelpSearch');
+		$this->page                 = $this->get('Page');
+		$this->toc                  = $this->get('Toc');
+		$this->lang_tag             = $this->get('LangTag');
+		$this->latest_version_check = $this->get('LatestVersionCheck');
 
 		$this->addToolbar();
 		parent::display($tpl);

--- a/administrator/components/com_admin/views/profile/view.html.php
+++ b/administrator/components/com_admin/views/profile/view.html.php
@@ -31,9 +31,9 @@ class AdminViewProfile extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form			= $this->get('Form');
-		$this->item			= $this->get('Item');
-		$this->state		= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -56,11 +56,11 @@ class AdminViewSysinfo extends JViewLegacy
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
-		$this->php_settings	= $this->get('PhpSettings');
-		$this->config		= $this->get('config');
-		$this->info			= $this->get('info');
-		$this->php_info		= $this->get('PhpInfo');
-		$this->directory	= $this->get('directory');
+		$this->php_settings = $this->get('PhpSettings');
+		$this->config       = $this->get('config');
+		$this->info         = $this->get('info');
+		$this->php_info     = $this->get('PhpInfo');
+		$this->directory    = $this->get('directory');
 
 		$this->addToolbar();
 		$this->_setSubMenu();

--- a/administrator/components/com_banners/controllers/banner.php
+++ b/administrator/components/com_banners/controllers/banner.php
@@ -67,8 +67,8 @@ class BannersControllerBanner extends JControllerForm
 	 */
 	protected function allowEdit($data = array(), $key = 'id')
 	{
-		$user		= JFactory::getUser();
-		$recordId	= (int) isset($data[$key]) ? $data[$key] : 0;
+		$user       = JFactory::getUser();
+		$recordId   = (int) isset($data[$key]) ? $data[$key] : 0;
 		$categoryId = 0;
 
 		if ($recordId)
@@ -95,14 +95,14 @@ class BannersControllerBanner extends JControllerForm
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since	2.5
+	 * @since   2.5
 	 */
 	public function batch($model = null)
 	{
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Set the model
-		$model	= $this->getModel('Banner', '', array());
+		$model = $this->getModel('Banner', '', array());
 
 		// Preset the redirect
 		$this->setRedirect(JRoute::_('index.php?option=com_banners&view=banners' . $this->getRedirectToListAppend(), false));

--- a/administrator/components/com_banners/controllers/tracks.raw.php
+++ b/administrator/components/com_banners/controllers/tracks.raw.php
@@ -55,9 +55,9 @@ class BannersControllerTracks extends JControllerLegacy
 	public function display($cachable = false, $urlparams = false)
 	{
 		// Get the document object.
-		$document	= JFactory::getDocument();
-		$vName		= 'tracks';
-		$vFormat	= 'raw';
+		$document = JFactory::getDocument();
+		$vName    = 'tracks';
+		$vFormat  = 'raw';
 
 		// Get and render the view.
 		if ($view = $this->getView($vName, $vFormat))

--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -193,7 +193,7 @@ class BannersModelBanner extends JModelAdmin
 			$table->state = 0;
 
 			// TODO: Deal with ordering?
-			// $table->ordering	= 1;
+			// $table->ordering = 1;
 
 			// Check the row.
 			if (!$table->check())
@@ -478,8 +478,8 @@ class BannersModelBanner extends JModelAdmin
 		else
 		{
 			// Set the values
-			$table->modified	= $date->toSql();
-			$table->modified_by	= $user->get('id');
+			$table->modified    = $date->toSql();
+			$table->modified_by = $user->get('id');
 		}
 		// Increment the content version number.
 		$table->version++;

--- a/administrator/components/com_banners/models/download.php
+++ b/administrator/components/com_banners/models/download.php
@@ -71,8 +71,8 @@ class BannersModelDownload extends JModelForm
 	protected function loadFormData()
 	{
 		$data = array(
-			'basename'		=> $this->getState('basename'),
-			'compressed'	=> $this->getState('compressed')
+			'basename'   => $this->getState('basename'),
+			'compressed' => $this->getState('compressed'),
 		);
 
 		$this->preprocessData('com_banners.download', $data);

--- a/administrator/components/com_banners/models/fields/imptotal.php
+++ b/administrator/components/com_banners/models/fields/imptotal.php
@@ -33,11 +33,11 @@ class JFormFieldImpTotal extends JFormField
 	 */
 	protected function getInput()
 	{
-		$class		= ' class="validate-numeric text_area"';
-		$onchange	= ' onchange="document.getElementById(\'' . $this->id . '_unlimited\').checked=document.getElementById(\'' . $this->id . '\').value==\'\';"';
-		$onclick	= ' onclick="if (document.getElementById(\'' . $this->id . '_unlimited\').checked) document.getElementById(\'' . $this->id . '\').value=\'\';"';
-		$value		= empty($this->value) ? '' : $this->value;
-		$checked	= empty($this->value) ? ' checked="checked"' : '';
+		$class    = ' class="validate-numeric text_area"';
+		$onchange = ' onchange="document.getElementById(\'' . $this->id . '_unlimited\').checked=document.getElementById(\'' . $this->id . '\').value==\'\';"';
+		$onclick  = ' onclick="if (document.getElementById(\'' . $this->id . '_unlimited\').checked) document.getElementById(\'' . $this->id . '\').value=\'\';"';
+		$value    = empty($this->value) ? '' : $this->value;
+		$checked  = empty($this->value) ? ' checked="checked"' : '';
 
 		return
 			'<input type="text" name="' . $this->name . '" id="' . $this->id . '" size="9" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8')

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -27,7 +27,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			var v = typeof(params) !== "object" ? $("#jform_type").val() : params.selected;
 			
 			var img_url = $("#image, #url");
-			var custom 	= $("#custom");
+			var custom  = $("#custom");
 			
 			switch (v) {
 				case "0":

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -34,9 +34,9 @@ class BannersViewBanner extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Initialiase variables.
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -62,13 +62,13 @@ class BannersViewBanner extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$userId		= $user->get('id');
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
+		$user       = JFactory::getUser();
+		$userId     = $user->get('id');
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 
 		// Since we don't track these assets at the item level, use the category id.
-		$canDo		= JHelperContent::getActions('com_banners', 'category', $this->item->catid);
+		$canDo = JHelperContent::getActions('com_banners', 'category', $this->item->catid);
 
 		JToolbarHelper::title($isNew ? JText::_('COM_BANNERS_MANAGER_BANNER_NEW') : JText::_('COM_BANNERS_MANAGER_BANNER_EDIT'), 'bookmark banners');
 

--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -15,14 +15,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_banners.category');
-$archived	= $this->state->get('filter.state') == 2 ? true : false;
-$trashed	= $this->state->get('filter.state') == -2 ? true : false;
-$saveOrder	= $listOrder == 'a.ordering';
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_banners.category');
+$archived  = $this->state->get('filter.state') == 2 ? true : false;
+$trashed   = $this->state->get('filter.state') == -2 ? true : false;
+$saveOrder = $listOrder == 'a.ordering';
 
 if ($saveOrder)
 {

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -38,10 +38,10 @@ class BannersViewClient extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions('com_banners');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
+		$this->canDo = JHelperContent::getActions('com_banners');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -66,10 +66,10 @@ class BannersViewClient extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
-		$canDo		= $this->canDo;
+		$user       = JFactory::getUser();
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+		$canDo      = $this->canDo;
 
 		JToolbarHelper::title(
 			$isNew ? JText::_('COM_BANNERS_MANAGER_CLIENT_NEW') : JText::_('COM_BANNERS_MANAGER_CLIENT_EDIT'),

--- a/administrator/components/com_banners/views/tracks/view.raw.php
+++ b/administrator/components/com_banners/views/tracks/view.raw.php
@@ -25,10 +25,10 @@ class BannersViewTracks extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$basename		= $this->get('BaseName');
-		$filetype		= $this->get('FileType');
-		$mimetype		= $this->get('MimeType');
-		$content		= $this->get('Content');
+		$basename = $this->get('BaseName');
+		$filetype = $this->get('FileType');
+		$mimetype = $this->get('MimeType');
+		$content  = $this->get('Content');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -112,10 +112,10 @@ class CacheModelCache extends JModelList
 		$conf = JFactory::getConfig();
 
 		$options = array(
-			'defaultgroup'	=> '',
-			'storage' 		=> $conf->get('cache_handler', ''),
-			'caching'		=> true,
-			'cachebase'		=> ($this->getState('clientId') == 1) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache')
+			'defaultgroup' => '',
+			'storage'      => $conf->get('cache_handler', ''),
+			'caching'      => true,
+			'cachebase'    => ($this->getState('clientId') == 1) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache')
 		);
 
 		$cache = JCache::getInstance('', $options);

--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -11,8 +11,8 @@ defined('_JEXEC') or die;
 
 JHtml::_('formbehavior.chosen', 'select');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_cache'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_cache/views/cache/view.html.php
+++ b/administrator/components/com_cache/views/cache/view.html.php
@@ -33,10 +33,10 @@ class CacheViewCache extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->data			= $this->get('Data');
-		$this->client		= $this->get('Client');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->data       = $this->get('Data');
+		$this->client     = $this->get('Client');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -946,7 +946,7 @@ class CategoriesModelCategory extends JModelAdmin
 			$this->table->setLocation($this->table->parent_id, 'last-child');
 
 			// @TODO: Deal with ordering?
-			// $this->table->ordering	= 1;
+			// $this->table->ordering = 1;
 			$this->table->level = null;
 			$this->table->asset_id = null;
 			$this->table->lft = null;
@@ -954,8 +954,8 @@ class CategoriesModelCategory extends JModelAdmin
 
 			// Alter the title & alias
 			list($title, $alias) = $this->generateNewTitle($this->table->parent_id, $this->table->alias, $this->table->title);
-			$this->table->title = $title;
-			$this->table->alias = $alias;
+			$this->table->title  = $title;
+			$this->table->alias  = $alias;
 
 			// Unpublish because we are making a copy
 			$this->table->published = 0;

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -42,8 +42,8 @@ class JFormFieldModal_Category extends JFormField
 			$extension = (string) JFactory::getApplication()->input->get('extension', 'com_content');
 		}
 
-		$allowEdit		= ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear		= ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
+		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
 
 		// Load language
 		JFactory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
@@ -103,7 +103,7 @@ class JFormFieldModal_Category extends JFormField
 
 		if ((int) $this->value > 0)
 		{
-			$db	= JFactory::getDbo();
+			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('title'))
 				->from($db->quoteName('#__categories'))

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -16,14 +16,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$extension	= $this->escape($this->state->get('filter.extension'));
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$ordering 	= ($listOrder == 'a.lft');
-$saveOrder 	= ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$extension = $this->escape($this->state->get('filter.extension'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$ordering  = ($listOrder == 'a.lft');
+$saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 
 if ($saveOrder)
 {

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -23,10 +23,10 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 
-$extension	= $this->escape($this->state->get('filter.extension'));
-$function  	= $app->input->getCmd('function', 'jSelectCategory');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$extension = $this->escape($this->state->get('filter.extension'));
+$function  = $app->input->getCmd('function', 'jSelectCategory');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -55,17 +55,17 @@ class CategoriesViewCategories extends JViewLegacy
 		}
 
 		// Levels filter.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', JText::_('J1'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('J2'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('J3'));
-		$options[]	= JHtml::_('select.option', '4', JText::_('J4'));
-		$options[]	= JHtml::_('select.option', '5', JText::_('J5'));
-		$options[]	= JHtml::_('select.option', '6', JText::_('J6'));
-		$options[]	= JHtml::_('select.option', '7', JText::_('J7'));
-		$options[]	= JHtml::_('select.option', '8', JText::_('J8'));
-		$options[]	= JHtml::_('select.option', '9', JText::_('J9'));
-		$options[]	= JHtml::_('select.option', '10', JText::_('J10'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
+		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
+		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
+		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
+		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
+		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
+		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
+		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
+		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
+		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
 
 		$this->f_levels = $options;
 
@@ -83,11 +83,11 @@ class CategoriesViewCategories extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$categoryId	= $this->state->get('filter.category_id');
-		$component	= $this->state->get('filter.component');
-		$section	= $this->state->get('filter.section');
-		$canDo		= JHelperContent::getActions($component, 'category', $categoryId);
-		$user		= JFactory::getUser();
+		$categoryId = $this->state->get('filter.category_id');
+		$component  = $this->state->get('filter.component');
+		$section    = $this->state->get('filter.section');
+		$canDo      = JHelperContent::getActions($component, 'category', $categoryId);
+		$user       = JFactory::getUser();
 		$extension  = JFactory::getApplication()->input->get('extension', '', 'word');
 
 		// Get the toolbar object instance

--- a/administrator/components/com_checkin/views/checkin/view.html.php
+++ b/administrator/components/com_checkin/views/checkin/view.html.php
@@ -27,9 +27,9 @@ class CheckinViewCheckin extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -86,7 +86,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 		}
 
 		// Attempt to save the configuration.
-		$data	= $return;
+		$data   = $return;
 		$return = $model->save($data);
 
 		// Check the return value.

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -55,14 +55,14 @@ class ConfigModelApplication extends ConfigModelForm
 	public function getData()
 	{
 		// Get the config data.
-		$config	= new JConfig;
-		$data	= JArrayHelper::fromObject($config);
+		$config = new JConfig;
+		$data   = JArrayHelper::fromObject($config);
 
 		// Prime the asset_id for the rules.
 		$data['asset_id'] = 1;
 
 		// Get the text filter data
-		$params = JComponentHelper::getParams('com_config');
+		$params          = JComponentHelper::getParams('com_config');
 		$data['filters'] = JArrayHelper::fromObject($params->get('filters'));
 
 		// If no filter data found, get from com_content (update of 1.6/1.7 site)
@@ -100,12 +100,12 @@ class ConfigModelApplication extends ConfigModelForm
 		// Save the rules
 		if (isset($data['rules']))
 		{
-			$rules	= new JAccessRules($data['rules']);
+			$rules = new JAccessRules($data['rules']);
 
 			// Check that we aren't removing our Super User permission
 			// Need to get groups from database, since they might have changed
-			$myGroups = JAccess::getGroupsByUser(JFactory::getUser()->get('id'));
-			$myRules = $rules->getData();
+			$myGroups      = JAccess::getGroupsByUser(JFactory::getUser()->get('id'));
+			$myRules       = $rules->getData();
 			$hasSuperAdmin = $myRules['core.admin']->allow($myGroups);
 
 			if (!$hasSuperAdmin)

--- a/administrator/components/com_contact/helpers/html/contact.php
+++ b/administrator/components/com_contact/helpers/html/contact.php
@@ -115,21 +115,21 @@ abstract class JHtmlContact
 	{
 
 		// Array of image, task, title, action
-		$states	= array(
-			0	=> array('unfeatured', 'contacts.featured', 'COM_CONTACT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
-			1	=> array('featured', 'contacts.unfeatured', 'JFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
+		$states = array(
+			0 => array('unfeatured', 'contacts.featured', 'COM_CONTACT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
+			1 => array('featured', 'contacts.unfeatured', 'JFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 		);
-		$state	= JArrayHelper::getValue($states, (int) $value, $states[1]);
-		$icon	= $state[0];
+		$state = JArrayHelper::getValue($states, (int) $value, $states[1]);
+		$icon  = $state[0];
 
 		if ($canChange)
 		{
-			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
+			$html = '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
 				. $icon . '"></span></a>';
 		}
 		else
 		{
-			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><span class="icon-'
+			$html = '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><span class="icon-'
 				. $icon . '"></span></a>';
 		}
 

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -33,8 +33,8 @@ class JFormFieldModal_Contact extends JFormField
 	 */
 	protected function getInput()
 	{
-		$allowEdit		= ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear		= ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
+		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
 
 		// Load language
 		JFactory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
@@ -93,8 +93,8 @@ class JFormFieldModal_Contact extends JFormField
 		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 		// Setup variables for display.
-		$html	= array();
-		$link	= 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;function=jSelectContact_' . $this->id;
+		$html = array();
+		$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;function=jSelectContact_' . $this->id;
 
 		if (isset($this->element['language']))
 		{

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -60,15 +60,15 @@ class ContactTableContact extends JTable
 			$this->params = (string) $registry;
 		}
 
-		$date	= JFactory::getDate();
-		$user	= JFactory::getUser();
+		$date = JFactory::getDate();
+		$user = JFactory::getUser();
 
-		$this->modified		= $date->toSql();
+		$this->modified = $date->toSql();
 
 		if ($this->id)
 		{
 			// Existing item
-			$this->modified_by	= $user->get('id');
+			$this->modified_by = $user->get('id');
 		}
 		else
 		{

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -32,9 +32,9 @@ class ContactViewContact extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Initialise variables.
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -65,13 +65,13 @@ class ContactViewContact extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$userId		= $user->get('id');
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
+		$user       = JFactory::getUser();
+		$userId     = $user->get('id');
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 
 		// Since we don't track these assets at the item level, use the category id.
-		$canDo		= JHelperContent::getActions('com_contact', 'category', $this->item->catid);
+		$canDo = JHelperContent::getActions('com_contact', 'category', $this->item->catid);
 
 		JToolbarHelper::title($isNew ? JText::_('COM_CONTACT_MANAGER_CONTACT_NEW') : JText::_('COM_CONTACT_MANAGER_CONTACT_EDIT'), 'address contact');
 

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -32,7 +32,7 @@ if ($saveOrder)
 }
 
 $sortFields = $this->getSortFields();
-$assoc		= JLanguageAssociations::isEnabled();
+$assoc      = JLanguageAssociations::isEnabled();
 
 JFactory::getDocument()->addScriptDeclaration(
 	'Joomla.orderTable = function()

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -31,9 +31,9 @@ class ContactViewContacts extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		ContactHelper::addSubmenu('contacts');
 
@@ -67,8 +67,8 @@ class ContactViewContacts extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_contact', 'category', $this->state->get('filter.category_id'));
-		$user	= JFactory::getUser();
+		$canDo = JHelperContent::getActions('com_contact', 'category', $this->state->get('filter.category_id'));
+		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
 		$bar = JToolBar::getInstance('toolbar');

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -100,21 +100,21 @@ abstract class JHtmlContentAdministrator
 		JHtml::_('bootstrap.tooltip');
 
 		// Array of image, task, title, action
-		$states	= array(
-			0	=> array('unfeatured',	'articles.featured',	'COM_CONTENT_UNFEATURED',	'JGLOBAL_TOGGLE_FEATURED'),
-			1	=> array('featured',	'articles.unfeatured',	'COM_CONTENT_FEATURED',		'JGLOBAL_TOGGLE_FEATURED'),
+		$states = array(
+			0 => array('unfeatured', 'articles.featured', 'COM_CONTENT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
+			1 => array('featured', 'articles.unfeatured', 'COM_CONTENT_FEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 		);
-		$state	= JArrayHelper::getValue($states, (int) $value, $states[1]);
-		$icon	= $state[0];
+		$state = JArrayHelper::getValue($states, (int) $value, $states[1]);
+		$icon  = $state[0];
 
 		if ($canChange)
 		{
-			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
+			$html = '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
 					. $icon . '"></span></a>';
 		}
 		else
 		{
-			$html	= '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><span class="icon-'
+			$html = '<a class="btn btn-micro hasTooltip disabled' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[2]) . '"><span class="icon-'
 					. $icon . '"></span></a>';
 		}
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -108,7 +108,7 @@ class ContentModelArticle extends JModelAdmin
 			$this->table->catid = $categoryId;
 
 			// TODO: Deal with ordering?
-			// $table->ordering	= 1;
+			// $table->ordering = 1;
 
 			// Get the featured state
 			$featured = $this->table->featured;

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -33,8 +33,8 @@ class JFormFieldModal_Article extends JFormField
 	 */
 	protected function getInput()
 	{
-		$allowEdit		= ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear		= ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
+		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
 
 		// Load language
 		JFactory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
@@ -90,8 +90,8 @@ class JFormFieldModal_Article extends JFormField
 		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 		// Setup variables for display.
-		$html	= array();
-		$link	= 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
+		$html = array();
+		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
 
 		if (isset($this->element['language']))
 		{
@@ -100,7 +100,7 @@ class JFormFieldModal_Article extends JFormField
 
 		if ((int) $this->value > 0)
 		{
-			$db	= JFactory::getDbo();
+			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('title'))
 				->from($db->quoteName('#__content'))

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -46,10 +46,10 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions('com_content', 'article', $this->item->id);
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
+		$this->canDo = JHelperContent::getActions('com_content', 'article', $this->item->id);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -78,13 +78,14 @@ class ContentViewArticle extends JViewLegacy
 	protected function addToolbar()
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
-		$user		= JFactory::getUser();
-		$userId		= $user->get('id');
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
+		$user       = JFactory::getUser();
+		$userId     = $user->get('id');
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 
 		// Built the actions for new and existing records.
-		$canDo		= $this->canDo;
+		$canDo = $this->canDo;
+
 		JToolbarHelper::title(
 			JText::_('COM_CONTENT_PAGE_' . ($checkedOut ? 'VIEW_ARTICLE' : ($isNew ? 'ADD_ARTICLE' : 'EDIT_ARTICLE'))),
 			'pencil-2 article-add'

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -15,15 +15,15 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$archived	= $this->state->get('filter.published') == 2 ? true : false;
-$trashed	= $this->state->get('filter.published') == -2 ? true : false;
-$saveOrder	= $listOrder == 'a.ordering';
-$columns	= 10;
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$archived  = $this->state->get('filter.published') == 2 ? true : false;
+$trashed   = $this->state->get('filter.published') == -2 ? true : false;
+$saveOrder = $listOrder == 'a.ordering';
+$columns   = 10;
 
 if ($saveOrder)
 {
@@ -31,7 +31,7 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'articleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
 
-$assoc		= JLanguageAssociations::isEnabled();
+$assoc = JLanguageAssociations::isEnabled();
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -52,17 +52,17 @@ class ContentViewArticles extends JViewLegacy
 		}
 
 		// Levels filter.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', JText::_('J1'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('J2'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('J3'));
-		$options[]	= JHtml::_('select.option', '4', JText::_('J4'));
-		$options[]	= JHtml::_('select.option', '5', JText::_('J5'));
-		$options[]	= JHtml::_('select.option', '6', JText::_('J6'));
-		$options[]	= JHtml::_('select.option', '7', JText::_('J7'));
-		$options[]	= JHtml::_('select.option', '8', JText::_('J8'));
-		$options[]	= JHtml::_('select.option', '9', JText::_('J9'));
-		$options[]	= JHtml::_('select.option', '10', JText::_('J10'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
+		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
+		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
+		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
+		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
+		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
+		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
+		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
+		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
+		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
 
 		$this->f_levels = $options;
 

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -15,14 +15,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_content.article');
-$archived	= $this->state->get('filter.published') == 2 ? true : false;
-$trashed	= $this->state->get('filter.published') == -2 ? true : false;
-$saveOrder	= $listOrder == 'fp.ordering';
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_content.article');
+$archived  = $this->state->get('filter.published') == 2 ? true : false;
+$trashed   = $this->state->get('filter.published') == -2 ? true : false;
+$saveOrder = $listOrder == 'fp.ordering';
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=featured'); ?>" method="post" name="adminForm" id="adminForm">
@@ -89,12 +89,12 @@ $saveOrder	= $listOrder == 'fp.ordering';
 				<?php $count = count($this->items); ?>
 				<?php foreach ($this->items as $i => $item) :
 					$item->max_ordering = 0;
-					$ordering	= ($listOrder == 'fp.ordering');
-					$assetId	= 'com_content.article.' . $item->id;
-					$canCreate	= $user->authorise('core.create',     'com_content.category.' . $item->catid);
-					$canEdit	= $user->authorise('core.edit',       'com_content.article.' . $item->id);
-					$canCheckin	= $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
-					$canChange	= $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+					$ordering   = ($listOrder == 'fp.ordering');
+					$assetId    = 'com_content.article.' . $item->id;
+					$canCreate  = $user->authorise('core.create', 'com_content.category.' . $item->catid);
+					$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
+					$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
+					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="center">

--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -49,17 +49,17 @@ class ContentViewFeatured extends JViewLegacy
 		}
 
 		// Levels filter.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', JText::_('J1'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('J2'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('J3'));
-		$options[]	= JHtml::_('select.option', '4', JText::_('J4'));
-		$options[]	= JHtml::_('select.option', '5', JText::_('J5'));
-		$options[]	= JHtml::_('select.option', '6', JText::_('J6'));
-		$options[]	= JHtml::_('select.option', '7', JText::_('J7'));
-		$options[]	= JHtml::_('select.option', '8', JText::_('J8'));
-		$options[]	= JHtml::_('select.option', '9', JText::_('J9'));
-		$options[]	= JHtml::_('select.option', '10', JText::_('J10'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
+		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
+		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
+		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
+		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
+		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
+		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
+		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
+		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
+		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
 
 		$this->f_levels = $options;
 
@@ -77,8 +77,8 @@ class ContentViewFeatured extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_content', 'category', $this->state->get('filter.category_id'));
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_content', 'category', $this->state->get('filter.category_id'));
 
 		JToolbarHelper::title(JText::_('COM_CONTENT_FEATURED_TITLE'), 'star featured');
 

--- a/administrator/components/com_cpanel/cpanel.php
+++ b/administrator/components/com_cpanel/cpanel.php
@@ -11,6 +11,6 @@ defined('_JEXEC') or die;
 
 // No access check.
 
-$controller	= JControllerLegacy::getInstance('Cpanel');
+$controller = JControllerLegacy::getInstance('Cpanel');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -148,11 +148,11 @@ class FinderControllerIndexer extends JControllerLegacy
 
 		// Get the document properties.
 		$attributes = array (
-			'charset'	=> 'utf-8',
-			'lineend'	=> 'unix',
-			'tab'		=> '  ',
-			'language'	=> $lang->getTag(),
-			'direction'	=> $lang->isRtl() ? 'rtl' : 'ltr'
+			'charset'   => 'utf-8',
+			'lineend'   => 'unix',
+			'tab'       => '  ',
+			'language'  => $lang->getTag(),
+			'direction' => $lang->isRtl() ? 'rtl' : 'ltr'
 		);
 
 		// Get the HTML document.

--- a/administrator/components/com_finder/finder.php
+++ b/administrator/components/com_finder/finder.php
@@ -14,6 +14,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_finder'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Finder');
+$controller = JControllerLegacy::getInstance('Finder');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -286,7 +286,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 		 * aggregated data will be inserted into #__finder_tokens_aggregate
 		 * table.
 		 */
-		$query	= 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
+		$query = 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
 				' (' . $db->quoteName('term_id') .
 				', ' . $db->quoteName('term') .
 				', ' . $db->quoteName('stem') .

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -278,7 +278,7 @@ class FinderIndexerDriverPostgresql extends FinderIndexer
 		 * aggregated data will be inserted into #__finder_tokens_aggregate
 		 * table.
 		 */
-		$query	= 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
+		$query = 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
 				' (' . $db->quoteName('term_id') .
 				', ' . $db->quoteName('term') .
 				', ' . $db->quoteName('stem') .

--- a/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
@@ -286,7 +286,7 @@ class FinderIndexerDriverSqlsrv extends FinderIndexer
 		 * aggregated data will be inserted into #__finder_tokens_aggregate
 		 * table.
 		 */
-		$query	= 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
+		$query = 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
 				' (' . $db->quoteName('term_id') .
 				', ' . $db->quoteName('term') .
 				', ' . $db->quoteName('stem') .

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -157,11 +157,11 @@ abstract class FinderIndexer
 
 			// Setup the weight lookup information.
 			$data->weights = array(
-				self::TITLE_CONTEXT	=> round($data->options->get('title_multiplier', 1.7), 2),
-				self::TEXT_CONTEXT	=> round($data->options->get('text_multiplier', 0.7), 2),
-				self::META_CONTEXT	=> round($data->options->get('meta_multiplier', 1.2), 2),
-				self::PATH_CONTEXT	=> round($data->options->get('path_multiplier', 2.0), 2),
-				self::MISC_CONTEXT	=> round($data->options->get('misc_multiplier', 0.3), 2)
+				self::TITLE_CONTEXT => round($data->options->get('title_multiplier', 1.7), 2),
+				self::TEXT_CONTEXT  => round($data->options->get('text_multiplier', 0.7), 2),
+				self::META_CONTEXT  => round($data->options->get('meta_multiplier', 1.2), 2),
+				self::PATH_CONTEXT  => round($data->options->get('path_multiplier', 2.0), 2),
+				self::MISC_CONTEXT  => round($data->options->get('misc_multiplier', 0.3), 2)
 			);
 
 			// Set the current time as the start time.

--- a/administrator/components/com_finder/views/index/view.html.php
+++ b/administrator/components/com_finder/views/index/view.html.php
@@ -32,11 +32,11 @@ class FinderViewIndex extends JViewLegacy
 		// Load plug-in language files.
 		FinderHelperLanguage::loadPluginLanguage();
 
-		$this->items		= $this->get('Items');
-		$this->total		= $this->get('Total');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
-		$this->pluginState  = $this->get('pluginState');
+		$this->items       = $this->get('Items');
+		$this->total       = $this->get('Total');
+		$this->pagination  = $this->get('Pagination');
+		$this->state       = $this->get('State');
+		$this->pluginState = $this->get('pluginState');
 
 		FinderHelper::addSubmenu('index');
 
@@ -65,7 +65,7 @@ class FinderViewIndex extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_finder');
+		$canDo = JHelperContent::getActions('com_finder');
 
 		JToolbarHelper::title(JText::_('COM_FINDER_INDEX_TOOLBAR_TITLE'), 'zoom-in finder');
 

--- a/administrator/components/com_finder/views/maps/view.html.php
+++ b/administrator/components/com_finder/views/maps/view.html.php
@@ -33,10 +33,10 @@ class FinderViewMaps extends JViewLegacy
 		FinderHelperLanguage::loadPluginLanguage();
 
 		// Load the view data.
-		$this->items		= $this->get('Items');
-		$this->total		= $this->get('Total');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->total      = $this->get('Total');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		FinderHelper::addSubmenu('maps');
 
@@ -65,7 +65,7 @@ class FinderViewMaps extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_finder');
+		$canDo = JHelperContent::getActions('com_finder');
 
 		JToolbarHelper::title(JText::_('COM_FINDER_MAPS_TOOLBAR_TITLE'), 'zoom-in finder');
 		$toolbar = JToolbar::getInstance('toolbar');

--- a/administrator/components/com_finder/views/statistics/view.html.php
+++ b/administrator/components/com_finder/views/statistics/view.html.php
@@ -28,7 +28,7 @@ class FinderViewStatistics extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Load the view data.
-		$this->data		= $this->get('Data');
+		$this->data = $this->get('Data');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_installer/controllers/languages.php
+++ b/administrator/components/com_installer/controllers/languages.php
@@ -38,7 +38,7 @@ class InstallerControllerLanguages extends JControllerLegacy
 		$cache_timeout = 3600 * $cache_timeout;
 
 		// Find updates
-		$model	= $this->getModel('languages');
+		$model = $this->getModel('languages');
 
 		if (!$model->findLanguages($cache_timeout))
 		{

--- a/administrator/components/com_installer/controllers/manage.php
+++ b/administrator/components/com_installer/controllers/manage.php
@@ -56,7 +56,7 @@ class InstallerControllerManage extends JControllerLegacy
 		else
 		{
 			// Get the model.
-			$model	= $this->getModel('manage');
+			$model = $this->getModel('manage');
 
 			// Change the state of the records.
 			if (!$model->publish($ids, $value))

--- a/administrator/components/com_installer/controllers/updatesites.php
+++ b/administrator/components/com_installer/controllers/updatesites.php
@@ -59,7 +59,7 @@ class InstallerControllerUpdatesites extends JControllerLegacy
 		}
 
 		// Get the model.
-		$model	= $this->getModel('Updatesites');
+		$model = $this->getModel('Updatesites');
 
 		// Change the state of the records.
 		if (!$model->publish($ids, $value))

--- a/administrator/components/com_installer/helpers/html/manage.php
+++ b/administrator/components/com_installer/helpers/html/manage.php
@@ -32,7 +32,7 @@ abstract class InstallerHtmlManage
 	 */
 	public static function state($value, $i, $enabled = true, $checkbox = 'cb')
 	{
-		$states	= array(
+		$states = array(
 			2 => array(
 				'',
 				'COM_INSTALLER_EXTENSION_PROTECTED',

--- a/administrator/components/com_installer/installer.php
+++ b/administrator/components/com_installer/installer.php
@@ -15,6 +15,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_installer'))
 	return JError::raiseWarning(403, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Installer');
+$controller = JControllerLegacy::getInstance('Installer');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_installer/models/discover.php
+++ b/administrator/components/com_installer/models/discover.php
@@ -113,8 +113,8 @@ class InstallerModelDiscover extends InstallerModel
 		// Purge the list of discovered extensions
 		$this->purge();
 
-		$installer	= JInstaller::getInstance();
-		$results	= $installer->discover();
+		$installer = JInstaller::getInstance();
+		$results   = $installer->discover();
 
 		// Get all templates, including discovered ones
 		$db = $this->getDbo();
@@ -209,8 +209,8 @@ class InstallerModelDiscover extends InstallerModel
 	 */
 	public function purge()
 	{
-		$db		= $this->getDbo();
-		$query	= $db->getQuery(true)
+		$db    = $this->getDbo();
+		$query = $db->getQuery(true)
 			->delete('#__extensions')
 			->where('state = -1');
 		$db->setQuery($query);

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -52,12 +52,12 @@ class InstallerModel extends JModelList
 	 */
 	protected function _getList($query, $limitstart = 0, $limit = 0)
 	{
-		$ordering	= $this->getState('list.ordering');
-		$search		= $this->getState('filter.search');
+		$ordering = $this->getState('list.ordering');
+		$search   = $this->getState('filter.search');
 
 		// Replace slashes so preg_match will work
-		$search 	= str_replace('/', ' ', $search);
-		$db			= $this->getDbo();
+		$search = str_replace('/', ' ', $search);
+		$db     = $this->getDbo();
 
 		if ($ordering == 'name' || (!empty($search) && stripos($search, 'id:') !== 0))
 		{

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -174,7 +174,7 @@ class InstallerModelInstall extends JModelLegacy
 		$dispatcher->trigger('onInstallerAfterInstaller', array($this, &$package, $installer, &$result, &$msg));
 
 		// Set some model state values.
-		$app	= JFactory::getApplication();
+		$app = JFactory::getApplication();
 		$app->enqueueMessage($msg, $msgType);
 		$this->setState('name', $installer->get('name'));
 		$this->setState('result', $result);
@@ -255,9 +255,9 @@ class InstallerModelInstall extends JModelLegacy
 		}
 
 		// Build the appropriate paths.
-		$config		= JFactory::getConfig();
-		$tmp_dest	= $config->get('tmp_path') . '/' . $userfile['name'];
-		$tmp_src	= $userfile['tmp_name'];
+		$config   = JFactory::getConfig();
+		$tmp_dest = $config->get('tmp_path') . '/' . $userfile['name'];
+		$tmp_src  = $userfile['tmp_name'];
 
 		// Move uploaded file.
 		jimport('joomla.filesystem.file');

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -322,27 +322,27 @@ class InstallerModelUpdate extends JModelList
 			return false;
 		}
 
-		$config		= JFactory::getConfig();
-		$tmp_dest	= $config->get('tmp_path');
+		$config   = JFactory::getConfig();
+		$tmp_dest = $config->get('tmp_path');
 
 		// Unpack the downloaded package file
-		$package	= JInstallerHelper::unpack($tmp_dest . '/' . $p_file);
+		$package = JInstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
 		// Get an installer instance
-		$installer	= JInstaller::getInstance();
+		$installer = JInstaller::getInstance();
 		$update->set('type', $package['type']);
 
 		// Install the package
 		if (!$installer->update($package['dir']))
 		{
 			// There was an error updating the package
-			$msg = JText::sprintf('COM_INSTALLER_MSG_UPDATE_ERROR', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
+			$msg    = JText::sprintf('COM_INSTALLER_MSG_UPDATE_ERROR', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = false;
 		}
 		else
 		{
 			// Package updated successfully
-			$msg = JText::sprintf('COM_INSTALLER_MSG_UPDATE_SUCCESS', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
+			$msg    = JText::sprintf('COM_INSTALLER_MSG_UPDATE_SUCCESS', JText::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($package['type'])));
 			$result = true;
 		}
 

--- a/administrator/components/com_installer/views/default/view.php
+++ b/administrator/components/com_installer/views/default/view.php
@@ -50,13 +50,13 @@ class InstallerViewDefault extends JViewLegacy
 
 		if (is_object($state))
 		{
-			$message1		= $state->get('message');
-			$message2		= $state->get('extension_message');
-			$showMessage	= ($message1 || $message2);
+			$message1    = $state->get('message');
+			$message2    = $state->get('extension_message');
+			$showMessage = ($message1 || $message2);
 		}
 
 		$this->showMessage = $showMessage;
-		$this->state = &$state;
+		$this->state       = &$state;
 
 		$this->addToolbar();
 		parent::display($tpl);
@@ -71,7 +71,7 @@ class InstallerViewDefault extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_installer');
+		$canDo = JHelperContent::getActions('com_installer');
 		JToolbarHelper::title(JText::_('COM_INSTALLER_HEADER_' . $this->getName()), 'puzzle install');
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))

--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -30,9 +30,9 @@ class InstallerViewDiscover extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state		= $this->get('State');
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
+		$this->state      = $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
 
 		parent::display($tpl);
 	}

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -13,8 +13,8 @@ JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div id="installer-manage" class="clearfix">
 <form action="<?php echo JRoute::_('index.php?option=com_installer&view=manage');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -66,7 +66,7 @@ class InstallerViewManage extends InstallerViewDefault
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_installer');
+		$canDo = JHelperContent::getActions('com_installer');
 
 		if ($canDo->get('core.edit.state'))
 		{

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -13,8 +13,8 @@ JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div id="installer-update" class="clearfix">
 	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=update');?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_joomlaupdate/joomlaupdate.php
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.php
@@ -14,6 +14,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_joomlaupdate'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Joomlaupdate');
+$controller = JControllerLegacy::getInstance('Joomlaupdate');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_languages/controllers/override.php
+++ b/administrator/components/com_languages/controllers/override.php
@@ -103,7 +103,7 @@ class LanguagesControllerOverride extends JControllerForm
 		if ($validData === false)
 		{
 			// Get the validation messages.
-			$errors	= $model->getErrors();
+			$errors = $model->getErrors();
 
 			// Push up to three validation messages out to the user.
 			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)

--- a/administrator/components/com_languages/helpers/html/languages.php
+++ b/administrator/components/com_languages/helpers/html/languages.php
@@ -76,11 +76,11 @@ abstract class JHtmlLanguages
 	public static function publishedOptions()
 	{
 		// Build the active state filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', 'JPUBLISHED');
-		$options[]	= JHtml::_('select.option', '0', 'JUNPUBLISHED');
-		$options[]	= JHtml::_('select.option', '-2', 'JTRASHED');
-		$options[]	= JHtml::_('select.option', '*', 'JALL');
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', 'JPUBLISHED');
+		$options[] = JHtml::_('select.option', '0', 'JUNPUBLISHED');
+		$options[] = JHtml::_('select.option', '-2', 'JTRASHED');
+		$options[] = JHtml::_('select.option', '*', 'JALL');
 
 		return $options;
 	}

--- a/administrator/components/com_languages/helpers/jsonresponse.php
+++ b/administrator/components/com_languages/helpers/jsonresponse.php
@@ -101,15 +101,15 @@ class JJsonResponse
 		{
 			// Prepare the error response.
 			$this->success = false;
-			$this->error = true;
-			$this->message	= $response->getMessage();
+			$this->error   = true;
+			$this->message = $response->getMessage();
 		}
 		else
 		{
 			// Prepare the response data.
 			$this->success = !$error;
-			$this->error = $error;
-			$this->data = $response;
+			$this->error   = $error;
+			$this->data    = $response;
 		}
 	}
 

--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -165,12 +165,12 @@ class LanguagesModelInstalled extends JModelList
 		if (is_null($this->data))
 		{
 			// Get information.
-			$path		= $this->getPath();
-			$client		= $this->getClient();
-			$langlist   = $this->getLanguageList();
+			$path     = $this->getPath();
+			$client   = $this->getClient();
+			$langlist = $this->getLanguageList();
 
 			// Compute all the languages.
-			$data	= array ();
+			$data = array ();
 
 			foreach ($langlist as $lang)
 			{
@@ -200,7 +200,7 @@ class LanguagesModelInstalled extends JModelList
 
 				if ($params->get($client->name, 'en-GB') == $row->language)
 				{
-					$row->published	= 1;
+					$row->published = 1;
 				}
 				else
 				{
@@ -239,7 +239,7 @@ class LanguagesModelInstalled extends JModelList
 			}
 
 			// Compute the displayed languages.
-			$this->data	= array();
+			$this->data = array();
 
 			for ($i = $start; $i < $end; $i++)
 			{
@@ -314,13 +314,13 @@ class LanguagesModelInstalled extends JModelList
 	{
 		if ($cid)
 		{
-			$client	= $this->getClient();
+			$client = $this->getClient();
 
 			$params = JComponentHelper::getParams('com_languages');
 			$params->set($client->name, $cid);
 
 			$table = JTable::getInstance('extension');
-			$id = $table->find(array('element' => 'com_languages'));
+			$id    = $table->find(array('element' => 'com_languages'));
 
 			// Load.
 			if (!$table->load($id))

--- a/administrator/components/com_languages/models/language.php
+++ b/administrator/components/com_languages/models/language.php
@@ -85,7 +85,7 @@ class LanguagesModelLanguage extends JModelAdmin
 	 */
 	public function getItem($langId = null)
 	{
-		$langId	= (!empty($langId)) ? $langId : (int) $this->getState('language.id');
+		$langId = (!empty($langId)) ? $langId : (int) $this->getState('language.id');
 		$false  = false;
 
 		// Get a member row instance.
@@ -171,7 +171,7 @@ class LanguagesModelLanguage extends JModelAdmin
 	public function save($data)
 	{
 		$langId = (!empty($data['lang_id'])) ? $data['lang_id'] : (int) $this->getState('language.id');
-		$isNew	= true;
+		$isNew  = true;
 
 		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin($this->events_map['save']);

--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -38,9 +38,9 @@ class LanguagesModelOverride extends JModelAdmin
 			return false;
 		}
 
-		$client		= $this->getState('filter.client', 'site');
-		$language	= $this->getState('filter.language', 'en-GB');
-		$langName	= JLanguage::getInstance($language)->getName();
+		$client   = $this->getState('filter.client', 'site');
+		$language = $this->getState('filter.language', 'en-GB');
+		$langName = JLanguage::getInstance($language)->getName();
 
 		if (!$langName)
 		{
@@ -91,8 +91,8 @@ class LanguagesModelOverride extends JModelAdmin
 	{
 		require_once JPATH_COMPONENT . '/helpers/languages.php';
 
-		$input = JFactory::getApplication()->input;
-		$pk	= (!empty($pk)) ? $pk : $input->get('id');
+		$input    = JFactory::getApplication()->input;
+		$pk       = (!empty($pk)) ? $pk : $input->get('id');
 		$filename = constant('JPATH_' . strtoupper($this->getState('filter.client')))
 			. '/language/overrides/' . $this->getState('filter.language', 'en-GB') . '.override.ini';
 		$strings = LanguagesHelper::parseFile($filename);
@@ -126,8 +126,8 @@ class LanguagesModelOverride extends JModelAdmin
 		require_once JPATH_COMPONENT . '/helpers/languages.php';
 		jimport('joomla.filesystem.file');
 
-		$client		= $app->getUserState('com_languages.overrides.filter.client', 0);
-		$language	= $app->getUserState('com_languages.overrides.filter.language', 'en-GB');
+		$client   = $app->getUserState('com_languages.overrides.filter.client', 0);
+		$language = $app->getUserState('com_languages.overrides.filter.language', 'en-GB');
 
 		// If the override should be created for both.
 		if ($opposite_client)
@@ -148,8 +148,8 @@ class LanguagesModelOverride extends JModelAdmin
 		$client = $client ? 'administrator' : 'site';
 
 		// Parse the override.ini file in oder to get the keys and strings.
-		$filename	= constant('JPATH_' . strtoupper($client)) . '/language/overrides/' . $language . '.override.ini';
-		$strings	= LanguagesHelper::parseFile($filename);
+		$filename = constant('JPATH_' . strtoupper($client)) . '/language/overrides/' . $language . '.override.ini';
+		$strings  = LanguagesHelper::parseFile($filename);
 
 		if (isset($strings[$data['id']]))
 		{

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -203,9 +203,9 @@ class LanguagesModelOverrides extends JModelList
 		}
 
 		// Get all languages of frontend and backend.
-		$languages 			= array();
-		$site_languages 	= JLanguage::getKnownLanguages(JPATH_SITE);
-		$admin_languages	= JLanguage::getKnownLanguages(JPATH_ADMINISTRATOR);
+		$languages       = array();
+		$site_languages  = JLanguage::getKnownLanguages(JPATH_SITE);
+		$admin_languages = JLanguage::getKnownLanguages(JPATH_ADMINISTRATOR);
 
 		// Create a single array of them.
 		foreach ($site_languages as $tag => $language)

--- a/administrator/components/com_languages/models/strings.php
+++ b/administrator/components/com_languages/models/strings.php
@@ -48,8 +48,8 @@ class LanguagesModelStrings extends JModelLegacy
 					->columns('constant, string, file');
 
 		// Initialize some variables.
-		$client		= $app->getUserState('com_languages.overrides.filter.client', 'site') ? 'administrator' : 'site';
-		$language	= $app->getUserState('com_languages.overrides.filter.language', 'en-GB');
+		$client   = $app->getUserState('com_languages.overrides.filter.client', 'site') ? 'administrator' : 'site';
+		$language = $app->getUserState('com_languages.overrides.filter.language', 'en-GB');
 
 		$base = constant('JPATH_' . strtoupper($client));
 		$path = $base . '/language/' . $language;

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -14,11 +14,12 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$client		= $this->state->get('filter.client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
-$clientId	= $this->state->get('filter.client_id', 0);
+$user     = JFactory::getUser();
+$userId   = $user->get('id');
+$client   = $this->state->get('filter.client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
+$clientId = $this->state->get('filter.client_id', 0);
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client=' . $clientId); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty($this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_languages/views/installed/view.html.php
+++ b/administrator/components/com_languages/views/installed/view.html.php
@@ -77,7 +77,7 @@ class LanguagesViewInstalled extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_languages');
+		$canDo = JHelperContent::getActions('com_languages');
 
 		JToolbarHelper::title(JText::_('COM_LANGUAGES_VIEW_INSTALLED_TITLE'), 'comments-2 langmanager');
 

--- a/administrator/components/com_languages/views/language/view.html.php
+++ b/administrator/components/com_languages/views/language/view.html.php
@@ -31,10 +31,10 @@ class LanguagesViewLanguage extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->item 	= $this->get('Item');
-		$this->form 	= $this->get('Form');
-		$this->state 	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions('com_languages');
+		$this->item  = $this->get('Item');
+		$this->form  = $this->get('Form');
+		$this->state = $this->get('State');
+		$this->canDo = JHelperContent::getActions('com_languages');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_languages/views/languages/view.html.php
+++ b/administrator/components/com_languages/views/languages/view.html.php
@@ -31,9 +31,9 @@ class LanguagesViewLanguages extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		LanguagesHelper::addSubmenu('languages');
 
@@ -59,7 +59,7 @@ class LanguagesViewLanguages extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_languages');
+		$canDo = JHelperContent::getActions('com_languages');
 
 		JToolbarHelper::title(JText::_('COM_LANGUAGES_VIEW_LANGUAGES_TITLE'), 'comments-2 langmanager');
 

--- a/administrator/components/com_languages/views/multilangstatus/view.html.php
+++ b/administrator/components/com_languages/views/multilangstatus/view.html.php
@@ -27,14 +27,14 @@ class LanguagesViewMultilangstatus extends JViewLegacy
 	{
 		require_once JPATH_COMPONENT . '/helpers/multilangstatus.php';
 
-		$this->homes			= MultilangstatusHelper::getHomes();
-		$this->language_filter	= JLanguageMultilang::isEnabled();
-		$this->switchers		= MultilangstatusHelper::getLangswitchers();
-		$this->listUsersError	= MultilangstatusHelper::getContacts();
-		$this->contentlangs		= MultilangstatusHelper::getContentlangs();
-		$this->site_langs		= MultilangstatusHelper::getSitelangs();
-		$this->statuses			= MultilangstatusHelper::getStatus();
-		$this->homepages		= MultilangstatusHelper::getHomepages();
+		$this->homes           = MultilangstatusHelper::getHomes();
+		$this->language_filter = JLanguageMultilang::isEnabled();
+		$this->switchers       = MultilangstatusHelper::getLangswitchers();
+		$this->listUsersError  = MultilangstatusHelper::getContacts();
+		$this->contentlangs    = MultilangstatusHelper::getContentlangs();
+		$this->site_langs      = MultilangstatusHelper::getSitelangs();
+		$this->statuses        = MultilangstatusHelper::getStatus();
+		$this->homepages       = MultilangstatusHelper::getHomepages();
 
 		parent::display($tpl);
 	}

--- a/administrator/components/com_languages/views/override/view.html.php
+++ b/administrator/components/com_languages/views/override/view.html.php
@@ -95,7 +95,7 @@ class LanguagesViewOverride extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$canDo	= JHelperContent::getActions('com_languages');
+		$canDo = JHelperContent::getActions('com_languages');
 
 		JToolbarHelper::title(JText::_('COM_LANGUAGES_VIEW_OVERRIDE_EDIT_TITLE'), 'comments-2 langmanager');
 

--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -35,28 +35,29 @@ class MediaController extends JControllerLegacy
 		{
 			case 'images':
 				$vLayout = $this->input->get('layout', 'default', 'string');
-				$mName = 'manager';
+				$mName   = 'manager';
 
 				break;
 
 			case 'imagesList':
-				$mName = 'list';
+				$mName   = 'list';
 				$vLayout = $this->input->get('layout', 'default', 'string');
 
 				break;
 
 			case 'mediaList':
-				$app	= JFactory::getApplication();
-				$mName = 'list';
+				$app     = JFactory::getApplication();
+				$mName   = 'list';
 				$vLayout = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 'word');
 
 				break;
 
 			case 'media':
 			default:
-				$vName = 'media';
+				$vName   = 'media';
 				$vLayout = $this->input->get('layout', 'default', 'string');
-				$mName = 'manager';
+				$mName   = 'manager';
+
 				break;
 		}
 

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -106,7 +106,7 @@ class MediaControllerFile extends JControllerLegacy
 
 		// Trigger the onContentBeforeSave event.
 		JPluginHelper::importPlugin('content');
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher  = JEventDispatcher::getInstance();
 		$object_file = new JObject($file);
 		$object_file->filepath = $filepath;
 		$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -126,7 +126,7 @@ class MediaControllerFile extends JControllerLegacy
 		// Set FTP credentials, if given
 		JClientHelper::setCredentialsFromRequest('ftp');
 		JPluginHelper::importPlugin('content');
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 
 		foreach ($files as &$file)
 		{
@@ -202,8 +202,8 @@ class MediaControllerFile extends JControllerLegacy
 		JSession::checkToken('request') or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Get some data from the request
-		$tmpl	= $this->input->get('tmpl');
-		$paths	= $this->input->get('rm', array(), 'array');
+		$tmpl   = $this->input->get('tmpl');
+		$paths  = $this->input->get('rm', array(), 'array');
 		$folder = $this->input->get('folder', '', 'path');
 
 		$redirect = 'index.php?option=com_media&folder=' . $folder;
@@ -232,7 +232,7 @@ class MediaControllerFile extends JControllerLegacy
 		JClientHelper::setCredentialsFromRequest('ftp');
 
 		JPluginHelper::importPlugin('content');
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 
 		$ret = true;
 

--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -30,7 +30,7 @@ class MediaControllerFolder extends JControllerLegacy
 	{
 		JSession::checkToken('request') or jexit(JText::_('JINVALID_TOKEN'));
 
-		$user	= JFactory::getUser();
+		$user = JFactory::getUser();
 
 		// Get some data from the request
 		$tmpl   = $this->input->get('tmpl');
@@ -69,7 +69,7 @@ class MediaControllerFolder extends JControllerLegacy
 		$ret = true;
 
 		JPluginHelper::importPlugin('content');
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 
 		if (count($paths))
 		{
@@ -190,8 +190,8 @@ class MediaControllerFolder extends JControllerLegacy
 				// Trigger the onContentBeforeSave event.
 				$object_file = new JObject(array('filepath' => $path));
 				JPluginHelper::importPlugin('content');
-				$dispatcher	= JEventDispatcher::getInstance();
-				$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file, true));
+				$dispatcher = JEventDispatcher::getInstance();
+				$result     = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file, true));
 
 				if (in_array(false, $result, true))
 				{

--- a/administrator/components/com_media/media.php
+++ b/administrator/components/com_media/media.php
@@ -30,18 +30,17 @@ require_once JPATH_COMPONENT_ADMINISTRATOR . '/helpers/media.php';
 
 // Set the path definitions
 $popup_upload = $input->get('pop_up', null);
-$path = 'file_path';
-
-$view = $input->get('view');
+$path         = 'file_path';
+$view         = $input->get('view');
 
 if (substr(strtolower($view), 0, 6) == 'images' || $popup_upload == 1)
 {
 	$path = 'image_path';
 }
 
-define('COM_MEDIA_BASE',    JPATH_ROOT . '/' . $params->get($path, 'images'));
+define('COM_MEDIA_BASE', JPATH_ROOT . '/' . $params->get($path, 'images'));
 define('COM_MEDIA_BASEURL', JUri::root() . $params->get($path, 'images'));
 
-$controller	= JControllerLegacy::getInstance('Media', array('base_path' => JPATH_COMPONENT_ADMINISTRATOR));
+$controller = JControllerLegacy::getInstance('Media', array('base_path' => JPATH_COMPONENT_ADMINISTRATOR));
 $controller->execute($input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_media/models/list.php
+++ b/administrator/components/com_media/models/list.php
@@ -110,21 +110,20 @@ class MediaModelList extends JModelLegacy
 		// Get current path from request
 		$current = (string) $this->getState('folder');
 
-		$basePath = COM_MEDIA_BASE . ((strlen($current) > 0) ? '/' . $current : '');
-
+		$basePath  = COM_MEDIA_BASE . ((strlen($current) > 0) ? '/' . $current : '');
 		$mediaBase = str_replace(DIRECTORY_SEPARATOR, '/', COM_MEDIA_BASE . '/');
 
 		$images  = array ();
 		$folders = array ();
 		$docs    = array ();
 
-		$fileList = false;
+		$fileList   = false;
 		$folderList = false;
 
 		if (file_exists($basePath))
 		{
 			// Get the list of files and folders from the given folder
-			$fileList	= JFolder::files($basePath);
+			$fileList   = JFolder::files($basePath);
 			$folderList = JFolder::folders($basePath);
 		}
 
@@ -156,10 +155,10 @@ class MediaModelList extends JModelLegacy
 						case 'jpeg':
 						case 'ico':
 							$info = @getimagesize($tmp->path);
-							$tmp->width		= @$info[0];
-							$tmp->height	= @$info[1];
-							$tmp->type		= @$info[2];
-							$tmp->mime		= @$info['mime'];
+							$tmp->width  = @$info[0];
+							$tmp->height = @$info[1];
+							$tmp->type   = @$info[2];
+							$tmp->mime   = @$info['mime'];
 
 							if (($info[0] > 60) || ($info[1] > 60))
 							{

--- a/administrator/components/com_media/models/manager.php
+++ b/administrator/components/com_media/models/manager.php
@@ -81,10 +81,10 @@ class MediaModelManager extends JModelLegacy
 
 		foreach ($folders as $folder)
 		{
-			$folder		= str_replace($com_media_base_uni, "", str_replace(DIRECTORY_SEPARATOR, '/', $folder));
-			$value		= substr($folder, 1);
-			$text		= str_replace(DIRECTORY_SEPARATOR, "/", $folder);
-			$options[]	= JHtml::_('select.option', $value, $text);
+			$folder    = str_replace($com_media_base_uni, "", str_replace(DIRECTORY_SEPARATOR, '/', $folder));
+			$value     = substr($folder, 1);
+			$text      = str_replace(DIRECTORY_SEPARATOR, "/", $folder);
+			$options[] = JHtml::_('select.option', $value, $text);
 		}
 
 		// Sort the folder list array
@@ -140,14 +140,13 @@ class MediaModelManager extends JModelLegacy
 
 		foreach ($folders as $folder)
 		{
-			$folder		= str_replace(DIRECTORY_SEPARATOR, '/', $folder);
-			$name		= substr($folder, strrpos($folder, '/') + 1);
-			$relative	= str_replace($mediaBase, '', $folder);
-			$absolute	= $folder;
-			$path		= explode('/', $relative);
-			$node		= (object) array('name' => $name, 'relative' => $relative, 'absolute' => $absolute);
-
-			$tmp = &$tree;
+			$folder   = str_replace(DIRECTORY_SEPARATOR, '/', $folder);
+			$name     = substr($folder, strrpos($folder, '/') + 1);
+			$relative = str_replace($mediaBase, '', $folder);
+			$absolute = $folder;
+			$path     = explode('/', $relative);
+			$node     = (object) array('name' => $name, 'relative' => $relative, 'absolute' => $absolute);
+			$tmp      = &$tree;
 
 			for ($i = 0, $n = count($path); $i < $n; $i++)
 			{
@@ -160,6 +159,7 @@ class MediaModelManager extends JModelLegacy
 				{
 					// We need to place the node
 					$tmp['children'][$relative] = array('data' => $node, 'children' => array());
+
 					break;
 				}
 

--- a/administrator/components/com_media/views/images/view.html.php
+++ b/administrator/components/com_media/views/images/view.html.php
@@ -28,7 +28,7 @@ class MediaViewImages extends JViewLegacy
 	public function display($tpl = null)
 	{
 		$config = JComponentHelper::getParams('com_media');
-		$lang	= JFactory::getLanguage();
+		$lang   = JFactory::getLanguage();
 
 		// Include jQuery
 		JHtml::_('jquery.framework');

--- a/administrator/components/com_media/views/imageslist/tmpl/default_image.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default_image.php
@@ -11,10 +11,11 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
-$params = new Registry;
-$dispatcher	= JEventDispatcher::getInstance();
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
 $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
 ?>
+
 <li class="imgOutline thumbnail height-80 width-80 center">
 	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_img->path_relative; ?>')" title="<?php echo $this->_tmp_img->name; ?>" >
 		<div class="height-50">

--- a/administrator/components/com_media/views/imageslist/view.html.php
+++ b/administrator/components/com_media/views/imageslist/view.html.php
@@ -30,7 +30,7 @@ class MediaViewImagesList extends JViewLegacy
 		// Do not allow cache
 		JFactory::getApplication()->allowCache(false);
 
-		$lang	= JFactory::getLanguage();
+		$lang = JFactory::getLanguage();
 
 		JHtml::_('stylesheet', 'media/popup-imagelist.css', array(), true);
 

--- a/administrator/components/com_media/views/media/tmpl/default_navigation.php
+++ b/administrator/components/com_media/views/media/tmpl/default_navigation.php
@@ -8,9 +8,10 @@
  */
 
 defined('_JEXEC') or die;
-$app	= JFactory::getApplication();
+$app   = JFactory::getApplication();
 $style = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 'word');
 ?>
+
 <div class="media btn-group">
 	<a href="#" id="thumbs" onclick="MediaManager.setViewType('thumbs')" class="btn <?php echo ($style == "thumbs") ? 'active' : '';?>">
 	<span class="icon-grid-view-2"></span> <?php echo JText::_('COM_MEDIA_THUMBNAIL_VIEW'); ?></a>

--- a/administrator/components/com_media/views/media/view.html.php
+++ b/administrator/components/com_media/views/media/view.html.php
@@ -30,7 +30,7 @@ class MediaViewMedia extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$app	= JFactory::getApplication();
+		$app    = JFactory::getApplication();
 		$config = JComponentHelper::getParams('com_media');
 
 		if (!$app->isAdmin())
@@ -38,17 +38,14 @@ class MediaViewMedia extends JViewLegacy
 			return $app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
 		}
 
-		$lang	= JFactory::getLanguage();
-
-		$style = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 'word');
-
+		$lang     = JFactory::getLanguage();
+		$style    = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 'word');
 		$document = JFactory::getDocument();
 
 		JHtml::_('behavior.framework', true);
-
 		JHtml::_('script', 'media/mediamanager.min.js', true, true);
-
 		JHtml::_('behavior.modal');
+
 		$document->addScriptDeclaration("
 		window.addEvent('domready', function()
 		{
@@ -83,14 +80,14 @@ class MediaViewMedia extends JViewLegacy
 		 */
 		$ftp = !JClientHelper::hasCredentials('ftp');
 
-		$session	= JFactory::getSession();
-		$state		= $this->get('state');
-		$this->session = $session;
-		$this->config = &$config;
-		$this->state = &$state;
+		$session           = JFactory::getSession();
+		$state             = $this->get('state');
+		$this->session     = $session;
+		$this->config      = &$config;
+		$this->state       = &$state;
 		$this->require_ftp = $ftp;
-		$this->folders_id = ' id="media-tree"';
-		$this->folders = $this->get('folderTree');
+		$this->folders_id  = ' id="media-tree"';
+		$this->folders     = $this->get('folderTree');
 
 		// Set the toolbar
 		$this->addToolbar();
@@ -109,7 +106,7 @@ class MediaViewMedia extends JViewLegacy
 	protected function addToolbar()
 	{
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar  = JToolBar::getInstance('toolbar');
 		$user = JFactory::getUser();
 
 		// The toolbar functions depend on Bootstrap JS
@@ -170,13 +167,13 @@ class MediaViewMedia extends JViewLegacy
 	protected function getFolderLevel($folder)
 	{
 		$this->folders_id = null;
-		$txt = null;
+		$txt              = null;
 
 		if (isset($folder['children']) && count($folder['children']))
 		{
-			$tmp = $this->folders;
+			$tmp           = $this->folders;
 			$this->folders = $folder;
-			$txt = $this->loadTemplate('folders');
+			$txt           = $this->loadTemplate('folders');
 			$this->folders = $tmp;
 		}
 

--- a/administrator/components/com_media/views/medialist/tmpl/details_doc.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_doc.php
@@ -12,11 +12,12 @@ use Joomla\Registry\Registry;
 
 JHtml::_('bootstrap.tooltip');
 
-$user = JFactory::getUser();
-$params = new Registry;
-$dispatcher	= JEventDispatcher::getInstance();
+$user       = JFactory::getUser();
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
 $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
 ?>
+
 <tr>
 	<td>
 		<a  title="<?php echo $this->_tmp_doc->name; ?>">
@@ -38,5 +39,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	</td>
 <?php endif;?>
 </tr>
-<?php
-	$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));

--- a/administrator/components/com_media/views/medialist/tmpl/details_img.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_img.php
@@ -13,11 +13,12 @@ use Joomla\Registry\Registry;
 
 JHtml::_('bootstrap.tooltip');
 
-$user = JFactory::getUser();
-$params = new Registry;
-$dispatcher	= JEventDispatcher::getInstance();
+$user       = JFactory::getUser();
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
 $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
 ?>
+
 <tr>
 	<td>
 		<a class="img-preview" href="<?php echo COM_MEDIA_BASEURL . '/' . $this->_tmp_img->path_relative; ?>" title="<?php echo $this->_tmp_img->name; ?>"><?php echo JHtml::_('image', COM_MEDIA_BASEURL . '/' . $this->_tmp_img->path_relative, JText::sprintf('COM_MEDIA_IMAGE_TITLE', $this->_tmp_img->title, JHtml::_('number.bytes', $this->_tmp_img->size)), array('width' => $this->_tmp_img->width_16, 'height' => $this->_tmp_img->height_16)); ?></a>
@@ -38,5 +39,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 		</td>
 	<?php endif;?>
 </tr>
-<?php
-	$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_doc.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_doc.php
@@ -11,11 +11,12 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
-$user = JFactory::getUser();
-$params = new Registry;
-$dispatcher	= JEventDispatcher::getInstance();
+$user       = JFactory::getUser();
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
 $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
 ?>
+
 <li class="imgOutline thumbnail height-80 width-80 center">
 	<?php if ($user->authorise('core.delete', 'com_media')):?>
 		<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $this->_tmp_doc->name; ?>" rel="<?php echo $this->_tmp_doc->name; ?>" title="<?php echo JText::_('JACTION_DELETE');?>">&#215;</a>
@@ -30,5 +31,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 		<?php echo JHtml::_('string.truncate', $this->_tmp_doc->name, 10, false); ?>
 	</div>
 </li>
-<?php
-	$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_img.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_img.php
@@ -11,19 +11,20 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
-$user = JFactory::getUser();
-$params = new Registry;
-$dispatcher	= JEventDispatcher::getInstance();
+$user       = JFactory::getUser();
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
 $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
 ?>
+
 <li class="imgOutline thumbnail height-80 width-80 center">
 	<?php if ($user->authorise('core.delete', 'com_media')):?>
 		<a class="close delete-item" target="_top"
 		href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $this->_tmp_img->name; ?>"
-		rel="<?php echo $this->_tmp_img->name; ?>" title="<?php echo JText::_('JACTION_DELETE');?>">&#215;</a>
+		rel="<?php echo $this->_tmp_img->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 		<input class="pull-left" type="checkbox" name="rm[]" value="<?php echo $this->_tmp_img->name; ?>" />
 		<div class="clearfix"></div>
-	<?php endif;?>
+	<?php endif; ?>
 	<div class="height-50">
 		<a class="img-preview" href="<?php echo COM_MEDIA_BASEURL . '/' . $this->_tmp_img->path_relative; ?>" title="<?php echo $this->_tmp_img->name; ?>" >
 			<?php echo JHtml::_('image', COM_MEDIA_BASEURL . '/' . $this->_tmp_img->path_relative, JText::sprintf('COM_MEDIA_IMAGE_TITLE', $this->_tmp_img->title, JHtml::_('number.bytes', $this->_tmp_img->size)), array('width' => $this->_tmp_img->width_60, 'height' => $this->_tmp_img->height_60)); ?>
@@ -33,5 +34,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 		<a href="<?php echo COM_MEDIA_BASEURL . '/' . $this->_tmp_img->path_relative; ?>" title="<?php echo $this->_tmp_img->name; ?>" class="preview"><?php echo JHtml::_('string.truncate', $this->_tmp_img->name, 10, false); ?></a>
 	</div>
 </li>
-<?php
-	$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));

--- a/administrator/components/com_menus/controllers/menu.php
+++ b/administrator/components/com_menus/controllers/menu.php
@@ -79,8 +79,8 @@ class MenusControllerMenu extends JControllerForm
 		$data['id'] = $recordId;
 
 		// Get the model and attempt to validate the posted data.
-		$model	= $this->getModel('Menu');
-		$form	= $model->getForm();
+		$model = $this->getModel('Menu');
+		$form  = $model->getForm();
 
 		if (!$form)
 		{
@@ -89,13 +89,13 @@ class MenusControllerMenu extends JControllerForm
 			return false;
 		}
 
-		$data	= $model->validate($form, $data);
+		$data = $model->validate($form, $data);
 
 		// Check for validation errors.
 		if ($data === false)
 		{
 			// Get the validation messages.
-			$errors	= $model->getErrors();
+			$errors = $model->getErrors();
 
 			// Push up to three validation messages out to the user.
 			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -102,8 +102,8 @@ abstract class MenusHtmlMenus
 	 */
 	public static function state($value, $i, $enabled = true, $checkbox = 'cb')
 	{
-		$states	= array(
-			9	=> array(
+		$states = array(
+			9 => array(
 				'unpublish',
 				'',
 				'COM_MENUS_HTML_UNPUBLISH_HEADING',
@@ -112,7 +112,7 @@ abstract class MenusHtmlMenus
 				'publish',
 				'publish'
 			),
-			8	=> array(
+			8 => array(
 				'publish',
 				'',
 				'COM_MENUS_HTML_PUBLISH_HEADING',
@@ -121,7 +121,7 @@ abstract class MenusHtmlMenus
 				'unpublish',
 				'unpublish'
 			),
-			7	=> array(
+			7 => array(
 				'unpublish',
 				'',
 				'COM_MENUS_HTML_UNPUBLISH_SEPARATOR',
@@ -130,7 +130,7 @@ abstract class MenusHtmlMenus
 				'publish',
 				'publish'
 			),
-			6	=> array(
+			6 => array(
 				'publish',
 				'',
 				'COM_MENUS_HTML_PUBLISH_SEPARATOR',
@@ -139,7 +139,7 @@ abstract class MenusHtmlMenus
 				'unpublish',
 				'unpublish'
 			),
-			5	=> array(
+			5 => array(
 				'unpublish',
 				'',
 				'COM_MENUS_HTML_UNPUBLISH_ALIAS',
@@ -148,7 +148,7 @@ abstract class MenusHtmlMenus
 				'publish',
 				'publish'
 			),
-			4	=> array(
+			4 => array(
 				'publish',
 				'',
 				'COM_MENUS_HTML_PUBLISH_ALIAS',
@@ -157,7 +157,7 @@ abstract class MenusHtmlMenus
 				'unpublish',
 				'unpublish'
 			),
-			3	=> array(
+			3 => array(
 				'unpublish',
 				'',
 				'COM_MENUS_HTML_UNPUBLISH_URL',
@@ -166,7 +166,7 @@ abstract class MenusHtmlMenus
 				'publish',
 				'publish'
 			),
-			2	=> array(
+			2 => array(
 				'publish',
 				'',
 				'COM_MENUS_HTML_PUBLISH_URL',
@@ -175,7 +175,7 @@ abstract class MenusHtmlMenus
 				'unpublish',
 				'unpublish'
 			),
-			1	=> array(
+			1 => array(
 				'unpublish',
 				'COM_MENUS_EXTENSION_PUBLISHED_ENABLED',
 				'COM_MENUS_HTML_UNPUBLISH_ENABLED',
@@ -184,7 +184,7 @@ abstract class MenusHtmlMenus
 				'publish',
 				'publish'
 			),
-			0	=> array(
+			0 => array(
 				'publish',
 				'COM_MENUS_EXTENSION_UNPUBLISHED_ENABLED',
 				'COM_MENUS_HTML_PUBLISH_ENABLED',
@@ -193,7 +193,7 @@ abstract class MenusHtmlMenus
 				'unpublish',
 				'unpublish'
 			),
-			-1	=> array(
+			-1 => array(
 				'unpublish',
 				'COM_MENUS_EXTENSION_PUBLISHED_DISABLED',
 				'COM_MENUS_HTML_UNPUBLISH_DISABLED',
@@ -202,7 +202,7 @@ abstract class MenusHtmlMenus
 				'warning',
 				'warning'
 			),
-			-2	=> array(
+			-2 => array(
 				'publish',
 				'COM_MENUS_EXTENSION_UNPUBLISHED_DISABLED',
 				'COM_MENUS_HTML_PUBLISH_DISABLED',
@@ -211,7 +211,7 @@ abstract class MenusHtmlMenus
 				'trash',
 				'trash'
 			),
-			-3	=> array(
+			-3 => array(
 				'publish',
 				'',
 				'COM_MENUS_HTML_PUBLISH',

--- a/administrator/components/com_menus/menus.php
+++ b/administrator/components/com_menus/menus.php
@@ -14,6 +14,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_menus'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Menus');
+$controller = JControllerLegacy::getInstance('Menus');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -35,15 +35,15 @@ class JFormFieldMenutype extends JFormFieldList
 	 */
 	protected function getInput()
 	{
-		$html 		= array();
-		$recordId	= (int) $this->form->getValue('id');
-		$size		= ($v = $this->element['size']) ? ' size="' . $v . '"' : '';
-		$class		= ($v = $this->element['class']) ? ' class="' . $v . '"' : 'class="text_area"';
-		$required	= ($v = $this->element['required']) ? ' required="required"' : '';
+		$html     = array();
+		$recordId = (int) $this->form->getValue('id');
+		$size     = ($v = $this->element['size']) ? ' size="' . $v . '"' : '';
+		$class    = ($v = $this->element['class']) ? ' class="' . $v . '"' : 'class="text_area"';
+		$required = ($v = $this->element['required']) ? ' required="required"' : '';
 
 		// Get a reverse lookup of the base link URL to Title
-		$model 	= JModelLegacy::getInstance('menutypes', 'menusModel');
-		$rlu 	= $model->getReverseLookup();
+		$model = JModelLegacy::getInstance('menutypes', 'menusModel');
+		$rlu   = $model->getReverseLookup();
 
 		switch ($this->value)
 		{
@@ -64,10 +64,10 @@ class JFormFieldMenutype extends JFormFieldList
 				break;
 
 			default:
-				$link	= $this->form->getValue('link');
+				$link = $this->form->getValue('link');
 
 				// Clean the link back to the option, view and layout
-				$value	= JText::_(JArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
+				$value = JText::_(JArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
 				break;
 		}
 		// Include jQuery
@@ -89,9 +89,9 @@ class JFormFieldMenutype extends JFormFieldList
 			'bootstrap.renderModal',
 			'menuTypeModal',
 			array(
-				'url' => $link,
-				'title' => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
-				'width' => '800px',
+				'url'    => $link,
+				'title'  => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+				'width'  => '800px',
 				'height' => '300px',
 				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
 					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -245,11 +245,11 @@ class MenusModelItem extends JModelAdmin
 			$table->setLocation($table->parent_id, 'last-child');
 
 			// TODO: Deal with ordering?
-			// $table->ordering	= 1;
+			// $table->ordering = 1;
 			$table->level = null;
-			$table->lft = null;
-			$table->rgt = null;
-			$table->home = 0;
+			$table->lft   = null;
+			$table->rgt   = null;
+			$table->home  = 0;
 
 			// Alter the title & alias
 			list($title, $alias) = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
@@ -318,12 +318,12 @@ class MenusModelItem extends JModelAdmin
 	protected function batchMove($value, $pks, $contexts)
 	{
 		// $value comes as {menutype}.{parent_id}
-		$parts = explode('.', $value);
+		$parts    = explode('.', $value);
 		$menuType = $parts[0];
 		$parentId = (int) JArrayHelper::getValue($parts, 1, 0);
 
 		$table = $this->getTable();
-		$db = $this->getDbo();
+		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
 
 		// Check that the parent exists.

--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -175,9 +175,9 @@ class MenusModelMenutypes extends JModelLegacy
 		{
 			// Create the menu option for the component.
 			$o = new JObject;
-			$o->title		= (string) $menu['name'];
-			$o->description	= (string) $menu['msg'];
-			$o->request		= array('option' => $component);
+			$o->title       = (string) $menu['name'];
+			$o->description = (string) $menu['msg'];
+			$o->request     = array('option' => $component);
 
 			$options[] = $o;
 
@@ -208,9 +208,9 @@ class MenusModelMenutypes extends JModelLegacy
 				{
 					// Create the menu option for the component.
 					$o = new JObject;
-					$o->title		= (string) $child['name'];
-					$o->description	= (string) $child['msg'];
-					$o->request		= array('option' => $component, (string) $optionsNode['var'] => (string) $child['value']);
+					$o->title       = (string) $child['name'];
+					$o->description = (string) $child['msg'];
+					$o->request     = array('option' => $component, (string) $optionsNode['var'] => (string) $child['value']);
 
 					$options[] = $o;
 				}
@@ -218,9 +218,9 @@ class MenusModelMenutypes extends JModelLegacy
 				{
 					// Create the menu option for the component.
 					$o = new JObject;
-					$o->title		= (string) $child['name'];
-					$o->description	= (string) $child['msg'];
-					$o->request		= array('option' => $component);
+					$o->title       = (string) $child['name'];
+					$o->description = (string) $child['msg'];
+					$o->request     = array('option' => $component);
 
 					$options[] = $o;
 				}
@@ -306,9 +306,9 @@ class MenusModelMenutypes extends JModelLegacy
 										{
 											// Create the menu option for the component.
 											$o = new JObject;
-											$o->title		= (string) $child['name'];
-											$o->description	= (string) $child['msg'];
-											$o->request		= array('option' => $component, 'view' => $view, (string) $optionsNode['var'] => (string) $child['value']);
+											$o->title       = (string) $child['name'];
+											$o->description = (string) $child['msg'];
+											$o->request     = array('option' => $component, 'view' => $view, (string) $optionsNode['var'] => (string) $child['value']);
 
 											$options[] = $o;
 										}
@@ -316,9 +316,9 @@ class MenusModelMenutypes extends JModelLegacy
 										{
 											// Create the menu option for the component.
 											$o = new JObject;
-											$o->title		= (string) $child['name'];
-											$o->description	= (string) $child['msg'];
-											$o->request		= array('option' => $component, 'view' => $view);
+											$o->title       = (string) $child['name'];
+											$o->description = (string) $child['msg'];
+											$o->request     = array('option' => $component, 'view' => $view);
 
 											$options[] = $o;
 										}
@@ -356,11 +356,11 @@ class MenusModelMenutypes extends JModelLegacy
 	 */
 	protected function getTypeOptionsFromLayouts($component, $view)
 	{
-		$options = array();
-		$layouts = array();
+		$options     = array();
+		$layouts     = array();
 		$layoutNames = array();
-		$lang = JFactory::getLanguage();
-		$path = '';
+		$lang        = JFactory::getLanguage();
+		$path        = '';
 
 		// Get the views for this component.
 		if (is_dir(JPATH_SITE . '/components/' . $component))
@@ -406,7 +406,7 @@ class MenusModelMenutypes extends JModelLegacy
 			{
 				$template = basename($folder);
 				$lang->load('tpl_' . $template . '.sys', JPATH_SITE, null, false, true)
-				||	$lang->load('tpl_' . $template . '.sys', JPATH_SITE . '/templates/' . $template, null, false, true);
+				|| $lang->load('tpl_' . $template . '.sys', JPATH_SITE . '/templates/' . $template, null, false, true);
 
 				$templateLayouts = JFolder::files($folder . '/html/' . $component . '/' . $view, '.xml$', false, true);
 
@@ -440,9 +440,9 @@ class MenusModelMenutypes extends JModelLegacy
 
 				// Create the menu option for the layout.
 				$o = new JObject;
-				$o->title		= ucfirst($layout);
-				$o->description	= '';
-				$o->request		= array('option' => $component, 'view' => $view);
+				$o->title       = ucfirst($layout);
+				$o->description = '';
+				$o->request     = array('option' => $component, 'view' => $view);
 
 				// Only add the layout request argument if not the default layout.
 				if ($layout != 'default')

--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -47,12 +47,12 @@ class MenusViewItem extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->modules	= $this->get('Modules');
-		$this->levels	= $this->get('ViewLevels');
-		$this->state	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions('com_menus');
+		$this->form    = $this->get('Form');
+		$this->item    = $this->get('Item');
+		$this->modules = $this->get('Modules');
+		$this->levels  = $this->get('ViewLevels');
+		$this->state   = $this->get('State');
+		$this->canDo   = JHelperContent::getActions('com_menus');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -78,10 +78,10 @@ class MenusViewItem extends JViewLegacy
 		$input = JFactory::getApplication()->input;
 		$input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
-		$canDo		= $this->canDo;
+		$user       = JFactory::getUser();
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+		$canDo      = $this->canDo;
 
 		JToolbarHelper::title(JText::_($isNew ? 'COM_MENUS_VIEW_NEW_ITEM_TITLE' : 'COM_MENUS_VIEW_EDIT_ITEM_TITLE'), 'list menu-add');
 
@@ -134,7 +134,7 @@ class MenusViewItem extends JViewLegacy
 		if ($lang->hasKey($help->url))
 		{
 			$debug = $lang->setDebug(false);
-			$url = JText::_($help->url);
+			$url   = JText::_($help->url);
 			$lang->setDebug($debug);
 		}
 		else

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -16,14 +16,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$app		= JFactory::getApplication();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$ordering 	= ($listOrder == 'a.lft');
-$canOrder	= $user->authorise('core.edit.state',	'com_menus');
-$saveOrder 	= ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$user      = JFactory::getUser();
+$app       = JFactory::getApplication();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state',	'com_menus');
+$saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 
 if ($saveOrder)
 {
@@ -31,8 +31,9 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'itemList', 'adminForm', strtolower($listDirn), $saveOrderingUrl, false, true);
 }
 
-$assoc		= JLanguageAssociations::isEnabled();
+$assoc = JLanguageAssociations::isEnabled();
 ?>
+
 <?php // Set up the filter bar. ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -47,10 +47,10 @@ class MenusViewItems extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$lang 		= JFactory::getLanguage();
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$lang = JFactory::getLanguage();
+		$this->items         = $this->get('Items');
+		$this->pagination    = $this->get('Pagination');
+		$this->state         = $this->get('State');
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 
@@ -94,12 +94,12 @@ class MenusViewItems extends JViewLegacy
 				default:
 					// Load language
 						$lang->load($item->componentname . '.sys', JPATH_ADMINISTRATOR, null, false, true)
-					||	$lang->load($item->componentname . '.sys', JPATH_ADMINISTRATOR . '/components/' . $item->componentname, null, false, true);
+					|| $lang->load($item->componentname . '.sys', JPATH_ADMINISTRATOR . '/components/' . $item->componentname, null, false, true);
 
 					if (!empty($item->componentname))
 					{
-						$value	= JText::_($item->componentname);
-						$vars	= null;
+						$value = JText::_($item->componentname);
+						$vars  = null;
 
 						parse_str($item->link, $vars);
 
@@ -132,7 +132,7 @@ class MenusViewItems extends JViewLegacy
 
 											// Load template language file
 											$lang->load('tpl_' . $temp[0] . '.sys', JPATH_SITE, null, false, true)
-											||	$lang->load('tpl_' . $temp[0] . '.sys', JPATH_SITE . '/templates/' . $temp[0], null, false, true);
+											|| $lang->load('tpl_' . $temp[0] . '.sys', JPATH_SITE . '/templates/' . $temp[0], null, false, true);
 										}
 										else
 										{
@@ -191,17 +191,17 @@ class MenusViewItems extends JViewLegacy
 		}
 
 		// Levels filter.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', JText::_('J1'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('J2'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('J3'));
-		$options[]	= JHtml::_('select.option', '4', JText::_('J4'));
-		$options[]	= JHtml::_('select.option', '5', JText::_('J5'));
-		$options[]	= JHtml::_('select.option', '6', JText::_('J6'));
-		$options[]	= JHtml::_('select.option', '7', JText::_('J7'));
-		$options[]	= JHtml::_('select.option', '8', JText::_('J8'));
-		$options[]	= JHtml::_('select.option', '9', JText::_('J9'));
-		$options[]	= JHtml::_('select.option', '10', JText::_('J10'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
+		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
+		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
+		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
+		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
+		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
+		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
+		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
+		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
+		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
 
 		$this->f_levels = $options;
 
@@ -223,7 +223,7 @@ class MenusViewItems extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_menus');
+		$canDo = JHelperContent::getActions('com_menus');
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
@@ -298,14 +298,14 @@ class MenusViewItems extends JViewLegacy
 	protected function getSortFields()
 	{
 		return array(
-			'a.lft' => JText::_('JGRID_HEADING_ORDERING'),
+			'a.lft'       => JText::_('JGRID_HEADING_ORDERING'),
 			'a.published' => JText::_('JSTATUS'),
-			'a.title' => JText::_('JGLOBAL_TITLE'),
-			'a.home' => JText::_('COM_MENUS_HEADING_HOME'),
-			'a.access' => JText::_('JGRID_HEADING_ACCESS'),
+			'a.title'     => JText::_('JGLOBAL_TITLE'),
+			'a.home'      => JText::_('COM_MENUS_HEADING_HOME'),
+			'a.access'    => JText::_('JGRID_HEADING_ACCESS'),
 			'association' => JText::_('COM_MENUS_HEADING_ASSOCIATION'),
-			'language' => JText::_('JGRID_HEADING_LANGUAGE'),
-			'a.id' => JText::_('JGRID_HEADING_ID')
+			'language'    => JText::_('JGRID_HEADING_LANGUAGE'),
+			'a.id'        => JText::_('JGRID_HEADING_ID')
 		);
 	}
 }

--- a/administrator/components/com_menus/views/menus/view.html.php
+++ b/administrator/components/com_menus/views/menus/view.html.php
@@ -47,10 +47,10 @@ class MenusViewMenus extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->modules		= $this->get('Modules');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->modules    = $this->get('Modules');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		MenusHelper::addSubmenu('menus');
 
@@ -76,7 +76,7 @@ class MenusViewMenus extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_menus');
+		$canDo = JHelperContent::getActions('com_menus');
 
 		JToolbarHelper::title(JText::_('COM_MENUS_VIEW_MENUS_TITLE'), 'list menumgr');
 

--- a/administrator/components/com_messages/controllers/config.php
+++ b/administrator/components/com_messages/controllers/config.php
@@ -33,7 +33,7 @@ class MessagesControllerConfig extends JControllerLegacy
 		$data  = $this->input->post->get('jform', array(), 'array');
 
 		// Validate the posted data.
-		$form	= $model->getForm();
+		$form = $model->getForm();
 
 		if (!$form)
 		{
@@ -48,7 +48,7 @@ class MessagesControllerConfig extends JControllerLegacy
 		if ($data === false)
 		{
 			// Get the validation messages.
-			$errors	= $model->getErrors();
+			$errors = $model->getErrors();
 
 			// Push up to three validation messages out to the user.
 			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)

--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -67,17 +67,18 @@ class JHtmlMessages
 	public static function status($i, $value = 0, $canChange = false)
 	{
 		// Array of image, task, title, action.
-		$states	= array(
-			-2	=> array('trash',       'messages.unpublish',	'JTRASHED',				        'COM_MESSAGES_MARK_AS_UNREAD'),
-			1	=> array('publish',	'messages.unpublish',	'COM_MESSAGES_OPTION_READ',		'COM_MESSAGES_MARK_AS_UNREAD'),
-			0	=> array('unpublish',	    'messages.publish',		'COM_MESSAGES_OPTION_UNREAD',	'COM_MESSAGES_MARK_AS_READ')
+		$states = array(
+			-2 => array('trash', 'messages.unpublish', 'JTRASHED', 'COM_MESSAGES_MARK_AS_UNREAD'),
+			1 => array('publish', 'messages.unpublish', 'COM_MESSAGES_OPTION_READ', 'COM_MESSAGES_MARK_AS_UNREAD'),
+			0 => array('unpublish', 'messages.publish', 'COM_MESSAGES_OPTION_UNREAD', 'COM_MESSAGES_MARK_AS_READ'),
 		);
-		$state	= JArrayHelper::getValue($states, (int) $value, $states[0]);
-		$icon	= $state[0];
+
+		$state = JArrayHelper::getValue($states, (int) $value, $states[0]);
+		$icon  = $state[0];
 
 		if ($canChange)
 		{
-			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
+			$html = '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
 				. $icon . '"></span></a>';
 		}
 

--- a/administrator/components/com_messages/helpers/messages.php
+++ b/administrator/components/com_messages/helpers/messages.php
@@ -68,10 +68,10 @@ class MessagesHelper
 	public static function getStateOptions()
 	{
 		// Build the filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option',	'1',	JText::_('COM_MESSAGES_OPTION_READ'));
-		$options[]	= JHtml::_('select.option',	'0',	JText::_('COM_MESSAGES_OPTION_UNREAD'));
-		$options[]	= JHtml::_('select.option',	'-2',	JText::_('JTRASHED'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('COM_MESSAGES_OPTION_READ'));
+		$options[] = JHtml::_('select.option', '0', JText::_('COM_MESSAGES_OPTION_UNREAD'));
+		$options[] = JHtml::_('select.option', '-2', JText::_('JTRASHED'));
 
 		return $options;
 	}

--- a/administrator/components/com_messages/messages.php
+++ b/administrator/components/com_messages/messages.php
@@ -14,8 +14,7 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_messages'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$task = JFactory::getApplication()->input->get('task');
-
-$controller	= JControllerLegacy::getInstance('Messages');
+$task       = JFactory::getApplication()->input->get('task');
+$controller = JControllerLegacy::getInstance('Messages');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_messages/models/config.php
+++ b/administrator/components/com_messages/models/config.php
@@ -31,12 +31,12 @@ class MessagesModelConfig extends JModelForm
 	 */
 	protected function populateState()
 	{
-		$user	= JFactory::getUser();
+		$user = JFactory::getUser();
 
 		$this->setState('user.id', $user->get('id'));
 
 		// Load the parameters.
-		$params	= JComponentHelper::getParams('com_messages');
+		$params = JComponentHelper::getParams('com_messages');
 		$this->setState('params', $params);
 	}
 

--- a/administrator/components/com_messages/views/config/view.html.php
+++ b/administrator/components/com_messages/views/config/view.html.php
@@ -33,9 +33,9 @@ class MessagesViewConfig extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_messages/views/message/view.html.php
+++ b/administrator/components/com_messages/views/message/view.html.php
@@ -33,9 +33,9 @@ class MessagesViewMessage extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -16,9 +16,9 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_messages&view=messages'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -34,9 +34,9 @@ class MessagesViewMessages extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -60,8 +60,8 @@ class MessagesViewMessages extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_messages');
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_messages');
 
 		JToolbarHelper::title(JText::_('COM_MESSAGES_MANAGER_MESSAGES'), 'envelope inbox');
 

--- a/administrator/components/com_modules/controllers/module.php
+++ b/administrator/components/com_modules/controllers/module.php
@@ -143,7 +143,7 @@ class ModulesControllerModule extends JControllerForm
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Set the model
-		$model	= $this->getModel('Module', '', array());
+		$model = $this->getModel('Module', '', array());
 
 		// Preset the redirect
 		$redirectUrl = 'index.php?option=com_modules&view=modules' . $this->getRedirectToListAppend();

--- a/administrator/components/com_modules/helpers/html/modules.php
+++ b/administrator/components/com_modules/helpers/html/modules.php
@@ -31,7 +31,7 @@ abstract class JHtmlModules
 
 		foreach ($templates as $template)
 		{
-			$options[]	= JHtml::_('select.option', $template->element, $template->name);
+			$options[] = JHtml::_('select.option', $template->element, $template->name);
 		}
 
 		return $options;
@@ -80,7 +80,7 @@ abstract class JHtmlModules
 	 */
 	public static function state($value, $i, $enabled = true, $checkbox = 'cb')
 	{
-		$states	= array(
+		$states = array(
 			1 => array(
 				'unpublish',
 				'COM_MODULES_EXTENSION_PUBLISHED_ENABLED',
@@ -88,7 +88,7 @@ abstract class JHtmlModules
 				'COM_MODULES_EXTENSION_PUBLISHED_ENABLED',
 				true,
 				'publish',
-				'publish'
+				'publish',
 			),
 			0 => array(
 				'publish',
@@ -97,7 +97,7 @@ abstract class JHtmlModules
 				'COM_MODULES_EXTENSION_UNPUBLISHED_ENABLED',
 				true,
 				'unpublish',
-				'unpublish'
+				'unpublish',
 			),
 			-1 => array(
 				'unpublish',
@@ -106,7 +106,7 @@ abstract class JHtmlModules
 				'COM_MODULES_EXTENSION_PUBLISHED_DISABLED',
 				true,
 				'warning',
-				'warning'
+				'warning',
 			),
 			-2 => array(
 				'publish',
@@ -115,7 +115,7 @@ abstract class JHtmlModules
 				'COM_MODULES_EXTENSION_UNPUBLISHED_DISABLED',
 				true,
 				'unpublish',
-				'unpublish'
+				'unpublish',
 			),
 		);
 
@@ -209,8 +209,8 @@ abstract class JHtmlModules
 	 */
 	public static function positionList($clientId = 0)
 	{
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
 			->select('DISTINCT(position) as value')
 			->select('position as text')
 			->from($db->quoteName('#__modules'))

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -63,11 +63,11 @@ abstract class ModulesHelper
 	public static function getStateOptions()
 	{
 		// Build the filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option',	'1',	JText::_('JPUBLISHED'));
-		$options[]	= JHtml::_('select.option',	'0',	JText::_('JUNPUBLISHED'));
-		$options[]	= JHtml::_('select.option',	'-2',	JText::_('JTRASHED'));
-		$options[]	= JHtml::_('select.option',	'*',	JText::_('JALL'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('JPUBLISHED'));
+		$options[] = JHtml::_('select.option', '0', JText::_('JUNPUBLISHED'));
+		$options[] = JHtml::_('select.option', '-2', JText::_('JTRASHED'));
+		$options[] = JHtml::_('select.option', '*', JText::_('JALL'));
 
 		return $options;
 	}
@@ -80,9 +80,9 @@ abstract class ModulesHelper
 	public static function getClientOptions()
 	{
 		// Build the filter options.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '0', JText::_('JSITE'));
-		$options[]	= JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '0', JText::_('JSITE'));
+		$options[] = JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
 
 		return $options;
 	}
@@ -97,8 +97,8 @@ abstract class ModulesHelper
 	 */
 	public static function getPositions($clientId, $editPositions = false)
 	{
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
 			->select('DISTINCT(position)')
 			->from('#__modules')
 			->where($db->quoteName('client_id') . ' = ' . (int) $clientId)
@@ -125,11 +125,11 @@ abstract class ModulesHelper
 		{
 			if (!$position && !$editPositions)
 			{
-				$options[]	= JHtml::_('select.option', 'none', ':: ' . JText::_('JNONE') . ' ::');
+				$options[] = JHtml::_('select.option', 'none', ':: ' . JText::_('JNONE') . ' ::');
 			}
 			else
 			{
-				$options[]	= JHtml::_('select.option', $position, $position);
+				$options[] = JHtml::_('select.option', $position, $position);
 			}
 		}
 
@@ -150,7 +150,7 @@ abstract class ModulesHelper
 		$db = JFactory::getDbo();
 
 		// Get the database object and a new query object.
-		$query	= $db->getQuery(true);
+		$query = $db->getQuery(true);
 
 		// Build the query.
 		$query->select('element, name, enabled')
@@ -184,8 +184,8 @@ abstract class ModulesHelper
 	 */
 	public static function getModules($clientId)
 	{
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
 			->select('element AS value, name AS text')
 			->from('#__extensions as e')
 			->where('e.client_id = ' . (int) $clientId)

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -112,7 +112,7 @@ class ModulesModelModule extends JModelAdmin
 		$this->setState('module.id', $pk);
 
 		// Load the parameters.
-		$params	= JComponentHelper::getParams('com_modules');
+		$params = JComponentHelper::getParams('com_modules');
 		$this->setState('params', $params);
 	}
 
@@ -178,7 +178,7 @@ class ModulesModelModule extends JModelAdmin
 				$newId = $table->get('id');
 
 				// Add the new ID to the array
-				$newIds[$pk]	= $newId;
+				$newIds[$pk] = $newId;
 
 				// Now we need to handle the module assignments
 				$db = $this->getDbo();
@@ -389,8 +389,8 @@ class ModulesModelModule extends JModelAdmin
 	 */
 	public function duplicate(&$pks)
 	{
-		$user	= JFactory::getUser();
-		$db		= $this->getDbo();
+		$user = JFactory::getUser();
+		$db   = $this->getDbo();
 
 		// Access checks.
 		if (!$user->authorise('core.create', 'com_modules'))
@@ -426,7 +426,7 @@ class ModulesModelModule extends JModelAdmin
 					throw new Exception($table->getError());
 				}
 
-				$query	= $db->getQuery(true)
+				$query = $db->getQuery(true)
 					->select($db->quoteName('menuid'))
 					->from($db->quoteName('#__modules_menu'))
 					->where($db->quoteName('moduleid') . ' = ' . (int) $pk);
@@ -522,16 +522,16 @@ class ModulesModelModule extends JModelAdmin
 		// The folder and element vars are passed when saving the form.
 		if (empty($data))
 		{
-			$item		= $this->getItem();
-			$clientId	= $item->client_id;
-			$module		= $item->module;
-			$id			= $item->id;
+			$item     = $this->getItem();
+			$clientId = $item->client_id;
+			$module   = $item->module;
+			$id       = $item->id;
 		}
 		else
 		{
-			$clientId	= JArrayHelper::getValue($data, 'client_id');
-			$module		= JArrayHelper::getValue($data, 'module');
-			$id			= JArrayHelper::getValue($data, 'id');
+			$clientId = JArrayHelper::getValue($data, 'client_id');
+			$module   = JArrayHelper::getValue($data, 'module');
+			$id       = JArrayHelper::getValue($data, 'id');
 		}
 
 		// These variables are used to add data from the plugin XML files.
@@ -653,7 +653,7 @@ class ModulesModelModule extends JModelAdmin
 			{
 				if ($extensionId = (int) $this->getState('extension.id'))
 				{
-					$query	= $db->getQuery(true)
+					$query = $db->getQuery(true)
 						->select('element, client_id')
 						->from('#__extensions')
 						->where('extension_id = ' . $extensionId)
@@ -701,7 +701,7 @@ class ModulesModelModule extends JModelAdmin
 			$this->_cache[$pk]->params = $registry->toArray();
 
 			// Determine the page assignment mode.
-			$query	= $db->getQuery(true)
+			$query = $db->getQuery(true)
 				->select($db->quoteName('menuid'))
 				->from($db->quoteName('#__modules_menu'))
 				->where($db->quoteName('moduleid') . ' = ' . (int) $pk);
@@ -793,8 +793,8 @@ class ModulesModelModule extends JModelAdmin
 	 */
 	protected function prepareTable($table)
 	{
-		$table->title		= htmlspecialchars_decode($table->title, ENT_QUOTES);
-		$table->position	= trim($table->position);
+		$table->title    = htmlspecialchars_decode($table->title, ENT_QUOTES);
+		$table->position = trim($table->position);
 	}
 
 	/**
@@ -1045,7 +1045,7 @@ class ModulesModelModule extends JModelAdmin
 		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
 
 		// Compute the extension id of this module in case the controller wants it.
-		$query	= $db->getQuery(true)
+		$query = $db->getQuery(true)
 			->select('extension_id')
 			->from('#__extensions AS e')
 			->join('LEFT', '#__modules AS m ON e.element = m.module')

--- a/administrator/components/com_modules/models/positions.php
+++ b/administrator/components/com_modules/models/positions.php
@@ -103,7 +103,7 @@ class ModulesModelPositions extends JModelList
 			if ($type != 'template')
 			{
 				// Get the database object and a new query object.
-				$query	= $this->_db->getQuery(true)
+				$query = $this->_db->getQuery(true)
 					->select('DISTINCT(position) as value')
 					->from('#__modules')
 					->where($this->_db->quoteName('client_id') . ' = ' . (int) $clientId);

--- a/administrator/components/com_modules/modules.php
+++ b/administrator/components/com_modules/modules.php
@@ -15,6 +15,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_modules'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Modules');
+$controller = JControllerLegacy::getInstance('Modules');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_modules/views/module/view.html.php
+++ b/administrator/components/com_modules/views/module/view.html.php
@@ -31,10 +31,10 @@ class ModulesViewModule extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
-		$this->canDo	= JHelperContent::getActions('com_modules', 'module', $this->item->id);
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
+		$this->canDo = JHelperContent::getActions('com_modules', 'module', $this->item->id);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -59,10 +59,10 @@ class ModulesViewModule extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
-		$canDo		= $this->canDo;
+		$user       = JFactory::getUser();
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+		$canDo      = $this->canDo;
 
 		JToolbarHelper::title(JText::sprintf('COM_MODULES_MANAGER_MODULE', JText::_($this->item->module)), 'cube module');
 

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -13,18 +13,20 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$client		= $this->state->get('filter.client_id') ? 'administrator' : 'site';
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$trashed	= $this->state->get('filter.state') == -2 ? true : false;
-$canOrder	= $user->authorise('core.edit.state', 'com_modules');
-$saveOrder	= $listOrder == 'ordering';
+$client    = $this->state->get('filter.client_id') ? 'administrator' : 'site';
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$trashed   = $this->state->get('filter.state') == -2 ? true : false;
+$canOrder  = $user->authorise('core.edit.state', 'com_modules');
+$saveOrder = $listOrder == 'ordering';
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_modules&task=modules.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'moduleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
+
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
@@ -45,6 +47,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		};
 ');
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
@@ -135,9 +138,9 @@ JFactory::getDocument()->addScriptDeclaration('
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$ordering   = ($listOrder == 'ordering');
-					$canCreate  = $user->authorise('core.create',     'com_modules');
-					$canEdit	= $user->authorise('core.edit',		  'com_modules.module.' . $item->id);
-					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
+					$canCreate  = $user->authorise('core.create', 'com_modules');
+					$canEdit    = $user->authorise('core.edit', 'com_modules.module.' . $item->id);
+					$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
 					$canChange  = $user->authorise('core.edit.state', 'com_modules.module.' . $item->id) && $canCheckin;
 				?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->position?>">

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -23,8 +23,8 @@ $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 
 // Build field
 $attr = array(
-	'id'		=> 'batch-position-id',
-	'list.attr'	=> 'class="chzn-custom-value input-xlarge" '
+	'id'        => 'batch-position-id',
+	'list.attr' => 'class="chzn-custom-value input-xlarge" '
 	. 'data-custom_group_text="' . $customGroupText . '" '
 	. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
 	. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -21,8 +21,8 @@ $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 
 // Build field
 $attr = array(
-	'id'		=> 'batch-position-id',
-	'list.attr'	=> 'class="chzn-custom-value input-xlarge" '
+	'id'        => 'batch-position-id',
+	'list.attr' => 'class="chzn-custom-value input-xlarge" '
 		. 'data-custom_group_text="' . $customGroupText . '" '
 		. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
 		. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -31,9 +31,9 @@ class ModulesViewModules extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -59,8 +59,8 @@ class ModulesViewModules extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_modules');
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_modules');
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance

--- a/administrator/components/com_modules/views/positions/view.html.php
+++ b/administrator/components/com_modules/views/positions/view.html.php
@@ -31,9 +31,9 @@ class ModulesViewPositions extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_modules/views/select/view.html.php
+++ b/administrator/components/com_modules/views/select/view.html.php
@@ -29,8 +29,8 @@ class ModulesViewSelect extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$state		= $this->get('State');
-		$items		= $this->get('Items');
+		$state = $this->get('State');
+		$items = $this->get('Items');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -33,8 +33,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 	 */
 	protected function getInput()
 	{
-		$allowEdit		= ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear		= ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
+		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
 
 		// Load language
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
@@ -93,8 +93,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 		// Setup variables for display.
-		$html	= array();
-		$link	= 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;function=jSelectNewsfeed_' . $this->id;
+		$html = array();
+		$link = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;function=jSelectNewsfeed_' . $this->id;
 
 		if (isset($this->element['language']))
 		{

--- a/administrator/components/com_newsfeeds/models/fields/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/fields/newsfeeds.php
@@ -37,8 +37,8 @@ class JFormFieldNewsfeeds extends JFormFieldList
 	{
 		$options = array();
 
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
 			->select('id As value, name As text')
 			->from('#__newsfeeds AS a')
 			->order('a.name');

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -105,7 +105,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 			$this->table->catid = $categoryId;
 
 			// TODO: Deal with ordering?
-			// $this->table->ordering	= 1;
+			// $this->table->ordering = 1;
 
 			// Check the row.
 			if (!$this->table->check())

--- a/administrator/components/com_newsfeeds/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/newsfeeds.php
@@ -15,6 +15,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_newsfeeds'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Newsfeeds');
+$controller = JControllerLegacy::getInstance('Newsfeeds');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -120,15 +120,15 @@ class NewsfeedsTableNewsfeed extends JTable
 	 */
 	public function store($updateNulls = false)
 	{
-		$date	= JFactory::getDate();
-		$user	= JFactory::getUser();
+		$date = JFactory::getDate();
+		$user = JFactory::getUser();
 
-		$this->modified	= $date->toSql();
+		$this->modified = $date->toSql();
 
 		if ($this->id)
 		{
 			// Existing item
-			$this->modified_by	= $user->get('id');
+			$this->modified_by = $user->get('id');
 		}
 		else
 		{

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -51,9 +51,9 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->state	= $this->get('State');
-		$this->item		= $this->get('Item');
-		$this->form		= $this->get('Form');
+		$this->state = $this->get('State');
+		$this->item  = $this->get('Item');
+		$this->form  = $this->get('Form');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -84,12 +84,12 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user		= JFactory::getUser();
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+		$user       = JFactory::getUser();
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
 
 		// Since we don't track these assets at the item level, use the category id.
-		$canDo		= JHelperContent::getActions('com_newsfeeds', 'category', $this->item->catid);
+		$canDo = JHelperContent::getActions('com_newsfeeds', 'category', $this->item->catid);
 
 		JToolbarHelper::title($isNew ? JText::_('COM_NEWSFEEDS_MANAGER_NEWSFEED_NEW') : JText::_('COM_NEWSFEEDS_MANAGER_NEWSFEED_EDIT'), 'feed newsfeeds');
 

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -16,22 +16,24 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$archived	= $this->state->get('filter.published') == 2 ? true : false;
-$trashed	= $this->state->get('filter.published') == -2 ? true : false;
-$canOrder	= $user->authorise('core.edit.state', 'com_newsfeeds.category');
-$saveOrder	= $listOrder == 'a.ordering';
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$archived  = $this->state->get('filter.published') == 2 ? true : false;
+$trashed   = $this->state->get('filter.published') == -2 ? true : false;
+$canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
+$saveOrder = $listOrder == 'a.ordering';
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_newsfeeds&task=newsfeeds.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'newsfeedList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
+
 $sortFields = $this->getSortFields();
-$assoc		= JLanguageAssociations::isEnabled();
+$assoc      = JLanguageAssociations::isEnabled();
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()
@@ -51,6 +53,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	};
 ');
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -51,9 +51,9 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
 
 		NewsfeedsHelper::addSubmenu('newsfeeds');
 
@@ -78,9 +78,9 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_newsfeeds', 'category', $state->get('filter.category_id'));
-		$user	= JFactory::getUser();
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_newsfeeds', 'category', $state->get('filter.category_id'));
+		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
 		$bar = JToolBar::getInstance('toolbar');
@@ -181,15 +181,15 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 	protected function getSortFields()
 	{
 		return array(
-			'a.ordering' => JText::_('JGRID_HEADING_ORDERING'),
-			'a.published' => JText::_('JSTATUS'),
-			'a.name' => JText::_('JGLOBAL_TITLE'),
+			'a.ordering'     => JText::_('JGRID_HEADING_ORDERING'),
+			'a.published'    => JText::_('JSTATUS'),
+			'a.name'         => JText::_('JGLOBAL_TITLE'),
 			'category_title' => JText::_('JCATEGORY'),
-			'a.access' => JText::_('JGRID_HEADING_ACCESS'),
-			'numarticles' => JText::_('COM_NEWSFEEDS_NUM_ARTICLES_HEADING'),
-			'a.cache_time' => JText::_('COM_NEWSFEEDS_CACHE_TIME_HEADING'),
-			'a.language' => JText::_('JGRID_HEADING_LANGUAGE'),
-			'a.id' => JText::_('JGRID_HEADING_ID')
+			'a.access'       => JText::_('JGRID_HEADING_ACCESS'),
+			'numarticles'    => JText::_('COM_NEWSFEEDS_NUM_ARTICLES_HEADING'),
+			'a.cache_time'   => JText::_('COM_NEWSFEEDS_CACHE_TIME_HEADING'),
+			'a.language'     => JText::_('JGRID_HEADING_LANGUAGE'),
+			'a.id'           => JText::_('JGRID_HEADING_ID')
 		);
 	}
 }

--- a/administrator/components/com_plugins/models/fields/pluginordering.php
+++ b/administrator/components/com_plugins/models/fields/pluginordering.php
@@ -33,8 +33,8 @@ class JFormFieldPluginordering extends JFormFieldOrdering
 	 */
 	protected function getQuery()
 	{
-		$db = JFactory::getDbo();
-		$folder	= $this->form->getValue('folder');
+		$db     = JFactory::getDbo();
+		$folder = $this->form->getValue('folder');
 
 		// Build the query for the ordering list.
 		$query = $db->getQuery(true)

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -71,19 +71,19 @@ class PluginsModelPlugin extends JModelAdmin
 		// The folder and element vars are passed when saving the form.
 		if (empty($data))
 		{
-			$item		= $this->getItem();
-			$folder		= $item->folder;
-			$element	= $item->element;
+			$item    = $this->getItem();
+			$folder  = $item->folder;
+			$element = $item->element;
 		}
 		else
 		{
-			$folder		= JArrayHelper::getValue($data, 'folder', '', 'cmd');
-			$element	= JArrayHelper::getValue($data, 'element', '', 'cmd');
+			$folder  = JArrayHelper::getValue($data, 'folder', '', 'cmd');
+			$element = JArrayHelper::getValue($data, 'element', '', 'cmd');
 		}
 
 		// These variables are used to add data from the plugin XML files.
-		$this->setState('item.folder',	$folder);
-		$this->setState('item.element',	$element);
+		$this->setState('item.folder', $folder);
+		$this->setState('item.element', $element);
 
 		// Get the form.
 		$form = $this->loadForm('com_plugins.plugin', 'plugin', array('control' => 'jform', 'load_data' => $loadData));
@@ -144,7 +144,7 @@ class PluginsModelPlugin extends JModelAdmin
 
 		if (!isset($this->_cache[$pk]))
 		{
-			$false	= false;
+			$false = false;
 
 			// Get a row instance.
 			$table = $this->getTable();
@@ -236,12 +236,12 @@ class PluginsModelPlugin extends JModelAdmin
 	{
 		jimport('joomla.filesystem.path');
 
-		$folder		= $this->getState('item.folder');
-		$element	= $this->getState('item.element');
-		$lang		= JFactory::getLanguage();
+		$folder  = $this->getState('item.folder');
+		$element = $this->getState('item.element');
+		$lang    = JFactory::getLanguage();
 
 		// Load the core and/or local language sys file(s) for the ordering field.
-		$db = $this->getDbo();
+		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('element'))
 			->from($db->quoteName('#__extensions'))
@@ -252,8 +252,8 @@ class PluginsModelPlugin extends JModelAdmin
 
 		foreach ($elements as $elementa)
 		{
-				$lang->load('plg_' . $folder . '_' . $elementa . '.sys', JPATH_ADMINISTRATOR, null, false, true)
-			||	$lang->load('plg_' . $folder . '_' . $elementa . '.sys', JPATH_PLUGINS . '/' . $folder . '/' . $elementa, null, false, true);
+			$lang->load('plg_' . $folder . '_' . $elementa . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+			|| $lang->load('plg_' . $folder . '_' . $elementa . '.sys', JPATH_PLUGINS . '/' . $folder . '/' . $elementa, null, false, true);
 		}
 
 		if (empty($folder) || empty($element))

--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -15,6 +15,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Plugins');
+$controller = JControllerLegacy::getInstance('Plugins');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_plugins/views/plugin/view.html.php
+++ b/administrator/components/com_plugins/views/plugin/view.html.php
@@ -31,9 +31,9 @@ class PluginsViewPlugin extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->state	= $this->get('State');
-		$this->item		= $this->get('Item');
-		$this->form		= $this->get('Form');
+		$this->state = $this->get('State');
+		$this->item  = $this->get('Item');
+		$this->form  = $this->get('Form');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -16,16 +16,18 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_plugins');
-$saveOrder	= $listOrder == 'ordering';
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_plugins');
+$saveOrder = $listOrder == 'ordering';
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_plugins&task=plugins.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'pluginList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
+
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
@@ -46,6 +48,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	};
 ');
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_redirect/helpers/html/redirect.php
+++ b/administrator/components/com_redirect/helpers/html/redirect.php
@@ -38,18 +38,19 @@ class JHtmlRedirect
 		}
 
 		// Array of image, task, title, action
-		$states	= array(
-			1	=> array('publish',		'links.unpublish',	'JENABLED',	'COM_REDIRECT_DISABLE_LINK'),
-			0	=> array('unpublish',	'links.publish',		'JDISABLED',	'COM_REDIRECT_ENABLE_LINK'),
-			2	=> array('archive',	'links.unpublish',	'JARCHIVED',	'JUNARCHIVE'),
-			-2	=> array('trash',		'links.publish',		'JTRASHED',	'COM_REDIRECT_ENABLE_LINK'),
+		$states = array(
+			1  => array('publish', 'links.unpublish', 'JENABLED', 'COM_REDIRECT_DISABLE_LINK'),
+			0  => array('unpublish', 'links.publish', 'JDISABLED', 'COM_REDIRECT_ENABLE_LINK'),
+			2  => array('archive', 'links.unpublish', 'JARCHIVED', 'JUNARCHIVE'),
+			-2 => array('trash', 'links.publish', 'JTRASHED', 'COM_REDIRECT_ENABLE_LINK'),
 		);
-		$state	= JArrayHelper::getValue($states, (int) $value, $states[0]);
-		$icon	= $state[0];
+
+		$state = JArrayHelper::getValue($states, (int) $value, $states[0]);
+		$icon  = $state[0];
 
 		if ($canChange)
 		{
-			$html	= '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
+			$html = '<a href="#" onclick="return listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="btn btn-micro hasTooltip' . ($value == 1 ? ' active' : '') . '" title="' . JHtml::tooltipText($state[3]) . '"><span class="icon-'
 				. $icon . '"></span></a>';
 		}
 

--- a/administrator/components/com_redirect/redirect.php
+++ b/administrator/components/com_redirect/redirect.php
@@ -14,6 +14,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_redirect'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Redirect');
+$controller = JControllerLegacy::getInstance('Redirect');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_redirect/views/link/view.html.php
+++ b/administrator/components/com_redirect/views/link/view.html.php
@@ -33,9 +33,9 @@ class RedirectViewLink extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->form		= $this->get('Form');
-		$this->item		= $this->get('Item');
-		$this->state	= $this->get('State');
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -60,8 +60,8 @@ class RedirectViewLink extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$isNew		= ($this->item->id == 0);
-		$canDo		= JHelperContent::getActions('com_redirect');
+		$isNew = ($this->item->id == 0);
+		$canDo = JHelperContent::getActions('com_redirect');
 
 		JToolbarHelper::title($isNew ? JText::_('COM_REDIRECT_MANAGER_LINK_NEW') : JText::_('COM_REDIRECT_MANAGER_LINK_EDIT'), 'refresh redirect');
 

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -16,9 +16,9 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_redirect&view=links'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -65,8 +65,8 @@ class RedirectViewLinks extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_redirect');
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_redirect');
 
 		JToolbarHelper::title(JText::_('COM_REDIRECT_MANAGER_LINKS'), 'refresh redirect');
 

--- a/administrator/components/com_search/search.php
+++ b/administrator/components/com_search/search.php
@@ -14,6 +14,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_search'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Search');
+$controller = JControllerLegacy::getInstance('Search');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -16,9 +16,10 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 ?>
+
 <form action="<?php echo JRoute::_('index.php?option=com_search&view=searches'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="filter-bar" class="btn-toolbar">
 		<div class="filter-search btn-group pull-left">

--- a/administrator/components/com_search/views/searches/view.html.php
+++ b/administrator/components/com_search/views/searches/view.html.php
@@ -33,11 +33,11 @@ class SearchViewSearches extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items		= $this->get('Items');
-		$this->pagination	= $this->get('Pagination');
-		$this->state		= $this->get('State');
-		$this->enabled		= $this->state->params->get('enabled');
-		$this->canDo		= JHelperContent::getActions('com_search');
+		$this->items      = $this->get('Items');
+		$this->pagination = $this->get('Pagination');
+		$this->state      = $this->get('State');
+		$this->enabled    = $this->state->params->get('enabled');
+		$this->canDo      = JHelperContent::getActions('com_search');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -60,7 +60,7 @@ class SearchViewSearches extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= $this->canDo;
+		$canDo = $this->canDo;
 
 		JToolbarHelper::title(JText::_('COM_SEARCH_MANAGER_SEARCHES'), 'search');
 

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -145,47 +145,58 @@ class TagsTableTag extends JTableNested
 			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
 		}
 		// Not Null sanity check
-		$date	= JFactory::getDate();
+		$date = JFactory::getDate();
+
 		if (empty($this->params))
 		{
 			$this->params = '{}';
 		}
+
 		if (empty($this->metadesc))
 		{
 			$this->metadesc = ' ';
 		}
+
 		if (empty($this->metakey))
 		{
 			$this->metakey = ' ';
 		}
+
 		if (empty($this->metadata))
 		{
 			$this->metadata = '{}';
 		}
+
 		if (empty($this->urls))
 		{
 			$this->urls = '{}';
 		}
+
 		if (empty($this->images))
 		{
 			$this->images = '{}';
 		}
+
 		if (!(int) $this->checked_out_time)
 		{
 			$this->checked_out_time = $date->toSql();
 		}
+
 		if (!(int) $this->modified_time)
 		{
 			$this->modified_time = $date->toSql();
 		}
+
 		if (!(int) $this->modified_time)
 		{
 			$this->modified_time = $date->toSql();
 		}
+
 		if (!(int) $this->publish_up)
 		{
 			$this->publish_up = $date->toSql();
 		}
+
 		if (!(int) $this->publish_down)
 		{
 			$this->publish_down = $date->toSql();
@@ -205,15 +216,15 @@ class TagsTableTag extends JTableNested
 	 */
 	public function store($updateNulls = false)
 	{
-		$date	= JFactory::getDate();
-		$user	= JFactory::getUser();
+		$date = JFactory::getDate();
+		$user = JFactory::getUser();
 
-		$this->modified_time		= $date->toSql();
+		$this->modified_time = $date->toSql();
 
 		if ($this->id)
 		{
 			// Existing item
-			$this->modified_user_id	= $user->get('id');
+			$this->modified_user_id = $user->get('id');
 		}
 		else
 		{

--- a/administrator/components/com_tags/tags.php
+++ b/administrator/components/com_tags/tags.php
@@ -15,6 +15,6 @@ if (!JFactory::getUser()->authorise('core.manage', 'com_tags'))
 	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 }
 
-$controller	= JControllerLegacy::getInstance('Tags');
+$controller = JControllerLegacy::getInstance('Tags');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -63,27 +63,26 @@ class TagsViewTag extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$user		= JFactory::getUser();
-		$userId		= $user->get('id');
+		$user   = JFactory::getUser();
+		$userId = $user->get('id');
 
-		$isNew		= ($this->item->id == 0);
-		$checkedOut	= !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
+		$isNew      = ($this->item->id == 0);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 
 		// Need to load the menu language file as mod_menu hasn't been loaded yet.
 		$lang = JFactory::getLanguage();
-			$lang->load('com_tags', JPATH_BASE, null, false, true)
-		||	$lang->load('com_tags', JPATH_ADMINISTRATOR . '/components/com_tags', null, false, true);
+		$lang->load('com_tags', JPATH_BASE, null, false, true)
+		|| $lang->load('com_tags', JPATH_ADMINISTRATOR . '/components/com_tags', null, false, true);
 
 		// Load the tags helper.
 		require_once JPATH_COMPONENT . '/helpers/tags.php';
 
 		// Get the results for each action.
 		$canDo = $this->canDo;
-
-		$title = JText::_('COM_TAGS_BASE_' . ($isNew?'ADD':'EDIT') . '_TITLE');
+		$title = JText::_('COM_TAGS_BASE_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE');
 
 		// Prepare the toolbar.
-		JToolbarHelper::title($title, 'tag tag-' . ($isNew?'add':'edit') . ($isNew?'add':'edit'));
+		JToolbarHelper::title($title, 'tag tag-' . ($isNew ? 'add' : 'edit') . ($isNew ? 'add' : 'edit'));
 
 		// For new records, check the create permission.
 		if ($isNew)

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -16,19 +16,21 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$ordering 	= ($listOrder == 'a.lft');
-$canOrder	= $user->authorise('core.edit.state',	'com_tags');
-$saveOrder 	= ($listOrder == 'a.lft' && $listDirn == 'asc');
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state', 'com_tags');
+$saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_tags&task=tags.saveOrderAjax';
 	JHtml::_('sortablelist.sortable', 'categoryList', 'adminForm', strtolower($listDirn), $saveOrderingUrl, false, true);
 }
+
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -50,17 +50,17 @@ class TagsViewTags extends JViewLegacy
 		}
 
 		// Levels filter.
-		$options	= array();
-		$options[]	= JHtml::_('select.option', '1', JText::_('J1'));
-		$options[]	= JHtml::_('select.option', '2', JText::_('J2'));
-		$options[]	= JHtml::_('select.option', '3', JText::_('J3'));
-		$options[]	= JHtml::_('select.option', '4', JText::_('J4'));
-		$options[]	= JHtml::_('select.option', '5', JText::_('J5'));
-		$options[]	= JHtml::_('select.option', '6', JText::_('J6'));
-		$options[]	= JHtml::_('select.option', '7', JText::_('J7'));
-		$options[]	= JHtml::_('select.option', '8', JText::_('J8'));
-		$options[]	= JHtml::_('select.option', '9', JText::_('J9'));
-		$options[]	= JHtml::_('select.option', '10', JText::_('J10'));
+		$options   = array();
+		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
+		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
+		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
+		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
+		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
+		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
+		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
+		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
+		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
+		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
 
 		$this->f_levels = $options;
 
@@ -78,9 +78,9 @@ class TagsViewTags extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$state	= $this->get('State');
-		$canDo	= JHelperContent::getActions('com_tags');
-		$user	= JFactory::getUser();
+		$state = $this->get('State');
+		$canDo = JHelperContent::getActions('com_tags');
+		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
 		$bar = JToolBar::getInstance('toolbar');
@@ -170,12 +170,12 @@ class TagsViewTags extends JViewLegacy
 	protected function getSortFields()
 	{
 		return array(
-			'a.lft' => JText::_('JGRID_HEADING_ORDERING'),
-			'a.state' => JText::_('JSTATUS'),
-			'a.title' => JText::_('JGLOBAL_TITLE'),
+			'a.lft'    => JText::_('JGRID_HEADING_ORDERING'),
+			'a.state'  => JText::_('JSTATUS'),
+			'a.title'  => JText::_('JGLOBAL_TITLE'),
 			'a.access' => JText::_('JGRID_HEADING_ACCESS'),
 			'language' => JText::_('JGRID_HEADING_LANGUAGE'),
-			'a.id' => JText::_('JGRID_HEADING_ID')
+			'a.id'     => JText::_('JGRID_HEADING_ID')
 		);
 	}
 }

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -259,7 +259,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 		if ($data === false)
 		{
 			// Get the validation messages.
-			$errors	= $model->getErrors();
+			$errors = $model->getErrors();
 
 			// Push up to three validation messages out to the user.
 			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)

--- a/administrator/components/com_templates/helpers/template.php
+++ b/administrator/components/com_templates/helpers/template.php
@@ -88,10 +88,10 @@ abstract class TemplateHelper
 
 		$format = strtolower(JFile::getExt($file['name']));
 
-		$imageTypes		= explode(',', $params->get('image_formats'));
-		$sourceTypes	= explode(',', $params->get('source_formats'));
-		$fontTypes		= explode(',', $params->get('font_formats'));
-		$archiveTypes	= explode(',', $params->get('compressed_formats'));
+		$imageTypes   = explode(',', $params->get('image_formats'));
+		$sourceTypes  = explode(',', $params->get('source_formats'));
+		$fontTypes    = explode(',', $params->get('font_formats'));
+		$archiveTypes = explode(',', $params->get('compressed_formats'));
 
 		$allowable = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes);
 
@@ -111,13 +111,13 @@ abstract class TemplateHelper
 			{
 				for ($i = 0; $i < $zip->numFiles; $i++)
 				{
-					$entry = $zip->getNameIndex($i);
+					$entry     = $zip->getNameIndex($i);
 					$endString = substr($entry, -1);
 
 					if ($endString != DIRECTORY_SEPARATOR)
 					{
 						$explodeArray = explode('.', $entry);
-						$ext = end($explodeArray);
+						$ext          = end($explodeArray);
 
 						if (!in_array($ext, $allowable))
 						{

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -80,7 +80,7 @@ class TemplatesModelStyle extends JModelAdmin
 		$this->setState('style.id', $pk);
 
 		// Load the parameters.
-		$params	= JComponentHelper::getParams('com_templates');
+		$params = JComponentHelper::getParams('com_templates');
 		$this->setState('params', $params);
 	}
 
@@ -329,7 +329,7 @@ class TemplatesModelStyle extends JModelAdmin
 
 		if (!isset($this->_cache[$pk]))
 		{
-			$false	= false;
+			$false = false;
 
 			// Get a row instance.
 			$table = $this->getTable();
@@ -355,8 +355,8 @@ class TemplatesModelStyle extends JModelAdmin
 			$this->_cache[$pk]->params = $registry->toArray();
 
 			// Get the template XML.
-			$client	= JApplicationHelper::getClientInfo($table->client_id);
-			$path	= JPath::clean($client->path . '/templates/' . $table->template . '/templateDetails.xml');
+			$client = JApplicationHelper::getClientInfo($table->client_id);
+			$path   = JPath::clean($client->path . '/templates/' . $table->template . '/templateDetails.xml');
 
 			if (file_exists($path))
 			{

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -64,7 +64,7 @@ class TemplatesModelTemplate extends JModelForm
 	 */
 	public function getFiles()
 	{
-		$result	= array();
+		$result = array();
 
 		if ($template = $this->getTemplate())
 		{
@@ -552,19 +552,19 @@ class TemplatesModelTemplate extends JModelForm
 	{
 		if ($template = $this->getTemplate())
 		{
-			$client 	        = JApplicationHelper::getClientInfo($template->client_id);
-			$componentPath		= JPath::clean($client->path . '/components/');
-			$modulePath		    = JPath::clean($client->path . '/modules/');
-			$layoutPath		    = JPath::clean(JPATH_ROOT . '/layouts/joomla/');
-			$components         = JFolder::folders($componentPath);
+			$client        = JApplicationHelper::getClientInfo($template->client_id);
+			$componentPath = JPath::clean($client->path . '/components/');
+			$modulePath    = JPath::clean($client->path . '/modules/');
+			$layoutPath    = JPath::clean(JPATH_ROOT . '/layouts/joomla/');
+			$components    = JFolder::folders($componentPath);
 
 			foreach ($components as $component)
 			{
-				$viewPath	= JPath::clean($componentPath . '/' . $component . '/views/');
+				$viewPath = JPath::clean($componentPath . '/' . $component . '/views/');
 
 				if (file_exists($viewPath))
 				{
-					$views	= JFolder::folders($viewPath);
+					$views = JFolder::folders($viewPath);
 
 					foreach ($views as $view)
 					{
@@ -1033,10 +1033,10 @@ class TemplatesModelTemplate extends JModelForm
 			if (file_exists(JPath::clean($path . $fileName)))
 			{
 				$JImage = new JImage(JPath::clean($path . $fileName));
-				$image['address'] 	= $uri . $fileName;
-				$image['path']		= $fileName;
-				$image['height'] 	= $JImage->getHeight();
-				$image['width']  	= $JImage->getWidth();
+				$image['address'] = $uri . $fileName;
+				$image['path']    = $fileName;
+				$image['height']  = $JImage->getHeight();
+				$image['width']   = $JImage->getWidth();
 			}
 
 			else

--- a/administrator/components/com_templates/templates.php
+++ b/administrator/components/com_templates/templates.php
@@ -22,6 +22,6 @@ if (!$user->authorise('core.manage', 'com_templates'))
 
 JLoader::register('TemplatesHelper', __DIR__ . '/helpers/templates.php');
 
-$controller	= JControllerLegacy::getInstance('Templates');
+$controller = JControllerLegacy::getInstance('Templates');
 $controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_templates/views/style/view.json.php
+++ b/administrator/components/com_templates/views/style/view.json.php
@@ -50,7 +50,7 @@ class TemplatesViewStyle extends JViewLegacy
 	{
 		try
 		{
-			$this->item		= $this->get('Item');
+			$this->item = $this->get('Item');
 		}
 		catch (Exception $e)
 		{

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -16,9 +16,9 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user      = JFactory::getUser();
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_templates&view=templates'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -159,22 +159,22 @@ class JHtmlUsers
 		{
 			$states = array(
 				1 => array(
-					'task'				=> 'unblock',
-					'text'				=> '',
-					'active_title'		=> 'COM_USERS_USER_FIELD_BLOCK_DESC',
-					'inactive_title'	=> '',
-					'tip'				=> true,
-					'active_class'		=> 'unpublish',
-					'inactive_class'	=> 'unpublish'
+					'task'           => 'unblock',
+					'text'           => '',
+					'active_title'   => 'COM_USERS_USER_FIELD_BLOCK_DESC',
+					'inactive_title' => '',
+					'tip'            => true,
+					'active_class'   => 'unpublish',
+					'inactive_class' => 'unpublish',
 				),
 				0 => array(
-					'task'				=> 'block',
-					'text'				=> '',
-					'active_title'		=> '',
-					'inactive_title'	=> 'COM_USERS_USERS_ERROR_CANNOT_BLOCK_SELF',
-					'tip'				=> true,
-					'active_class'		=> 'publish',
-					'inactive_class'	=> 'publish'
+					'task'           => 'block',
+					'text'           => '',
+					'active_title'   => '',
+					'inactive_title' => 'COM_USERS_USERS_ERROR_CANNOT_BLOCK_SELF',
+					'tip'            => true,
+					'active_class'   => 'publish',
+					'inactive_class' => 'publish',
 				)
 			);
 		}
@@ -182,22 +182,22 @@ class JHtmlUsers
 		{
 			$states = array(
 				1 => array(
-					'task'				=> 'unblock',
-					'text'				=> '',
-					'active_title'		=> 'COM_USERS_TOOLBAR_UNBLOCK',
-					'inactive_title'	=> '',
-					'tip'				=> true,
-					'active_class'		=> 'unpublish',
-					'inactive_class'	=> 'unpublish'
+					'task'           => 'unblock',
+					'text'           => '',
+					'active_title'   => 'COM_USERS_TOOLBAR_UNBLOCK',
+					'inactive_title' => '',
+					'tip'            => true,
+					'active_class'   => 'unpublish',
+					'inactive_class' => 'unpublish',
 				),
 				0 => array(
-					'task'				=> 'block',
-					'text'				=> '',
-					'active_title'		=> 'COM_USERS_USER_FIELD_BLOCK_DESC',
-					'inactive_title'	=> '',
-					'tip'				=> true,
-					'active_class'		=> 'publish',
-					'inactive_class'	=> 'publish'
+					'task'           => 'block',
+					'text'           => '',
+					'active_title'   => 'COM_USERS_USER_FIELD_BLOCK_DESC',
+					'inactive_title' => '',
+					'tip'            => true,
+					'active_class'   => 'publish',
+					'inactive_class' => 'publish',
 				)
 			);
 		}
@@ -215,23 +215,23 @@ class JHtmlUsers
 	public static function activateStates()
 	{
 		$states = array(
-			1	=> array(
-				'task'				=> 'activate',
-				'text'				=> '',
-				'active_title'		=> 'COM_USERS_TOOLBAR_ACTIVATE',
-				'inactive_title'	=> '',
-				'tip'				=> true,
-				'active_class'		=> 'unpublish',
-				'inactive_class'	=> 'unpublish'
+			1 => array(
+				'task'           => 'activate',
+				'text'           => '',
+				'active_title'   => 'COM_USERS_TOOLBAR_ACTIVATE',
+				'inactive_title' => '',
+				'tip'            => true,
+				'active_class'   => 'unpublish',
+				'inactive_class' => 'unpublish',
 			),
-			0	=> array(
-				'task'				=> '',
-				'text'				=> '',
-				'active_title'		=> '',
-				'inactive_title'	=> 'COM_USERS_ACTIVATED',
-				'tip'				=> true,
-				'active_class'		=> 'publish',
-				'inactive_class'	=> 'publish'
+			0 => array(
+				'task'           => '',
+				'text'           => '',
+				'active_title'   => '',
+				'inactive_title' => 'COM_USERS_ACTIVATED',
+				'tip'            => true,
+				'active_class'   => 'publish',
+				'inactive_class' => 'publish',
 			)
 		);
 

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -164,7 +164,7 @@ class UsersModelGroup extends JModelAdmin
 		}
 
 		// Check for non-super admin trying to save with super admin group
-		$iAmSuperAdmin	= JFactory::getUser()->authorise('core.admin');
+		$iAmSuperAdmin = JFactory::getUser()->authorise('core.admin');
 
 		if ((!$iAmSuperAdmin) && ($groupSuperAdmin))
 		{
@@ -228,8 +228,8 @@ class UsersModelGroup extends JModelAdmin
 	public function delete(&$pks)
 	{
 		// Typecast variable.
-		$pks = (array) $pks;
-		$user	= JFactory::getUser();
+		$pks    = (array) $pks;
+		$user   = JFactory::getUser();
 		$groups = JAccess::getGroupsByUser($user->get('id'));
 
 		// Get a row instance.
@@ -240,7 +240,7 @@ class UsersModelGroup extends JModelAdmin
 		$dispatcher = JEventDispatcher::getInstance();
 
 		// Check if I am a Super Admin
-		$iAmSuperAdmin	= $user->authorise('core.admin');
+		$iAmSuperAdmin = $user->authorise('core.admin');
 
 		// Do not allow to delete groups to which the current user belongs
 		foreach ($pks as $pk)

--- a/administrator/components/com_users/models/level.php
+++ b/administrator/components/com_users/models/level.php
@@ -39,13 +39,12 @@ class UsersModelLevel extends JModelAdmin
 			// Populate the list once.
 			$this->levelsInUse = array();
 
-			$db		= $this->getDbo();
-			$query	= $db->getQuery(true)
+			$db    = $this->getDbo();
+			$query = $db->getQuery(true)
 				->select('DISTINCT access');
 
 			// Get all the tables and the prefix
 			$tables = $db->getTableList();
-
 			$prefix = $db->getPrefix();
 
 			foreach ($tables as $table)

--- a/administrator/components/com_users/models/mail.php
+++ b/administrator/components/com_users/models/mail.php
@@ -113,7 +113,7 @@ class UsersModelMail extends JModelAdmin
 		$to = $access->getUsersByGroup($grp, $recurse);
 
 		// Get all users email and group except for senders
-		$query	= $db->getQuery(true)
+		$query = $db->getQuery(true)
 			->select('email')
 			->from('#__users')
 			->where('id != ' . (int) $user->get('id'));

--- a/administrator/components/com_users/models/note.php
+++ b/administrator/components/com_users/models/note.php
@@ -61,7 +61,7 @@ class UsersModelNote extends JModelAdmin
 		$result = parent::getItem($pk);
 
 		// Get the dispatcher and load the content plugins.
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('content');
 
 		// Load the user plugins for backward compatibility (v3.3.3 and earlier).

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -83,7 +83,7 @@ class UsersModelUser extends JModelAdmin
 		$result->tags->getTagIds($result->id, $context);
 
 		// Get the dispatcher and load the content plugins.
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('content');
 
 		// Load the user plugins for backward compatibility (v3.3.3 and earlier).
@@ -506,8 +506,8 @@ class UsersModelUser extends JModelAdmin
 	 */
 	public function activate(&$pks)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
-		$user		= JFactory::getUser();
+		$dispatcher = JEventDispatcher::getInstance();
+		$user       = JFactory::getUser();
 
 		// Check if I am a Super Admin
 		$iAmSuperAdmin = $user->authorise('core.admin');
@@ -521,8 +521,8 @@ class UsersModelUser extends JModelAdmin
 		{
 			if ($table->load($pk))
 			{
-				$old	= $table->getProperties();
-				$allow	= $user->authorise('core.edit.state', 'com_users');
+				$old   = $table->getProperties();
+				$allow = $user->authorise('core.edit.state', 'com_users');
 
 				// Don't allow non-super-admin to delete a super admin
 				$allow = (!$iAmSuperAdmin && JAccess::check($pk, 'core.admin')) ? false : $allow;
@@ -534,8 +534,8 @@ class UsersModelUser extends JModelAdmin
 				}
 				elseif ($allow)
 				{
-					$table->block		= 0;
-					$table->activation	= '';
+					$table->block      = 0;
+					$table->activation = '';
 
 					// Allow an exception to be thrown.
 					try

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -16,9 +16,9 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
+$user       = JFactory::getUser();
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
 $sortFields = $this->getSortFields();
 
 JText::script('COM_USERS_GROUPS_CONFIRM_DELETE');
@@ -143,14 +143,14 @@ JFactory::getDocument()->addScriptDeclaration('
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$canCreate = $user->authorise('core.create', 'com_users');
-					$canEdit   = $user->authorise('core.edit',    'com_users');
+					$canEdit   = $user->authorise('core.edit', 'com_users');
 
 					// If this group is super admin and this user is not super admin, $canEdit is false
 					if (!$user->authorise('core.admin') && (JAccess::checkGroup($item->id, 'core.admin')))
 					{
 						$canEdit = false;
 					}
-					$canChange	= $user->authorise('core.edit.state',	'com_users');
+					$canChange = $user->authorise('core.edit.state', 'com_users');
 				?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center">

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -16,13 +16,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canOrder	= $user->authorise('core.edit.state', 'com_users');
-$saveOrder	= $listOrder == 'a.ordering';
+$user       = JFactory::getUser();
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
+$canOrder   = $user->authorise('core.edit.state', 'com_users');
+$saveOrder  = $listOrder == 'a.ordering';
 $sortFields = $this->getSortFields();
-$saveOrder	= $listOrder == 'a.ordering';
+$saveOrder  = $listOrder == 'a.ordering';
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_users&task=levels.saveOrderAjax&tmpl=component';

--- a/administrator/components/com_users/views/levels/view.html.php
+++ b/administrator/components/com_users/views/levels/view.html.php
@@ -77,7 +77,7 @@ class UsersViewLevels extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= JHelperContent::getActions('com_users');
+		$canDo = JHelperContent::getActions('com_users');
 
 		JToolbarHelper::title(JText::_('COM_USERS_VIEW_LEVELS_TITLE'), 'users levels');
 

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -12,11 +12,11 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 
-$user		= JFactory::getUser();
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$canEdit	= $user->authorise('core.edit', 'com_users');
-$sortFields	= $this->getSortFields();
+$user       = JFactory::getUser();
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
+$canEdit    = $user->authorise('core.edit', 'com_users');
+$sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -107,7 +107,7 @@ $fieldsets = $this->form->getFieldsets();
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					   title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
+						title="<?php echo '<strong>' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong><br />' . JText::_('COM_USERS_USER_FIELD_TWOFACTOR_DESC'); ?>">
 					<?php echo JText::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -84,8 +84,8 @@ class UsersViewUsers extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$canDo	= $this->canDo;
-		$user 	= JFactory::getUser();
+		$canDo = $this->canDo;
+		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
 		$bar = JToolBar::getInstance('toolbar');


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the admin components folder.
