### PR TITLE
Don't add alt links for newsfeed category view (Fix #7912)

### DIFF
--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -45,7 +45,7 @@ class NewsfeedsViewCategory extends JViewCategory
 	 */
 	public function display($tpl = null)
 	{
-		parent::commonCategoryDisplay();
+		$this->commonCategoryDisplay();
 
 		// Prepare the data.
 		// Compute the newsfeed slug.
@@ -69,6 +69,7 @@ class NewsfeedsViewCategory extends JViewCategory
 	protected function prepareDocument()
 	{
 		parent::prepareDocument();
+
 		$id = (int) @$menu->query['id'];
 
 		$menu = $this->menu;
@@ -91,7 +92,5 @@ class NewsfeedsViewCategory extends JViewCategory
 				$this->pathway->addItem($item['title'], $item['link']);
 			}
 		}
-
-		parent::addFeed();
 	}
 }


### PR DESCRIPTION
See #7912 for details

---
#### Steps to reproduce the issue

1) new clean Installation of Joomla 3.4.4 package nothing else
2) in Backend -> Create a newsfeed category and create a news feed item and assign to the new category 
3) Create a menu item, type: News Feeds » List News Feeds in a Category 
4) open then your site & Navigate to your newsfeed category item in frontend 

![screen shot 2015-09-19 at 14 45 52](http://issues.joomla.org/uploads/1/a06b40f5a18edbfefafcce20853397bc.png)

5) see the source code generated by Joomla for this site within the RSS & Atom links 

![screen shot 2015-09-19 at 14 46 14](http://issues.joomla.org/uploads/1/e7ebe4bf6546bf3681661679582891dd.png)

6) follow the rss & atom link and you will get: 500 View not found [name, type, prefix]: category, feed, newsfeedsView

![screen shot 2015-09-19 at 14 46 29](http://issues.joomla.org/uploads/1/ba36d3a8c76a76211e8a2870e533316e.png)
#### Expected result

i think there are 2 option a) there is a view for Newsfeed categories again as in older Versions of Joomla or b) avoid html output of broken rss/atom links 
#### Actual result

Error Page 500 View not found [name, type, prefix]: category, feed, newsfeedsView

Call stack
1   JApplicationCms->execute()  C:\xampp\htdocs\joomla\index.php:45
2   JApplicationSite->doExecute()   C:\xampp\htdocs\joomla\libraries\cms\application\cms.php:252
3   JApplicationSite->dispatch()    C:\xampp\htdocs\joomla\libraries\cms\application\site.php:230
4   JComponentHelper::renderComponent() C:\xampp\htdocs\joomla\libraries\cms\application\site.php:191
5   JComponentHelper::executeComponent()    C:\xampp\htdocs\joomla\libraries\cms\component\helper.php:372
6   require_once()  C:\xampp\htdocs\joomla\libraries\cms\component\helper.php:392
7   JControllerLegacy->execute()    C:\xampp\htdocs\joomla\components\com_newsfeeds\newsfeeds.php:16
8   NewsfeedsController->display()  C:\xampp\htdocs\joomla\libraries\legacy\controller\legacy.php:728
9   JControllerLegacy->display()    C:\xampp\htdocs\joomla\components\com_newsfeeds\controller.php:47
10  JControllerLegacy->getView()    C:\xampp\htdocs\joomla\libraries\legacy\controller\legacy.php:645
#### System information (as much as possible)

Joomla 3.4.4 new installation out of the box
tested local within xampp & live apache webserver under Linux
tested different PHP Versions 5.3 -> 5.6
#### Additional comments

I searched around and this seems to be an old recurring issue with no satisfying answer.
my intension is to point out that joomla generates broken links for newsfeeds category view (even if this function was never forseen to have it as mentioned in older Bugtracker entrys) out of the box and it has nothing to do with the function of displaying external Feeds or feeds from content. Above I described how I did it and also Attached some snapshots to make it more clear. 

Well this broken links are recogniced by Search engines and it should not be the case to have broken links by design... 
