### PR TITLE
allow to add fields to article's main tab through a fieldset.

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -17,7 +17,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
 $this->configFieldsets  = array('editorConfig');
-$this->hiddenFieldsets  = array('basic-limited');
+$this->hiddenFieldsets  = array('basic-limited', 'extra-content');
 $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
@@ -85,6 +85,10 @@ JFactory::getDocument()->addScriptDeclaration('
 			<div class="span9">
 				<fieldset class="adminform">
 					<?php echo $this->form->getInput('articletext'); ?>
+					<?php
+						$extra = $this->form->renderFieldset('extra-content');
+						if ($extra) echo '<div class="extraFieldset">' . $extra . '</div>';
+					?>
 				</fieldset>
 			</div>
 			<div class="span3">


### PR DESCRIPTION
We often opt to add multiple blocks of text in articles through a plugin when developing custom websites (altering the forms based on the article's chosen layout).

Sometimes adding them in their own tab is not the preferable option - sometimes the UX is better when the content is right on the main content tab.

In such cases, we use the 'extra-content' fieldset and this modification adds to the UI in the backend.
