### PR TITLE
[FIX] Extension names are not set properly with JText in the Update Sites view

### DIFF
--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -92,7 +92,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</td>
 						<td>
 							<label for="cb<?php echo $i; ?>">
-								<?php echo $item->update_site_name; ?>
+								<?php echo JText::_($item->update_site_name); ?>
 								<br />
 								<span class="small">
 									<a href="<?php echo $item->location; ?>" target="_blank"><?php echo $this->escape($item->location); ?></a>


### PR DESCRIPTION
In **Extensions - Manage - Update Sites** the names of the extensions are not set properly if the language string variable is used for the name attribute in the server tag in the manifest xml file of the corresponding extension.

_Before patch:_
![2015-09-23 21_42_15-dev joomla 3 - administration - extensions_ update sites](https://cloud.githubusercontent.com/assets/1976103/10056654/5966c2de-623c-11e5-9e2f-e601e4358754.png)

_After patch:_
![2015-09-23 21_43_12-dev joomla 3 - administration - extensions_ update sites](https://cloud.githubusercontent.com/assets/1976103/10056658/5fc22484-623c-11e5-8fa7-512d8ceebfec.png)

**How to test**
1. Install for example this extension: https://joomla-extensions.kubik-rubik.de/downloads/efseo-easy-frontend-seo/joomla-3
2. Check the name in **Extensions - Manage - Update Sites**
3. Apply patch and reload the page
