### PR TITLE
New tooltip replacing #6050

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3679,6 +3679,9 @@ table.adminlist .item-associations li a {
 	line-height: 1.4;
 	opacity: 0;
 	filter: alpha(opacity=0);
+	-webkit-border-radius: 4px;
+	-moz-border-radius: 4px;
+	border-radius: 4px;
 }
 .tooltip.in {
 	opacity: 0.8;
@@ -3703,10 +3706,10 @@ table.adminlist .item-associations li a {
 .tooltip-inner {
 	max-width: 200px;
 	padding: 8px;
-	color: #ffffff;
+	color: #111;
 	text-align: center;
 	text-decoration: none;
-	background-color: #000000;
+	background-color: #fff;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
@@ -3723,42 +3726,28 @@ table.adminlist .item-associations li a {
 	left: 50%;
 	margin-left: -5px;
 	border-width: 5px 5px 0;
-	border-top-color: #000000;
+	border-top-color: #aaa;
 }
 .tooltip.right .tooltip-arrow {
 	top: 50%;
 	left: 0;
 	margin-top: -5px;
 	border-width: 5px 5px 5px 0;
-	border-right-color: #000000;
+	border-right-color: #aaa;
 }
 .tooltip.left .tooltip-arrow {
 	top: 50%;
 	right: 0;
 	margin-top: -5px;
 	border-width: 5px 0 5px 5px;
-	border-left-color: #000000;
+	border-left-color: #aaa;
 }
 .tooltip.bottom .tooltip-arrow {
 	top: 0;
 	left: 50%;
 	margin-left: -5px;
 	border-width: 0 5px 5px;
-	border-bottom-color: #000000;
-}
-.tooltip {
-	max-width: 400px;
-}
-.tooltip-inner {
-	max-width: none;
-	text-align: left;
-	text-shadow: none;
-}
-th .tooltip-inner {
-	font-weight: normal;
-}
-.tooltip.hasimage {
-	opacity: 1;
+	border-bottom-color: #aaa;
 }
 fieldset.panelform .tooltip img {
 	float: none;
@@ -3785,4 +3774,59 @@ div.toggle-editor {
 }
 .muted {
 	color: #999;
+}
+.tooltip {
+	max-width: 400px;
+	opacity: 0;
+	filter: alpha(opacity=0);
+	-webkit-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	box-shadow: 0 0 5px rgba(0,0,0,0.3);
+}
+.tooltip.in {
+	opacity: 1;
+	filter: alpha(opacity=100);
+}
+.tooltip-inner {
+	max-width: none;
+	text-shadow: none;
+	text-align: left;
+	background-color: #fff;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 1px solid #aaa;
+}
+.tooltip-arrow {
+	margin-bottom: -5px;
+}
+.tooltip.top {
+	padding: 0 0;
+}
+.tooltip-inner .tooltip-title {
+	display: block;
+	margin: -6px -8px -12px;
+	padding: 6px 10px;
+	font-weight: bold;
+	background: #f5f5f5;
+	-webkit-border-radius: 4px 4px 0 0;
+	-moz-border-radius: 4px 4px 0 0;
+	border-radius: 4px 4px 0 0;
+}
+.tooltip.top .tooltip-arrow {
+	border-top-color: #aaa;
+}
+.tooltip.right .tooltip-arrow {
+	border-right-color: #aaa;
+}
+.tooltip.left .tooltip-arrow {
+	border-left-color: #aaa;
+}
+.tooltip.bottom .tooltip-arrow {
+	border-bottom-color: #aaa;
+}
+th .tooltip-inner {
+	font-weight: normal;
+}
+.tooltip.hasimage {
+	opacity: 1;
 }

--- a/administrator/templates/hathor/less/hathor_variables.less
+++ b/administrator/templates/hathor/less/hathor_variables.less
@@ -113,10 +113,11 @@
 
 // Tooltips and popovers
 // -------------------------
-@tooltipColor:            @white;
-@tooltipBackground:       @black;
+@tooltipColor:            #111;
+@tooltipBackground:       #fff;
 @tooltipArrowWidth:       5px;
-@tooltipArrowColor:       @tooltipBackground;
+@tooltipArrowColor:       #aaa;
+@tableBackgroundHover:    #f5f5f5;
 
 @popoverBackground:       @white;
 @popoverArrowWidth:       10px;

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3486,20 +3486,6 @@ table.adminlist .item-associations li a  {
 // Bootstrap Tooltips (need to load last, something is overriding these styles in the CSS, debug later ;-) )
 @import "../../../../media/jui/less/tooltip.less";
 
-.tooltip {
-	max-width: 400px;
-}
-.tooltip-inner {
-	max-width: none;
-	text-align: left;
-	text-shadow: none;
-}
-th .tooltip-inner {
-	font-weight: normal;
-}
-.tooltip.hasimage {
-	opacity: 1;
-}
 fieldset.panelform .tooltip img {
 	float: none;
 	margin: 0;
@@ -3527,4 +3513,62 @@ div.toggle-editor {
 }
 .muted {
 	color: #999;
+}
+
+/* Tweaking of tooltips */
+.tooltip {
+	max-width: 400px;
+	.opacity(0);
+	&.in { .opacity(100); }
+	.box-shadow(0 0 5px rgba(0,0,0,0.3));
+}
+
+.tooltip-inner {
+	max-width: none;
+	text-shadow: none;
+	text-align: left;
+	background-color: @tooltipBackground;
+	padding: 6px 8px;
+	font-size: @baseFontSize;
+	border: 1px solid #aaa;
+}
+
+.tooltip-arrow {
+	margin-bottom: -5px;
+}
+
+.tooltip.top {
+	padding: 0 0;
+}
+
+.tooltip-inner .tooltip-title {
+	display:block;
+	margin:-6px -8px -12px;
+	padding:6px 10px;
+	font-weight: bold;
+	background:@tableBackgroundHover;
+	.border-radius(@baseBorderRadius @baseBorderRadius 0 0);
+}
+
+.tooltip {
+	&.top .tooltip-arrow {
+		border-top-color: @tooltipArrowColor;
+	}
+	&.right .tooltip-arrow {
+		border-right-color: @tooltipArrowColor;
+	}
+	&.left .tooltip-arrow {
+		border-left-color: @tooltipArrowColor;
+	}
+	&.bottom .tooltip-arrow {
+		border-bottom-color: @tooltipArrowColor;
+	}
+}
+
+th .tooltip-inner {
+	font-weight: normal;
+}
+
+.tooltip.hasimage {
+	opacity: 1;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -3988,10 +3988,10 @@ input[type="submit"].btn.btn-mini {
 .tooltip-inner {
 	max-width: 200px;
 	padding: 8px;
-	color: #fff;
+	color: #111;
 	text-align: center;
 	text-decoration: none;
-	background-color: #000;
+	background-color: #fff;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
@@ -4008,28 +4008,28 @@ input[type="submit"].btn.btn-mini {
 	left: 50%;
 	margin-left: -5px;
 	border-width: 5px 5px 0;
-	border-top-color: #000;
+	border-top-color: #ddd;
 }
 .tooltip.right .tooltip-arrow {
 	top: 50%;
 	left: 0;
 	margin-top: -5px;
 	border-width: 5px 5px 5px 0;
-	border-right-color: #000;
+	border-right-color: #ddd;
 }
 .tooltip.left .tooltip-arrow {
 	top: 50%;
 	right: 0;
 	margin-top: -5px;
 	border-width: 5px 0 5px 5px;
-	border-left-color: #000;
+	border-left-color: #ddd;
 }
 .tooltip.bottom .tooltip-arrow {
 	top: 0;
 	left: 50%;
 	margin-left: -5px;
 	border-width: 0 5px 5px;
-	border-bottom-color: #000;
+	border-bottom-color: #ddd;
 }
 .popover {
 	position: absolute;
@@ -7830,11 +7830,42 @@ td.nowrap.has-context {
 }
 .tooltip {
 	max-width: 400px;
+	max-width: 400px;
+	opacity: 0;
+	filter: alpha(opacity=0);
+}
+.tooltip.in {
+	opacity: 1;
+	filter: alpha(opacity=100);
 }
 .tooltip-inner {
 	max-width: none;
-	text-align: left;
 	text-shadow: none;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 2px solid #aaa;
+}
+.tooltip-inner .tooltip-title {
+	display: block;
+	margin: -6px -8px -12px;
+	padding: 6px 10px;
+	font-weight: bold;
+	background: #f5f5f5;
+	-webkit-border-radius: 4px 4px 0 0;
+	-moz-border-radius: 4px 4px 0 0;
+	border-radius: 4px 4px 0 0;
+}
+.tooltip.top .tooltip-arrow {
+	border-top-color: #ddd;
+}
+.tooltip.right .tooltip-arrow {
+	border-right-color: #ddd;
+}
+.tooltip.left .tooltip-arrow {
+	border-left-color: #ddd;
+}
+.tooltip.bottom .tooltip-arrow {
+	border-bottom-color: #ddd;
 }
 th .tooltip-inner {
 	font-weight: normal;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -3988,10 +3988,10 @@ input[type="submit"].btn.btn-mini {
 .tooltip-inner {
 	max-width: 200px;
 	padding: 8px;
-	color: #fff;
+	color: #111;
 	text-align: center;
 	text-decoration: none;
-	background-color: #000;
+	background-color: #fff;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
@@ -4008,28 +4008,28 @@ input[type="submit"].btn.btn-mini {
 	left: 50%;
 	margin-left: -5px;
 	border-width: 5px 5px 0;
-	border-top-color: #000;
+	border-top-color: #ddd;
 }
 .tooltip.right .tooltip-arrow {
 	top: 50%;
 	left: 0;
 	margin-top: -5px;
 	border-width: 5px 5px 5px 0;
-	border-right-color: #000;
+	border-right-color: #ddd;
 }
 .tooltip.left .tooltip-arrow {
 	top: 50%;
 	right: 0;
 	margin-top: -5px;
 	border-width: 5px 0 5px 5px;
-	border-left-color: #000;
+	border-left-color: #ddd;
 }
 .tooltip.bottom .tooltip-arrow {
 	top: 0;
 	left: 50%;
 	margin-left: -5px;
 	border-width: 0 5px 5px;
-	border-bottom-color: #000;
+	border-bottom-color: #ddd;
 }
 .popover {
 	position: absolute;
@@ -7830,11 +7830,42 @@ td.nowrap.has-context {
 }
 .tooltip {
 	max-width: 400px;
+	max-width: 400px;
+	opacity: 0;
+	filter: alpha(opacity=0);
+}
+.tooltip.in {
+	opacity: 1;
+	filter: alpha(opacity=100);
 }
 .tooltip-inner {
 	max-width: none;
-	text-align: left;
 	text-shadow: none;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 2px solid #aaa;
+}
+.tooltip-inner .tooltip-title {
+	display: block;
+	margin: -6px -8px -12px;
+	padding: 6px 10px;
+	font-weight: bold;
+	background: #f5f5f5;
+	-webkit-border-radius: 4px 4px 0 0;
+	-moz-border-radius: 4px 4px 0 0;
+	border-radius: 4px 4px 0 0;
+}
+.tooltip.top .tooltip-arrow {
+	border-top-color: #ddd;
+}
+.tooltip.right .tooltip-arrow {
+	border-right-color: #ddd;
+}
+.tooltip.left .tooltip-arrow {
+	border-left-color: #ddd;
+}
+.tooltip.bottom .tooltip-arrow {
+	border-bottom-color: #ddd;
 }
 th .tooltip-inner {
 	font-weight: normal;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1043,12 +1043,40 @@ td.nowrap.has-context {
 /* Tweaking of tooltips */
 .tooltip {
 	max-width: 400px;
+	max-width: 400px;
+	.opacity(0);
+	&.in { .opacity(100); }
 }
 
 .tooltip-inner {
 	max-width: none;
-	text-align: left;
 	text-shadow: none;
+	padding: 6px 8px;
+	font-size: @baseFontSize;
+	border: 2px solid #aaa;
+}
+
+.tooltip-inner .tooltip-title {
+	display:block;
+	margin:-6px -8px -12px;
+	padding:6px 10px;
+	font-weight: bold;
+	background:@tableBackgroundHover;
+	.border-radius(@baseBorderRadius @baseBorderRadius 0 0);
+}
+.tooltip {
+	&.top .tooltip-arrow {
+		border-top-color: @tooltipArrowColor;
+	}
+	&.right .tooltip-arrow {
+		border-right-color: @tooltipArrowColor;
+	}
+	&.left .tooltip-arrow {
+		border-left-color: @tooltipArrowColor;
+	}
+	&.bottom .tooltip-arrow {
+		border-bottom-color: @tooltipArrowColor;
+	}
 }
 
 th .tooltip-inner {

--- a/administrator/templates/isis/less/variables.less
+++ b/administrator/templates/isis/less/variables.less
@@ -260,10 +260,10 @@
 
 // Tooltips and popovers
 // -------------------------
-@tooltipColor:            #fff;
-@tooltipBackground:       #000;
+@tooltipColor:            #111;
+@tooltipBackground:       #fff;
 @tooltipArrowWidth:       5px;
-@tooltipArrowColor:       @tooltipBackground;
+@tooltipArrowColor:       #ddd;
 
 @popoverBackground:       #fff;
 @popoverArrowWidth:       10px;

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -932,7 +932,7 @@ abstract class JHtml
 			// Escape everything, if required.
 			if ($escape)
 			{
-				$result = htmlspecialchars($result);
+				$result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8');
 			}
 		}
 

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -932,7 +932,7 @@ abstract class JHtml
 			// Escape everything, if required.
 			if ($escape)
 			{
-				$result = htmlspecialchars($result, ENT_COMPAT, 'UTF-8');
+				$result = htmlspecialchars($result, ENT_QUOTES, 'UTF-8');
 			}
 		}
 

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -917,12 +917,12 @@ abstract class JHtml
 			// Use only the title, if title and text are the same.
 			elseif ($title == $content)
 			{
-				$result = '<strong>' . $title . '</strong>';
+				$result = '<span class="tooltip-title">' . $title . '</span>';
 			}
 			// Use a formatted string combining the title and content.
 			elseif ($content != '')
 			{
-				$result = '<strong>' . $title . '</strong><br />' . $content;
+				$result = '<span class="tooltip-title">' . $title . '</span><br />' . $content;
 			}
 			else
 			{

--- a/media/jui/less/tooltip.less
+++ b/media/jui/less/tooltip.less
@@ -12,6 +12,7 @@
   font-size: 11px;
   line-height: 1.4;
   .opacity(0);
+  .border-radius(@baseBorderRadius);
   &.in     { .opacity(80); }
   &.top    { margin-top:  -3px; padding: 5px 0; }
   &.right  { margin-left:  3px; padding: 0 5px; }

--- a/templates/beez3/css/general.css
+++ b/templates/beez3/css/general.css
@@ -351,38 +351,26 @@ span.optional
 	z-index: 103000;
 	display: block;
 	visibility: visible;
-	font-size: 11px;
 	line-height: 1.4;
+	max-width: 400px;
 	opacity: 0;
 	filter: alpha(opacity=0);
+	-webkit-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	box-shadow: 0 0 5px rgba(0,0,0,0.3);
 }
 .tooltip.in {
-	opacity: 0.8;
-	filter: alpha(opacity=80);
-}
-.tooltip.top {
-	margin-top: -3px;
-	padding: 5px 0;
-}
-.tooltip.right {
-	margin-left: 3px;
-	padding: 0 5px;
-}
-.tooltip.bottom {
-	margin-top: 3px;
-	padding: 5px 0;
-}
-.tooltip.left {
-	margin-left: -3px;
-	padding: 0 5px;
+	opacity: 1;
+	filter: alpha(opacity=100);
 }
 .tooltip-inner {
-	max-width: 200px;
-	padding: 8px;
-	color: #fff;
-	text-align: left;
-	text-decoration: none;
-	background-color: #000;
+	max-width: none;
+	text-shadow: none;
+	background-color: #fff;
+	color: #000;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 1px solid #aaa;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
@@ -393,6 +381,7 @@ span.optional
 	height: 0;
 	border-color: transparent;
 	border-style: solid;
+	margin-bottom: -5px;
 }
 .tooltip.top .tooltip-arrow {
 	bottom: 0;
@@ -421,6 +410,51 @@ span.optional
 	margin-left: -5px;
 	border-width: 0 5px 5px;
 	border-bottom-color: #000;
+}
+
+.tooltip.top {
+	margin-top: -3px;
+	padding: 0 0;
+}
+.tooltip.right {
+	margin-left: 3px;
+	padding: 0 5px;
+}
+.tooltip.bottom {
+	margin-top: 3px;
+	padding: 5px 0;
+}
+.tooltip.left {
+	margin-left: -3px;
+	padding: 0 5px;
+}
+.tooltip-inner .tooltip-title {
+	display: block;
+	margin: -6px -8px -12px;
+	padding: 6px 10px;
+	font-weight: bold;
+	background: #f5f5f5;
+	-webkit-border-radius:   0 0;
+	-moz-border-radius:   0 0;
+	border-radius:   0 0;
+}
+.tooltip.top .tooltip-arrow {
+	border-top-color: #aaa;
+}
+.tooltip.right .tooltip-arrow {
+	border-right-color: #aaa;
+}
+.tooltip.left .tooltip-arrow {
+	border-left-color: #aaa;
+}
+.tooltip.bottom .tooltip-arrow {
+	border-bottom-color: #aaa;
+}
+th .tooltip-inner {
+	font-weight: normal;
+}
+.tooltip.hasimage {
+	opacity: 1;
 }
 .element-invisible {
 	position: absolute;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7284,7 +7284,7 @@ figcaption {
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0076b2', GradientType=0);
 }
 .categories-list .collapse {
-	margin-left: 20px;
+	margin: 0 0 0 20px;
 }
 @media (max-width: 480px) {
 	.item-info > span {

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3979,6 +3979,9 @@ input[type="submit"].btn.btn-mini {
 	line-height: 1.4;
 	opacity: 0;
 	filter: alpha(opacity=0);
+	-webkit-border-radius: 4px;
+	-moz-border-radius: 4px;
+	border-radius: 4px;
 }
 .tooltip.in {
 	opacity: 0.8;
@@ -4003,10 +4006,10 @@ input[type="submit"].btn.btn-mini {
 .tooltip-inner {
 	max-width: 200px;
 	padding: 8px;
-	color: #fff;
+	color: #111;
 	text-align: center;
 	text-decoration: none;
-	background-color: #000;
+	background-color: #fff;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
@@ -4023,28 +4026,28 @@ input[type="submit"].btn.btn-mini {
 	left: 50%;
 	margin-left: -5px;
 	border-width: 5px 5px 0;
-	border-top-color: #000;
+	border-top-color: #aaa;
 }
 .tooltip.right .tooltip-arrow {
 	top: 50%;
 	left: 0;
 	margin-top: -5px;
 	border-width: 5px 5px 5px 0;
-	border-right-color: #000;
+	border-right-color: #aaa;
 }
 .tooltip.left .tooltip-arrow {
 	top: 50%;
 	right: 0;
 	margin-top: -5px;
 	border-width: 5px 0 5px 5px;
-	border-left-color: #000;
+	border-left-color: #aaa;
 }
 .tooltip.bottom .tooltip-arrow {
 	top: 0;
 	left: 50%;
 	margin-left: -5px;
 	border-width: 0 5px 5px;
-	border-bottom-color: #000;
+	border-bottom-color: #aaa;
 }
 .popover {
 	position: absolute;
@@ -7496,4 +7499,57 @@ body.modal-open {
 }
 #users-profile-custom label {
 	display: inline;
+}
+.tooltip {
+	max-width: 400px;
+	opacity: 0;
+	filter: alpha(opacity=0);
+	-webkit-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 0 5px rgba(0,0,0,0.3);
+	box-shadow: 0 0 5px rgba(0,0,0,0.3);
+}
+.tooltip.in {
+	opacity: 1;
+	filter: alpha(opacity=100);
+}
+.tooltip-inner {
+	max-width: none;
+	text-shadow: none;
+	padding: 6px 8px;
+	font-size: 13px;
+	border: 1px solid #aaa;
+}
+.tooltip-arrow {
+	margin-bottom: -5px;
+}
+.tooltip.top {
+	padding: 0 0;
+}
+.tooltip-inner .tooltip-title {
+	display: block;
+	margin: -6px -8px -12px;
+	padding: 6px 10px;
+	font-weight: bold;
+	background: #f5f5f5;
+	-webkit-border-radius: 4px 4px 0 0;
+	-moz-border-radius: 4px 4px 0 0;
+	border-radius: 4px 4px 0 0;
+}
+.tooltip.top .tooltip-arrow {
+	border-top-color: #aaa;
+}
+.tooltip.right .tooltip-arrow {
+	border-right-color: #aaa;
+}
+.tooltip.left .tooltip-arrow {
+	border-left-color: #aaa;
+}
+.tooltip.bottom .tooltip-arrow {
+	border-bottom-color: #aaa;
+}
+th .tooltip-inner {
+	font-weight: normal;
+}
+.tooltip.hasimage {
+	opacity: 1;
 }

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -623,3 +623,59 @@ body.modal-open {
 #users-profile-custom label {
 	display: inline;
 }
+
+/* Tweaking of tooltips */
+.tooltip {
+	max-width: 400px;
+	.opacity(0);
+	&.in { .opacity(100); }
+	.box-shadow(0 0 5px rgba(0,0,0,0.3));
+}
+
+.tooltip-inner {
+	max-width: none;
+	text-shadow: none;
+	padding: 6px 8px;
+	font-size: @baseFontSize;
+	border: 1px solid #aaa;
+}
+
+.tooltip-arrow {
+	margin-bottom: -5px;
+}
+
+.tooltip.top {
+	padding: 0 0;
+}
+
+.tooltip-inner .tooltip-title {
+	display:block;
+	margin:-6px -8px -12px;
+	padding:6px 10px;
+	font-weight: bold;
+	background:@tableBackgroundHover;
+	.border-radius(@baseBorderRadius @baseBorderRadius 0 0);
+}
+
+.tooltip {
+	&.top .tooltip-arrow {
+		border-top-color: @tooltipArrowColor;
+	}
+	&.right .tooltip-arrow {
+		border-right-color: @tooltipArrowColor;
+	}
+	&.left .tooltip-arrow {
+		border-left-color: @tooltipArrowColor;
+	}
+	&.bottom .tooltip-arrow {
+		border-bottom-color: @tooltipArrowColor;
+	}
+}
+
+th .tooltip-inner {
+	font-weight: normal;
+}
+
+.tooltip.hasimage {
+	opacity: 1;
+}

--- a/templates/protostar/less/variables.less
+++ b/templates/protostar/less/variables.less
@@ -255,10 +255,10 @@
 
 // Tooltips and popovers
 // -------------------------
-@tooltipColor:            #fff;
-@tooltipBackground:       #000;
+@tooltipColor:            #111;
+@tooltipBackground:       #fff;
 @tooltipArrowWidth:       5px;
-@tooltipArrowColor:       @tooltipBackground;
+@tooltipArrowColor:       #aaa;
 
 @popoverBackground:       #fff;
 @popoverArrowWidth:       10px;

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1307,39 +1307,31 @@ class JHtmlTest extends TestCase
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title'),
-			'<span class="hasTooltip" title="' .
-			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
-			'"><img src="/media/system/images/tooltip.png" alt="Tooltip" /></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="/media/system/images/tooltip.png" alt="Tooltip" /></span>',
 			'Tooltip with title and content failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title', null, 'Text'),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content">Text</span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content">Text</span>',
 			'Tooltip with title and content and text failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title', null, 'Text', 'http://www.monsite.com'),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>',
 			'Tooltip with title and content and text and href failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title', 'tooltip.png', null, null, 'MyAlt'),
-			'<span class="hasTooltip" title="' .
-			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
-			'"><img src="' .
-			JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="' . JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>',
 			'Tooltip with title and content and alt failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title', 'tooltip.png', null, null, 'MyAlt', 'hasTooltip2'),
-			'<span class="hasTooltip2" title="'.
-			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
-			'"><img src="' . JUri::base(true) .
-			'/media/system/images/tooltip.png" alt="MyAlt" /></span>',
+			'<span class="hasTooltip2" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="' . JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>',
 			'Tooltip with title and content and alt and class failed'
 		);
 
@@ -1352,34 +1344,31 @@ class JHtmlTest extends TestCase
 		// Testing where title is an array
 		$this->assertEquals(
 			JHtml::tooltip('Content', array('title' => 'Title')),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
-			JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="' . JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>',
 			'Tooltip with title and content failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', array('title' => 'Title', 'text' => 'Text')),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content">Text</span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content">Text</span>',
 			'Tooltip with title and content and text failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', array('title' => 'Title', 'text' => 'Text', 'href' => 'http://www.monsite.com')),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><a href="http://www.monsite.com">Text</a></span>',
 			'Tooltip with title and content and text and href failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', array('title' => 'Title', 'alt' => 'MyAlt')),
-			'<span class="hasTooltip" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
-			JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>',
+			'<span class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="' . JUri::base(true) . '/media/system/images/tooltip.png" alt="MyAlt" /></span>',
 			'Tooltip with title and content and alt failed'
 		);
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', array('title' => 'Title', 'class' => 'hasTooltip2')),
-			'<span class="hasTooltip2" title="&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content"><img src="' .
-			JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>',
+			'<span class="hasTooltip2" title="&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content"><img src="' . JUri::base(true) . '/media/system/images/tooltip.png" alt="Tooltip" /></span>',
 			'Tooltip with title and content and class failed'
 		);
 		$this->assertEquals(
@@ -1550,7 +1539,7 @@ class JHtmlTest extends TestCase
 			array(
 				'Title::Content',
 				'',
-				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content',
+				'&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content',
 				'A string with "::" should be converted',
 			),
 			array(
@@ -1562,7 +1551,7 @@ class JHtmlTest extends TestCase
 			array(
 				'Title',
 				'Content',
-				'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content',
+				'&lt;span class=&quot;tooltip-title&quot;&gt;Title&lt;/span&gt;&lt;br /&gt;Content',
 				'A title and content should be combined',
 			),
 			array(

--- a/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
@@ -210,7 +210,7 @@ class JFormFieldTest extends TestCaseDatabase
 				'attributes' => array(
 						'for'   => 'title_id',
 						'class' => 'hasTooltip required',
-						'title' => '<strong>Title</strong><br />The title.'
+						'title' => '<span class="tooltip-title">Title</span><br />The title.'
 					),
 				'content'    => 'regexp:/Title.*\*/',
 				'child'      => array(
@@ -394,7 +394,7 @@ class JFormFieldTest extends TestCaseDatabase
 				'attributes' => array(
 						'for'   => 'myId',
 						'class' => 'hasTooltip',
-						'title' => '<strong>My Title</strong><br />The description.'
+						'title' => '<span class="tooltip-title">My Title</span><br />The description.'
 					),
 				'content'    => 'regexp:/My Title/'
 			);

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1216,7 +1216,7 @@ class JFormTest extends TestCaseDatabase
 				'attributes' => array(
 						'for'   => 'title_id',
 						'class' => 'hasTooltip required',
-						'title' => '<strong>Title</strong><br />The title.'
+						'title' => '<span class="tooltip-title">Title</span><br />The title.'
 					),
 				'content'    => 'regexp:/Title.*\*/',
 				'child'      => array(

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
@@ -119,7 +119,7 @@ class JFormFieldSpacerTest extends TestCase
 		);
 
 		$equals = '<span class="spacer"><span class="before"></span><span>' .
-			'<label id="spacer-lbl" class="hasTooltip" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label></span>' .
+			'<label id="spacer-lbl" class="hasTooltip" title="&lt;span class=&quot;tooltip-title&quot;&gt;spacer&lt;/span&gt;">spacer</label></span>' .
 			'<span class="after"></span></span>';
 
 		$this->assertEquals(


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/6050

This solves the `<strong>` issue.

After patch (clear your caches) you should get:
![screen shot 2015-10-25 at 09 31 25](https://cloud.githubusercontent.com/assets/869724/10714852/4fd760b0-7b01-11e5-8714-abf47b24d291.png)
![screen shot 2015-10-25 at 10 16 01](https://cloud.githubusercontent.com/assets/869724/10714853/6b629de0-7b01-11e5-8c14-84f270029769.png)
![screen shot 2015-10-25 at 10 16 28](https://cloud.githubusercontent.com/assets/869724/10714856/7d464d5e-7b01-11e5-9a6f-521c0b8a4eba.png)
