### PR TITLE
Replace last instance of JResponse

### DIFF
--- a/administrator/components/com_installer/controllers/update.php
+++ b/administrator/components/com_installer/controllers/update.php
@@ -144,7 +144,7 @@ class InstallerControllerUpdate extends JControllerLegacy
 
 		if (!JSession::checkToken('get'))
 		{
-			JResponse::setHeader('status', 403, true);
+			$app->setHeader('status', 403, true);
 			$app->sendHeaders();
 			echo JText::_('JINVALID_TOKEN');
 			$app->close();


### PR DESCRIPTION
This removes the last instance of the deprecated JResponse class in the CMS. This only sets a header to be 403 when an ajax call is unsuccessful so it's going to be near impossible to test. Hopefully someone can merge this on review. 

Note that JResponse is currently a direct proxy to the JApplication method
