### PR TITLE
fix for #7797 make sure that all form filed rendered

### DIFF
--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -358,6 +358,7 @@ $prev = $useftp ? 'ftp' : 'database';
 		</div>
 	</div>
 
+	<?php echo $this->form->getInput('db_type'); ?>
 	<input type="hidden" name="task" value="summary" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>


### PR DESCRIPTION
this is fix for #7797 
caused by changes in #7381

The main purpose of #7381 was make sure that the client has sent all fields that in `form.xml`.
The installation use hidden field "db_type" in `summary.xml` form for determine which "sample data" can be installed ... but do not render this field, this is cause "db_type" value reset on the last step.

This pull fix it

**test**
make sure that installation work correct 
