### PR TITLE
Add doc comments for add() and sub() methods to enhance IDE hinting

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -13,6 +13,9 @@ defined('JPATH_PLATFORM') or die;
  * JDate is a class that stores a date and provides logic to manipulate
  * and render that date in a variety of formats.
  *
+ * @method  JDate  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object
+ * @method  JDate  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object
+ *
  * @property-read  string   $daysinmonth   t - Number of days in the given month.
  * @property-read  string   $dayofweek     N - ISO-8601 numeric representation of the day of the week.
  * @property-read  string   $dayofyear     z - The day of the year (starting from 0).


### PR DESCRIPTION
Add doc comments for `add()` and `sub()` methods in `JDate` to enhance IDE hinting as the parent method hints the return value to be `DateTime` object only.
