### PR TITLE
Missing message status "success"

### DIFF
--- a/templates/protostar/html/layouts/joomla/system/message.php
+++ b/templates/protostar/html/layouts/joomla/system/message.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $msgList = $displayData['msgList'];
 
-$alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
+$alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success', 'success' => 'alert-success');
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>


### PR DESCRIPTION
without array-index "success" this message output create a PHP-Notice "undefined index on..."
