### PR TITLE
Clean and close the output buffer as it is no longer needed.

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -977,6 +977,9 @@ abstract class JInstallerAdapter extends JAdapterInstance
 					{
 						if ($method != 'postflight')
 						{
+							// Clean and close the output buffer
+							ob_end_clean();
+
 							// The script failed, rollback changes
 							throw new RuntimeException(
 								JText::sprintf(
@@ -996,6 +999,9 @@ abstract class JInstallerAdapter extends JAdapterInstance
 					{
 						if ($method != 'uninstall')
 						{
+							// Clean and close the output buffer
+							ob_end_clean();
+
 							// The script failed, rollback changes
 							throw new RuntimeException(
 								JText::sprintf(


### PR DESCRIPTION
When running the unit test, it would generate this error:

> Test code or tested code did not (only) close its own output buffers

This error is generated because the triggerManifestScript() method would run into an error and then throws a RuntimeException without closing the output buffers which were opened. This change cleans and closes the output buffer as the output is not used anyway.

Test instructions
Only way I can see this tested is that you run the unit test and see the error, after applying the patch the error is gone.

Normal installation of an extension which fails should also still behave as usual.
