### PR TITLE
Check only for unpublished/archived categories when flag is set

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -242,6 +242,12 @@ class JCategories
 		if ($this->_options['published'] == 1)
 		{
 			$query->where('c.published = 1');
+
+			$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
+				'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
+				' AND parent.published != 1 GROUP BY cat.id) ';
+			$query->join('LEFT', $subQuery . 'AS badcats ON badcats.id = c.id')
+				->where('badcats.id is null');
 		}
 
 		$query->order('c.lft');
@@ -253,12 +259,6 @@ class JCategories
 			$query->join('LEFT', '#__categories AS s ON (s.lft <= c.lft AND s.rgt >= c.rgt) OR (s.lft > c.lft AND s.rgt < c.rgt)')
 				->where('s.id=' . (int) $id);
 		}
-
-		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
-			'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-			' AND parent.published != 1 GROUP BY cat.id) ';
-		$query->join('LEFT', $subQuery . 'AS badcats ON badcats.id = c.id')
-			->where('badcats.id is null');
 
 		// Note: i for item
 		if ($this->_options['countItems'] == 1)


### PR DESCRIPTION
A state check when loading the categories should only be done when the publishing flag is set, otherwise it is not possible to get the unpublished or archived categories trough JCategories.
### Testing instructions
1. Open the categories manager for articles in the back end, Content -> Category Manager.
2. Create two categories with status flag set to **Unpublished**.
3. Add the following code to the file administrator/components/com_content/views/articles/view.html.php after the line 33 (`public function display($tpl = null) {`)
   
   ``` php
   $categories = JCategories::getInstance('Content', array(
       'access' => false,
       'published' => false
   ));
   $cats = $categories->get('root')->getChildren();
   echo 'Found '.count($cats).' categories!';die;
   ```
4. On the back end go to Content -> Article Manager.
### Expected result

On the web browser is shown `Found 0 categories!`. After applying the patch, you will see `Found 2 categories!`. This is correct, because we want to fetch all categories, ignoring the categories where we don't have access and which are archived or unpublished.

---

This is a follow up PR of #3870 because I've accidentally deleted the repository of the old PR. Apology for that :see_no_evil: .
