### PR TITLE
Accept the source data to be array in fromObject

### DIFF
--- a/libraries/vendor/joomla/utilities/src/ArrayHelper.php
+++ b/libraries/vendor/joomla/utilities/src/ArrayHelper.php
@@ -139,7 +139,7 @@ final class ArrayHelper
 	 */
 	public static function fromObject($p_obj, $recurse = true, $regex = null)
 	{
-		if (is_object($p_obj))
+		if (is_object($p_obj) || is_array($p_obj))
 		{
 			return self::arrayFromObject($p_obj, $recurse, $regex);
 		}


### PR DESCRIPTION
in `fromObject()` we call the private function `arrayFromObject()` which is capable of handling arrays as well. Allowing an `array` as argument to `fromObject()` will not break anything **plus** it will convert any nested `object` type values in it appropriately and give desired result.
