### PR TITLE
Fix JInputCookie setter to work with arrays (fixes #8073 )

### DIFF
--- a/libraries/joomla/input/cookie.php
+++ b/libraries/joomla/input/cookie.php
@@ -82,7 +82,7 @@ class JInputCookie extends JInput
 	 */
 	public function set($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httpOnly = false)
 	{
-
+		
 		if (is_array($value))
 		{
 			foreach ($value as $key => $val)
@@ -95,7 +95,6 @@ class JInputCookie extends JInput
 			setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
 		}
 		
-
 		$this->data[$name] = $value;
 	}
 }

--- a/libraries/joomla/input/cookie.php
+++ b/libraries/joomla/input/cookie.php
@@ -82,7 +82,19 @@ class JInputCookie extends JInput
 	 */
 	public function set($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httpOnly = false)
 	{
-		setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+
+		if (is_array($value))
+		{
+			foreach ($value as $key => $val)
+			{
+				setcookie($name . "[$key]", $val, $expire, $path, $domain, $secure, $httpOnly);
+			}
+		}
+		else
+		{
+			setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+		}
+		
 
 		$this->data[$name] = $value;
 	}

--- a/libraries/joomla/input/cookie.php
+++ b/libraries/joomla/input/cookie.php
@@ -82,7 +82,6 @@ class JInputCookie extends JInput
 	 */
 	public function set($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httpOnly = false)
 	{
-
 		if (is_array($value))
 		{
 			foreach ($value as $key => $val)

--- a/libraries/joomla/input/cookie.php
+++ b/libraries/joomla/input/cookie.php
@@ -82,7 +82,7 @@ class JInputCookie extends JInput
 	 */
 	public function set($name, $value, $expire = 0, $path = '', $domain = '', $secure = false, $httpOnly = false)
 	{
-		
+
 		if (is_array($value))
 		{
 			foreach ($value as $key => $val)
@@ -94,7 +94,7 @@ class JInputCookie extends JInput
 		{
 			setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
 		}
-		
+
 		$this->data[$name] = $value;
 	}
 }


### PR DESCRIPTION
Fix JInputCookie set method to support array values (fixes #8073 )

---
## Steps to reproduce the issue

Run this code 
JFactory::getApplication()->input->cookie->set("arraytest", array("asssoc1"=>"assoc1value","asssoc2"=>"assoc2value" ),time() + 365 \* 86400);
## Expected result

Cookies arraytest[asssoc1] with value "assoc1value", and arraytest[asssoc2] with value "assoc2value" beeing set
## Actual result

Warning: setcookie() expects parameter 2 to be string, array given in libraries\joomla\input\cookie.php on line 85
No cookie is set
