### PR TITLE
Unit test improvements

### DIFF
--- a/tests/unit/suites/libraries/joomla/base/JAdapterTest.php
+++ b/tests/unit/suites/libraries/joomla/base/JAdapterTest.php
@@ -66,7 +66,7 @@ class JAdapterTest extends TestCase
 
 		$this->assertThat(
 			$this->object->getDbo(),
-			$this->isInstanceOf('JDatabase')
+			$this->isInstanceOf('JDatabaseDriver')
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
@@ -1351,22 +1351,6 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Sets up the fixture.
-	 *
-	 * This method is called before a test is executed.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	protected function setUp()
-	{
-		parent::setUp();
-
-		require_once JPATH_PLATFORM . '/joomla/string/string.php';
-	}
-
-	/**
 	 * Tests the JArrayHelper::arrayUnique method.
 	 *
 	 * @param   array   $input     The array being input.


### PR DESCRIPTION
This just ports two minor unit tests improvements. First is to check for an instance of `JDatabaseDriver` rather than the deprecated `JDatabase` in the `JAdapter` unit test (in all other places in our test suite we check for `JDatabaseDriver` so this makes things consistent).

It also removes a require of the JString package. JString is autoloaded - so this require is completely unnecessary
