### PR TITLE
Use PHP_INT_MAX for maxLevel all in category view.

### DIFF
--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -145,7 +145,7 @@ class JViewCategory extends JViewLegacy
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
 
-		$maxLevel         = $params->get('maxLevel', -1);
+		$maxLevel         = $params->get('maxLevel', -1) < 0 ? PHP_INT_MAX : $params->get('maxLevel', PHP_INT_MAX);
 		$this->maxLevel   = &$maxLevel;
 		$this->state      = &$state;
 		$this->items      = &$items;


### PR DESCRIPTION
This is an adaption of #5469 for the category view.
## Testing instructions
1. Create a content category with several levels of subcategories.
2. Create a menu item for the category.
   - Type: Category List
   -  Subcategory Levels: All
3. Navigate to the menu item in frontend, mind there is no "plus" icon to expand the subcategories.
4. Apply this patch.
5. There should be a plus icon now to expand the subcategories, like when "Subcategory Levels" is set to a number > 1.

This bug was reported by user fahl5 on Joomla-Bugs.de: http://www.joomla-bugs.de/forum/index.php/topic,687.msg3159.html#msg3159
