### PR TITLE
Protostar template markup output as HTML5.

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -26,6 +26,9 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
+// output as HTML5
+$doc->setHtml5(true);
+
 if($task == "edit" || $layout == "form" )
 {
 	$fullWidth = 1;

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -26,7 +26,7 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
-// output as HTML5
+// Output as HTML5
 $doc->setHtml5(true);
 
 if($task == "edit" || $layout == "form" )


### PR DESCRIPTION
We have setHtml5 function [in core](https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/document/html/html.php#L337)
Why we aren't use it in default template? It's 2016 year on yard...
