### PR TITLE
consitent use of the classname for JToolbar

### DIFF
--- a/administrator/components/com_banners/views/banners/view.html.php
+++ b/administrator/components/com_banners/views/banners/view.html.php
@@ -77,7 +77,7 @@ class BannersViewBanners extends JViewLegacy
 		$user = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_BANNERS_MANAGER_BANNERS'), 'bookmark banners');
 

--- a/administrator/components/com_banners/views/tracks/view.html.php
+++ b/administrator/components/com_banners/views/tracks/view.html.php
@@ -69,7 +69,7 @@ class BannersViewTracks extends JViewLegacy
 
 		JToolbarHelper::title(JText::_('COM_BANNERS_MANAGER_TRACKS'), 'bookmark banners-tracks');
 
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 		$bar->appendButton('Popup', 'download', 'JTOOLBAR_EXPORT', 'index.php?option=com_banners&amp;view=download&amp;tmpl=component', 600, 300);
 
 		if ($canDo->get('core.delete'))

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -91,7 +91,7 @@ class CategoriesViewCategories extends JViewLegacy
 		$extension  = JFactory::getApplication()->input->get('extension', '', 'word');
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		// Avoid nonsense situation.
 		if ($component == 'com_categories')

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -73,7 +73,7 @@ class ContactViewContacts extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_CONTACT_MANAGER_CONTACTS'), 'address contact');
 

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -89,7 +89,7 @@ class ContentViewArticles extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_CONTENT_ARTICLES_TITLE'), 'stack article');
 

--- a/administrator/components/com_media/views/media/view.html.php
+++ b/administrator/components/com_media/views/media/view.html.php
@@ -66,7 +66,7 @@ class MediaViewMedia extends JViewLegacy
 	protected function addToolbar()
 	{
 		// Get the toolbar object instance
-		$bar  = JToolBar::getInstance('toolbar');
+		$bar  = JToolbar::getInstance('toolbar');
 		$user = JFactory::getUser();
 
 		// Set the titlebar text

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -227,7 +227,7 @@ class MenusViewItems extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_MENUS_VIEW_ITEMS_TITLE'), 'list menumgr');
 

--- a/administrator/components/com_menus/views/menutypes/view.html.php
+++ b/administrator/components/com_menus/views/menutypes/view.html.php
@@ -99,7 +99,7 @@ class MenusViewMenutypes extends JViewLegacy
 		JToolbarHelper::title(JText::_('COM_MENUS'), 'list menumgr');
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		// Cancel
 		$title = JText::_('JTOOLBAR_CANCEL');

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -78,7 +78,7 @@ class MessagesViewMessages extends JViewLegacy
 		}
 
 		JToolbarHelper::divider();
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		JHtml::_('behavior.modal', 'a.messagesSettings');

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -64,7 +64,7 @@ class ModulesViewModules extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_MODULES_MANAGER_MODULES'), 'cube module');
 

--- a/administrator/components/com_modules/views/select/view.html.php
+++ b/administrator/components/com_modules/views/select/view.html.php
@@ -60,7 +60,7 @@ class ModulesViewSelect extends JViewLegacy
 		JToolbarHelper::title(JText::_('COM_MODULES_MANAGER_MODULES'), 'cube module');
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('toolbar.cancelselect');

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -83,7 +83,7 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 		JToolbarHelper::title(JText::_('COM_NEWSFEEDS_MANAGER_NEWSFEEDS'), 'feed newsfeeds');
 
 		if (count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -107,7 +107,7 @@ class RedirectViewLinks extends JViewLegacy
 		if ($canDo->get('core.create'))
 		{
 			// Get the toolbar object instance
-			$bar = JToolBar::getInstance('toolbar');
+			$bar = JToolbar::getInstance('toolbar');
 
 			$title = JText::_('JTOOLBAR_BATCH');
 

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -83,7 +83,7 @@ class TagsViewTags extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_TAGS_MANAGER_TAGS'), 'tags');
 

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -176,7 +176,7 @@ class TemplatesViewTemplate extends JViewLegacy
 		$isSuperUser = $user->authorise('core.admin');
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 		$explodeArray = explode('.', $this->fileName);
 		$ext = end($explodeArray);
 

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -88,7 +88,7 @@ class UsersViewUsers extends JViewLegacy
 		$user  = JFactory::getUser();
 
 		// Get the toolbar object instance
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_USERS_VIEW_USERS_TITLE'), 'users user');
 

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -566,7 +566,7 @@ abstract class JToolbarHelper
 	{
 		$component = urlencode($component);
 		$path = urlencode($path);
-		$bar = JToolBar::getInstance('toolbar');
+		$bar = JToolbar::getInstance('toolbar');
 
 		$uri = (string) JUri::getInstance();
 		$return = urlencode(base64_encode($uri));


### PR DESCRIPTION
This fixes a inconsitency in the use of the classname for JToolbar, most of the times the correct classname JToolbar is used but in some cases JToolBar is used.
# Testing instructions

Check if the touched views are still working

e.g. Banners, categories, articles, ... , users
