### PR TITLE
Canceling of authentication

### DIFF
--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -281,7 +281,7 @@ class JAuthentication extends JObject
 
 			// Try to authenticate
 			$plugin->onUserAuthenticate($credentials, $options, $response);
-			
+
 			// If authentication is canceled break out of the loop
 			if ($response->status === self::STATUS_CANCEL)
 				break;

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -284,7 +284,9 @@ class JAuthentication extends JObject
 
 			// If authentication is canceled break out of the loop
 			if ($response->status === self::STATUS_CANCEL)
+			{
 				break;
+			}
 
 			// If authentication is successful break out of the loop
 			if ($response->status === self::STATUS_SUCCESS)

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -24,10 +24,9 @@ class JAuthentication extends JObject
 	 */
 	const STATUS_SUCCESS = 1;
 
-	// These are for authentication purposes (username and password is valid)
 	/**
-	 * Status to indicate cancellation of authentication (unused)
-	 * @const  STATUS_CANCEL cancelled request (unused)
+	 * Status to indicate cancellation of authentication
+	 * @const  STATUS_CANCEL cancelled request
 	 * @since  11.2
 	 */
 	const STATUS_CANCEL = 2;
@@ -282,6 +281,10 @@ class JAuthentication extends JObject
 
 			// Try to authenticate
 			$plugin->onUserAuthenticate($credentials, $options, $response);
+			
+			// If authentication is canceled break out of the loop
+			if ($response->status === self::STATUS_CANCEL)
+				break;
 
 			// If authentication is successful break out of the loop
 			if ($response->status === self::STATUS_SUCCESS)


### PR DESCRIPTION
For a security issue, if an authentication plugin detects an anomaly (ex : a lot of tests of authentication in a short time, a suspect IP or a blacklisted IP...), this plugin should have a mean to cancel the current authentication.

Today, the only way to cancel the authentication process is to disable authentication plugin of Joomla and rewrite another on the same model.

The status "cancel" is unused and perhaps it would be a good use.
