### PR TITLE
Update recaptcha.php for correct override $code use in function onCheckanwser

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -118,26 +118,34 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			case '1.0':
 				$challenge = $input->get('recaptcha_challenge_field', '', 'string');
-				
- 				//We check the override $code param
-                                if (!empty($code))
-                      		    $response = $code;
-                		else
-         			    $response  = $input->get('recaptcha_response_field', '', 'string');
 
-				$spam      = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
+				// We check the override $code param
+                                if (!empty($code))
+                                {
+					$response = $code;
+                                }
+				else
+				{
+					$response = $input->get('recaptcha_response_field', '', 'string');
+				}
+
+				$spam = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-				
- 				//We check the override $code param
-		                if (!empty($code))
-                		      $response = $code;
-                		else
-         			      $response  = $input->get('g-recaptcha-response', '', 'string');
-				
-				$spam      = ($response == null || strlen($response) == 0);
+
+				// We check the override $code param
+                                if (!empty($code))
+                                {
+					$response = $code;
+                                }
+				else
+				{
+					$response = $input->get('g-recaptcha-response', '', 'string');
+				}
+
+				$spam = ($response == null || strlen($response) == 0);
 				break;
 		}
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -118,13 +118,25 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			case '1.0':
 				$challenge = $input->get('recaptcha_challenge_field', '', 'string');
-				$response  = $input->get('recaptcha_response_field', '', 'string');
+				
+ 				//We check the override $code param
+                                if (!empty($code))
+                      		    $response = $code;
+                		else
+         			    $response  = $input->get('recaptcha_response_field', '', 'string');
+
 				$spam      = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-				$response  = $input->get('g-recaptcha-response', '', 'string');
+				
+ 				//We check the override $code param
+		                if (!empty($code))
+                		      $response = $code;
+                		else
+         			      $response  = $input->get('g-recaptcha-response', '', 'string');
+				
 				$spam      = ($response == null || strlen($response) == 0);
 				break;
 		}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -128,13 +128,13 @@ class PlgCaptchaRecaptcha extends JPlugin
 				{
 					$response = $input->get('recaptcha_response_field', '', 'string');
 				}
-				
+
 				$spam = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-				
+
 				// We check the override $code param
 				if (!empty($code))
 				{
@@ -144,7 +144,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 				{
 					$response = $input->get('g-recaptcha-response', '', 'string');
 				}
-				
+
 				$spam = ($response == null || strlen($response) == 0);
 				break;
 		}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -120,31 +120,31 @@ class PlgCaptchaRecaptcha extends JPlugin
 				$challenge = $input->get('recaptcha_challenge_field', '', 'string');
 
 				// We check the override $code param
-                                if (!empty($code))
-                                {
+				if (!empty($code))
+				{
 					$response = $code;
-                                }
+				}
 				else
 				{
 					$response = $input->get('recaptcha_response_field', '', 'string');
 				}
-
+				
 				$spam = ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0);
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-
+				
 				// We check the override $code param
-                                if (!empty($code))
-                                {
+				if (!empty($code))
+				{
 					$response = $code;
-                                }
+				}
 				else
 				{
 					$response = $input->get('g-recaptcha-response', '', 'string');
 				}
-
+				
 				$spam = ($response == null || strlen($response) == 0);
 				break;
 		}


### PR DESCRIPTION
Pull request based on the issue tracked as zero-24 asked:

http://issues.joomla.org/tracker/joomla-cms/7921

---
#### Steps to reproduce the issue

Use recaptcha plugin in custom component. Use multiple instances of it so each instance has it's own input name.

When you call the recaptcha plugin to validate you can pass the $code to validate instead of the "standard" code from input.

see the function declaration: public function onCheckAnswer(**$code = null**)

e.g.

$alldata = JFactory::getApplication()->input;
$cresponse     = $alldata->get('grecaptcharesponse','','string'); //here we have the catcha code to validate

  //call captcha plugin to validate code
  JPluginHelper::importPlugin('captcha');
  $dispatcher = JEventDispatcher::getInstance();  
  $res = $dispatcher->trigger('onCheckAnswer',$cresponse);
### Expected result

A true validation of the $cresponce
#### Actual result

Always false
#### System information (as much as possible)

Joomla! 3.4.4 Stable [ Ember ] 8-September-2015 21:30 GMT
PHP: 5.4.43
Mysql: 5.5.42-37.1-log
#### Additional comments

The issue is on the onCheckReponse function of the captch plugin where has the $code param that your are able to pass but in true code the $code param is totally ignored.

I have a solution to propose that working ok:

in /plugins/captcha/recaptcha.php replace (about line 127):

$response  = $input->get('g-recaptcha-response', '', 'string');

with:

 if (!empty($code))
     $response = $code;
 else
     $response  = $input->get('g-recaptcha-response', '', 'string');                

And issue will be solved.

thanks and i hope helped

christopher
