### PR TITLE
Newsfeeds List Layout Filter Feed [fix] - #8013

### DIFF
--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -305,7 +305,7 @@
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			>
 				<option value="1">JSHOW</option>
-				<option value="hide">JHIDE</option>
+				<option value="0">JHIDE</option>
 		</field>
 
 		<field

--- a/components/com_newsfeeds/views/category/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/category/tmpl/default_items.php
@@ -20,9 +20,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <?php else : ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-	<?php if ($this->params->get('filter_field') != 'hide' || $this->params->get('show_pagination_limit')) :?>
+	<?php if ((($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) || $this->params->get('show_pagination_limit')) :?>
 	<fieldset class="filters btn-toolbar">
-		<?php if ($this->params->get('filter_field') != 'hide') :?>
+		<?php if (($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) :?>
 			<div class="btn-group">
 				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_NEWSFEEDS_FILTER_LABEL') . '&#160;'; ?></label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>" />


### PR DESCRIPTION
as reported by #8013
#### After patch

![jmongo administration news feed options](https://cloud.githubusercontent.com/assets/181681/10274224/981faf7e-6b3b-11e5-9aa9-4405028f44a4.png)

---
#### Steps to reproduce the issue

Navigate to Joomla Backend -> Components -> Newsfeeds -> Options -> List Layout
#### Expected result

In filter field, Hide should be red color.![screen shot 2015-10-04 at 10 59 42](http://issues.joomla.org/uploads/1/4297f4e8b42d3feeb95734c7effff987.png)
