### PR TITLE
Repair parameter for hidding filter field in com_contact

### DIFF
--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -117,7 +117,7 @@
 				label="JGLOBAL_FILTER_FIELD_LABEL"
 			>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="hide">JHIDE</option>
+				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
 

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -19,9 +19,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <?php else : ?>
 
 	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-	<?php if ((($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) || $this->params->get('show_pagination_limit')) :?>
+	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) :?>
 	<fieldset class="filters btn-toolbar">
-		<?php if (($this->params->get('filter_field') != 'hide') || ($this->params->get('filter_field') != '0')) :?>
+		<?php if ($this->params->get('filter_field')) :?>
 			<div class="btn-group">
 				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_CONTACT_FILTER_LABEL') . '&#160;'; ?></label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" />


### PR DESCRIPTION
This is a PR for #8051 
## What this PR does

This PR repair the parameter for hidding the filter field in a list view of com_contact.
## How to test his PR
1. Make a menu of the type: List Contacts in a Category, make sure the parameter <i>Filter field</i> is set on "Use global"
2. Make sure the parameter <i>Filter field</i> in the settings of com_contact is set on "Hide"
3. Confirm, on the front-end, the filter field is still visible, like this:
   ![knipsel](https://cloud.githubusercontent.com/assets/2659866/10411390/2a848dcc-6f64-11e5-88a7-e030dd77efc1.PNG)
4. Apply the patch
5. Confirm the filter field is not visible, like this:
   ![knipsel](https://cloud.githubusercontent.com/assets/2659866/10411395/452f4702-6f64-11e5-9ecf-d2deedb1061a.PNG)
6. Test various combinations of the parameter in the menu and the parameter in the options of com_contact  
# Important note

You have to use the latest version of Joomla! staging to reproduce this bug
