### PR TITLE
Fix a javascript error in com_media

### DIFF
--- a/media/media/js/popup-imagemanager.js
+++ b/media/media/js/popup-imagemanager.js
@@ -55,7 +55,7 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
-				if (this.folderlist.className.test(/\bchzn-done\b/)) {
+				if (this.folderlist.className.indexOf('chzn-done')) {
 					$(this.folderlist).trigger('liszt:updated');
 				}
 				break;
@@ -143,7 +143,7 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
-				if (this.folderlist.className.test(/\bchzn-done\b/)) {
+				if (this.folderlist.className.indexOf('chzn-done')) {
 					$(this.folderlist).trigger('liszt:updated');
 				}
 				break;

--- a/media/media/js/popup-imagemanager.js
+++ b/media/media/js/popup-imagemanager.js
@@ -55,7 +55,7 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
-				if (this.folderlist.className.indexOf('chzn-done')) {
+				if ($(this.folderlist).hasClass('chzn-done')) {
 					$(this.folderlist).trigger('liszt:updated');
 				}
 				break;
@@ -143,7 +143,7 @@ var ImageManager = this.ImageManager = {
 		{
 			if (folder == this.folderlist.options[i].value) {
 				this.folderlist.selectedIndex = i;
-				if (this.folderlist.className.indexOf('chzn-done')) {
+				if ($(this.folderlist).hasClass('chzn-done')) {
 					$(this.folderlist).trigger('liszt:updated');
 				}
 				break;


### PR DESCRIPTION
#### How to replicate the error:

Make sure you are using the latest staging
Create an article
Use the XTD button to insert an image and try to use the dropdown for the folders navigation
Not cool
![screenshot 2015-10-06 00 47 37](https://cloud.githubusercontent.com/assets/3889375/10294761/ef0a8d8e-6bc4-11e5-9340-1a920747d572.png)
#### Testing

Apply this patch with patch tester and follow the above instructions
make sure that dropdown and the up folder buttons are working correctly and observe that there are no errors logged in your browsers console
#### What is changed?

The code `test(/\bchzn-done\b/)` is replaced by `hasClass('chzn-done')`.
The test() method tests for a match in a string and is using regular expression to achieve that. The hasClass() method will return true if the class is found without the regular expression.

This problem comes from the Mootools removal in the com_media views PR: #7819 
