### PR TITLE
PHP Warnings when the requested editor is not available

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -502,7 +502,9 @@ class JEditor extends JObject
 		require_once $path;
 
 		// Get the plugin
-		$plugin = JPluginHelper::getPlugin('editors', $this->_name);
+		// Ensure to deal with a valid object in case of no plugin found
+		$plugin = JPluginHelper::getPlugin('editors', $this->_name)
+			  or $plugin = (object)array('name' => $this->_name, 'params' => '{}', 'type' => 'editors');
 		$params = new Registry;
 		$params->loadString($plugin->params);
 		$params->loadArray($config);

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -504,7 +504,7 @@ class JEditor extends JObject
 		// Get the plugin
 		// Ensure to deal with a valid object in case of no plugin found
 		$plugin = JPluginHelper::getPlugin('editors', $this->_name)
-			  or $plugin = (object)array('name' => $this->_name, 'params' => '{}', 'type' => 'editors');
+			or $plugin = (object) array('name' => $this->_name, 'params' => '{}', 'type' => 'editors');
 		$params = new Registry;
 		$params->loadString($plugin->params);
 		$params->loadArray($config);


### PR DESCRIPTION
## How to reproduce

On the plugin manager, disable the user's default editor plugin and the system's default editor plugin. If unsure, feel free to disable all the editor plugins.
Open Article Manager to edit an article. This involves the editor and raises the warnings.
## Symptoms

Trying to instantiate an editor that is not available, a PHP notice and a PHP warning are generated in the error output:

PHP Notice: Trying to get property of non-object in [...]/libraries/cms/editor/editor.php on line 508
PHP Warning: Attempt to assign property of non-object in [...]/libraries/cms/editor/editor.php on line 510
## Cause

This happens because JEditor::_loadEditor() function calls JPluginHelper::getPlugin() without considering its return type.
JPluginHelper::getPlugin() can return either an object or an array (WTF?), while JEditor::_loadEditor() always suppose (ingenuously) to deal with an object.

When no matching plugin is found, an empty array is returned to $plugin;
`$plugin = JPluginHelper::getPlugin('editors', $this->_name);`

this subsequent code raises the PHP Notice
`$params->loadString($plugin->params);`

this subsequent code raises the PHP Warning
`$plugin->params = $params;`
## Fix

As the subsequent code needs to deal with a valid object, simply ensure to provide a valid object rather than overcomplicate the code adding further if / else / return statements.
