### PR TITLE
[codestyle] Use spaces instead of tabs for equal signs at the other folders

### DIFF
--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -363,9 +363,9 @@ class FinderCli extends JApplicationCli
 			foreach ($taxonomies as $taxonomy)
 			{
 				$this->filters[$filter->filter_id][] = array(
-					'filter'	=> $filter->title,
-					'title'		=> $taxonomy->title,
-					'parent'	=> $taxonomy->parent,
+					'filter' => $filter->title,
+					'title'  => $taxonomy->title,
+					'parent' => $taxonomy->parent,
 				);
 			}
 		}

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -20,12 +20,12 @@ defined('_JEXEC') or die;
  * 	$position     : (string)  The tooltip position. Bottom for alias
  */
 
-$text		= $displayData['text'];
-$desc		= $displayData['description'];
-$for		= $displayData['for'];
-$req		= $displayData['required'];
-$classes	= array_filter((array) $displayData['classes']);
-$position	= $displayData['position'];
+$text     = $displayData['text'];
+$desc     = $displayData['description'];
+$for      = $displayData['for'];
+$req      = $displayData['required'];
+$classes  = array_filter((array) $displayData['classes']);
+$position = $displayData['position'];
 
 $id = $for . '-lbl';
 $title = '';
@@ -35,7 +35,7 @@ if (!empty($desc))
 {
 	JHtml::_('bootstrap.tooltip');
 	$classes[] = 'hasTooltip';
-	$title = ' title="' . JHtml::tooltipText(trim($text, ':'), $desc, 0) . '"';
+	$title     = ' title="' . JHtml::tooltipText(trim($text, ':'), $desc, 0) . '"';
 }
 
 // If required, there's a class for that.

--- a/media/jui/js/jquery.ui.sortable.js
+++ b/media/jui/js/jquery.ui.sortable.js
@@ -646,9 +646,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 		} else {
 			for (var i = this.containers.length - 1; i >= 0; i--){
 				var p = this.containers[i].element.offset();
-				this.containers[i].containerCache.left = p.left;
-				this.containers[i].containerCache.top = p.top;
-				this.containers[i].containerCache.width	= this.containers[i].element.outerWidth();
+				this.containers[i].containerCache.left   = p.left;
+				this.containers[i].containerCache.top    = p.top;
+				this.containers[i].containerCache.width  = this.containers[i].element.outerWidth();
 				this.containers[i].containerCache.height = this.containers[i].element.outerHeight();
 			};
 		}

--- a/media/media/js/popup-imagemanager.js
+++ b/media/media/js/popup-imagemanager.js
@@ -20,19 +20,19 @@ var ImageManager = this.ImageManager = {
 		this.editor = decodeURIComponent(q['e_name']);
 
 		// Setup image manager fields object
-		this.fields			= new Object();
-		this.fields.url		= document.getElementById("f_url");
-		this.fields.alt		= document.getElementById("f_alt");
-		this.fields.align	= document.getElementById("f_align");
-		this.fields.title	= document.getElementById("f_title");
-		this.fields.caption	= document.getElementById("f_caption");
-		this.fields.c_class	= document.getElementById("f_caption_class");
+		this.fields         = new Object();
+		this.fields.url     = document.getElementById("f_url");
+		this.fields.alt     = document.getElementById("f_alt");
+		this.fields.align   = document.getElementById("f_align");
+		this.fields.title   = document.getElementById("f_title");
+		this.fields.caption = document.getElementById("f_caption");
+		this.fields.c_class = document.getElementById("f_caption_class");
 
 		// Setup image listing objects
 		this.folderlist = document.getElementById('folderlist');
 
-		this.frame		= window.frames['imageframe'];
-		this.frameurl	= this.frame.location.href;
+		this.frame    = window.frames['imageframe'];
+		this.frameurl = this.frame.location.href;
 
 		// Setup imave listing frame
 		this.imageframe = document.getElementById('imageframe');
@@ -82,24 +82,24 @@ var ImageManager = this.ImageManager = {
 
 	getImageFolder: function()
 	{
-		var url 	= this.frame.location.search.substring(1);
-		var args	= this.parseQuery(url);
+		var url  = this.frame.location.search.substring(1);
+		var args = this.parseQuery(url);
 
 		return args['folder'];
 	},
 
 	onok: function()
 	{
-		var tag		= '';
-		var extra	= '';
+		var tag   = '';
+		var extra = '';
 
 		// Get the image tag field information
-		var url		= this.fields.url.value;
-		var alt		= this.fields.alt.value;
-		var align	= this.fields.align.value;
-		var title	= this.fields.title.value;
-		var caption	= this.fields.caption.value;
-		var c_class	= this.fields.c_class.value;
+		var url     = this.fields.url.value;
+		var alt     = this.fields.alt.value;
+		var align   = this.fields.align.value;
+		var title   = this.fields.title.value;
+		var caption = this.fields.caption.value;
+		var c_class = this.fields.c_class.value;
 
 		if (url != '') {
 			// Set alt attribute

--- a/media/overrider/js/overrider.js
+++ b/media/overrider/js/overrider.js
@@ -79,8 +79,8 @@ Joomla.overrider.searchStrings = function(more)
 	// was used to start the search (that will be the case if 'more' is null)
 	if (!more)
 	{
-		this.states.searchstring 	= $('#jform_searchstring').val();
-		this.states.searchtype = $('#jform_searchtype') !== null ? $('#jform_searchtype').val() : 'value';
+		this.states.searchstring = $('#jform_searchstring').val();
+		this.states.searchtype   = $('#jform_searchtype') !== null ? $('#jform_searchtype').val() : 'value';
 	}
 
 	if (!this.states.searchstring)


### PR DESCRIPTION
This PR make sure that we use spaces instead of tabs for equal signs in the other folders.
