### PR TITLE
Code review on com_contact component

### DIFF
--- a/administrator/components/com_contact/controller.php
+++ b/administrator/components/com_contact/controller.php
@@ -17,8 +17,10 @@ defined('_JEXEC') or die;
 class ContactController extends JControllerLegacy
 {
 	/**
-	 * @var		string	The default view.
-	 * @since   1.6
+	 * The default view.
+	 *
+	 * @var    string
+	 * @since  1.6
 	 */
 	protected $default_view = 'contacts';
 
@@ -28,11 +30,11 @@ class ContactController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  ContactController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cachable = false, $urlparams = array())
 	{
 		require_once JPATH_COMPONENT . '/helpers/contact.php';
 
@@ -51,8 +53,6 @@ class ContactController extends JControllerLegacy
 			return false;
 		}
 
-		parent::display();
-
-		return $this;
+		return parent::display();
 	}
 }

--- a/administrator/components/com_contact/controllers/contact.php
+++ b/administrator/components/com_contact/controllers/contact.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Controller for a single contact
  *
@@ -27,14 +29,13 @@ class ContactControllerContact extends JControllerForm
 	 */
 	protected function allowAdd($data = array())
 	{
-		$user = JFactory::getUser();
-		$categoryId = JArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
+		$categoryId = ArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
 		$allow = null;
 
 		if ($categoryId)
 		{
 			// If the category has been passed in the URL check it.
-			$allow = $user->authorise('core.create', $this->option . '.category.' . $categoryId);
+			$allow = JFactory::getUser()->authorise('core.create', $this->option . '.category.' . $categoryId);
 		}
 
 		if ($allow === null)
@@ -42,10 +43,8 @@ class ContactControllerContact extends JControllerForm
 			// In the absense of better information, revert to the component permissions.
 			return parent::allowAdd($data);
 		}
-		else
-		{
-			return $allow;
-		}
+
+		return $allow;
 	}
 
 	/**
@@ -73,11 +72,9 @@ class ContactControllerContact extends JControllerForm
 			// The category has been set. Check the category permissions.
 			return JFactory::getUser()->authorise('core.edit', $this->option . '.category.' . $categoryId);
 		}
-		else
-		{
-			// Since there is no asset tracking, revert to the component permissions.
-			return parent::allowEdit($data, $key);
-		}
+
+		// Since there is no asset tracking, revert to the component permissions.
+		return parent::allowEdit($data, $key);
 	}
 
 	/**
@@ -94,25 +91,12 @@ class ContactControllerContact extends JControllerForm
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Set the model
+		/** @var ContactModelContact $model */
 		$model = $this->getModel('Contact', '', array());
 
 		// Preset the redirect
 		$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contacts' . $this->getRedirectToListAppend(), false));
 
 		return parent::batch($model);
-	}
-
-	/**
-	 * Function that allows child controller access to model data after the data has been saved.
-	 *
-	 * @param   JModelLegacy  $model      The data model object.
-	 * @param   array         $validData  The validated data.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	protected function postSaveHook(JModelLegacy $model, $validData = array())
-	{
 	}
 }

--- a/administrator/components/com_contact/controllers/contacts.php
+++ b/administrator/components/com_contact/controllers/contacts.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Contacts list controller class.
  *
@@ -21,7 +23,7 @@ class ContactControllerContacts extends JControllerAdmin
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -43,13 +45,13 @@ class ContactControllerContacts extends JControllerAdmin
 		// Check for request forgeries
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$user   = JFactory::getUser();
 		$ids    = $this->input->get('cid', array(), 'array');
 		$values = array('featured' => 1, 'unfeatured' => 0);
 		$task   = $this->getTask();
-		$value  = JArrayHelper::getValue($values, $task, 0, 'int');
+		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
 
 		// Get the model.
+		/** @var ContactModelContact $model */
 		$model  = $this->getModel();
 
 		// Access checks.
@@ -57,7 +59,7 @@ class ContactControllerContacts extends JControllerAdmin
 		{
 			$item = $model->getItem($id);
 
-			if (!$user->authorise('core.edit.state', 'com_contact.category.' . (int) $item->catid))
+			if (!JFactory::getUser()->authorise('core.edit.state', 'com_contact.category.' . (int) $item->catid))
 			{
 				// Prune items that you can't change.
 				unset($ids[$i]);
@@ -88,29 +90,12 @@ class ContactControllerContacts extends JControllerAdmin
 	 * @param   string  $prefix  The prefix for the PHP class name.
 	 * @param   array   $config  Array of configuration parameters.
 	 *
-	 * @return  JModel
+	 * @return  JModelLegacy
 	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Contact', $prefix = 'ContactModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
-	}
-
-	/**
-	 * Function that allows child controller access to model data
-	 * after the item has been deleted.
-	 *
-	 * @param   JModelLegacy  $model  The data model object.
-	 * @param   integer       $ids    The array of ids for items being deleted.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.2
-	 */
-	protected function postDeleteHook(JModelLegacy $model, $ids = null)
-	{
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_contact/helpers/html/contact.php
+++ b/administrator/components/com_contact/helpers/html/contact.php
@@ -9,23 +9,25 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('ContactHelper', JPATH_ADMINISTRATOR . '/components/com_contact/helpers/contact.php');
 
 /**
  * Contact HTML helper class.
  *
- * @package     Joomla.Administrator
- * @subpackage  com_contact
- * @since       1.6
+ * @since  1.6
  */
 abstract class JHtmlContact
 {
 	/**
 	 * Get the associated language flags
 	 *
-	 * @param   int  $contactid  The item id to search associations
+	 * @param   integer  $contactid  The item id to search associations
 	 *
 	 * @return  string  The language HTML
+	 *
+	 * @throws  Exception
 	 */
 	public static function association($contactid)
 	{
@@ -58,11 +60,9 @@ abstract class JHtmlContact
 			{
 				$items = $db->loadObjectList('id');
 			}
-			catch (runtimeException $e)
+			catch (RuntimeException $e)
 			{
-				throw new Exception($e->getMessage(), 500);
-
-				return false;
+				throw new Exception($e->getMessage(), 500, $e);
 			}
 
 			if ($items)
@@ -72,10 +72,12 @@ abstract class JHtmlContact
 					$text = strtoupper($item->lang_sef);
 					$url = JRoute::_('index.php?option=com_contact&task=contact.edit&id=' . (int) $item->id);
 					$tooltipParts = array(
-						JHtml::_('image', 'mod_languages/' . $item->image . '.gif',
-								$item->language_title,
-								array('title' => $item->language_title),
-								true
+						JHtml::_(
+							'image',
+							'mod_languages/' . $item->image . '.gif',
+							$item->language_title,
+							array('title' => $item->language_title),
+							true
 						),
 						$item->title,
 						'(' . $item->category_title . ')'
@@ -103,9 +105,9 @@ abstract class JHtmlContact
 	/**
 	 * Show the featured/not-featured icon.
 	 *
-	 * @param   int   $value      The featured value.
-	 * @param   int   $i          Id of the item.
-	 * @param   bool  $canChange  Whether the value can be changed or not.
+	 * @param   integer  $value      The featured value.
+	 * @param   integer  $i          Id of the item.
+	 * @param   boolean  $canChange  Whether the value can be changed or not.
 	 *
 	 * @return  string	The anchor tag to toggle featured/unfeatured contacts.
 	 *
@@ -119,7 +121,7 @@ abstract class JHtmlContact
 			0 => array('unfeatured', 'contacts.featured', 'COM_CONTACT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 			1 => array('featured', 'contacts.unfeatured', 'JFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),
 		);
-		$state = JArrayHelper::getValue($states, (int) $value, $states[1]);
+		$state = ArrayHelper::getValue($states, (int) $value, $states[1]);
 		$icon  = $state[0];
 
 		if ($canChange)

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ContactHelper', JPATH_ADMINISTRATOR . '/components/com_contact/helpers/contact.php');
 
@@ -23,24 +24,23 @@ class ContactModelContact extends JModelAdmin
 	/**
 	 * The type alias for this content type.
 	 *
-	 * @var      string
-	 * @since    3.2
+	 * @var    string
+	 * @since  3.2
 	 */
 	public $typeAlias = 'com_contact.contact';
 
 	/**
 	 * The context used for the associations table
 	 *
-	 * @var      string
-	 * @since    3.4.4
+	 * @var    string
+	 * @since  3.4.4
 	 */
 	protected $associationsContext = 'com_contact.item';
 
 	/**
-	 * Batch copy/move command. If set to false, 
-	 * the batch copy/move command is not supported
+	 * Batch copy/move command. If set to false, the batch copy/move command is not supported
 	 *
-	 * @var string
+	 * @var  string
 	 */
 	protected $batch_copymove = 'category_id';
 
@@ -71,7 +71,6 @@ class ContactModelContact extends JModelAdmin
 	{
 		$categoryId = (int) $value;
 
-		$table = $this->getTable();
 		$newIds = array();
 
 		if (!parent::checkCategoryId($categoryId))
@@ -129,7 +128,7 @@ class ContactModelContact extends JModelAdmin
 				return false;
 			}
 
-			parent::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 			// Store the row.
 			if (!$this->table->store())
@@ -173,7 +172,7 @@ class ContactModelContact extends JModelAdmin
 				$this->table->load($pk);
 				$this->table->user_id = (int) $value;
 
-				static::createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+				$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 
 				if (!$this->table->store())
 				{
@@ -214,9 +213,7 @@ class ContactModelContact extends JModelAdmin
 				return;
 			}
 
-			$user = JFactory::getUser();
-
-			return $user->authorise('core.delete', 'com_contact.category.' . (int) $record->catid);
+			return JFactory::getUser()->authorise('core.delete', 'com_contact.category.' . (int) $record->catid);
 		}
 	}
 
@@ -234,21 +231,17 @@ class ContactModelContact extends JModelAdmin
 		// Check against the category.
 		if (!empty($record->catid))
 		{
-			$user = JFactory::getUser();
+			return JFactory::getUser()->authorise('core.edit.state', 'com_contact.category.' . (int) $record->catid);
+		}
 
-			return $user->authorise('core.edit.state', 'com_contact.category.' . (int) $record->catid);
-		}
 		// Default to component settings if category not known.
-		else
-		{
-			return parent::canEditState($record);
-		}
+		return parent::canEditState($record);
 	}
 
 	/**
 	 * Returns a Table object, always creating it
 	 *
-	 * @param   type    $type    The table type to instantiate
+	 * @param   string  $type    The table type to instantiate
 	 * @param   string  $prefix  A prefix for the table class name. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
@@ -267,7 +260,7 @@ class ContactModelContact extends JModelAdmin
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A JForm object on success, false on failure
+	 * @return  JForm|boolean  A JForm object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -321,7 +314,6 @@ class ContactModelContact extends JModelAdmin
 		}
 
 		// Load associated contact items
-		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 
 		if ($assoc)
@@ -358,8 +350,10 @@ class ContactModelContact extends JModelAdmin
 	 */
 	protected function loadFormData()
 	{
+		$app = JFactory::getApplication();
+
 		// Check the session for previously entered form data.
-		$data = JFactory::getApplication()->getUserState('com_contact.edit.contact.data', array());
+		$data = $app->getUserState('com_contact.edit.contact.data', array());
 
 		if (empty($data))
 		{
@@ -368,7 +362,6 @@ class ContactModelContact extends JModelAdmin
 			// Prime some default values.
 			if ($this->getState('contact.id') == 0)
 			{
-				$app = JFactory::getApplication();
 				$data->set('catid', $app->input->get('catid', $app->getUserState('com_contact.contacts.filter.category_id'), 'int'));
 			}
 		}
@@ -385,7 +378,7 @@ class ContactModelContact extends JModelAdmin
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since    3.0
+	 * @since   3.0
 	 */
 	public function save($data)
 	{
@@ -437,8 +430,7 @@ class ContactModelContact extends JModelAdmin
 	 */
 	protected function prepareTable($table)
 	{
-		$date = JFactory::getDate();
-		$user = JFactory::getUser();
+		$date = JFactory::getDate()->toSql();
 
 		$table->name = htmlspecialchars_decode($table->name, ENT_QUOTES);
 
@@ -447,7 +439,7 @@ class ContactModelContact extends JModelAdmin
 		if (empty($table->id))
 		{
 			// Set the values
-			$table->created = $date->toSql();
+			$table->created = $date;
 
 			// Set ordering to the last item if not set
 			if (empty($table->ordering))
@@ -465,9 +457,10 @@ class ContactModelContact extends JModelAdmin
 		else
 		{
 			// Set the values
-			$table->modified = $date->toSql();
-			$table->modified_by = $user->get('id');
+			$table->modified = $date;
+			$table->modified_by = JFactory::getUser()->id;
 		}
+
 		// Increment the content version number.
 		$table->version++;
 	}
@@ -483,10 +476,7 @@ class ContactModelContact extends JModelAdmin
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-		$condition[] = 'catid = ' . (int) $table->catid;
-
-		return $condition;
+		return array('catid = ' . (int) $table->catid);
 	}
 
 	/**
@@ -501,7 +491,6 @@ class ContactModelContact extends JModelAdmin
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
 		// Association content items
-		$app = JFactory::getApplication();
 		$assoc = JLanguageAssociations::isEnabled();
 
 		if ($assoc)
@@ -553,8 +542,7 @@ class ContactModelContact extends JModelAdmin
 	public function featured($pks, $value = 0)
 	{
 		// Sanitize the ids.
-		$pks = (array) $pks;
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger((array) $pks);
 
 		if (empty($pks))
 		{

--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Methods supporting a list of contact records.
  *
@@ -21,7 +23,7 @@ class ContactModelContacts extends JModelList
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 * @since   1.6
 	 */
 	public function __construct($config = array())
@@ -71,7 +73,7 @@ class ContactModelContacts extends JModelList
 	 *
 	 * @since   1.6
 	 */
-	protected function populateState($ordering = null, $direction = null)
+	protected function populateState($ordering = 'a.name', $direction = 'asc')
 	{
 		$app = JFactory::getApplication();
 
@@ -109,7 +111,7 @@ class ContactModelContacts extends JModelList
 		$this->setState('filter.tag', $tag);
 
 		// List state information.
-		parent::populateState('a.name', 'asc');
+		parent::populateState($ordering, $direction);
 	}
 
 	/**
@@ -173,36 +175,36 @@ class ContactModelContacts extends JModelList
 				)
 			)
 			->join(
-				'LEFT', $db->quoteName('#__users', 'ul')
-				. ' ON ' . $db->quoteName('ul.id') . ' = ' . $db->quoteName('a.user_id')
+				'LEFT',
+				$db->quoteName('#__users', 'ul') . ' ON ' . $db->quoteName('ul.id') . ' = ' . $db->quoteName('a.user_id')
 			);
 
 		// Join over the language
 		$query->select($db->quoteName('l.title', 'language_title'))
 			->join(
-				'LEFT', $db->quoteName('#__languages', 'l')
-				. ' ON ' . $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.language')
+				'LEFT',
+				$db->quoteName('#__languages', 'l') . ' ON ' . $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.language')
 			);
 
 		// Join over the users for the checked out user.
 		$query->select($db->quoteName('uc.name', 'editor'))
 			->join(
-				'LEFT', $db->quoteName('#__users', 'uc')
-				. ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('a.checked_out')
+				'LEFT',
+				$db->quoteName('#__users', 'uc') . ' ON ' . $db->quoteName('uc.id') . ' = ' . $db->quoteName('a.checked_out')
 			);
 
 		// Join over the asset groups.
 		$query->select($db->quoteName('ag.title', 'access_level'))
 			->join(
-				'LEFT', $db->quoteName('#__viewlevels', 'ag')
-				. ' ON ' . $db->quoteName('ag.id') . ' = ' . $db->quoteName('a.access')
+				'LEFT',
+				$db->quoteName('#__viewlevels', 'ag') . ' ON ' . $db->quoteName('ag.id') . ' = ' . $db->quoteName('a.access')
 			);
 
 		// Join over the categories.
 		$query->select($db->quoteName('c.title', 'category_title'))
 			->join(
-				'LEFT', $db->quoteName('#__categories', 'c')
-				. ' ON ' . $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid')
+				'LEFT',
+				$db->quoteName('#__categories', 'c') . ' ON ' . $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid')
 			);
 
 		// Join over the associations.
@@ -212,13 +214,13 @@ class ContactModelContacts extends JModelList
 		{
 			$query->select('COUNT(' . $db->quoteName('asso2.id') . ') > 1 as ' . $db->quoteName('association'))
 				->join(
-					'LEFT', $db->quoteName('#__associations', 'asso')
-					. ' ON ' . $db->quoteName('asso.id') . ' = ' . $db->quoteName('a.id')
+					'LEFT',
+					$db->quoteName('#__associations', 'asso') . ' ON ' . $db->quoteName('asso.id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('asso.context') . ' = ' . $db->quote('com_contact.item')
 				)
 				->join(
-					'LEFT', $db->quoteName('#__associations', 'asso2')
-					. ' ON ' . $db->quoteName('asso2.key') . ' = ' . $db->quoteName('asso.key')
+					'LEFT',
+					$db->quoteName('#__associations', 'asso2') . ' ON ' . $db->quoteName('asso2.key') . ' = ' . $db->quoteName('asso.key')
 				)
 				->group(
 					$db->quoteName(
@@ -268,9 +270,7 @@ class ContactModelContacts extends JModelList
 		}
 		elseif (is_array($categoryId))
 		{
-			$categoryId = Joomla\Utilities\ArrayHelper::toInteger($categoryId);
-			$categoryId = implode(',', $categoryId);
-			$query->where($db->quoteName('a.catid') . ' IN (' . $categoryId . ')');
+			$query->where($db->quoteName('a.catid') . ' IN (' . implode(',', ArrayHelper::toInteger($categoryId)) . ')');
 		}
 
 		// Filter by search in name.
@@ -311,7 +311,8 @@ class ContactModelContacts extends JModelList
 		{
 			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId)
 				->join(
-					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
+					'LEFT',
+					$db->quoteName('#__contentitem_tag_map', 'tagmap')
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_contact.contact')
 				);

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -60,15 +60,15 @@ class ContactTableContact extends JTable
 			$this->params = (string) $registry;
 		}
 
-		$date = JFactory::getDate();
-		$user = JFactory::getUser();
+		$date   = JFactory::getDate()->toSql();
+		$userId = JFactory::getUser()->id;
 
-		$this->modified = $date->toSql();
+		$this->modified = $date;
 
 		if ($this->id)
 		{
 			// Existing item
-			$this->modified_by = $user->get('id');
+			$this->modified_by = $userId;
 		}
 		else
 		{
@@ -76,12 +76,12 @@ class ContactTableContact extends JTable
 			// so we don't touch either of these if they are set.
 			if (!(int) $this->created)
 			{
-				$this->created = $date->toSql();
+				$this->created = $date;
 			}
 
 			if (empty($this->created_by))
 			{
-				$this->created_by = $user->get('id');
+				$this->created_by = $userId;
 			}
 		}
 
@@ -127,14 +127,14 @@ class ContactTableContact extends JTable
 	 *
 	 * @return  boolean  True on success, false on failure
 	 *
-	 * @see JTable::check
-	 * @since 1.5
+	 * @see     JTable::check
+	 * @since   1.5
 	 */
 	public function check()
 	{
 		$this->default_con = (int) $this->default_con;
 
-		if (JFilterInput::checkAttribute(array ('href', $this->webpage)))
+		if (JFilterInput::checkAttribute(array('href', $this->webpage)))
 		{
 			$this->setError(JText::_('COM_CONTACT_WARNING_PROVIDE_VALID_URL'));
 
@@ -159,7 +159,8 @@ class ContactTableContact extends JTable
 
 			return false;
 		}
-		// Sanity check for user_id */
+
+		// Sanity check for user_id
 		if (!($this->user_id))
 		{
 			$this->user_id = 0;

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -16,10 +16,25 @@ defined('_JEXEC') or die;
  */
 class ContactViewContact extends JViewLegacy
 {
+	/**
+	 * The JForm object
+	 *
+	 * @var  JForm
+	 */
 	protected $form;
 
+	/**
+	 * The active item
+	 *
+	 * @var  object
+	 */
 	protected $item;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
 
 	/**
@@ -51,7 +66,8 @@ class ContactViewContact extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**
@@ -66,7 +82,7 @@ class ContactViewContact extends JViewLegacy
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
 		$user       = JFactory::getUser();
-		$userId     = $user->get('id');
+		$userId     = $user->id;
 		$isNew      = ($this->item->id == 0);
 		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
 

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -16,11 +16,47 @@ defined('_JEXEC') or die;
  */
 class ContactViewContacts extends JViewLegacy
 {
+	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
 	protected $items;
 
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
 	protected $pagination;
 
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
 	protected $state;
+
+	/**
+	 * Form object for search filters
+	 *
+	 * @var  JForm
+	 */
+	public $filterForm;
+
+	/**
+	 * The active search filters
+	 *
+	 * @var  array
+	 */
+	public $activeFilters;
+
+	/**
+	 * The sidebar markup
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
 
 	/**
 	 * Display the view.
@@ -57,7 +93,8 @@ class ContactViewContacts extends JViewLegacy
 
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**
@@ -71,9 +108,6 @@ class ContactViewContacts extends JViewLegacy
 	{
 		$canDo = JHelperContent::getActions('com_contact', 'category', $this->state->get('filter.category_id'));
 		$user  = JFactory::getUser();
-
-		// Get the toolbar object instance
-		$bar = JToolbar::getInstance('toolbar');
 
 		JToolbarHelper::title(JText::_('COM_CONTACT_MANAGER_CONTACTS'), 'address contact');
 
@@ -106,7 +140,7 @@ class ContactViewContacts extends JViewLegacy
 			$layout = new JLayoutFile('joomla.toolbar.batch');
 
 			$dhtml = $layout->render(array('title' => $title));
-			$bar->appendButton('Custom', $dhtml, 'batch');
+			JToolbar::getInstance('toolbar')->appendButton('Custom', $dhtml, 'batch');
 		}
 
 		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the admin com_contact component. Changes of note:
- Doc blocks cleaned up some to follow standard
- Return the results of the view's `display()` methods to be consistent with the documented return
- Not using variables for items only referenced once
- Use `Joomla\Utilities\ArrayHelper` instead of `JArrayHelper`
- Removed empty override methods (the parent class' method is also empty)
### Testing Instructions

The admin com_contact component should continue to function correctly
