### PR TITLE
Update deprecations in com_config

### DIFF
--- a/administrator/components/com_config/controller.php
+++ b/administrator/components/com_config/controller.php
@@ -12,7 +12,8 @@ defined('_JEXEC') or die;
 /**
  * Config Component Controller
  *
- * @since  1.5
+ * @since       1.5
+ * @deprecated  4.0
  */
 class ConfigController extends JControllerLegacy
 {

--- a/administrator/components/com_config/controllers/application.php
+++ b/administrator/components/com_config/controllers/application.php
@@ -71,7 +71,7 @@ class ConfigControllerApplication extends JControllerLegacy
 	 *
 	 * @return  void
 	 *
-	 * @deprecated  4,0  Use ConfigControllerApplicationRefreshhelp instead.
+	 * @deprecated  4.0  Use ConfigControllerApplicationRefreshhelp instead.
 	 */
 	public function refreshHelp()
 	{

--- a/administrator/components/com_config/models/component.php
+++ b/administrator/components/com_config/models/component.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JLog::add(
-	'ConfigModelApplication has moved from ' . __DIR__ . '/component.php to ' . dirname(__DIR__) . '/model/component.php.',
+	'ConfigModelComponent has moved from ' . __FILE__ . ' to ' . dirname(__DIR__) . '/model/component.php.',
 	JLog::WARNING,
 	'deprecated'
 );


### PR DESCRIPTION
This updates the deprecation notices in the admin com_config component with the following changes:
- Deprecates `ConfigController`, this is the legacy MVC base controller and all other legacy MVC classes in the component were deprecated already (assuming we missed the tag on this one)
- Corrects JLog notice for `ConfigModelComponent` legacy file location
