### PR TITLE
allow to use other tabs in Installer while Install From Web is busy

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -89,6 +89,10 @@ JText::script('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL');
 			'height': 	outerDiv.height(),
 			'display':  'none'
 		});
+		// allow to use other tabs while Install From Web is busy
+		$('a[href="#upload"], a[href="#web"], a[href="#url"]').click(function(){
+			$('#appsloading').css('display', 'none');
+		});
 	});
 </script>
 <style type="text/css">


### PR DESCRIPTION
Hides the spinner when user clicks on other tabs.
When  Install From Web is too slow, this allows not to wait and to be able to upload the extension from local disk, for instance.
