### PR TITLE
Prevent captcha field from setup in Joomla Admin

### DIFF
--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -84,9 +84,10 @@ class JFormFieldCaptcha extends JFormField
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		$result = parent::setup($element, $value, $group);
-		
-		if (JFactory::getApplication()->isAdmin()) {
-			return $result;	
+
+		if (JFactory::getApplication()->isAdmin())
+		{
+			return $result;
 		}
 
 		$plugin = $this->element['plugin'] ?

--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -84,6 +84,10 @@ class JFormFieldCaptcha extends JFormField
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		$result = parent::setup($element, $value, $group);
+		
+		if (JFactory::getApplication()->isAdmin()) {
+			return $result;	
+		}
 
 		$plugin = $this->element['plugin'] ?
 			(string) $this->element['plugin'] :


### PR DESCRIPTION
It is possible, under certain circumstances (for example when JForm::getFieldset is called), for JFormFieldCaptcha to be initiated in the Joomla Administration. This causes a fatal error as  JFactory::getApplication()->getParams() (called on line 94), is not available in JApplicationAdministrator.

Line 88-89 added in this PR ends the setup process in this case.

I don't know of a use case for captcha in the Joomla Admin, but if there is one, then 

JFactory::getApplication()->getParams()->get('captcha', JFactory::getConfig()->get('captcha'));

needs to be altered accordingly.
### Testing

This is difficult to test as the error occurs in few circumstances, but was noticed in JCalPro following a recent JCE update which included a system plugin that uses JForm::getFieldset to get a list of all JFormField elements loaded. When editing a JCalPro Event, the form can include a captcha field in the front-end. When editing the Event in JCalPro in the Joomla Admin, the captcha field is not used, but  JForm::getFieldset will still initiate it, resulting in the error described above.

A test could be created using the Joomla Article Manager by adding the following field to /administrator/components/com_content/models/forms/article.xml:

``` xml
<fieldset
            name="captcha"
            label="Test Captcha"
        >
            <field
                name="captcha"
                type="captcha"
                label="Test Captcha"
                description="Test Captcha"
                validate="captcha"
            />
        </fieldset>
```

Then creating or editing an article with the latest version of JCE installed.
