### PR TITLE
Fix: Cannot add internal link to URL links in 'images and links'

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -108,7 +108,7 @@ class ContentModelArticle extends JModelAdmin
 			$this->table->catid = $categoryId;
 
 			// TODO: Deal with ordering?
-			// $table->ordering = 1;
+			// $table->ordering	= 1;
 
 			// Get the featured state
 			$featured = $this->table->featured;
@@ -482,14 +482,22 @@ class ContentModelArticle extends JModelAdmin
 
 		if (isset($data['urls']) && is_array($data['urls']))
 		{
+			$check = $input->post->get('jform', array(), 'array');
 			foreach ($data['urls'] as $i => $url)
 			{
 				if ($url != false && ($i == 'urla' || $i == 'urlb' || $i == 'urlc'))
 				{
-					$data['urls'][$i] = JStringPunycode::urlToPunycode($url);
+					if (preg_match('~^#[a-zA-Z]{1}[a-zA-Z0-9-_:.]*$~', $check['urls'][$i]) == 1)
+					{
+						$data['urls'][$i] = $check['urls'][$i];
+					}
+					else
+					{
+						$data['urls'][$i] = JStringPunycode::urlToPunycode($url);
+					}
 				}
 			}
-
+			unset($check);
 			$registry = new Registry;
 			$registry->loadArray($data['urls']);
 			$data['urls'] = (string) $registry;


### PR DESCRIPTION
Solved issue from #7352

The issue:
When a user enters an internal link into the field link a, b or c on the tab images and links of the edit content page and presses save, an unexpected result will show up. Instead of an internal link of the same page, he gets a modified link, that links to the root of the Joomla instance. For instance, let's assume that the user enters #title . This will be modified to /#title. Or - if joomla is installed in an subfolder - it will be modifed to /subfolder/#title.

How to test:
2. Go to Content > Content Manager
3. Open a random content item
4. Go to tab "Images and Links"
5. Enter "#to-some-position-on-page" in field "Link A"
6. Click button "Save"
7. Go back to "Images and Links"

With the unsolved issue:
 See that the content of field "Link A" has changed from "#to-some-position-on-page" to "/#to-some-position-on-page

After the Pull Request

See that the content of field "Link A" hasn’t changed. It’s shows still the internal link. 

The solution:

To solve this issue, one has to distinguish between a usual link to another page and an internal link. For this reason I check with a regex pattern, if the entry is a valid internal link. If this is true, the link will not be modified. If the pattern doesn't match, the link is passed by the normal way. 
The file is located at ./administrator/components/com_content/models/article.php. 

Worked as a group on that issue: @icampus, @FPerisa, @flow87 and @kathastaden
