### PR TITLE
Protostar: Correcting classes for alert messages (Solves #7786)

### DIFF
--- a/templates/protostar/html/layouts/joomla/system/message.php
+++ b/templates/protostar/html/layouts/joomla/system/message.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Template.protostar
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$msgList = $displayData['msgList'];
+
+$alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
+?>
+<div id="system-message-container">
+	<?php if (is_array($msgList) && !empty($msgList)) : ?>
+		<div id="system-message">
+			<?php foreach ($msgList as $type => $msgs) : ?>
+				<div class="alert <?php echo $alert[$type]; ?>">
+					<?php // This requires JS so we should add it trough JS. Progressive enhancement and stuff. ?>
+					<a class="close" data-dismiss="alert">×</a>
+
+					<?php if (!empty($msgs)) : ?>
+						<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
+						<div>
+							<?php foreach ($msgs as $msg) : ?>
+								<p class="alert-message"><?php echo $msg; ?></p>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/7786
Edit and save an article in frontend in protostar.
After patch the alert message will now be in green for success.
![screen shot 2015-08-31 at 09 08 13](https://cloud.githubusercontent.com/assets/869724/9573723/eaf523e2-4fbf-11e5-8b75-4548e47b3046.png)
