### PR TITLE
Use application API for Smart Search suggestions

### DIFF
--- a/components/com_finder/controllers/suggestions.json.php
+++ b/components/com_finder/controllers/suggestions.json.php
@@ -25,14 +25,16 @@ class FinderControllerSuggestions extends JControllerLegacy
 	 */
 	public function suggest()
 	{
+		$app = JFactory::getApplication();
+		$app->mimeType = 'application/json';
+
 		$suggestions = $this->getSuggestions();
 
-		// Use the correct json mime-type
-		header('Content-Type: application/json');
-
 		// Send the response.
+		$app->setHeader('Content-Type', $app->mimeType . '; charset=' . $app->charSet);
+		$app->sendHeaders();
 		echo '{ "suggestions": ' . json_encode($suggestions) . ' }';
-		JFactory::getApplication()->close();
+		$app->close();
 	}
 
 	/**
@@ -48,29 +50,31 @@ class FinderControllerSuggestions extends JControllerLegacy
 	 */
 	public function display($cachable = false, $urlparams = false)
 	{
+		$app = JFactory::getApplication();
+		$app->mimeType = 'application/json';
 
 		$suggestions = $this->getSuggestions();
 
-		// Use the correct json mime-type
-		header('Content-Type: application/json');
-
 		// Send the response.
+		$app->setHeader('Content-Type', $app->mimeType . '; charset=' . $app->charSet);
+		$app->sendHeaders();
 		echo json_encode($suggestions);
-		JFactory::getApplication()->close();
+		$app->close();
 	}
 
 	/**
 	 * Method to retrieve the data from the database
 	 *
-	 * @return  array The suggested words
+	 * @return  array  The suggested words
 	 *
-	 * @since 3.4
+	 * @since   3.4
 	 */
 	protected function getSuggestions()
 	{
 		$return = array();
 
 		$params = JComponentHelper::getParams('com_finder');
+
 		if ($params->get('show_autosuggest', 1))
 		{
 			// Get the suggestions.


### PR DESCRIPTION
This PR updates the Smart Search suggestions controller methods to use the application API for setting the document MIME type and sending the response headers instead of the direct PHP method used before.
### Testing Instructions

Set up Smart Search, pre- and post- patch the suggestions should work correctly.
