### PR TITLE
Regression from tinyMCE editors XTD buttons

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -406,6 +406,9 @@ abstract class JHtmlBehavior
 			});
 		});
 		function jModalClose() {
+			if (jQuery('.mce-window').length ){
+				tinyMCE.activeEditor.windowManager.close();
+			}
 			SqueezeBox.close();
 		}"
 		);

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -999,12 +999,6 @@ class PlgEditorTinymce extends JPlugin
 				if ($button->get('modal') || $href)
 				{
 					$tempConstructor .= "
-							SqueezeBox.close = (function(){
-								return function() {
-									tinyMCE.activeEditor.windowManager.close();
-									SqueezeBox.close();
-								}
-							})();
 							editor.windowManager.open({
 								title  : \"" . $title . "\",
 								url : '" . $href . "',";


### PR DESCRIPTION
#### The problem:

With the code from the 3.5-dev repo try to edit an article. Also try to insert an image with the new button in tinyMCE’s toolbar. Everything works as expected. Now try to change tab to Images and links and try to change the intro or the full text image. The modal will not close, the functionality is broken.
#### The solution:

Trying to redefine the jModalClose function (javascript) is not the best way to solve this. It’s far better to tackle this in the initial declaration of the function: in the file behavior.php
#### Testing:

Try to repeat the steps described above. Everything should work without any errors. 

@roland-d Sorry for this mess, I just found this testing something different.
