### PR TITLE
Improve Exception handling in libraries folder

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -209,7 +209,7 @@ class JApplicationCms extends JApplicationWeb
 			}
 			catch (RuntimeException $e)
 			{
-				throw new RuntimeException(JText::_('JERROR_SESSION_STARTUP'));
+				throw new RuntimeException(JText::_('JERROR_SESSION_STARTUP'), $e->getCode(), $e);
 			}
 		}
 	}
@@ -408,7 +408,7 @@ class JApplicationCms extends JApplicationWeb
 	 * @param   string  $name     The name of the application/client.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JMenu
+	 * @return  JMenu|null
 	 *
 	 * @since   3.2
 	 */
@@ -474,7 +474,7 @@ class JApplicationCms extends JApplicationWeb
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JPathway
+	 * @return  JPathway|null
 	 *
 	 * @since   3.2
 	 */
@@ -503,7 +503,7 @@ class JApplicationCms extends JApplicationWeb
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JRouter
+	 * @return  JRouter|null
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/captcha/captcha.php
+++ b/libraries/cms/captcha/captcha.php
@@ -89,9 +89,9 @@ class JCaptcha extends JObject
 	 * @param   string  $captcha  The plugin to use.
 	 * @param   array   $options  Associative array of options.
 	 *
-	 * @return  JCaptcha  Instance of this class.
+	 * @return  JCaptcha|null  Instance of this class.
 	 *
-	 * @since 2.5
+	 * @since   2.5
 	 */
 	public static function getInstance($captcha, array $options = array())
 	{

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -162,7 +162,9 @@ abstract class JInstallerAdapter extends JAdapterInstance
 					'JLIB_INSTALLER_ABORT_ROLLBACK',
 					JText::_('JLIB_INSTALLER_' . $this->route),
 					$e->getMessage()
-				)
+				),
+				$e->getCode(),
+				$e
 			);
 		}
 	}

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -500,7 +500,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			}
 			catch (RuntimeException $e)
 			{
-				throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_COMP_DISCOVER_STORE_DETAILS'));
+				throw new RuntimeException(JText::_('JLIB_INSTALLER_ERROR_COMP_DISCOVER_STORE_DETAILS'), $e->getCode(), $e);
 			}
 		}
 	}

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -62,7 +62,9 @@ class JInstallerAdapterModule extends JInstallerAdapter
 					'JLIB_INSTALLER_ABORT_ROLLBACK',
 					JText::_('JLIB_INSTALLER_' . $this->route),
 					$e->getMessage()
-				)
+				),
+				$e->getCode(),
+				$e
 			);
 		}
 	}

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -58,7 +58,9 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 					'JLIB_INSTALLER_ABORT_ROLLBACK',
 					JText::_('JLIB_INSTALLER_' . $this->route),
 					$e->getMessage()
-				)
+				),
+				$e->getCode(),
+				$e
 			);
 		}
 	}

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -54,7 +54,9 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 					'JLIB_INSTALLER_ABORT_ROLLBACK',
 					JText::_('JLIB_INSTALLER_' . $this->route),
 					$e->getMessage()
-				)
+				),
+				$e->getCode(),
+				$e
 			);
 		}
 	}

--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -26,7 +26,7 @@ abstract class JInstallerHelper
 	 * @param   string  $url     URL of file to download
 	 * @param   mixed   $target  Download target filename or false to get the filename from the URL
 	 *
-	 * @return  mixed  Path to downloaded package or boolean false on failure
+	 * @return  string|boolean  Path to downloaded package or boolean false on failure
 	 *
 	 * @since   3.1
 	 */
@@ -109,7 +109,7 @@ abstract class JInstallerHelper
 	 * @param   string   $p_filename         The uploaded package filename or install directory
 	 * @param   boolean  $alwaysReturnArray  If should return false (and leave garbage behind) or return $retval['type']=false
 	 *
-	 * @return  mixed  Array on success or boolean false on failure
+	 * @return  array|boolean  Array on success or boolean false on failure
 	 *
 	 * @since   3.1
 	 */

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -89,7 +89,7 @@ class JLanguageAssociations
 		}
 		catch (RuntimeException $e)
 		{
-			throw new Exception($e->getMessage(), 500);
+			throw new Exception($e->getMessage(), 500, $e);
 		}
 
 		if ($items)

--- a/libraries/cms/ucm/base.php
+++ b/libraries/cms/ucm/base.php
@@ -82,7 +82,7 @@ class JUcmBase implements JUcm
 		}
 		catch (RuntimeException $e)
 		{
-			throw new Exception($e->getMessage(), 500);
+			throw new Exception($e->getMessage(), 500, $e);
 		}
 
 		try
@@ -91,7 +91,7 @@ class JUcmBase implements JUcm
 		}
 		catch (RuntimeException $e)
 		{
-			throw new Exception($e->getMessage(), 500);
+			throw new Exception($e->getMessage(), 500, $e);
 		}
 
 		return true;

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -299,7 +299,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			}
 			catch (RuntimeException $e)
 			{
-				throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
+				throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()), $e->getCode(), $e);
 			}
 
 			// Set the new connector to the global instances based on signature.

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -326,7 +326,8 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				{
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+
+					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -337,6 +338,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			{
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
+
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
@@ -447,7 +449,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 *
 	 * @return  boolean
 	 *
-	 * @since 3.1.3
+	 * @since   3.1.3
 	 */
 	private function hasProfiling()
 	{

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -597,7 +597,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+
+					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -607,6 +608,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			else
 			{
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
+
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
@@ -850,7 +852,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 *
 	 * @return  boolean
 	 *
-	 * @since 3.1.3
+	 * @since   3.1.3
 	 */
 	private function hasProfiling()
 	{

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -459,7 +459,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+
+					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -474,6 +475,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
+
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -716,7 +716,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-					throw new RuntimeException($this->errorMsg);
+
+					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -731,7 +732,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-				throw new RuntimeException($this->errorMsg);
+
+				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -717,7 +717,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
-					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
+					throw new RuntimeException($this->errorMsg, null, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -733,7 +733,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
+				throw new RuntimeException($this->errorMsg);
 			}
 		}
 

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -652,7 +652,8 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+
+					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -668,6 +669,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
+
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}

--- a/libraries/joomla/database/factory.php
+++ b/libraries/joomla/database/factory.php
@@ -64,7 +64,7 @@ class JDatabaseFactory
 		}
 		catch (RuntimeException $e)
 		{
-			throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
+			throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()), $e->getCode(), $e);
 		}
 
 		return $instance;

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -193,15 +193,7 @@ abstract class JDatabaseImporter
 					foreach ($queries as $query)
 					{
 						$this->db->setQuery((string) $query);
-
-						try
-						{
-							$this->db->execute();
-						}
-						catch (RuntimeException $e)
-						{
-							throw $e;
-						}
+						$this->db->execute();
 					}
 				}
 			}
@@ -211,15 +203,7 @@ abstract class JDatabaseImporter
 				$sql = $this->xmlToCreate($table);
 
 				$this->db->setQuery((string) $sql);
-
-				try
-				{
-					$this->db->execute();
-				}
-				catch (RuntimeException $e)
-				{
-					throw $e;
-				}
+				$this->db->execute();
 			}
 		}
 	}

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -74,7 +74,7 @@ class JFeedFactory
 		}
 		catch (Exception $e)
 		{
-			throw new RuntimeException('Error reading feed.');
+			throw new RuntimeException('Error reading feed.', $e->getCode(), $e);
 		}
 
 		// Setup the appopriate feed parser for the feed.

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -292,7 +292,6 @@ abstract class JFolder
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
-	 * @throws  UnexpectedValueException
 	 */
 	public static function delete($path)
 	{
@@ -310,15 +309,8 @@ abstract class JFolder
 
 		$FTPOptions = JClientHelper::getCredentials('ftp');
 
-		try
-		{
-			// Check to make sure the path valid and clean
-			$path = $pathObject->clean($path);
-		}
-		catch (UnexpectedValueException $e)
-		{
-			throw $e;
-		}
+		// Check to make sure the path valid and clean
+		$path = $pathObject->clean($path);
 
 		// Is this really a folder?
 		if (!is_dir($path))

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -86,7 +86,7 @@ abstract class JGoogleData
 		}
 		catch (Exception $e)
 		{
-			throw new UnexpectedValueException("Unexpected data received from Google: `$data`.");
+			throw new UnexpectedValueException("Unexpected data received from Google: `$data`.", $e->getCode(), $e);
 		}
 	}
 

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -77,7 +77,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new RuntimeException("Etag match failed: `$match`.", $e->getCode(), $e);
 				}
 
 				throw $e;
@@ -270,6 +270,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 	 * @return  mixed  Data from Google.
 	 *
 	 * @since   12.3
+	 * @throws  Exception
 	 */
 	public function save($match = '*')
 	{
@@ -292,7 +293,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new RuntimeException("Etag match failed: `$match`.", $e->getCode(), $e);
 				}
 
 				throw $e;

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -77,7 +77,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new RuntimeException("Etag match failed: `$match`.", $e->getCode(), $e);
 				}
 
 				throw $e;
@@ -334,7 +334,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new RuntimeException("Etag match failed: `$match`.", $e->getCode(), $e);
 				}
 
 				throw $e;

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -663,9 +663,6 @@ class JTableNested extends JTable
 	 * @return  boolean  True if all checks pass.
 	 *
 	 * @since   11.1
-	 * @throws  Exception
-	 * @throws  RuntimeException on database error.
-	 * @throws  UnexpectedValueException
 	 */
 	public function check()
 	{
@@ -697,13 +694,6 @@ class JTableNested extends JTable
 
 			return false;
 		}
-		// @codeCoverageIgnoreStart
-		catch (Exception $e)
-		{
-			// Database error - rethrow.
-			throw $e;
-		}
-		// @codeCoverageIgnoreEnd
 
 		return true;
 	}

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -804,7 +804,7 @@ class JApplication extends JApplicationBase
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JRouter  A JRouter object
+	 * @return  JRouter|null  A JRouter object
 	 *
 	 * @since   11.1
 	 * @deprecated  4.0
@@ -852,7 +852,7 @@ class JApplication extends JApplicationBase
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JPathway  A JPathway object
+	 * @return  JPathway|null  A JPathway object
 	 *
 	 * @since   11.1
 	 * @deprecated  4.0
@@ -882,7 +882,7 @@ class JApplication extends JApplicationBase
 	 * @param   string  $name     The name of the application/client.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JMenu  JMenu object.
+	 * @return  JMenu|null  JMenu object.
 	 *
 	 * @since   11.1
 	 * @deprecated  4.0


### PR DESCRIPTION
This pull requests makes some improvements to the handling of Exceptions in the libraries folder.

In places where we are catching an Exception and throwing a new one, the new Exception will now include the previously caught Exception using the Exception API's ability to chain Exception objects.

Additionally, there were a couple of places where we were catching an Exception object and simply rethrowing it without any other processing, those places no longer catch Exceptions.

Minor doc block changes are included here.
### Testing Instructions

This patch is a "needs review only" patch.  There isn't a feasible way to write code that tests every one of these exception cases for the adjusted handling.
