### PR TITLE
Use of variables outside scope in JModelLegacy::loadHistory

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -484,37 +484,37 @@ abstract class JModelLegacy extends JObject
 	 */
 	public function loadHistory($version_id, JTable &$table)
 	{
-		// Only attempt to check the row in if it exists.
-		if ($version_id)
+		// Only attempt to check the row in if it exists, otherwise do an early exit.
+		if (!$version_id)
 		{
-			$user = JFactory::getUser();
+			return false;
+		}
 
-			// Get an instance of the row to checkout.
-			$historyTable = JTable::getInstance('Contenthistory');
+		// Get an instance of the row to checkout.
+		$historyTable = JTable::getInstance('Contenthistory');
 
-			if (!$historyTable->load($version_id))
+		if (!$historyTable->load($version_id))
+		{
+			$this->setError($historyTable->getError());
+
+			return false;
+		}
+
+		$rowArray = JArrayHelper::fromObject(json_decode($historyTable->version_data));
+		$typeId   = JTable::getInstance('Contenttype')->getTypeId($this->typeAlias);
+
+		if ($historyTable->ucm_type_id != $typeId)
+		{
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_HISTORY_ID_MISMATCH'));
+
+			$key = $table->getKeyName();
+
+			if (isset($rowArray[$key]))
 			{
-				$this->setError($historyTable->getError());
-
-				return false;
+				$table->checkIn($rowArray[$key]);
 			}
 
-			$rowArray = JArrayHelper::fromObject(json_decode($historyTable->version_data));
-
-			$typeId = JTable::getInstance('Contenttype')->getTypeId($this->typeAlias);
-
-			if ($historyTable->ucm_type_id != $typeId)
-			{
-				$this->setError(JText::_('JLIB_APPLICATION_ERROR_HISTORY_ID_MISMATCH'));
-				$key = $table->getKeyName();
-
-				if (isset($rowArray[$key]))
-				{
-					$table->checkIn($rowArray[$key]);
-				}
-
-				return false;
-			}
+			return false;
 		}
 
 		$this->setState('save_date', $historyTable->save_date);


### PR DESCRIPTION
Removed unused variable `$user`.
Variables `$historyTable` and `$rowArray` were used outside the `IF` body where they weren't defined.

To test this call the `JModelLegacy::loadHistory` with `$version_id = 0` with and without this fix.
