### PR TITLE
Add (rudimentary) page exclusion support for the Page Cache plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_cache.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_cache.ini
@@ -5,6 +5,8 @@
 
 PLG_CACHE_FIELD_BROWSERCACHE_DESC="If yes, use mechanism for storing page cache in the browser."
 PLG_CACHE_FIELD_BROWSERCACHE_LABEL="Use Browser Caching"
+PLG_CACHE_FIELD_EXCLUDE_DESC="Specify which pages you wish to exclude from caching, each on a separate line. Regular expressions are supported."
+PLG_CACHE_FIELD_EXCLUDE_LABEL="Exclude Pages"
 PLG_CACHE_FIELD_LIFETIME_DESC="Page cache lifetime in minutes."
 PLG_CACHE_FIELD_LIFETIME_LABEL="Cache Lifetime"
 PLG_CACHE_XML_DESCRIPTION="Provides page caching."

--- a/administrator/language/en-GB/en-GB.plg_system_cache.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_cache.ini
@@ -5,8 +5,8 @@
 
 PLG_CACHE_FIELD_BROWSERCACHE_DESC="If yes, use mechanism for storing page cache in the browser."
 PLG_CACHE_FIELD_BROWSERCACHE_LABEL="Use Browser Caching"
-PLG_CACHE_FIELD_EXCLUDE_DESC="Specify which pages you want to exclude from caching, each on a separate line. Regular expressions are supported."
-PLG_CACHE_FIELD_EXCLUDE_LABEL="Exclude Pages"
+PLG_CACHE_FIELD_EXCLUDE_DESC="Specify which URLs you want to exclude from caching, each on a separate line. Regular expressions are supported, eg. <br /><strong>about\-[a-z]+</strong> - will exclude all URLs that contain 'about-', for example 'about-us', 'about-me', 'about-joomla' etc.<br /><strong>\/component\/users\/</strong> - will exclude all URLs that contain /component/users/"
+PLG_CACHE_FIELD_EXCLUDE_LABEL="Exclude URLs"
 PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_DESC="Select which menu items you want to exclude from caching."
 PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_LABEL="Exclude Menu Items"
 PLG_CACHE_FIELD_LIFETIME_DESC="Page cache lifetime in minutes."

--- a/administrator/language/en-GB/en-GB.plg_system_cache.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_cache.ini
@@ -5,8 +5,10 @@
 
 PLG_CACHE_FIELD_BROWSERCACHE_DESC="If yes, use mechanism for storing page cache in the browser."
 PLG_CACHE_FIELD_BROWSERCACHE_LABEL="Use Browser Caching"
-PLG_CACHE_FIELD_EXCLUDE_DESC="Specify which pages you wish to exclude from caching, each on a separate line. Regular expressions are supported."
+PLG_CACHE_FIELD_EXCLUDE_DESC="Specify which pages you want to exclude from caching, each on a separate line. Regular expressions are supported."
 PLG_CACHE_FIELD_EXCLUDE_LABEL="Exclude Pages"
+PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_DESC="Select which menu items you want to exclude from caching."
+PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_LABEL="Exclude Menu Items"
 PLG_CACHE_FIELD_LIFETIME_DESC="Page cache lifetime in minutes."
 PLG_CACHE_FIELD_LIFETIME_LABEL="Cache Lifetime"
 PLG_CACHE_XML_DESCRIPTION="Provides page caching."

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -123,7 +123,7 @@ class PlgSystemCache extends JPlugin
 	/**
 	 * Check if the page is excluded from the cache or not.
 	 *
-	 * @return   boolean   True if the page is excluded else false
+	 * @return   boolean  True if the page is excluded else false
 	 *
 	 * @since    3.5
 	 */

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -113,10 +113,37 @@ class PlgSystemCache extends JPlugin
 
 		$user = JFactory::getUser();
 
-		if ($user->get('guest'))
+		if ($user->get('guest') && !$this->isExcluded())
 		{
 			// We need to check again here, because auto-login plugins have not been fired before the first aid check.
 			$this->_cache->store(null, $this->_cache_key);
 		}
+	}
+
+	protected function isExcluded() {
+		if ($exclusions = $this->params->get('exclude', '')) {
+			// Normalize line endings
+			$exclusions = str_replace(array("\r\n", "\r"), "\n", $exclusions);
+
+			// Split them
+			$exclusions = explode("\n", $exclusions);
+
+			// Get current path to match against
+			$path = JUri::getInstance()->toString(array('path', 'query', 'fragment'));
+
+			// Loop through each pattern
+			if ($exclusions) {
+				foreach ($exclusions as $exclusion) {
+					// Make sure the exclusion has some content
+					if (strlen($exclusion)) {
+						if (preg_match('/'.$exclusion.'/is', $path, $match)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -120,7 +120,15 @@ class PlgSystemCache extends JPlugin
 		}
 	}
 
-	protected function isExcluded() {
+	/**
+	 * Check if the page is excluded from the cache or not.
+	 *
+	 * @return   boolean   True if the page is excluded else false
+	 *
+	 * @since    3.5
+	 */
+	protected function isExcluded()
+	{
 		// Check if menu items have been excluded
 		if ($exclusions = $this->params->get('exclude_menu_items', array()))
 		{
@@ -153,7 +161,7 @@ class PlgSystemCache extends JPlugin
 					// Make sure the exclusion has some content
 					if (strlen($exclusion))
 					{
-						if (preg_match('/'.$exclusion.'/is', $path, $match))
+						if (preg_match('/' . $exclusion . '/is', $path, $match))
 						{
 							return true;
 						}

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -121,7 +121,21 @@ class PlgSystemCache extends JPlugin
 	}
 
 	protected function isExcluded() {
-		if ($exclusions = $this->params->get('exclude', '')) {
+		// Check if menu items have been excluded
+		if ($exclusions = $this->params->get('exclude_menu_items', array()))
+		{
+			// Get the current menu item
+			$active = JFactory::getApplication()->getMenu()->getActive();
+			
+			if ($active && $active->id && in_array($active->id, (array) $exclusions))
+			{
+				return true;
+			}
+		}
+
+		// Check if regular expressions are being used
+		if ($exclusions = $this->params->get('exclude', ''))
+		{
 			// Normalize line endings
 			$exclusions = str_replace(array("\r\n", "\r"), "\n", $exclusions);
 
@@ -132,11 +146,15 @@ class PlgSystemCache extends JPlugin
 			$path = JUri::getInstance()->toString(array('path', 'query', 'fragment'));
 
 			// Loop through each pattern
-			if ($exclusions) {
-				foreach ($exclusions as $exclusion) {
+			if ($exclusions)
+			{
+				foreach ($exclusions as $exclusion)
+				{
 					// Make sure the exclusion has some content
-					if (strlen($exclusion)) {
-						if (preg_match('/'.$exclusion.'/is', $path, $match)) {
+					if (strlen($exclusion))
+					{
+						if (preg_match('/'.$exclusion.'/is', $path, $match))
+						{
 							return true;
 						}
 					}

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -37,6 +37,8 @@
 		</fieldset>
 		<fieldset name="advanced">
 			<field name="exclude" type="textarea"
+				class="input-xxlarge"
+				rows="15"
 				filter="raw"
 				default=""
 				description="PLG_CACHE_FIELD_EXCLUDE_DESC"

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -28,6 +28,12 @@
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
+			<field name="exclude" type="textarea"
+				filter="raw"
+				default=""
+				description="PLG_CACHE_FIELD_EXCLUDE_DESC"
+				label="PLG_CACHE_FIELD_EXCLUDE_LABEL"
+			/>
 		</fieldset>
 	</fields>
 	</config>

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -28,6 +28,14 @@
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
+			<field name="exclude_menu_items" type="menuitem"
+				default=""
+				multiple="multiple"
+				description="PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_DESC"
+				label="PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_LABEL"
+			/>
+		</fieldset>
+		<fieldset name="advanced">
 			<field name="exclude" type="textarea"
 				filter="raw"
 				default=""


### PR DESCRIPTION
# Problem

What has really bothered me for some time is that once you enable `System - Page Cache` you have no control over which pages are being cached. For example, you might want not to cache a particular page. You can't do that unless you disable the plugin completely.
# Proposed solution

In the `System - Page Cache` plugin parameters I've added two new fields:
- `Exclude Menu Items`. This is a multiple option dropdown that lists all of your menu items. You can select which menu items will not be cached.
-  `Exclude Pages`. This is just a `<textarea>` that accepts regex patterns, each on a new line. I'm sure most people won't know how to use this but then again I'm sure they won't need to. It's also placed in the `Advanced` tab, I hope not too many people find it :)
# Backwards compatibility

I've made all efforts to ensure that this does not break current installations. By default these fields will be empty and will only be checked if they actually have contents.
# How to test
## Exclude Menu Items

After you create a few menu items, activate the plugin and select them from the list. They will no longer get cached.
## Exclude Pages

The matches are performed against the path, including query and fragment (eg. `/joomla/index.php?option=com_test&task=something#header`).
You can test by activating the plugin, creating some menu items and adding regular expressions to match them in the `Exclude Pages` field. For example if you create a menu item called `contact` and your URL will point to `/joomla/index.php/contact` you can use `\/contact\/?` as a pattern to exclude all pages that match `/contact/` (that means that sub-menu items will be excluded as well).
