### PR TITLE
Call JApplicationHelper::stringURLSafe() directly

### DIFF
--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -65,11 +65,11 @@ class BannersTableBanner extends JTable
 		$this->name = htmlspecialchars_decode($this->name, ENT_QUOTES);
 
 		// Set alias
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (empty($this->alias))
 		{
-			$this->alias = JApplication::stringURLSafe($this->name);
+			$this->alias = JApplicationHelper::stringURLSafe($this->name);
 		}
 
 		// Check the publish down date is not earlier than publish up.

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -227,7 +227,7 @@ class ContactTableContact extends JTable
 			$this->alias = $this->name;
 		}
 
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -72,7 +72,7 @@ class FinderTableFilter extends JTable
 			$this->alias = $this->title;
 		}
 
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -393,11 +393,11 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 		$user = JFactory::getUser();
 
 		$table->name = htmlspecialchars_decode($table->name, ENT_QUOTES);
-		$table->alias = JApplication::stringURLSafe($table->alias);
+		$table->alias = JApplicationHelper::stringURLSafe($table->alias);
 
 		if (empty($table->alias))
 		{
-			$table->alias = JApplication::stringURLSafe($table->name);
+			$table->alias = JApplicationHelper::stringURLSafe($table->name);
 		}
 
 		if (empty($table->id))

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -56,7 +56,7 @@ class NewsfeedsTableNewsfeed extends JTable
 			$this->alias = $this->name;
 		}
 
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -96,7 +96,7 @@ class TagsTableTag extends JTableNested
 			$this->alias = $this->title;
 		}
 
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -104,7 +104,7 @@ class JTableCorecontent extends JTable
 			$this->core_alias = $this->core_title;
 		}
 
-		$this->core_alias = JApplication::stringURLSafe($this->core_alias);
+		$this->core_alias = JApplicationHelper::stringURLSafe($this->core_alias);
 
 		if (trim(str_replace('-', '', $this->core_alias)) == '')
 		{

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -148,7 +148,7 @@ class JTableCategory extends JTableNested
 			$this->alias = $this->title;
 		}
 
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -128,7 +128,7 @@ class JTableMenu extends JTableNested
 		}
 
 		// Make the alias URL safe.
-		$this->alias = JApplication::stringURLSafe($this->alias);
+		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
 
 		if (trim(str_replace('-', '', $this->alias)) == '')
 		{

--- a/libraries/legacy/table/menu/type.php
+++ b/libraries/legacy/table/menu/type.php
@@ -38,7 +38,7 @@ class JTableMenuType extends JTable
 	 */
 	public function check()
 	{
-		$this->menutype = JApplication::stringURLSafe($this->menutype);
+		$this->menutype = JApplicationHelper::stringURLSafe($this->menutype);
 
 		if (empty($this->menutype))
 		{


### PR DESCRIPTION
This PR changes calls for `JApplication::stringURLSafe()` to call `JApplicationHelper::stringURLSafe()` instead.  The former is a deprecated method and just proxies to the newer method.
### Test Instructions

This one can be review only.  Otherwise, for testing, ensure aliases on items are still generated correctly.
