### PR TITLE
Fix black areas in JPGs when resize with JImage

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -733,10 +733,9 @@ class JImage
 
 			$handle = imagecreatetruecolor($width, $height);
 
-			// Make image transparent, otherwise cavas outside initial image would default to black
 			if (!$this->isTransparent())
 			{
-				$transparency = imagecolorAllocateAlpha($this->handle, 0, 0, 0, 127);
+				$transparency = imagecolorAllocateAlpha($this->handle, 255, 255, 255, 127);
 				imagecolorTransparent($this->handle, $transparency);
 			}
 		}


### PR DESCRIPTION
If you for example create thumbnails from a JPG and use the method `SCALE_FIT` the "new" areas will be black.

After this fix, they will be white.

Test: take an image (JPG) with a 1:2 ratio (e.g. 200x400px) and the following code:

```
$jimage = new JImage($path_to_file);
$jimage->createThumbs(array(200 . 'x' . 200, JImage::SCALE_FIT);
```

Before patch => the area around the images are black
After patch => the area around the images are white
