### PR TITLE
Callback isn't a PHP object type

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -391,7 +391,7 @@ class JRouter
 	/**
 	 * Attach a build rule
 	 *
-	 * @param   callback  $callback  The function to be called
+	 * @param   callable  $callback  The function to be called
 	 * @param   string    $stage     The stage of the build process that
 	 *                               this should be added to. Possible values:
 	 *                               'preprocess', '' for the main build process,
@@ -414,7 +414,7 @@ class JRouter
 	/**
 	 * Attach a parse rule
 	 *
-	 * @param   callback  $callback  The function to be called.
+	 * @param   callable  $callback  The function to be called.
 	 * @param   string    $stage     The stage of the parse process that
 	 *                               this should be added to. Possible values:
 	 *                               'preprocess', '' for the main parse process,


### PR DESCRIPTION
`callback` isn't a valid PHP object type for doc blocks or objects.  Updates to use `callable`.
