### PR TITLE
[Proposition] integret shortcode with my plug on cms joomla master

### DIFF
--- a/administrator/components/com_banners/controllers/tracks.php
+++ b/administrator/components/com_banners/controllers/tracks.php
@@ -84,7 +84,7 @@ class BannersControllerTracks extends JControllerLegacy
 		{
 			JError::raiseWarning(500, $model->getError());
 		}
-		elseif (count > 0)
+		elseif ($count > 0)
 		{
 			$this->setMessage(JText::plural('COM_BANNERS_TRACKS_N_ITEMS_DELETED', $count));
 		}

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -625,7 +625,7 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished."
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is published."
 
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."

--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.4" client="administrator">
 	<name>English (en-GB)</name>
-	<version>3.4.3</version>
+	<version>3.4.5</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.4" client="administrator" type="language" method="upgrade">
 	<name>English (United Kingdom)</name>
 	<tag>en-GB</tag>
-	<version>3.4.2</version>
+	<version>3.4.5</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -625,7 +625,7 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
 
-JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is plublished."
+JLIB_NO_EDITOR_PLUGIN_PUBLISHED="We can't show an editor because no editor plugin is published."
 
 JLIB_PLUGIN_ERROR_LOADING_PLUGINS="Error loading Plugins: %s"
 JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS="Unable to load format class."

--- a/language/en-GB/en-GB.localise.php
+++ b/language/en-GB/en-GB.localise.php
@@ -18,7 +18,7 @@ abstract class En_GBLocalise
 	/**
 	 * Returns the potential suffixes for a specific number of items
 	 *
-	 * @param   int  $count  The number of items.
+	 * @param   integer  $count  The number of items.
 	 *
 	 * @return  array  An array of potential suffixes.
 	 *
@@ -28,17 +28,16 @@ abstract class En_GBLocalise
 	{
 		if ($count == 0)
 		{
-			$return = array('0');
+			return array('0');
 		}
 		elseif ($count == 1)
 		{
-			$return = array('1');
+			return array('1');
 		}
 		else
 		{
-			$return = array('MORE');
+			return array('MORE');
 		}
-		return $return;
 	}
 
 	/**
@@ -50,11 +49,7 @@ abstract class En_GBLocalise
 	 */
 	public static function getIgnoredSearchWords()
 	{
-		$search_ignore = array();
-		$search_ignore[] = "and";
-		$search_ignore[] = "in";
-		$search_ignore[] = "on";
-		return $search_ignore;
+		return array('and', 'in', 'on');
 	}
 
 	/**

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.4" client="site">
 	<name>English (en-GB)</name>
-	<version>3.4.3</version>
+	<version>3.4.5</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.4" client="site" type="language" method="upgrade">
 	<name>English (United Kingdom)</name>
 	<tag>en-GB</tag>
-	<version>3.4.2</version>
+	<version>3.4.5</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -172,6 +172,9 @@ textarea {
 	left: auto;
 	right: 13px;
 }
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}
 .clearfix {
 	*zoom: 1;
 }
@@ -7279,6 +7282,9 @@ figcaption {
 	background-image: linear-gradient(to bottom,#08c,#0077b3);
 	background-repeat: repeat-x;
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0076b2', GradientType=0);
+}
+.categories-list .collapse {
+	margin-left: 20px;
 }
 @media (max-width: 480px) {
 	.item-info > span {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -393,6 +393,10 @@ figcaption {
   #gradient > .vertical(@dropdownLinkBackgroundHover, darken(@dropdownLinkBackgroundHover, 5%));
 }
 
+// Category collapse
+.categories-list .collapse {
+	margin: 0 0 0 20px;
+}
 @media (max-width: 480px) {
 	.item-info > span {
 		display:block;

--- a/templates/protostar/less/template_rtl.less
+++ b/templates/protostar/less/template_rtl.less
@@ -13,3 +13,8 @@
 	left: auto;
 	right:13px;
 }
+
+// Category collapse
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}


### PR DESCRIPTION
exemple demo for create post here
![free-test-joomla3 5](https://cloud.githubusercontent.com/assets/6099946/10550996/68511284-744a-11e5-8952-0809273f3f25.PNG)
For editable add sources libs wp-shortcodes on joomla.
Its maybe a concurents to wordpress.

But how want manual code some devepper want to do it.

the shortcode show you trial with the file index.php Work also after "template/tpl_named/" folder
exemple here
![test templates](https://cloud.githubusercontent.com/assets/6099946/10551670/8590596e-744e-11e5-8958-c169ad05c65b.PNG)

The specialist webmaster can use PHP/HTML or PHP/shortcodes (realy pure) integrate microdata independance sys
