### PR TITLE
Code review on com_categories component

### DIFF
--- a/administrator/components/com_categories/categories.php
+++ b/administrator/components/com_categories/categories.php
@@ -23,8 +23,6 @@ if (!JFactory::getUser()->authorise('core.manage', $component))
 
 JLoader::register('JHtmlCategoriesAdministrator', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/html/categoriesadministrator.php');
 
-$task = $input->get('task');
-
 $controller = JControllerLegacy::getInstance('Categories');
 $controller->execute($input->get('task'));
 $controller->redirect();

--- a/administrator/components/com_categories/controller.php
+++ b/administrator/components/com_categories/controller.php
@@ -17,7 +17,9 @@ defined('_JEXEC') or die;
 class CategoriesController extends JControllerLegacy
 {
 	/**
-	 * @var    string  The extension for which the categories apply.
+	 * The extension for which the categories apply.
+	 *
+	 * @var    string
 	 * @since  1.6
 	 */
 	protected $extension;
@@ -27,7 +29,7 @@ class CategoriesController extends JControllerLegacy
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -47,11 +49,11 @@ class CategoriesController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  This object to support chaining.
+	 * @return  CategoriesController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cachable = false, $urlparams = array())
 	{
 		// Get the document object.
 		$document = JFactory::getDocument();

--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * The Categories List Controller
  *
@@ -23,15 +25,13 @@ class CategoriesControllerCategories extends JControllerAdmin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  The array of possible config values. Optional.
 	 *
-	 * @return  object  The model.
+	 * @return  JModelLegacy  The model.
 	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Category', $prefix = 'CategoriesModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**
@@ -48,6 +48,7 @@ class CategoriesControllerCategories extends JControllerAdmin
 		$extension = $this->input->get('extension');
 		$this->setRedirect(JRoute::_('index.php?option=com_categories&view=categories&extension=' . $extension, false));
 
+		/** @var CategoriesModelCategory $model */
 		$model = $this->getModel();
 
 		if ($model->rebuild())
@@ -57,13 +58,11 @@ class CategoriesControllerCategories extends JControllerAdmin
 
 			return true;
 		}
-		else
-		{
-			// Rebuild failed.
-			$this->setMessage(JText::_('COM_CATEGORIES_REBUILD_FAILURE'));
 
-			return false;
-		}
+		// Rebuild failed.
+		$this->setMessage(JText::_('COM_CATEGORIES_REBUILD_FAILURE'));
+
+		return false;
 	}
 
 	/**
@@ -121,11 +120,11 @@ class CategoriesControllerCategories extends JControllerAdmin
 		else
 		{
 			// Get the model.
+			/** @var CategoriesModelCategory $model */
 			$model = $this->getModel();
 
 			// Make sure the item ids are integers
-			jimport('joomla.utilities.arrayhelper');
-			JArrayHelper::toInteger($cid);
+			$cid = ArrayHelper::toInteger($cid);
 
 			// Remove the items.
 			if ($model->delete($cid))

--- a/administrator/components/com_categories/controllers/category.php
+++ b/administrator/components/com_categories/controllers/category.php
@@ -32,7 +32,7 @@ class CategoriesControllerCategory extends JControllerForm
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
 	 * @since  1.6
-	 * @see    JController
+	 * @see    JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
@@ -75,7 +75,6 @@ class CategoriesControllerCategory extends JControllerForm
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
-		$userId = $user->get('id');
 
 		// Check general edit permission first.
 		if ($user->authorise('core.edit', $this->extension))
@@ -110,7 +109,7 @@ class CategoriesControllerCategory extends JControllerForm
 			}
 
 			// If the owner matches 'me' then do the test.
-			if ($ownerId == $userId)
+			if ($ownerId == $user->id)
 			{
 				return true;
 			}
@@ -133,6 +132,7 @@ class CategoriesControllerCategory extends JControllerForm
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Set the model
+		/** @var CategoriesModelCategory $model */
 		$model = $this->getModel('Category');
 
 		// Preset the redirect
@@ -201,7 +201,5 @@ class CategoriesControllerCategory extends JControllerForm
 			$registry->loadArray($item->metadata);
 			$item->metadata = (string) $registry;
 		}
-
-		return;
 	}
 }

--- a/administrator/components/com_categories/helpers/association.php
+++ b/administrator/components/com_categories/helpers/association.php
@@ -30,7 +30,6 @@ abstract class CategoryHelperAssociation
 	 *
 	 * @since  3.0
 	 */
-
 	public static function getCategoryAssociations($id = 0, $extension = 'com_content')
 	{
 		$return = array();

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -86,9 +86,7 @@ class CategoriesHelper
 		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
 
 		// Get list of actions
-		$result = JHelperContent::getActions($extension, 'category', $categoryId);
-
-		return $result;
+		return JHelperContent::getActions($extension, 'category', $categoryId);
 	}
 
 	/**
@@ -97,7 +95,7 @@ class CategoriesHelper
 	 * @param   integer  $pk         Content item key.
 	 * @param   string   $extension  Optional extension name.
 	 *
-	 * @return  array of associations. 
+	 * @return  array of associations.
 	 */
 	public static function getAssociations($pk, $extension = 'com_content')
 	{
@@ -116,14 +114,16 @@ class CategoriesHelper
 		);
 		$query->select($select);
 		$db->setQuery($query);
-		$contentitems = $db->loadObjectList('language');
 
-		// Check for a database error.
-		if ($error = $db->getErrorMsg())
+		try
 		{
-			JError::raiseWarning(500, $error);
+			$contentitems = $db->loadObjectList('language');
+		}
+		catch (RuntimeException $exception)
+		{
+			JError::raiseWarning(500, $exception->getMessage());
 
-			return false;
+			return array();
 		}
 
 		foreach ($contentitems as $tag => $item)

--- a/administrator/components/com_categories/helpers/html/categoriesadministrator.php
+++ b/administrator/components/com_categories/helpers/html/categoriesadministrator.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
 
 /**
@@ -25,6 +27,9 @@ abstract class JHtmlCategoriesAdministrator
 	 * @param   string   $extension  Category Extension
 	 *
 	 * @return  string   The language HTML
+	 *
+	 * @since   3.2
+	 * @throws  Exception
 	 */
 	public static function association($catid, $extension = 'com_content')
 	{
@@ -34,7 +39,7 @@ abstract class JHtmlCategoriesAdministrator
 		// Get the associations
 		if ($associations = CategoriesHelper::getAssociations($catid, $extension))
 		{
-			JArrayHelper::toInteger($associations);
+			$associations = ArrayHelper::toInteger($associations);
 
 			// Get the associated categories
 			$db = JFactory::getDbo();
@@ -54,7 +59,7 @@ abstract class JHtmlCategoriesAdministrator
 			}
 			catch (RuntimeException $e)
 			{
-				throw new Exception($e->getMessage(), 500);
+				throw new Exception($e->getMessage(), 500, $e);
 			}
 
 			if ($items)
@@ -65,7 +70,8 @@ abstract class JHtmlCategoriesAdministrator
 					$url = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . (int) $item->id . '&extension=' . $extension);
 					$tooltipParts = array(
 						JHtml::_(
-							'image', 'mod_languages/' . $item->image . '.gif',
+							'image',
+							'mod_languages/' . $item->image . '.gif',
 							$item->language_title,
 							array('title' => $item->language_title),
 							true

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -21,7 +21,7 @@ class CategoriesModelCategories extends JModelList
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -284,9 +284,8 @@ class CategoriesModelCategories extends JModelList
 	 *
 	 * @return  boolean  True if the association exists
 	 *
-	 * @since  3.0
+	 * @since   3.0
 	 */
-
 	public function getAssoc()
 	{
 		static $assoc = null;
@@ -296,7 +295,6 @@ class CategoriesModelCategories extends JModelList
 			return $assoc;
 		}
 
-		$app = JFactory::getApplication();
 		$extension = $this->getState('filter.extension');
 
 		$assoc = JLanguageAssociations::isEnabled();

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Categories Component Category Model
@@ -19,7 +20,9 @@ use Joomla\Registry\Registry;
 class CategoriesModelCategory extends JModelAdmin
 {
 	/**
-	 * @var    string  The prefix to use with controller messages.
+	 * The prefix to use with controller messages.
+	 *
+	 * @var    string
 	 * @since  1.6
 	 */
 	protected $text_prefix = 'COM_CATEGORIES';
@@ -73,9 +76,7 @@ class CategoriesModelCategory extends JModelAdmin
 				return;
 			}
 
-			$user = JFactory::getUser();
-
-			return $user->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
+			return JFactory::getUser()->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
 		}
 	}
 
@@ -97,16 +98,15 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			return $user->authorise('core.edit.state', $record->extension . '.category.' . (int) $record->id);
 		}
+
 		// New category, so check against the parent.
-		elseif (!empty($record->parent_id))
+		if (!empty($record->parent_id))
 		{
 			return $user->authorise('core.edit.state', $record->extension . '.category.' . (int) $record->parent_id);
 		}
+
 		// Default to component settings if neither category nor parent known.
-		else
-		{
-			return $user->authorise('core.edit.state', $record->extension);
-		}
+		return $user->authorise('core.edit.state', $record->extension);
 	}
 
 	/**
@@ -223,8 +223,7 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			if ($result->id != null)
 			{
-				$result->associations = CategoriesHelper::getAssociations($result->id, $result->extension);
-				JArrayHelper::toInteger($result->associations);
+				$result->associations = ArrayHelper::toInteger(CategoriesHelper::getAssociations($result->id, $result->extension));
 			}
 			else
 			{
@@ -241,7 +240,7 @@ class CategoriesModelCategory extends JModelAdmin
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed    A JForm object on success, false on failure
+	 * @return  JForm|boolean  A JForm object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -296,7 +295,7 @@ class CategoriesModelCategory extends JModelAdmin
 	 * A protected method to get the where clause for the reorder
 	 * This ensures that the row will be moved relative to a row with the same extension
 	 *
-	 * @param   JCategoryTable  $table  Current table instance
+	 * @param   JTableCategory  $table  Current table instance
 	 *
 	 * @return  array           An array of conditions to add to add to ordering queries.
 	 *
@@ -600,11 +599,14 @@ class CategoriesModelCategory extends JModelAdmin
 				->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext))
 				->where($db->quoteName('id') . ' IN (' . implode(',', $associations) . ')');
 			$db->setQuery($query);
-			$db->execute();
 
-			if ($error = $db->getErrorMsg())
+			try
 			{
-				$this->setError($error);
+				$db->execute();
+			}
+			catch (RuntimeException $e)
+			{
+				$this->setError($e->getMessage());
 
 				return false;
 			}
@@ -622,11 +624,14 @@ class CategoriesModelCategory extends JModelAdmin
 				}
 
 				$db->setQuery($query);
-				$db->execute();
 
-				if ($error = $db->getErrorMsg())
+				try
 				{
-					$this->setError($error);
+					$db->execute();
+				}
+				catch (RuntimeException $e)
+				{
+					$this->setError($e->getMessage());
 
 					return false;
 				}
@@ -765,9 +770,7 @@ class CategoriesModelCategory extends JModelAdmin
 				$table->load($pk);
 				$tags = array($value);
 
-				/**
-				 * @var  JTableObserverTags  $tagsObserver
-				 */
+				/** @var  JTableObserverTags  $tagsObserver */
 				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
 				$result = $tagsObserver->setNewTags($tags, false);
 
@@ -810,7 +813,7 @@ class CategoriesModelCategory extends JModelAdmin
 
 		// $value comes as {parent_id}.{extension}
 		$parts = explode('.', $value);
-		$parentId = (int) JArrayHelper::getValue($parts, 0, 1);
+		$parentId = (int) ArrayHelper::getValue($parts, 0, 1);
 
 		$db = $this->getDbo();
 		$extension = JFactory::getApplication()->input->get('extension', '', 'word');
@@ -966,7 +969,7 @@ class CategoriesModelCategory extends JModelAdmin
 			// Unpublish because we are making a copy
 			$this->table->published = 0;
 
-			parent::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 			// Store the row.
 			if (!$this->table->store())
@@ -1128,7 +1131,7 @@ class CategoriesModelCategory extends JModelAdmin
 				}
 			}
 
-			parent::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 			// Store the row.
 			if (!$this->table->store())
@@ -1152,7 +1155,7 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			// Remove any duplicates and sanitize ids.
 			$children = array_unique($children);
-			JArrayHelper::toInteger($children);
+			$children = ArrayHelper::toInteger($children);
 		}
 
 		return true;
@@ -1228,7 +1231,6 @@ class CategoriesModelCategory extends JModelAdmin
 			return $assoc;
 		}
 
-		$app = JFactory::getApplication();
 		$extension = $this->getState('category.extension');
 
 		$assoc = JLanguageAssociations::isEnabled();

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JFormHelper::loadFieldClass('list');
 
 /**
@@ -21,8 +23,8 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * A flexible category list that respects access controls
 	 *
-	 * @var        string
-	 * @since   1.6
+	 * @var    string
+	 * @since  1.6
 	 */
 	public $type = 'CategoryEdit';
 
@@ -90,11 +92,10 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		}
 		elseif (is_array($published))
 		{
-			JArrayHelper::toInteger($published);
-			$subQuery->where('published IN (' . implode(',', $published) . ')');
+			$subQuery->where('published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
 		}
 
-		$query->from('(' . $subQuery->__toString() . ') AS a')
+		$query->from('(' . (string) $subQuery . ') AS a')
 			->join('LEFT', $db->quoteName('#__categories') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 		$query->order('a.lft ASC');
 
@@ -226,8 +227,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -21,8 +21,8 @@ class JFormFieldCategoryParent extends JFormFieldList
 	/**
 	 * The form field type.
 	 *
-	 * @var        string
-	 * @since   1.6
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $type = 'CategoryParent';
 
@@ -168,8 +168,6 @@ class JFormFieldCategoryParent extends JFormFieldList
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -16,20 +16,61 @@ defined('_JEXEC') or die;
  */
 class CategoriesViewCategories extends JViewLegacy
 {
+	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
 	protected $items;
 
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
 	protected $pagination;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
 
+	/**
+	 * Flag if an association exists
+	 *
+	 * @var  boolean
+	 */
 	protected $assoc;
+
+	/**
+	 * Form object for search filters
+	 *
+	 * @var  JForm
+	 */
+	public $filterForm;
+
+	/**
+	 * The active search filters
+	 *
+	 * @var  array
+	 */
+	public $activeFilters;
+
+	/**
+	 * The sidebar markup
+	 *
+	 * @var  string
+	 */
+	protected $string;
 
 	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  void
+	 * @return  mixed  A string if successful, otherwise a Error object.
 	 */
 	public function display($tpl = null)
 	{
@@ -54,24 +95,24 @@ class CategoriesViewCategories extends JViewLegacy
 			$this->ordering[$item->parent_id][] = $item->id;
 		}
 
-		// Levels filter.
-		$options   = array();
-		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
-		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
-		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
-		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
-		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
-		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
-		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
-		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
-		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
-		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
-
-		$this->f_levels = $options;
+		// Levels filter - Used in Hathor.
+		$this->f_levels = array(
+			JHtml::_('select.option', '1', JText::_('J1')),
+			JHtml::_('select.option', '2', JText::_('J2')),
+			JHtml::_('select.option', '3', JText::_('J3')),
+			JHtml::_('select.option', '4', JText::_('J4')),
+			JHtml::_('select.option', '5', JText::_('J5')),
+			JHtml::_('select.option', '6', JText::_('J6')),
+			JHtml::_('select.option', '7', JText::_('J7')),
+			JHtml::_('select.option', '8', JText::_('J8')),
+			JHtml::_('select.option', '9', JText::_('J9')),
+			JHtml::_('select.option', '10', JText::_('J10')),
+		);
 
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -16,20 +16,47 @@ defined('_JEXEC') or die;
  */
 class CategoriesViewCategory extends JViewLegacy
 {
+	/**
+	 * The JForm object
+	 *
+	 * @var  JForm
+	 */
 	protected $form;
 
+	/**
+	 * The active item
+	 *
+	 * @var  object
+	 */
 	protected $item;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
 
+	/**
+	 * Flag if an association exists
+	 *
+	 * @var  boolean
+	 */
 	protected $assoc;
+
+	/**
+	 * The actions the user is authorised to perform
+	 *
+	 * @var  JObject
+	 */
+	protected $canDo;
 
 	/**
 	 * Display the view.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  void
+	 * @return  mixed  A string if successful, otherwise a Error object.
 	 */
 	public function display($tpl = null)
 	{
@@ -39,8 +66,6 @@ class CategoriesViewCategory extends JViewLegacy
 		$section = $this->state->get('category.section') ? $this->state->get('category.section') . '.' : '';
 		$this->canDo = JHelperContent::getActions($this->state->get('category.component'), $section . 'category', $this->item->id);
 		$this->assoc = $this->get('Assoc');
-
-		$input = JFactory::getApplication()->input;
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -53,7 +78,7 @@ class CategoriesViewCategory extends JViewLegacy
 		// Check for tag type
 		$this->checkTags = JHelperTags::getTypes('objectList', array($this->state->get('category.extension') . '.category'), true);
 
-		$input->set('hidemainmenu', true);
+		JFactory::getApplication()->input->set('hidemainmenu', true);
 
 		if ($this->getLayout() == 'modal')
 		{
@@ -62,7 +87,8 @@ class CategoriesViewCategory extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**
@@ -74,10 +100,9 @@ class CategoriesViewCategory extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$input = JFactory::getApplication()->input;
-		$extension = $input->get('extension');
+		$extension = JFactory::getApplication()->input->get('extension');
 		$user = JFactory::getUser();
-		$userId = $user->get('id');
+		$userId = $user->id;
 
 		$isNew = ($this->item->id == 0);
 		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the admin com_categories component. Changes of note:
- Doc blocks cleaned up some to follow standard
- Return the results of the view's `display()` methods to be consistent with the documented return
- Not using variables for items only referenced once
- Use `Joomla\Utilities\ArrayHelper` instead of `JArrayHelper`
- Catch Exceptions from the database API instead of using the legacy error handling API
### Testing Instructions

The admin com_categories component should continue to function correctly
