### PR TITLE
Fix com_contact > created vcf in contactform can´t handle german umlauts (issue #7937)

### DIFF
--- a/components/com_contact/views/contact/view.vcf.php
+++ b/components/com_contact/views/contact/view.vcf.php
@@ -88,26 +88,24 @@ class ContactViewContact extends JViewLegacy
 
 		$rev = date('c', strtotime($item->modified));
 
-        JFactory::getApplication()->setHeader('Content-disposition', 'attachment; filename="' . utf8_decode($card_name) . '.vcf"', true);
+		JFactory::getApplication()->setHeader('Content-disposition', 'attachment; filename="' . utf8_decode($card_name) . '.vcf"', true);
 
-        $vcard = array();
-        $vcard[].= 'BEGIN:VCARD';
-        $vcard[].= 'VERSION:3.0';
-        $vcard[] = 'N:'. utf8_decode($lastname.';'.$firstname.';'.$middlename);
-        /* Zeichensatz auf UTF-8 geändert -> */
-        $vcard[] = 'FN:'. utf8_decode($item->name);
-        $vcard[] = 'TITLE:'. utf8_decode($item->con_position);
-        /* <- Zeichensatz auf UTF-8 geändert */
-        $vcard[] = 'TEL;TYPE=WORK,VOICE:'.$item->telephone;
-        $vcard[] = 'TEL;TYPE=WORK,FAX:'.$item->fax;
-        $vcard[] = 'TEL;TYPE=WORK,MOBILE:'.$item->mobile;
-        $vcard[] = 'ADR;TYPE=WORK:;;'. utf8_decode($item->address.';'.$item->suburb.';'.$item->state.';'.$item->postcode.';'.$item->country);
-        $vcard[] = 'LABEL;TYPE=WORK:'. utf8_decode($item->address."\n".$item->suburb."\n".$item->state."\n".$item->postcode."\n".$item->country);
-        $vcard[] = 'EMAIL;TYPE=PREF,INTERNET:'.$item->email_to;
-        $vcard[] = 'URL:'.$item->webpage;
-        $vcard[] = 'REV:'.$rev.'Z';
-        $vcard[] = 'END:VCARD';
+		$vcard = array();
+		$vcard[].= 'BEGIN:VCARD';
+		$vcard[].= 'VERSION:3.0';
+		$vcard[] = 'N:' . utf8_decode($lastname . ';' . $firstname . ';' . $middlename);
+		$vcard[] = 'FN:' . utf8_decode($item->name);
+		$vcard[] = 'TITLE:' . utf8_decode($item->con_position);
+		$vcard[] = 'TEL;TYPE=WORK,VOICE:' . $item->telephone;
+		$vcard[] = 'TEL;TYPE=WORK,FAX:' . $item->fax;
+		$vcard[] = 'TEL;TYPE=WORK,MOBILE:' . $item->mobile;
+		$vcard[] = 'ADR;TYPE=WORK:;;' . utf8_decode($item->address . ';' . $item->suburb . ';' . $item->state . ';' . $item->postcode . ';' . $item->country);
+		$vcard[] = 'LABEL;TYPE=WORK:' . utf8_decode($item->address . "\n" . $item->suburb . "\n" . $item->state . "\n" . $item->postcode . "\n" . $item->country);
+		$vcard[] = 'EMAIL;TYPE=PREF,INTERNET:' . $item->email_to;
+		$vcard[] = 'URL:' . $item->webpage;
+		$vcard[] = 'REV:' . $rev . 'Z';
+		$vcard[] = 'END:VCARD';
 
-        echo implode("\n", $vcard);
+		echo implode("\n", $vcard);
 	}
 }

--- a/components/com_contact/views/contact/view.vcf.php
+++ b/components/com_contact/views/contact/view.vcf.php
@@ -91,16 +91,18 @@ class ContactViewContact extends JViewLegacy
 		JFactory::getApplication()->setHeader('Content-disposition', 'attachment; filename="' . utf8_decode($card_name) . '.vcf"', true);
 
 		$vcard = array();
-		$vcard[].= 'BEGIN:VCARD';
-		$vcard[].= 'VERSION:3.0';
+		$vcard[] .= 'BEGIN:VCARD';
+		$vcard[] .= 'VERSION:3.0';
 		$vcard[] = 'N:' . utf8_decode($lastname . ';' . $firstname . ';' . $middlename);
 		$vcard[] = 'FN:' . utf8_decode($item->name);
 		$vcard[] = 'TITLE:' . utf8_decode($item->con_position);
 		$vcard[] = 'TEL;TYPE=WORK,VOICE:' . $item->telephone;
 		$vcard[] = 'TEL;TYPE=WORK,FAX:' . $item->fax;
 		$vcard[] = 'TEL;TYPE=WORK,MOBILE:' . $item->mobile;
-		$vcard[] = 'ADR;TYPE=WORK:;;' . utf8_decode($item->address . ';' . $item->suburb . ';' . $item->state . ';' . $item->postcode . ';' . $item->country);
-		$vcard[] = 'LABEL;TYPE=WORK:' . utf8_decode($item->address . "\n" . $item->suburb . "\n" . $item->state . "\n" . $item->postcode . "\n" . $item->country);
+		$vcard[] = 'ADR;TYPE=WORK:;;' . utf8_decode($item->address . ';' . $item->suburb . ';'
+				. $item->state . ';' . $item->postcode . ';' . $item->country);
+		$vcard[] = 'LABEL;TYPE=WORK:' . utf8_decode($item->address . "\n" . $item->suburb 
+				. "\n" . $item->state . "\n" . $item->postcode . "\n" . $item->country);
 		$vcard[] = 'EMAIL;TYPE=PREF,INTERNET:' . $item->email_to;
 		$vcard[] = 'URL:' . $item->webpage;
 		$vcard[] = 'REV:' . $rev . 'Z';

--- a/components/com_contact/views/contact/view.vcf.php
+++ b/components/com_contact/views/contact/view.vcf.php
@@ -88,24 +88,26 @@ class ContactViewContact extends JViewLegacy
 
 		$rev = date('c', strtotime($item->modified));
 
-		JFactory::getApplication()->setHeader('Content-disposition', 'attachment; filename="' . $card_name . '.vcf"', true);
+        JFactory::getApplication()->setHeader('Content-disposition', 'attachment; filename="' . utf8_decode($card_name) . '.vcf"', true);
 
-		$vcard = array();
-		$vcard[] .= 'BEGIN:VCARD';
-		$vcard[] .= 'VERSION:3.0';
-		$vcard[]  = 'N:' . $lastname . ';' . $firstname . ';' . $middlename;
-		$vcard[]  = 'FN:' . $item->name;
-		$vcard[]  = 'TITLE:' . $item->con_position;
-		$vcard[]  = 'TEL;TYPE=WORK,VOICE:' . $item->telephone;
-		$vcard[]  = 'TEL;TYPE=WORK,FAX:' . $item->fax;
-		$vcard[]  = 'TEL;TYPE=WORK,MOBILE:' . $item->mobile;
-		$vcard[]  = 'ADR;TYPE=WORK:;;' . $item->address . ';' . $item->suburb . ';' . $item->state . ';' . $item->postcode . ';' . $item->country;
-		$vcard[]  = 'LABEL;TYPE=WORK:' . $item->address . "\n" . $item->suburb . "\n" . $item->state . "\n" . $item->postcode . "\n" . $item->country;
-		$vcard[]  = 'EMAIL;TYPE=PREF,INTERNET:' . $item->email_to;
-		$vcard[]  = 'URL:' . $item->webpage;
-		$vcard[]  = 'REV:' . $rev . 'Z';
-		$vcard[]  = 'END:VCARD';
+        $vcard = array();
+        $vcard[].= 'BEGIN:VCARD';
+        $vcard[].= 'VERSION:3.0';
+        $vcard[] = 'N:'. utf8_decode($lastname.';'.$firstname.';'.$middlename);
+        /* Zeichensatz auf UTF-8 geändert -> */
+        $vcard[] = 'FN:'. utf8_decode($item->name);
+        $vcard[] = 'TITLE:'. utf8_decode($item->con_position);
+        /* <- Zeichensatz auf UTF-8 geändert */
+        $vcard[] = 'TEL;TYPE=WORK,VOICE:'.$item->telephone;
+        $vcard[] = 'TEL;TYPE=WORK,FAX:'.$item->fax;
+        $vcard[] = 'TEL;TYPE=WORK,MOBILE:'.$item->mobile;
+        $vcard[] = 'ADR;TYPE=WORK:;;'. utf8_decode($item->address.';'.$item->suburb.';'.$item->state.';'.$item->postcode.';'.$item->country);
+        $vcard[] = 'LABEL;TYPE=WORK:'. utf8_decode($item->address."\n".$item->suburb."\n".$item->state."\n".$item->postcode."\n".$item->country);
+        $vcard[] = 'EMAIL;TYPE=PREF,INTERNET:'.$item->email_to;
+        $vcard[] = 'URL:'.$item->webpage;
+        $vcard[] = 'REV:'.$rev.'Z';
+        $vcard[] = 'END:VCARD';
 
-		echo implode("\n", $vcard);
+        echo implode("\n", $vcard);
 	}
 }


### PR DESCRIPTION
Steps to reproduce the issue

Put in some contact information with ß ä ö ü inside and enable the Option .vcf for the contact view.
Download the vcf

Expected result

The vcf should contain the umlauts.

Actual result

On Apple devices the umlauts are shown correctly but but not in outlook on windows.

System information (as much as possible)

Additional comments

I added utf8decoding in the code, that fixes the problem. As i´m not a developer please review also the way how i fixed it.

This fixes issue: https://github.com/joomla/joomla-cms/issues/7937
