### PR TITLE
Add more info to installation errors

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -145,7 +145,7 @@ abstract class JFolder
 						{
 							if (!@copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Copy file failed', -1);
+								throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
 							}
 						}
 						break;
@@ -292,6 +292,7 @@ abstract class JFolder
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public static function delete($path)
 	{
@@ -309,8 +310,15 @@ abstract class JFolder
 
 		$FTPOptions = JClientHelper::getCredentials('ftp');
 
-		// Check to make sure the path valid and clean
-		$path = $pathObject->clean($path);
+		try
+		{
+			// Check to make sure the path valid and clean
+			$path = $pathObject->clean($path);
+		}
+		catch (UnexpectedValueException $e)
+		{
+			throw $e;
+		}
 
 		// Is this really a folder?
 		if (!is_dir($path))

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -145,7 +145,7 @@ abstract class JFolder
 						{
 							if (!@copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
+								throw new RuntimeException('Copy file failed', -1);
 							}
 						}
 						break;
@@ -292,7 +292,6 @@ abstract class JFolder
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
-	 * @throws  UnexpectedValueException
 	 */
 	public static function delete($path)
 	{
@@ -310,15 +309,8 @@ abstract class JFolder
 
 		$FTPOptions = JClientHelper::getCredentials('ftp');
 
-		try
-		{
-			// Check to make sure the path valid and clean
-			$path = $pathObject->clean($path);
-		}
-		catch (UnexpectedValueException $e)
-		{
-			throw $e;
-		}
+		// Check to make sure the path valid and clean
+		$path = $pathObject->clean($path);
 
 		// Is this really a folder?
 		if (!is_dir($path))

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -99,7 +99,7 @@ abstract class JFolder
 
 						if (!$ftp->store($sfid, $dfid))
 						{
-							throw new RuntimeException('Copy file failed', -1);
+							throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
 						}
 						break;
 				}
@@ -145,7 +145,7 @@ abstract class JFolder
 						{
 							if (!@copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Copy file failed', -1);
+								throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
 							}
 						}
 						break;

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -99,7 +99,7 @@ abstract class JFolder
 
 						if (!$ftp->store($sfid, $dfid))
 						{
-							throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
+							throw new RuntimeException('Copy file failed (' . $sfid . "=>" . $dfid . ")", -1);
 						}
 						break;
 				}
@@ -145,7 +145,7 @@ abstract class JFolder
 						{
 							if (!@copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Copy file failed ('.$sfid."=>".$dfid.")", -1);
+								throw new RuntimeException('Copy file failed (' . $sfid . "=>" . $dfid . ")", -1);
 							}
 						}
 						break;


### PR DESCRIPTION
Shows which file cannot be copied. It allows to fix issues when the target file was made read-only and thus cannot be overwritten, causing installation failure.
