### PR TITLE
restricted Contact page displays error stack instead of 404 or 403 error page (Fix #7053)

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,7 +327,7 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'),404);
+					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
 				}
 			}
 			catch (Exception $e)

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -329,12 +329,13 @@ class ContactModelContact extends JModelForm
 				{
 					$access = $this->getState('filter.access');
 
-					if ($access) {
+					if ($access)
+					{
 						throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
 					}
 					else
 					{
-						throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'),403);
+						throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 					}
 				}
 			}

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -6,14 +6,9 @@
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
-
 defined('_JEXEC') or die;
-
 use Joomla\Registry\Registry;
-
 /**
- * Single item model for a contact
- *
  * @package     Joomla.Site
  * @subpackage  com_contact
  * @since       1.5
@@ -26,21 +21,18 @@ class ContactModelContact extends JModelForm
 	 * @since   1.6
 	 */
 	protected $view_item = 'contact';
-
 	/**
 	 * A loaded item
 	 *
 	 * @since   1.6
 	 */
 	protected $_item = null;
-
 	/**
 	 * Model context string.
 	 *
 	 * @var		string
 	 */
 	protected $_context = 'com_contact.contact';
-
 	/**
 	 * Method to auto-populate the model state.
 	 *
@@ -53,24 +45,19 @@ class ContactModelContact extends JModelForm
 	protected function populateState()
 	{
 		$app = JFactory::getApplication('site');
-
 		// Load state from the request.
 		$pk = $app->input->getInt('id');
 		$this->setState('contact.id', $pk);
-
 		// Load the parameters.
 		$params = $app->getParams();
 		$this->setState('params', $params);
-
 		$user = JFactory::getUser();
-
 		if ((!$user->authorise('core.edit.state', 'com_contact')) &&  (!$user->authorise('core.edit', 'com_contact')))
 		{
 			$this->setState('filter.published', 1);
 			$this->setState('filter.archived', 2);
 		}
 	}
-
 	/**
 	 * Method to get the contact form.
 	 * The base form is loaded from XML and then an event is fired
@@ -86,25 +73,20 @@ class ContactModelContact extends JModelForm
 	{
 		// Get the form.
 		$form = $this->loadForm('com_contact.contact', 'contact', array('control' => 'jform', 'load_data' => true));
-
 		if (empty($form))
 		{
 			return false;
 		}
-
 		$id = $this->getState('contact.id');
 		$params = $this->getState('params');
 		$contact = $this->_item[$id];
 		$params->merge($contact->params);
-
 		if (!$params->get('show_email_copy', 0))
 		{
 			$form->removeField('contact_email_copy');
 		}
-
 		return $form;
 	}
-
 	/**
 	 * Method to get the data that should be injected in the form.
 	 *
@@ -115,12 +97,9 @@ class ContactModelContact extends JModelForm
 	protected function loadFormData()
 	{
 		$data = (array) JFactory::getApplication()->getUserState('com_contact.contact.data', array());
-
 		$this->preprocessData('com_contact.contact', $data);
-
 		return $data;
 	}
-
 	/**
 	 * Gets a contact
 	 *
@@ -133,19 +112,16 @@ class ContactModelContact extends JModelForm
 	public function &getItem($pk = null)
 	{
 		$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
-
 		if ($this->_item === null)
 		{
 			$this->_item = array();
 		}
-
 		if (!isset($this->_item[$pk]))
 		{
 			try
 			{
 				$db = $this->getDbo();
 				$query = $db->getQuery(true);
-
 				// Changes for sqlsrv
 				$case_when = ' CASE WHEN ';
 				$case_when .= $query->charLength('a.alias', '!=', '0');
@@ -154,7 +130,6 @@ class ContactModelContact extends JModelForm
 				$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 				$case_when .= ' ELSE ';
 				$case_when .= $a_id . ' END as slug';
-
 				$case_when1 = ' CASE WHEN ';
 				$case_when1 .= $query->charLength('c.alias', '!=', '0');
 				$case_when1 .= ' THEN ';
@@ -162,24 +137,18 @@ class ContactModelContact extends JModelForm
 				$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
 				$case_when1 .= ' ELSE ';
 				$case_when1 .= $c_id . ' END as catslug';
-
 				$query->select($this->getState('item.select', 'a.*') . ',' . $case_when . ',' . $case_when1)
 					->from('#__contact_details AS a')
-
-				// Join on category table.
+					// Join on category table.
 					->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
 					->join('LEFT', '#__categories AS c on c.id = a.catid')
-
-				// Join over the categories to get parent category titles
+					// Join over the categories to get parent category titles
 					->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias')
 					->join('LEFT', '#__categories as parent ON parent.id = c.parent_id')
-
 					->where('a.id = ' . (int) $pk);
-
 				// Filter by start and end dates.
 				$nullDate = $db->quote($db->getNullDate());
 				$nowDate = $db->quote(JFactory::getDate()->toSql());
-
 				// Filter by published state.
 				$published = $this->getState('filter.published');
 				$archived = $this->getState('filter.archived');
@@ -189,38 +158,30 @@ class ContactModelContact extends JModelForm
 						->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 						->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 				}
-
 				$db->setQuery($query);
 				$data = $db->loadObject();
-
 				if (empty($data))
 				{
 					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
-
 				// Check for published state if filter set.
 				if (((is_numeric($published)) || (is_numeric($archived))) && (($data->published != $published) && ($data->published != $archived)))
 				{
 					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
-
 				// Convert parameter fields to objects.
 				$registry = new Registry;
 				$registry->loadString($data->params);
 				$data->params = clone $this->getState('params');
 				$data->params->merge($registry);
-
 				$registry = new Registry;
 				$registry->loadString($data->metadata);
 				$data->metadata = $registry;
-
 				$data->tags = new JHelperTags;
 				$data->tags->getItemTags('com_contact.contact', $data->id);
-
 				// Compute access permissions.
 				if ($access = $this->getState('filter.access'))
 				{
-
 					// If the access filter has been set, we already know this user can view.
 					$data->params->set('access-view', true);
 				}
@@ -229,7 +190,6 @@ class ContactModelContact extends JModelForm
 					// If no access filter is set, the layout takes some responsibility for display of limited information.
 					$user = JFactory::getUser();
 					$groups = $user->getAuthorisedViewLevels();
-
 					if ($data->catid == 0 || $data->category_access === null)
 					{
 						$data->params->set('access-view', in_array($data->access, $groups));
@@ -239,7 +199,6 @@ class ContactModelContact extends JModelForm
 						$data->params->set('access-view', in_array($data->access, $groups) && in_array($data->category_access, $groups));
 					}
 				}
-
 				$this->_item[$pk] = $data;
 			}
 			catch (Exception $e)
@@ -248,19 +207,16 @@ class ContactModelContact extends JModelForm
 				$this->_item[$pk] = false;
 			}
 		}
-
 		if ($this->_item[$pk])
 		{
-			if ($extendedData = $this->getContactQuery($pk))
+			if ($extendedData = $this->getContactExtendedData($this->_item[$pk]))
 			{
 				$this->_item[$pk]->articles = $extendedData->articles;
 				$this->_item[$pk]->profile = $extendedData->profile;
 			}
 		}
-
 		return $this->_item[$pk];
 	}
-
 	/**
 	 * Gets the query to load a contact item
 	 *
@@ -273,34 +229,29 @@ class ContactModelContact extends JModelForm
 	protected function getContactQuery($pk = null)
 	{
 		// @todo Cache on the fingerprint of the arguments
-		$db       = $this->getDbo();
+		$db		= $this->getDbo();
 		$nullDate = $db->quote($db->getNullDate());
-		$nowDate  = $db->quote(JFactory::getDate()->toSql());
-		$user     = JFactory::getUser();
-		$pk       = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
-		$query    = $db->getQuery(true);
-
+		$nowDate = $db->quote(JFactory::getDate()->toSql());
+		$user	= JFactory::getUser();
+		$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
+		$query	= $db->getQuery(true);
 		if ($pk)
 		{
 			// Sqlsrv changes
-			$case_when  = ' CASE WHEN ';
+			$case_when = ' CASE WHEN ';
 			$case_when .= $query->charLength('a.alias', '!=', '0');
 			$case_when .= ' THEN ';
-
-			$a_id       = $query->castAsChar('a.id');
+			$a_id = $query->castAsChar('a.id');
 			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 			$case_when .= ' ELSE ';
 			$case_when .= $a_id . ' END as slug';
-
-			$case_when1  = ' CASE WHEN ';
+			$case_when1 = ' CASE WHEN ';
 			$case_when1 .= $query->charLength('cc.alias', '!=', '0');
 			$case_when1 .= ' THEN ';
-
-			$c_id        = $query->castAsChar('cc.id');
+			$c_id = $query->castAsChar('cc.id');
 			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
 			$case_when1 .= ' ELSE ';
 			$case_when1 .= $c_id . ' END as catslug';
-
 			$query->select(
 				'a.*, cc.access as category_access, cc.title as category_name, '
 				. $case_when . ',' . $case_when1
@@ -308,62 +259,42 @@ class ContactModelContact extends JModelForm
 				->from('#__contact_details AS a')
 				->join('INNER', '#__categories AS cc on cc.id = a.catid')
 				->where('a.id = ' . (int) $pk);
-
 			$published = $this->getState('filter.published');
-
 			if (is_numeric($published))
 			{
 				$query->where('a.published IN (1,2)')
 					->where('cc.published IN (1,2)');
 			}
-
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ')');
-
 			try
 			{
 				$db->setQuery($query);
 				$result = $db->loadObject();
-
 				if (empty($result))
 				{
-					$access = $this->getState('filter.access');
-
-					if ($access)
-					{
-						throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
-					}
-					else
-					{
-						throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'), 403);
-					}
+					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
 				}
 			}
 			catch (Exception $e)
 			{
-				$this->setError($e->getMessage());
-
+				$this->setError($e);
 				return false;
 			}
-
 			if ($result)
 			{
-
 				$contactParams = new Registry;
 				$contactParams->loadString($result->params);
-
 				// If we are showing a contact list, then the contact parameters take priority
 				// So merge the contact parameters with the merged parameters
 				if ($this->getState('params')->get('show_contact_list'))
 				{
 					$this->getState('params')->merge($contactParams);
 				}
-
 				// Get the com_content articles by the linked user
 				if ((int) $result->user_id && $this->getState('params')->get('show_articles'))
 				{
-
-					$query = $db->getQuery(true)
+					$query	= $db->getQuery(true)
 						->select('a.id')
 						->select('a.title')
 						->select('a.state')
@@ -371,7 +302,6 @@ class ContactModelContact extends JModelForm
 						->select('a.catid')
 						->select('a.created')
 						->select('a.language');
-
 					// SQL Server changes
 					$case_when = ' CASE WHEN ';
 					$case_when .= $query->charLength('a.alias', '!=', '0');
@@ -393,7 +323,6 @@ class ContactModelContact extends JModelForm
 						->where('a.created_by = ' . (int) $result->user_id)
 						->where('a.access IN (' . $groups . ')')
 						->order('a.state DESC, a.created DESC');
-
 					// Filter per language if plugin published
 					if (JLanguageMultilang::isEnabled())
 					{
@@ -402,29 +331,24 @@ class ContactModelContact extends JModelForm
 							('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
 						);
 					}
-
 					if (is_numeric($published))
 					{
 						$query->where('a.state IN (1,2)')
 							->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 							->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 					}
-
 					// Number of articles to display from config/menu params
 					$articles_display_num = $this->getState('params')->get('articles_display_num', 10);
-
 					// Use contact setting?
 					if ($articles_display_num === 'use_contact')
 					{
 						$articles_display_num = $contactParams->get('articles_display_num', 10);
-
 						// Use global?
 						if ((string) $articles_display_num === '')
 						{
 							$articles_display_num = JComponentHelper::getParams('com_contact')->get('articles_display_num', 10);
 						}
 					}
-
 					$db->setQuery($query, 0, (int) $articles_display_num);
 					$articles = $db->loadObjectList();
 					$result->articles = $articles;
@@ -433,36 +357,127 @@ class ContactModelContact extends JModelForm
 				{
 					$result->articles = null;
 				}
-
 				// Get the profile information for the linked user
 				require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
 				$userModel = JModelLegacy::getInstance('User', 'UsersModel', array('ignore_request' => true));
 				$data = $userModel->getItem((int) $result->user_id);
-
 				JPluginHelper::importPlugin('user');
 				$form = new JForm('com_users.profile');
-
 				// Get the dispatcher.
-				$dispatcher = JEventDispatcher::getInstance();
-
+				$dispatcher	= JEventDispatcher::getInstance();
 				// Trigger the form preparation event.
 				$dispatcher->trigger('onContentPrepareForm', array($form, $data));
-
 				// Trigger the data preparation event.
 				$dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
-
 				// Load the data into the form after the plugins have operated.
 				$form->bind($data);
 				$result->profile = $form;
 				$this->contact = $result;
-
 				return $result;
 			}
 		}
-
 		return false;
 	}
-
+	protected function getContactExtendedData($contact)
+	{
+		$db		= $this->getDbo();
+		$user	= JFactory::getUser();
+		$nullDate = $db->quote($db->getNullDate());
+		$nowDate = $db->quote(JFactory::getDate()->toSql());
+		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$contactParams = new Registry;
+		$contactParams->loadString($contact->params);
+		$published = $this->getState('filter.published');
+		// If we are showing a contact list, then the contact parameters take priority
+		// So merge the contact parameters with the merged parameters
+		if ($this->getState('params')->get('show_contact_list'))
+		{
+			$this->getState('params')->merge($contactParams);
+		}
+		// Get the com_content articles by the linked user
+		if ((int) $contact->user_id && $this->getState('params')->get('show_articles'))
+		{
+			$query	= $db->getQuery(true)
+				->select('a.id')
+				->select('a.title')
+				->select('a.state')
+				->select('a.access')
+				->select('a.catid')
+				->select('a.created')
+				->select('a.language');
+			// SQL Server changes
+			$case_when = ' CASE WHEN ';
+			$case_when .= $query->charLength('a.alias', '!=', '0');
+			$case_when .= ' THEN ';
+			$a_id = $query->castAsChar('a.id');
+			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
+			$case_when .= ' ELSE ';
+			$case_when .= $a_id . ' END as slug';
+			$case_when1 = ' CASE WHEN ';
+			$case_when1 .= $query->charLength('c.alias', '!=', '0');
+			$case_when1 .= ' THEN ';
+			$c_id = $query->castAsChar('c.id');
+			$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
+			$case_when1 .= ' ELSE ';
+			$case_when1 .= $c_id . ' END as catslug';
+			$query->select($case_when1 . ',' . $case_when)
+				->from('#__content as a')
+				->join('LEFT', '#__categories as c on a.catid=c.id')
+				->where('a.created_by = ' . (int) $contact->user_id)
+				->where('a.access IN (' . $groups . ')')
+				->order('a.state DESC, a.created DESC');
+			// Filter per language if plugin published
+			if (JLanguageMultilang::isEnabled())
+			{
+				$query->where(
+					('a.created_by = ' . (int) $contact->user_id) . ' AND ' .
+					('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
+				);
+			}
+			if (is_numeric($published))
+			{
+				$query->where('a.state IN (1,2)')
+					->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
+					->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
+			}
+			// Number of articles to display from config/menu params
+			$articles_display_num = $this->getState('params')->get('articles_display_num', 10);
+			// Use contact setting?
+			if ($articles_display_num === 'use_contact')
+			{
+				$articles_display_num = $contactParams->get('articles_display_num', 10);
+				// Use global?
+				if ((string) $articles_display_num === '')
+				{
+					$articles_display_num = JComponentHelper::getParams('com_contact')->get('articles_display_num', 10);
+				}
+			}
+			$db->setQuery($query, 0, (int) $articles_display_num);
+			$articles = $db->loadObjectList();
+			$contact->articles = $articles;
+		}
+		else
+		{
+			$contact->articles = null;
+		}
+		// Get the profile information for the linked user
+		require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
+		$userModel = JModelLegacy::getInstance('User', 'UsersModel', array('ignore_request' => true));
+		$data = $userModel->getItem((int) $contact->user_id);
+		JPluginHelper::importPlugin('user');
+		$form = new JForm('com_users.profile');
+		// Get the dispatcher.
+		$dispatcher	= JEventDispatcher::getInstance();
+		// Trigger the form preparation event.
+		$dispatcher->trigger('onContentPrepareForm', array($form, $data));
+		// Trigger the data preparation event.
+		$dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
+		// Load the data into the form after the plugins have operated.
+		$form->bind($data);
+		$contact->profile = $form;
+		$this->contact = $contact;
+		return $contact;
+	}
 	/**
 	 * Increment the hit counter for the contact.
 	 *
@@ -476,16 +491,13 @@ class ContactModelContact extends JModelForm
 	{
 		$input = JFactory::getApplication()->input;
 		$hitcount = $input->getInt('hitcount', 1);
-
 		if ($hitcount)
 		{
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
-
 			$table = JTable::getInstance('Contact', 'ContactTable');
 			$table->load($pk);
 			$table->hit($pk);
 		}
-
 		return true;
 	}
 }

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,12 +327,12 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
+					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
 			}
 			catch (Exception $e)
 			{
-				$this->setError($e);
+				$this->setError($e->getMessage());
 
 				return false;
 			}

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,7 +327,15 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
+					$access = $this->getState('filter.access');
+
+					if ($access) {
+						throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
+					}
+					else
+					{
+						throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'),403);
+					}
 				}
 			}
 			catch (Exception $e)

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,7 +327,7 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
+					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
 			}
 			catch (Exception $e)

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -6,9 +6,14 @@
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
+
 use Joomla\Registry\Registry;
+
 /**
+ * Single item model for a contact
+ *
  * @package     Joomla.Site
  * @subpackage  com_contact
  * @since       1.5
@@ -21,18 +26,21 @@ class ContactModelContact extends JModelForm
 	 * @since   1.6
 	 */
 	protected $view_item = 'contact';
+
 	/**
 	 * A loaded item
 	 *
 	 * @since   1.6
 	 */
 	protected $_item = null;
+
 	/**
 	 * Model context string.
 	 *
 	 * @var		string
 	 */
 	protected $_context = 'com_contact.contact';
+
 	/**
 	 * Method to auto-populate the model state.
 	 *
@@ -45,19 +53,24 @@ class ContactModelContact extends JModelForm
 	protected function populateState()
 	{
 		$app = JFactory::getApplication('site');
+
 		// Load state from the request.
 		$pk = $app->input->getInt('id');
 		$this->setState('contact.id', $pk);
+
 		// Load the parameters.
 		$params = $app->getParams();
 		$this->setState('params', $params);
+
 		$user = JFactory::getUser();
+
 		if ((!$user->authorise('core.edit.state', 'com_contact')) &&  (!$user->authorise('core.edit', 'com_contact')))
 		{
 			$this->setState('filter.published', 1);
 			$this->setState('filter.archived', 2);
 		}
 	}
+
 	/**
 	 * Method to get the contact form.
 	 * The base form is loaded from XML and then an event is fired
@@ -73,20 +86,25 @@ class ContactModelContact extends JModelForm
 	{
 		// Get the form.
 		$form = $this->loadForm('com_contact.contact', 'contact', array('control' => 'jform', 'load_data' => true));
+
 		if (empty($form))
 		{
 			return false;
 		}
+
 		$id = $this->getState('contact.id');
 		$params = $this->getState('params');
 		$contact = $this->_item[$id];
 		$params->merge($contact->params);
+
 		if (!$params->get('show_email_copy', 0))
 		{
 			$form->removeField('contact_email_copy');
 		}
+
 		return $form;
 	}
+
 	/**
 	 * Method to get the data that should be injected in the form.
 	 *
@@ -97,9 +115,12 @@ class ContactModelContact extends JModelForm
 	protected function loadFormData()
 	{
 		$data = (array) JFactory::getApplication()->getUserState('com_contact.contact.data', array());
+
 		$this->preprocessData('com_contact.contact', $data);
+
 		return $data;
 	}
+
 	/**
 	 * Gets a contact
 	 *
@@ -112,16 +133,19 @@ class ContactModelContact extends JModelForm
 	public function &getItem($pk = null)
 	{
 		$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
+
 		if ($this->_item === null)
 		{
 			$this->_item = array();
 		}
+
 		if (!isset($this->_item[$pk]))
 		{
 			try
 			{
 				$db = $this->getDbo();
 				$query = $db->getQuery(true);
+
 				// Changes for sqlsrv
 				$case_when = ' CASE WHEN ';
 				$case_when .= $query->charLength('a.alias', '!=', '0');
@@ -130,6 +154,7 @@ class ContactModelContact extends JModelForm
 				$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 				$case_when .= ' ELSE ';
 				$case_when .= $a_id . ' END as slug';
+
 				$case_when1 = ' CASE WHEN ';
 				$case_when1 .= $query->charLength('c.alias', '!=', '0');
 				$case_when1 .= ' THEN ';
@@ -137,18 +162,24 @@ class ContactModelContact extends JModelForm
 				$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
 				$case_when1 .= ' ELSE ';
 				$case_when1 .= $c_id . ' END as catslug';
+
 				$query->select($this->getState('item.select', 'a.*') . ',' . $case_when . ',' . $case_when1)
 					->from('#__contact_details AS a')
-					// Join on category table.
+
+				// Join on category table.
 					->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
 					->join('LEFT', '#__categories AS c on c.id = a.catid')
-					// Join over the categories to get parent category titles
+
+				// Join over the categories to get parent category titles
 					->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias')
 					->join('LEFT', '#__categories as parent ON parent.id = c.parent_id')
+
 					->where('a.id = ' . (int) $pk);
+
 				// Filter by start and end dates.
 				$nullDate = $db->quote($db->getNullDate());
 				$nowDate = $db->quote(JFactory::getDate()->toSql());
+
 				// Filter by published state.
 				$published = $this->getState('filter.published');
 				$archived = $this->getState('filter.archived');
@@ -158,30 +189,38 @@ class ContactModelContact extends JModelForm
 						->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 						->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 				}
+
 				$db->setQuery($query);
 				$data = $db->loadObject();
+
 				if (empty($data))
 				{
 					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
+
 				// Check for published state if filter set.
 				if (((is_numeric($published)) || (is_numeric($archived))) && (($data->published != $published) && ($data->published != $archived)))
 				{
 					JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
 				}
+
 				// Convert parameter fields to objects.
 				$registry = new Registry;
 				$registry->loadString($data->params);
 				$data->params = clone $this->getState('params');
 				$data->params->merge($registry);
+
 				$registry = new Registry;
 				$registry->loadString($data->metadata);
 				$data->metadata = $registry;
+
 				$data->tags = new JHelperTags;
 				$data->tags->getItemTags('com_contact.contact', $data->id);
+
 				// Compute access permissions.
 				if ($access = $this->getState('filter.access'))
 				{
+
 					// If the access filter has been set, we already know this user can view.
 					$data->params->set('access-view', true);
 				}
@@ -190,6 +229,7 @@ class ContactModelContact extends JModelForm
 					// If no access filter is set, the layout takes some responsibility for display of limited information.
 					$user = JFactory::getUser();
 					$groups = $user->getAuthorisedViewLevels();
+
 					if ($data->catid == 0 || $data->category_access === null)
 					{
 						$data->params->set('access-view', in_array($data->access, $groups));
@@ -199,6 +239,7 @@ class ContactModelContact extends JModelForm
 						$data->params->set('access-view', in_array($data->access, $groups) && in_array($data->category_access, $groups));
 					}
 				}
+
 				$this->_item[$pk] = $data;
 			}
 			catch (Exception $e)
@@ -207,197 +248,46 @@ class ContactModelContact extends JModelForm
 				$this->_item[$pk] = false;
 			}
 		}
+
 		if ($this->_item[$pk])
 		{
-			if ($extendedData = $this->getContactExtendedData($this->_item[$pk]))
-			{
-				$this->_item[$pk]->articles = $extendedData->articles;
-				$this->_item[$pk]->profile = $extendedData->profile;
-			}
+			$this->buildContactExtendedData($this->_item[$pk]);
 		}
+
 		return $this->_item[$pk];
 	}
+
 	/**
-	 * Gets the query to load a contact item
+	 * Load extended data (profile, articles) for a contact
 	 *
-	 * @param   integer  $pk  The item to be loaded
+	 * @param   object  $contact  The contact object
 	 *
-	 * @return  mixed    The contact object on success, false on failure
-	 *
-	 * @throws  Exception  On database failure
+	 * @return  void
 	 */
-	protected function getContactQuery($pk = null)
+	protected function buildContactExtendedData($contact)
 	{
-		// @todo Cache on the fingerprint of the arguments
-		$db		= $this->getDbo();
-		$nullDate = $db->quote($db->getNullDate());
-		$nowDate = $db->quote(JFactory::getDate()->toSql());
-		$user	= JFactory::getUser();
-		$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
-		$query	= $db->getQuery(true);
-		if ($pk)
-		{
-			// Sqlsrv changes
-			$case_when = ' CASE WHEN ';
-			$case_when .= $query->charLength('a.alias', '!=', '0');
-			$case_when .= ' THEN ';
-			$a_id = $query->castAsChar('a.id');
-			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
-			$case_when .= ' ELSE ';
-			$case_when .= $a_id . ' END as slug';
-			$case_when1 = ' CASE WHEN ';
-			$case_when1 .= $query->charLength('cc.alias', '!=', '0');
-			$case_when1 .= ' THEN ';
-			$c_id = $query->castAsChar('cc.id');
-			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
-			$case_when1 .= ' ELSE ';
-			$case_when1 .= $c_id . ' END as catslug';
-			$query->select(
-				'a.*, cc.access as category_access, cc.title as category_name, '
-				. $case_when . ',' . $case_when1
-			)
-				->from('#__contact_details AS a')
-				->join('INNER', '#__categories AS cc on cc.id = a.catid')
-				->where('a.id = ' . (int) $pk);
-			$published = $this->getState('filter.published');
-			if (is_numeric($published))
-			{
-				$query->where('a.published IN (1,2)')
-					->where('cc.published IN (1,2)');
-			}
-			$groups = implode(',', $user->getAuthorisedViewLevels());
-			$query->where('a.access IN (' . $groups . ')');
-			try
-			{
-				$db->setQuery($query);
-				$result = $db->loadObject();
-				if (empty($result))
-				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
-				}
-			}
-			catch (Exception $e)
-			{
-				$this->setError($e);
-				return false;
-			}
-			if ($result)
-			{
-				$contactParams = new Registry;
-				$contactParams->loadString($result->params);
-				// If we are showing a contact list, then the contact parameters take priority
-				// So merge the contact parameters with the merged parameters
-				if ($this->getState('params')->get('show_contact_list'))
-				{
-					$this->getState('params')->merge($contactParams);
-				}
-				// Get the com_content articles by the linked user
-				if ((int) $result->user_id && $this->getState('params')->get('show_articles'))
-				{
-					$query	= $db->getQuery(true)
-						->select('a.id')
-						->select('a.title')
-						->select('a.state')
-						->select('a.access')
-						->select('a.catid')
-						->select('a.created')
-						->select('a.language');
-					// SQL Server changes
-					$case_when = ' CASE WHEN ';
-					$case_when .= $query->charLength('a.alias', '!=', '0');
-					$case_when .= ' THEN ';
-					$a_id = $query->castAsChar('a.id');
-					$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
-					$case_when .= ' ELSE ';
-					$case_when .= $a_id . ' END as slug';
-					$case_when1 = ' CASE WHEN ';
-					$case_when1 .= $query->charLength('c.alias', '!=', '0');
-					$case_when1 .= ' THEN ';
-					$c_id = $query->castAsChar('c.id');
-					$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
-					$case_when1 .= ' ELSE ';
-					$case_when1 .= $c_id . ' END as catslug';
-					$query->select($case_when1 . ',' . $case_when)
-						->from('#__content as a')
-						->join('LEFT', '#__categories as c on a.catid=c.id')
-						->where('a.created_by = ' . (int) $result->user_id)
-						->where('a.access IN (' . $groups . ')')
-						->order('a.state DESC, a.created DESC');
-					// Filter per language if plugin published
-					if (JLanguageMultilang::isEnabled())
-					{
-						$query->where(
-							('a.created_by = ' . (int) $result->user_id) . ' AND ' .
-							('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
-						);
-					}
-					if (is_numeric($published))
-					{
-						$query->where('a.state IN (1,2)')
-							->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
-							->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
-					}
-					// Number of articles to display from config/menu params
-					$articles_display_num = $this->getState('params')->get('articles_display_num', 10);
-					// Use contact setting?
-					if ($articles_display_num === 'use_contact')
-					{
-						$articles_display_num = $contactParams->get('articles_display_num', 10);
-						// Use global?
-						if ((string) $articles_display_num === '')
-						{
-							$articles_display_num = JComponentHelper::getParams('com_contact')->get('articles_display_num', 10);
-						}
-					}
-					$db->setQuery($query, 0, (int) $articles_display_num);
-					$articles = $db->loadObjectList();
-					$result->articles = $articles;
-				}
-				else
-				{
-					$result->articles = null;
-				}
-				// Get the profile information for the linked user
-				require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
-				$userModel = JModelLegacy::getInstance('User', 'UsersModel', array('ignore_request' => true));
-				$data = $userModel->getItem((int) $result->user_id);
-				JPluginHelper::importPlugin('user');
-				$form = new JForm('com_users.profile');
-				// Get the dispatcher.
-				$dispatcher	= JEventDispatcher::getInstance();
-				// Trigger the form preparation event.
-				$dispatcher->trigger('onContentPrepareForm', array($form, $data));
-				// Trigger the data preparation event.
-				$dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
-				// Load the data into the form after the plugins have operated.
-				$form->bind($data);
-				$result->profile = $form;
-				$this->contact = $result;
-				return $result;
-			}
-		}
-		return false;
-	}
-	protected function getContactExtendedData($contact)
-	{
-		$db		= $this->getDbo();
-		$user	= JFactory::getUser();
-		$nullDate = $db->quote($db->getNullDate());
-		$nowDate = $db->quote(JFactory::getDate()->toSql());
-		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$db        = $this->getDbo();
+		$nullDate  = $db->quote($db->getNullDate());
+		$nowDate   = $db->quote(JFactory::getDate()->toSql());
+		$user      = JFactory::getUser();
+		$groups    = implode(',', $user->getAuthorisedViewLevels());
+		$published = $this->getState('filter.published');
+
 		$contactParams = new Registry;
 		$contactParams->loadString($contact->params);
-		$published = $this->getState('filter.published');
+
 		// If we are showing a contact list, then the contact parameters take priority
 		// So merge the contact parameters with the merged parameters
 		if ($this->getState('params')->get('show_contact_list'))
 		{
 			$this->getState('params')->merge($contactParams);
 		}
+
 		// Get the com_content articles by the linked user
 		if ((int) $contact->user_id && $this->getState('params')->get('show_articles'))
 		{
-			$query	= $db->getQuery(true)
+
+			$query = $db->getQuery(true)
 				->select('a.id')
 				->select('a.title')
 				->select('a.state')
@@ -405,6 +295,7 @@ class ContactModelContact extends JModelForm
 				->select('a.catid')
 				->select('a.created')
 				->select('a.language');
+
 			// SQL Server changes
 			$case_when = ' CASE WHEN ';
 			$case_when .= $query->charLength('a.alias', '!=', '0');
@@ -426,6 +317,7 @@ class ContactModelContact extends JModelForm
 				->where('a.created_by = ' . (int) $contact->user_id)
 				->where('a.access IN (' . $groups . ')')
 				->order('a.state DESC, a.created DESC');
+
 			// Filter per language if plugin published
 			if (JLanguageMultilang::isEnabled())
 			{
@@ -434,24 +326,29 @@ class ContactModelContact extends JModelForm
 					('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
 				);
 			}
+
 			if (is_numeric($published))
 			{
 				$query->where('a.state IN (1,2)')
 					->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 					->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 			}
+
 			// Number of articles to display from config/menu params
 			$articles_display_num = $this->getState('params')->get('articles_display_num', 10);
+
 			// Use contact setting?
 			if ($articles_display_num === 'use_contact')
 			{
 				$articles_display_num = $contactParams->get('articles_display_num', 10);
+
 				// Use global?
 				if ((string) $articles_display_num === '')
 				{
 					$articles_display_num = JComponentHelper::getParams('com_contact')->get('articles_display_num', 10);
 				}
 			}
+
 			$db->setQuery($query, 0, (int) $articles_display_num);
 			$articles = $db->loadObjectList();
 			$contact->articles = $articles;
@@ -460,24 +357,222 @@ class ContactModelContact extends JModelForm
 		{
 			$contact->articles = null;
 		}
+
 		// Get the profile information for the linked user
 		require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
 		$userModel = JModelLegacy::getInstance('User', 'UsersModel', array('ignore_request' => true));
 		$data = $userModel->getItem((int) $contact->user_id);
+
 		JPluginHelper::importPlugin('user');
 		$form = new JForm('com_users.profile');
+
 		// Get the dispatcher.
-		$dispatcher	= JEventDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
+
 		// Trigger the form preparation event.
 		$dispatcher->trigger('onContentPrepareForm', array($form, $data));
+
 		// Trigger the data preparation event.
 		$dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
+
 		// Load the data into the form after the plugins have operated.
 		$form->bind($data);
 		$contact->profile = $form;
-		$this->contact = $contact;
-		return $contact;
 	}
+
+	/**
+	 * Gets the query to load a contact item
+	 *
+	 * @param   integer  $pk  The item to be loaded
+	 *
+	 * @return  mixed    The contact object on success, false on failure
+	 *
+	 * @throws  Exception  On database failure
+	 */
+	protected function getContactQuery($pk = null)
+	{
+		// @todo Cache on the fingerprint of the arguments
+		$db       = $this->getDbo();
+		$nullDate = $db->quote($db->getNullDate());
+		$nowDate  = $db->quote(JFactory::getDate()->toSql());
+		$user     = JFactory::getUser();
+		$pk       = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
+		$query    = $db->getQuery(true);
+
+		if ($pk)
+		{
+			// Sqlsrv changes
+			$case_when  = ' CASE WHEN ';
+			$case_when .= $query->charLength('a.alias', '!=', '0');
+			$case_when .= ' THEN ';
+
+			$a_id       = $query->castAsChar('a.id');
+			$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
+			$case_when .= ' ELSE ';
+			$case_when .= $a_id . ' END as slug';
+
+			$case_when1  = ' CASE WHEN ';
+			$case_when1 .= $query->charLength('cc.alias', '!=', '0');
+			$case_when1 .= ' THEN ';
+
+			$c_id        = $query->castAsChar('cc.id');
+			$case_when1 .= $query->concatenate(array($c_id, 'cc.alias'), ':');
+			$case_when1 .= ' ELSE ';
+			$case_when1 .= $c_id . ' END as catslug';
+
+			$query->select(
+				'a.*, cc.access as category_access, cc.title as category_name, '
+				. $case_when . ',' . $case_when1
+			)
+				->from('#__contact_details AS a')
+				->join('INNER', '#__categories AS cc on cc.id = a.catid')
+				->where('a.id = ' . (int) $pk);
+
+			$published = $this->getState('filter.published');
+
+			if (is_numeric($published))
+			{
+				$query->where('a.published IN (1,2)')
+					->where('cc.published IN (1,2)');
+			}
+
+			$groups = implode(',', $user->getAuthorisedViewLevels());
+			$query->where('a.access IN (' . $groups . ')');
+
+			try
+			{
+				$db->setQuery($query);
+				$result = $db->loadObject();
+
+				if (empty($result))
+				{
+					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
+				}
+			}
+			catch (Exception $e)
+			{
+				$this->setError($e->getMessage());
+
+				return false;
+			}
+
+			if ($result)
+			{
+
+				$contactParams = new Registry;
+				$contactParams->loadString($result->params);
+
+				// If we are showing a contact list, then the contact parameters take priority
+				// So merge the contact parameters with the merged parameters
+				if ($this->getState('params')->get('show_contact_list'))
+				{
+					$this->getState('params')->merge($contactParams);
+				}
+
+				// Get the com_content articles by the linked user
+				if ((int) $result->user_id && $this->getState('params')->get('show_articles'))
+				{
+
+					$query = $db->getQuery(true)
+						->select('a.id')
+						->select('a.title')
+						->select('a.state')
+						->select('a.access')
+						->select('a.catid')
+						->select('a.created')
+						->select('a.language');
+
+					// SQL Server changes
+					$case_when = ' CASE WHEN ';
+					$case_when .= $query->charLength('a.alias', '!=', '0');
+					$case_when .= ' THEN ';
+					$a_id = $query->castAsChar('a.id');
+					$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
+					$case_when .= ' ELSE ';
+					$case_when .= $a_id . ' END as slug';
+					$case_when1 = ' CASE WHEN ';
+					$case_when1 .= $query->charLength('c.alias', '!=', '0');
+					$case_when1 .= ' THEN ';
+					$c_id = $query->castAsChar('c.id');
+					$case_when1 .= $query->concatenate(array($c_id, 'c.alias'), ':');
+					$case_when1 .= ' ELSE ';
+					$case_when1 .= $c_id . ' END as catslug';
+					$query->select($case_when1 . ',' . $case_when)
+						->from('#__content as a')
+						->join('LEFT', '#__categories as c on a.catid=c.id')
+						->where('a.created_by = ' . (int) $result->user_id)
+						->where('a.access IN (' . $groups . ')')
+						->order('a.state DESC, a.created DESC');
+
+					// Filter per language if plugin published
+					if (JLanguageMultilang::isEnabled())
+					{
+						$query->where(
+							('a.created_by = ' . (int) $result->user_id) . ' AND ' .
+							('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
+						);
+					}
+
+					if (is_numeric($published))
+					{
+						$query->where('a.state IN (1,2)')
+							->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
+							->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
+					}
+
+					// Number of articles to display from config/menu params
+					$articles_display_num = $this->getState('params')->get('articles_display_num', 10);
+
+					// Use contact setting?
+					if ($articles_display_num === 'use_contact')
+					{
+						$articles_display_num = $contactParams->get('articles_display_num', 10);
+
+						// Use global?
+						if ((string) $articles_display_num === '')
+						{
+							$articles_display_num = JComponentHelper::getParams('com_contact')->get('articles_display_num', 10);
+						}
+					}
+
+					$db->setQuery($query, 0, (int) $articles_display_num);
+					$articles = $db->loadObjectList();
+					$result->articles = $articles;
+				}
+				else
+				{
+					$result->articles = null;
+				}
+
+				// Get the profile information for the linked user
+				require_once JPATH_ADMINISTRATOR . '/components/com_users/models/user.php';
+				$userModel = JModelLegacy::getInstance('User', 'UsersModel', array('ignore_request' => true));
+				$data = $userModel->getItem((int) $result->user_id);
+
+				JPluginHelper::importPlugin('user');
+				$form = new JForm('com_users.profile');
+
+				// Get the dispatcher.
+				$dispatcher = JEventDispatcher::getInstance();
+
+				// Trigger the form preparation event.
+				$dispatcher->trigger('onContentPrepareForm', array($form, $data));
+
+				// Trigger the data preparation event.
+				$dispatcher->trigger('onContentPrepareData', array('com_users.profile', $data));
+
+				// Load the data into the form after the plugins have operated.
+				$form->bind($data);
+				$result->profile = $form;
+				$this->contact = $result;
+
+				return $result;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Increment the hit counter for the contact.
 	 *
@@ -491,13 +586,16 @@ class ContactModelContact extends JModelForm
 	{
 		$input = JFactory::getApplication()->input;
 		$hitcount = $input->getInt('hitcount', 1);
+
 		if ($hitcount)
 		{
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
+
 			$table = JTable::getInstance('Contact', 'ContactTable');
 			$table->load($pk);
 			$table->hit($pk);
 		}
+
 		return true;
 	}
 }

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,7 +327,7 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
+					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'),404);
 				}
 			}
 			catch (Exception $e)


### PR DESCRIPTION
This is a fix for the issue #7053. It is solved as suggested on the report.

---
#### Steps to reproduce the issue

Create a contact, public & published, save, memorise id (1).
Create another contact, public & unpublished, save, memorise id (2).
Create another contact, registered & published, save, memorise id (3).
Create a menu item "list contacts in category", call it "contacts".
Navigate to http://mysite.com/contacts to see the list of contacts as public, you'll see just one contact (1).

Navigate to this contact (http://mysite.com/contacts/1-somename), all good.

Navigate to unpublished contact (http://mysite.com/contacts/2-somename), see 404 "Contact not found" error page. All good.

Navigate to registered contact (http://mysite.com/contacts/3-somename), see long error message with stack trace.
#### Expected result

404 or 403 Error page (error template based) saying "contact not found" or "not authorised"
#### Actual result

Normal page (not error template based) with just an error message:

Error

exception 'Exception' with message 'Contact not found' in C:\home\bgpa\j31\components\com_contact\models\contact.php:328 Stack trace: #0 C:\home\bgpa\j31\components\com_contact\models\contact.php(252): ContactModelContact->getContactQuery(28) #1 C:\home\bgpa\j31\libraries\legacy\view\legacy.php(401): ContactModelContact->getItem() #2 C:\home\bgpa\j31\components\com_contact\views\contact\view.html.php(66): JViewLegacy->get('Item') #3 C:\home\bgpa\j31\libraries\legacy\controller\legacy.php(690): ContactViewContact->display() #4 C:\home\bgpa\j31\components\com_contact\controller.php(42): JControllerLegacy->display(true, Array) #5 C:\home\bgpa\j31\libraries\legacy\controller\legacy.php(728): ContactController->display() #6 C:\home\bgpa\j31\components\com_contact\contact.php(15): JControllerLegacy->execute(NULL) #7 C:\home\bgpa\j31\libraries\cms\component\helper.php(391): require_once('C:\home\bgpa\j3...') #8 C:\home\bgpa\j31\libraries\cms\component\helper.php(371): JComponentHelper::executeComponent('C:\home\bgpa\j3...') #9 C:\home\bgpa\j31\libraries\cms\application\site.php(191): JComponentHelper::renderComponent('com_contact') #10 C:\home\bgpa\j31\libraries\cms\application\site.php(230): JApplicationSite->dispatch() #11 C:\home\bgpa\j31\libraries\cms\application\cms.php(252): JApplicationSite->doExecute() #12 C:\home\bgpa\j31\index.php(40): JApplicationCms->execute() #13 {main}
#### System information (as much as possible)

J3.4.1, SEF on, error reporting off (!!!)
#### Additional comments

Probably a clash of old and new ways of raising errors (JError vs Exception) in contact model.

adding this line in components/com_contact/models/contact.php @ line 257 fixes the situation:

else JError::raiseError(404, JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'));
