### PR TITLE
$model->validate() requires the form parameter.

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -146,7 +146,17 @@ class UsersControllerUser extends UsersController
 
 		// Get the model and validate the data.
 		$model  = $this->getModel('Registration', 'UsersModel');
-		$return = $model->validate($data);
+		
+		$form = $model->getForm();
+		
+		if(!$form)
+		{
+			JError::raiseError(500, $model->getError());
+			
+			return false;
+		}
+		
+		$return = $model->validate($form, $data);
 
 		// Check for errors.
 		if ($return === false)


### PR DESCRIPTION
This is my first pull request so please bear with me. So I've been using this register function, but I noticed in the code that $model->validate() was called with $data as its only parameter, resulting in a fatal error afterwards.
This fixes it and -I think- respects Joomla's coding guidelines.
