### PR TITLE
Hide sql error messages without debug enabled (frontend)

### DIFF
--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -157,15 +157,16 @@ $this->direction = $doc->direction;
 							<h3>
 								<?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?>
 							</h3>
-							<h2>#<?php echo $this->error->getCode(); ?>&nbsp;<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
-							</h2>
-							<br />
+							<?php if ($this->debug) : ?>
+								<h2>#<?php echo $this->error->getCode(); ?>&nbsp;<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></h2>
+								<br />
+							<?php endif; ?>
 						</div><!-- end errorboxbody -->
 					</div><!-- end wrapper2 -->
 				</div><!-- end contentarea2 -->
-				<?php if ($this->debug) :
-					echo $this->renderBacktrace();
-				endif; ?>
+				<?php if ($this->debug) : ?>
+					<?php echo $this->renderBacktrace(); ?>
+				<?php endif; ?>
 			</div><!--end back -->
 		</div><!--end all -->
 		<div id="footer-outer">

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -164,10 +164,10 @@ else
 						</div>
 						<hr />
 						<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
-						<blockquote>
-							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
-						</blockquote>
 						<?php if ($this->debug) : ?>
+							<blockquote>
+								<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
+							</blockquote>
 							<?php echo $this->renderBacktrace(); ?>
 						<?php endif; ?>
 					</div>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -54,13 +54,13 @@ $this->direction = $doc->direction;
 				<li><a href="<?php echo $this->baseurl; ?>/index.php" title="<?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?>"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
 			</ul>
 			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
-			<div id="techinfo">
-			<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
-			<p>
-				<?php if ($this->debug) : ?>
+			<?php if ($this->debug) : ?>
+				<div id="techinfo">
+				<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+				<p>
 					<?php echo $this->renderBacktrace(); ?>
-				<?php endif; ?>
-			</p>
+				</p>
+			<?php endif; ?>
 			</div>
 			</div>
 		</div>


### PR DESCRIPTION
This PR hide the Error Message if the debug is disabled.
### How to test
- produce any error message in the frontend
- see the error message
- apply this patch
- produce any error message in the frontend
- see that the error message is gone
- enable debug
- see the message comming back
### Why this not replace #8129

This only works for templates that use the system layout as well as the default templates.
### Question

Do we need the same for the backend? Or can we say "if you are in the backend you can do more things than detect the Table prefix"?
