### PR TITLE
Directly set $feed_email in configuration.php created during installation

### DIFF
--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -134,6 +134,8 @@ class InstallationModelConfiguration extends JModelBase
 
 		// Feed settings.
 		$registry->set('feed_limit', 10);
+		$registry->set('feed_email', 'author');
+		
 		$registry->set('log_path', JPATH_ROOT . '/logs');
 		$registry->set('tmp_path', JPATH_ROOT . '/tmp');
 

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -135,7 +135,7 @@ class InstallationModelConfiguration extends JModelBase
 		// Feed settings.
 		$registry->set('feed_limit', 10);
 		$registry->set('feed_email', 'author');
-		
+
 		$registry->set('log_path', JPATH_ROOT . '/logs');
 		$registry->set('tmp_path', JPATH_ROOT . '/tmp');
 

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -134,7 +134,7 @@ class InstallationModelConfiguration extends JModelBase
 
 		// Feed settings.
 		$registry->set('feed_limit', 10);
-		$registry->set('feed_email', 'author');
+		$registry->set('feed_email', 'none');
 
 		$registry->set('log_path', JPATH_ROOT . '/logs');
 		$registry->set('tmp_path', JPATH_ROOT . '/tmp');


### PR DESCRIPTION
Hello
IMHO configuration.php created during the installation should not differ as to set the value of this created after saving the global settings without making any changes immediately after installation. This PR sets a the default setting that display RSS email address = author. If PR #7411 by @pe7er to be approved before my then this PR will need to be adjusted.
