### PR TITLE
Add html data to the html array instead of echoing

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -89,7 +89,7 @@ else
 		{
 			foreach ($form->getFieldset($name) as $field)
 			{
-				echo $field->input;
+				$html[] = $field->input;
 			}
 		}
 	}


### PR DESCRIPTION
Instead of echoing the input field in place, the html code for the input field should be added to the html array otherwise the html code will end up outside of the intended div.
