### PR TITLE
Global Configuration. Option "Cache Handler:File" gets lost - [FiX]

### DIFF
--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -247,7 +247,23 @@ class JCacheStorageCachelite extends JCacheStorage
 					$clmode = $group;
 					self::$CacheLiteInstance->setOption('cacheDir', $this->_root . '/' . $group . '/');
 					$success = self::$CacheLiteInstance->clean($group, $clmode);
-					JFolder::delete($this->_root . '/' . $group);
+					// Remove sub-folders of folder; disable all filtering
+					$folders = JFolder::folders($this->_root . '/' . $group, '.', false, true, array(), array());
+
+					foreach ($folders as $folder)
+					{
+						if (is_link($folder))
+						{
+							if (JFile::delete($folder) !== true)
+							{
+								return false;
+							}
+						}
+						elseif (JFolder::delete($folder) !== true)
+						{
+							return false;
+						}
+					}
 				}
 				else
 				{

--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -233,6 +233,7 @@ class JCacheStorageCachelite extends JCacheStorage
 	public function clean($group, $mode = null)
 	{
 		jimport('joomla.filesystem.folder');
+		jimport('joomla.filesystem.file');
 
 		switch ($mode)
 		{


### PR DESCRIPTION
#### Steps to reproduce the issue

as reported  #7997 @bertmert

Go to System > Global Configuration.
Tabulator: System.
Set Cache: ON
Set Cache Handler: Cache_Lite.
Save.
Set Cache: OFF
Save again.

Try to set Set Cache Handler: File.
#### Expected result

The File Handler is still an option
![jmongo administration global configuration_3](https://cloud.githubusercontent.com/assets/181681/10261827/a43bb820-69ab-11e5-9308-a9ced105ad79.png)
#### Actual result

The File handler is not more  an option
![jmongo administration global configuration_2](https://cloud.githubusercontent.com/assets/181681/10261830/db520e9a-69ab-11e5-97a1-19b7243e0d97.png)
#### Test Info

Apply the pr and
create the folder /administrator/cache/  that was deleted due to the issue #7997 
#### Comment

Should be related only on cache_lite
