### PR TITLE
Issue  #7771 - router.php changed to handle SEO links for Archive view

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -205,7 +205,7 @@ class ContentRouter extends JComponentRouterBase
 
 				$segments[] = $view;
 			}
-			
+
 			unset($query['view']);
 
 			if (isset($query['year']))

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -197,8 +197,9 @@ class ContentRouter extends JComponentRouterBase
 		{
 			if (!$menuItemGiven || $menuItem->query['view'] != 'archive')
 			{
-				//did not work without removing Itemid
-				if (isset($menuItem)) {
+				// did not work without removing Itemid
+				if (isset($menuItem))
+				{
 					unset($query['Itemid']);
 				}
 				$segments[] = $view;
@@ -221,7 +222,6 @@ class ContentRouter extends JComponentRouterBase
 				unset($query['month']);
 			}
 		}
-
 
 		if ($view == 'featured')
 		{
@@ -300,7 +300,7 @@ class ContentRouter extends JComponentRouterBase
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			//called if no menu item created
+			// called if no menu item created
 			if ($vars['view'] == 'archive')
 			{
 				$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
@@ -312,8 +312,8 @@ class ContentRouter extends JComponentRouterBase
 			}
 			return $vars;
 		}
-		
-		//first handle archive view
+
+		// first handle archive view
 		if ($item->query['view'] == 'archive')
 		{
 			$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
@@ -322,7 +322,7 @@ class ContentRouter extends JComponentRouterBase
 
 			return $vars;
 		}
-		
+
 		/*
 		 * If there is only one segment, then it points to either an article or a category.
 		 * We test it first to see if it is a category.  If the id and alias match a category,

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -202,6 +202,7 @@ class ContentRouter extends JComponentRouterBase
 				{
 					unset($query['Itemid']);
 				}
+
 				$segments[] = $view;
 				unset($query['view']);
 			}
@@ -304,22 +305,23 @@ class ContentRouter extends JComponentRouterBase
 			// Called if no menu item created
 			if ($vars['view'] == 'archive')
 			{
-				$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+				$vars['year']  = $count >= 2 ? $segments[$count - 2] : null;
 				$vars['month'] = $segments[$count - 1];
 			}
 			else
 			{
 				$vars['id'] = $segments[$count - 1];
 			}
+
 			return $vars;
 		}
 
 		// First handle archive view
 		if ($item->query['view'] == 'archive')
 		{
-			$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+			$vars['year']  = $count >= 2 ? $segments[$count - 2] : null;
 			$vars['month'] = $segments[$count - 1];
-			$vars['view'] = 'archive';
+			$vars['view']  = 'archive';
 
 			return $vars;
 		}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -300,6 +300,7 @@ class ContentRouter extends JComponentRouterBase
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
+
 			// Called if no menu item created
 			if ($vars['view'] == 'archive')
 			{

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -197,7 +197,7 @@ class ContentRouter extends JComponentRouterBase
 		{
 			if (!$menuItemGiven || $menuItem->query['view'] != 'archive')
 			{
-				// did not work without removing Itemid
+				// Did not work without removing Itemid
 				if (isset($menuItem))
 				{
 					unset($query['Itemid']);
@@ -300,7 +300,7 @@ class ContentRouter extends JComponentRouterBase
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			// called if no menu item created
+			// Called if no menu item created
 			if ($vars['view'] == 'archive')
 			{
 				$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
@@ -313,7 +313,7 @@ class ContentRouter extends JComponentRouterBase
 			return $vars;
 		}
 
-		// first handle archive view
+		// First handle archive view
 		if ($item->query['view'] == 'archive')
 		{
 			$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -204,12 +204,9 @@ class ContentRouter extends JComponentRouterBase
 				}
 
 				$segments[] = $view;
-				unset($query['view']);
 			}
-			else
-			{
-				unset($query['view']);
-			}
+			
+			unset($query['view']);
 
 			if (isset($query['year']))
 			{

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -195,30 +195,33 @@ class ContentRouter extends JComponentRouterBase
 
 		if ($view == 'archive')
 		{
-			if (!$menuItemGiven)
+			if (!$menuItemGiven || $menuItem->query['view'] != 'archive')
 			{
+				//did not work without removing Itemid
+				if (isset($menuItem)) {
+					unset($query['Itemid']);
+				}
 				$segments[] = $view;
+				unset($query['view']);
+			}
+			else
+			{
 				unset($query['view']);
 			}
 
 			if (isset($query['year']))
 			{
-				if ($menuItemGiven)
-				{
-					$segments[] = $query['year'];
-					unset($query['year']);
-				}
+				$segments[] = $query['year'];
+				unset($query['year']);
 			}
 
-			if (isset($query['year']) && isset($query['month']))
+			if (isset($query['month']))
 			{
-				if ($menuItemGiven)
-				{
-					$segments[] = $query['month'];
-					unset($query['month']);
-				}
+				$segments[] = $query['month'];
+				unset($query['month']);
 			}
 		}
+
 
 		if ($view == 'featured')
 		{
@@ -297,11 +300,29 @@ class ContentRouter extends JComponentRouterBase
 		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
-			$vars['id'] = $segments[$count - 1];
+			//called if no menu item created
+			if ($vars['view'] == 'archive')
+			{
+				$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+				$vars['month'] = $segments[$count - 1];
+			}
+			else
+			{
+				$vars['id'] = $segments[$count - 1];
+			}
+			return $vars;
+		}
+		
+		//first handle archive view
+		if ($item->query['view'] == 'archive')
+		{
+			$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+			$vars['month'] = $segments[$count - 1];
+			$vars['view'] = 'archive';
 
 			return $vars;
 		}
-
+		
 		/*
 		 * If there is only one segment, then it points to either an article or a category.
 		 * We test it first to see if it is a category.  If the id and alias match a category,
@@ -431,17 +452,7 @@ class ContentRouter extends JComponentRouterBase
 				}
 
 				$vars['id'] = $cid;
-
-				if ($item->query['view'] == 'archive' && $count != 1)
-				{
-					$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
-					$vars['month'] = $segments[$count - 1];
-					$vars['view'] = 'archive';
-				}
-				else
-				{
-					$vars['view'] = 'article';
-				}
+				$vars['view'] = 'article';
 			}
 
 			$found = 0;


### PR DESCRIPTION
Tested with Archive module and standard search.

**With a Menu item** for Archived articles
link: "to-your-joomla/archived-articles/2010/12"

**Without a Menu item** for Archived articles I have 2 cases
1. The active menu item is not a Content menu.
link: "to-your-joomla/component/content/archive/2010/12"
2. The active menu item is a Content menu.
link: "to-your-joomla/component/content/archive/2010/12?Itemid=101
i.e. sometimes the Itemid is added automaticly
