### PR TITLE
Introduce JLayout for JHtml sortableList

### DIFF
--- a/layouts/joomla/html/sortablelist.php
+++ b/layouts/joomla/html/sortablelist.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * @package     Joomla.Site
@@ -37,7 +36,6 @@ JFactory::getDocument()->addScriptDeclaration(
 			var sortableList = new $.JSortableList('#"
 	. $tableId . " tbody','" . $formId . "','" . $sortDir . "' , '" . $saveOrderingUrl . "','','" . $nestedList . "');
 		});
-
 	"
 );
 
@@ -64,4 +62,3 @@ if ($proceedSaveOrderButton)
 		"
 	);
 }
-

--- a/layouts/joomla/html/sortablelist.php
+++ b/layouts/joomla/html/sortablelist.php
@@ -1,0 +1,67 @@
+
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $tableId                 The id of the table
+ * @var  string   $formId                  The id of the form
+ * @var  string   $saveOrderingUrl         Save the ordering URL?
+ * @var  string   $sortDir                 The direction of the order (asc/desc)
+ * @var  string   $nestedList              Is it nested list?
+ * @var  string   $proceedSaveOrderButton  Is there a button to initiate the ordering?
+ */
+
+extract($displayData);
+
+// Depends on jQuery UI
+JHtml::_('jquery.ui', array('core', 'sortable'));
+
+JHtml::_('script', 'jui/sortablelist.js', false, true);
+JHtml::_('stylesheet', 'jui/sortablelist.css', false, true, false);
+
+// Attach sortable to document
+JFactory::getDocument()->addScriptDeclaration(
+	"
+		jQuery(document).ready(function ($){
+			var sortableList = new $.JSortableList('#"
+	. $tableId . " tbody','" . $formId . "','" . $sortDir . "' , '" . $saveOrderingUrl . "','','" . $nestedList . "');
+		});
+
+	"
+);
+
+if ($proceedSaveOrderButton)
+{
+	JFactory::getDocument()->addScriptDeclaration(
+		"
+		jQuery(document).ready(function ($){
+			var saveOrderButton = $('.saveorder');
+			saveOrderButton.css({'opacity':'0.2', 'cursor':'default'}).attr('onclick','return false;');
+			var oldOrderingValue = '';
+			$('.text-area-order').focus(function ()
+			{
+				oldOrderingValue = $(this).attr('value');
+			})
+			.keyup(function (){
+				var newOrderingValue = $(this).attr('value');
+				if (oldOrderingValue != newOrderingValue)
+				{
+					saveOrderButton.css({'opacity':'1', 'cursor':'pointer'}).removeAttr('onclick')
+				}
+			});
+		});
+		"
+	);
+}
+

--- a/libraries/cms/html/sortablelist.php
+++ b/libraries/cms/html/sortablelist.php
@@ -52,27 +52,16 @@ abstract class JHtmlSortablelist
 			throw new InvalidArgumentException('$saveOrderingUrl is a required argument in JHtmlSortablelist::sortable');
 		}
 
-		// Depends on jQuery UI
-		JHtml::_('jquery.ui', array('core', 'sortable'));
-
-		JHtml::_('script', 'jui/sortablelist.js', false, true);
-		JHtml::_('stylesheet', 'jui/sortablelist.css', false, true, false);
-
-		// Attach sortable to document
-		JFactory::getDocument()->addScriptDeclaration("
-			(function ($){
-				$(document).ready(function (){
-					var sortableList = new $.JSortableList('#"
-						. $tableId . " tbody','" . $formId . "','" . $sortDir . "' , '" . $saveOrderingUrl . "','','" . $nestedList . "');
-				});
-			})(jQuery);
-			"
+		$displayData = array(
+			'tableId'                => $tableId,
+			'formId'                 => $formId,
+			'sortDir'                => $sortDir,
+			'saveOrderingUrl'        => $saveOrderingUrl,
+			'nestedList'             => $nestedList,
+			'proceedSaveOrderButton' => $proceedSaveOrderButton
 		);
 
-		if ($proceedSaveOrderButton)
-		{
-			static::_proceedSaveOrderButton();
-		}
+		JLayoutHelper::render('joomla.html.sortablelist', $displayData);
 
 		// Set static array
 		static::$loaded[__METHOD__] = true;
@@ -87,6 +76,8 @@ abstract class JHtmlSortablelist
 	 * @return  void
 	 *
 	 * @since   3.0
+	 *
+	 * @deprecated 4.0 The logic is merged in the JLayout file
 	 */
 	public static function _proceedSaveOrderButton()
 	{


### PR DESCRIPTION
#### What the title says

In the JHtml sortableList we inject the javascript for the sortable list. By moving this code to JLayout we enable an easier way to override this part.
#### Testing

Apply this PR
In the Articles view (the listing view) check if the table headers still work (should change the sorting asc/desc)
