### PR TITLE
Manage the situation without editor plugins published - 2

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -846,7 +846,7 @@
 			default="tinymce"
 			label="COM_CONFIG_FIELD_DEFAULT_EDITOR_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_EDITOR_DESC"
-			required="true"
+			required="false"
 			filter="cmd" />
 
 		<field


### PR DESCRIPTION
#### Steps to reproduce the issue

Suppose for whatever reason to run a site without editor plugins
Disable all Editor plugins
Go Global Configuration abd click save 
#### Supposed Expected result

the Global Configuration data are saved
#### Actual result

You are unable to save
