### PR TITLE
Fix for #8034 - smart search fail on $

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -700,6 +700,15 @@ abstract class JHtmlBehavior
 			return;
 		}
 
+		$terms = array_filter($terms, 'strlen');
+
+		// Nothing to Highlight
+		if (empty($terms))
+		{
+			static::$loaded[__METHOD__][$sig] = true;
+			return;
+		}
+
 		// Include core
 		static::core();
 


### PR DESCRIPTION
this fix for #8034
the problem was that `$` is striped and the highlighter script tries to highlight the emptiness, that cause high resource usage by highlight.js

for testing please look the description in related issue :wink: 

---
#### Steps to reproduce the issue
- enable smart search & smart search module
- index content so it's not empty
- search for "$" (single dollar sign)
#### Expected result

some search results
#### Actual result

javascript loop resulting in massive memory leak and eventual browser crash
#### System information (as much as possible)

browser = firefox
OS = Win 10
#### Additional comments
