### PR TITLE
Language: Error when mass changing directory to folder

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_authentication_ldap.ini
+++ b/administrator/language/en-GB/en-GB.plg_authentication_ldap.ini
@@ -24,7 +24,7 @@ PLG_LDAP_FIELD_REFERRALS_DESC="This option sets the value of the LDAP_OPT_REFERR
 PLG_LDAP_FIELD_REFERRALS_LABEL="Follow Referrals"
 PLG_LDAP_FIELD_SEARCHSTRING_DESC="A query string used to search for a given User. The [search] keyword is dynamically replaced by the User-provided login. An example string is: uid=[search]. Several strings can be used separated by semicolons. Only used when searching."
 PLG_LDAP_FIELD_SEARCHSTRING_LABEL="Search String"
-PLG_LDAP_FIELD_UID_DESC="LDAP Attribute which contains the User's Login ID. For Active Folder this is sAMAccountName."
+PLG_LDAP_FIELD_UID_DESC="LDAP Attribute which contains the User's Login ID. For Active Directory this is sAMAccountName."
 PLG_LDAP_FIELD_UID_LABEL="Map: User ID"
 PLG_LDAP_FIELD_USERNAME_DESC="The Connect Username and Connect Password define connection parameters for the DN lookup phase. Two options are available:- Anonymous DN lookup (leave both fields blank); Administrative connection: Connect Username is the username of an administrative account, for example Administrator. Connect password is the actual password of your administrative account."
 PLG_LDAP_FIELD_USERNAME_LABEL="Connect Username"


### PR DESCRIPTION
Thanks Balazs Csontos.

Active Directory (AD) is a directory service in Microsoft systems. 
It should not have been changed to Active Folder.
