### PR TITLE
Improvements for doc blocks in libraries/cms

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -29,7 +29,7 @@ class JApplicationCms extends JApplicationWeb
 	/**
 	 * Application instances container.
 	 *
-	 * @var    array
+	 * @var    JApplicationCms[]
 	 * @since  3.2
 	 */
 	protected static $instances = array();
@@ -582,7 +582,7 @@ class JApplicationCms extends JApplicationWeb
 	 * @param   string  $default  The default value for the variable if not found. Optional.
 	 * @param   string  $type     Filter for the variable, for valid values see {@link JFilterInput::clean()}. Optional.
 	 *
-	 * @return  object  The request user state.
+	 * @return  mixed  The request user state.
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -279,7 +279,7 @@ final class JApplicationSite extends JApplicationCms
 	 *
 	 * @param   string  $option  The component option
 	 *
-	 * @return  object  The parameters object
+	 * @return  Registry  The parameters object
 	 *
 	 * @since   3.2
 	 * @deprecated  4.0  Use getParams() instead
@@ -294,7 +294,7 @@ final class JApplicationSite extends JApplicationCms
 	 *
 	 * @param   string  $option  The component option
 	 *
-	 * @return  object  The parameters object
+	 * @return  Registry  The parameters object
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/captcha/captcha.php
+++ b/libraries/cms/captcha/captcha.php
@@ -56,7 +56,7 @@ class JCaptcha extends JObject
 	/**
 	 * Editor Plugin name
 	 *
-	 * @var string
+	 * @var    string
 	 * @since  2.5
 	 */
 	private $_name;
@@ -64,7 +64,8 @@ class JCaptcha extends JObject
 	/**
 	 * Array of instances of this class.
 	 *
-	 * @var	array
+	 * @var	   JCaptcha[]
+	 * @since  2.5
 	 */
 	private static $_instances = array();
 
@@ -74,7 +75,7 @@ class JCaptcha extends JObject
 	 * @param   string  $captcha  The editor to use.
 	 * @param   array   $options  Associative array of options.
 	 *
-	 * @since 2.5
+	 * @since   2.5
 	 */
 	public function __construct($captcha, $options)
 	{

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -32,7 +32,7 @@ class JComponentHelper
 	 * @param   string   $option  The component option.
 	 * @param   boolean  $strict  If set and the component does not exist, the enabled attribute will be set to false.
 	 *
-	 * @return  object   An object with the information for the component.
+	 * @return  stdClass   An object with the information for the component.
 	 *
 	 * @since   1.5
 	 */
@@ -308,7 +308,7 @@ class JComponentHelper
 	 * @param   string  $option  The component option.
 	 * @param   array   $params  The component parameters
 	 *
-	 * @return  object
+	 * @return  string
 	 *
 	 * @since   1.5
 	 * @throws  Exception

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -75,7 +75,9 @@ class JEditor extends JObject
 	protected $author = null;
 
 	/**
-	 * @var    array  JEditor instances container.
+	 * JEditor instances container.
+	 *
+	 * @var    JEditor[]
 	 * @since  2.5
 	 */
 	protected static $instances = array();

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -98,7 +98,7 @@ class JHelper
 	 *
 	 * @param   JTableInterface  $table  JTable object.
 	 *
-	 * @return  object Contains all of the columns and values.
+	 * @return  stdClass  Contains all of the columns and values.
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -381,7 +381,7 @@ abstract class JHtmlSelect
 	 * @param   string  $optKey   The returned object property name for the value
 	 * @param   string  $optText  The returned object property name for the text
 	 *
-	 * @return  object
+	 * @return  stdClass
 	 *
 	 * @deprecated  4.0  Use JHtmlSelect::groupedList()
 	 * @see     JHtmlSelect::groupedList()
@@ -441,7 +441,7 @@ abstract class JHtmlSelect
 	 *                             parameter is ignored if an options array is passed.
 	 * @param   boolean  $disable  Not used.
 	 *
-	 * @return  object
+	 * @return  stdClass
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -504,7 +504,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	/**
 	 * Get the manifest object.
 	 *
-	 * @return  object  Manifest object
+	 * @return  SimpleXMLElement  Manifest object
 	 *
 	 * @since   3.4
 	 */

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -265,7 +265,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Get the installation manifest object
 	 *
-	 * @return  object  Manifest object
+	 * @return  SimpleXMLElement  Manifest object
 	 *
 	 * @since   3.1
 	 */
@@ -1933,7 +1933,7 @@ class JInstaller extends JAdapter
 	 *
 	 * @param   string  $file  An xmlfile path to check
 	 *
-	 * @return  mixed  A SimpleXMLElement, or null if the file failed to parse
+	 * @return  SimpleXMLElement|null  A SimpleXMLElement, or null if the file failed to parse
 	 *
 	 * @since   3.1
 	 */

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -32,7 +32,7 @@ class JLibraryHelper
 	 * @param   string   $element  Element of the library in the extensions table.
 	 * @param   boolean  $strict   If set and the library does not exist, the enabled attribute will be set to false.
 	 *
-	 * @return  object   An object with the library's information.
+	 * @return  stdClass   An object with the library's information.
 	 *
 	 * @since   3.2
 	 */

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -46,7 +46,9 @@ class JMenu
 	protected $_active = 0;
 
 	/**
-	 * @var    array  JMenu instances container.
+	 * JMenu instances container.
+	 *
+	 * @var    JMenu[]
 	 * @since  1.7
 	 */
 	protected static $instances = array();

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -24,7 +24,7 @@ abstract class JModuleHelper
 	 * @param   string  $name   The name of the module
 	 * @param   string  $title  The title of the module, optional
 	 *
-	 * @return  object  The Module object
+	 * @return  stdClass  The Module object
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -237,7 +237,7 @@ class JPagination
 	/**
 	 * Return the pagination data object, only creating it if it doesn't already exist.
 	 *
-	 * @return  object   Pagination data object.
+	 * @return  stdClass  Pagination data object.
 	 *
 	 * @since   1.5
 	 */
@@ -745,7 +745,7 @@ class JPagination
 	/**
 	 * Create and return the pagination data object.
 	 *
-	 * @return  object  Pagination data object.
+	 * @return  stdClass  Pagination data object.
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/pathway/pathway.php
+++ b/libraries/cms/pathway/pathway.php
@@ -33,7 +33,9 @@ class JPathway
 	protected $_count = 0;
 
 	/**
-	 * @var    array  JPathway instances container.
+	 * JPathway instances container.
+	 *
+	 * @var    JPathway[]
 	 * @since  1.7
 	 */
 	protected static $instances = array();

--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -130,7 +130,7 @@ class JRouter
 	/**
 	 * JRouter instances container.
 	 *
-	 * @var    array
+	 * @var    JRouter[]
 	 * @since  1.7
 	 */
 	protected static $instances = array();

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -24,7 +24,7 @@ class JSchemaChangeset
 	/**
 	 * Array of JSchemaChangeitem objects
 	 *
-	 * @var    array
+	 * @var    JSchemaChangeitem[]
 	 * @since  2.5
 	 */
 	protected $changeItems = array();

--- a/libraries/cms/ucm/base.php
+++ b/libraries/cms/ucm/base.php
@@ -100,15 +100,13 @@ class JUcmBase implements JUcm
 	/**
 	 * Get the UCM Content type.
 	 *
-	 * @return  object  The UCM content type
+	 * @return  JUcmType  The UCM content type
 	 *
 	 * @since   3.1
 	 */
 	public function getType()
 	{
-		$type = new JUcmType($this->alias);
-
-		return $type;
+		return new JUcmType($this->alias);
 	}
 
 	/**

--- a/libraries/cms/ucm/content.php
+++ b/libraries/cms/ucm/content.php
@@ -125,7 +125,7 @@ class JUcmContent extends JUcmBase
 	 * @param   array     $original  The original data array
 	 * @param   JUcmType  $type      Type object for this data
 	 *
-	 * @return  object  $ucmData  The mapped UCM data
+	 * @return  array  $ucmData  The mapped UCM data
 	 *
 	 * @since   3.1
 	 */

--- a/libraries/cms/ucm/type.php
+++ b/libraries/cms/ucm/type.php
@@ -69,7 +69,7 @@ class JUcmType implements JUcm
 	/**
 	 * The alias for the content type
 	 *
-	 * @var	  string
+	 * @var	   string
 	 * @since  3.1
 	 */
 	protected $alias;


### PR DESCRIPTION
This PR updates several doc blocks in the `libraries/cms` directory to better document containers and return types.  For containers that store a specific object type, the doc block is updated from a generic `array` to the doc block representation that an array of an object type is stored (i.e. `JApplicationCms[]`).  For doc blocks that indicated `@return object`, doc blocks are updated to provide a more specific return type (either the actual object or `stdClass` in the case that object type is actually returned).
