### PR TITLE
Custom ACL fine-tuning through plugins

### DIFF
--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -339,6 +339,9 @@ class ModulesModelModules extends JModelList
 		{
 			$query->where('a.language = ' . $db->quote($language));
 		}
+		
+		$dispatcher = JDispatcher::getInstance();
+		$dispatcher->trigger('onComModulesGetListQuery', array( &$query));
 
 		return $query;
 	}

--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -99,6 +99,9 @@ class ModulesModelSelect extends JModelList
 		// Add the list ordering clause.
 		$query->order($db->escape($this->getState('list.ordering', 'a.ordering')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
+		$dispatcher = JDispatcher::getInstance();
+		$dispatcher->trigger('onComModulesSelectGetListQuery', array( &$query));
+
 		return $query;
 	}
 

--- a/administrator/components/com_modules/views/module/view.html.php
+++ b/administrator/components/com_modules/views/module/view.html.php
@@ -36,6 +36,9 @@ class ModulesViewModule extends JViewLegacy
 		$this->state = $this->get('State');
 		$this->canDo = JHelperContent::getActions('com_modules', 'module', $this->item->id);
 
+		$dispatcher = JDispatcher::getInstance();
+		$dispatcher->trigger('onComModulesView', array( $this, $this->item));
+		
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -146,6 +146,12 @@ class JAdminCssMenu extends JObject
 	 */
 	public function renderLevel($depth)
 	{
+		$dispatcher = JDispatcher::getInstance();
+		// If a plugin returns 404, prevent rendering the menu item		
+		$res = $dispatcher->trigger('onModMenuRender', array($this->_current));
+		if (in_array(404, $res))
+			return;
+
 		// Build the CSS class suffix
 		$class = '';
 


### PR DESCRIPTION
This is a series of dispatches we've been using since Joomla 2.5.

Essentially, we try to provide Web site managers with the best streamlined UX possible, which means removing any features from the backend that is not used to manage the Web site's content.

This series of dispatchers allows our plugin to hide certain components and modules from the backend using our own logic, going beyond what the standard Joomla ACL allows to do.

For example: allowing only certain types of modules to be created, preventing the modification of certain modules, hiding parts from the UI that is out of reach of the ACL (ex: blocking user notes and user mail)
