### PR TITLE
Needs to specify the fieldset name 'params'

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $app       = JFactory::getApplication();
 $form      = $displayData->getForm();
-$fieldSets = $form->getFieldsets();
+$fieldSets = $form->getFieldsets('params');
 
 if (empty($fieldSets))
 {


### PR DESCRIPTION
The fieldset 'params' needs to specified here, otherwise all fieldsets of the entire form will be rendered here, causing all kinds of unwanted behaviour like displaying the layout for the basic data twice and thus rendering the editor unsable for instance. This looks like a regression to me. Unless I am doing something wrong. However, when specifying JLayoutHelper::render('joomla.edit.params'); I expect to see only the layout for the params fieldset and not the other fieldsets like basic data and metadata.
