### PR TITLE
RFC Drop JHtml and use Layout instead for the Batch functions

### DIFF
--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ * None
+ */
+
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+
+?>
+
+<label id="batch-access-lbl" for="batch-access" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_ACCESS_LABEL', 'JLIB_HTML_BATCH_ACCESS_LABEL_DESC'); ?>">
+	<?php echo JText::_('JLIB_HTML_BATCH_ACCESS_LABEL'); ?></label>
+	<?php echo JHtml::_(
+		'access.assetgrouplist',
+		'batch[assetgroup_id]', '',
+		'class="inputbox"',
+		array(
+			'title' => JText::_('JLIB_HTML_BATCH_NOCHANGE'),
+			'id' => 'batch-access'
+		)
+	); ?>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $extension The extension name
+ */
+
+extract($displayData);
+
+// Create the copy/move options.
+$options = array(
+	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
+	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
+);
+?>
+<label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo JText::_('JLIB_HTML_BATCH_MENU_LABEL'); ?></label>
+<div id="batch-choose-action" class="control-group">
+	<select name="batch[category_id]" class="inputbox" id="batch-category-id">
+		<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
+		<?php echo JHtml::_('select.options', JHtml::_('category.options', $extension)); ?>
+	</select>
+</div>
+<div id="batch-copy-move" class="control-group radio">'
+	<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+	<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+</div>

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ * None
+ */
+
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+
+JFactory::getDocument()->addScriptDeclaration(
+	'
+		jQuery(document).ready(function($){
+			if ($("#batch-category-id").length){var batchSelector = $("#batch-category-id");}
+			if ($("#batch-menu-id").length){var batchSelector = $("#batch-menu-id");}
+			if ($("#batch-position-id").length){var batchSelector = $("#batch-position-id");}
+			if ($("#batch-copy-move").length) {
+				$("#batch-copy-move").hide();
+				batchSelector.on("change", function(){
+					if (batchSelector.val() != 0 || batchSelector.val() != "") {
+						$("#batch-copy-move").show();
+					} else {
+						$("#batch-copy-move").hide();
+					}
+				});
+			}
+		});
+			'
+);
+?>
+<label id="batch-language-lbl" for="batch-language-id" class="modalTooltip" title="<?php echo JHtml::tooltipText('JLIB_HTML_BATCH_LANGUAGE_LABEL', 'JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC'); ?>">
+	<?php echo JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'); ?>
+</label>
+<select name="batch[language_id]" class="inputbox" id="batch-language-id">
+	<option value=""><?php echo JText::_('JLIB_HTML_BATCH_LANGUAGE_NOCHANGE'); ?></option>
+	<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text'); ?>
+</select>

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -37,7 +37,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			'
 );
 ?>
-<label id="batch-language-lbl" for="batch-language-id" class="modalTooltip" title="<?php echo JHtml::tooltipText('JLIB_HTML_BATCH_LANGUAGE_LABEL', 'JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC'); ?>">
+<label id="batch-language-lbl" for="batch-language-id" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_LANGUAGE_LABEL', 'JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC'); ?>">
 	<?php echo JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'); ?>
 </label>
 <select name="batch[language_id]" class="inputbox" id="batch-language-id">

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ * None
+ */
+
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+?>
+<label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip" title="<?php
+echo JHtml::tooltipText('JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC'); ?>">
+<?php echo JText::_('JLIB_HTML_BATCH_TAG_LABEL'); ?>
+</label>
+<select name="batch[tag]" class="inputbox" id="batch-tag-id">
+	<option value=""><?php echo JText::_('JLIB_HTML_BATCH_TAG_NOCHANGE'); ?></option>
+	<?php echo JHtml::_('select.options', JHtml::_('tag.tags', array('filter.published' => array(1))), 'value', 'text'); ?>
+</select>

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
 ?>
 <label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip" title="<?php
-echo JHtml::tooltipText('JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC'); ?>">
+echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC'); ?>">
 <?php echo JText::_('JLIB_HTML_BATCH_TAG_LABEL'); ?>
 </label>
 <select name="batch[tag]" class="inputbox" id="batch-tag-id">

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  boolean   $noUser Inject an option for no user?
+ */
+
+extract($displayData);
+
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+
+$optionNo = '';
+
+if ($noUser)
+{
+	$optionNo = '<option value="0">' . JText::_('JLIB_HTML_BATCH_USER_NOUSER') . '</option>';
+}
+?>
+<label id="batch-user-lbl" for="batch-user" class="modalTooltip" title="<?php
+echo JHtml::tooltipText('JLIB_HTML_BATCH_USER_LABEL', 'JLIB_HTML_BATCH_USER_LABEL_DESC'); ?>">
+	<?php echo JText::_('JLIB_HTML_BATCH_USER_LABEL'); ?>
+</label>
+<select name="batch[user_id]" class="inputbox" id="batch-user-id">
+	<option value=""><?php echo JText::_('JLIB_HTML_BATCH_USER_NOCHANGE'); ?></option>
+	<?php echo $optionNo; ?>
+	<?php echo JHtml::_('select.options', JHtml::_('user.userlist'), 'value', 'text'); ?>
+</select>

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -28,7 +28,7 @@ if ($noUser)
 }
 ?>
 <label id="batch-user-lbl" for="batch-user" class="modalTooltip" title="<?php
-echo JHtml::tooltipText('JLIB_HTML_BATCH_USER_LABEL', 'JLIB_HTML_BATCH_USER_LABEL_DESC'); ?>">
+echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_USER_LABEL', 'JLIB_HTML_BATCH_USER_LABEL_DESC'); ?>">
 	<?php echo JText::_('JLIB_HTML_BATCH_USER_LABEL'); ?>
 </label>
 <select name="batch[user_id]" class="inputbox" id="batch-user-id">

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -25,7 +25,7 @@ abstract class JHtmlBatch
 	 *
 	 * @since       1.7
 	 *
-	 * @deprecated  4 instead of JHtml::_('batch.access'); use JLayoutHelper::render('joomla.html.batch.access', array());
+	 * @deprecated  4.0 instead of JHtml::_('batch.access'); use JLayoutHelper::render('joomla.html.batch.access', array());
 	 */
 	public static function access()
 	{
@@ -43,7 +43,7 @@ abstract class JHtmlBatch
 	 *
 	 * @since       1.7
 	 *
-	 * @deprecated  4 instead of JHtml::_('batch.item'); use JLayoutHelper::render('joomla.html.batch.item', array('extension' => 'com_XXX'));
+	 * @deprecated  4.0 instead of JHtml::_('batch.item'); use JLayoutHelper::render('joomla.html.batch.item', array('extension' => 'com_XXX'));
 	 */
 	public static function item($extension)
 	{
@@ -61,7 +61,7 @@ abstract class JHtmlBatch
 	 *
 	 * @since       2.5
 	 *
-	 * @deprecated  4 instead of JHtml::_('batch.language'); use JLayoutHelper::render('joomla.html.batch.language', array());
+	 * @deprecated  4.0 instead of JHtml::_('batch.language'); use JLayoutHelper::render('joomla.html.batch.language', array());
 	 */
 	public static function language()
 	{
@@ -79,7 +79,7 @@ abstract class JHtmlBatch
 	 *
 	 * @since       2.5
 	 *
-	 * @deprecated  4 instead of JHtml::_('batch.user'); use JLayoutHelper::render('joomla.html.batch.user', array());
+	 * @deprecated  4.0 instead of JHtml::_('batch.user'); use JLayoutHelper::render('joomla.html.batch.user', array());
 	 */
 	public static function user($noUser = true)
 	{
@@ -97,7 +97,7 @@ abstract class JHtmlBatch
 	 *
 	 * @since       3.1
 	 *
-	 * @deprecated  4 instead of JHtml::_('batch.tag'); use JLayoutHelper::render('joomla.html.batch.tag', array());
+	 * @deprecated  4.0 instead of JHtml::_('batch.tag'); use JLayoutHelper::render('joomla.html.batch.tag', array());
 	 */
 	public static function tag()
 	{

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -12,7 +12,9 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Extended Utility class for batch processing widgets.
  *
- * @since  1.7
+ * @since       1.7
+ *
+ * @deprecated  3.5 To be removed 4.0
  */
 abstract class JHtmlBatch
 {
@@ -21,27 +23,15 @@ abstract class JHtmlBatch
 	 *
 	 * @return  string  The necessary HTML for the widget.
 	 *
-	 * @since   1.7
+	 * @since       1.7
+	 *
+	 * @deprecated  4 instead of JHtml::_('batch.access'); use JLayoutHelper::render('joomla.html.batch.access', array());
 	 */
 	public static function access()
 	{
-		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+		JLog::add('The use of JHtml::_("batch.access") is deprecated use JLayout instead.', JLog::WARNING, 'deprecated');
 
-		// Create the batch selector to change an access level on a selection list.
-		return
-			'<label id="batch-access-lbl" for="batch-access" class="modalTooltip" '
-			. 'title="' . JHtml::tooltipText('JLIB_HTML_BATCH_ACCESS_LABEL', 'JLIB_HTML_BATCH_ACCESS_LABEL_DESC') . '">'
-			. JText::_('JLIB_HTML_BATCH_ACCESS_LABEL')
-			. '</label>'
-			. JHtml::_(
-				'access.assetgrouplist',
-				'batch[assetgroup_id]', '',
-				'class="inputbox"',
-				array(
-					'title' => JText::_('JLIB_HTML_BATCH_NOCHANGE'),
-					'id' => 'batch-access'
-				)
-			);
+		return JLayoutHelper::render('joomla.html.batch.access', array());
 	}
 
 	/**
@@ -51,29 +41,17 @@ abstract class JHtmlBatch
 	 *
 	 * @return  string  The necessary HTML for the widget.
 	 *
-	 * @since   1.7
+	 * @since       1.7
+	 *
+	 * @deprecated  4 instead of JHtml::_('batch.item'); use JLayoutHelper::render('joomla.html.batch.item', array('extension' => 'com_XXX'));
 	 */
 	public static function item($extension)
 	{
-		// Create the copy/move options.
-		$options = array(
-			JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
-			JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
-		);
+		$displayData = array('extension' => $extension);
 
-		// Create the batch selector to change select the category by which to move or copy.
-		return
-			'<label id="batch-choose-action-lbl" for="batch-choose-action">' . JText::_('JLIB_HTML_BATCH_MENU_LABEL') . '</label>'
-			. '<div id="batch-choose-action" class="control-group">'
-			. '<select name="batch[category_id]" class="inputbox" id="batch-category-id">'
-			. '<option value="">' . JText::_('JLIB_HTML_BATCH_NO_CATEGORY') . '</option>'
-			. JHtml::_('select.options', JHtml::_('category.options', $extension))
-			. '</select>'
-			. '</div>'
-			. '<div id="batch-copy-move" class="control-group radio">'
-			. JText::_('JLIB_HTML_BATCH_MOVE_QUESTION')
-			. JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm')
-			. '</div>';
+		JLog::add('The use of JHtml::_("batch.item") is deprecated use JLayout instead.', JLog::WARNING, 'deprecated');
+
+		return JLayoutHelper::render('joomla.html.batch.item', $displayData);
 	}
 
 	/**
@@ -81,42 +59,15 @@ abstract class JHtmlBatch
 	 *
 	 * @return  string  The necessary HTML for the widget.
 	 *
-	 * @since   2.5
+	 * @since       2.5
+	 *
+	 * @deprecated  4 instead of JHtml::_('batch.language'); use JLayoutHelper::render('joomla.html.batch.language', array());
 	 */
 	public static function language()
 	{
-		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+		JLog::add('The use of JHtml::_("batch.language") is deprecated use JLayout instead.', JLog::WARNING, 'deprecated');
 
-		JFactory::getDocument()->addScriptDeclaration(
-			'
-		jQuery(document).ready(function($){
-			if ($("#batch-category-id").length){var batchSelector = $("#batch-category-id");}
-			if ($("#batch-menu-id").length){var batchSelector = $("#batch-menu-id");}
-			if ($("#batch-position-id").length){var batchSelector = $("#batch-position-id");}
-			if ($("#batch-copy-move").length) {
-				$("#batch-copy-move").hide();
-				batchSelector.on("change", function(){
-					if (batchSelector.val() != 0 || batchSelector.val() != "") {
-						$("#batch-copy-move").show();
-					} else {
-						$("#batch-copy-move").hide();
-					}
-				});
-			}
-		});
-			'
-		);
-
-		// Create the batch selector to change the language on a selection list.
-		return
-			'<label id="batch-language-lbl" for="batch-language-id" class="modalTooltip"'
-			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_LANGUAGE_LABEL', 'JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">'
-			. JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL')
-			. '</label>'
-			. '<select name="batch[language_id]" class="inputbox" id="batch-language-id">'
-			. '<option value="">' . JText::_('JLIB_HTML_BATCH_LANGUAGE_NOCHANGE') . '</option>'
-			. JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text')
-			. '</select>';
+		return JLayoutHelper::render('joomla.html.batch.language', array());
 	}
 
 	/**
@@ -126,30 +77,17 @@ abstract class JHtmlBatch
 	 *
 	 * @return  string  The necessary HTML for the widget.
 	 *
-	 * @since   2.5
+	 * @since       2.5
+	 *
+	 * @deprecated  4 instead of JHtml::_('batch.user'); use JLayoutHelper::render('joomla.html.batch.user', array());
 	 */
 	public static function user($noUser = true)
 	{
-		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+		$displayData = array('noUser' => $noUser);
 
-		$optionNo = '';
+		JLog::add('The use of JHtml::_("batch.user") is deprecated use JLayout instead.', JLog::WARNING, 'deprecated');
 
-		if ($noUser)
-		{
-			$optionNo = '<option value="0">' . JText::_('JLIB_HTML_BATCH_USER_NOUSER') . '</option>';
-		}
-
-		// Create the batch selector to select a user on a selection list.
-		return
-			'<label id="batch-user-lbl" for="batch-user" class="modalTooltip"'
-			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_USER_LABEL', 'JLIB_HTML_BATCH_USER_LABEL_DESC') . '">'
-			. JText::_('JLIB_HTML_BATCH_USER_LABEL')
-			. '</label>'
-			. '<select name="batch[user_id]" class="inputbox" id="batch-user-id">'
-			. '<option value="">' . JText::_('JLIB_HTML_BATCH_USER_NOCHANGE') . '</option>'
-			. $optionNo
-			. JHtml::_('select.options', JHtml::_('user.userlist'), 'value', 'text')
-			. '</select>';
+		return JLayoutHelper::render('joomla.html.batch.user', $displayData);
 	}
 
 	/**
@@ -157,21 +95,14 @@ abstract class JHtmlBatch
 	 *
 	 * @return  string  The necessary HTML for the widget.
 	 *
-	 * @since   3.1
+	 * @since       3.1
+	 *
+	 * @deprecated  4 instead of JHtml::_('batch.tag'); use JLayoutHelper::render('joomla.html.batch.tag', array());
 	 */
 	public static function tag()
 	{
-		JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+		JLog::add('The use of JHtml::_("batch.tag") is deprecated use JLayout instead.', JLog::WARNING, 'deprecated');
 
-		// Create the batch selector to tag items on a selection list.
-		return
-			'<label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip"'
-			. ' title="' . JHtml::tooltipText('JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC') . '">'
-			. JText::_('JLIB_HTML_BATCH_TAG_LABEL')
-			. '</label>'
-			. '<select name="batch[tag]" class="inputbox" id="batch-tag-id">'
-			. '<option value="">' . JText::_('JLIB_HTML_BATCH_TAG_NOCHANGE') . '</option>'
-			. JHtml::_('select.options', JHtml::_('tag.tags', array('filter.published' => array(1))), 'value', 'text')
-			. '</select>';
+		return JLayoutHelper::render('joomla.html.batch.tag', array());
 	}
 }

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since       1.7
  *
- * @deprecated  4 Use JLayout directly
+ * @deprecated  4.0 Use JLayout directly
  */
 abstract class JHtmlBatch
 {

--- a/libraries/cms/html/batch.php
+++ b/libraries/cms/html/batch.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since       1.7
  *
- * @deprecated  3.5 To be removed 4.0
+ * @deprecated  4 Use JLayout directly
  */
 abstract class JHtmlBatch
 {


### PR DESCRIPTION
#### What is this?

Well, we use JHtml for rendering the body of the modal for the batch commands but there are not many arguments passed neither some complex computation for this particular task. Therefore we can drop the JHtml and use JLayout directly here.
I already replaced all the old instances, so other devs can use as an example for their code.
The proposal is to remove the file batch.php from the html folder in v4.
