### PR TITLE
SQL errors when installing extensions on MS SQL Server

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1133,12 +1133,12 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		// Update all menu items which contain 'index.php?option=com_extension' or 'index.php?option=com_extension&...'
 		// to use the new component id.
 		$query = $db->getQuery(true)
-					->update('#__menu AS m')
-					->set('m.component_id = ' . $db->quote($component_id))
-					->where("m.type = " . $db->quote('component'))
-					->where('m.client_id = 0')
-					->where('m.link LIKE ' . $db->quote('index.php?option=' . $option)
-							. " OR m.link LIKE '" . $db->escape('index.php?option=' . $option . '&') . "%'");
+					->update('#__menu')
+					->set('component_id = ' . $db->quote($component_id))
+					->where("type = " . $db->quote('component'))
+					->where('client_id = 0')
+					->where('link LIKE ' . $db->quote('index.php?option=' . $option)
+							. " OR link LIKE '" . $db->escape('index.php?option=' . $option . '&') . "%'");
 
 		$db->setQuery($query);
 

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -630,6 +630,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$this->extension->access    = 0;
 			$this->extension->client_id = 1;
 			$this->extension->params    = $this->parent->getParams();
+			$this->extension->custom_data = '';
 		}
 
 		$this->extension->manifest_cache = $this->parent->generateManifestCache();
@@ -951,6 +952,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$data['component_id'] = $component_id;
 			$data['img'] = ((string) $menuElement->attributes()->img) ? (string) $menuElement->attributes()->img : 'class:component';
 			$data['home'] = 0;
+			$data['path'] = '';
+			$data['params'] = '';
 		}
 		else
 		{
@@ -967,6 +970,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$data['component_id'] = $component_id;
 			$data['img'] = 'class:component';
 			$data['home'] = 0;
+			$data['path'] = '';
+			$data['params'] = '';
 		}
 
 		// Try to create the menu item in the database

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -259,6 +259,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 			$this->extension->params = '';
 			$this->extension->system_data = '';
 			$this->extension->manifest_cache = $this->parent->generateManifestCache();
+			$this->extension->custom_data = '';
 
 			if (!$this->extension->store())
 			{


### PR DESCRIPTION
# Executive summary

When Joomla is using MS SQL Server database, is not possible to install any extension. A SQL error message is shown or the user is logged out without any message.
As final result the installation is aborted and no extension is added to the site.
# Test instructions

Apply the patch, then try to install any extension (a Joomla installation using MSSQL is required).
No error messages should be presented and you could use the extension without any issue.
# Technical information

The main problem is caused by columns flagged as `NOT NULL`, we have to prime them with empty data.
An error occurred while updating site menu entries, too, due a syntax error in the query
# Backwards compatibility

This PR does not affect backwards compatibility
# Translation impact

This PR does not add, remove or modify any language strings
