### PR TITLE
CLI runner for the CMS

### DIFF
--- a/administrator/components/com_finder/commands/index.php
+++ b/administrator/components/com_finder/commands/index.php
@@ -70,6 +70,7 @@ class FinderCommandIndex extends JControllerBase
 		// Fool the system into thinking we are running as JApplicationSite with Smart Search as the active component.
 		$_SERVER['HTTP_HOST'] = 'domain.com';
 		JFactory::$application = JApplicationCms::getInstance('site');
+		defined('JPATH_COMPONENT_ADMINISTRATOR') or define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/com_finder');
 
 		// Purge before indexing if --purge on the command line.
 		if ($this->getInput()->getString('purge', false))

--- a/administrator/components/com_finder/commands/index.php
+++ b/administrator/components/com_finder/commands/index.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_finder
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * A command line cron job to run the Smart Search indexer.
+ *
+ * @since  3.5
+ */
+class FinderCommandIndex extends JControllerBase
+{
+	/**
+	 * Start time for the index process
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	private $time = null;
+
+	/**
+	 * Start time for each batch
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	private $qtime = null;
+
+	/**
+	 * Static filters information.
+	 *
+	 * @var    array
+	 * @since  3.3
+	 */
+	private $filters = array();
+
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5
+	 */
+	public function execute()
+	{
+		// Load Library language
+		$lang = JFactory::getLanguage();
+
+		// Try the finder_cli file in the current language (without allowing the loading of the file in the default language)
+		$lang->load('finder_cli', JPATH_SITE, null, false, false)
+		// Fallback to the finder_cli file in the default language
+		|| $lang->load('finder_cli', JPATH_SITE, null, true);
+
+		// Print a blank line.
+		$this->getApplication()->out(JText::_('FINDER_CLI'));
+		$this->getApplication()->out('============================');
+
+		// Initialize the time value.
+		$this->time = microtime(true);
+
+		// Remove the script time limit.
+		@set_time_limit(0);
+
+		// Fool the system into thinking we are running as JApplicationSite with Smart Search as the active component.
+		$_SERVER['HTTP_HOST'] = 'domain.com';
+		JFactory::$application = JApplicationCms::getInstance('site');
+
+		// Purge before indexing if --purge on the command line.
+		if ($this->getInput()->getString('purge', false))
+		{
+			// Taxonomy ids will change following a purge/index, so save filter information first.
+			$this->getFilters();
+
+			// Purge the index.
+			$this->purge();
+
+			// Run the indexer.
+			$this->index();
+
+			// Restore the filters again.
+			$this->putFilters();
+		}
+		else
+		{
+			// Run the indexer.
+			$this->index();
+		}
+
+		// Total reporting.
+		$this->getApplication()->out(JText::sprintf('FINDER_CLI_PROCESS_COMPLETE', round(microtime(true) - $this->time, 3)), true);
+
+		// Print a blank line at the end.
+		$this->getApplication()->out();
+	}
+
+	/**
+	 * Run the indexer.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private function index()
+	{
+		require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php';
+
+		// Disable caching.
+		$config = JFactory::getConfig();
+		$config->set('caching', 0);
+		$config->set('cache_handler', 'file');
+
+		// Reset the indexer state.
+		FinderIndexer::resetState();
+
+		// Import the finder plugins.
+		JPluginHelper::importPlugin('finder');
+
+		// Starting Indexer.
+		$this->getApplication()->out(JText::_('FINDER_CLI_STARTING_INDEXER'), true);
+
+		// Trigger the onStartIndex event.
+		JEventDispatcher::getInstance()->trigger('onStartIndex');
+
+		// Remove the script time limit.
+		@set_time_limit(0);
+
+		// Get the indexer state.
+		$state = FinderIndexer::getState();
+
+		// Setting up plugins.
+		$this->getApplication()->out(JText::_('FINDER_CLI_SETTING_UP_PLUGINS'), true);
+
+		// Trigger the onBeforeIndex event.
+		JEventDispatcher::getInstance()->trigger('onBeforeIndex');
+
+		// Startup reporting.
+		$this->getApplication()->out(JText::sprintf('FINDER_CLI_SETUP_ITEMS', $state->totalItems, round(microtime(true) - $this->time, 3)), true);
+
+		// Get the number of batches.
+		$t = (int) $state->totalItems;
+		$c = (int) ceil($t / $state->batchSize);
+		$c = $c === 0 ? 1 : $c;
+
+		try
+		{
+			// Process the batches.
+			for ($i = 0; $i < $c; $i++)
+			{
+				// Set the batch start time.
+				$this->qtime = microtime(true);
+
+				// Reset the batch offset.
+				$state->batchOffset = 0;
+
+				// Trigger the onBuildIndex event.
+				JEventDispatcher::getInstance()->trigger('onBuildIndex');
+
+				// Batch reporting.
+				$this->getApplication()->out(JText::sprintf('FINDER_CLI_BATCH_COMPLETE', ($i + 1), round(microtime(true) - $this->qtime, 3)), true);
+			}
+		}
+		catch (Exception $e)
+		{
+			// Display the error
+			$this->getApplication()->out($e->getMessage(), true);
+
+			// Reset the indexer state.
+			FinderIndexer::resetState();
+
+			// Close the app
+			$this->getApplication()->close($e->getCode());
+		}
+
+		// Reset the indexer state.
+		FinderIndexer::resetState();
+	}
+
+	/**
+	 * Purge the index.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private function purge()
+	{
+		$this->getApplication()->out(JText::_('FINDER_CLI_INDEX_PURGE'));
+
+		// Load the model.
+		JModelLegacy::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/models', 'FinderModel');
+		$model = JModelLegacy::getInstance('Index', 'FinderModel');
+
+		// Attempt to purge the index.
+		$return = $model->purge();
+
+		// If unsuccessful then abort.
+		if (!$return)
+		{
+			$message = JText::_('FINDER_CLI_INDEX_PURGE_FAILED', $model->getError());
+			$this->getApplication()->out($message);
+			exit();
+		}
+
+		$this->getApplication()->out(JText::_('FINDER_CLI_INDEX_PURGE_SUCCESS'));
+	}
+
+	/**
+	 * Restore static filters.
+	 *
+	 * Using the saved filter information, update the filter records
+	 * with the new taxonomy ids.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private function putFilters()
+	{
+		$this->getApplication()->out(JText::_('FINDER_CLI_RESTORE_FILTERS'));
+
+		$db = JFactory::getDbo();
+
+		// Use the temporary filter information to update the filter taxonomy ids.
+		foreach ($this->filters as $filter_id => $filter)
+		{
+			$tids = array();
+
+			foreach ($filter as $element)
+			{
+				// Look for the old taxonomy in the new taxonomy table.
+				$query = $db->getQuery(true);
+				$query
+					->select('t.id')
+					->from($db->qn('#__finder_taxonomy') . ' AS t')
+					->leftjoin($db->qn('#__finder_taxonomy') . ' AS p ON p.id = t.parent_id')
+					->where($db->qn('t.title') . ' = ' . $db->q($element['title']))
+					->where($db->qn('p.title') . ' = ' . $db->q($element['parent']));
+				$taxonomy = $db->setQuery($query)->loadResult();
+
+				// If we found it then add it to the list.
+				if ($taxonomy)
+				{
+					$tids[] = $taxonomy;
+				}
+				else
+				{
+					$this->getApplication()->out(JText::sprintf('FINDER_CLI_FILTER_RESTORE_WARNING', $element['parent'], $element['title'], $element['filter']));
+				}
+			}
+
+			// Construct a comma-separated string from the taxonomy ids.
+			$taxonomyIds = empty($tids) ? '' : implode(',', $tids);
+
+			// Update the filter with the new taxonomy ids.
+			$query = $db->getQuery(true)
+				->update($db->qn('#__finder_filters'))
+				->set($db->qn('data') . ' = ' . $db->q($taxonomyIds))
+				->where($db->qn('filter_id') . ' = ' . (int) $filter_id);
+			$db->setQuery($query)->execute();
+		}
+
+		$this->getApplication()->out(JText::sprintf('FINDER_CLI_RESTORE_FILTER_COMPLETED', count($this->filters)));
+	}
+
+	/**
+	 * Save static filters.
+	 *
+	 * Since a purge/index cycle will cause all the taxonomy ids to change,
+	 * the static filters need to be updated with the new taxonomy ids.
+	 * The static filter information is saved prior to the purge/index
+	 * so that it can later be used to update the filters with new ids.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private function getFilters()
+	{
+		$this->getApplication()->out(JText::_('FINDER_CLI_SAVE_FILTERS'));
+
+		// Get the taxonomy ids used by the filters.
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('filter_id, title, data')
+			->from($db->qn('#__finder_filters'));
+		$filters = $db->setQuery($query)->loadObjectList();
+
+		// Get the name of each taxonomy and the name of its parent.
+		foreach ($filters as $filter)
+		{
+			// Skip empty filters.
+			if ($filter->data == '')
+			{
+				continue;
+			}
+
+			// Get taxonomy records.
+			$query = $db->getQuery(true)
+				->select('t.title, p.title AS parent')
+				->from($db->qn('#__finder_taxonomy') . ' AS t')
+				->leftjoin($db->qn('#__finder_taxonomy') . ' AS p ON p.id = t.parent_id')
+				->where($db->qn('t.id') . ' IN (' . $filter->data . ')');
+			$taxonomies = $db->setQuery($query)->loadObjectList();
+
+			// Construct a temporary data structure to hold the filter information.
+			foreach ($taxonomies as $taxonomy)
+			{
+				$this->filters[$filter->filter_id][] = array(
+					'filter'	=> $filter->title,
+					'title'		=> $taxonomy->title,
+					'parent'	=> $taxonomy->parent,
+				);
+			}
+		}
+
+		$this->getApplication()->out(JText::sprintf('FINDER_CLI_SAVE_FILTER_COMPLETED', count($filters)));
+	}
+}

--- a/administrator/components/com_finder/finder.xml
+++ b/administrator/components/com_finder/finder.xml
@@ -45,6 +45,7 @@
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
 			<filename>finder.php</filename>
+			<folder>commands</folder>
 			<folder>controllers</folder>
 			<folder>helpers</folder>
 			<folder>models</folder>

--- a/cli/cms.php
+++ b/cli/cms.php
@@ -104,8 +104,14 @@ class JoomlaCmsCli extends JApplicationCli
 			$class = ucfirst($component) . 'Command';
 			$path  = JPATH_ADMINISTRATOR . '/components/com_' . strtolower($component) . '/commands';
 
-			foreach ($command as $part)
+			foreach ($command as $key => $part)
 			{
+				// Skip the first key
+				if ($key === 0)
+				{
+					continue;
+				}
+
 				$class .= ucfirst(strtolower($part));
 				$path  .= '/' . strtolower($part);
 			}

--- a/cli/cms.php
+++ b/cli/cms.php
@@ -27,6 +27,9 @@ require_once JPATH_LIBRARIES . '/import.legacy.php';
 // Bootstrap the CMS libraries.
 require_once JPATH_LIBRARIES . '/cms.php';
 
+// Make sure the app config is loaded to JFactory
+JFactory::getConfig(JPATH_CONFIGURATION . '/configuration.php');
+
 /**
  * A command line job runner for the Joomla! CMS
  *

--- a/cli/cms.php
+++ b/cli/cms.php
@@ -30,6 +30,10 @@ require_once JPATH_LIBRARIES . '/cms.php';
 // Make sure the app config is loaded to JFactory
 JFactory::getConfig(JPATH_CONFIGURATION . '/configuration.php');
 
+// Import namespaced Framework classes
+use Joomla\Application\Cli\Output\Stdout;
+use Joomla\Application\Cli\Output\Processor\ColorProcessor;
+
 /**
  * A command line job runner for the Joomla! CMS
  *
@@ -47,6 +51,11 @@ class JoomlaCmsCli extends JApplicationCli
 		parent::__construct();
 
 		JFactory::$application = $this;
+
+		// We're going to use a Stdout object for output and inject the ColorProcessor object into it to use colored output
+		$output = new Stdout;
+		$output->setProcessor(new ColorProcessor);
+		$this->setOutput($output);
 	}
 
 	/**

--- a/cli/cms.php
+++ b/cli/cms.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// We are a valid entry point.
+const _JEXEC = 1;
+
+// Load system defines
+if (file_exists(dirname(__DIR__) . '/defines.php'))
+{
+	require_once dirname(__DIR__) . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', dirname(__DIR__));
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+// Get the framework.
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+/**
+ * A command line job runner for the Joomla! CMS
+ *
+ * @since  3.5
+ */
+class JoomlaCmsCli extends JApplicationCli
+{
+	/**
+	 * Constructor
+	 *
+	 * @since   3.5
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+		JFactory::$application = $this;
+	}
+
+	/**
+	 * Method to run the application routines.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 * @throws  RuntimeException
+	 */
+	public function doExecute()
+	{
+		// Make sure there's a command set...
+		if (!isset($this->input->args[0]))
+		{
+			throw new RuntimeException('No command was given to execute.');
+		}
+
+		$command = explode(':', $this->input->args[0]);
+
+		// If the command only has a single part, then it is a core command
+		if (count($command) === 1)
+		{
+			$class = 'CliCommand' . ucfirst($command[0]);
+			$path  = __DIR__ . '/commands/' . strtolower($command[0]) . '.php';
+		}
+		else
+		{
+			/*
+			 * For two parts or greater, the command exists in a component.  Assemble the class name and folder path lookup.
+			 * Command classes are stored in a "commands" folder within the admin component path.
+			 *
+			 * The class should be named in the convention of <component>Command<command_name> where:
+			 *
+			 * - <component> is the component's name (similar to how MVC classes are prefixed)
+			 * - <command_name> is the command's name
+			 *
+			 * The <command_name> is assembled by piecing together all remaining parts after the first part of the command.
+			 * The : separator acts as a directory separator, enabling commands to be grouped into folders.
+			 *
+			 * For example, assuming com_content has the following commands, these would be the resulting class and path names:
+			 *
+			 * content:publish - ContentCommandPublish - JPATH_ADMINISTRATOR . /components/com_content/commands/publish.php
+			 * content:delete:category - ContentCommandDeleteCategory - JPATH_ADMINISTRATOR . /components/com_content/commands/delete/category.php
+			 */
+
+			$component = $command[0];
+
+			// Validate the component exists
+			if (!is_dir(JPATH_ADMINISTRATOR . '/components/com_' . strtolower($component)))
+			{
+				throw new RuntimeException(sprintf('The "%s" component does not exist.', 'com_' . strtolower(($component))));
+			}
+
+			$class = ucfirst($component) . 'Command';
+			$path  = JPATH_ADMINISTRATOR . '/components/com_' . strtolower($component) . '/commands';
+
+			foreach ($command as $part)
+			{
+				$class .= ucfirst(strtolower($part));
+				$path  .= '/' . strtolower($part);
+			}
+
+			$path .= '.php';
+		}
+
+		// Verify the path to the command file exists
+		if (!file_exists($path))
+		{
+			throw new RuntimeException(sprintf('A command class was not found at "%s".', $path));
+		}
+
+		include_once $path;
+
+		// Verify the command's class exists
+		if (!class_exists($class))
+		{
+			throw new RuntimeException(sprintf('The "%1$s" class was not found for the "%2$s" command.', $class, implode(':', $command)));
+		}
+
+		// Execute the command
+		/** @var JController $command */
+		$command = new $class;
+		$command->execute();
+	}
+}
+
+// Execute the application
+try
+{
+	JApplicationCli::getInstance('JoomlaCmsCli')->execute();
+}
+catch (\Exception $e)
+{
+	fwrite(STDOUT, "\nAn error occurred while executing the application: " . get_class($e) . " - {$e->getMessage()}\n");
+	fwrite(STDOUT, "\n" . $e->getTraceAsString() . "\n");
+
+	if ($e->getPrevious())
+	{
+		$prev = $e->getPrevious();
+
+		fwrite(STDOUT, "\nPrevious Exception: " . get_class($prev) . " - {$prev->getMessage()}\n");
+		fwrite(STDOUT, "\n{$prev->getTraceAsString()}\n");
+	}
+
+	exit(1);
+}

--- a/cli/commands/deletefiles.php
+++ b/cli/commands/deletefiles.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * A command line cron job to attempt to remove files that should have been deleted at update.
+ *
+ * @since  3.5
+ */
+class CliCommandDeletefiles extends JControllerBase
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5
+	 */
+	public function execute()
+	{
+		// Import the dependencies
+		jimport('joomla.filesystem.file');
+		jimport('joomla.filesystem.folder');
+
+		// We need the update script
+		JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
+
+		// Instantiate the class
+		$class = new JoomlaInstallerScript;
+
+		// Run the delete method
+		$class->deleteUnexistingFiles();
+
+		return true;
+	}
+}

--- a/cli/commands/garbagecron.php
+++ b/cli/commands/garbagecron.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Cron job to trash expired cache data.
+ *
+ * @since  3.5
+ */
+class CliCommandGarbagecron extends JControllerBase
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5
+	 */
+	public function execute()
+	{
+		JFactory::getCache()->gc();
+
+		return true;
+	}
+}

--- a/cli/commands/updatecheck.php
+++ b/cli/commands/updatecheck.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * This script will fetch the update information for all extensions and store them in the database, speeding up your administrator.
+ *
+ * @since  3.5
+ */
+class CliCommandUpdatecheck extends JControllerBase
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5
+	 */
+	public function execute()
+	{
+		// Get the update cache time
+		$component = JComponentHelper::getComponent('com_installer');
+
+		/** @var \Joomla\Registry\Registry $params */
+		$params = $component->params;
+		$cache_timeout = 3600 * (int) $params->get('cachetimeout', 6);
+
+		// Find all updates
+		$this->getApplication()->out('Fetching updates...');
+		JUpdater::getInstance()->findUpdates(0, $cache_timeout);
+		$this->getApplication()->out('Finished fetching updates');
+
+		return true;
+	}
+}


### PR DESCRIPTION
This PR introduces a new CLI class for the CMS which functions as a CLI command runner.  This deprecates the present methodology of new CLI commands being implemented always as `JApplicationCli` objects.
### Summary

A `JoomlaCmsCli` class is added at `cli/cms.php` and is the command line entry point to the command runner system.  The first argument given to this script represents the CLI command to be executed.

CLI commands are namespaced with a `:` separator with the component's name being required to be the first part of this (for example, `finder:index` triggers a command in `com_finder`).  A command with no separator is assumed to be a "core" command and is processed as such.

Core commands live in the `cli/commands` folder and have a class name prefix of `CliCommand`.  The command name finishes the class name as well as defines the file name.  So the `updatecheck` command uses a class name of `CliCommandUpdatecheck` and the file path is `cli/commands/updatecheck.php`.

Component commands must have at least one `:` separator, however additional separators are supported and processed.  Component commands must live in the component's administrator folder in a `commands` subfolder.  The class name uses the component as the first part (similar to the MVC layer) followed by `Command` and the command name part(s).  The `:` separator acts as a directory separator for the filesystem and each part uses an uppercase character for the first character when the class name is created.  So, the `finder:index` command would use the `FinderCommandIndex` class name and the file path is `administrator/components/com_finder/commands/index.php`.  If a `content:category:delete` command existed, the class name would be `ContentCommandCategoryDelete` and its file path would be `administrator/components/com_content/commands/category/delete.php`.
### Command Requirements

Commands follow the single task methodology already in place by their structure.  The new command classes extend `JControllerBase` from the "new" MVC and are triggered from the CLI runner via the interface's `execute` method.
### Extension Use

Third party extensions may immediately use this feature by adding CLI commands to their admin component folder in a `commands` folder.  The only manifest change necessary is to ensure the folder is installed.  This is different from the existing "practice" of using an install script to place CLI files in the CLI folder.
### Existing CLI scripts

These scripts should be considered deprecated and removed at 4.0.
