### PR TITLE
Fix undefined notice message

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/system/message.php
+++ b/administrator/templates/isis/html/layouts/joomla/system/message.php
@@ -17,7 +17,7 @@ $alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-inf
 	<?php if (is_array($msgList) && $msgList) : ?>
 		<button type="button" class="close" data-dismiss="alert">&times;</button>
 		<?php foreach ($msgList as $type => $msgs) : ?>
-			<div class="alert <?php echo $alert[$type]; ?>">
+			<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
 				<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
 				<?php if ($msgs) : ?>
 					<?php foreach ($msgs as $msg) : ?>

--- a/templates/protostar/html/layouts/joomla/system/message.php
+++ b/templates/protostar/html/layouts/joomla/system/message.php
@@ -17,7 +17,7 @@ $alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-inf
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>
 		<div id="system-message">
 			<?php foreach ($msgList as $type => $msgs) : ?>
-				<div class="alert <?php echo $alert[$type]; ?>">
+				<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
 					<?php // This requires JS so we should add it trough JS. Progressive enhancement and stuff. ?>
 					<a class="close" data-dismiss="alert">×</a>
 


### PR DESCRIPTION
This PR proposes a better fix than https://github.com/joomla/joomla-cms/pull/7884
### Issue

If an extension uses a custom message type in the enqueueMessage($message, $type) method, then it will currently show a notice:

> Notice: Undefined index: foo in ...\templates\protostar\html\layouts\joomla\system\message.php`
### Solution

Check first if the array key is set before calling it. If not set, just use the $type directly.
### Testing

Simplest is to just add the following line to the start of the index.php of the template:
`JFactory::getApplication()->enqueueMessage('test', 'success');` (should create a green message)
or 
`JFactory::getApplication()->enqueueMessage('test', 'foo');` (should create a orange message)
### Note

The Isis template uses the same JLayout, so I changed it there as well.
