### PR TITLE
Update to Registry 1.5 package

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -329,16 +329,16 @@
         },
         {
             "name": "joomla/registry",
-            "version": "1.4.5",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
-                "reference": "4f926ba961ca45eb95076a1598c3ae689cb02fc5"
+                "reference": "db55cf426bd27524557affbe95b18d6a2f959657"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/4f926ba961ca45eb95076a1598c3ae689cb02fc5",
-                "reference": "4f926ba961ca45eb95076a1598c3ae689cb02fc5",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/db55cf426bd27524557affbe95b18d6a2f959657",
+                "reference": "db55cf426bd27524557affbe95b18d6a2f959657",
                 "shasum": ""
             },
             "require": {
@@ -379,7 +379,7 @@
                 "joomla",
                 "registry"
             ],
-            "time": "2015-03-28 17:54:38"
+            "time": "2015-10-14 17:01:46"
         },
         {
             "name": "joomla/session",

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -320,62 +320,6 @@
         ]
     },
     {
-        "name": "joomla/registry",
-        "version": "1.4.5",
-        "version_normalized": "1.4.5.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/registry.git",
-            "reference": "4f926ba961ca45eb95076a1598c3ae689cb02fc5"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/4f926ba961ca45eb95076a1598c3ae689cb02fc5",
-            "reference": "4f926ba961ca45eb95076a1598c3ae689cb02fc5",
-            "shasum": ""
-        },
-        "require": {
-            "joomla/compat": "~1.0",
-            "joomla/string": "~1.3",
-            "joomla/utilities": "~1.0",
-            "php": ">=5.3.10"
-        },
-        "require-dev": {
-            "joomla/test": "~1.0",
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*",
-            "symfony/yaml": "~2.0"
-        },
-        "suggest": {
-            "symfony/yaml": "Install 2.* if you require YAML support."
-        },
-        "time": "2015-03-28 17:54:38",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Registry\\": "src/",
-                "Joomla\\Registry\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Registry Package",
-        "homepage": "https://github.com/joomla-framework/registry",
-        "keywords": [
-            "framework",
-            "joomla",
-            "registry"
-        ]
-    },
-    {
         "name": "joomla/event",
         "version": "1.1.1",
         "version_normalized": "1.1.1.0",
@@ -765,6 +709,62 @@
             "application",
             "framework",
             "joomla"
+        ]
+    },
+    {
+        "name": "joomla/registry",
+        "version": "1.5.0",
+        "version_normalized": "1.5.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/registry.git",
+            "reference": "db55cf426bd27524557affbe95b18d6a2f959657"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/db55cf426bd27524557affbe95b18d6a2f959657",
+            "reference": "db55cf426bd27524557affbe95b18d6a2f959657",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/compat": "~1.0",
+            "joomla/string": "~1.3",
+            "joomla/utilities": "~1.0",
+            "php": ">=5.3.10"
+        },
+        "require-dev": {
+            "joomla/test": "~1.0",
+            "phpunit/phpunit": "4.*",
+            "squizlabs/php_codesniffer": "1.*",
+            "symfony/yaml": "~2.0"
+        },
+        "suggest": {
+            "symfony/yaml": "Install 2.* if you require YAML support."
+        },
+        "time": "2015-10-14 17:01:46",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Registry\\": "src/",
+                "Joomla\\Registry\\Tests\\": "Tests/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Registry Package",
+        "homepage": "https://github.com/joomla-framework/registry",
+        "keywords": [
+            "framework",
+            "joomla",
+            "registry"
         ]
     }
 ]

--- a/libraries/vendor/joomla/registry/src/AbstractRegistryFormat.php
+++ b/libraries/vendor/joomla/registry/src/AbstractRegistryFormat.php
@@ -11,13 +11,15 @@ namespace Joomla\Registry;
 /**
  * Abstract Format for Registry
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Format objects should directly implement the FormatInterface
  */
-abstract class AbstractRegistryFormat
+abstract class AbstractRegistryFormat implements FormatInterface
 {
 	/**
-	 * @var    array  Format instances container.
+	 * @var    AbstractRegistryFormat[]  Format instances container.
 	 * @since  1.0
+	 * @deprecated  2.0  Object caching will no longer be supported
 	 */
 	protected static $instances = array();
 
@@ -25,55 +27,17 @@ abstract class AbstractRegistryFormat
 	 * Returns a reference to a Format object, only creating it
 	 * if it doesn't already exist.
 	 *
-	 * @param   string  $type  The format to load
+	 * @param   string  $type     The format to load
+	 * @param   array   $options  Additional options to configure the object
 	 *
 	 * @return  AbstractRegistryFormat  Registry format handler
 	 *
+	 * @deprecated  2.0  Use Factory::getFormat() instead
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function getInstance($type)
+	public static function getInstance($type, array $options = array())
 	{
-		// Sanitize format type.
-		$type = strtolower(preg_replace('/[^A-Z0-9_]/i', '', $type));
-
-		// Only instantiate the object if it doesn't already exist.
-		if (!isset(self::$instances[$type]))
-		{
-			$class = '\\Joomla\\Registry\\Format\\' . ucfirst($type);
-
-			if (!class_exists($class))
-			{
-				throw new \InvalidArgumentException('Unable to load format class.', 500);
-			}
-
-			self::$instances[$type] = new $class;
-		}
-
-		return self::$instances[$type];
+		return Factory::getFormat($type, $options);
 	}
-
-	/**
-	 * Converts an object into a formatted string.
-	 *
-	 * @param   object  $object   Data Source Object.
-	 * @param   array   $options  An array of options for the formatter.
-	 *
-	 * @return  string  Formatted string.
-	 *
-	 * @since   1.0
-	 */
-	abstract public function objectToString($object, $options = null);
-
-	/**
-	 * Converts a formatted string into an object.
-	 *
-	 * @param   string  $data     Formatted string
-	 * @param   array   $options  An array of options for the formatter.
-	 *
-	 * @return  object  Data Object
-	 *
-	 * @since   1.0
-	 */
-	abstract public function stringToObject($data, array $options = array());
 }

--- a/libraries/vendor/joomla/registry/src/Factory.php
+++ b/libraries/vendor/joomla/registry/src/Factory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Part of the Joomla Framework Registry Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry;
+
+/**
+ * Factory class to fetch Registry objects
+ *
+ * @since  1.5.0
+ */
+class Factory
+{
+	/**
+	 * Format instances container - for backward compatibility with AbstractRegistryFormat::getInstance().
+	 *
+	 * @var    FormatInterface[]
+	 * @since  1.5.0
+	 * @deprecated  2.0  Object caching will no longer be supported
+	 */
+	protected static $formatInstances = array();
+
+	/**
+	 * Returns a AbstractRegistryFormat object, only creating it if it doesn't already exist.
+	 *
+	 * @param   string  $type     The format to load
+	 * @param   array   $options  Additional options to configure the object
+	 *
+	 * @return  FormatInterface  Registry format handler
+	 *
+	 * @since   1.5.0
+	 * @throws  \InvalidArgumentException
+	 */
+	public static function getFormat($type, array $options = array())
+	{
+		// Sanitize format type.
+		$type = strtolower(preg_replace('/[^A-Z0-9_]/i', '', $type));
+
+		/*
+		 * Only instantiate the object if it doesn't already exist.
+		 * @deprecated 2.0 Object caching will no longer be supported, a new instance will be returned every time
+		 */
+		if (!isset(self::$formatInstances[$type]))
+		{
+			$localNamespace = __NAMESPACE__ . '\\Format';
+			$namespace      = isset($options['format_namespace']) ? $options['format_namespace'] : $localNamespace;
+			$class          = $namespace . '\\' . ucfirst($type);
+
+			if (!class_exists($class))
+			{
+				// Were we given a custom namespace?  If not, there's nothing else we can do
+				if ($namespace === $localNamespace)
+				{
+					throw new \InvalidArgumentException(sprintf('Unable to load format class for type "%s".', $type), 500);
+				}
+
+				$class = $localNamespace . '\\' . ucfirst($type);
+
+				if (!class_exists($class))
+				{
+					throw new \InvalidArgumentException(sprintf('Unable to load format class for type "%s".', $type), 500);
+				}
+			}
+
+			self::$formatInstances[$type] = new $class;
+		}
+
+		return self::$formatInstances[$type];
+	}
+}

--- a/libraries/vendor/joomla/registry/src/Format/Ini.php
+++ b/libraries/vendor/joomla/registry/src/Format/Ini.php
@@ -91,12 +91,12 @@ class Ini extends AbstractRegistryFormat
 						foreach ($v as $array_key => $item)
 						{
 							$array_key = ($assoc) ? $array_key : '';
-							$local[] = $k . '[' . $array_key . ']=' . $this->getValueAsINI($item);
+							$local[] = $k . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 						}
 					}
 					else
 					{
-						$local[] = $k . '=' . $this->getValueAsINI($v);
+						$local[] = $k . '=' . $this->getValueAsIni($v);
 					}
 				}
 
@@ -113,13 +113,13 @@ class Ini extends AbstractRegistryFormat
 				foreach ($value as $array_key => $item)
 				{
 					$array_key = ($assoc) ? $array_key : '';
-					$global[] = $key . '[' . $array_key . ']=' . $this->getValueAsINI($item);
+					$global[] = $key . '[' . $array_key . ']=' . $this->getValueAsIni($item);
 				}
 			}
 			else
 			{
 				// Not in a section so add the property to the global array.
-				$global[] = $key . '=' . $this->getValueAsINI($value);
+				$global[] = $key . '=' . $this->getValueAsIni($value);
 				$in_section = false;
 			}
 		}
@@ -338,7 +338,7 @@ class Ini extends AbstractRegistryFormat
 	 *
 	 * @since   1.0
 	 */
-	protected function getValueAsINI($value)
+	protected function getValueAsIni($value)
 	{
 		$string = '';
 

--- a/libraries/vendor/joomla/registry/src/FormatInterface.php
+++ b/libraries/vendor/joomla/registry/src/FormatInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Part of the Joomla Framework Registry Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Registry;
+
+/**
+ * Interface defining a format object
+ *
+ * @since  1.5.0
+ */
+interface FormatInterface
+{
+	/**
+	 * Converts an object into a formatted string.
+	 *
+	 * @param   object  $object   Data Source Object.
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  string  Formatted string.
+	 *
+	 * @since   1.5.0
+	 */
+	public function objectToString($object, $options = null);
+
+	/**
+	 * Converts a formatted string into an object.
+	 *
+	 * @param   string  $data     Formatted string
+	 * @param   array   $options  An array of options for the formatter.
+	 *
+	 * @return  object  Data Object
+	 *
+	 * @since   1.5.0
+	 */
+	public function stringToObject($data, array $options = array());
+}

--- a/libraries/vendor/joomla/registry/src/Registry.php
+++ b/libraries/vendor/joomla/registry/src/Registry.php
@@ -30,6 +30,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @var    array
 	 * @since  1.0
+	 * @deprecated  2.0  Object caching will no longer be supported
 	 */
 	protected static $instances = array();
 
@@ -251,6 +252,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  Registry  The Registry object.
 	 *
+	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 * @since   1.0
 	 */
 	public static function getInstance($id)
@@ -354,7 +356,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	public function loadString($data, $format = 'JSON', $options = array())
 	{
 		// Load a string into the given namespace [or default namespace if not given]
-		$handler = AbstractRegistryFormat::getInstance($format);
+		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		$obj = $handler->stringToObject($data, $options);
 		$this->loadObject($obj);
@@ -644,7 +646,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	public function toString($format = 'JSON', $options = array())
 	{
 		// Return a namespace in a given format
-		$handler = AbstractRegistryFormat::getInstance($format);
+		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		return $handler->objectToString($this->data, $options);
 	}


### PR DESCRIPTION
This PR updates the `joomla/registry` package to the 1.5.0 tag.
### Test Instructions

CMS functions as before.  There aren't major changes in this tag that would break extensions or core.
