### PR TITLE
More attributes for $list in mod_related_items

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -35,10 +35,10 @@ abstract class ModRelatedItemsHelper
 		$groups = implode(',', $user->getAuthorisedViewLevels());
 		$date = JFactory::getDate();
 		$maximum = (int) $params->get('maximum', 5);
-		
+
 		// Get an instance of the generic articles model
 		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
-		
+
 		// Set application parameters in model
 		$appParams = $app->getParams();
 		$articles->setState('params', $appParams);
@@ -173,7 +173,8 @@ abstract class ModRelatedItemsHelper
 			}
 		}
 
-		if (count($related)) {
+		if (count($related))
+		{
 			// Prepare data for display using display options
 			foreach ($related as &$item)
 			{

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -35,6 +35,13 @@ abstract class ModRelatedItemsHelper
 		$groups = implode(',', $user->getAuthorisedViewLevels());
 		$date = JFactory::getDate();
 		$maximum = (int) $params->get('maximum', 5);
+		
+		// Get an instance of the generic articles model
+		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+		
+		// Set application parameters in model
+		$appParams = $app->getParams();
+		$articles->setState('params', $appParams);
 
 		$option = $app->input->get('option');
 		$view = $app->input->get('view');
@@ -150,17 +157,30 @@ abstract class ModRelatedItemsHelper
 
 				if (count($temp))
 				{
+					$articles_ids = array();
+
 					foreach ($temp as $row)
 					{
-						if ($row->cat_state == 1)
-						{
-							$row->route = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
-							$related[] = $row;
-						}
+						$articles_ids[] = $row->id;
 					}
+
+					$articles->setState('filter.article_id', $articles_ids);
+					$articles->setState('filter.published', 1);
+					$related = $articles->getItems();
 				}
 
 				unset ($temp);
+			}
+		}
+
+		if (count($related)) {
+			// Prepare data for display using display options
+			foreach ($related as &$item)
+			{
+				$item->slug    = $item->id . ':' . $item->alias;
+				$item->catslug = $item->catid . ':' . $item->category_alias;
+
+				$item->route = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 			}
 		}
 


### PR DESCRIPTION
With this change, article properties will be easily used in template customization, in other words, now you can show images and intro text in every related article

**This code is backwards compatible**, needless to modify other files (including "tmpl/default.php").

Variable $list has the same structure as the variable $items in the mod_articles_category.
