### PR TITLE
Remove empty div in control panel if there are no postinstall messages.

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -31,7 +31,7 @@ $user = JFactory::getUser();
 	<div class="span<?php echo ($iconmodules) ? 9 : 12; ?>">
 		<?php if ($user->authorise('core.manage', 'com_postinstall') && $this->postinstall_message_count) : ?>
 			<div class="row-fluid">
-					<div class="alert alert-info">
+				<div class="alert alert-info">
 					<h4>
 						<?php echo JText::_('COM_CPANEL_MESSAGES_TITLE'); ?>
 					</h4>
@@ -43,10 +43,10 @@ $user = JFactory::getUser();
 					</p>
 					<p>
 						<a href="index.php?option=com_postinstall&amp;eid=700" class="btn btn-primary">
-						<?php echo JText::_('COM_CPANEL_MESSAGES_REVIEW'); ?>
+							<?php echo JText::_('COM_CPANEL_MESSAGES_REVIEW'); ?>
 						</a>
 					</p>
-					</div>
+				</div>
 			</div>
 		<?php endif; ?>
 		<div class="row-fluid">

--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -29,9 +29,8 @@ $user = JFactory::getUser();
 		</div>
 	<?php endif; ?>
 	<div class="span<?php echo ($iconmodules) ? 9 : 12; ?>">
-		<?php if ($user->authorise('core.manage', 'com_postinstall')) : ?>
+		<?php if ($user->authorise('core.manage', 'com_postinstall') && $this->postinstall_message_count) : ?>
 			<div class="row-fluid">
-				<?php if ($this->postinstall_message_count): ?>
 					<div class="alert alert-info">
 					<h4>
 						<?php echo JText::_('COM_CPANEL_MESSAGES_TITLE'); ?>
@@ -48,7 +47,6 @@ $user = JFactory::getUser();
 						</a>
 					</p>
 					</div>
-				<?php endif; ?>
 			</div>
 		<?php endif; ?>
 		<div class="row-fluid">


### PR DESCRIPTION
## Testing instructions
1. Log in to backend.
2. Hide all postinstall messages.
3. Inspect the source code for the admin control panel (administrator/index.php). There is an empty div that previously contained the postinstall messages.
4. Apply the patch.
5. Inspect the source code again. The empty div should be gone.
6. Reset the postinstall messages to display them again in the control panel.
7. Make sure the messages are still displayed correctly.
## Attribution

This issue and the corresponding fix have been reported / proposed by user Cartho on joomla-bugs.de ([Original Thread](http://www.joomla-bugs.de/forum/index.php/topic,690.0/topicseen.html)).
