### PR TITLE
[UX] Form Field Menuitem language

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -148,9 +148,15 @@ class MenusHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.alias, a.level, a.menutype, a.type, a.template_style_id, a.checked_out')
+			->select('a.id AS value, a.title AS text, a.alias, a.level, a.menutype, a.type, a.published, a.template_style_id, a.checked_out, a.language')
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+
+		if (JLanguageMultilang::isEnabled())
+		{
+			$query->select('l.title AS language_title, l.image as language_image')
+				->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = a.language');
+		}
 
 		// Filter by the type
 		if ($menuType)

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -159,8 +159,6 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 		// Get the menu items.
 		$items = MenusHelper::getMenuLinks($menuType, 0, 0, $this->published, $this->language);
 
-		$multilangIsEnabled = JLanguageMultilang::isEnabled();
-
 		// Build group for a specific menu type.
 		if ($menuType)
 		{
@@ -170,7 +168,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			// Build the options array.
 			foreach ($items as $link)
 			{
-				if ($multilangIsEnabled && $link->language != '' && $link->language != '*')
+				if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
 				{
 					$link->text .= ' (' . $link->language . ')';
 				}
@@ -189,7 +187,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 				// Build the options array.
 				foreach ($menu->links as $link)
 				{
-					if ($multilangIsEnabled && $link->language != '' && $link->language != '*')
+					if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*')
 					{
 						$link->text .= ' (' . $link->language . ')';
 					}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -159,6 +159,8 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 		// Get the menu items.
 		$items = MenusHelper::getMenuLinks($menuType, 0, 0, $this->published, $this->language);
 
+		$multilangIsEnabled = JLanguageMultilang::isEnabled();
+
 		// Build group for a specific menu type.
 		if ($menuType)
 		{
@@ -168,6 +170,10 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			// Build the options array.
 			foreach ($items as $link)
 			{
+				if ($multilangIsEnabled && $link->language != '' && $link->language != '*')
+				{
+					$link->text .= ' (' . $link->language . ')';
+				}
 				$groups[$menuType][] = JHtml::_('select.option', $link->value, $link->text, 'value', 'text', in_array($link->type, $this->disable));
 			}
 		}
@@ -183,6 +189,10 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 				// Build the options array.
 				foreach ($menu->links as $link)
 				{
+					if ($multilangIsEnabled && $link->language != '' && $link->language != '*')
+					{
+						$link->text .= ' (' . $link->language . ')';
+					}
 					$groups[$menu->menutype][] = JHtml::_(
 						'select.option', $link->value, $link->text, 'value', 'text',
 						in_array($link->type, $this->disable)


### PR DESCRIPTION
## Summary

Form field menuitem doesnt indicate language of an item.
## Important thing

This PR could conflict with https://github.com/joomla/joomla-cms/pull/7148
## Test
- Create many menuitem with different language
- Enable plugin "System - Language Filter "
- Create menu module and use " Base Item"
- Unable to know language of menuitem
- Apply patch
- Now you can know language of menuitem
### Other

I wanted to add flag picture but choosen dont allow that :/
### Preview

![Preview](http://issues.joomla.org/uploads/1/00a4996979c5b19dbd4eb4a93ff7721b.jpg)
