### PR TITLE
Update Symbol in Admin #7815

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -40,7 +40,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$this->assign('methodSelect', JoomlaupdateHelperSelect::getMethods($ftp['enabled']));
 
 		// Set the toolbar information.
-		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'arrow-up-2 install');
+		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'loop install');
 		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'JTOOLBAR_PURGE_CACHE', false);
 
 		// Add toolbar buttons.

--- a/administrator/components/com_joomlaupdate/views/update/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/update/view.html.php
@@ -31,7 +31,7 @@ class JoomlaupdateViewUpdate extends JViewLegacy
 		$returnUrl = 'index.php?option=com_joomlaupdate&task=update.finalise';
 
 		// Set the toolbar information.
-		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'arrow-up-2 install');
+		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'loop install');
 		JToolBarHelper::divider();
 		JToolBarHelper::help('JHELP_COMPONENTS_JOOMLA_UPDATE');
 


### PR DESCRIPTION
After updating Joomla CMS you will see icomoon arrow-up-2 symbol to the left of Joomla! Update heading. This PR changes that symbol to 'loop' which is more appropriate.

![update-symbol](https://cloud.githubusercontent.com/assets/736887/9685221/c78096a0-5314-11e5-81d4-f387d26a6010.PNG)

https://docs.joomla.org/J3.x:Joomla_Standard_Icomoon_Fonts
