### PR TITLE
Newsfeed category image option [#7978]

### DIFF
--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -169,8 +169,8 @@
 			label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
 			description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
 		>
-	 		<option value="0">JHIDE</option>
 	 		<option value="1">JSHOW</option>
+	 		<option value="0">JHIDE</option>
 	 	</field>
 
 		<field name="maxLevel" type="list"


### PR DESCRIPTION
as reported  #7978
#### After patch

![jmongo administration news feed options](https://cloud.githubusercontent.com/assets/181681/10174070/1713999c-66e8-11e5-9c50-300fe95d9c12.png)
#### Additional comments

now the show (green) button of Category Image option is on the left
