### PR TITLE
Repair slider view and add tab view for Beez template

### DIFF
--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -11,12 +11,13 @@ defined('_JEXEC') or die;
 
 $cparams = JComponentHelper::getParams('com_media');
 ?>
+
 <div class="contact<?php echo $this->pageclass_sfx?>">
-<?php if ($this->params->get('show_page_heading')) : ?>
-<h1>
-	<?php echo $this->escape($this->params->get('page_heading')); ?>
-</h1>
-<?php endif; ?>
+	<?php if ($this->params->get('show_page_heading')) : ?>
+		<h1>
+			<?php echo $this->escape($this->params->get('page_heading')); ?>
+		</h1>
+	<?php endif; ?>
 	<?php if ($this->contact->name && $this->params->get('show_name')) : ?>
 		<div class="page-header">
 			<h2>
@@ -49,20 +50,18 @@ $cparams = JComponentHelper::getParams('com_media');
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>
 
-	<?php  if ($this->params->get('presentation_style') == 'sliders'):?>
-		<div class="accordion" id="accordionContact">
-			<div class="accordion-group">
-				<div class="accordion-heading">
-					<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#basic-details">
-					<?php echo JText::_('COM_CONTACT_DETAILS');?>
-					</a>
-				</div>
-				<div id="basic-details" class="accordion-body collapse in">
-					<div class="accordion-inner">
+	<?php  if ($this->params->get('presentation_style') == 'sliders') : ?>
+		<?php echo JHtml::_('sliders.start', 'panel-sliders', array('useCookie' => '1')); ?>
+		<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
+	<?php endif; ?>
+	<?php  if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php echo JHtmlTabs::start('tabs', array('useCookie' => '1')); ?>
+		<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'plain'):?>
 		<?php  echo '<h3>' . JText::_('COM_CONTACT_DETAILS') . '</h3>';  ?>
 	<?php endif; ?>
+
 	<?php if ($this->contact->image && $this->params->get('show_image')) : ?>
 		<div class="thumbnail pull-right">
 			<?php echo JHtml::_('image', $this->contact->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('align' => 'middle')); ?>
@@ -84,33 +83,20 @@ $cparams = JComponentHelper::getParams('com_media');
 			<a href="<?php echo JRoute::_('index.php?option=com_contact&amp;view=contact&amp;id='.$this->contact->id . '&amp;format=vcf'); ?>">
 			<?php echo JText::_('COM_CONTACT_VCARD');?></a>
 	<?php endif; ?>
-	<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-					</div>
-				</div>
-			</div>
-		</div>
-	<?php endif; ?>
+
 	<?php if ($this->params->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
 
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-			<div class="accordion-group">
-				<div class="accordion-heading">
-					<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#display-form">
-					<?php echo JText::_('COM_CONTACT_EMAIL_FORM');?>
-					</a>
-				</div>
-				<div id="display-form" class="accordion-body collapse">
-					<div class="accordion-inner">
+		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+			<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
+		<?php endif; ?>
+		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php  echo '<h3>'. JText::_('COM_CONTACT_EMAIL_FORM').'</h3>';  ?>
 		<?php endif; ?>
 		<?php  echo $this->loadTemplate('form');  ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-					</div>
-				</div>
-			</div>
-		<?php endif; ?>
+
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_links')) : ?>
@@ -118,79 +104,66 @@ $cparams = JComponentHelper::getParams('com_media');
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
-			<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-			<div class="accordion-group">
-				<div class="accordion-heading">
-					<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#display-articles">
-					<?php echo JText::_('JGLOBAL_ARTICLES');?>
-					</a>
-				</div>
-				<div id="display-articles" class="accordion-body collapse">
-					<div class="accordion-inner">
-			<?php endif; ?>
-			<?php if  ($this->params->get('presentation_style') == 'plain'):?>
+
+		<?php if ($this->params->get('presentation_style') == 'sliders') :
+			echo JHtml::_('sliders.panel', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
+		<?php endif; ?>
+		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+			<?php echo JHtmlTabs::panel(JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
+		<?php endif; ?>
+		<?php if  ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>'; ?>
-			<?php endif; ?>
-			<?php echo $this->loadTemplate('articles'); ?>
-			<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-					</div>
-				</div>
-			</div>
-			<?php endif; ?>
+		<?php endif; ?>
+
+		<?php echo $this->loadTemplate('articles'); ?>
+
 	<?php endif; ?>
+
 	<?php if ($this->params->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-			<div class="accordion-group">
-				<div class="accordion-heading">
-					<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#display-profile">
-					<?php echo JText::_('COM_CONTACT_PROFILE');?>
-					</a>
-				</div>
-				<div id="display-profile" class="accordion-body collapse">
-					<div class="accordion-inner">
+
+		<?php if ($this->params->get('presentation_style') == 'sliders') :
+			echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
+		<?php endif; ?>
+		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_PROFILE').'</h3>'; ?>
 		<?php endif; ?>
+
 		<?php echo $this->loadTemplate('profile'); ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-					</div>
-				</div>
-			</div>
-		<?php endif; ?>
+
 	<?php endif; ?>
+
 	<?php if ($this->contact->misc && $this->params->get('show_misc')) : ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-			<div class="accordion-group">
-				<div class="accordion-heading">
-					<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#display-misc">
-					<?php echo JText::_('COM_CONTACT_OTHER_INFORMATION');?>
-					</a>
-				</div>
-				<div id="display-misc" class="accordion-body collapse">
-					<div class="accordion-inner">
+
+		<?php if ($this->params->get('presentation_style') == 'sliders') :
+			echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
+		<?php endif; ?>
+		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_OTHER_INFORMATION').'</h3>'; ?>
 		<?php endif; ?>
-				<div class="contact-miscinfo">
-					<dl class="dl-horizontal">
-						<dt>
-							<span class="<?php echo $this->params->get('marker_class'); ?>">
-								<?php echo $this->params->get('marker_misc'); ?>
-							</span>
-						</dt>
-						<dd>
-							<span class="contact-misc">
-								<?php echo $this->contact->misc; ?>
-							</span>
-						</dd>
-					</dl>
-				</div>
-		<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-					</div>
-				</div>
-			</div>
-		<?php endif; ?>
+
+		<div class="contact-miscinfo">
+			<dl class="dl-horizontal">
+				<dt>
+					<span class="<?php echo $this->params->get('marker_class'); ?>">
+						<?php echo $this->params->get('marker_misc'); ?>
+					</span>
+				</dt>
+				<dd>
+					<span class="contact-misc">
+						<?php echo $this->contact->misc; ?>
+					</span>
+				</dd>
+			</dl>
+		</div>
 	<?php endif; ?>
+
+	<?php if ($this->params->get('presentation_style') == 'sliders') :
+		echo JHtml::_('sliders.end');
+	endif; ?>
 </div>

--- a/templates/beez3/html/com_contact/contact/default_links.php
+++ b/templates/beez3/html/com_contact/contact/default_links.php
@@ -16,7 +16,7 @@ if ($this->params->get('presentation_style') == 'sliders') : ?>
 	<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_LINKS'), 'display-links'); ?>
 <?php endif; ?>
 <?php if  ($this->params->get('presentation_style') == 'plain'):?>
-	<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>'; ?>
+	<?php echo '<h3>'. JText::_('COM_CONTACT_LINKS').'</h3>'; ?>
 <?php endif; ?>
 
 <div class="contact-links">

--- a/templates/beez3/html/com_contact/contact/default_links.php
+++ b/templates/beez3/html/com_contact/contact/default_links.php
@@ -9,48 +9,37 @@
 
 defined('_JEXEC') or die;
 
-if ($this->params->get('presentation_style') == 'sliders'):?>
-<div class="accordion-group">
-	<div class="accordion-heading">
-		<a class="accordion-toggle" data-toggle="collapse" data-parent="accordionContact" href="#display-links">
-		<?php echo JText::_('COM_CONTACT_LINKS');?>
-		</a>
-	</div>
-	<div id="display-links" class="accordion-body collapse">
-		<div class="accordion-inner">
+if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_LINKS'), 'display-links'); ?>
+<?php endif; ?>
+<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+	<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_LINKS'), 'display-links'); ?>
 <?php endif; ?>
 <?php if  ($this->params->get('presentation_style') == 'plain'):?>
-<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>'; ?>
+	<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>'; ?>
 <?php endif; ?>
 
-			<div class="contact-links">
-				<ul class="nav nav-list">
-					<?php
-					foreach (range('a', 'e') as $char) :// letters 'a' to 'e'
-						$link = $this->contact->params->get('link'.$char);
-						$label = $this->contact->params->get('link'.$char.'_name');
+<div class="contact-links">
+	<ul class="nav nav-list">
+		<?php foreach (range('a', 'e') as $char) :// letters 'a' to 'e'
+			$link = $this->contact->params->get('link'.$char);
+			$label = $this->contact->params->get('link'.$char.'_name');
 
-						if (!$link) :
-							continue;
-						endif;
+			if (!$link) :
+				continue;
+			endif;
 
-						// Add 'http://' if not present
-						$link = (0 === strpos($link, 'http')) ? $link : 'http://'.$link;
+			// Add 'http://' if not present
+			$link = (0 === strpos($link, 'http')) ? $link : 'http://'.$link;
 
-						// If no label is present, take the link
-						$label = ($label) ? $label : $link;
-						?>
-						<li>
-							<a href="<?php echo $link; ?>">
-							    <?php echo $label; ?>
-							</a>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-			</div>
-
-<?php if ($this->params->get('presentation_style') == 'sliders'):?>
-		</div>
-	</div>
+			// If no label is present, take the link
+			$label = ($label) ? $label : $link;
+			?>
+			<li>
+				<a href="<?php echo $link; ?>">
+				    <?php echo $label; ?>
+				</a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
 </div>
-<?php endif; ?>


### PR DESCRIPTION
This PR is the solution for issue #7662 
## What this PR does

This PR repair the slider display for com_contact in the beez template, and adds the tab display. I used `JHtml` instead of hard coded sliders.
I also changed a wrong placed language string in default_links.php
## How to test this PR

1) Create a menu item of the type "Single contact" and make sure all information of this contact will be shown
2) Set "Beez3" as default template
3) In the options of com_contact set the parameter "Display Format" to the option: Sliders
4) Confirm all sliders are displayed correctly, like this:
![knipsel](https://cloud.githubusercontent.com/assets/2659866/10419310/0778a6ea-7074-11e5-96fd-c7361b05ec2a.PNG)

4) In the options of com_contact set the parameter "Display Format" to the option: Tabs
5) Confirm all tabs are displayed correctly, like this:
![knipsel](https://cloud.githubusercontent.com/assets/2659866/10419320/3dde55ea-7074-11e5-8d72-6e4b0209d848.PNG)

5) In the options of com_contact set the parameter "Display Format" to the option: Plain
6) Confirm all information is displayed under each other, with the good headings
