### PR TITLE
Override `add()` and `sub()` for return type JDate

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -460,4 +460,34 @@ class JDate extends DateTime
 	{
 		return (int) parent::format('U');
 	}
+
+	/**
+	 * Adds an amount of days, months, years, hours, minutes and seconds to a JDate object
+	 *
+	 * @param  DateInterval  $interval
+	 *
+	 * @return  JDate  This method allows chaining
+	 * @link    http://php.net/manual/en/datetime.add.php
+	 */
+	public function add($interval)
+	{
+		parent::add($interval);
+
+		return $this;
+	}
+
+	/**
+	 * Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object
+	 *
+	 * @param  DateInterval  $interval
+	 *
+	 * @return JDate
+	 * @link   http://php.net/manual/en/datetime.sub.php
+	 */
+	public function sub($interval)
+	{
+		parent::sub($interval);
+
+		return $this;
+	}
 }


### PR DESCRIPTION
Override `add()` and `sub()` functions to provide appropriate chaining that currently breaks due to return type of the parent class `DateTime`.
