### PR TITLE
Update query.php to have MySQL REPLACE command...

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -208,6 +208,12 @@ abstract class JDatabaseQuery
 	 * @since  11.1
 	 */
 	protected $set = null;
+	
+	/**
+	 * @var    JDatabaseQueryElement  The replace element.
+	 * @since  11.1
+	 */
+	protected $replace = null;
 
 	/**
 	 * @var    JDatabaseQueryElement  The where element.
@@ -420,6 +426,11 @@ abstract class JDatabaseQuery
 				}
 
 				$query .= (string) $this->set;
+				
+				if ($this->replace)
+				{
+					$query .= (string) $this->replace;
+				}
 
 				if ($this->where)
 				{
@@ -1399,6 +1410,24 @@ abstract class JDatabaseQuery
 		else
 		{
 			$this->set->append($conditions);
+		}
+
+		return $this;
+	}
+	
+	/**
+	 * Add the MySQL function REPLACE
+	 */
+	public function replace($conditions, $glue = ',')
+	{
+		if (is_null($this->replace))
+		{
+			$glue = strtoupper($glue);
+			$this->replace = new JDatabaseQueryElement('= REPLACE', $conditions, "\n\t$glue ");
+		}
+		else
+		{
+			$this->replace->append($conditions);
 		}
 
 		return $this;

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -208,7 +208,7 @@ abstract class JDatabaseQuery
 	 * @since  11.1
 	 */
 	protected $set = null;
-	
+
 	/**
 	 * @var    JDatabaseQueryElement  The replace element.
 	 * @since  11.1
@@ -426,7 +426,7 @@ abstract class JDatabaseQuery
 				}
 
 				$query .= (string) $this->set;
-				
+
 				if ($this->replace)
 				{
 					$query .= (string) $this->replace;
@@ -1414,9 +1414,20 @@ abstract class JDatabaseQuery
 
 		return $this;
 	}
-	
+
 	/**
 	 * Add the MySQL function REPLACE
+	 *
+	 * Usage:
+	 * $query->replace(*some example here*);
+	 *
+	 * @param   mixed   $conditions  A string or array of string conditions.
+	 * @param   string  $glue        The glue by which to join the condition strings. Defaults to ,.
+	 *                               Note that the glue is set on first use and cannot be changed.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   11.1
 	 */
 	public function replace($conditions, $glue = ',')
 	{


### PR DESCRIPTION
For example if i want to turn off help menu in joomla backend i´ll do something like this:

``` php
//Replacing a Record

$db = JFactory::getDbo();

$query = $db->getQuery(true);


$query->update($db->quoteName('#__modules'))

      ->set($db->quoteName('params'))

      ->replace('(`params`, \'showhelp\":\"1\', \'showhelp\":\"0\')')

      ->where('id' ."=" .'12');


$db->setQuery($query);

$result = $db->execute();
```
