### PR TITLE
PDO driver fail on host:port configuration

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -77,6 +77,13 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
 		$options['driverOptions'] = (isset($options['driverOptions'])) ? $options['driverOptions'] : array();
 
+		$hostParts = explode(':', $options['host']);
+		if (!empty($hostParts[1]))
+		{
+			$options['host'] = $hostParts[0];
+			$options['port'] = $hostParts[1];
+		}
+
 		// Finalize initialisation
 		parent::__construct($options);
 	}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -78,6 +78,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		$options['driverOptions'] = (isset($options['driverOptions'])) ? $options['driverOptions'] : array();
 
 		$hostParts = explode(':', $options['host']);
+
 		if (!empty($hostParts[1]))
 		{
 			$options['host'] = $hostParts[0];


### PR DESCRIPTION
Database Host with Port definition like `localhost:3306` is incorrect for PDO driver.
PDO expect Port as separated options.

**test**
set database driver to  MySql (PDO)
add Port to your database host, eg `localhost:3306` (3306 is default MySql port)

**expected**
all works fine

**actual**
you got error `Error displaying the error page: Application Instantiation Error: Could not connect to PDO: SQLSTATE[HY000] [2005] Unknown MySQL server host 'localhost:3306' (2)`
