### PR TITLE
Rendering params fieldsets on site article form

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -444,6 +444,12 @@ class ContentModelArticle extends JModelAdmin
 			}
 		}
 
+		// If there are params fieldsets in the form it will fail with a registry object
+		if (isset($data->params) && $data->params instanceof Registry)
+		{
+			$data->params = $data->params->toArray();
+		}
+
 		$this->preprocessData('com_content.article', $data);
 
 		return $data;

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -70,6 +70,9 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php if ($params->get('show_urls_images_frontend') ) : ?>
 				<li><a href="#images" data-toggle="tab"><?php echo JText::_('COM_CONTENT_IMAGES_AND_URLS') ?></a></li>
 				<?php endif; ?>
+				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) :?>
+				<li><a href="#params-<?php echo $name;?>" data-toggle="tab"><?php echo JText::_($fieldSet->label);?></a></li>
+				<?php endforeach; ?>
 				<li><a href="#publishing" data-toggle="tab"><?php echo JText::_('COM_CONTENT_PUBLISHING') ?></a></li>
 				<li><a href="#language" data-toggle="tab"><?php echo JText::_('JFIELD_LANGUAGE_LABEL') ?></a></li>
 				<li><a href="#metadata" data-toggle="tab"><?php echo JText::_('COM_CONTENT_METADATA') ?></a></li>
@@ -118,6 +121,13 @@ JFactory::getDocument()->addScriptDeclaration("
 					</div>
 				</div>
 				<?php endif; ?>
+				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
+					<div class="tab-pane" id="params-<?php echo $name;?>">
+						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
+							<?php echo $field->renderField(); ?>
+						<?php endforeach; ?>
+					</div>
+				<?php endforeach; ?>
 				<div class="tab-pane" id="publishing">
 					<?php echo $this->form->renderField('catid'); ?>
 					<?php echo $this->form->renderField('tags'); ?>

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -21,6 +21,7 @@ $params = $this->state->get('params');
 
 // This checks if the editor config options have ever been saved. If they haven't they will fall back to the original settings.
 $editoroptions = isset($params->show_publishing_options);
+
 if (!$editoroptions)
 {
 	$params->show_urls_images_frontend = '0';
@@ -70,8 +71,8 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php if ($params->get('show_urls_images_frontend') ) : ?>
 				<li><a href="#images" data-toggle="tab"><?php echo JText::_('COM_CONTENT_IMAGES_AND_URLS') ?></a></li>
 				<?php endif; ?>
-				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) :?>
-				<li><a href="#params-<?php echo $name;?>" data-toggle="tab"><?php echo JText::_($fieldSet->label);?></a></li>
+				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
+				<li><a href="#params-<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($fieldSet->label); ?></a></li>
 				<?php endforeach; ?>
 				<li><a href="#publishing" data-toggle="tab"><?php echo JText::_('COM_CONTENT_PUBLISHING') ?></a></li>
 				<li><a href="#language" data-toggle="tab"><?php echo JText::_('JFIELD_LANGUAGE_LABEL') ?></a></li>
@@ -122,7 +123,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				</div>
 				<?php endif; ?>
 				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-					<div class="tab-pane" id="params-<?php echo $name;?>">
+					<div class="tab-pane" id="params-<?php echo $name; ?>">
 						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
 							<?php echo $field->renderField(); ?>
 						<?php endforeach; ?>


### PR DESCRIPTION
On the back end, the article manager supports to add custom fieldsets with the name params. Unfortunately this doesn't work on the front. This patch renders custom fieldsets with the name params on the front as well.
### Testing instructions
1. Apply the patch :smile:.
2. In the file components/com_content/models/forms/article.xml add the following code after the line 369 (basically after the last `<fields>` group).
   
   ``` xml
   <fields name="params">
       <fieldset name="demo" label="Fields">
           <field name="demo" type="text" label="Demo Text Field" description="Demo Field Description" />
       </fieldset>
   </fields>
   ```
3. Edit an article in the front.
### Testing instructions with DPFields
1. Apply the patch :smile:.
2. Install [DPFields](https://joomla.digital-peak.com/download/dpfields)
3. Create some custom fields on the Article Manager as described [here](https://joomla.digital-peak.com/documentation/162-dpfields/2746-getting-started).
4. Edit an article in the front.
### Outcome

You should see a new tab with name `Fields` and the `Demo Text Field`.
![article-params-fieldset-front](https://cloud.githubusercontent.com/assets/251072/9468966/d255179a-4b44-11e5-8156-42a3f5904897.png)
