### PR TITLE
[fix #7986] Problem in searching with space using chosen

### DIFF
--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -60,6 +60,12 @@ abstract class JHtmlFormbehavior
 			$options['disable_search_threshold'] = 10;
 		}
 
+		// Allow searching contains space in query
+		if (!isset($options['search_contains']))
+		{
+			$options['search_contains'] = true;
+		}
+
 		if (!isset($options['allow_single_deselect']))
 		{
 			$options['allow_single_deselect'] = true;


### PR DESCRIPTION
#### Steps to reproduce the issue
- Create a category having space in name. For example: "Events and Forms"
- Make sure you have more than 10 categories, if not try to copy it.
- Go to article create/edit page, In category selection try to search "event and "

![screen shot 2015-09-30 at 05 00 45](http://issues.joomla.org/uploads/1/483cba7e71c100824543e0f8b9d35905.png)
- Now, close the article edit page and go to article listing page. Select any article and click on batch button from toolbar and try to search "event and " like below and notice it is working.

![screen shot 2015-09-30 at 05 04 18](http://issues.joomla.org/uploads/1/f59d9073b5ee1e1f80d74c1d1e8980f8.png)
#### Expected result

It should looks like below in article edit page.
![screen shot 2015-09-30 at 05 05 36](http://issues.joomla.org/uploads/1/6435a326b0a44f88ce045cd4b6883849.png)
#### System information (as much as possible)

I have tested it in FF41.0 Ubuntu. But I believe it's not dependent on browser or OS.
