### PR TITLE
add autocomplete=email to form filds (Ref #6998)

### DIFF
--- a/components/com_contact/models/forms/contact.xml
+++ b/components/com_contact/models/forms/contact.xml
@@ -19,6 +19,7 @@
 			filter="string"
 			validate="contactemail"
 			required="true"
+			autocomplete="email"
 		/>
 		<field name="contact_subject"
 			type="text"

--- a/components/com_contact/models/forms/form.xml
+++ b/components/com_contact/models/forms/form.xml
@@ -87,7 +87,7 @@
 		<field name="email_to" type="email"
 			description="CONTACT_INFORMATION_EMAIL_DESC"
 			label="CONTACT_INFORMATION_EMAIL_LABEL"
-			size="30" validate="email" filter="string"
+			size="30" validate="email" filter="string" autocomplete="email"
 		/>
 
 		<field name="address" type="textarea"

--- a/components/com_users/models/forms/profile.xml
+++ b/components/com_users/models/forms/profile.xml
@@ -67,6 +67,7 @@
 			size="30"
 			unique="true"
 			validate="email"
+			autocomplete="email"
 		/>
 
 		<field

--- a/components/com_users/models/forms/registration.xml
+++ b/components/com_users/models/forms/registration.xml
@@ -72,6 +72,7 @@
 			size="30"
 			unique="true"
 			validate="email"
+			autocomplete="email"
 		/>
 
 		<field

--- a/components/com_users/models/forms/remind.xml
+++ b/components/com_users/models/forms/remind.xml
@@ -9,6 +9,7 @@
 			required="true"
 			size="30"
 			validate="email"
+			autocomplete="email"
 		/>
 		
 		<field


### PR DESCRIPTION
Additional support, to help user by autocompleting there email address in requested forms.
Fully supports the "autocomplete" attribute for form fields according to the current WHATWG HTML Standard.
Informational link to that topic:
[http://googlewebmastercentral.blogspot.ru/2015/03/helping-users-fill-out-online-forms.html](http://googlewebmastercentral.blogspot.ru/2015/03/helping-users-fill-out-online-forms.html)
Added attribute to email address field on the following forms:
com_contact : contact
com_user : registration, profile , remind
