### PR TITLE
Add support for the second argument of JLoader::import() to jimport()

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -627,12 +627,13 @@ function jexit($message = 0)
  * Intelligent file importer.
  *
  * @param   string  $path  A dot syntax path.
+ * @param   string  $base  Search this directory for the class.
  *
  * @return  boolean  True on success.
  *
  * @since   11.1
  */
-function jimport($path)
+function jimport($path, $base = null)
 {
-	return JLoader::import($path);
+	return JLoader::import($path, $base);
 }


### PR DESCRIPTION
`jimport()` is a proxy to `JLoader::import()` however the proxy does not support both method arguments that the real method does.  This PR adds the second argument for `jimport()` to be able to pass it forward.
### Testing Instructions

So I found this issue actually on a review of com_categories, but I'm not totally familiar with how the associations stuff works.  Essentially though [this line](https://github.com/joomla/joomla-cms/blob/3.4.5/administrator/components/com_categories/helpers/association.php#L41) shouldn't actually import the right object in the current code since the second argument never gets forwarded so the right lookup path is never used.  So if you can figure that out, you might actually validate a potential bug fix along the way.  If you're lazy like I am though, you'll just read the code to validate the changes.
