### PR TITLE
Change how the result variable is used in JTable::store()

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -776,6 +776,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 */
 	public function store($updateNulls = false)
 	{
+		$result = true;
+
 		$k = $this->_tbl_keys;
 
 		// Implement JObservableInterface: Pre-processing by observers
@@ -797,11 +799,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// If a primary key exists update the object, otherwise insert it.
 		if ($this->hasPrimaryKey())
 		{
-			$result = $this->_db->updateObject($this->_tbl, $this, $this->_tbl_keys, $updateNulls);
+			$this->_db->updateObject($this->_tbl, $this, $this->_tbl_keys, $updateNulls);
 		}
 		else
 		{
-			$result = $this->_db->insertObject($this->_tbl, $this, $this->_tbl_keys[0]);
+			$this->_db->insertObject($this->_tbl, $this, $this->_tbl_keys[0]);
 		}
 
 		// If the table is not set to track assets return true.


### PR DESCRIPTION
In `JTable::store()` there exists a use case where the `$result` variable, which should be a boolean and is used as such in observers, can be set as the database cursor object which introduces the potential for code to handle that variable incorrectly.  This PR updates the `$result` variable to default to a true value and only in error conditions that already exist is when it gets set to false.  We no longer catch the result of the JDatabaseDriver (insert/update)Object methods as well as it is unused.
### Testing Instructions

Saving items should still work.
