### PR TITLE
+ added a new parameter nolangfilter. If it is set to 1, then we don'…

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -336,9 +336,10 @@ class PlgSystemLanguageFilter extends JPlugin
 			$lang_code = $this->sefs[$lang]->lang_code;
 		}
 
-		// We are called via POST. We don't care about the language
+		// We are called via POST or the nolangfilter url parameter was set. We don't care about the language
 		// and simply set the default language as our current language.
 		if ($this->app->input->getMethod() == "POST"
+			|| $this->app->input->get('nolangfilter', 0) == 1
 			|| count($this->app->input->post) > 0
 			|| count($this->app->input->files) > 0)
 		{


### PR DESCRIPTION
…t care about the language, we can use the default and don't need to do any redirects

The language filter is really annoying in the context of ajax requests. If you are trying to do a simple GET ajax request and the language filter is on and you haven't provided a lang, then the language filter is going to catch your call and do a redirect and screw your request. 

The only way to go around that problem when doing an ajax request is to use POST. But what is when you want to do DELETE, PUT or whatever and don't care about the stupid language (your app doesn't need to know anything about it)? 
That's why I've added a check for the nolangfilter parameter. If it is set, then the language filter will behave as it is dealing with a POST request - it will set a default language and won't bother redirecting you somewhere else. 

I need someone of the core team to look at this and tell me if it is a good idea or not. If it is I'll provide you with an option to test :)
