### PR TITLE
Adjust column widths in Admin Logged Users Module

### DIFF
--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>
 		<div class="row-fluid">
-			<div class="span9">
+			<div class="span7">
 				<?php if ($user->client_id == 0) : ?>
 					<a class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini">
 						<span class="icon-remove icon-white" title="<?php echo JText::_('JLOGOUT'); ?>"></span>
@@ -39,7 +39,7 @@ JHtml::_('bootstrap.tooltip');
 					<?php endif; ?>
 				</small>
 			</div>
-			<div class="span3">
+			<div class="span5">
 				<span class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
 					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC2')); ?>
 				</span>


### PR DESCRIPTION
Since the date format used in the Administrator mod_logged module was updated in PR #7402 to be DATE_FORMAT_LC2, when we have longer days (i.e. Wednesday) and longer months (i.e. September) in our date, it can break the column into 2 lines.

This PR adjusts the column widths to _(hopefully)_ prevent the breaking onto two lines of the longer date/time format now used.
### Before

![mod_logged_before](https://cloud.githubusercontent.com/assets/13225615/10076402/683455f2-62a9-11e5-8ce6-ce9ded97f5ac.png)
### After

![mod_logged_after](https://cloud.githubusercontent.com/assets/13225615/10076410/6bd6930a-62a9-11e5-8dcb-e6f3091e025d.png)
### To Test
1. Apply the patch to adjust the column widths.
2. The Module's date/time column should now be wider and the name column smaller. Hopefully preventing the breaking of longer dates.
