### PR TITLE
Syncing frontend en-GB.localise.php with backend one.

### DIFF
--- a/language/en-GB/en-GB.localise.php
+++ b/language/en-GB/en-GB.localise.php
@@ -18,7 +18,7 @@ abstract class En_GBLocalise
 	/**
 	 * Returns the potential suffixes for a specific number of items
 	 *
-	 * @param   int  $count  The number of items.
+	 * @param   integer  $count  The number of items.
 	 *
 	 * @return  array  An array of potential suffixes.
 	 *
@@ -28,17 +28,16 @@ abstract class En_GBLocalise
 	{
 		if ($count == 0)
 		{
-			$return = array('0');
+			return array('0');
 		}
 		elseif ($count == 1)
 		{
-			$return = array('1');
+			return array('1');
 		}
 		else
 		{
-			$return = array('MORE');
+			return array('MORE');
 		}
-		return $return;
 	}
 
 	/**
@@ -50,11 +49,7 @@ abstract class En_GBLocalise
 	 */
 	public static function getIgnoredSearchWords()
 	{
-		$search_ignore = array();
-		$search_ignore[] = "and";
-		$search_ignore[] = "in";
-		$search_ignore[] = "on";
-		return $search_ignore;
+		return array('and', 'in', 'on');
 	}
 
 	/**


### PR DESCRIPTION
### Issue

Currently, the frontend en-GB.localise.php is a bit different in codestyle from the backend one.
This isn't an issue by itself, but since they are actually identical files otherwise, it makes sense to make the identical :smile: 
Having them identical helps when translators use a translation tool (eg Crowdin) since the "Translation Memory" and duplicate string detection will then automatically "translate" the other file for them.
### Solution

I just copied the backend file over to the frontend.
### Testing

There is nothing really to test, code does the same before and after and since it works in backend, it will also work in frontend :smile: 
Imho, it can be merged on review.
