### PR TITLE
Make sure $value parameter passed to JHtml::calendar method is valid

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -487,7 +487,7 @@ abstract class JHtml
 								{
 									$md5 = dirname($path) . '/MD5SUM';
 									$includes[] = JUri::root(true) . "/media/system/$folder/$file" .
-										(file_exists($md5) ? ('?' . file_get_contents($md5)) : '');
+											(file_exists($md5) ? ('?' . file_get_contents($md5)) : '');
 
 									break;
 								}
@@ -996,7 +996,7 @@ abstract class JHtml
 			$document = JFactory::getDocument();
 			$document
 				->addScriptDeclaration(
-					'jQuery(document).ready(function($) {Calendar.setup({
+				'jQuery(document).ready(function($) {Calendar.setup({
 			// Id of the input field
 			inputField: "' . $id . '",
 			// Format of the input field
@@ -1008,7 +1008,7 @@ abstract class JHtml
 			singleClick: true,
 			firstDay: ' . JFactory::getLanguage()->getFirstDay() . '
 			});});'
-				);
+			);
 			$done[] = $id;
 		}
 
@@ -1017,10 +1017,10 @@ abstract class JHtml
 		$div_class = (!$readonly && !$disabled) ? ' class="input-append"' : '';
 
 		return '<div' . $div_class . '>'
-		. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
-		. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
-		. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
-		. '</div>';
+				. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
+				. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
+				. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
+			. '</div>';
 	}
 
 	/**

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -487,7 +487,7 @@ abstract class JHtml
 								{
 									$md5 = dirname($path) . '/MD5SUM';
 									$includes[] = JUri::root(true) . "/media/system/$folder/$file" .
-											(file_exists($md5) ? ('?' . file_get_contents($md5)) : '');
+										(file_exists($md5) ? ('?' . file_get_contents($md5)) : '');
 
 									break;
 								}
@@ -975,7 +975,7 @@ abstract class JHtml
 		static::_('bootstrap.tooltip');
 
 		// Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
-		if ($value && $value != JFactory::getDbo()->getNullDate())
+		if ($value && $value != JFactory::getDbo()->getNullDate() && strtotime($value) !== false)
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
@@ -996,7 +996,7 @@ abstract class JHtml
 			$document = JFactory::getDocument();
 			$document
 				->addScriptDeclaration(
-				'jQuery(document).ready(function($) {Calendar.setup({
+					'jQuery(document).ready(function($) {Calendar.setup({
 			// Id of the input field
 			inputField: "' . $id . '",
 			// Format of the input field
@@ -1008,7 +1008,7 @@ abstract class JHtml
 			singleClick: true,
 			firstDay: ' . JFactory::getLanguage()->getFirstDay() . '
 			});});'
-			);
+				);
 			$done[] = $id;
 		}
 
@@ -1017,10 +1017,10 @@ abstract class JHtml
 		$div_class = (!$readonly && !$disabled) ? ' class="input-append"' : '';
 
 		return '<div' . $div_class . '>'
-				. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
-				. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
-				. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
-			. '</div>';
+		. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
+		. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
+		. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
+		. '</div>';
 	}
 
 	/**


### PR DESCRIPTION
This PR fixed the issue https://github.com/joomla/joomla-cms/issues/7846. It just add a check to make sure the value passed to JHtml::calendar method is valid. 

In case the value is invalid, instead of throwing exception at the moment, it will reset the value to be empty and prevent the error above from happening.
# Testing instructions

JHml::calendar is used in many places in Joomla core. To test this, you can try to edit an article, look at Publishing tab, make sure the calendar inputs such as Start Publishing, Created Date... stil display the correct value.
