### PR TITLE
contact item access level fix #7944

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -327,7 +327,7 @@ class ContactModelContact extends JModelForm
 
 				if (empty($result))
 				{
-					throw new Exception(JText::_('COM_CONTACT_ERROR_CONTACT_NOT_FOUND'), 404);
+					return false;
 				}
 			}
 			catch (Exception $e)


### PR DESCRIPTION
#### Steps to reproduce the issue

create/edit a contact item and set the access level to registered fox example
then set a menu item to that contact item and access
reported  #7944 @waveywhite
#### Expected result

An error message  your not authorzied...
#### Actual result

![contact_ko](https://cloud.githubusercontent.com/assets/181681/10116879/6c922af2-6443-11e5-919d-78ce4137a7ba.png)
#### After patch

![contact_patch](https://cloud.githubusercontent.com/assets/181681/10116882/86ef170c-6443-11e5-8d9f-19f4cea020b2.png)
