### PR TITLE
Fixes wrong behaviour in filter method of JForm class

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -242,10 +242,6 @@ class JForm
 			{
 				$output->set($key, $this->filterField($field, $input->get($key, (string) $field['default'])));
 			}
-			else
-			{
-				$output->set($key, null);
-			}
 		}
 
 		return $output->toArray();


### PR DESCRIPTION
This PR fixes the problem that was introduced in this PR #7381. The mentioned PR produces a major bug (Installation process is not possible any more / Form submitting can lead to data loss, see https://github.com/joomla/joomla-cms/pull/7799#issuecomment-137218387). Additionally this PR restores the default behaviour that if a default value is set in a multiple checkbox, then it should also be taken into account (see https://github.com/joomla/joomla-cms/pull/7799#issuecomment-137257821).

It will also solve problems with the validation process because we do not set an empty array as default value (Issue #7316).

**How and what to test**

_Installation process of version 3.4.4 RC_
1. Download the full package of the RC version (https://github.com/joomla/joomla-cms/releases/tag/3.4.4-rc)
2. Unzip it locally and do the changes from this PR
3. Start the installation process and verify that it runs properly

_Intro image in frontend editing_
1. Create a new article and assign an intro image
2. Sign in into the frontend and edit the article (e.g. change title)
3. After the save the intro image should still be available
