### PR TITLE
Reimplementing CPanel modules automatic title (fix for https://github.com/joomla/joomla-cms/issues/7917 )

### DIFF
--- a/administrator/modules/mod_latest/mod_latest.php
+++ b/administrator/modules/mod_latest/mod_latest.php
@@ -13,4 +13,10 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $list = ModLatestHelper::getList($params);
+
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModLatestHelper::getTitle($params);
+}
+
 require JModuleHelper::getLayoutPath('mod_latest', $params->get('layout', 'default'));

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -96,9 +96,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -88,6 +88,18 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
+				<field
+					name="automatic_title"
+					type="radio"
+					class="btn-group btn-group-yesno"
+					default="0"
+					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
+					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
+					<option
+						value="0">JNO</option>
+					<option
+						value="1">JYES</option>
+				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/administrator/modules/mod_logged/mod_logged.php
+++ b/administrator/modules/mod_logged/mod_logged.php
@@ -14,4 +14,9 @@ require_once __DIR__ . '/helper.php';
 
 $users = ModLoggedHelper::getList($params);
 
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModLoggedHelper::getTitle($params);
+}
+
 require JModuleHelper::getLayoutPath('mod_logged', $params->get('layout', 'default'));

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -62,8 +62,19 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
+				<field
+					name="automatic_title"
+					type="radio"
+					class="btn-group btn-group-yesno"
+					default="0"
+					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
+					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
+					<option
+						value="0">JNO</option>
+					<option
+						value="1">JYES</option>
+				</field>
 			</fieldset>
 		</fields>
 	</config>
 </extension>
-

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -70,9 +70,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_popular/mod_popular.php
+++ b/administrator/modules/mod_popular/mod_popular.php
@@ -15,5 +15,10 @@ require_once __DIR__ . '/helper.php';
 // Get module data.
 $list = ModPopularHelper::getList($params);
 
+if ($params->get('automatic_title', 0))
+{
+	$module->title = ModPopularHelper::getTitle($params);
+}
+
 // Render the module
 require JModuleHelper::getLayoutPath('mod_popular', $params->get('layout', 'default'));

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -85,9 +85,9 @@
 					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
 					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
 					<option
-						value="0">JNO</option>
-					<option
 						value="1">JYES</option>
+					<option
+						value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -77,6 +77,18 @@
 					<option
 						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
+				<field
+					name="automatic_title"
+					type="radio"
+					class="btn-group btn-group-yesno"
+					default="0"
+					label="COM_MODULES_FIELD_AUTOMATIC_TITLE_LABEL"
+					description="COM_MODULES_FIELD_AUTOMATIC_TITLE_DESC">
+					<option
+						value="0">JNO</option>
+					<option
+						value="1">JYES</option>
+				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/administrator/modules/mod_quickicon/helper.php
+++ b/administrator/modules/mod_quickicon/helper.php
@@ -201,6 +201,7 @@ abstract class ModQuickIconHelper
 	 * @param   JObject  $module  The module.
 	 *
 	 * @return  string	The alternate title for the module.
+	 * @deprecated  4.0 Unused. Title can be adjusted in module itself if needed.
 	 */
 	public static function getTitle($params, $module)
 	{

--- a/administrator/modules/mod_quickicon/helper.php
+++ b/administrator/modules/mod_quickicon/helper.php
@@ -201,6 +201,7 @@ abstract class ModQuickIconHelper
 	 * @param   JObject  $module  The module.
 	 *
 	 * @return  string	The alternate title for the module.
+	 *
 	 * @deprecated  4.0 Unused. Title can be adjusted in module itself if needed.
 	 */
 	public static function getTitle($params, $module)

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -192,20 +192,6 @@ abstract class JModuleHelper
 			ob_end_clean();
 		}
 
-		// Automatic title
-		if ($params->get('automatic_title', '0') == '0')
-		{
-			$module->title = $module->title;
-		}
-		elseif (method_exists('mod' . $module->name . 'Helper', 'getTitle'))
-		{
-			$module->title = call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params));
-		}
-		else
-		{
-			$module->title = JText::_('MOD_' . $module->name . '_TITLE');
-		}
-
 		// Load the module chrome functions
 		if (!$chrome)
 		{

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -192,6 +192,20 @@ abstract class JModuleHelper
 			ob_end_clean();
 		}
 
+		// Automatic title
+		if ($params->get('automatic_title', '0') == '0')
+		{
+			$module->title = $module->title;
+		}
+		elseif (method_exists('mod' . $module->name . 'Helper', 'getTitle'))
+		{
+			$module->title = call_user_func_array(array('mod' . $module->name . 'Helper', 'getTitle'), array($params));
+		}
+		else
+		{
+			$module->title = JText::_('MOD_' . $module->name . '_TITLE');
+		}
+
 		// Load the module chrome functions
 		if (!$chrome)
 		{


### PR DESCRIPTION
No idea why, but the automatic title used in 2.5 for the CPanel modules (Logged users, Popular articles and Latest articles) was taken off from version 3.x on. See  https://github.com/joomla/joomla-cms/issues/7917 

The strings have remained in core. The code exists in each module helper. Just remained to add the field in the xmls and the code in JModuleHelper.

This is what we now get after patch IF the Automatic Title parameter is set to Yes for these modules in their Advanced tab.
![screen shot 2015-09-21 at 11 45 17](https://cloud.githubusercontent.com/assets/869724/9989516/50c9bd82-6059-11e5-9f2e-d0252a8ecaac.png)
