### PR TITLE
Wrong datetime NOW for JForm field calendar

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -167,7 +167,7 @@ class JFormFieldCalendar extends JFormField
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')
 		{
-			$this->value = strftime($format);
+			$this->value = JFactory::getDate()->toSql();
 		}
 
 		// Get some system objects.

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -167,7 +167,7 @@ class JFormFieldCalendar extends JFormField
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')
 		{
-			$this->value = JFactory::getDate()->toSql();
+			$this->value = JFactory::getDate()->format('Y-m-d H:i:s');
 		}
 
 		// Get some system objects.

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCalendarTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCalendarTest.php
@@ -192,7 +192,7 @@ class JFormFieldCalendarTest extends TestCase
 					'name' => 'myCalendarElement',
 					'id' => 'myCalendarId',
 					'value' => 'NOW',
-					'format' => '%Y-%m-%d',
+					'format' => 'Y-m-d',
 					'size' => 25,
 					'maxlength' => 45,
 					'disabled' => true,
@@ -203,7 +203,7 @@ class JFormFieldCalendarTest extends TestCase
 					'strftime(\'%Y-%m-%d\')',
 					'myCalendarElement',
 					'myCalendarId',
-					'%Y-%m-%d',
+					'Y-m-d',
 					array(
 						'size' => 25,
 						'maxlength' => 45,
@@ -294,7 +294,7 @@ class JFormFieldCalendarTest extends TestCase
 		if ($expectedParameters[0] == 'strftime(\'%Y-%m-%d\')')
 		{
 			date_default_timezone_set('UTC');
-			$expectedParameters[0] = strftime('%Y-%m-%d');
+			$expectedParameters[0] = strftime('%Y-%m-%d %H:%M:%S');
 		}
 
 		// Setup our values from our data set


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/4508 for info

---
#### Steps to reproduce the issue

For a calendar form field you set the default value to "NOW" and add a new item.
To  test you can edit any form with a calendar field.
#### Expected result
1. The actual user date and time shown
   or
2. The actual server date and time shown
   depending on the filter used
#### Actual result

The date and time is wrongly calculated with the actual server date and time as basis.
Must use UTC+0 as basis.
#### System information (as much as possible)

J 3.3.6
#### Additional comments

PR on GitHub
calendar.php
        // Handle the special case for "now".
        if (strtoupper($this->value) == 'NOW')
        {
            //$this->value = strftime($format);
            $this->value = JFactory::getDate()->toSql();
        }
