### PR TITLE
Fix issues with color picker simplecolors.js

### DIFF
--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -223,7 +223,7 @@ class JFormFieldColor extends JFormField
 			$split = $split ? $split : 3;
 
 			$html = array();
-			$html[] = '<select name="' . $this->name . '" id="' . $this->id . '"' . $disabled . $required
+			$html[] = '<select data-chosen="true" name="' . $this->name . '" id="' . $this->id . '"' . $disabled . $required
 				. $class . $position . $onchange . $autofocus . ' style="visibility:hidden;width:22px;height:1px">';
 
 			foreach ($colors as $i => $c)


### PR DESCRIPTION
Since 3.2.3, bug due to chosen.js change with display of a wrong dropdown list, next to the color box picker.

![joomla_color_simple_fix](https://cloud.githubusercontent.com/assets/2385058/9789169/a922395c-57ce-11e5-871e-c7d337044222.jpg)

<h4>Test instructions:</h4>


Add this field to the settings part of an xml file of one extension (eg. template). Then go to that extension settings in the admin and test the rendering of the input.

```
<field name="color_test" type="color" label="Simple: Custom Color List" default="transparent" control="simple" colors="transparent,#FFFFFF,#000000,#FF0000,#00FF00,#0000FF,#00FFFF,#FF00FF,#FFFF00" />
```
