### PR TITLE
Code review on com_admin component

### DIFF
--- a/administrator/components/com_admin/controllers/profile.php
+++ b/administrator/components/com_admin/controllers/profile.php
@@ -63,7 +63,7 @@ class AdminControllerProfile extends JControllerForm
 	 *
 	 * @param   string  $key  The name of the primary key of the URL variable.
 	 *
-	 * @return  Boolean  True if access level checks pass, false otherwise.
+	 * @return  boolean  True if access level checks pass, false otherwise.
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_admin/models/help.php
+++ b/administrator/components/com_admin/models/help.php
@@ -20,7 +20,6 @@ class AdminModelHelp extends JModelLegacy
 	 * The search string
 	 *
 	 * @var    string
-	 *
 	 * @since  1.6
 	 */
 	protected $help_search = null;
@@ -29,16 +28,14 @@ class AdminModelHelp extends JModelLegacy
 	 * The page to be viewed
 	 *
 	 * @var    string
-	 *
 	 * @since  1.6
 	 */
 	protected $page = null;
 
 	/**
-	 * The iso language tag
+	 * The ISO language tag
 	 *
 	 * @var    string
-	 *
 	 * @since  1.6
 	 */
 	protected $lang_tag = null;
@@ -47,7 +44,6 @@ class AdminModelHelp extends JModelLegacy
 	 * Table of contents
 	 *
 	 * @var    array
-	 *
 	 * @since  1.6
 	 */
 	protected $toc = null;
@@ -56,7 +52,6 @@ class AdminModelHelp extends JModelLegacy
 	 * URL for the latest version check
 	 *
 	 * @var    string
-	 *
 	 * @since  1.6
 	 */
 	protected $latest_version_check = null;
@@ -66,7 +61,7 @@ class AdminModelHelp extends JModelLegacy
 	 *
 	 * @return  string  Help search string
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function &getHelpSearch()
 	{
@@ -83,14 +78,13 @@ class AdminModelHelp extends JModelLegacy
 	 *
 	 * @return  string  The page
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function &getPage()
 	{
 		if (is_null($this->page))
 		{
-			$page = JFactory::getApplication()->input->get('page', 'JHELP_START_HERE');
-			$this->page = JHelp::createUrl($page);
+			$this->page = JHelp::createUrl(JFactory::getApplication()->input->get('page', 'JHELP_START_HERE'));
 		}
 
 		return $this->page;
@@ -107,12 +101,11 @@ class AdminModelHelp extends JModelLegacy
 	{
 		if (is_null($this->lang_tag))
 		{
-			$lang = JFactory::getLanguage();
-			$this->lang_tag = $lang->getTag();
+			$this->lang_tag = JFactory::getLanguage()->getTag();
 
 			if (!is_dir(JPATH_BASE . '/help/' . $this->lang_tag))
 			{
-				// Use english as fallback
+				// Use English as fallback
 				$this->lang_tag = 'en-GB';
 			}
 		}
@@ -121,7 +114,7 @@ class AdminModelHelp extends JModelLegacy
 	}
 
 	/**
-	 * Method to get the toc
+	 * Method to get the table of contents
 	 *
 	 * @return  array  Table of contents
 	 */
@@ -133,7 +126,7 @@ class AdminModelHelp extends JModelLegacy
 		}
 
 		// Get vars
-		$lang_tag = $this->getLangTag();
+		$lang_tag    = $this->getLangTag();
 		$help_search = $this->getHelpSearch();
 
 		// New style - Check for a TOC JSON file

--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -103,9 +103,7 @@ class AdminModelProfile extends UsersModelUser
 	 */
 	public function getItem($pk = null)
 	{
-		$user = JFactory::getUser();
-
-		return parent::getItem($user->get('id'));
+		return parent::getItem(JFactory::getUser()->id);
 	}
 
 	/**

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -19,25 +19,33 @@ use Joomla\Registry\Registry;
 class AdminModelSysInfo extends JModelLegacy
 {
 	/**
-	 * @var array Some PHP settings
+	 * Some PHP settings
+	 *
+	 * @var    array
 	 * @since  1.6
 	 */
-	protected $php_settings = null;
+	protected $php_settings = array();
 
 	/**
-	 * @var array Config values
+	 * Config values
+	 *
+	 * @var    array
 	 * @since  1.6
 	 */
-	protected $config = null;
+	protected $config = array();
 
 	/**
-	 * @var array Some system values
+	 * Some system values
+	 *
+	 * @var    array
 	 * @since  1.6
 	 */
-	protected $info = null;
+	protected $info = array();
 
 	/**
-	 * @var string PHP info
+	 * PHP info
+	 *
+	 * @var    string
 	 * @since  1.6
 	 */
 	protected $php_info = null;
@@ -45,50 +53,51 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Information about writable state of directories
 	 *
-	 * @var array
+	 * @var    array
 	 * @since  1.6
 	 */
-	protected $directories = null;
+	protected $directories = array();
 
 	/**
 	 * The current editor.
 	 *
-	 * @var string
+	 * @var    string
 	 * @since  1.6
 	 */
 	protected $editor = null;
 
 	/**
-	 * Method to get the ChangeLog
+	 * Method to get the PHP settings
 	 *
-	 * @return array some php settings
+	 * @return  array  Some PHP settings
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function &getPhpSettings()
 	{
-		if (!is_null($this->php_settings))
+		if (!empty($this->php_settings))
 		{
 			return $this->php_settings;
 		}
 
-		$this->php_settings = array();
-		$this->php_settings['safe_mode'] = ini_get('safe_mode') == '1';
-		$this->php_settings['display_errors'] = ini_get('display_errors') == '1';
-		$this->php_settings['short_open_tag'] = ini_get('short_open_tag') == '1';
-		$this->php_settings['file_uploads'] = ini_get('file_uploads') == '1';
-		$this->php_settings['magic_quotes_gpc'] = ini_get('magic_quotes_gpc') == '1';
-		$this->php_settings['register_globals'] = ini_get('register_globals') == '1';
-		$this->php_settings['output_buffering'] = (bool) ini_get('output_buffering');
-		$this->php_settings['open_basedir'] = ini_get('open_basedir');
-		$this->php_settings['session.save_path'] = ini_get('session.save_path');
-		$this->php_settings['session.auto_start'] = ini_get('session.auto_start');
-		$this->php_settings['disable_functions'] = ini_get('disable_functions');
-		$this->php_settings['xml'] = extension_loaded('xml');
-		$this->php_settings['zlib'] = extension_loaded('zlib');
-		$this->php_settings['zip'] = function_exists('zip_open') && function_exists('zip_read');
-		$this->php_settings['mbstring'] = extension_loaded('mbstring');
-		$this->php_settings['iconv'] = function_exists('iconv');
+		$this->php_settings = array(
+			'safe_mode'          => ini_get('safe_mode') == '1',
+			'display_errors'     => ini_get('display_errors') == '1',
+			'short_open_tag'     => ini_get('short_open_tag') == '1',
+			'file_uploads'       => ini_get('file_uploads') == '1',
+			'magic_quotes_gpc'   => ini_get('magic_quotes_gpc') == '1',
+			'register_globals'   => ini_get('register_globals') == '1',
+			'output_buffering'   => (bool) ini_get('output_buffering'),
+			'open_basedir'       => ini_get('open_basedir'),
+			'session.save_path'  => ini_get('session.save_path'),
+			'session.auto_start' => ini_get('session.auto_start'),
+			'disable_functions'  => ini_get('disable_functions'),
+			'xml'                => extension_loaded('xml'),
+			'zlib'               => extension_loaded('zlib'),
+			'zip'                => function_exists('zip_open') && function_exists('zip_read'),
+			'mbstring'           => extension_loaded('mbstring'),
+			'iconv'              => function_exists('iconv')
+		);
 
 		return $this->php_settings;
 	}
@@ -98,11 +107,11 @@ class AdminModelSysInfo extends JModelLegacy
 	 *
 	 * @return  array  config values
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function &getConfig()
 	{
-		if (!is_null($this->config))
+		if (!empty($this->config))
 		{
 			return $this->config;
 		}
@@ -122,41 +131,42 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Method to get the system information
 	 *
-	 * @return  array system information values
+	 * @return  array  System information values
 	 *
 	 * @since   1.6
 	 */
 	public function &getInfo()
 	{
-		if (!is_null($this->info))
+		if (!empty($this->info))
 		{
 			return $this->info;
 		}
 
-		$this->info = array();
-		$version = new JVersion;
-		$platform = new JPlatform;
-		$db = $this->getDbo();
+		$version    = new JVersion;
+		$platform   = new JPlatform;
+		$db         = $this->getDbo();
 
-		$this->info['php'] = php_uname();
-		$this->info['dbversion'] = $db->getVersion();
-		$this->info['dbcollation'] = $db->getCollation();
-		$this->info['phpversion'] = phpversion();
-		$this->info['server'] = isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : getenv('SERVER_SOFTWARE');
-		$this->info['sapi_name'] = php_sapi_name();
-		$this->info['version'] = $version->getLongVersion();
-		$this->info['platform'] = $platform->getLongVersion();
-		$this->info['useragent'] = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : "";
+		$this->info = array(
+			'php'         => php_uname(),
+			'dbversion'   => $db->getVersion(),
+			'dbcollation' => $db->getCollation(),
+			'phpversion'  => phpversion(),
+			'server'      => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : getenv('SERVER_SOFTWARE'),
+			'sapi_name'   => php_sapi_name(),
+			'version'     => $version->getLongVersion(),
+			'platform'    => $platform->getLongVersion(),
+			'useragent'   => isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : ""
+		);
 
 		return $this->info;
 	}
 
 	/**
-	 * Method to get if phpinfo method is enabled from php.ini
+	 * Check if the phpinfo function is enabled
 	 *
 	 * @return  boolean True if enabled
 	 *
-	 * @since  3.4.1
+	 * @since   3.4.1
 	 */
 	public function phpinfoEnabled()
 	{
@@ -166,9 +176,9 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Method to get the PHP info
 	 *
-	 * @return  string PHP info
+	 * @return  string  PHP info
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function &getPHPInfo()
 	{
@@ -205,13 +215,13 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Method to get the directory states
 	 *
-	 * @return array States of directories
+	 * @return  array States of directories
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function getDirectory()
 	{
-		if (!is_null($this->directories))
+		if (!empty($this->directories))
 		{
 			return $this->directories;
 		}
@@ -219,10 +229,10 @@ class AdminModelSysInfo extends JModelLegacy
 		$this->directories = array();
 
 		$registry = JFactory::getConfig();
-		$cparams = JComponentHelper::getParams('com_media');
+		$cparams  = JComponentHelper::getParams('com_media');
 
-		$this->_addDirectory('administrator/components', JPATH_ADMINISTRATOR . '/components');
-		$this->_addDirectory('administrator/language', JPATH_ADMINISTRATOR . '/language');
+		$this->addDirectory('administrator/components', JPATH_ADMINISTRATOR . '/components');
+		$this->addDirectory('administrator/language', JPATH_ADMINISTRATOR . '/language');
 
 		// List all admin languages
 		$admin_langs = new DirectoryIterator(JPATH_ADMINISTRATOR . '/language');
@@ -234,7 +244,7 @@ class AdminModelSysInfo extends JModelLegacy
 				continue;
 			}
 
-			$this->_addDirectory('administrator/language/' . $folder->getFilename(), JPATH_ADMINISTRATOR . '/language/' . $folder->getFilename());
+			$this->addDirectory('administrator/language/' . $folder->getFilename(), JPATH_ADMINISTRATOR . '/language/' . $folder->getFilename());
 		}
 
 		// List all manifests folders
@@ -247,15 +257,15 @@ class AdminModelSysInfo extends JModelLegacy
 				continue;
 			}
 
-			$this->_addDirectory('administrator/manifests/' . $folder->getFilename(), JPATH_ADMINISTRATOR . '/manifests/' . $folder->getFilename());
+			$this->addDirectory('administrator/manifests/' . $folder->getFilename(), JPATH_ADMINISTRATOR . '/manifests/' . $folder->getFilename());
 		}
 
-		$this->_addDirectory('administrator/modules', JPATH_ADMINISTRATOR . '/modules');
-		$this->_addDirectory('administrator/templates', JPATH_THEMES);
+		$this->addDirectory('administrator/modules', JPATH_ADMINISTRATOR . '/modules');
+		$this->addDirectory('administrator/templates', JPATH_THEMES);
 
-		$this->_addDirectory('components', JPATH_SITE . '/components');
+		$this->addDirectory('components', JPATH_SITE . '/components');
 
-		$this->_addDirectory($cparams->get('image_path'), JPATH_SITE . '/' . $cparams->get('image_path'));
+		$this->addDirectory($cparams->get('image_path'), JPATH_SITE . '/' . $cparams->get('image_path'));
 
 		// List all images folders
 		$image_folders = new DirectoryIterator(JPATH_SITE . '/' . $cparams->get('image_path'));
@@ -267,10 +277,10 @@ class AdminModelSysInfo extends JModelLegacy
 				continue;
 			}
 
-			$this->_addDirectory('images/' . $folder->getFilename(), JPATH_SITE . '/' . $cparams->get('image_path') . '/' . $folder->getFilename());
+			$this->addDirectory('images/' . $folder->getFilename(), JPATH_SITE . '/' . $cparams->get('image_path') . '/' . $folder->getFilename());
 		}
 
-		$this->_addDirectory('language', JPATH_SITE . '/language');
+		$this->addDirectory('language', JPATH_SITE . '/language');
 
 		// List all site languages
 		$site_langs = new DirectoryIterator(JPATH_SITE . '/language');
@@ -282,14 +292,14 @@ class AdminModelSysInfo extends JModelLegacy
 				continue;
 			}
 
-			$this->_addDirectory('language/' . $folder->getFilename(), JPATH_SITE . '/language/' . $folder->getFilename());
+			$this->addDirectory('language/' . $folder->getFilename(), JPATH_SITE . '/language/' . $folder->getFilename());
 		}
 
-		$this->_addDirectory('libraries', JPATH_LIBRARIES);
+		$this->addDirectory('libraries', JPATH_LIBRARIES);
 
-		$this->_addDirectory('media', JPATH_SITE . '/media');
-		$this->_addDirectory('modules', JPATH_SITE . '/modules');
-		$this->_addDirectory('plugins', JPATH_PLUGINS);
+		$this->addDirectory('media', JPATH_SITE . '/media');
+		$this->addDirectory('modules', JPATH_SITE . '/modules');
+		$this->addDirectory('plugins', JPATH_PLUGINS);
 
 		$plugin_groups = new DirectoryIterator(JPATH_SITE . '/plugins');
 
@@ -300,26 +310,26 @@ class AdminModelSysInfo extends JModelLegacy
 				continue;
 			}
 
-			$this->_addDirectory('plugins/' . $folder->getFilename(), JPATH_PLUGINS . '/' . $folder->getFilename());
+			$this->addDirectory('plugins/' . $folder->getFilename(), JPATH_PLUGINS . '/' . $folder->getFilename());
 		}
 
-		$this->_addDirectory('templates', JPATH_SITE . '/templates');
-		$this->_addDirectory('configuration.php', JPATH_CONFIGURATION . '/configuration.php');
+		$this->addDirectory('templates', JPATH_SITE . '/templates');
+		$this->addDirectory('configuration.php', JPATH_CONFIGURATION . '/configuration.php');
 
 		// Is there a cache path in configuration.php?
 		if ($cache_path = trim($registry->get('cache_path', '')))
 		{
 			// Frontend and backend use same directory for caching.
-			$this->_addDirectory($cache_path, $cache_path, 'COM_ADMIN_CACHE_DIRECTORY');
+			$this->addDirectory($cache_path, $cache_path, 'COM_ADMIN_CACHE_DIRECTORY');
 		}
 		else
 		{
-			$this->_addDirectory('cache', JPATH_SITE . '/cache', 'COM_ADMIN_CACHE_DIRECTORY');
-			$this->_addDirectory('administrator/cache', JPATH_CACHE, 'COM_ADMIN_CACHE_DIRECTORY');
+			$this->addDirectory('cache', JPATH_SITE . '/cache', 'COM_ADMIN_CACHE_DIRECTORY');
+			$this->addDirectory('administrator/cache', JPATH_CACHE, 'COM_ADMIN_CACHE_DIRECTORY');
 		}
 
-		$this->_addDirectory($registry->get('log_path', JPATH_ROOT . '/log'), $registry->get('log_path', JPATH_ROOT . '/log'), 'COM_ADMIN_LOG_DIRECTORY');
-		$this->_addDirectory($registry->get('tmp_path', JPATH_ROOT . '/tmp'), $registry->get('tmp_path', JPATH_ROOT . '/tmp'), 'COM_ADMIN_TEMP_DIRECTORY');
+		$this->addDirectory($registry->get('log_path', JPATH_ROOT . '/log'), $registry->get('log_path', JPATH_ROOT . '/log'), 'COM_ADMIN_LOG_DIRECTORY');
+		$this->addDirectory($registry->get('tmp_path', JPATH_ROOT . '/tmp'), $registry->get('tmp_path', JPATH_ROOT . '/tmp'), 'COM_ADMIN_TEMP_DIRECTORY');
 
 		return $this->directories;
 	}
@@ -327,19 +337,15 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Method to add a directory
 	 *
-	 * @return void
-	 * @since  1.6
-	 */
-	/**
-	 * Method to add a directory
-	 *
 	 * @param   string  $name     Directory Name
 	 * @param   string  $path     Directory path
 	 * @param   string  $message  Message
 	 *
-	 * @return   void
+	 * @return  void
+	 *
+	 * @since   1.6
 	 */
-	private function _addDirectory($name, $path, $message = '')
+	private function addDirectory($name, $path, $message = '')
 	{
 		$this->directories[$name] = array('writable' => is_writable($path), 'message' => $message);
 	}
@@ -347,11 +353,10 @@ class AdminModelSysInfo extends JModelLegacy
 	/**
 	 * Method to get the editor
 	 *
-	 * @return  string The default editor
+	 * @return  string  The default editor
 	 *
-	 * @note: has to be removed (it is present in the config...)
-	 *
-	 * @since  1.6
+	 * @note    Has to be removed (it is present in the config...)
+	 * @since   1.6
 	 */
 	public function &getEditor()
 	{

--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -12,15 +12,15 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
- * Checks if the eAccelerator caching method is enabled. This check should be
- * done through the 3.x series as the issue impacts migrated sites which will
- * most often come from the previous LTS release (2.5). Remove for version 4 or
- * when eAccelerator support is added.
+ * Checks if the eAccelerator caching method is enabled.
  *
- * This check returns true when the eAccelerator caching method is user, meaning
- * that the message concerning it should be displayed.
+ * This check should be done through the 3.x series as the issue impacts migrated sites which will
+ * most often come from the previous LTS release (2.5). Remove for version 4 or when eAccelerator support is added.
+ *
+ * This check returns true when the eAccelerator caching method is user, meaning that the message concerning it should be displayed.
  *
  * @return  integer
  *
@@ -35,8 +35,7 @@ function admin_postinstall_eaccelerator_condition()
 }
 
 /**
- * Disables the unsupported eAccelerator caching method, replacing it with the
- * "file" caching method.
+ * Disables the unsupported eAccelerator caching method, replacing it with the "file" caching method.
  *
  * @return  void
  *
@@ -44,12 +43,8 @@ function admin_postinstall_eaccelerator_condition()
  */
 function admin_postinstall_eaccelerator_action()
 {
-	$prev = new JConfig;
-	$prev = JArrayHelper::fromObject($prev);
-
-	$data = array('cacheHandler' => 'file');
-
-	$data = array_merge($prev, $data);
+	$prev = ArrayHelper::fromObject(new JConfig);
+	$data = array_merge($prev, array('cacheHandler' => 'file'));
 
 	$config = new Registry('config');
 	$config->loadArray($data);

--- a/administrator/components/com_admin/postinstall/languageaccess340.php
+++ b/administrator/components/com_admin/postinstall/languageaccess340.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
  * @see     https://github.com/joomla/joomla-cms/pull/6172
  * @see     https://github.com/joomla/joomla-cms/pull/6194
  *
- * @return  bool
+ * @return  boolean
  *
  * @since   3.4.1
  */
@@ -35,8 +35,7 @@ function admin_postinstall_languageaccess340_condition()
 
 	if (isset($numRows) && $numRows != 0)
 	{
-		// We have rows here so we have at minumum
-		// one row with access set to 0
+		// We have rows here so we have at minumum one row with access set to 0
 		return true;
 	}
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -21,7 +21,7 @@ class JoomlaInstallerScript
 	 *
 	 * @param   JInstallerFile  $installer  The class calling this method
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	public function update($installer)
 	{
@@ -41,7 +41,7 @@ class JoomlaInstallerScript
 	/**
 	 * Method to update Database
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function updateDatabase()
 	{
@@ -58,7 +58,7 @@ class JoomlaInstallerScript
 	/**
 	 * Method to update MySQL Database
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function updateDatabaseMysql()
 	{
@@ -104,7 +104,7 @@ class JoomlaInstallerScript
 	/**
 	 * Uninstall the 2.5 EOS plugin
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function uninstallEosPlugin()
 	{
@@ -138,7 +138,7 @@ class JoomlaInstallerScript
 	/**
 	 * Update the manifest caches
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function updateManifestCaches()
 	{
@@ -334,7 +334,7 @@ class JoomlaInstallerScript
 	/**
 	 * Delete files that should not exist
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	public function deleteUnexistingFiles()
 	{
@@ -1416,8 +1416,9 @@ class JoomlaInstallerScript
 	}
 
 	/**
-	 * Clears the RAD layer's table cache. The cache vastly improves performance
-	 * but needs to be cleared every time you update the database schema.
+	 * Clears the RAD layer's table cache.
+	 *
+	 * The cache vastly improves performance but needs to be cleared every time you update the database schema.
 	 *
 	 * @return  void
 	 *
@@ -1454,6 +1455,7 @@ class JoomlaInstallerScript
 
 		foreach ($newComponents as $component)
 		{
+			/** @var JTableAsset $asset */
 			$asset = JTable::getInstance('Asset');
 
 			if ($asset->loadByName($component))

--- a/administrator/components/com_admin/views/help/view.html.php
+++ b/administrator/components/com_admin/views/help/view.html.php
@@ -17,32 +17,50 @@ defined('_JEXEC') or die;
 class AdminViewHelp extends JViewLegacy
 {
 	/**
-	 * @var string the search string
+	 * The search string
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $help_search = null;
 
 	/**
-	 * @var string the page to be viewed
+	 * The page to be viewed
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $page = null;
 
 	/**
-	 * @var string the iso language tag
+	 * The iso language tag
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $lang_tag = null;
 
 	/**
-	 * @var array Table of contents
+	 * Table of contents
+	 *
+	 * @var    array
+	 * @since  1.6
 	 */
-	protected $toc = null;
+	protected $toc = array();
 
 	/**
-	 * @var string url for the latest version check
+	 * URL for the latest version check
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $latest_version_check = 'https://www.joomla.org/download.html';
 
 	/**
-	 * @var string url for the start here link.
+	 * URL for the start here link
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $start_here = null;
 
@@ -52,6 +70,8 @@ class AdminViewHelp extends JViewLegacy
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
 	 * @return  mixed  A string if successful, otherwise a Error object.
+	 *
+	 * @since   1.6
 	 */
 	public function display($tpl = null)
 	{
@@ -62,7 +82,8 @@ class AdminViewHelp extends JViewLegacy
 		$this->latest_version_check = $this->get('LatestVersionCheck');
 
 		$this->addToolbar();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_admin/views/profile/view.html.php
+++ b/administrator/components/com_admin/views/profile/view.html.php
@@ -16,10 +16,28 @@ defined('_JEXEC') or die;
  */
 class AdminViewProfile extends JViewLegacy
 {
+	/**
+	 * The JForm object
+	 *
+	 * @var    JForm
+	 * @since  1.6
+	 */
 	protected $form;
 
+	/**
+	 * The item being viewed
+	 *
+	 * @var    object
+	 * @since  1.6
+	 */
 	protected $item;
 
+	/**
+	 * The model state
+	 *
+	 * @var    object
+	 * @since  1.6
+	 */
 	protected $state;
 
 	/**
@@ -28,6 +46,8 @@ class AdminViewProfile extends JViewLegacy
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
 	 * @return  mixed  A string if successful, otherwise a Error object.
+	 *
+	 * @since   1.6
 	 */
 	public function display($tpl = null)
 	{
@@ -46,8 +66,9 @@ class AdminViewProfile extends JViewLegacy
 		$this->form->setValue('password',	null);
 		$this->form->setValue('password2',	null);
 
-		parent::display($tpl);
 		$this->addToolbar();
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -17,29 +17,44 @@ defined('_JEXEC') or die;
 class AdminViewSysinfo extends JViewLegacy
 {
 	/**
-	 * @var array some php settings
+	 * Some PHP settings
+	 *
+	 * @var    array
+	 * @since  1.6
 	 */
-	protected $php_settings = null;
+	protected $php_settings = array();
 
 	/**
-	 * @var array config values
+	 * Config values
+	 *
+	 * @var    array
+	 * @since  1.6
 	 */
-	protected $config = null;
+	protected $config = array();
 
 	/**
-	 * @var array somme system values
+	 * Some system values
+	 *
+	 * @var    array
+	 * @since  1.6
 	 */
-	protected $info = null;
+	protected $info = array();
 
 	/**
-	 * @var string php info
+	 * PHP info
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $php_info = null;
 
 	/**
-	 * @var array informations about writable state of directories
+	 * Information about writable state of directories
+	 *
+	 * @var    array
+	 * @since  1.6
 	 */
-	protected $directory = null;
+	protected $directory = array();
 
 	/**
 	 * Execute and display a template script.
@@ -47,6 +62,8 @@ class AdminViewSysinfo extends JViewLegacy
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
 	 * @return  mixed  A string if successful, otherwise a Error object.
+	 *
+	 * @since   1.6
 	 */
 	public function display($tpl = null)
 	{
@@ -64,7 +81,8 @@ class AdminViewSysinfo extends JViewLegacy
 
 		$this->addToolbar();
 		$this->_setSubMenu();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the com_admin component.  Changes of note:
- Doc blocks cleaned up some to follow standard
- Default object types set to match the documented type
- Not using variables for items only referenced once
- Construct of the arrays in the sysinfo model
- Renamed private `_addDirectory()` method to `addDirectory()` to comply with code style
- Return the results of the view's `display()` methods to be consistent with the documented return
### Testing Instructions

Pages from com_admin (the System Information, Joomla! Help, and the Edit Account menu items) function correctly pre- and post- patch.
