### PR TITLE
Show a message in the installer regarding PHP version support

### DIFF
--- a/installation/language/en-AU/en-AU.ini
+++ b/installation/language/en-AU/en-AU.ini
@@ -266,6 +266,14 @@ INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_ZLIB_COMPRESSION_SUPPORT="Zlib Compression Support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait..."
 
+;PHP Support Status
+INSTL_PHP_MESSAGE_SECURITY_ONLY="Your PHP version, %1$s, is only receiving security fixes at this time. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on %2$s. Please contact your host for upgrade instructions."
+INSTL_PHP_MESSAGE_UNSUPPORTED="Your PHP version, %1$s, is no longer supported by the PHP project. Support for this version of PHP ended on %2$s. We highly recommend upgrading your server to a newer PHP version. Please contact your host for upgrade instructions."
+INSTL_PHP_VERSION_SUPPORT="PHP Version Support"
+
+;Date Format
+DATE_FORMAT_LC4="Y-m-d"
+
 ;Global strings
 JADMINISTRATOR="Administrator"
 JCHECK_AGAIN="Check Again"

--- a/installation/language/en-CA/en-CA.ini
+++ b/installation/language/en-CA/en-CA.ini
@@ -266,6 +266,14 @@ INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_ZLIB_COMPRESSION_SUPPORT="Zlib Compression Support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait..."
 
+;PHP Support Status
+INSTL_PHP_MESSAGE_SECURITY_ONLY="Your PHP version, %1$s, is only receiving security fixes at this time. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on %2$s. Please contact your host for upgrade instructions."
+INSTL_PHP_MESSAGE_UNSUPPORTED="Your PHP version, %1$s, is no longer supported by the PHP project. Support for this version of PHP ended on %2$s. We highly recommend upgrading your server to a newer PHP version. Please contact your host for upgrade instructions."
+INSTL_PHP_VERSION_SUPPORT="PHP Version Support"
+
+;Date Format
+DATE_FORMAT_LC4="Y-m-d"
+
 ;Global strings
 JADMINISTRATOR="Administrator"
 JCHECK_AGAIN="Check Again"

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -264,6 +264,14 @@ INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_ZLIB_COMPRESSION_SUPPORT="Zlib Compression Support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait ..."
 
+;PHP Support Status
+INSTL_PHP_MESSAGE_SECURITY_ONLY="Your PHP version, %1$s, is only receiving security fixes at this time. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on %2$s. Please contact your host for upgrade instructions."
+INSTL_PHP_MESSAGE_UNSUPPORTED="Your PHP version, %1$s, is no longer supported by the PHP project. Support for this version of PHP ended on %2$s. We highly recommend upgrading your server to a newer PHP version. Please contact your host for upgrade instructions."
+INSTL_PHP_VERSION_SUPPORT="PHP Version Support"
+
+;Date Format
+DATE_FORMAT_LC4="Y-m-d"
+
 ;Global strings
 JADMINISTRATOR="Administrator"
 JCHECK_AGAIN="Check Again"

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -266,6 +266,14 @@ INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_ZLIB_COMPRESSION_SUPPORT="Zlib Compression Support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait..."
 
+;PHP Support Status
+INSTL_PHP_MESSAGE_SECURITY_ONLY="Your PHP version, %1$s, is only receiving security fixes at this time. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on %2$s. Please contact your host for upgrade instructions."
+INSTL_PHP_MESSAGE_UNSUPPORTED="Your PHP version, %1$s, is no longer supported by the PHP project. Support for this version of PHP ended on %2$s. We highly recommend upgrading your server to a newer PHP version. Please contact your host for upgrade instructions."
+INSTL_PHP_VERSION_SUPPORT="PHP Version Support"
+
+;Date Format
+DATE_FORMAT_LC4="Y-m-d"
+
 ;Global strings
 JADMINISTRATOR="Administrator"
 JCHECK_AGAIN="Check Again"

--- a/installation/view/summary/html.php
+++ b/installation/view/summary/html.php
@@ -41,6 +41,14 @@ class InstallationViewSummaryHtml extends InstallationViewDefault
 	protected $phpsettings;
 
 	/**
+	 * The PHP support status checked by the installer
+	 *
+	 * @var    array
+	 * @since  3.5
+	 */
+	protected $phpsupport;
+
+	/**
 	 * Method to render the view.
 	 *
 	 * @return  string  The rendered view.
@@ -52,6 +60,7 @@ class InstallationViewSummaryHtml extends InstallationViewDefault
 		$this->options     = $this->model->getOptions();
 		$this->phpoptions  = $this->model->getPhpOptions();
 		$this->phpsettings = $this->model->getPhpSettings();
+		$this->phpsupport  = $this->model->getPhpSupport();
 
 		return parent::render();
 	}

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -28,6 +28,13 @@ $prev = $useftp ? 'ftp' : 'database';
 	<h3><?php echo JText::_('INSTL_FINALISATION'); ?></h3>
 	<hr class="hr-condensed" />
 
+	<?php // If the PHP version is not fully supported, display a message informing the user ?>
+	<?php if ($this->phpsupport['status'] !== InstallationModelSetup::PHP_SUPPORTED) : ?>
+		<div class="alert alert-info">
+			<h4><?php echo JText::_('INSTL_PHP_VERSION_SUPPORT'); ?></h4>
+			<?php echo $this->phpsupport['message']; ?>
+		</div>
+	<?php endif; ?>
 	<div class="control-group">
 		<div class="control-label">
 			<?php echo $this->form->getLabel('sample_file'); ?>


### PR DESCRIPTION
This PR adds an alert to the "Finalisation" page in the installer if the active PHP version is either no longer supported by the PHP project or is only receiving security fixes.  This is intended to inform users of the support status of their chosen PHP version and provide them with the data to make an informed upgrade decision.
### Test Instructions

You'll need to either download my `php-version-alert` branch from GitHub or patch your git clone of the CMS repository.  Once applied, run through the installer and when reaching the final page, you should see an alert similar to the below screenshots if you are running PHP 5.5 or earlier.  No alert is rendered for fully supported versions or versions we do not have support data for (i.e. the 7.0 release candidates).
### Maintenance Requirements

The `InstallationModelSetup::getPhpSupport()` method will need to be updated with new releases (approximately once a year) or if support dates for a version change.  This data should be acquired from [PHP.net](http://php.net/supported-versions.php).

Screenshots:
![screen shot 2015-09-24 at 10 02 01 am](https://cloud.githubusercontent.com/assets/368545/10075461/eb295a8a-62a3-11e5-8e19-4186a351d667.png)

![screen shot 2015-09-24 at 10 03 17 am](https://cloud.githubusercontent.com/assets/368545/10075472/f25030cc-62a3-11e5-8e43-f6f63498cc14.png)
