### PR TITLE
Update contact form layout in favor of extending the form via plugins

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -22,51 +22,30 @@ if (isset($this->error)) : ?>
 	<form id="contact-form" action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-validate form-horizontal">
 		<fieldset>
 			<legend><?php echo JText::_('COM_CONTACT_FORM_LABEL'); ?></legend>
-			<div class="control-group">
-				<div class="control-label"><?php echo $this->form->getLabel('contact_name'); ?></div>
-				<div class="controls"><?php echo $this->form->getInput('contact_name'); ?></div>
-			</div>
-			<div class="control-group">
-				<div class="control-label"><?php echo $this->form->getLabel('contact_email'); ?></div>
-				<div class="controls"><?php echo $this->form->getInput('contact_email'); ?></div>
-			</div>
-			<div class="control-group">
-				<div class="control-label"><?php echo $this->form->getLabel('contact_subject'); ?></div>
-				<div class="controls"><?php echo $this->form->getInput('contact_subject'); ?></div>
-			</div>
-			<div class="control-group">
-				<div class="control-label"><?php echo $this->form->getLabel('contact_message'); ?></div>
-				<div class="controls"><?php echo $this->form->getInput('contact_message'); ?></div>
-			</div>
-			<?php if ($this->params->get('show_email_copy')) : ?>
-				<div class="control-group">
-					<div class="control-label"><?php echo $this->form->getLabel('contact_email_copy'); ?></div>
-					<div class="controls"><?php echo $this->form->getInput('contact_email_copy'); ?></div>
-				</div>
-			<?php endif; ?>
-			<?php // Dynamically load any additional fields from plugins. ?>
+
 			<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
-				<?php if ($fieldset->name != 'contact') : ?>
-					<?php $fields = $this->form->getFieldset($fieldset->name); ?>
-					<?php foreach ($fields as $field) : ?>
-						<div class="control-group">
-							<?php if ($field->hidden) : ?>
-								<div class="controls">
-									<?php echo $field->input; ?>
-								</div>
-							<?php else: ?>
-								<div class="control-label">
-									<?php echo $field->label; ?>
-									<?php if (!$field->required && $field->type != "Spacer") : ?>
-										<span class="optional"><?php echo JText::_('COM_CONTACT_OPTIONAL'); ?></span>
-									<?php endif; ?>
-								</div>
-								<div class="controls"><?php echo $field->input; ?></div>
-							<?php endif; ?>
-						</div>
-					<?php endforeach; ?>
-				<?php endif; ?>
+				<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
+					<?php if ($field->name === 'contact_email_copy' && !$this->params->get('show_email_copy')) : ?>
+						<?php continue; ?>
+					<?php endif; ?>
+					<div class="control-group">
+						<?php if ($field->hidden) : ?>
+							<div class="controls">
+								<?php echo $field->input; ?>
+							</div>
+						<?php else: ?>
+							<div class="control-label">
+								<?php echo $field->label; ?>
+								<?php if (!$field->required && $field->type != 'Spacer') : ?>
+									<span class="optional"><?php echo JText::_('COM_CONTACT_OPTIONAL'); ?></span>
+								<?php endif; ?>
+							</div>
+							<div class="controls"><?php echo $field->input; ?></div>
+						<?php endif; ?>
+					</div>
+				<?php endforeach; ?>
 			<?php endforeach; ?>
+
 			<div class="form-actions">
 				<button class="btn btn-primary validate" type="submit"><?php echo JText::_('COM_CONTACT_CONTACT_SEND'); ?></button>
 				<input type="hidden" name="option" value="com_contact" />


### PR DESCRIPTION
Im currently working on a plugin to extend the contact form and noticed that with the current implementation of the form layout, the standard fields e.g. name, email, subject, message, [...] are rendered statically, followed by an iteration over custom **fieldsets** (see [default_form.php](https://github.com/joomla/joomla-cms/blob/staging/components/com_contact/views/contact/tmpl/default_form.php)).

This way you cannot insert custom fields (via plugins) between the default fields without creating a template override for default_form.php.

With this pull request, a system and / or content plugin can override and / or extend the fields and their **ordering** while maintaining the normal behavior for custom fieldsets without the need to create a template override.
### Test instructions:
- Install the rudimentary test / demo [plugin](http://dz.qshb.de/plg_system_contact.zip) and activate it
- Create a contact item
- Create a link to that contact item in a menu of your choice (doesn't need to be assigned to an existing user)
- Navigate to that link and make sure to open the form tab / slide if it is not visible / selected by default

This would be the time where one has to create a template override to use custom fields in the default contact form. You could do either that or apply the patch to make the custom field show up in the form. **Note:** For this test, I included a field called: "Bazquirk" in the plugin.

I mentioned earlier that the default static output would result in custom fields being appended to the form, regardless in which fieldset you put the custom field. This is and still will be the normal behavior, even with this patch (bc).

To include a custom field at the position of your choice you can now "override" the order with a plugin. In our example, it can be done by uncommenting line ~51 of the contact.php file (test / demo plugin).

Before the patch, the custom field would be appended (if not manually added in the template override).

After the patch and in combination with "reset" from line ~51, the output of the fields will be in the order of how the fields are arranged in the form manifest that extends the form.

**Note:** Make sure to delete the template override if you created one. Another way to test it would be to use the changed file of this pull request as the template override.
