### PR TITLE
[UX] Module menu assignment improvement

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -148,9 +148,15 @@ class MenusHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.published AS published, a.title AS text, a.alias, a.level, a.menutype, a.type, a.template_style_id, a.checked_out')
+			->select('a.id AS value, a.title AS text, a.alias, a.level, a.menutype, a.type, a.published, a.template_style_id, a.checked_out, a.language')
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+
+		if (JLanguageMultilang::isEnabled())
+		{
+			$query->select('l.title AS language_title, l.image as language_image')
+				->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = a.language');
+		}
 
 		// Filter by the type
 		if ($menuType)

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -148,7 +148,7 @@ class MenusHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.alias, a.level, a.menutype, a.type, a.template_style_id, a.checked_out')
+			->select('a.id AS value, a.published AS published, a.title AS text, a.alias, a.level, a.menutype, a.type, a.template_style_id, a.checked_out')
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -109,7 +109,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php if ($link->published == 0) : ?><i class="icon icon-unpublish"></i><?php endif;?>
+										<?php if ($link->published == 0) : ?><span class="icon icon-unpublish"></span><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
 										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
 										{

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -111,6 +111,11 @@ JFactory::getDocument()->addScriptDeclaration($script);
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
 										<?php if ($link->published == 0) : ?><i class="icon icon-unpublish"></i><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
+										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
+										{
+											echo JHtml::_('image', 'mod_languages/' . $link->language_image . '.gif', $link->language_title, array('title' => $link->language_title), true);
+										}
+										?>
 									</label>
 								</div>
 						<?php

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -109,12 +109,8 @@ JFactory::getDocument()->addScriptDeclaration($script);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php if($link->published==0):?>
-											<del>
-											<i class="icon icon-unpublish"></i>
-										<?php endif;?>
+										<?php if($link->published==0):?><i class="icon icon-unpublish"></i><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
-										<?php if($link->published==0):?></del><?php endif;?>
 									</label>
 								</div>
 						<?php

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -109,7 +109,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php if ($link->published == 0) : ?><span class="icon icon-unpublish"></span><?php endif;?>
+										<?php if ($link->published == 0) : ?><span class="label"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
 										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
 										{

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -109,11 +109,14 @@ JFactory::getDocument()->addScriptDeclaration($script);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php if ($link->published == 0) : ?><span class="label"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
 										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
 										{
 											echo JHtml::_('image', 'mod_languages/' . $link->language_image . '.gif', $link->language_title, array('title' => $link->language_title), true);
+										}
+										if ($link->published == 0)
+										{
+											echo ' <span class="label">' . JText::_('JUNPUBLISHED') . '</span>';
 										}
 										?>
 									</label>

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -109,7 +109,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php if($link->published==0):?><i class="icon icon-unpublish"></i><?php endif;?>
+										<?php if ($link->published == 0) : ?><i class="icon icon-unpublish"></i><?php endif;?>
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
 									</label>
 								</div>

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -108,7 +108,14 @@ JFactory::getDocument()->addScriptDeclaration($script);
 							<li>
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" class="pull-left" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; ?> />
-									<label for="<?php echo $id . $link->value; ?>" class="pull-left"><?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span></label>
+									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
+										<?php if($link->published==0):?>
+											<del>
+											<i class="icon icon-unpublish"></i>
+										<?php endif;?>
+										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
+										<?php if($link->published==0):?></del><?php endif;?>
+									</label>
 								</div>
 						<?php
 


### PR DESCRIPTION
## Summary

When you create/edit module, you can select page where module only show.
All menuitem are listed without knowing if item are published or not and without language if multilang enabled.
## Test
- Create many menuitem as parent and many child
- Unpublish some menuitem
- Create custom module and goto menu assignment, select "Only on the pages selected"
- Unable to know if menuitem  published or not
- Set many menuitem in different language
- Enable plugin "System - Language Filter "
- Goto module, all menuitem dont include langcode or flag
- Apply patch
- Now you can know if menuitem is unpublished and language
### Preview
#### Version 1

![Preview](http://issues.joomla.org/uploads/1/95332eba3f1a58215d63ebec87606fb1.jpg)
#### Version 2

![Preview](http://issues.joomla.org/uploads/1/546e7ea8f5299d2caf599b23effbbb92.jpg)
#### Version 3 - actual commit

![Preview](http://issues.joomla.org/uploads/1/e3113ab981654a6e62e63c4b8a9c42a1.jpg)
