### PR TITLE
Multilanguage: filtering categories

### DIFF
--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -25,7 +25,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 			<div <?php echo $class; ?> >
 			<?php $class = ''; ?>
 				<h3 class="page-header item-title">
-					<a href="<?php echo JRoute::_(ContactHelperRoute::getCategoryRoute($item->id)); ?>">
+					<a href="<?php echo JRoute::_(ContactHelperRoute::getCategoryRoute($item->id, $item->language)); ?>">
 					<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTACT_NUM_ITEMS'); ?>">
@@ -33,7 +33,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 						</span>
 					<?php endif; ?>
 					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>"
 							data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>

--- a/components/com_content/views/categories/tmpl/default_items.php
+++ b/components/com_content/views/categories/tmpl/default_items.php
@@ -27,7 +27,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 		<div <?php echo $class; ?> >
 		<?php $class = ''; ?>
 			<h3 class="page-header item-title">
-				<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id));?>">
+				<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id, $item->language));?>">
 				<?php echo $this->escape($item->title); ?></a>
 				<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
 					<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTENT_NUM_ITEMS'); ?>">
@@ -35,7 +35,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					</span>
 				<?php endif; ?>
 				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-					<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+					<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>"
 						data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 				<?php endif;?>
 			</h3>

--- a/components/com_newsfeeds/views/categories/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default_items.php
@@ -25,7 +25,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 			<div <?php echo $class; ?> >
 			<?php $class = ''; ?>
 				<h3 class="page-header item-title">
-				<a href="<?php echo JRoute::_(NewsfeedsHelperRoute::getCategoryRoute($item->id));?>">
+				<a href="<?php echo JRoute::_(NewsfeedsHelperRoute::getCategoryRoute($item->id, $item->language));?>">
 					<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_NEWSFEEDS_NUM_ITEMS'); ?>">
@@ -33,7 +33,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 						</span>
 					<?php endif; ?>
 					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>" 
+						<a id="category-btn-<?php echo $item->id;?>" href="#category-<?php echo $item->id;?>"
 							data-toggle="collapse" data-toggle="button" class="btn btn-mini pull-right"><span class="icon-plus"></span></a>
 					<?php endif;?>
 				</h3>

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -210,6 +210,7 @@ class JCategories
 	protected function _load($id)
 	{
 		$db = JFactory::getDbo();
+		$app = JFactory::getApplication();
 		$user = JFactory::getUser();
 		$extension = $this->_extension;
 
@@ -250,8 +251,23 @@ class JCategories
 		if ($id != 'root')
 		{
 			// Get the selected category
-			$query->join('LEFT', '#__categories AS s ON (s.lft <= c.lft AND s.rgt >= c.rgt) OR (s.lft > c.lft AND s.rgt < c.rgt)')
-				->where('s.id=' . (int) $id);
+			$query->where('s.id=' . (int) $id);
+
+			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			{
+				$query->join('LEFT', '#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt AND c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
+			}
+			else
+			{
+				$query->join('LEFT', '#__categories AS s ON (s.lft <= c.lft AND s.rgt >= c.rgt) OR (s.lft > c.lft AND s.rgt < c.rgt)');
+			}
+		}
+		else
+		{
+			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			{
+				$query->where('c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
+			}
 		}
 
 		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -210,7 +210,6 @@ class JCategories
 	protected function _load($id)
 	{
 		$db = JFactory::getDbo();
-		$app = JFactory::getApplication();
 		$user = JFactory::getUser();
 		$extension = $this->_extension;
 
@@ -243,6 +242,12 @@ class JCategories
 		if ($this->_options['published'] == 1)
 		{
 			$query->where('c.published = 1');
+
+			$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
+				'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
+				' AND parent.published != 1 GROUP BY cat.id) ';
+			$query->join('LEFT', $subQuery . 'AS badcats ON badcats.id = c.id')
+				->where('badcats.id is null');
 		}
 
 		$query->order('c.lft');
@@ -259,12 +264,6 @@ class JCategories
 		{
 			$query->where('c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
-
-		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
-			'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-			' AND parent.published != 1 GROUP BY cat.id) ';
-		$query->join('LEFT', $subQuery . 'AS badcats ON badcats.id = c.id')
-			->where('badcats.id is null');
 
 		// Note: i for item
 		if ($this->_options['countItems'] == 1)

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -255,7 +255,8 @@ class JCategories
 
 			if ($app->isSite() && JLanguageMultilang::isEnabled())
 			{
-				$query->join('LEFT', '#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt AND c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
+				$query->join('LEFT', '#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt
+					 AND c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
 			}
 			else
 			{

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -251,24 +251,13 @@ class JCategories
 		if ($id != 'root')
 		{
 			// Get the selected category
-			$query->where('s.id=' . (int) $id);
-
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
-			{
-				$query->join('LEFT', '#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt
-					 AND c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
-			}
-			else
-			{
-				$query->join('LEFT', '#__categories AS s ON (s.lft <= c.lft AND s.rgt >= c.rgt) OR (s.lft > c.lft AND s.rgt < c.rgt)');
-			}
+			$query->join('LEFT', '#__categories AS s ON (s.lft <= c.lft AND s.rgt >= c.rgt) OR (s.lft > c.lft AND s.rgt < c.rgt)')
+				->where('s.id=' . (int) $id);
 		}
-		else
+
+		if ($app->isSite() && JLanguageMultilang::isEnabled())
 		{
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
-			{
-				$query->where('c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
-			}
+			$query->where('c.language in (' . $db->Quote(JFactory::getLanguage()->getTag()) . ',' . $db->Quote('*') . ')');
 		}
 
 		$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .


### PR DESCRIPTION
Test:
Create a multilanguage site (2 languages are enough).
Make sure you have 1 category and 1 subcategory per language (test with com_content for example)

Create a List All Categories menu item with base set to ROOT in each language.

Display the menu item in frontend: the categories not belonging to the current language will be displayed.
Their article count is 0 and clicking on the + icon has no effect.
Clicking on their title will fail to display the category as it keeps the wrong URL Language Code which is the one of the Current language. 
In the screenshot below the link to "English Categories" is `/index.php?option=com_content&view=category&id=10&Itemid=622&lang=fr` as we are in the French interface.

Result:
![screen shot 2015-09-17 at 12 06 43](https://cloud.githubusercontent.com/assets/869724/9930542/a73573f0-5d34-11e5-822c-5ac5cbdc41df.png)

Patch and test again:, you will get.
![screen shot 2015-09-17 at 12 09 27](https://cloud.githubusercontent.com/assets/869724/9930581/0156fb2e-5d35-11e5-8433-6adb39d78af0.png)

This patch also normalises the urls in default_items as done elsewhere in core. It has no impact on the results when the categories are filtered.
