### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the modules folder

### DIFF
--- a/modules/mod_banners/helper.php
+++ b/modules/mod_banners/helper.php
@@ -28,9 +28,9 @@ class ModBannersHelper
 	public static function &getList(&$params)
 	{
 		JModelLegacy::addIncludePath(JPATH_ROOT . '/components/com_banners/models', 'BannersModel');
-		$document	= JFactory::getDocument();
-		$app		= JFactory::getApplication();
-		$keywords	= explode(',', $document->getMetaData('keywords'));
+		$document = JFactory::getDocument();
+		$app      = JFactory::getApplication();
+		$keywords = explode(',', $document->getMetaData('keywords'));
 
 		$model = JModelLegacy::getInstance('Banners', 'BannersModel', array('ignore_request' => true));
 		$model->setState('filter.client_id', (int) $params->get('cid'));

--- a/modules/mod_banners/mod_banners.php
+++ b/modules/mod_banners/mod_banners.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$headerText	= trim($params->get('header_text'));
-$footerText	= trim($params->get('footer_text'));
+$headerText = trim($params->get('header_text'));
+$footerText = trim($params->get('footer_text'));
 
 require_once JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php';
 BannersHelper::updateReset();

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -28,11 +28,11 @@ class ModBreadCrumbsHelper
 	public static function getList(&$params)
 	{
 		// Get the PathWay object from the application
-		$app		= JFactory::getApplication();
-		$pathway	= $app->getPathway();
-		$items		= $pathway->getPathWay();
-		$lang = JFactory::getLanguage();
-		$menu = $app->getMenu();
+		$app     = JFactory::getApplication();
+		$pathway = $app->getPathway();
+		$items   = $pathway->getPathWay();
+		$lang    = JFactory::getLanguage();
+		$menu    = $app->getMenu();
 
 		// Look for the home menu
 		if (JLanguageMultilang::isEnabled())
@@ -47,7 +47,7 @@ class ModBreadCrumbsHelper
 		$count = count($items);
 
 		// Don't use $items here as it references JPathway properties directly
-		$crumbs	= array();
+		$crumbs = array();
 
 		for ($i = 0; $i < $count; $i ++)
 		{

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.php
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.php
@@ -13,8 +13,8 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 // Get the breadcrumbs
-$list	= ModBreadCrumbsHelper::getList($params);
-$count	= count($list);
+$list  = ModBreadCrumbsHelper::getList($params);
+$count = count($list);
 
 // Set the default separator
 $separator = ModBreadCrumbsHelper::setSeparator($params->get('separator'));

--- a/modules/mod_feed/helper.php
+++ b/modules/mod_feed/helper.php
@@ -28,12 +28,12 @@ class ModFeedHelper
 	public static function getFeed($params)
 	{
 		// Module params
-		$rssurl	= $params->get('rssurl', '');
+		$rssurl = $params->get('rssurl', '');
 
 		// Get RSS parsed object
 		try
 		{
-			$feed = new JFeedFactory;
+			$feed   = new JFeedFactory;
 			$rssDoc = $feed->getFeed($rssurl);
 		}
 		catch (InvalidArgumentException $e)

--- a/modules/mod_feed/mod_feed.php
+++ b/modules/mod_feed/mod_feed.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$rssurl	= $params->get('rssurl', '');
-$rssrtl	= $params->get('rssrtl', 0);
+$rssurl = $params->get('rssurl', '');
+$rssrtl = $params->get('rssrtl', 0);
 
 // Check if feed URL has been set
 if (empty ($rssurl))

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -53,7 +53,7 @@ else
 	if ($feed != false)
 	{
 		// Image handling
-		$iUrl	= isset($feed->image) ? $feed->image : null;
+		$iUrl   = isset($feed->image) ? $feed->image : null;
 		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
 		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> ! important"  class="feed<?php echo $moduleclass_sfx; ?>">

--- a/modules/mod_footer/mod_footer.php
+++ b/modules/mod_footer/mod_footer.php
@@ -9,10 +9,10 @@
 
 defined('_JEXEC') or die;
 
-$app		= JFactory::getApplication();
-$date		= JFactory::getDate();
-$cur_year	= JHtml::_('date', $date, 'Y');
-$csite_name	= $app->get('sitename');
+$app        = JFactory::getApplication();
+$date       = JFactory::getDate();
+$cur_year   = JHtml::_('date', $date, 'Y');
+$csite_name = $app->get('sitename');
 
 if (is_int(JString::strpos(JText :: _('MOD_FOOTER_LINE1'), '%date%')))
 {

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -31,11 +31,11 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-		$user		= JFactory::getUser();
-		$lang		= JFactory::getLanguage();
-		$languages	= JLanguageHelper::getLanguages();
-		$app		= JFactory::getApplication();
-		$menu		= $app->getMenu();
+		$user      = JFactory::getUser();
+		$lang      = JFactory::getLanguage();
+		$languages = JLanguageHelper::getLanguages();
+		$app       = JFactory::getApplication();
+		$menu      = $app->getMenu();
 
 		// Get menu home items
 		$homes = array();
@@ -73,7 +73,7 @@ abstract class ModLanguagesHelper
 			}
 		}
 
-		$levels		= $user->getAuthorisedViewLevels();
+		$levels = $user->getAuthorisedViewLevels();
 
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)

--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$headerText	= JString::trim($params->get('header_text'));
-$footerText	= JString::trim($params->get('footer_text'));
+$headerText = JString::trim($params->get('header_text'));
+$footerText = JString::trim($params->get('footer_text'));
 
 $list = ModLanguagesHelper::getList($params);
 

--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -12,14 +12,13 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$list		= ModMenuHelper::getList($params);
-$base		= ModMenuHelper::getBase($params);
-$active		= ModMenuHelper::getActive($params);
-$active_id 	= $active->id;
-$path		= $base->tree;
-
-$showAll	= $params->get('showAllChildren');
-$class_sfx	= htmlspecialchars($params->get('class_sfx'));
+$list      = ModMenuHelper::getList($params);
+$base      = ModMenuHelper::getBase($params);
+$active    = ModMenuHelper::getActive($params);
+$active_id = $active->id;
+$path      = $base->tree;
+$showAll   = $params->get('showAllChildren');
+$class_sfx = htmlspecialchars($params->get('class_sfx'));
 
 if (count($list))
 {

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -28,8 +28,8 @@ class ModRandomImageHelper
 	 */
 	public static function getRandomImage(&$params, $images)
 	{
-		$width	= $params->get('width');
-		$height	= $params->get('height');
+		$width  = $params->get('width');
+		$height = $params->get('height');
 
 		$i      = count($images);
 		$random = mt_rand(0, $i - 1);
@@ -66,9 +66,9 @@ class ModRandomImageHelper
 			}
 		}
 
-		$image->width	= $width;
-		$image->height	= $height;
-		$image->folder	= str_replace('\\', '/', $image->folder);
+		$image->width  = $width;
+		$image->height = $height;
+		$image->folder = str_replace('\\', '/', $image->folder);
 
 		return $image;
 	}
@@ -83,10 +83,9 @@ class ModRandomImageHelper
 	 */
 	public static function getImages(&$params, $folder)
 	{
-		$type		= $params->get('type', 'jpg');
-
-		$files	= array();
-		$images	= array();
+		$type   = $params->get('type', 'jpg');
+		$files  = array();
+		$images = array();
 
 		$dir = JPATH_BASE . '/' . $folder;
 
@@ -116,8 +115,8 @@ class ModRandomImageHelper
 					{
 						$images[$i] = new stdClass;
 
-						$images[$i]->name	= $img;
-						$images[$i]->folder	= $folder;
+						$images[$i]->name   = $img;
+						$images[$i]->folder = $folder;
 						$i++;
 					}
 				}
@@ -136,9 +135,8 @@ class ModRandomImageHelper
 	 */
 	public static function getFolder(&$params)
 	{
-		$folder	= $params->get('folder');
-
-		$LiveSite	= JUri::base();
+		$folder   = $params->get('folder');
+		$LiveSite = JUri::base();
 
 		// If folder includes livesite info, remove
 		if (JString::strpos($folder, $LiveSite) === 0)

--- a/modules/mod_random_image/mod_random_image.php
+++ b/modules/mod_random_image/mod_random_image.php
@@ -12,10 +12,9 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$link	= $params->get('link');
-
-$folder	= ModRandomImageHelper::getFolder($params);
-$images	= ModRandomImageHelper::getImages($params, $folder);
+$link   = $params->get('link');
+$folder = ModRandomImageHelper::getFolder($params);
+$images = ModRandomImageHelper::getImages($params, $folder);
 
 if (!count($images))
 {

--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -30,18 +30,17 @@ if ($params->get('opensearch', 1))
 		);
 }
 
-$upper_limit = $lang->getUpperLimitSearchWord();
-
-$button			= $params->get('button', 0);
-$imagebutton		= $params->get('imagebutton', 0);
-$button_pos		= $params->get('button_pos', 'left');
-$button_text		= htmlspecialchars($params->get('button_text', JText::_('MOD_SEARCH_SEARCHBUTTON_TEXT')));
-$width			= (int) $params->get('width');
-$maxlength		= $upper_limit;
-$text			= htmlspecialchars($params->get('text', JText::_('MOD_SEARCH_SEARCHBOX_TEXT')));
-$label			= htmlspecialchars($params->get('label', JText::_('MOD_SEARCH_LABEL_TEXT')));
-$set_Itemid		= (int) $params->get('set_itemid', 0);
-$moduleclass_sfx	= htmlspecialchars($params->get('moduleclass_sfx'));
+$upper_limit     = $lang->getUpperLimitSearchWord();
+$button          = $params->get('button', 0);
+$imagebutton     = $params->get('imagebutton', 0);
+$button_pos      = $params->get('button_pos', 'left');
+$button_text     = htmlspecialchars($params->get('button_text', JText::_('MOD_SEARCH_SEARCHBUTTON_TEXT')));
+$width           = (int) $params->get('width');
+$maxlength       = $upper_limit;
+$text            = htmlspecialchars($params->get('text', JText::_('MOD_SEARCH_SEARCHBOX_TEXT')));
+$label           = htmlspecialchars($params->get('label', JText::_('MOD_SEARCH_LABEL_TEXT')));
+$set_Itemid      = (int) $params->get('set_itemid', 0);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
 
 if ($imagebutton)
 {

--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -27,48 +27,47 @@ class ModStatsHelper
 	 */
 	public static function &getList(&$params)
 	{
-		$app	= JFactory::getApplication();
-		$db		= JFactory::getDbo();
-		$rows	= array();
-		$query	= $db->getQuery(true);
-
+		$app        = JFactory::getApplication();
+		$db         = JFactory::getDbo();
+		$rows       = array();
+		$query      = $db->getQuery(true);
 		$serverinfo = $params->get('serverinfo');
-		$siteinfo	= $params->get('siteinfo');
-		$counter	= $params->get('counter');
-		$increase	= $params->get('increase');
+		$siteinfo   = $params->get('siteinfo');
+		$counter    = $params->get('counter');
+		$increase   = $params->get('increase');
 
 		$i = 0;
 
 		if ($serverinfo)
 		{
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_OS');
-			$rows[$i]->data		= substr(php_uname(), 0, 7);
+			$rows[$i]->title = JText::_('MOD_STATS_OS');
+			$rows[$i]->data  = substr(php_uname(), 0, 7);
 			$i++;
 
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_PHP');
-			$rows[$i]->data	= phpversion();
+			$rows[$i]->title = JText::_('MOD_STATS_PHP');
+			$rows[$i]->data  = phpversion();
 			$i++;
 
 			$rows[$i] = new stdClass;
 			$rows[$i]->title = JText::_($db->name);
-			$rows[$i]->data	= $db->getVersion();
+			$rows[$i]->data  = $db->getVersion();
 			$i++;
 
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_TIME');
-			$rows[$i]->data	= JHtml::_('date', 'now', 'H:i');
+			$rows[$i]->title = JText::_('MOD_STATS_TIME');
+			$rows[$i]->data  = JHtml::_('date', 'now', 'H:i');
 			$i++;
 
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_CACHING');
-			$rows[$i]->data	= $app->get('caching') ? JText::_('JENABLED') : JText::_('JDISABLED');
+			$rows[$i]->title = JText::_('MOD_STATS_CACHING');
+			$rows[$i]->data  = $app->get('caching') ? JText::_('JENABLED') : JText::_('JDISABLED');
 			$i++;
 
 			$rows[$i] = new stdClass;
-			$rows[$i]->title	= JText::_('MOD_STATS_GZIP');
-			$rows[$i]->data	= $app->get('gzip') ? JText::_('JENABLED') : JText::_('JDISABLED');
+			$rows[$i]->title = JText::_('MOD_STATS_GZIP');
+			$rows[$i]->data  = $app->get('gzip') ? JText::_('JENABLED') : JText::_('JDISABLED');
 			$i++;
 		}
 
@@ -103,16 +102,16 @@ class ModStatsHelper
 			if ($users)
 			{
 				$rows[$i] = new stdClass;
-				$rows[$i]->title	= JText::_('MOD_STATS_USERS');
-				$rows[$i]->data	= $users;
+				$rows[$i]->title = JText::_('MOD_STATS_USERS');
+				$rows[$i]->data  = $users;
 				$i++;
 			}
 
 			if ($items)
 			{
 				$rows[$i] = new stdClass;
-				$rows[$i]->title	= JText::_('MOD_STATS_ARTICLES');
-				$rows[$i]->data	= $items;
+				$rows[$i]->title = JText::_('MOD_STATS_ARTICLES');
+				$rows[$i]->data  = $items;
 				$i++;
 			}
 
@@ -162,8 +161,8 @@ class ModStatsHelper
 			if ($hits)
 			{
 				$rows[$i] = new stdClass;
-				$rows[$i]->title	= JText::_('MOD_STATS_ARTICLES_VIEW_HITS');
-				$rows[$i]->data	= $hits + $increase;
+				$rows[$i]->title = JText::_('MOD_STATS_ARTICLES_VIEW_HITS');
+				$rows[$i]->data  = $hits + $increase;
 			}
 		}
 

--- a/modules/mod_stats/mod_stats.php
+++ b/modules/mod_stats/mod_stats.php
@@ -12,10 +12,9 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$serverinfo = $params->get('serverinfo');
-$siteinfo	= $params->get('siteinfo');
-
-$list = ModStatsHelper::getList($params);
+$serverinfo      = $params->get('serverinfo');
+$siteinfo        = $params->get('siteinfo');
+$list            = ModStatsHelper::getList($params);
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
 
 require JModuleHelper::getLayoutPath('mod_stats', $params->get('layout', 'default'));

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -27,23 +27,23 @@ abstract class ModTagsPopularHelper
 	 */
 	public static function getList(&$params)
 	{
-		$db				= JFactory::getDbo();
-		$user     		= JFactory::getUser();
-		$groups 		= implode(',', $user->getAuthorisedViewLevels());
-		$timeframe		= $params->get('timeframe', 'alltime');
-		$maximum		= $params->get('maximum', 5);
-		$order_value	= $params->get('order_value', 'title');
-		$nowDate		= JFactory::getDate()->toSql();
-		$nullDate		= $db->quote($db->getNullDate());
+		$db          = JFactory::getDbo();
+		$user        = JFactory::getUser();
+		$groups      = implode(',', $user->getAuthorisedViewLevels());
+		$timeframe   = $params->get('timeframe', 'alltime');
+		$maximum     = $params->get('maximum', 5);
+		$order_value = $params->get('order_value', 'title');
+		$nowDate     = JFactory::getDate()->toSql();
+		$nullDate    = $db->quote($db->getNullDate());
 
 		if ($order_value == 'rand()')
 		{
-			$order_direction	= '';
+			$order_direction = '';
 		}
 		else
 		{
-			$order_value		= $db->quoteName($order_value);
-			$order_direction	= $params->get('order_direction', 1) ? 'DESC' : 'ASC';
+			$order_value     = $db->quoteName($order_value);
+			$order_direction = $params->get('order_direction', 1) ? 'DESC' : 'ASC';
 		}
 
 		$query = $db->getQuery(true)

--- a/modules/mod_tags_popular/mod_tags_popular.php
+++ b/modules/mod_tags_popular/mod_tags_popular.php
@@ -26,8 +26,8 @@ if (!count($list) && !$params->get('no_results_text'))
 	return;
 }
 
-$moduleclass_sfx	= htmlspecialchars($params->get('moduleclass_sfx'));
-$display_count		= $params->get('display_count', 0);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$display_count   = $params->get('display_count', 0);
 
 
 require JModuleHelper::getLayoutPath('mod_tags_popular', $params->get('layout', 'default'));

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 
-$minsize	= $params->get('minsize', 1);
-$maxsize	= $params->get('maxsize', 2);
+$minsize = $params->get('minsize', 1);
+$maxsize = $params->get('maxsize', 2);
 
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 ?>

--- a/modules/mod_users_latest/helper.php
+++ b/modules/mod_users_latest/helper.php
@@ -30,8 +30,8 @@ class ModUsersLatestHelper
 	 */
 	public static function getUsers($params)
 	{
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
 			->select($db->quoteName(array('a.id', 'a.name', 'a.username', 'a.registerDate')))
 			->order($db->quoteName('a.registerDate') . ' DESC')
 			->from('#__users AS a');

--- a/modules/mod_users_latest/mod_users_latest.php
+++ b/modules/mod_users_latest/mod_users_latest.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $shownumber = $params->get('shownumber', 5);
-$names	= ModUsersLatestHelper::getUsers($params);
+$names = ModUsersLatestHelper::getUsers($params);
 $linknames = $params->get('linknames', 0);
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
 

--- a/modules/mod_whosonline/mod_whosonline.php
+++ b/modules/mod_whosonline/mod_whosonline.php
@@ -16,12 +16,12 @@ $showmode = $params->get('showmode', 0);
 
 if ($showmode == 0 || $showmode == 2)
 {
-	$count	= ModWhosonlineHelper::getOnlineCount();
+	$count = ModWhosonlineHelper::getOnlineCount();
 }
 
 if ($showmode > 0)
 {
-	$names	= ModWhosonlineHelper::getOnlineUserNames($params);
+	$names = ModWhosonlineHelper::getOnlineUserNames($params);
 }
 
 $linknames = $params->get('linknames', 0);

--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -14,13 +14,13 @@ require_once __DIR__ . '/helper.php';
 
 $params = ModWrapperHelper::getParams($params);
 
-$load	= $params->get('load');
-$url	= htmlspecialchars($params->get('url'));
-$target = htmlspecialchars($params->get('target'));
-$width	= htmlspecialchars($params->get('width'));
-$height = htmlspecialchars($params->get('height'));
-$scroll = htmlspecialchars($params->get('scrolling'));
+$load            = $params->get('load');
+$url             = htmlspecialchars($params->get('url'));
+$target          = htmlspecialchars($params->get('target'));
+$width           = htmlspecialchars($params->get('width'));
+$height          = htmlspecialchars($params->get('height'));
+$scroll          = htmlspecialchars($params->get('scrolling'));
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
-$frameborder = htmlspecialchars($params->get('frameborder'));
+$frameborder     = htmlspecialchars($params->get('frameborder'));
 
 require JModuleHelper::getLayoutPath('mod_wrapper', $params->get('layout', 'default'));


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the modules folder.
