### PR TITLE
Hide database error prefix

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -336,14 +336,14 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 					// Get the error number and message.
 					$this->errorNum = (int) mysql_errno($this->connection);
 					$errorMessage   = (string) mysql_error($this->connection);
-		
+
 					// Replace the Databaseprefix with `#__` if we are not in Debug
 					if (!$this->debug)
 					{
 						$query        = str_replace($this->tablePrefix, '#__', $query);
 						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 					}
-		
+
 					$this->errorMsg = $errorMessage . ' SQL=' . $query;
 
 					// Throw the normal query exception.

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -308,9 +308,9 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-			// Get the error number and message.
-			$this->errorNum = (int) mysql_errno($this->connection);
-			$errorMessage   = (string) mysql_error($this->connection);
+			// Get the error number and message before we execute any more queries.
+			$errorNum     = (int) mysql_errno($this->connection);
+			$errorMessage = (string) mysql_error($this->connection);
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
@@ -319,7 +319,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = $errorMessage . ' SQL=' . $query;
+			$errorMsg = $errorMessage . ' SQL=' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -333,6 +333,19 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
+					// Get the error number and message.
+					$this->errorNum = (int) mysql_errno($this->connection);
+					$errorMessage   = (string) mysql_error($this->connection);
+		
+					// Replace the Databaseprefix with `#__` if we are not in Debug
+					if (!$this->debug)
+					{
+						$query        = str_replace($this->tablePrefix, '#__', $query);
+						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+					}
+		
+					$this->errorMsg = $errorMessage . ' SQL=' . $query;
+
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -345,6 +358,10 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			// The server was not disconnected.
 			else
 			{
+				// Get the error number and message from before we tried to reconnect.
+				$this->errorNum = $errorNum;
+				$this->errorMsg = $errorMsg;
+
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -310,7 +310,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNumber();
-			$errorMsg = $this->getErrorMessage();
+			$errorMsg = $this->getErrorMessage($query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -326,7 +326,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
+					$this->errorMsg = $this->getErrorMessage($query);
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -489,11 +489,13 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	/**
 	 * Return the actual SQL Error message
 	 *
+	 * @param   string  The SQL Query that fails
+	 *
 	 * @return  string  The SQL Error message
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMessage()
+	protected function getErrorMessage($query)
 	{
 		$errorMessage = (string) mysql_error($this->connection);
 
@@ -501,8 +503,9 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		if (!$this->debug)
 		{
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+			$query        = str_replace($this->tablePrefix, '#__', $query);
 		}
 
-		return $errorMessage . ' SQL=' . $this->sql;
+		return $errorMessage . ' SQL=' . $query;
 	}
 }

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -309,17 +309,8 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum     = (int) mysql_errno($this->connection);
-			$errorMessage = (string) mysql_error($this->connection);
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query        = str_replace($this->tablePrefix, '#__', $query);
-				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-			}
-
-			$errorMsg = $errorMessage . ' SQL=' . $query;
+			$errorNum = $this->getErrorNum();
+			$errorMsg = $this->getErrorMsg();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -334,17 +325,8 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = (int) mysql_errno($this->connection);
-					$errorMessage   = (string) mysql_error($this->connection);
-
-					// Replace the Databaseprefix with `#__` if we are not in Debug
-					if (!$this->debug)
-					{
-						$query        = str_replace($this->tablePrefix, '#__', $query);
-						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-					}
-
-					$this->errorMsg = $errorMessage . ' SQL=' . $query;
+					$this->errorNum = $this->getErrorNum();
+					$this->errorMsg = $this->getErrorMsg();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -309,7 +309,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = $this->getErrorNum();
+			$errorNum = $this->getErrorNumber();
 			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
@@ -325,7 +325,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = $this->getErrorNum();
+					$this->errorNum = $this->getErrorNumber();
 					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
@@ -481,7 +481,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorNum()
+	protected function getErrorNumber()
 	{
 		return (int) mysql_errno($this->connection);
 	}

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -491,4 +491,36 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			return false;
 		}
 	}
+
+	/**
+	 * Return the actual SQL Error number
+	 *
+	 * @return  integer  The SQL Error number
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorNum()
+	{
+		return (int) mysql_errno($this->connection);
+	}
+
+	/**
+	 * Return the actual SQL Error message
+	 *
+	 * @return  string  The SQL Error message
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorMsg()
+	{
+		$errorMessage = (string) mysql_error($this->connection);
+
+		// Replace the Databaseprefix with `#__` if we are not in Debug
+		if (!$this->debug)
+		{
+			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+		}
+
+		return $errorMessage . ' SQL=' . $this->query;
+	}
 }

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -493,7 +493,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMsg()
+	protected function getErrorMessage()
 	{
 		$errorMessage = (string) mysql_error($this->connection);
 

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -503,6 +503,6 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 		}
 
-		return $errorMessage . ' SQL=' . $this->query;
+		return $errorMessage . ' SQL=' . $this->sql;
 	}
 }

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -310,7 +310,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNum();
-			$errorMsg = $this->getErrorMsg();
+			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -326,7 +326,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNum();
-					$this->errorMsg = $this->getErrorMsg();
+					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -310,14 +310,16 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		{
 			// Get the error number and message.
 			$this->errorNum = (int) mysql_errno($this->connection);
+			$errorMessage   = (string) mysql_error($this->connection);
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
 			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
+				$query        = str_replace($this->tablePrefix, '#__', $query);
+				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $query;
+			$this->errorMsg = $errorMessage . ' SQL=' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -310,6 +310,13 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		{
 			// Get the error number and message.
 			$this->errorNum = (int) mysql_errno($this->connection);
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
 			$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $query;
 
 			// Check if the server was disconnected.

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -489,7 +489,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	/**
 	 * Return the actual SQL Error message
 	 *
-	 * @param   string  The SQL Query that fails
+	 * @param   string  $query  The SQL Query that fails
 	 *
 	 * @return  string  The SQL Error message
 	 *

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -581,8 +581,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-			$this->errorNum = (int) mysqli_errno($this->connection);
-			$errorMessage   = (string) mysqli_error($this->connection);
+			$errorNum     = (int) mysqli_errno($this->connection);
+			$errorMessage = (string) mysqli_error($this->connection);
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
@@ -591,7 +591,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = $errorMessage . ' SQL=' . $query;
+			$errorMsg = $errorMessage . ' SQL=' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -605,6 +605,19 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
+					// Get the error number and message.
+					$this->errorNum = (int) mysqli_errno($this->connection);
+					$errorMessage   = (string) mysqli_error($this->connection);
+
+					// Replace the Databaseprefix with `#__` if we are not in Debug
+					if (!$this->debug)
+					{
+						$query        = str_replace($this->tablePrefix, '#__', $query);
+						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+					}
+
+					$this->errorMsg = $errorMessage . ' SQL=' . $query;
+
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
 					throw new RuntimeException($this->errorMsg, $this->errorNum, $e);
@@ -616,6 +629,10 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
+				// Get the error number and message from before we tried to reconnect.
+				$this->errorNum = $errorNum;
+				$this->errorMsg = $errorMsg;
+
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
 				throw new RuntimeException($this->errorMsg, $this->errorNum);

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -581,6 +581,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
+			// Get the error number and message before we execute any more queries.
 			$errorNum     = (int) mysqli_errno($this->connection);
 			$errorMessage = (string) mysqli_error($this->connection);
 

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -583,7 +583,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNum();
-			$errorMsg = $this->getErrorMsg();
+			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -599,7 +599,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNum();
-					$this->errorMsg = $this->getErrorMsg();
+					$this->errorMsg = $this->getErrorMessage();
 
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -897,7 +897,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMsg()
+	protected function getErrorMessage()
 	{
 		$errorMessage = (string) mysqli_error($this->connection);
 

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -582,14 +582,16 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			$this->errorNum = (int) mysqli_errno($this->connection);
+			$errorMessage   = (string) mysqli_error($this->connection);
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
 			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
+				$query        = str_replace($this->tablePrefix, '#__', $query);
+				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $query;
+			$this->errorMsg = $errorMessage . ' SQL=' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -893,7 +893,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
-	 * @param   string  The SQL Query that fails
+	 * @param   string  $query  The SQL Query that fails
 	 *
 	 * @return  string  The SQL Error message
 	 *

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -583,7 +583,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNumber();
-			$errorMsg = $this->getErrorMessage();
+			$errorMsg = $this->getErrorMessage($query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -599,7 +599,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
+					$this->errorMsg = $this->getErrorMessage($query);
 
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -893,11 +893,13 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
+	 * @param   string  The SQL Query that fails
+	 *
 	 * @return  string  The SQL Error message
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMessage()
+	protected function getErrorMessage($query)
 	{
 		$errorMessage = (string) mysqli_error($this->connection);
 
@@ -905,8 +907,9 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->debug)
 		{
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+			$query        = str_replace($this->tablePrefix, '#__', $query);
 		}
 
-		return $errorMessage . ' SQL=' . $this->sql;
+		return $errorMessage . ' SQL=' . $query;
 	}
 }

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -582,6 +582,13 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			$this->errorNum = (int) mysqli_errno($this->connection);
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
 			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $query;
 
 			// Check if the server was disconnected.

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -582,7 +582,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = $this->getErrorNum();
+			$errorNum = $this->getErrorNumber();
 			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
@@ -598,7 +598,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = $this->getErrorNum();
+					$this->errorNum = $this->getErrorNumber();
 					$this->errorMsg = $this->getErrorMessage();
 
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -885,7 +885,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorNum()
+	protected function getErrorNumber()
 	{
 		return (int) mysqli_errno($this->connection);
 	}

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -582,17 +582,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum     = (int) mysqli_errno($this->connection);
-			$errorMessage = (string) mysqli_error($this->connection);
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query        = str_replace($this->tablePrefix, '#__', $query);
-				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-			}
-
-			$errorMsg = $errorMessage . ' SQL=' . $query;
+			$errorNum = $this->getErrorNum();
+			$errorMsg = $this->getErrorMsg();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -607,17 +598,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = (int) mysqli_errno($this->connection);
-					$errorMessage   = (string) mysqli_error($this->connection);
-
-					// Replace the Databaseprefix with `#__` if we are not in Debug
-					if (!$this->debug)
-					{
-						$query        = str_replace($this->tablePrefix, '#__', $query);
-						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-					}
-
-					$this->errorMsg = $errorMessage . ' SQL=' . $query;
+					$this->errorNum = $this->getErrorNum();
+					$this->errorMsg = $this->getErrorMsg();
 
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -894,5 +876,37 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			return false;
 		}
+	}
+
+	/**
+	 * Return the actual SQL Error number
+	 *
+	 * @return  integer  The SQL Error number
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorNum()
+	{
+		return (int) mysqli_errno($this->connection);
+	}
+
+	/**
+	 * Return the actual SQL Error message
+	 *
+	 * @return  string  The SQL Error message
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorMsg()
+	{
+		$errorMessage = (string) mysqli_error($this->connection);
+
+		// Replace the Databaseprefix with `#__` if we are not in Debug
+		if (!$this->debug)
+		{
+			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+		}
+
+		return $errorMessage . ' SQL=' . $this->query;
 	}
 }

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -907,6 +907,6 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 		}
 
-		return $errorMessage . ' SQL=' . $this->query;
+		return $errorMessage . ' SQL=' . $this->sql;
 	}
 }

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -449,7 +449,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				$query = str_replace($this->tablePrefix, '#__', $query);
 			}
 
-			$errorMsg = (string) 'SQL: ' . $query);
+			$errorMsg = (string) 'SQL: ' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -475,7 +475,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 						$query = str_replace($this->tablePrefix, '#__', $query);
 					}
 
-					$this->errorMsg = (string) 'SQL: ' . $query);
+					$this->errorMsg = (string) 'SQL: ' . $query;
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -463,7 +463,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message
+					// Get the error number and message.
 					$this->errorNum = (int) $this->connection->errorCode();
 
 					// The SQL Error Information

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -439,7 +439,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNumber();
-			$errorMsg = $this->getErrorMessage();
+			$errorMsg = $this->getErrorMessage($query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -455,7 +455,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
+					$this->errorMsg = $this->getErrorMessage($query);
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1054,21 +1054,25 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
+	 * @param   string  The SQL Query that fails
+	 *
 	 * @return  string  The SQL Error message
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMessage()
+	protected function getErrorMessage($query)
 	{
+		// Note we ignoring $query here as it not used in the original code.
+		
 		// The SQL Error Information
-		$query = implode(", ", $this->connection->errorInfo());
+		$errorInfo = implode(", ", $this->connection->errorInfo());
 
 		// Replace the Databaseprefix with `#__` if we are not in Debug
 		if (!$this->debug)
 		{
-			$query = str_replace($this->tablePrefix, '#__', $query);
+			$errorInfo = str_replace($this->tablePrefix, '#__', $errorInfo);
 		}
 
-		return 'SQL: ' . $query;
+		return 'SQL: ' . $errorInfo;
 	}
 }

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -438,7 +438,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if (!$this->executed)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = $this->getErrorNum();
+			$errorNum = $this->getErrorNumber();
 			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
@@ -454,7 +454,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = $this->getErrorNum();
+					$this->errorNum = $this->getErrorNumber();
 					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
@@ -1046,7 +1046,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorNum()
+	protected function getErrorNumber()
 	{
 		return (int) $this->connection->errorCode();
 	}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -437,6 +437,20 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->executed)
 		{
+			// Get the error number and message before we execute any more queries.
+			$errorNum = (int) $this->connection->errorCode();
+
+			// The SQL Error Information
+			$query = implode(", ", $this->connection->errorInfo());
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
+			$errorMsg = (string) 'SQL: ' . $query);
+
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
@@ -449,7 +463,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message before we execute any more queries.
+					// Get the error number and message
 					$this->errorNum = (int) $this->connection->errorCode();
 
 					// The SQL Error Information
@@ -475,19 +489,9 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
-				// Get the error number and message before we execute any more queries.
-				$this->errorNum = (int) $this->connection->errorCode();
-
-				// The SQL Error Information
-				$query = implode(", ", $this->connection->errorInfo());
-
-				// Replace the Databaseprefix with `#__` if we are not in Debug
-				if (!$this->debug)
-				{
-					$query = str_replace($this->tablePrefix, '#__', $query);
-				}
-
-				$this->errorMsg = (string) 'SQL: ' . $query);
+				// Get the error number and message from before we tried to reconnect.
+				$this->errorNum = $errorNum;
+				$this->errorMsg = $errorMsg;
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -438,8 +438,18 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if (!$this->executed)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = (int) $this->connection->errorCode();
-			$errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
+			$this->errorNum = (int) $this->connection->errorCode();
+
+			// The SQL Error Information
+			$query = implode(", ", $this->connection->errorInfo();
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
+			$this->errorMsg = (string) 'SQL: ' . $query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -453,10 +463,6 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message.
-					$this->errorNum = (int) $this->connection->errorCode();
-					$this->errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
-
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -469,10 +475,6 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
-				// Get the error number and message from before we tried to reconnect.
-				$this->errorNum = $errorNum;
-				$this->errorMsg = $errorMsg;
-
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -1063,7 +1063,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	protected function getErrorMessage($query)
 	{
 		// Note we ignoring $query here as it not used in the original code.
-		
+
 		// The SQL Error Information
 		$errorInfo = implode(", ", $this->connection->errorInfo());
 

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -438,18 +438,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if (!$this->executed)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = (int) $this->connection->errorCode();
-
-			// The SQL Error Information
-			$query = implode(", ", $this->connection->errorInfo());
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
-			}
-
-			$errorMsg = (string) 'SQL: ' . $query;
+			$errorNum = $this->getErrorNum();
+			$errorMsg = $this->getErrorMsg();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -464,18 +454,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = (int) $this->connection->errorCode();
-
-					// The SQL Error Information
-					$query = implode(", ", $this->connection->errorInfo());
-
-					// Replace the Databaseprefix with `#__` if we are not in Debug
-					if (!$this->debug)
-					{
-						$query = str_replace($this->tablePrefix, '#__', $query);
-					}
-
-					$this->errorMsg = (string) 'SQL: ' . $query;
+					$this->errorNum = $this->getErrorNum();
+					$this->errorMsg = $this->getErrorMsg();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -437,20 +437,6 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->executed)
 		{
-			// Get the error number and message before we execute any more queries.
-			$this->errorNum = (int) $this->connection->errorCode();
-
-			// The SQL Error Information
-			$query = implode(", ", $this->connection->errorInfo();
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
-			}
-
-			$this->errorMsg = (string) 'SQL: ' . $query);
-
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
@@ -463,6 +449,20 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
+					// Get the error number and message before we execute any more queries.
+					$this->errorNum = (int) $this->connection->errorCode();
+
+					// The SQL Error Information
+					$query = implode(", ", $this->connection->errorInfo());
+
+					// Replace the Databaseprefix with `#__` if we are not in Debug
+					if (!$this->debug)
+					{
+						$query = str_replace($this->tablePrefix, '#__', $query);
+					}
+
+					$this->errorMsg = (string) 'SQL: ' . $query);
+
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -475,6 +475,20 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
+				// Get the error number and message before we execute any more queries.
+				$this->errorNum = (int) $this->connection->errorCode();
+
+				// The SQL Error Information
+				$query = implode(", ", $this->connection->errorInfo());
+
+				// Replace the Databaseprefix with `#__` if we are not in Debug
+				if (!$this->debug)
+				{
+					$query = str_replace($this->tablePrefix, '#__', $query);
+				}
+
+				$this->errorMsg = (string) 'SQL: ' . $query);
+
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -1054,7 +1054,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
-	 * @param   string  The SQL Query that fails
+	 * @param   string  $query  The SQL Query that fails
 	 *
 	 * @return  string  The SQL Error message
 	 *

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -1058,4 +1058,37 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// Get connection back
 		$this->__construct($this->options);
 	}
+
+	/**
+	 * Return the actual SQL Error number
+	 *
+	 * @return  integer  The SQL Error number
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorNum()
+	{
+		return (int) $this->connection->errorCode();
+	}
+
+	/**
+	 * Return the actual SQL Error message
+	 *
+	 * @return  string  The SQL Error message
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorMsg()
+	{
+		// The SQL Error Information
+		$query = implode(", ", $this->connection->errorInfo());
+
+		// Replace the Databaseprefix with `#__` if we are not in Debug
+		if (!$this->debug)
+		{
+			$query = str_replace($this->tablePrefix, '#__', $query);
+		}
+
+		return 'SQL: ' . $query;
+	}
 }

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -439,7 +439,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNum();
-			$errorMsg = $this->getErrorMsg();
+			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -455,7 +455,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNum();
-					$this->errorMsg = $this->getErrorMsg();
+					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1058,7 +1058,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMsg()
+	protected function getErrorMessage()
 	{
 		// The SQL Error Information
 		$query = implode(", ", $this->connection->errorInfo());

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -725,14 +725,14 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				{
 					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
 					$errorMessage   = (string) pg_last_error($this->connection);
-		
+
 					// Replace the Databaseprefix with `#__` if we are not in Debug
 					if (!$this->debug)
 					{
 						$query        = str_replace($this->tablePrefix, '#__', $query);
 						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 					}
-		
+
 					$this->errorMsg = $errorMessage . "SQL=" . $query;
 
 					// Throw the normal query exception.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -698,6 +698,17 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
+			// Get the error number and message.
+			$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
+			$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
+
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
@@ -710,10 +721,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message.
-					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-					$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
-
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -726,10 +733,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
-				// Get the error number and message.
-				$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-				$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
-
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -699,17 +699,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum     = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-			$errorMessage = (string) pg_last_error($this->connection);
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query        = str_replace($this->tablePrefix, '#__', $query);
-				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-			}
-
-			$errorMsg = $errorMessage . "SQL=" . $query;
+			$errorNum = $this->getErrorNum();
+			$errorMsg = $this->getErrorMsg();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -723,17 +714,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-					$errorMessage   = (string) pg_last_error($this->connection);
-
-					// Replace the Databaseprefix with `#__` if we are not in Debug
-					if (!$this->debug)
-					{
-						$query        = str_replace($this->tablePrefix, '#__', $query);
-						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-					}
-
-					$this->errorMsg = $errorMessage . "SQL=" . $query;
+					$this->errorNum = $this->getErrorNum();
+					$this->errorMsg = $this->getErrorMsg();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1472,5 +1454,37 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$this->setQuery(sprintf($statement, implode(",", $fields), implode(' AND ', $where)));
 
 		return $this->execute();
+	}
+
+	/**
+	 * Return the actual SQL Error number
+	 *
+	 * @return  integer  The SQL Error number
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorNum()
+	{
+		return (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+	}
+
+	/**
+	 * Return the actual SQL Error message
+	 *
+	 * @return  string  The SQL Error message
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorMsg()
+	{
+		$errorMessage = (string) pg_last_error($this->connection);
+
+		// Replace the Databaseprefix with `#__` if we are not in Debug
+		if (!$this->debug)
+		{
+			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+		}
+
+		return = $errorMessage . "SQL=" . $this->query;
 	}
 }

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1471,7 +1471,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
-	 * @param   string  The SQL Query that fails
+	 * @param   string  $query  The SQL Query that fails
 	 *
 	 * @return  string  The SQL Error message
 	 *

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -699,7 +699,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = $this->getErrorNum();
+			$errorNum = $this->getErrorNumber();
 			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
@@ -714,7 +714,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					$this->errorNum = $this->getErrorNum();
+					$this->errorNum = $this->getErrorNumber();
 					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
@@ -1463,7 +1463,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorNum()
+	protected function getErrorNumber()
 	{
 		return (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
 	}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1485,6 +1485,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 		}
 
-		return $errorMessage . "SQL=" . $this->query;
+		return $errorMessage . "SQL=" . $this->sql;
 	}
 }

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -700,7 +700,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNumber();
-			$errorMsg = $this->getErrorMessage();
+			$errorMsg = $this->getErrorMessage($query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -715,7 +715,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
+					$this->errorMsg = $this->getErrorMessage($query);
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1471,11 +1471,13 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
+	 * @param   string  The SQL Query that fails
+	 *
 	 * @return  string  The SQL Error message
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMessage()
+	protected function getErrorMessage($query)
 	{
 		$errorMessage = (string) pg_last_error($this->connection);
 
@@ -1483,8 +1485,9 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if (!$this->debug)
 		{
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+			$query        = str_replace($this->tablePrefix, '#__', $query);
 		}
 
-		return $errorMessage . "SQL=" . $this->sql;
+		return $errorMessage . "SQL=" . $query;
 	}
 }

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -700,7 +700,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNum();
-			$errorMsg = $this->getErrorMsg();
+			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -715,7 +715,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					$this->errorNum = $this->getErrorNum();
-					$this->errorMsg = $this->getErrorMsg();
+					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1475,7 +1475,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMsg()
+	protected function getErrorMessage()
 	{
 		$errorMessage = (string) pg_last_error($this->connection);
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -700,14 +700,16 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			// Get the error number and message.
 			$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+			$errorMessage   = (string) pg_last_error($this->connection);
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
 			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
+				$query        = str_replace($this->tablePrefix, '#__', $query);
+				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = (string) pg_last_error($this->connection) . "SQL=" . $query;
+			$this->errorMsg = $errorMessage . "SQL=" . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1485,6 +1485,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 		}
 
-		return = $errorMessage . "SQL=" . $this->query;
+		return $errorMessage . "SQL=" . $this->query;
 	}
 }

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -707,7 +707,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				$query = str_replace($this->tablePrefix, '#__', $query);
 			}
 
-			$this->errorMsg = pg_last_error($this->connection) . "SQL=" . $query;
+			$this->errorMsg = (string) pg_last_error($this->connection) . "SQL=" . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -663,14 +663,14 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 					$errors         = sqlsrv_errors();
 					$this->errorNum = $errors[0]['SQLSTATE'];
 					$errorMessage   = (string) $errors[0]['message'];
-		
+
 					// Replace the Databaseprefix with `#__` if we are not in Debug
 					if (!$this->debug)
 					{
 						$query        = str_replace($this->tablePrefix, '#__', $query);
 						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 					}
-		
+
 					$this->errorMsg = $errorMessage . 'SQL=' . $query;
 
 					// Throw the normal query exception.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -633,6 +633,18 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
+			// Get the error number and message.
+			$errors = sqlsrv_errors();
+			$this->errorNum = $errors[0]['SQLSTATE'];
+
+			// Replace the Databaseprefix with `#__` if we are not in Debug
+			if (!$this->debug)
+			{
+				$query = str_replace($this->tablePrefix, '#__', $query);
+			}
+
+			$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
+
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
@@ -645,11 +657,6 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message.
-					$errors = sqlsrv_errors();
-					$this->errorNum = $errors[0]['SQLSTATE'];
-					$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
-
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 
@@ -662,11 +669,6 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
-				// Get the error number and message.
-				$errors = sqlsrv_errors();
-				$this->errorNum = $errors[0]['SQLSTATE'];
-				$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
-
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
 

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -636,14 +636,16 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			// Get the error number and message.
 			$errors         = sqlsrv_errors();
 			$this->errorNum = $errors[0]['SQLSTATE'];
+			$errorMessage   = (string) $errors[0]['message'];
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
 			{
 				$query = str_replace($this->tablePrefix, '#__', $query);
+				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 
-			$this->errorMsg = $errors[0]['message'] . 'SQL=' . $query;
+			$this->errorMsg = $errorMessage . 'SQL=' . $query;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -634,18 +634,8 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errors       = sqlsrv_errors();
-			$errorNum     = $errors[0]['SQLSTATE'];
-			$errorMessage = (string) $errors[0]['message'];
-
-			// Replace the Databaseprefix with `#__` if we are not in Debug
-			if (!$this->debug)
-			{
-				$query        = str_replace($this->tablePrefix, '#__', $query);
-				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-			}
-
-			$errorMsg = $errorMessage . 'SQL=' . $query;
+			$errorNum = $this->getErrorNum();
+			$errorMsg = $this->getErrorMsg();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -660,18 +650,8 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$errors         = sqlsrv_errors();
-					$this->errorNum = $errors[0]['SQLSTATE'];
-					$errorMessage   = (string) $errors[0]['message'];
-
-					// Replace the Databaseprefix with `#__` if we are not in Debug
-					if (!$this->debug)
-					{
-						$query        = str_replace($this->tablePrefix, '#__', $query);
-						$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
-					}
-
-					$this->errorMsg = $errorMessage . 'SQL=' . $query;
+					$this->errorNum = $this->getErrorNum();
+					$this->errorMsg = $this->getErrorMsg();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1114,5 +1094,40 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	public function unlockTables()
 	{
 		return $this;
+	}
+
+	/**
+	 * Return the actual SQL Error number
+	 *
+	 * @return  integer  The SQL Error number
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorNum()
+	{
+		$errors = sqlsrv_errors();
+
+		return $errors[0]['SQLSTATE'];
+	}
+
+	/**
+	 * Return the actual SQL Error message
+	 *
+	 * @return  string  The SQL Error message
+	 *
+	 * @since   3.4.6
+	 */
+	protected function getErrorMsg()
+	{
+		$errors       = sqlsrv_errors();
+		$errorMessage = (string) $errors[0]['message'];
+
+		// Replace the Databaseprefix with `#__` if we are not in Debug
+		if (!$this->debug)
+		{
+			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+		}
+
+		return $errorMessage . 'SQL=' . $this->query;
 	}
 }

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -635,7 +635,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNum();
-			$errorMsg = $this->getErrorMsg();
+			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -651,7 +651,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNum();
-					$this->errorMsg = $this->getErrorMsg();
+					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1117,7 +1117,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMsg()
+	protected function getErrorMessage()
 	{
 		$errors       = sqlsrv_errors();
 		$errorMessage = (string) $errors[0]['message'];

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -634,7 +634,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message.
-			$errors = sqlsrv_errors();
+			$errors         = sqlsrv_errors();
 			$this->errorNum = $errors[0]['SQLSTATE'];
 
 			// Replace the Databaseprefix with `#__` if we are not in Debug

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -634,7 +634,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if (!$this->cursor)
 		{
 			// Get the error number and message before we execute any more queries.
-			$errorNum = $this->getErrorNum();
+			$errorNum = $this->getErrorNumber();
 			$errorMsg = $this->getErrorMessage();
 
 			// Check if the server was disconnected.
@@ -650,7 +650,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				catch (RuntimeException $e)
 				{
 					// Get the error number and message.
-					$this->errorNum = $this->getErrorNum();
+					$this->errorNum = $this->getErrorNumber();
 					$this->errorMsg = $this->getErrorMessage();
 
 					// Throw the normal query exception.
@@ -1103,7 +1103,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorNum()
+	protected function getErrorNumber()
 	{
 		$errors = sqlsrv_errors();
 

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -635,7 +635,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			// Get the error number and message before we execute any more queries.
 			$errorNum = $this->getErrorNumber();
-			$errorMsg = $this->getErrorMessage();
+			$errorMsg = $this->getErrorMessage($query);
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -651,7 +651,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				{
 					// Get the error number and message.
 					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
+					$this->errorMsg = $this->getErrorMessage($query);
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
@@ -1113,11 +1113,13 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
+	 * @param   string  The SQL Query that fails
+	 *
 	 * @return  string  The SQL Error message
 	 *
 	 * @since   3.4.6
 	 */
-	protected function getErrorMessage()
+	protected function getErrorMessage($query)
 	{
 		$errors       = sqlsrv_errors();
 		$errorMessage = (string) $errors[0]['message'];
@@ -1126,8 +1128,9 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if (!$this->debug)
 		{
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
+			$query        = str_replace($this->tablePrefix, '#__', $query);
 		}
 
-		return $errorMessage . 'SQL=' . $this->sql;
+		return $errorMessage . ' SQL=' . $query;
 	}
 }

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -1113,7 +1113,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	/**
 	 * Return the actual SQL Error message
 	 *
-	 * @param   string  The SQL Query that fails
+	 * @param   string  $query  The SQL Query that fails
 	 *
 	 * @return  string  The SQL Error message
 	 *

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -1128,6 +1128,6 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 		}
 
-		return $errorMessage . 'SQL=' . $this->query;
+		return $errorMessage . 'SQL=' . $this->sql;
 	}
 }

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -641,7 +641,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			// Replace the Databaseprefix with `#__` if we are not in Debug
 			if (!$this->debug)
 			{
-				$query = str_replace($this->tablePrefix, '#__', $query);
+				$query        = str_replace($this->tablePrefix, '#__', $query);
 				$errorMessage = str_replace($this->tablePrefix, '#__', $errorMessage);
 			}
 


### PR DESCRIPTION
This PR implements the hide of the SQL Table Prefix from error messages if the webseite is not in debugging mode.

In debugging mode we get the full error message.
#### How to test
- produce a SQL Error message in the frontend
- see that the prefixes get shown
- apply this patch
- see the prefixes are replaced with `#__`
- enable debug for your user
- see the prefixes are back

This implements the good idea by @ryandemmer from here: https://github.com/joomla/joomla-cms/issues/8129 Thanks. 
