### PR TITLE
Removed duplicated Wrapper in Menumanager

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1297,6 +1297,8 @@ class JoomlaInstallerScript
 			// Joomla 3.4.3
 			'/libraries/classloader.php',
 			'/libraries/ClassLoader.php',
+			// Joomla 3.4.6
+			'/components/com_wrapper/views/wrapper/metadata.xml',
 		);
 
 		// TODO There is an issue while deleting folders using the ftp mode

--- a/components/com_wrapper/views/wrapper/metadata.xml
+++ b/components/com_wrapper/views/wrapper/metadata.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<metadata>
-	<view title="COM_WRAPPER">
-		<message><![CDATA[COM_WRAPPER_XML_DESCRIPTION]]></message>
-	</view>
-</metadata>


### PR DESCRIPTION
### Issue

With https://github.com/joomla/joomla-cms/pull/7654 the menu manager now shows the view title if that title is specified and translated.
The only place in core this is the case is for the wrapper menuitem. For the wrapper, it's quite useless as it's just duplicated information. It looks like this:
![wrapper](https://cloud.githubusercontent.com/assets/1018684/10560522/a9de6ba2-750d-11e5-8057-23b6b330de25.PNG)
### Solution

This PR completely removes the metadata.xml as it is optional after the previous PR (the title was required, alltough never used).
Since we don't want to show the view title and don't specify any parameters for the view (they are specified at the layout level), we can safely remove the whole file.
### Testing
- Create a menu item for the Wrapper
- See that it shows as `Wrapper » Wrapper » Iframe Wrapper` in the menu manager
- Apply PR and check again, it shows now as `Wrapper » Iframe Wrapper`:
  ![wrapper2](https://cloud.githubusercontent.com/assets/1018684/10560539/5681908c-750e-11e5-853b-27bc9be764d5.PNG)

There should be no side effects other than that.
