### PR TITLE
Breadcrumbs - fixing invisible menu heading

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -55,7 +55,7 @@ JHtml::_('bootstrap.tooltip');
 					</a>
 				<?php else : ?>
 					<span itemprop="name">
-						<?php $item->name; ?>
+						<?php echo $item->name; ?>
 					</span>
 				<?php endif; ?>
 


### PR DESCRIPTION
In the breadcrumb module a menu item is not shown when it lacks a link (like a menu heading)
Fixes issue #7838 in the issue tracker
