### PR TITLE
Use hash_equals for constant-time string comparison

### DIFF
--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -256,6 +256,7 @@ class JCrypt
 	/**
 	 * A timing safe comparison method. This defeats hacking
 	 * attempts that use timing based attack vectors.
+	 * Length will leak.
 	 *
 	 * @param   string  $known    A known string to check against.
 	 * @param   string  $unknown  An unknown string to check.
@@ -266,6 +267,12 @@ class JCrypt
 	 */
 	public static function timingSafeCompare($known, $unknown)
 	{
+		// Use the build in function hash_equals if it exists
+		if (function_exists('hash_equals'))
+		{
+			return hash_equals((string) $known, (string) $unknown);
+		}
+
 		// Prevent issues if string length is 0
 		$known .= chr(0);
 		$unknown .= chr(0);

--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -274,10 +274,10 @@ class JCrypt
 		}
 
 		// Prevent issues if string length is 0
-		$known .= chr(0);
+		$known   .= chr(0);
 		$unknown .= chr(0);
 
-		$knownLength = strlen($known);
+		$knownLength   = strlen($known);
 		$unknownLength = strlen($unknown);
 
 		// Set the result to the difference between the lengths


### PR DESCRIPTION
This PR fixes the Codestyle Issues and replaces: https://github.com/joomla/joomla-cms/pull/4206 add kudos goes to @dunglas

@committer please mention @dunglas on commit. Thanks

---

Use the `hash_equals` function (introduced in PHP 5.6) for timing attack safe string comparison when available.
Add in the DocBlock that length will leak (see php/php-src#792).
