### PR TITLE
Make .travis.yml syntax consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,16 @@ before_script:
   # Set up Apache
   # - ./build/travis/php-apache.sh
   # Enable additional PHP extensions
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '7.0' ]; then phpenv config-add build/travis/phpenv/memcached.ini; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' == '5.3' ] || [ '$TRAVIS_PHP_VERSION' == '5.4' ]; then phpenv config-add build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '7.0' ]; then phpenv config-add build/travis/phpenv/redis.ini; fi"
-  # PHP 5.5+ needs APCu
-  - if [ '$TRAVIS_PHP_VERSION' == "5.5" ] || [ '$TRAVIS_PHP_VERSION' == "5.6" ]; then printf "\n" | echo -e "extension = apcu.so\napc.enabled=1\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [ $TRAVIS_PHP_VERSION != "7.0" ]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
+  # PHP 5.3 and 5.4 use APC
+  - if [ $TRAVIS_PHP_VERSION == "5.3" ] || [ $TRAVIS_PHP_VERSION == "5.4" ]; then phpenv config-add build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini; fi
+  # PHP 5.5+ use APCu
+  - if [ $TRAVIS_PHP_VERSION == "5.5" ] || [ $TRAVIS_PHP_VERSION == "5.6" ]; then printf "\n" | pecl install apcu-beta; fi
+  - if [ $TRAVIS_PHP_VERSION != "7.0" ]; then phpenv config-add build/travis/phpenv/redis.ini; fi
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '7.0' ]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .; fi"
+  - if [ $TRAVIS_PHP_VERSION != "7.0" ]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .; fi
 
 branches:
   except:

--- a/build/travis/phpenv/apc-5.5.ini
+++ b/build/travis/phpenv/apc-5.5.ini
@@ -1,2 +1,0 @@
-extension="apcu.so"
-apc.enable_cli=true

--- a/build/travis/phpenv/apc-5.6.ini
+++ b/build/travis/phpenv/apc-5.6.ini
@@ -1,2 +1,0 @@
-extension="apcu.so"
-apc.enable_cli=true


### PR DESCRIPTION
Our bash syntax in the `.travis.yml` file is somewhat inconsistent and includes syntax errors that actually kept APC(u) from ever being enabled.  This cleans it up so that all the bash syntax is consistent, removes the unused configuration files, and changes the APCu configuration for PHP 5.5+ to install the extension since it isn't installed on the Travis platform.
