### PR TITLE
Indent category list after collapse

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -172,6 +172,9 @@ textarea {
 	left: auto;
 	right: 13px;
 }
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}
 .clearfix {
 	*zoom: 1;
 }
@@ -7279,6 +7282,9 @@ figcaption {
 	background-image: linear-gradient(to bottom,#08c,#0077b3);
 	background-repeat: repeat-x;
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0076b2', GradientType=0);
+}
+.categories-list .collapse {
+	margin-left: 20px;
 }
 @media (max-width: 480px) {
 	.item-info > span {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -393,6 +393,10 @@ figcaption {
   #gradient > .vertical(@dropdownLinkBackgroundHover, darken(@dropdownLinkBackgroundHover, 5%));
 }
 
+// Category collapse
+.categories-list .collapse {
+	margin: 0 0 0 20px;
+}
 @media (max-width: 480px) {
 	.item-info > span {
 		display:block;

--- a/templates/protostar/less/template_rtl.less
+++ b/templates/protostar/less/template_rtl.less
@@ -13,3 +13,8 @@
 	left: auto;
 	right:13px;
 }
+
+// Category collapse
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}


### PR DESCRIPTION
Currently, category lists do not indent after collapse a sub category.
his PR add some indentation to subcategories:
## Before

![before](https://cloud.githubusercontent.com/assets/2659866/9516537/95af407a-4ca9-11e5-86b7-6829f5a92195.PNG)
## After

![after](https://cloud.githubusercontent.com/assets/2659866/9516551/a8d0f806-4ca9-11e5-8213-1966d9ea0776.PNG)
## How to test

1) Make some categories with subcategories (for example in com_contact)
2) Make a menu item of the type "List all categories"
3) Make sure the layout is correct with indentation
4) Switch to a RTL langauge
5) Make sure the layout is correct with indentation
