### PR TITLE
Improper use of Joomla\Utilities\ArrayHelper::toInteger.

### DIFF
--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -268,7 +268,7 @@ class ContactModelContacts extends JModelList
 		}
 		elseif (is_array($categoryId))
 		{
-			Joomla\Utilities\ArrayHelper::toInteger($categoryId);
+			$categoryId = Joomla\Utilities\ArrayHelper::toInteger($categoryId);
 			$categoryId = implode(',', $categoryId);
 			$query->where($db->quoteName('a.catid') . ' IN (' . $categoryId . ')');
 		}


### PR DESCRIPTION
The method _**toInteger()**_ returns converted array.
