### PR TITLE
JApplicationHelper's clients variable is an array, process it as such

### DIFF
--- a/libraries/cms/application/helper.php
+++ b/libraries/cms/application/helper.php
@@ -22,7 +22,7 @@ class JApplicationHelper
 	 * @var    array
 	 * @since  1.6
 	 */
-	protected static $_clients = null;
+	protected static $_clients = array();
 
 	/**
 	 * Return the name of the request component [main component]
@@ -110,8 +110,8 @@ class JApplicationHelper
 	 */
 	public static function getClientInfo($id = null, $byName = false)
 	{
-		// Only create the array if it does not exist
-		if (self::$_clients === null)
+		// Only create the array if it is empty
+		if (empty(self::$_clients))
 		{
 			$obj = new stdClass;
 


### PR DESCRIPTION
`JApplicationHelper::$_clients` is documented and used as an array within the class except for its default value.  This PR changes the default value of this class variable to match the documented object type.
### Testing Instructions

With the patch applied, there should be no change in behavior within the CMS.
