### PR TITLE
Code review on com_cache component, doc blocks for Cache package

### DIFF
--- a/administrator/components/com_cache/controller.php
+++ b/administrator/components/com_cache/controller.php
@@ -22,11 +22,11 @@ class CacheController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  This object to support chaining.
+	 * @return  CacheController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cachable = false, $urlparams = array())
 	{
 		require_once JPATH_COMPONENT . '/helpers/cache.php';
 
@@ -62,6 +62,8 @@ class CacheController extends JControllerLegacy
 
 			$view->display();
 		}
+
+		return $this;
 	}
 
 	/**
@@ -76,6 +78,7 @@ class CacheController extends JControllerLegacy
 
 		$cid = $this->input->post->get('cid', array(), 'array');
 
+		/** @var CacheModelCache $model */
 		$model = $this->getModel('cache');
 
 		if (empty($cid))
@@ -100,6 +103,7 @@ class CacheController extends JControllerLegacy
 		// Check for request forgeries
 		JSession::checkToken() or jexit(JText::_('JInvalid_Token'));
 
+		/** @var CacheModelCache $model */
 		$model = $this->getModel('cache');
 		$ret = $model->purge();
 

--- a/administrator/components/com_cache/helpers/cache.php
+++ b/administrator/components/com_cache/helpers/cache.php
@@ -19,16 +19,14 @@ class CacheHelper
 	/**
 	 * Get a list of filter options for the application clients.
 	 *
-	 * @return  array  An array of JHtmlOption elements.
+	 * @return  stdClass[]  An array of option elements.
 	 */
 	public static function getClientOptions()
 	{
-		// Build the filter options.
-		$options   = array();
-		$options[] = JHtml::_('select.option', '0', JText::_('JSITE'));
-		$options[] = JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'));
-
-		return $options;
+		return array(
+			JHtml::_('select.option', '0', JText::_('JSITE')),
+			JHtml::_('select.option', '1', JText::_('JADMINISTRATOR'))
+		);
 	}
 
 	/**

--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Cache Model
  *
@@ -19,21 +21,21 @@ class CacheModelCache extends JModelList
 	/**
 	 * An Array of CacheItems indexed by cache group ID
 	 *
-	 * @var Array
+	 * @var  array
 	 */
 	protected $_data = array();
 
 	/**
 	 * Group total
 	 *
-	 * @var integer
+	 * @var  integer
 	 */
 	protected $_total = null;
 
 	/**
 	 * Pagination object
 	 *
-	 * @var object
+	 * @var  JPagination
 	 */
 	protected $_pagination = null;
 
@@ -63,7 +65,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * Method to get cache data
 	 *
-	 * @return array
+	 * @return  array
 	 */
 	public function getData()
 	{
@@ -83,8 +85,7 @@ class CacheModelCache extends JModelList
 					$ordering = $this->getState('list.ordering');
 					$direction = ($this->getState('list.direction') == 'asc') ? 1 : (-1);
 
-					jimport('joomla.utilities.arrayhelper');
-					$this->_data = JArrayHelper::sortObjects($data, $ordering, $direction);
+					$this->_data = ArrayHelper::sortObjects($data, $ordering, $direction);
 
 					// Apply custom pagination.
 					if ($this->_total > $this->getState('list.limit') && $this->getState('list.limit'))
@@ -105,7 +106,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * Method to get cache instance.
 	 *
-	 * @return object
+	 * @return  JCacheController
 	 */
 	public function getCache()
 	{
@@ -118,15 +119,13 @@ class CacheModelCache extends JModelList
 			'cachebase'    => ($this->getState('clientId') == 1) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache')
 		);
 
-		$cache = JCache::getInstance('', $options);
-
-		return $cache;
+		return JCache::getInstance('', $options);
 	}
 
 	/**
 	 * Method to get client data.
 	 *
-	 * @return array
+	 * @return  array
 	 */
 	public function getClient()
 	{
@@ -136,7 +135,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * Get the number of current Cache Groups.
 	 *
-	 * @return  int
+	 * @return  integer
 	 */
 	public function getTotal()
 	{
@@ -151,7 +150,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * Method to get a pagination object for the cache.
 	 *
-	 * @return  integer
+	 * @return  JPagination
 	 */
 	public function getPagination()
 	{
@@ -173,8 +172,7 @@ class CacheModelCache extends JModelList
 	 */
 	public function clean($group = '')
 	{
-		$cache = $this->getCache();
-		$cache->clean($group);
+		$this->getCache()->clean($group);
 	}
 
 	/**
@@ -199,8 +197,6 @@ class CacheModelCache extends JModelList
 	 */
 	public function purge()
 	{
-		$cache = JFactory::getCache('');
-
-		return $cache->gc();
+		return JFactory::getCache('')->gc();
 	}
 }

--- a/administrator/components/com_cache/views/cache/view.html.php
+++ b/administrator/components/com_cache/views/cache/view.html.php
@@ -16,12 +16,32 @@ defined('_JEXEC') or die;
  */
 class CacheViewCache extends JViewLegacy
 {
+	/**
+	 * The client data
+	 *
+	 * @var  object
+	 */
 	protected $client;
 
+	/**
+	 * The cache data
+	 *
+	 * @var  array
+	 */
 	protected $data;
 
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
 	protected $pagination;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
 
 	/**
@@ -48,7 +68,8 @@ class CacheViewCache extends JViewLegacy
 
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_cache/views/purge/view.html.php
+++ b/administrator/components/com_cache/views/purge/view.html.php
@@ -27,7 +27,8 @@ class CacheViewPurge extends JViewLegacy
 	{
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -71,7 +71,7 @@ class JCache
 	 * @param   string  $type     The cache object type to instantiate
 	 * @param   array   $options  The array of options
 	 *
-	 * @return  JCache  A JCache object
+	 * @return  JCacheController  A JCacheController object
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -77,7 +77,7 @@ class JCacheController
 	 * @param   string  $type     The cache object type to instantiate; default is output.
 	 * @param   array   $options  Array of options
 	 *
-	 * @return  JCache  A JCache object
+	 * @return  JCacheController  A JCacheController object
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the admin com_cache component. This also updates a couple of doc blocks in the JCache class chain to reflect the correct return types (traced while reviewing this component's code) Changes of note:
- Doc blocks cleaned up some to follow standard
- Return the results of the view's `display()` methods to be consistent with the documented return
- Not using variables for items only referenced once
- Use `Joomla\Utilities\ArrayHelper` instead of `JArrayHelper`
### Testing Instructions

The admin com_cache component should continue to function correctly
