### PR TITLE
Code review on com_content component

### DIFF
--- a/administrator/components/com_content/controller.php
+++ b/administrator/components/com_content/controller.php
@@ -17,8 +17,10 @@ defined('_JEXEC') or die;
 class ContentController extends JControllerLegacy
 {
 	/**
-	 * @var		string	The default view.
-	 * @since   1.6
+	 * The default view.
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $default_view = 'articles';
 
@@ -28,7 +30,7 @@ class ContentController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  ContentController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_content/controllers/article.php
+++ b/administrator/components/com_content/controllers/article.php
@@ -9,12 +9,12 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * The article controller
  *
- * @package     Joomla.Administrator
- * @subpackage  com_content
- * @since       1.6
+ * @since  1.6
  */
 class ContentControllerArticle extends JControllerForm
 {
@@ -49,14 +49,13 @@ class ContentControllerArticle extends JControllerForm
 	 */
 	protected function allowAdd($data = array())
 	{
-		$user = JFactory::getUser();
-		$categoryId = JArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
+		$categoryId = ArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
 		$allow = null;
 
 		if ($categoryId)
 		{
 			// If the category has been passed in the data or URL check it.
-			$allow = $user->authorise('core.create', 'com_content.category.' . $categoryId);
+			$allow = JFactory::getUser()->authorise('core.create', 'com_content.category.' . $categoryId);
 		}
 
 		if ($allow === null)
@@ -64,10 +63,8 @@ class ContentControllerArticle extends JControllerForm
 			// In the absense of better information, revert to the component permissions.
 			return parent::allowAdd();
 		}
-		else
-		{
-			return $allow;
-		}
+
+		return $allow;
 	}
 
 	/**
@@ -84,7 +81,7 @@ class ContentControllerArticle extends JControllerForm
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
-		$userId = $user->get('id');
+		$userId = $user->id;
 
 		// Check general edit permission first.
 		if ($user->authorise('core.edit', 'com_content.article.' . $recordId))
@@ -98,6 +95,7 @@ class ContentControllerArticle extends JControllerForm
 		{
 			// Now test the owner is the user.
 			$ownerId = (int) isset($data['created_by']) ? $data['created_by'] : 0;
+
 			if (empty($ownerId) && $recordId)
 			{
 				// Need to do a lookup from the model.
@@ -136,27 +134,12 @@ class ContentControllerArticle extends JControllerForm
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Set the model
+		/** @var ContentModelArticle $model */
 		$model = $this->getModel('Article', '', array());
 
 		// Preset the redirect
 		$this->setRedirect(JRoute::_('index.php?option=com_content&view=articles' . $this->getRedirectToListAppend(), false));
 
 		return parent::batch($model);
-	}
-
-	/**
-	 * Function that allows child controller access to model data after the data has been saved.
-	 *
-	 * @param   JModelLegacy  $model      The data model object.
-	 * @param   array         $validData  The validated data.
-	 *
-	 * @return	void
-	 *
-	 * @since	3.1
-	 */
-	protected function postSaveHook(JModelLegacy $model, $validData = array())
-	{
-
-		return;
 	}
 }

--- a/administrator/components/com_content/controllers/articles.php
+++ b/administrator/components/com_content/controllers/articles.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Articles list controller class.
  *
@@ -21,7 +23,7 @@ class ContentControllerArticles extends JControllerAdmin
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -50,16 +52,15 @@ class ContentControllerArticles extends JControllerAdmin
 		// Check for request forgeries
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$user   = JFactory::getUser();
 		$ids    = $this->input->get('cid', array(), 'array');
 		$values = array('featured' => 1, 'unfeatured' => 0);
 		$task   = $this->getTask();
-		$value  = JArrayHelper::getValue($values, $task, 0, 'int');
+		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
 
 		// Access checks.
 		foreach ($ids as $i => $id)
 		{
-			if (!$user->authorise('core.edit.state', 'com_content.article.' . (int) $id))
+			if (!JFactory::getUser()->authorise('core.edit.state', 'com_content.article.' . (int) $id))
 			{
 				// Prune items that you can't change.
 				unset($ids[$i]);
@@ -74,6 +75,7 @@ class ContentControllerArticles extends JControllerAdmin
 		else
 		{
 			// Get the model.
+			/** @var ContentModelArticle $model */
 			$model = $this->getModel();
 
 			// Publish the items.
@@ -111,29 +113,12 @@ class ContentControllerArticles extends JControllerAdmin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  The array of possible config values. Optional.
 	 *
-	 * @return  JModel
+	 * @return  JModelLegacy
 	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Article', $prefix = 'ContentModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
-	}
-
-	/**
-	 * Function that allows child controller access to model data
-	 * after the item has been deleted.
-	 *
-	 * @param   JModelLegacy  $model  The data model object.
-	 * @param   integer       $ids    The array of ids for items being deleted.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.2
-	 */
-	protected function postDeleteHook(JModelLegacy $model, $ids = null)
-	{
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_content/controllers/featured.php
+++ b/administrator/components/com_content/controllers/featured.php
@@ -30,13 +30,12 @@ class ContentControllerFeatured extends ContentControllerArticles
 		// Check for request forgeries
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$user = JFactory::getUser();
 		$ids  = $this->input->get('cid', array(), 'array');
 
 		// Access checks.
 		foreach ($ids as $i => $id)
 		{
-			if (!$user->authorise('core.delete', 'com_content.article.' . (int) $id))
+			if (!JFactory::getUser()->authorise('core.delete', 'com_content.article.' . (int) $id))
 			{
 				// Prune items that you can't delete.
 				unset($ids[$i]);
@@ -51,6 +50,7 @@ class ContentControllerFeatured extends ContentControllerArticles
 		else
 		{
 			// Get the model.
+			/** @var ContentModelFeature $model */
 			$model = $this->getModel();
 
 			// Remove the items.
@@ -84,13 +84,12 @@ class ContentControllerFeatured extends ContentControllerArticles
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  object  The model.
+	 * @return  JModelLegacy  The model.
 	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Feature', $prefix = 'ContentModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
 
 /**
@@ -21,9 +23,11 @@ abstract class JHtmlContentAdministrator
 	/**
 	 * Render the list of associated items
 	 *
-	 * @param   int  $articleid  The article item id
+	 * @param   integer  $articleid  The article item id
 	 *
 	 * @return  string  The language HTML
+	 *
+	 * @throws  Exception
 	 */
 	public static function association($articleid)
 	{
@@ -58,7 +62,7 @@ abstract class JHtmlContentAdministrator
 			}
 			catch (RuntimeException $e)
 			{
-				throw new Exception($e->getMessage(), 500);
+				throw new Exception($e->getMessage(), 500, $e);
 			}
 
 			if ($items)
@@ -68,7 +72,9 @@ abstract class JHtmlContentAdministrator
 					$text = strtoupper($item->lang_sef);
 					$url = JRoute::_('index.php?option=com_content&task=article.edit&id=' . (int) $item->id);
 					$tooltipParts = array(
-						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
+						JHtml::_(
+							'image',
+							'mod_languages/' . $item->image . '.gif',
 							$item->language_title,
 							array('title' => $item->language_title),
 							true
@@ -99,8 +105,8 @@ abstract class JHtmlContentAdministrator
 	/**
 	 * Show the feature/unfeature links
 	 *
-	 * @param   int      $value      The state value
-	 * @param   int      $i          Row number
+	 * @param   integer  $value      The state value
+	 * @param   integer  $i          Row number
 	 * @param   boolean  $canChange  Is user allowed to change?
 	 *
 	 * @return  string       HTML code
@@ -114,7 +120,7 @@ abstract class JHtmlContentAdministrator
 			0 => array('unfeatured', 'articles.featured', 'COM_CONTENT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 			1 => array('featured', 'articles.unfeatured', 'COM_CONTENT_FEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 		);
-		$state = JArrayHelper::getValue($states, (int) $value, $states[1]);
+		$state = ArrayHelper::getValue($states, (int) $value, $states[1]);
 		$icon  = $state[0];
 
 		if ($canChange)

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
 
@@ -21,24 +22,26 @@ JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_conten
 class ContentModelArticle extends JModelAdmin
 {
 	/**
-	 * @var        string    The prefix to use with controller messages.
-	 * @since   1.6
+	 * The prefix to use with controller messages.
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $text_prefix = 'COM_CONTENT';
 
 	/**
 	 * The type alias for this content type (for example, 'com_content.article').
 	 *
-	 * @var      string
-	 * @since    3.2
+	 * @var    string
+	 * @since  3.2
 	 */
 	public $typeAlias = 'com_content.article';
 
 	/**
 	 * The context used for the associations table
 	 *
-	 * @var      string
-	 * @since    3.4.4
+	 * @var    string
+	 * @since  3.4.4
 	 */
 	protected $associationsContext = 'com_content.item';
 
@@ -59,7 +62,7 @@ class ContentModelArticle extends JModelAdmin
 
 		$newIds = array();
 
-		if (!parent::checkCategoryId($categoryId))
+		if (!$this->checkCategoryId($categoryId))
 		{
 			return false;
 		}
@@ -120,7 +123,7 @@ class ContentModelArticle extends JModelAdmin
 				return false;
 			}
 
-			parent::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 			// Store the row.
 			if (!$this->table->store())
@@ -170,9 +173,8 @@ class ContentModelArticle extends JModelAdmin
 			{
 				return false;
 			}
-			$user = JFactory::getUser();
 
-			return $user->authorise('core.delete', 'com_content.article.' . (int) $record->id);
+			return JFactory::getUser()->authorise('core.delete', 'com_content.article.' . (int) $record->id);
 		}
 
 		return false;
@@ -196,16 +198,15 @@ class ContentModelArticle extends JModelAdmin
 		{
 			return $user->authorise('core.edit.state', 'com_content.article.' . (int) $record->id);
 		}
+
 		// New article, so check against the category.
-		elseif (!empty($record->catid))
+		if (!empty($record->catid))
 		{
 			return $user->authorise('core.edit.state', 'com_content.category.' . (int) $record->catid);
 		}
+
 		// Default to component settings if neither article nor category known.
-		else
-		{
-			return parent::canEditState('com_content');
-		}
+		return parent::canEditState();
 	}
 
 	/**
@@ -220,8 +221,6 @@ class ContentModelArticle extends JModelAdmin
 	protected function prepareTable($table)
 	{
 		// Set the publish date to now
-		$db = $this->getDbo();
-
 		if ($table->state == 1 && (int) $table->publish_up == 0)
 		{
 			$table->publish_up = JFactory::getDate()->toSql();
@@ -229,7 +228,7 @@ class ContentModelArticle extends JModelAdmin
 
 		if ($table->state == 1 && intval($table->publish_down) == 0)
 		{
-			$table->publish_down = $db->getNullDate();
+			$table->publish_down = $this->getDbo()->getNullDate();
 		}
 
 		// Increment the content version number.
@@ -297,7 +296,6 @@ class ContentModelArticle extends JModelAdmin
 		}
 
 		// Load associated content items
-		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 
 		if ($assoc)
@@ -324,7 +322,7 @@ class ContentModelArticle extends JModelAdmin
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A JForm object on success, false on failure
+	 * @return  JForm|boolean  A JForm object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -332,10 +330,12 @@ class ContentModelArticle extends JModelAdmin
 	{
 		// Get the form.
 		$form = $this->loadForm('com_content.article', 'article', array('control' => 'jform', 'load_data' => $loadData));
+
 		if (empty($form))
 		{
 			return false;
 		}
+
 		$jinput = JFactory::getApplication()->input;
 
 		// The front end calls this model and uses a_id to avoid id clashes so we need to check for that first.
@@ -348,6 +348,7 @@ class ContentModelArticle extends JModelAdmin
 		{
 			$id = $jinput->get('id', 0);
 		}
+
 		// Determine correct permissions to check.
 		if ($this->getState('article.id'))
 		{
@@ -557,7 +558,6 @@ class ContentModelArticle extends JModelAdmin
 
 		if (parent::save($data))
 		{
-
 			if (isset($data['featured']))
 			{
 				$this->featured($this->getState($this->getName() . '.id'), $data['featured']);
@@ -580,8 +580,7 @@ class ContentModelArticle extends JModelAdmin
 	public function featured($pks, $value = 0)
 	{
 		// Sanitize the ids.
-		$pks = (array) $pks;
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger((array) $pks);
 
 		if (empty($pks))
 		{
@@ -596,9 +595,9 @@ class ContentModelArticle extends JModelAdmin
 		{
 			$db = $this->getDbo();
 			$query = $db->getQuery(true)
-						->update($db->quoteName('#__content'))
-						->set('featured = ' . (int) $value)
-						->where('id IN (' . implode(',', $pks) . ')');
+				->update($db->quoteName('#__content'))
+				->set('featured = ' . (int) $value)
+				->where('id IN (' . implode(',', $pks) . ')');
 			$db->setQuery($query);
 			$db->execute();
 
@@ -607,8 +606,8 @@ class ContentModelArticle extends JModelAdmin
 				// Adjust the mapping table.
 				// Clear the existing features settings.
 				$query = $db->getQuery(true)
-							->delete($db->quoteName('#__content_frontpage'))
-							->where('content_id IN (' . implode(',', $pks) . ')');
+					->delete($db->quoteName('#__content_frontpage'))
+					->where('content_id IN (' . implode(',', $pks) . ')');
 				$db->setQuery($query);
 				$db->execute();
 			}
@@ -636,7 +635,6 @@ class ContentModelArticle extends JModelAdmin
 
 				if (count($tuples))
 				{
-					$db = $this->getDbo();
 					$columns = array('content_id', 'ordering');
 					$query = $db->getQuery(true)
 						->insert($db->quoteName('#__content_frontpage'))
@@ -671,16 +669,11 @@ class ContentModelArticle extends JModelAdmin
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-		$condition[] = 'catid = ' . (int) $table->catid;
-
-		return $condition;
+		return array('catid = ' . (int) $table->catid);
 	}
 
 	/**
-	 * Auto-populate the model state.
-	 *
-	 * Note. Calling getState in this method will result in recursion.
+	 * Preprocess a form object
 	 *
 	 * @param   JForm   $form   The form object
 	 * @param   array   $data   The data to be merged into the form object
@@ -688,12 +681,11 @@ class ContentModelArticle extends JModelAdmin
 	 *
 	 * @return  void
 	 *
-	 * @since    3.0
+	 * @since   3.0
 	 */
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
 		// Association content items
-		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 
 		if ($assoc)

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Methods supporting a list of article records.
  *
@@ -22,7 +24,7 @@ class ContentModelArticles extends JModelList
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
 	 * @since   1.6
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
@@ -74,7 +76,7 @@ class ContentModelArticles extends JModelList
 	 *
 	 * @since   1.6
 	 */
-	protected function populateState($ordering = null, $direction = null)
+	protected function populateState($ordering = 'a.id', $direction = 'desc')
 	{
 		$app = JFactory::getApplication();
 
@@ -109,7 +111,7 @@ class ContentModelArticles extends JModelList
 		$this->setState('filter.tag', $tag);
 
 		// List state information.
-		parent::populateState('a.id', 'desc');
+		parent::populateState($ordering, $direction);
 
 		// Force a language
 		$forcedLanguage = $app->input->get('forcedLanguage');
@@ -160,7 +162,6 @@ class ContentModelArticles extends JModelList
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
 		$user = JFactory::getUser();
-		$app = JFactory::getApplication();
 
 		// Select the required fields from the table.
 		$query->select(
@@ -243,9 +244,7 @@ class ContentModelArticles extends JModelList
 		}
 		elseif (is_array($categoryId))
 		{
-			JArrayHelper::toInteger($categoryId);
-			$categoryId = implode(',', $categoryId);
-			$query->where('a.catid IN (' . $categoryId . ')');
+			$query->where('a.catid IN (' . implode(',', ArrayHelper::toInteger($categoryId)) . ')');
 		}
 
 		// Filter on the level.
@@ -297,7 +296,8 @@ class ContentModelArticles extends JModelList
 		{
 			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId)
 				->join(
-					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
+					'LEFT',
+					$db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
 				);
@@ -331,7 +331,7 @@ class ContentModelArticles extends JModelList
 	/**
 	 * Build a list of authors
 	 *
-	 * @return  JDatabaseQuery
+	 * @return  stdClass
 	 *
 	 * @since   1.6
 	 */
@@ -369,8 +369,7 @@ class ContentModelArticles extends JModelList
 
 		if (JFactory::getApplication()->isSite())
 		{
-			$user = JFactory::getUser();
-			$groups = $user->getAuthorisedViewLevels();
+			$groups = JFactory::getUser()->getAuthorisedViewLevels();
 
 			for ($x = 0, $count = count($items); $x < $count; $x++)
 			{

--- a/administrator/components/com_content/models/feature.php
+++ b/administrator/components/com_content/models/feature.php
@@ -45,8 +45,6 @@ class ContentModelFeature extends ContentModelArticle
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-
-		return $condition;
+		return array();
 	}
 }

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -9,10 +9,12 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 require_once __DIR__ . '/articles.php';
 
 /**
- * About Page Model
+ * Methods supporting a list of featured article records.
  *
  * @since  1.6
  */
@@ -23,7 +25,7 @@ class ContentModelFeatured extends ContentModelArticles
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -63,13 +65,11 @@ class ContentModelFeatured extends ContentModelArticles
 	/**
 	 * Build an SQL query to load the list data.
 	 *
-	 * @param   boolean  $resolveFKs  True to join selected foreign information
-	 *
-	 * @return  string
+	 * @return  JDatabaseQuery
 	 *
 	 * @since   1.6
 	 */
-	protected function getListQuery($resolveFKs = true)
+	protected function getListQuery()
 	{
 		// Create a new query object.
 		$db = $this->getDbo();
@@ -143,9 +143,8 @@ class ContentModelFeatured extends ContentModelArticles
 		}
 		elseif (is_array($categoryId))
 		{
-			JArrayHelper::toInteger($categoryId);
-			$categoryId = implode(',', $categoryId);
-			$query->where('a.catid IN (' . $categoryId . ')');
+			$categoryId = implode(',', ArrayHelper::toInteger($categoryId));
+			$query->where('a.catid IN (' . implode(',', ArrayHelper::toInteger($categoryId)) . ')');
 		}
 
 		// Filter on the level.
@@ -191,7 +190,8 @@ class ContentModelFeatured extends ContentModelArticles
 		{
 			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId)
 				->join(
-					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
+					'LEFT',
+					$db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
 				);

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -19,8 +19,8 @@ class JFormFieldModal_Article extends JFormField
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
-	 * @since   1.6
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $type = 'Modal_Article';
 
@@ -33,8 +33,8 @@ class JFormFieldModal_Article extends JFormField
 	 */
 	protected function getInput()
 	{
-		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowEdit  = (string) $this->element['edit'] == 'true';
+		$allowClear = (string) $this->element['clear'] != 'false';
 
 		// Load language
 		JFactory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -16,11 +16,33 @@ defined('_JEXEC') or die;
  */
 class ContentViewArticle extends JViewLegacy
 {
+	/**
+	 * The JForm object
+	 *
+	 * @var  JForm
+	 */
 	protected $form;
 
+	/**
+	 * The active item
+	 *
+	 * @var  object
+	 */
 	protected $item;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
+
+	/**
+	 * The actions the user is authorised to perform
+	 *
+	 * @var  JObject
+	 */
+	protected $canDo;
 
 	/**
 	 * Execute and display a template script.
@@ -36,14 +58,11 @@ class ContentViewArticle extends JViewLegacy
 		if ($this->getLayout() == 'pagebreak')
 		{
 			// TODO: This is really dogy - should change this one day.
-			$input = JFactory::getApplication()->input;
-			$eName = $input->getCmd('e_name');
-			$eName    = preg_replace('#[^A-Z0-9\-\_\[\]]#i', '', $eName);
-			$document = JFactory::getDocument();
-			$document->setTitle(JText::_('COM_CONTENT_PAGEBREAK_DOC_TITLE'));
+			$eName = JFactory::getApplication()->input->getCmd('e_name');
+			$eName = preg_replace('#[^A-Z0-9\-\_\[\]]#i', '', $eName);
+			JFactory::getDocument()->setTitle(JText::_('COM_CONTENT_PAGEBREAK_DOC_TITLE'));
 			$this->eName = &$eName;
-			parent::display($tpl);
-			return;
+			return parent::display($tpl);
 		}
 
 		$this->form  = $this->get('Form');
@@ -65,7 +84,8 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**
@@ -79,7 +99,7 @@ class ContentViewArticle extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 		$user       = JFactory::getUser();
-		$userId     = $user->get('id');
+		$userId     = $user->id;
 		$isNew      = ($this->item->id == 0);
 		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -16,18 +16,61 @@ defined('_JEXEC') or die;
  */
 class ContentViewArticles extends JViewLegacy
 {
+	/**
+	 * The item authors
+	 *
+	 * @var  stdClass
+	 */
+	protected $authors;
+
+	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
 	protected $items;
 
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
 	protected $pagination;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
+
+	/**
+	 * Form object for search filters
+	 *
+	 * @var  JForm
+	 */
+	public $filterForm;
+
+	/**
+	 * The active search filters
+	 *
+	 * @var  array
+	 */
+	public $activeFilters;
+
+	/**
+	 * The sidebar markup
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
 
 	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  void
+	 * @return  mixed  A string if successful, otherwise a Error object.
 	 */
 	public function display($tpl = null)
 	{
@@ -51,20 +94,19 @@ class ContentViewArticles extends JViewLegacy
 			return false;
 		}
 
-		// Levels filter.
-		$options   = array();
-		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
-		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
-		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
-		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
-		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
-		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
-		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
-		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
-		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
-		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
-
-		$this->f_levels = $options;
+		// Levels filter - Used in Hathor.
+		$this->f_levels = array(
+			JHtml::_('select.option', '1', JText::_('J1')),
+			JHtml::_('select.option', '2', JText::_('J2')),
+			JHtml::_('select.option', '3', JText::_('J3')),
+			JHtml::_('select.option', '4', JText::_('J4')),
+			JHtml::_('select.option', '5', JText::_('J5')),
+			JHtml::_('select.option', '6', JText::_('J6')),
+			JHtml::_('select.option', '7', JText::_('J7')),
+			JHtml::_('select.option', '8', JText::_('J8')),
+			JHtml::_('select.option', '9', JText::_('J9')),
+			JHtml::_('select.option', '10', JText::_('J10')),
+		);
 
 		// We don't need toolbar in the modal window.
 		if ($this->getLayout() !== 'modal')
@@ -73,7 +115,7 @@ class ContentViewArticles extends JViewLegacy
 			$this->sidebar = JHtmlSidebar::render();
 		}
 
-		parent::display($tpl);
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -16,18 +16,61 @@ defined('_JEXEC') or die;
  */
 class ContentViewFeatured extends JViewLegacy
 {
+	/**
+	 * The item authors
+	 *
+	 * @var  stdClass
+	 */
+	protected $authors;
+
+	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
 	protected $items;
 
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
 	protected $pagination;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
+
+	/**
+	 * Form object for search filters
+	 *
+	 * @var  JForm
+	 */
+	public $filterForm;
+
+	/**
+	 * The active search filters
+	 *
+	 * @var  array
+	 */
+	public $activeFilters;
+
+	/**
+	 * The sidebar markup
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
 
 	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  void
+	 * @return  mixed  A string if successful, otherwise a Error object.
 	 */
 	public function display($tpl = null)
 	{
@@ -48,24 +91,24 @@ class ContentViewFeatured extends JViewLegacy
 			return false;
 		}
 
-		// Levels filter.
-		$options   = array();
-		$options[] = JHtml::_('select.option', '1', JText::_('J1'));
-		$options[] = JHtml::_('select.option', '2', JText::_('J2'));
-		$options[] = JHtml::_('select.option', '3', JText::_('J3'));
-		$options[] = JHtml::_('select.option', '4', JText::_('J4'));
-		$options[] = JHtml::_('select.option', '5', JText::_('J5'));
-		$options[] = JHtml::_('select.option', '6', JText::_('J6'));
-		$options[] = JHtml::_('select.option', '7', JText::_('J7'));
-		$options[] = JHtml::_('select.option', '8', JText::_('J8'));
-		$options[] = JHtml::_('select.option', '9', JText::_('J9'));
-		$options[] = JHtml::_('select.option', '10', JText::_('J10'));
-
-		$this->f_levels = $options;
+		// Levels filter - Used in Hathor.
+		$this->f_levels = array(
+			JHtml::_('select.option', '1', JText::_('J1')),
+			JHtml::_('select.option', '2', JText::_('J2')),
+			JHtml::_('select.option', '3', JText::_('J3')),
+			JHtml::_('select.option', '4', JText::_('J4')),
+			JHtml::_('select.option', '5', JText::_('J5')),
+			JHtml::_('select.option', '6', JText::_('J6')),
+			JHtml::_('select.option', '7', JText::_('J7')),
+			JHtml::_('select.option', '8', JText::_('J8')),
+			JHtml::_('select.option', '9', JText::_('J9')),
+			JHtml::_('select.option', '10', JText::_('J10')),
+		);
 
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the admin com_content component. Changes of note:
- Doc blocks cleaned up some to follow standard
- Return the results of the view's `display()` methods to be consistent with the documented return
- Not using variables for items only referenced once
- Use `Joomla\Utilities\ArrayHelper` instead of `JArrayHelper`
- Removed empty override methods (the parent class' method is also empty)
### Testing Instructions

The admin com_content component should continue to function correctly
