### PR TITLE
Resolves Issue #5820

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -286,6 +286,15 @@ class JEditor extends JObject
 	{
 		$this->asset = $asset;
 		$this->author = $author;
+
+		// Backwards compatibility. Width and height should be passed without a semicolon from now on.
+		// If editor plugins need a unit like "px" for CSS styling, they need to take care of that
+		$width = str_replace(';', '', $width);
+		$height = str_replace(';', '', $height);
+
+		$params['html_height'] = $height;
+		$params['html_width'] = $width;
+
 		$this->_loadEditor($params);
 
 		// Check whether editor is already loaded
@@ -293,11 +302,6 @@ class JEditor extends JObject
 		{
 			return;
 		}
-
-		// Backwards compatibility. Width and height should be passed without a semicolon from now on.
-		// If editor plugins need a unit like "px" for CSS styling, they need to take care of that
-		$width = str_replace(';', '', $width);
-		$height = str_replace(';', '', $height);
 
 		$return = null;
 


### PR DESCRIPTION
This resolve an issue with TinyMCE and the use of width and height on JForm editor field element.
# How to test

Before applying the patch try to resize the TinyMCE editor via a JForm xml field definition. Add width and height attributes to the editor definition in the xml file

``` xml
        <field
                name="default_description"
                type="editor"
                buttons="true"
                label="CONTENT_TEXT_LABEL"
                description="CONTENT_TEXT_DESC"
                class="inputbox"
                filter="JComponentHelper::filterText"
                asset_id="com_content"
                width="50%"
                height="200px"
                />
```

then open the form to confirm that the editor width/height has not changed.

After applying the patch confirm that the width and height do change. 
