### PR TITLE
Update $explodedName with reversed array

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -439,7 +439,7 @@ class JFilterInput
 				if (!empty($options['forbidden_extensions']))
 				{
 					$explodedName = explode('.', $intendedName);
-					array_reverse($explodedName);
+					$explodedName =	array_reverse($explodedName);
 					array_pop($explodedName);
 					array_map('strtolower', $explodedName);
 


### PR DESCRIPTION
With reference to issue https://github.com/joomla/joomla-cms/issues/7813

array_reverse returns the reversed array, it does not change the original array.

---

Line 441 to 444 of libraries/joomla/filter/JInputFilter.php extracts possible extensions in the file name to check against a list of invalid extensions.

https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/filter/input.php

On line 442, array_reverse is used to re-arrange the array created so as to move the file name to the end, removing it with array_pop on line 443, but array_reverse returns the re-ordered array, it does not change the original array - http://php.net/manual/en/function.array-reverse.php

Therefore line 442 should be:

$explodedName = array_reverse($explodedName);
