### PR TITLE
com_messages - removed left menu

### DIFF
--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -47,7 +47,7 @@ class MessagesViewMessages extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		$this->sidebar = JHtmlSidebar::render();
+		
 		parent::display($tpl);
 	}
 

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -47,7 +47,7 @@ class MessagesViewMessages extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		
+
 		parent::display($tpl);
 	}
 


### PR DESCRIPTION
This PR removes the two left menu options in Messages
# Testing instructions
## Before this PR

Components > **Messaging**
- New Private Message -> duplicates the green "New" button directly above it.
- Messages -> after removing the "New Private Message" menu item, the "Messages" would be the only menu item, which makes it obsolete as menu item.

![messages_before](https://cloud.githubusercontent.com/assets/1217850/10413994/19895df2-6fc0-11e5-8ab8-4a43253128be.png)
## After this PR

Components > **Messaging**
The two left menu items "New Private Message" & "Messages" have been removed, and the space is used for the main column of the messaging component
![messages_after](https://cloud.githubusercontent.com/assets/1217850/10413993/1988edc2-6fc0-11e5-9121-35f0ac9d71fc.png)
