### PR TITLE
Update returns in error conditions to use documented return types

### DIFF
--- a/libraries/cms/form/field/contenttype.php
+++ b/libraries/cms/form/field/contenttype.php
@@ -48,9 +48,7 @@ class JFormFieldContenttype extends JFormFieldList
 			}
 		}
 
-		$input = parent::getInput();
-
-		return $input;
+		return parent::getInput();
 	}
 
 	/**
@@ -79,7 +77,7 @@ class JFormFieldContenttype extends JFormFieldList
 		}
 		catch (RuntimeException $e)
 		{
-			return false;
+			return array();
 		}
 
 		// Merge any additional options in the XML definition.

--- a/libraries/cms/form/field/moduleorder.php
+++ b/libraries/cms/form/field/moduleorder.php
@@ -71,7 +71,7 @@ class JFormFieldModuleOrder extends JFormField
 		{
 			JError::raiseWarning(500, $e->getMessage());
 
-			return false;
+			return '';
 		}
 
 		$orders2 = array();

--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -96,9 +96,7 @@ class JFormFieldTag extends JFormFieldList
 			}
 		}
 
-		$input = parent::getInput();
-
-		return $input;
+		return parent::getInput();
 	}
 
 	/**
@@ -148,7 +146,7 @@ class JFormFieldTag extends JFormFieldList
 		}
 		catch (RuntimeException $e)
 		{
-			return false;
+			return array();
 		}
 
 		// Block the possibility to set a tag as it own parent

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -953,13 +953,11 @@ class JHelperTags extends JHelper
 		}
 		catch (RuntimeException $e)
 		{
-			return false;
+			return array();
 		}
 
 		// We will replace path aliases with tag names
-		$results = self::convertPathsToNames($results);
-
-		return $results;
+		return self::convertPathsToNames($results);
 	}
 
 	/**


### PR DESCRIPTION
This pull request updates the error handling in the affected methods so that the return types match the method's documented return.
### Testing Instructions

This one is borderline review only.  In the case of the form fields, most of these cases are handled within the JForm API already and don't have public exposure.  For the tags helper, you could probably do something that causes the query to fail and check the return type pre- and post- patch.
