### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the plugins folder

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -77,8 +77,8 @@ class PlgAuthenticationCookie extends JPlugin
 		$response->type = 'Cookie';
 
 		// Filter series since we're going to use it in the query
-		$filter	= new JFilterInput;
-		$series	= $filter->clean($cookieArray[1], 'ALNUM');
+		$filter = new JFilterInput;
+		$series = $filter->clean($cookieArray[1], 'ALNUM');
 
 		// Remove expired tokens
 		$query = $this->db->getQuery(true)
@@ -228,12 +228,12 @@ class PlgAuthenticationCookie extends JPlugin
 
 			// Filter series since we're going to use it in the query
 			$filter = new JFilterInput;
-			$series	= $filter->clean($cookieArray[1], 'ALNUM');
+			$series = $filter->clean($cookieArray[1], 'ALNUM');
 		}
 		elseif (!empty($options['remember']))
 		{
 			// Remember checkbox is set
-			$cookieName		= JUserHelper::getShortHashedUserAgent();
+			$cookieName = JUserHelper::getShortHashedUserAgent();
 
 			// Create an unique series which will be used over the lifespan of the cookie
 			$unique     = false;

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -49,10 +49,10 @@ class PlgAuthenticationLdap extends JPlugin
 		}
 
 		// Load plugin params info
-		$ldap_email		= $this->params->get('ldap_email');
-		$ldap_fullname	= $this->params->get('ldap_fullname');
-		$ldap_uid		= $this->params->get('ldap_uid');
-		$auth_method	= $this->params->get('auth_method');
+		$ldap_email    = $this->params->get('ldap_email');
+		$ldap_fullname = $this->params->get('ldap_fullname');
+		$ldap_uid      = $this->params->get('ldap_uid');
+		$auth_method   = $this->params->get('auth_method');
 
 		$ldap = new JClientLdap($this->params);
 
@@ -154,7 +154,7 @@ class PlgAuthenticationLdap extends JPlugin
 			}
 
 			// Were good - So say so.
-			$response->status		= JAuthentication::STATUS_SUCCESS;
+			$response->status        = JAuthentication::STATUS_SUCCESS;
 			$response->error_message = '';
 		}
 

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -123,7 +123,7 @@ class PlgContentEmailcloak extends JPlugin
 		$searchText = '((?:[\x20-\x7f]|[\xA1-\xFF]|[\xC2-\xDF][\x80-\xBF]|[\xE0-\xEF][\x80-\xBF]{2}|[\xF0-\xF4][\x80-\xBF]{3})[^<>]+)';
 
 		// Any Image link
-		$searchImage	=	"(<img[^>]+>)";
+		$searchImage = "(<img[^>]+>)";
 
 		// Any Text with <span or <strong
 		$searchTextSpan = '(<span[^>]+>|<span>|<strong>|<strong><span[^>]+>|<strong><span>)' . $searchText . '(</span>|</strong>|</span></strong>)';

--- a/plugins/content/finder/finder.php
+++ b/plugins/content/finder/finder.php
@@ -27,11 +27,11 @@ class PlgContentFinder extends JPlugin
 	 *
 	 * @return  void
 	 *
-	 * @since	2.5
+	 * @since   2.5
 	 */
 	public function onContentAfterSave($context, $article, $isNew)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderAfterSave event.
@@ -52,7 +52,7 @@ class PlgContentFinder extends JPlugin
 	 */
 	public function onContentBeforeSave($context, $article, $isNew)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderBeforeSave event.
@@ -72,7 +72,7 @@ class PlgContentFinder extends JPlugin
 	 */
 	public function onContentAfterDelete($context, $article)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderAfterDelete event.
@@ -95,7 +95,7 @@ class PlgContentFinder extends JPlugin
 	 */
 	public function onContentChangeState($context, $pks, $value)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderChangeState event.
@@ -117,7 +117,7 @@ class PlgContentFinder extends JPlugin
 	 */
 	public function onCategoryChangeState($extension, $pks, $value)
 	{
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderCategoryChangeState event.

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -48,12 +48,12 @@ class PlgContentLoadmodule extends JPlugin
 		}
 
 		// Expression to search for (positions)
-		$regex		= '/{loadposition\s(.*?)}/i';
-		$style		= $this->params->def('style', 'none');
+		$regex = '/{loadposition\s(.*?)}/i';
+		$style = $this->params->def('style', 'none');
 
 		// Expression to search for(modules)
-		$regexmod	= '/{loadmodule\s(.*?)}/i';
-		$stylemod	= $this->params->def('style', 'none');
+		$regexmod = '/{loadmodule\s(.*?)}/i';
+		$stylemod = $this->params->def('style', 'none');
 
 		// Find all instances of plugin and put in $matches for loadposition
 		// $matches[0] is full pattern match, $matches[1] is the position
@@ -132,10 +132,10 @@ class PlgContentLoadmodule extends JPlugin
 	protected function _load($position, $style = 'none')
 	{
 		self::$modules[$position] = '';
-		$document	= JFactory::getDocument();
-		$renderer	= $document->loadRenderer('module');
-		$modules	= JModuleHelper::getModules($position);
-		$params		= array('style' => $style);
+		$document = JFactory::getDocument();
+		$renderer = $document->loadRenderer('module');
+		$modules  = JModuleHelper::getModules($position);
+		$params   = array('style' => $style);
 		ob_start();
 
 		foreach ($modules as $module)
@@ -163,9 +163,9 @@ class PlgContentLoadmodule extends JPlugin
 	protected function _loadmod($module, $title, $style = 'none')
 	{
 		self::$mods[$module] = '';
-		$document	= JFactory::getDocument();
-		$renderer	= $document->loadRenderer('module');
-		$mod		= JModuleHelper::getModule($module, $title);
+		$document = JFactory::getDocument();
+		$renderer = $document->loadRenderer('module');
+		$mod      = JModuleHelper::getModule($module, $title);
 
 		// If the module without the mod_ isn't found, try it with mod_.
 		// This allows people to enter it either way in the content

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -133,7 +133,7 @@ class PlgContentPagebreak extends JPlugin
 		// We have found at least one plugin, therefore at least 2 pages.
 		if ($n > 1)
 		{
-			$title	= $this->params->get('title', 1);
+			$title  = $this->params->get('title', 1);
 			$hasToc = $this->params->get('multipage_toc', 1);
 
 			// Adds heading or title to <site> Title.
@@ -212,15 +212,15 @@ class PlgContentPagebreak extends JPlugin
 
 						if (isset($match['alt']))
 						{
-							$title	= stripslashes($match['alt']);
+							$title = stripslashes($match['alt']);
 						}
 						elseif (isset($match['title']))
 						{
-							$title	= stripslashes($match['title']);
+							$title = stripslashes($match['title']);
 						}
 						else
 						{
-							$title	= JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $key + 1);
+							$title = JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $key + 1);
 						}
 
 						$t[] = (string) JHtml::_($style . '.panel', $title, 'article' . $row->id . '-' . $style . $key);
@@ -293,33 +293,33 @@ class PlgContentPagebreak extends JPlugin
 
 				if (@$attrs2['alt'])
 				{
-					$title	= stripslashes($attrs2['alt']);
+					$title = stripslashes($attrs2['alt']);
 				}
 				elseif (@$attrs2['title'])
 				{
-					$title	= stripslashes($attrs2['title']);
+					$title = stripslashes($attrs2['title']);
 				}
 				else
 				{
-					$title	= JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
+					$title = JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
 				}
 			}
 			else
 			{
-				$title	= JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
+				$title = JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
 			}
 
-			$liClass = ($limitstart == $i - 1) ? ' class="active"' : '';
-			$class   = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
+			$liClass   = ($limitstart == $i - 1) ? ' class="active"' : '';
+			$class     = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
 			$row->toc .= '<li' . $liClass . '><a href="' . $link . '" class="' . $class . '">' . $title . '</a></li>';
 			$i++;
 		}
 
 		if ($this->params->get('showall'))
 		{
-			$link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
-			$liClass = ($limitstart == $i - 1) ? ' class="active"' : '';
-			$class   = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
+			$link      = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
+			$liClass   = ($limitstart == $i - 1) ? ' class="active"' : '';
+			$class     = ($limitstart == $i - 1) ? 'toclink active' : 'toclink';
 			$row->toc .= '<li' . $liClass . '><a href="' . $link . '" class="' . $class . '">'
 				. JText::_('PLG_CONTENT_PAGEBREAK_ALL_PAGES') . '</a></li>';
 		}

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -236,7 +236,7 @@ class PlgEditorCodemirror extends JPlugin
 		$options = new stdClass;
 
 		// Should we focus on the editor on load?
-		$options->autofocus	= (boolean) $this->params->get('autoFocus', true);
+		$options->autofocus = (boolean) $this->params->get('autoFocus', true);
 
 		// Until there's a fix for the overflow problem, always wrap lines.
 		$options->lineWrapping = true;
@@ -299,8 +299,8 @@ class PlgEditorCodemirror extends JPlugin
 		$options->vimMode = (boolean) $this->params->get('vimKeyBinding', 0);
 
 		$html = array();
-		$html[]	= '<p class="label">' . JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $this->fullScreenCombo) . '</p>';
-		$html[]	= '<textarea name="' . $name . '" id="' . $id . '" cols="' . $col . '" rows="' . $row . '">' . $content . '</textarea>';
+		$html[] = '<p class="label">' . JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $this->fullScreenCombo) . '</p>';
+		$html[] = '<textarea name="' . $name . '" id="' . $id . '" cols="' . $col . '" rows="' . $row . '">' . $content . '</textarea>';
 		$html[] = $buttons;
 		$html[] = '<script type="text' . '/javascript">';
 		$html[] = '(function (id, options) {';

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -229,8 +229,8 @@ class PlgExtensionJoomla extends JPlugin
 	 */
 	private function processUpdateSites()
 	{
-		$manifest		= $this->installer->getManifest();
-		$updateservers	= $manifest->updateservers;
+		$manifest      = $this->installer->getManifest();
+		$updateservers = $manifest->updateservers;
 
 		if ($updateservers)
 		{

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -16,9 +16,9 @@ defined('_JEXEC') or die;
  */
 class PlgSystemCache extends JPlugin
 {
-	var $_cache		= null;
+	var $_cache = null;
 
-	var $_cache_key	= null;
+	var $_cache_key = null;
 
 	/**
 	 * Constructor.
@@ -34,13 +34,13 @@ class PlgSystemCache extends JPlugin
 
 		// Set the language in the class.
 		$options = array(
-			'defaultgroup'	=> 'page',
-			'browsercache'	=> $this->params->get('browsercache', false),
-			'caching'		=> false,
+			'defaultgroup' => 'page',
+			'browsercache' => $this->params->get('browsercache', false),
+			'caching'      => false,
 		);
 
-		$this->_cache		= JCache::getInstance('page', $options);
-		$this->_cache_key	= JUri::getInstance()->toString();
+		$this->_cache     = JCache::getInstance('page', $options);
+		$this->_cache_key = JUri::getInstance()->toString();
 	}
 
 	/**

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1615,16 +1615,13 @@ class PlgSystemDebug extends JPlugin
 		$regex = array(
 
 			// Tables are identified by the prefix.
-			'/(=)/'
-			=> '<b class="dbg-operator">$1</b>',
+			'/(=)/' => '<b class="dbg-operator">$1</b>',
 
 			// All uppercase words have a special meaning.
-			'/(?<!\w|>)([A-Z_]{2,})(?!\w)/x'
-			=> '<span class="dbg-command">$1</span>',
+			'/(?<!\w|>)([A-Z_]{2,})(?!\w)/x' => '<span class="dbg-command">$1</span>',
 
 			// Tables are identified by the prefix.
-			'/(' . JFactory::getDbo()->getPrefix() . '[a-z_0-9]+)/'
-			=> '<span class="dbg-table">$1</span>'
+			'/(' . JFactory::getDbo()->getPrefix() . '[a-z_0-9]+)/' => '<span class="dbg-table">$1</span>'
 
 		);
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -58,10 +58,10 @@ class PlgSystemLanguageFilter extends JPlugin
 		if ($this->app->isSite())
 		{
 			// Setup language data.
-			$this->mode_sef		= $this->app->get('sef', 0);
-			$this->sefs			= JLanguageHelper::getLanguages('sef');
-			$this->lang_codes	= JLanguageHelper::getLanguages('lang_code');
-			$this->default_lang	= JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+			$this->mode_sef     = $this->app->get('sef', 0);
+			$this->sefs         = JLanguageHelper::getLanguages('sef');
+			$this->lang_codes   = JLanguageHelper::getLanguages('lang_code');
+			$this->default_lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 
 			$levels = JFactory::getUser()->getAuthorisedViewLevels();
 

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -69,8 +69,8 @@ class PlgSystemLogout extends JPlugin
 			// Create the cookie.
 			$hash = JApplicationHelper::getHash('PlgSystemLogout');
 			$conf = JFactory::getConfig();
-			$cookie_domain 	= $conf->get('cookie_domain', '');
-			$cookie_path 	= $conf->get('cookie_path', '/');
+			$cookie_domain = $conf->get('cookie_domain', '');
+			$cookie_path   = $conf->get('cookie_path', '/');
 			setcookie($hash, true, time() + 86400, $cookie_path, $cookie_domain);
 		}
 

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -83,12 +83,12 @@ class PlgUserContactCreator extends JPlugin
 				$contact->published = $this->params->get('autopublish', 0);
 			}
 
-			$contact->name		= $user['name'];
-			$contact->user_id	= $user_id;
-			$contact->email_to	= $user['email'];
-			$contact->catid		= $categoryId;
-			$contact->access	= (int) JFactory::getConfig()->get('access');
-			$contact->language	= '*';
+			$contact->name     = $user['name'];
+			$contact->user_id  = $user_id;
+			$contact->email_to = $user['email'];
+			$contact->catid    = $categoryId;
+			$contact->access   = (int) JFactory::getConfig()->get('access');
+			$contact->language = '*';
 			$contact->generateAlias();
 
 			// Check if the contact already exists to generate new name & alias if required

--- a/plugins/user/profile/fields/dob.php
+++ b/plugins/user/profile/fields/dob.php
@@ -45,16 +45,16 @@ class JFormFieldDob extends JFormFieldCalendar
 
 		if ($text)
 		{
-			$app	= JFactory::getApplication();
-			$layout	= new JLayoutFile('plugins.user.profile.fields.dob');
-			$view	= $app->input->getString('view', '');
+			$app    = JFactory::getApplication();
+			$layout = new JLayoutFile('plugins.user.profile.fields.dob');
+			$view   = $app->input->getString('view', '');
 
 			// Only display the tip when editing profile
 			if ($app->isAdmin() || $view == 'profile' || $view == 'registration')
 			{
-				$layout	= new JLayoutFile('plugins.user.profile.fields.dob');
-				$info	= $layout->render(array('text' => $text));
-				$label	= $info . $label;
+				$layout = new JLayoutFile('plugins.user.profile.fields.dob');
+				$info   = $layout->render(array('text' => $text));
+				$label  = $info . $label;
 			}
 		}
 


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the plugins folder.
