### PR TITLE
user activation link doesn't enforce frontend base URL

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -414,7 +414,7 @@ class UsersModelRegistration extends JModelForm
 		{
 			// Set the link to confirm the user email.
 			$uri = JUri::getInstance();
- 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 			
 			// Remove administrator/ from activate url in case this method is called from admin
@@ -458,7 +458,7 @@ class UsersModelRegistration extends JModelForm
 		{
 			// Set the link to activate the user account.
 			$uri = JUri::getInstance();
- 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 			
 			// Remove administrator/ from activate url in case this method is called from admin

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -82,7 +82,15 @@ class UsersModelRegistration extends JModelForm
 			$user->set('activation', $data['activation']);
 			$data['siteurl'] = JUri::base();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			
+			// Remove administrator/ from activate url in case this method is called from admin
+			if (JFactory::getApplication()->isAdmin())
+			{
+				$adminPos = strrpos($data['activate'], 'administrator/');
+				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
+			}
+			
 			$data['fromname'] = $config->get('fromname');
 			$data['mailfrom'] = $config->get('mailfrom');
 			$data['sitename'] = $config->get('sitename');
@@ -405,7 +413,16 @@ class UsersModelRegistration extends JModelForm
 		if ($useractivation == 2)
 		{
 			// Set the link to confirm the user email.
-			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$uri = JUri::getInstance();
+ 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			
+			// Remove administrator/ from activate url in case this method is called from admin
+			if (JFactory::getApplication()->isAdmin())
+			{
+				$adminPos = strrpos($data['activate'], 'administrator/');
+				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
+			}
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',
@@ -440,7 +457,16 @@ class UsersModelRegistration extends JModelForm
 		elseif ($useractivation == 1)
 		{
 			// Set the link to activate the user account.
-			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$uri = JUri::getInstance();
+ 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			
+			// Remove administrator/ from activate url in case this method is called from admin
+			if (JFactory::getApplication()->isAdmin())
+			{
+				$adminPos = strrpos($data['activate'], 'administrator/');
+				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
+			}
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -405,9 +405,7 @@ class UsersModelRegistration extends JModelForm
 		if ($useractivation == 2)
 		{
 			// Set the link to confirm the user email.
-			$uri = JUri::getInstance();
-			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = JRoute::_($base . '/index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',
@@ -442,9 +440,7 @@ class UsersModelRegistration extends JModelForm
 		elseif ($useractivation == 1)
 		{
 			// Set the link to activate the user account.
-			$uri = JUri::getInstance();
-			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = JRoute::_($base . '/index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -83,14 +83,14 @@ class UsersModelRegistration extends JModelForm
 			$data['siteurl'] = JUri::base();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
-			
+
 			// Remove administrator/ from activate url in case this method is called from admin
 			if (JFactory::getApplication()->isAdmin())
 			{
-				$adminPos = strrpos($data['activate'], 'administrator/');
+				$adminPos         = strrpos($data['activate'], 'administrator/');
 				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
 			}
-			
+
 			$data['fromname'] = $config->get('fromname');
 			$data['mailfrom'] = $config->get('mailfrom');
 			$data['sitename'] = $config->get('sitename');
@@ -416,11 +416,11 @@ class UsersModelRegistration extends JModelForm
 			$uri = JUri::getInstance();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
-			
+
 			// Remove administrator/ from activate url in case this method is called from admin
 			if (JFactory::getApplication()->isAdmin())
 			{
-				$adminPos = strrpos($data['activate'], 'administrator/');
+				$adminPos         = strrpos($data['activate'], 'administrator/');
 				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
 			}
 
@@ -460,11 +460,11 @@ class UsersModelRegistration extends JModelForm
 			$uri = JUri::getInstance();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
-			
+
 			// Remove administrator/ from activate url in case this method is called from admin
 			if (JFactory::getApplication()->isAdmin())
 			{
-				$adminPos = strrpos($data['activate'], 'administrator/');
+				$adminPos         = strrpos($data['activate'], 'administrator/');
 				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
 			}
 

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -407,7 +407,7 @@ class UsersModelRegistration extends JModelForm
 			// Set the link to confirm the user email.
 			$uri = JUri::getInstance();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = JRoute::_($base . '/index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',
@@ -444,7 +444,7 @@ class UsersModelRegistration extends JModelForm
 			// Set the link to activate the user account.
 			$uri = JUri::getInstance();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = JRoute::_($base . '/index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -82,7 +82,7 @@ class UsersModelRegistration extends JModelForm
 			$user->set('activation', $data['activation']);
 			$data['siteurl'] = JUri::base();
 			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$data['activate'] = JRoute::_(JUri::root() . 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
 			$data['fromname'] = $config->get('fromname');
 			$data['mailfrom'] = $config->get('mailfrom');
 			$data['sitename'] = $config->get('sitename');


### PR DESCRIPTION
#7737 - enforce frontend construction for user activation URL

https://github.com/joomla/joomla-cms/issues/7737

---

when the register method constructs the user activation URL, it doesn't explicitly enforce a frontend URL. this means that 3rd party extensions wanting to trigger registration (and thus activation emails) from a backend tool cannot make use of the core register method.

since the activation URL is only valid from the frontend, we should always enforce the proper construction.

there are two locations to be modified:
https://github.com/joomla/joomla-cms/blob/staging/components/com_users/models/registration.php#L410
https://github.com/joomla/joomla-cms/blob/staging/components/com_users/models/registration.php#L447

In both cases, we can just include the base url inside JRoute::_() to achieve the enforcement:

$data['activate'] = JRoute::_($base . '/index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
