### PR TITLE
contact list layout option filter field

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -562,7 +562,7 @@
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			>
 				<option value="1">JSHOW</option>
-				<option value="hide">JHIDE</option>		
+				<option value="0">JHIDE</option>		
 		</field>
 
 		<field name="show_pagination_limit" type="radio"

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -19,9 +19,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <?php else : ?>
 
 	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-	<?php if ($this->params->get('filter_field') != 'hide' || $this->params->get('show_pagination_limit')) :?>
+	<?php if ((($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) || $this->params->get('show_pagination_limit')) :?>
 	<fieldset class="filters btn-toolbar">
-		<?php if ($this->params->get('filter_field') != 'hide') :?>
+		<?php if (($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) :?>
 			<div class="btn-group">
 				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_CONTACT_FILTER_LABEL') . '&#160;'; ?></label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" />


### PR DESCRIPTION
following the report #8013 by @infograf768 other components have this issue like com_contact
#### Before

the Fiter field hide button should be red
![jmongo administration contacts options-before](https://cloud.githubusercontent.com/assets/181681/10274521/e7d4d56e-6b3e-11e5-98b3-80e1284ae9db.png)
#### After

the Fiter field hide button is red
![jmongo administration contacts options-after](https://cloud.githubusercontent.com/assets/181681/10274569/6f43a73c-6b3f-11e5-97ca-2ce822d93ed4.png)
