### PR TITLE
Frontend: Changing JError to enqueueMessage when access is not permitted (Solves partly https://github.com/joomla/joomla-cms/issues/7812

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -99,7 +99,7 @@ class ContactViewContact extends JViewLegacy
 
 		if ((!in_array($item->access, $groups)) || (!in_array($item->category_access, $groups)))
 		{
-			JError::raiseWarning(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 			return;
 		}
 

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -100,6 +100,8 @@ class ContactViewContact extends JViewLegacy
 		if ((!in_array($item->access, $groups)) || (!in_array($item->category_access, $groups)))
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
+
 			return;
 		}
 

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -133,7 +133,7 @@ class ContentViewArticle extends JViewLegacy
 		// Check the view access to the article (the model has already computed the values).
 		if ($item->params->get('access-view') == false && ($item->params->get('show_noauth', '0') == '0'))
 		{
-			JError::raiseWarning(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 
 			return;
 		}

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -134,6 +134,7 @@ class ContentViewArticle extends JViewLegacy
 		if ($item->params->get('access-view') == false && ($item->params->get('show_noauth', '0') == '0'))
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
 
 			return;
 		}

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -34,6 +34,7 @@ class ContentViewForm extends JViewLegacy
 	public function display($tpl = null)
 	{
 		$user = JFactory::getUser();
+		$app  = JFactory::getApplication();
 
 		// Get model data.
 		$this->state       = $this->get('State');
@@ -52,7 +53,7 @@ class ContentViewForm extends JViewLegacy
 
 		if ($authorised !== true)
 		{
-			JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 
 			return false;
 		}

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -54,6 +54,7 @@ class ContentViewForm extends JViewLegacy
 		if ($authorised !== true)
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
 
 			return false;
 		}

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -152,6 +152,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		if (!in_array($item->access, $levels) or ((in_array($item->access, $levels) and (!in_array($item->category_access, $levels)))))
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
 
 			return;
 		}

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -151,7 +151,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 
 		if (!in_array($item->access, $levels) or ((in_array($item->access, $levels) and (!in_array($item->category_access, $levels)))))
 		{
-			JError::raiseWarning(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 
 			return;
 		}

--- a/components/com_users/controllers/profile.php
+++ b/components/com_users/controllers/profile.php
@@ -38,7 +38,7 @@ class UsersControllerProfile extends UsersController
 		// Check if the user is trying to edit another users profile.
 		if ($userId != $loginUserId)
 		{
-			JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 
 			return false;
 		}

--- a/components/com_users/controllers/profile.php
+++ b/components/com_users/controllers/profile.php
@@ -39,6 +39,7 @@ class UsersControllerProfile extends UsersController
 		if ($userId != $loginUserId)
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
 
 			return false;
 		}


### PR DESCRIPTION
See test instructions in https://github.com/joomla/joomla-cms/issues/7812

When access is not permitted, in the cases taken care off in this PR, we will get an Error message instead of loading the error.php page.
