### PR TITLE
Update calls to deprecated JApplication::getInstance()

### DIFF
--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -166,7 +166,7 @@ class FinderControllerIndexer extends JControllerLegacy
 		$admin = clone JFactory::getApplication();
 
 		// Get the site app.
-		$site = JApplication::getInstance('site');
+		$site = JApplicationCms::getInstance('site');
 
 		// Swap the app.
 		$app = JFactory::getApplication();

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -90,7 +90,7 @@ class JMenuSite extends JMenu
 	{
 		$attributes = (array) $attributes;
 		$values     = (array) $values;
-		$app        = JApplication::getInstance('site');
+		$app        = JApplicationCms::getInstance('site');
 
 		if ($app->isSite())
 		{
@@ -140,7 +140,7 @@ class JMenuSite extends JMenu
 	 */
 	public function getDefault($language = '*')
 	{
-		if (array_key_exists($language, $this->_default) && JApplication::getInstance('site')->getLanguageFilter())
+		if (array_key_exists($language, $this->_default) && JApplicationCms::getInstance('site')->getLanguageFilter())
 		{
 			return $this->_items[$this->_default[$language]];
 		}

--- a/libraries/cms/pathway/site.php
+++ b/libraries/cms/pathway/site.php
@@ -27,7 +27,7 @@ class JPathwaySite extends JPathway
 	{
 		$this->_pathway = array();
 
-		$app  = JApplication::getInstance('site');
+		$app  = JApplicationCms::getInstance('site');
 		$menu = $app->getMenu();
 		$lang = JFactory::getLanguage();
 


### PR DESCRIPTION
This PR changes calls for `JApplication::getInstance()` to call `JApplicationCms::getInstance()` instead.  The former is a deprecated method and just proxies to the newer method.
### Test Instructions

This one can be review only.  Otherwise, for testing, the Smart Search indexer and frontend menu and breadcrumbs should still work correctly.
