### PR TITLE
A11Y blog categories article count

### DIFF
--- a/components/com_contact/views/categories/tmpl/default_items.php
+++ b/components/com_contact/views/categories/tmpl/default_items.php
@@ -29,6 +29,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTACT_NUM_ITEMS'); ?>">
+							<?php echo JText::_('COM_CONTACT_NUM_ITEMS'); ?>&nbsp;
 							<?php echo $item->numitems; ?>
 						</span>
 					<?php endif; ?>

--- a/components/com_content/views/category/tmpl/blog_children.php
+++ b/components/com_content/views/category/tmpl/blog_children.php
@@ -44,6 +44,7 @@ if (count($this->children[$this->category->id]) > 0 && $this->maxLevel != 0) : ?
 				<?php echo $this->escape($child->title); ?></a>
 				<?php if ( $this->params->get('show_cat_num_articles', 1)) : ?>
 					<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTENT_NUM_ITEMS'); ?>">
+						<?php echo JText::_('COM_CONTENT_NUM_ITEMS'); ?>&nbsp;
 						<?php echo $child->getNumItems(true); ?>
 					</span>
 				<?php endif; ?>

--- a/components/com_newsfeeds/views/categories/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/categories/tmpl/default_items.php
@@ -29,6 +29,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 					<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_NEWSFEEDS_NUM_ITEMS'); ?>">
+							<?php echo JText::_('COM_NEWSFEEDS_NUM_ITEMS'); ?>&nbsp;
 							<?php echo $item->numitems; ?>
 						</span>
 					<?php endif; ?>


### PR DESCRIPTION
The Problem: Jaws does not read title tags into the span tag. So the screenreader will only read the number and not the title which discribes the number. Jaws is the most used screenreader in Germany. A lot of blind people reported me this issue.

To create the issue:
-> Use a template without overrides for blog_children in com_content, default_items in com_newsfeeds and default_items in com_contact
-> Make a categorie and subcategories in each
-> Put articles, newsfeeds and contacts into the categories and subcategories
-> create a menu item as an article categorie blog view, newsfeeds categories view and contact categories view
-> Set the following options in the menulink: -> tab Category -> subcategories levels: all
                                                                                        -> #Articles in category: Show
    for each.
Let JAWS read this and you will not hear the title tag.

Now apply the patch and you will see and hear.
Markus
