### PR TITLE
Prevent duplicate message output

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -233,10 +233,15 @@ class JApplicationCms extends JApplicationWeb
 		}
 
 		// For empty queue, if messages exists in the session, enqueue them first.
-		$this->getMessageQueue();
+		$messages = $this->getMessageQueue();
 
-		// Enqueue the message.
-		$this->_messageQueue[] = array('message' => $msg, 'type' => strtolower($type));
+		$message = array('message' => $msg, 'type' => strtolower($type));
+
+		if (!in_array($message, $this->_messageQueue))
+		{
+			// Enqueue the message.
+			$this->_messageQueue[] = $message;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Sometimes, Joomla! outputs the same message twice.
## Test:
1. Create a link to the user profile and set the access to "registered" (make sure, that you have no other link to the user component)
2. Activate the login module (public)
3. Log in
4. Go to the profile and log out over the module
5. The message "Please login first" should be shown twice
6. Apply patch => try again
