### PR TITLE
Fix PHPDoc for JHtmlJGrid::state

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -96,7 +96,7 @@ abstract class JHtmlJGrid
 	 * Returns a state on a grid
 	 *
 	 * @param   array         $states     array of value/state. Each state is an array of the form
-	 *                                    (task, text, title,html active class, HTML inactive class)
+	 *                                    (task, text, active title, inactive title, tip (boolean), HTML active class, HTML inactive class)
 	 *                                    or ('task'=>task, 'text'=>text, 'active_title'=>active title,
 	 *                                    'inactive_title'=>inactive title, 'tip'=>boolean, 'active_class'=>html active class,
 	 *                                    'inactive_class'=>html inactive class)


### PR DESCRIPTION
This PR fixes the documentation of JHtmlJGrid::state to show the correct order of the $states array.
### Testing instructions

Simply compare the structure of the array described in the comment with the following lines (126-132).
