### PR TITLE
Remove empty category from addLogEntry

### DIFF
--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -316,7 +316,7 @@ class JLog
 				else
 				{
 					// If either there are no set categories (meaning all) or the specific category is set, add this logger.
-					if (empty($category) || empty($rules->categories) || in_array($category, $rules->categories))
+					if (empty($rules->categories) || in_array($category, $rules->categories))
 					{
 						$loggers[] = $signature;
 					}


### PR DESCRIPTION
This prevents logging of messages where no category is specified as part of JLog::add.
### Test Instructions

Add `JLog::add("This shouldn't be here", JLog::INFO);` to your template's index.php file. 

Before this patched the logging statement `This shouldn't be here` will be included in the messages block.  According to the docs this should ONLY be displayed when the `jerror` category is set.  (https://docs.joomla.org/Using_JLog)

After this patch the message will not be displayed.  Logging entries will only be logged when category is included.  For example:

`JLog::add("This should be here", JLog::INFO,"jerror");`

if using the MessageQueue logger.

Eric.
