### PR TITLE
Move JDatabaseInterface into its own file

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -10,23 +10,6 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Joomla Platform Database Interface
- *
- * @since  11.2
-*/
-interface JDatabaseInterface
-{
-	/**
-	 * Test to see if the connector is available.
-	 *
-	 * @return  boolean  True on success, false otherwise.
-	 *
-	 * @since   11.2
-	 */
-	public static function isSupported();
-}
-
-/**
  * Joomla Platform Database Driver Class
  *
  * @since  12.1

--- a/libraries/joomla/database/interface.php
+++ b/libraries/joomla/database/interface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Database Interface
+ *
+ * @since  11.2
+*/
+interface JDatabaseInterface
+{
+	/**
+	 * Test to see if the connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   11.2
+	 */
+	public static function isSupported();
+}


### PR DESCRIPTION
This PR moves `JDatabaseInterface` to its own file to follow the one class per file rule.  Zero code changes are made at all.
### Testing Info

Apply patch and load a page in the CMS.  Since `JDatabaseDriver` implements this interface, if it doesn't get loaded, it'll be immediately evident.
