### PR TITLE
Fixes in defines.php to properly handle chrooted hosts

### DIFF
--- a/administrator/includes/defines.php
+++ b/administrator/includes/defines.php
@@ -8,12 +8,8 @@
 
 defined('_JEXEC') or die;
 
-// Global definitions
-$parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
-array_pop($parts);
-
 // Defines
-define('JPATH_ROOT',          implode(DIRECTORY_SEPARATOR, $parts));
+define('JPATH_ROOT',          dirname(JPATH_BASE);
 define('JPATH_SITE',          JPATH_ROOT);
 define('JPATH_CONFIGURATION', JPATH_ROOT);
 define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');

--- a/includes/defines.php
+++ b/includes/defines.php
@@ -8,11 +8,8 @@
 
 defined('_JEXEC') or die;
 
-// Global definitions
-$parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
-
 // Defines.
-define('JPATH_ROOT',          implode(DIRECTORY_SEPARATOR, $parts));
+define('JPATH_ROOT',          JPATH_BASE);
 define('JPATH_SITE',          JPATH_ROOT);
 define('JPATH_CONFIGURATION', JPATH_ROOT);
 define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');


### PR DESCRIPTION
I've got problems with updating Joomla! on my chrooted host. Update package was properly downloaded to temporary folder but instead of extracting into root of my server, it landed into `administrator/components/com_joomlaupdate`. This problem was reported before: https://github.com/joomla/joomla-cms/issues/7383 and https://github.com/joomla/joomla-cms/issues/7866. The latter report is especially valuable.

After closer examination, I found out that `JPATH_ROOT` is the most probable culprit. It is set independently in two places: `includes/defines.php` and `administrator/includes/defines.php`. The code in the first of these, simply “exploded” JPATH_BASE (which in fact is simply `__DIR__`) only to “reassemble” it back again to the same form as before. Unless I omitted something important, this didn't change a thing, so I removed this code and assigned `JPATH_BASE` to `JPATH_ROOT` directly.

When it comes to second file (`administrator/includes/defines.php`), it worked fine as long as there was more than one directory from root (`/`). As soon as `administrator` directory is placed directly in `/` (`JPATH_BASE` is `/administrator`), the code in `defines.php` sets `JPATH_ROOT` to an empty string instead of `/`. This is most probably what causes the update to be extracted into the wrong place.

The cause of this is this part:

`$parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);`
`array_pop($parts);`
`define('JPATH_ROOT',          implode(DIRECTORY_SEPARATOR, $parts));`

When `JPATH_BASE` value is `/administrator`, `explode()` splits it into array of 2 elements `''` (empty string) and `administrator`. `array_pop()` removes `administrator` part of the array (I guess, to establish “real” root of all Joomla! files) leaving array with only one element. However, when array has only one element, `implode()` returns only this element alone, without even adding separator. This leads to an empty string, which, further down the road, leads to acting in given script working directory instead of actual `JPATH_ROOT`.

Quick fix for this problem appears to be using `dirname()` function, instead of `explode()`→`array_pop()`→`implode()` chain, since it all seems to be about stripping `administrator` from `JPATH_BASE` in the first place.

Please review my pull request. Not being able to update Jommla! on chrooted host is really PITA :}.
