### PR TITLE
Add support for dependency injection to the JMenu class tree

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -419,6 +419,12 @@ class JApplicationCms extends JApplicationWeb
 			$name = $this->getName();
 		}
 
+		// Inject this application object into the JMenu tree if one isn't already specified
+		if (!isset($options['app']))
+		{
+			$options['app'] = $this;
+		}
+
 		try
 		{
 			$menu = JMenu::getInstance($name, $options);

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -4,7 +4,7 @@
  * @subpackage  Menu
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('JPATH_PLATFORM') or die;
@@ -54,6 +54,14 @@ class JMenu
 	protected static $instances = array();
 
 	/**
+	 * User object to check access levels for
+	 *
+	 * @var    JUser
+	 * @since  3.5
+	 */
+	protected $user;
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $options  An array of configuration options.
@@ -77,6 +85,8 @@ class JMenu
 			$result->loadString($item->params);
 			$item->params = $result;
 		}
+
+		$this->user = isset($options['user']) && $options['user'] instanceof JUser ? $options['user'] : JFactory::getUser();
 	}
 
 	/**
@@ -115,14 +125,12 @@ class JMenu
 				}
 			}
 
-			if (class_exists($classname))
-			{
-				self::$instances[$client] = new $classname($options);
-			}
-			else
+			if (!class_exists($classname))
 			{
 				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_MENU_LOAD', $client), 500);
 			}
+
+			self::$instances[$client] = new $classname($options);
 		}
 
 		return self::$instances[$client];
@@ -186,14 +194,13 @@ class JMenu
 		{
 			return $this->_items[$this->_default[$language]];
 		}
-		elseif (array_key_exists('*', $this->_default))
+
+		if (array_key_exists('*', $this->_default))
 		{
 			return $this->_items[$this->_default['*']];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -313,10 +320,8 @@ class JMenu
 		{
 			return $menu->params;
 		}
-		else
-		{
-			return new Registry;
-		}
+
+		return new Registry;
 	}
 
 	/**
@@ -344,16 +349,13 @@ class JMenu
 	public function authorise($id)
 	{
 		$menu = $this->getItem($id);
-		$user = JFactory::getUser();
 
 		if ($menu)
 		{
-			return in_array((int) $menu->access, $user->getAuthorisedViewLevels());
+			return in_array((int) $menu->access, $this->user->getAuthorisedViewLevels());
 		}
-		else
-		{
-			return true;
-		}
+
+		return true;
 	}
 
 	/**

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -17,6 +17,47 @@ defined('JPATH_PLATFORM') or die;
 class JMenuSite extends JMenu
 {
 	/**
+	 * Application object
+	 *
+	 * @var    JApplicationCms
+	 * @since  3.5
+	 */
+	protected $app;
+
+	/**
+	 * Database driver
+	 *
+	 * @var    JDatabaseDriver
+	 * @since  3.5
+	 */
+	protected $db;
+
+	/**
+	 * Language object
+	 *
+	 * @var    JLanguage
+	 * @since  3.5
+	 */
+	protected $language;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param   array  $options  An array of configuration options.
+	 *
+	 * @since   1.5
+	 */
+	public function __construct($options = array())
+	{
+		// Extract the internal dependencies before calling the parent constructor since it calls $this->load()
+		$this->app      = isset($options['app']) && $options['app'] instanceof JApplicationCms ? $options['app'] : JFactory::getApplication();
+		$this->db       = isset($options['db']) && $options['db'] instanceof JDatabaseDriver ? $options['db'] : JFactory::getDbo();
+		$this->language = isset($options['language']) && $options['language'] instanceof JLanguage ? $options['language'] : JFactory::getLanguage();
+
+		parent::__construct($options);
+	}
+
+	/**
 	 * Loads the entire menu table into memory.
 	 *
 	 * @return  boolean  True on success, false on failure
@@ -25,7 +66,7 @@ class JMenuSite extends JMenu
 	 */
 	public function load()
 	{
-		$db    = JFactory::getDbo();
+		$db    = $this->db;
 		$query = $db->getQuery(true)
 			->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
 			->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
@@ -90,9 +131,8 @@ class JMenuSite extends JMenu
 	{
 		$attributes = (array) $attributes;
 		$values     = (array) $values;
-		$app        = JApplicationCms::getInstance('site');
 
-		if ($app->isSite())
+		if ($this->app->isSite())
 		{
 			// Filter by language if not set
 			if (($key = array_search('language', $attributes)) === false)
@@ -100,7 +140,7 @@ class JMenuSite extends JMenu
 				if (JLanguageMultilang::isEnabled())
 				{
 					$attributes[] = 'language';
-					$values[]     = array(JFactory::getLanguage()->getTag(), '*');
+					$values[]     = array($this->language->getTag(), '*');
 				}
 			}
 			elseif ($values[$key] === null)
@@ -113,7 +153,7 @@ class JMenuSite extends JMenu
 			if (($key = array_search('access', $attributes)) === false)
 			{
 				$attributes[] = 'access';
-				$values[] = JFactory::getUser()->getAuthorisedViewLevels();
+				$values[] = $this->user->getAuthorisedViewLevels();
 			}
 			elseif ($values[$key] === null)
 			{
@@ -140,17 +180,16 @@ class JMenuSite extends JMenu
 	 */
 	public function getDefault($language = '*')
 	{
-		if (array_key_exists($language, $this->_default) && JApplicationCms::getInstance('site')->getLanguageFilter())
+		if (array_key_exists($language, $this->_default) && $this->app->isSite() && $this->app->getLanguageFilter())
 		{
 			return $this->_items[$this->_default[$language]];
 		}
-		elseif (array_key_exists('*', $this->_default))
+
+		if (array_key_exists('*', $this->_default))
 		{
 			return $this->_items[$this->_default['*']];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
This pull request adds "poor man's" support for dependency injection into the JMenu class tree by utilizing the existing options array to allow class objects to be injected.  This helps to identify the class chain's dependencies on other class objects, remove hard couplings to JFactory, and improve testability of the class chain.  Also included in this pull request is minor internal structure cleanup and improvements to a couple existing doc blocks.
### Test Instructions

With the patch applied, a user should be able to navigate the application (site and admin) without issue.
