### PR TITLE
Manage the situation without editor plugins published

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -671,3 +671,4 @@ JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to 
 JLIB_UTIL_ERROR_DOMIT="DommitDocument is deprecated. Use DomDocument instead."
 JLIB_UTIL_ERROR_LOADING_FEED_DATA="Error loading feed data."
 JLIB_UTIL_ERROR_XML_LOAD="Failed loading XML file."
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -625,6 +625,8 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "
+
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."
 
@@ -671,4 +673,3 @@ JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to 
 JLIB_UTIL_ERROR_DOMIT="DommitDocument is deprecated. Use DomDocument instead."
 JLIB_UTIL_ERROR_LOADING_FEED_DATA="Error loading feed data."
 JLIB_UTIL_ERROR_XML_LOAD="Failed loading XML file."
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -625,7 +625,7 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished."
 
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -671,3 +671,4 @@ JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to 
 JLIB_UTIL_ERROR_DOMIT="DommitDocument is deprecated. Use DomDocument instead."
 JLIB_UTIL_ERROR_LOADING_FEED_DATA="Error loading feed data."
 JLIB_UTIL_ERROR_XML_LOAD="Failed loading XML file."
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -625,6 +625,8 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "
+
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."
 
@@ -671,4 +673,3 @@ JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to 
 JLIB_UTIL_ERROR_DOMIT="DommitDocument is deprecated. Use DomDocument instead."
 JLIB_UTIL_ERROR_LOADING_FEED_DATA="Error loading feed data."
 JLIB_UTIL_ERROR_XML_LOAD="Failed loading XML file."
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -625,7 +625,7 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished "
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished."
 
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -293,6 +293,8 @@ class JEditor extends JObject
 		// Check whether editor is already loaded
 		if (is_null(($this->_editor)))
 		{
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_NO_EDITOR_PLUGIN_PUBLISHED'), 'error');
+
 			return;
 		}
 
@@ -505,6 +507,13 @@ class JEditor extends JObject
 
 		// Get the plugin
 		$plugin = JPluginHelper::getPlugin('editors', $this->_name);
+
+		// If no plugin is published we get an empty array and there not so much to do with it
+		if (empty($plugin))
+		{
+			return false;
+		}
+
 		$params = new Registry;
 		$params->loadString($plugin->params);
 		$params->loadArray($config);


### PR DESCRIPTION
# Executive summary

A different solution for the problem in #7774 

The Problem are PHP Warnings when no editor plugin available 
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

1 new Language tag
# Testing instructions
- Disable all Editor plugins
- Set Error Reporting to development
- Create a new article
- -> You should get PHP warning/notice
  *apply patch
- Create a new article
  -> no warning and notices should appear
