### PR TITLE
Additional Buttons on bottom during installation (redo of #6444)

### DIFF
--- a/installation/view/database/tmpl/default.php
+++ b/installation/view/database/tmpl/default.php
@@ -98,6 +98,14 @@ defined('_JEXEC') or die;
 			</p>
 		</div>
 	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a class="btn" href="#" onclick="return Install.goToPage('site');" rel="prev" title="<?php echo JText::_('JPrevious'); ?>"><span class="icon-arrow-left"></span> <?php echo JText::_('JPrevious'); ?></a>
+				<a  class="btn btn-primary" href="#" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNext'); ?>"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('JNext'); ?></a>
+			</div>
+		</div>
+	</div>
 
 	<input type="hidden" name="task" value="database" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/installation/view/defaultlanguage/tmpl/default.php
+++ b/installation/view/defaultlanguage/tmpl/default.php
@@ -159,6 +159,33 @@ defined('_JEXEC') or die;
 		<?php endforeach; ?>
 		</tbody>
 	</table>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a
+					class="btn"
+					href="#"
+					onclick="return Install.goToPage('languages');"
+					rel="prev"
+					title="<?php echo JText::_('JPREVIOUS'); ?>">
+					<span class="icon-arrow-left"></span>
+					<?php echo JText::_('JPREVIOUS'); ?>
+				</a>
+				<?php // Check if there are languages in the list, if not you cannot move forward ?>
+				<?php if ($this->items->administrator) : ?>
+					<a
+						class="btn btn-primary"
+						href="#"
+						onclick="Install.submitform();"
+						rel="next"
+						title="<?php echo JText::_('JNEXT'); ?>">
+						<span class="icon-arrow-right icon-white"></span>
+						<?php echo JText::_('JNEXT'); ?>
+					</a>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
 	<input type="hidden" name="task" value="setdefaultlanguage" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/installation/view/ftp/tmpl/default.php
+++ b/installation/view/ftp/tmpl/default.php
@@ -83,6 +83,14 @@ defined('_JEXEC') or die;
 			<?php echo $this->form->getInput('ftp_save'); ?>
 		</div>
 	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a class="btn" href="#" onclick="return Install.goToPage('database');" rel="prev" title="<?php echo JText::_('JPrevious'); ?>"><span class="icon-arrow-left"></span> <?php echo JText::_('JPrevious'); ?></a>
+				<a  class="btn btn-primary" href="#" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNext'); ?>"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('JNext'); ?></a>
+			</div>
+		</div>
+	</div>
 
 	<input type="hidden" name="task" value="ftp" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -67,7 +67,7 @@ $version = new JVersion;
 			<div id="wait_installing_spinner" class="spinner spinner-img" style="display: none;"></div>
 		</p>
 
-	<table class="table table-striped table-condensed">
+		<table class="table table-striped table-condensed">
 			<thead>
 					<tr>
 						<th>
@@ -107,4 +107,28 @@ $version = new JVersion;
 		<input type="hidden" name="task" value="InstallLanguages" />
 		<?php echo JHtml::_('form.token'); ?>
 	<?php endif; ?>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a
+					class="btn"
+					href="#"
+					onclick="return Install.goToPage('remove');"
+					rel="prev"
+					title="<?php echo JText::_('JPREVIOUS'); ?>">
+					<span class="icon-arrow-left"></span>
+					<?php echo JText::_('JPREVIOUS'); ?>
+				</a>
+				<a
+					class="btn btn-primary"
+					href="#"
+					onclick="installLanguages()"
+					rel="next"
+					title="<?php echo JText::_('JNEXT'); ?>">
+					<span class="icon-arrow-right icon-white"></span>
+					<?php echo JText::_('JNEXT'); ?>
+				</a>
+			</div>
+		</div>
+	</div>
 </form>

--- a/installation/view/preinstall/tmpl/default.php
+++ b/installation/view/preinstall/tmpl/default.php
@@ -10,12 +10,12 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewPreinstallHtml $this */
 ?>
-<div class="btn-toolbar">
-	<div class="btn-group pull-right">
-		<a href="#" class="btn btn-primary" onclick="Install.submitform();" title="<?php echo JText::_('JCHECK_AGAIN'); ?>"><span class="icon-refresh icon-white"></span> <?php echo JText::_('JCHECK_AGAIN'); ?></a>
-	</div>
-</div>
 <form action="index.php" method="post" id="languageForm" class="form-horizontal">
+	<div class="btn-toolbar">
+		<div class="btn-group pull-right">
+			<a href="#" class="btn btn-primary" onclick="Install.submitform();" title="<?php echo JText::_('JCHECK_AGAIN'); ?>"><span class="icon-refresh icon-white"></span> <?php echo JText::_('JCHECK_AGAIN'); ?></a>
+		</div>
+	</div>
 	<div class="control-group">
 		<label for="jform_language" class="control-label"><?php echo JText::_('INSTL_SELECT_LANGUAGE_TITLE'); ?></label>
 		<div class="controls">
@@ -104,6 +104,13 @@ defined('_JEXEC') or die;
 					</tr>
 				</tfoot>
 			</table>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a href="#" class="btn btn-primary" onclick="Install.submitform();" title="<?php echo JText::_('JCHECK_AGAIN'); ?>"><span class="icon-refresh icon-white"></span> <?php echo JText::_('JCHECK_AGAIN'); ?></a>
+			</div>
 		</div>
 	</div>
 

--- a/installation/view/site/tmpl/default.php
+++ b/installation/view/site/tmpl/default.php
@@ -107,6 +107,13 @@ defined('_JEXEC') or die;
 			</div>
 		</div>
 	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a href="#" class="btn btn-primary" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNext'); ?>"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('JNext'); ?></a>
+			</div>
+		</div>
+	</div>
 
 	<input type="hidden" name="task" value="site" />
 	<?php echo JHtml::_('form.token'); ?>

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -357,6 +357,14 @@ $prev = $useftp ? 'ftp' : 'database';
 			</table>
 		</div>
 	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a class="btn" href="#" onclick="return Install.goToPage('<?php echo $prev; ?>');" rel="prev" title="<?php echo JText::_('JPrevious'); ?>"><span class="icon-arrow-left"></span> <?php echo JText::_('JPrevious'); ?></a>
+				<a class="btn btn-primary" href="#" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('INSTL_SUMMARY_INSTALL'); ?>"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('INSTL_SUMMARY_INSTALL'); ?></a>
+			</div>
+		</div>
+	</div>
 
 	<input type="hidden" name="task" value="summary" />
 	<?php echo JHtml::_('form.token'); ?>


### PR DESCRIPTION
This Pull request is a redo of #6444
## What this PR does

This RP adds buttons to the bottom of the installation processes.
## How to test this PR
1. Apply the patch via the patch tester
2. remove you're configuration.php
3. Go to the installation of Joomla!, confirm that the buttons on top of the page are also viable on the bottom of the page. Like this:
   ![knipsel](https://cloud.githubusercontent.com/assets/2659866/10410825/db86518a-6f4d-11e5-984d-f751dfc24804.PNG)
4. Test this patch also with an RTL language. You can do this by select the as language <i>Arabic Unitag</i>. Screenshot of the installation processes with an RTL language:
   ![knipsel](https://cloud.githubusercontent.com/assets/2659866/10410833/588d3090-6f4e-11e5-9032-a5d968716b42.PNG)
