### PR TITLE
Index category after save in finder plugin

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -130,10 +130,10 @@ class PlgFinderCategories extends FinderIndexerAdapter
 			{
 				// Process the change.
 				$this->itemAccessChange($row);
-
-				// Reindex the category item.
-				$this->reindex($row->id);
 			}
+
+			// Reindex the category item.
+			$this->reindex($row->id);
 
 			// Check if the parent access level is different.
 			if (!$isNew && $this->old_cataccess != $row->access)


### PR DESCRIPTION
This is the PR for the issue #7711. 
#### Steps to reproduce the issue

1) Have smart search enabled incl. "categories" finder plugin
2) Edit a category: change title/alias/description, but do not touch state or access. Save.
3) Search for a relevant keyword to get this category in search results
#### Expected result

Updated title/alias/description of the category in search result
#### Actual result

Old title/alias/descriptipon
#### System information (as much as possible)
#### Additional comments

I believe a closing bracket should be moved from line 136 to line 133 in categories.php finder plugin. 

``` php
            if (!$isNew && $this->old_access != $row->access)
            {
                // Process the change.
                $this->itemAccessChange($row);

                // Reindex the category item.
                $this->reindex($row->id);
            }
```

to  become 

``` php
            if (!$isNew && $this->old_access != $row->access)
            {
                // Process the change.
                $this->itemAccessChange($row);
            }

            // Reindex the category item.
            $this->reindex($row->id);           
```
