### PR TITLE
Remove readonly on input element, increase size

### DIFF
--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -293,7 +293,7 @@ class JFormFieldMedia extends JFormField
 		$attr .= ' title="' . htmlspecialchars('<span id="TipImgpath"></span>', ENT_COMPAT, 'UTF-8') . '"';
 
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="input-small ' . $this->class . '"' : ' class="input-small"';
+		$attr .= !empty($this->class) ? ' class="input-small ' . $this->class . '"' : ' class="input-large"';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 
 		// Initialize JavaScript field attributes.
@@ -380,7 +380,7 @@ class JFormFieldMedia extends JFormField
 		}
 
 		$html[] = '	<input type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly"' . $attr . ' />';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $attr . ' />';
 
 		if ($this->value && file_exists(JPATH_ROOT . '/' . $this->value))
 		{

--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -293,7 +293,7 @@ class JFormFieldMedia extends JFormField
 		$attr .= ' title="' . htmlspecialchars('<span id="TipImgpath"></span>', ENT_COMPAT, 'UTF-8') . '"';
 
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="input-small ' . $this->class . '"' : ' class="input-large"';
+		$attr .= !empty($this->class) ? ' class="input-large ' . $this->class . '"' : ' class="input-large"';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 
 		// Initialize JavaScript field attributes.


### PR DESCRIPTION
This change increases the size of the input element by changing the input-small class to input-large, and removes the readonly="readonly" attribute on the input element.

This allows the user to enter in a value into the field, or select a value using the modal as before.
## Testing:

After applying the changes, create or edit an article using the Article Manager, then click on the Images and Links tab. The Intro Image and Full Text Image fields should be larger and a value can be typed/pasted into the field.
