### PR TITLE
Checks J config error_reporting before logging

### DIFF
--- a/libraries/joomla/log/logger/messagequeue.php
+++ b/libraries/joomla/log/logger/messagequeue.php
@@ -44,7 +44,7 @@ class JLogLoggerMessagequeue extends JLogLogger
 			case JLog::ALERT:
 			case JLog::CRITICAL:
 			case JLog::ERROR:
-				JFactory::getApplication()->enqueueMessage( $entry->message, 'error' );
+				JFactory::getApplication()->enqueueMessage($entry->message, 'error' );
 				break;
 			case JLog::WARNING:
 				JFactory::getApplication()->enqueueMessage($entry->message, 'warning');

--- a/libraries/joomla/log/logger/messagequeue.php
+++ b/libraries/joomla/log/logger/messagequeue.php
@@ -44,7 +44,7 @@ class JLogLoggerMessagequeue extends JLogLogger
 			case JLog::ALERT:
 			case JLog::CRITICAL:
 			case JLog::ERROR:
-				JFactory::getApplication()->enqueueMessage($entry->message, 'error' );
+				JFactory::getApplication()->enqueueMessage($entry->message, 'error');
 				break;
 			case JLog::WARNING:
 				JFactory::getApplication()->enqueueMessage($entry->message, 'warning');

--- a/libraries/joomla/log/logger/messagequeue.php
+++ b/libraries/joomla/log/logger/messagequeue.php
@@ -31,13 +31,20 @@ class JLogLoggerMessagequeue extends JLogLogger
 	 */
 	public function addEntry(JLogEntry $entry)
 	{
+		$errorReporting = JFactory::getConfig()->get("error_reporting");
+
+		if ($errorReporting == "none")
+		{
+			return;
+		}
+
 		switch ($entry->priority)
 		{
 			case JLog::EMERGENCY:
 			case JLog::ALERT:
 			case JLog::CRITICAL:
 			case JLog::ERROR:
-				JFactory::getApplication()->enqueueMessage($entry->message, 'error');
+				JFactory::getApplication()->enqueueMessage( $entry->message, 'error' );
 				break;
 			case JLog::WARNING:
 				JFactory::getApplication()->enqueueMessage($entry->message, 'warning');


### PR DESCRIPTION
Hi Folks,

Currently the Joomla JLog class will default to using JLogLoggerMessagequeue class if a custom logger hasn't been added.

This means that by default something like: `JLog::add("Some logging information here", JLog::INFO);` will output to the message queue on the front end.  This is done regardless of the error_reporting level defined in the Joomla main config.  So for example even with error_reporting set to none in the Joomla Global Configuration->Server settings error logging done with JLog where a component hasn't defined an alternative logger will print to the message queue.

This PR adds a check to the JLogLoggerMessagequeue to ensure that the error reporting level is not none before continuing to log the error.  This will help prevent logging statements appearing on the front end of a site as part of the message queue.
### To Test

Ensure your error reporting in your Joomla config is set to none.  Then add something like:

`JLog::add("Should this be here", JLog::INFO);`

to the top of your templates index.php file and reload the page.

Before this patch is applied the following will be displayed on the page refresh.

![jlog-before](https://cloud.githubusercontent.com/assets/9042878/10471415/ff461ffc-7258-11e5-8c21-cdaa7e0b4dd5.png)

Now apply the patch and still with error reporting set to none refresh the page.  The log message should now not be present on the site.
### Comments

I have only tested for error_reporting set to none.  Should this tests for other error_reporting levels?  If so how should we map the JLog levels to the Joomla config levels?

Cheers,
Eric.
