### PR TITLE
Code review on com_finder component

### DIFF
--- a/administrator/components/com_finder/controller.php
+++ b/administrator/components/com_finder/controller.php
@@ -17,7 +17,9 @@ defined('_JEXEC') or die;
 class FinderController extends JControllerLegacy
 {
 	/**
-	 * @var    string  The default view.
+	 * The default view.
+	 *
+	 * @var    string
 	 * @since  2.5
 	 */
 	protected $default_view = 'index';
@@ -28,7 +30,7 @@ class FinderController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  A JController object to support chaining.
+	 * @return  FinderController  A JControllerLegacy object to support chaining.
 	 *
 	 * @since	2.5
 	 */
@@ -51,8 +53,6 @@ class FinderController extends JControllerLegacy
 			return false;
 		}
 
-		parent::display();
-
-		return $this;
+		return parent::display();
 	}
 }

--- a/administrator/components/com_finder/controllers/filter.php
+++ b/administrator/components/com_finder/controllers/filter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Indexer controller class for Finder.
  *
@@ -33,7 +35,6 @@ class FinderControllerFilter extends JControllerForm
 
 		$app = JFactory::getApplication();
 		$input = $app->input;
-		$lang = JFactory::getLanguage();
 		$model = $this->getModel();
 		$table = $model->getTable();
 		$data = $input->post->get('jform', array(), 'array');
@@ -144,7 +145,7 @@ class FinderControllerFilter extends JControllerForm
 		// Get and sanitize the filter data.
 		$validData['data'] = $input->post->get('t', array(), 'array');
 		$validData['data'] = array_unique($validData['data']);
-		JArrayHelper::toInteger($validData['data']);
+		$validData['data'] = ArrayHelper::toInteger($validData['data']);
 
 		// Remove any values of zero.
 		if (array_search(0, $validData['data'], true))
@@ -184,7 +185,7 @@ class FinderControllerFilter extends JControllerForm
 
 		$this->setMessage(
 			JText::_(
-				($lang->hasKey($this->text_prefix . ($recordId == 0 && $app->isSite() ? '_SUBMIT' : '') . '_SAVE_SUCCESS')
+				(JFactory::getLanguage()->hasKey($this->text_prefix . ($recordId == 0 && $app->isSite() ? '_SUBMIT' : '') . '_SAVE_SUCCESS')
 				? $this->text_prefix : 'JLIB_APPLICATION') . ($recordId == 0 && $app->isSite() ? '_SUBMIT' : '') . '_SAVE_SUCCESS'
 			)
 		);

--- a/administrator/components/com_finder/controllers/filters.php
+++ b/administrator/components/com_finder/controllers/filters.php
@@ -23,14 +23,12 @@ class FinderControllerFilters extends JControllerAdmin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  object  The model.
+	 * @return  JModelLegacy  The model.
 	 *
 	 * @since   2.5
 	 */
 	public function getModel($name = 'Filter', $prefix = 'FinderModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_finder/controllers/index.php
+++ b/administrator/components/com_finder/controllers/index.php
@@ -23,15 +23,13 @@ class FinderControllerIndex extends JControllerAdmin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  object  The model.
+	 * @return  JModelLegacy  The model.
 	 *
 	 * @since   2.5
 	 */
 	public function getModel($name = 'Index', $prefix = 'FinderModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -28,27 +28,24 @@ class FinderControllerIndexer extends JControllerLegacy
 	 */
 	public function start()
 	{
-		static $log;
-
 		$params = JComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
 		{
-			if ($log == null)
-			{
-				$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
-				$options['text_file'] = 'indexer.php';
-				$log = JLog::addLogger($options);
-			}
+			$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
+			$options['text_file'] = 'indexer.php';
+			JLog::addLogger($options);
 		}
 
 		// Log the start
 		JLog::add('Starting the indexer', JLog::INFO);
 
 		// We don't want this form to be cached.
-		header('Pragma: no-cache');
-		header('Cache-Control: no-cache');
-		header('Expires: -1');
+		$app = JFactory::getApplication();
+		$app->setHeader('Expires', 'Mon, 1 Jan 2001 00:00:00 GMT', true);
+		$app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+		$app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+		$app->setHeader('Pragma', 'no-cache');
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
 		JSession::checkToken('request') or $this->sendResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
@@ -95,27 +92,24 @@ class FinderControllerIndexer extends JControllerLegacy
 	 */
 	public function batch()
 	{
-		static $log;
-
 		$params = JComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
 		{
-			if ($log == null)
-			{
-				$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
-				$options['text_file'] = 'indexer.php';
-				$log = JLog::addLogger($options);
-			}
+			$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
+			$options['text_file'] = 'indexer.php';
+			JLog::addLogger($options);
 		}
 
 		// Log the start
 		JLog::add('Starting the indexer batch process', JLog::INFO);
 
 		// We don't want this form to be cached.
-		header('Pragma: no-cache');
-		header('Cache-Control: no-cache');
-		header('Expires: -1');
+		$app = JFactory::getApplication();
+		$app->setHeader('Expires', 'Mon, 1 Jan 2001 00:00:00 GMT', true);
+		$app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+		$app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+		$app->setHeader('Pragma', 'no-cache');
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
 		JSession::checkToken('request') or $this->sendResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
@@ -216,9 +210,11 @@ class FinderControllerIndexer extends JControllerLegacy
 	public function optimize()
 	{
 		// We don't want this form to be cached.
-		header('Pragma: no-cache');
-		header('Cache-Control: no-cache');
-		header('Expires: -1');
+		$app = JFactory::getApplication();
+		$app->setHeader('Expires', 'Mon, 1 Jan 2001 00:00:00 GMT', true);
+		$app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+		$app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+		$app->setHeader('Pragma', 'no-cache');
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
 		JSession::checkToken('request') or $this->sendResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
@@ -262,27 +258,24 @@ class FinderControllerIndexer extends JControllerLegacy
 	 */
 	public static function sendResponse($data = null)
 	{
-		static $log;
+		// This method always sends a JSON response
+		$app = JFactory::getApplication();
+		$app->mimeType = 'application/json';
 
 		$params = JComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
 		{
-			if ($log == null)
-			{
-				$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
-				$options['text_file'] = 'indexer.php';
-				$log = JLog::addLogger($options);
-			}
+			$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
+			$options['text_file'] = 'indexer.php';
+			JLog::addLogger($options);
 		}
 
 		// Send the assigned error code if we are catching an exception.
 		if ($data instanceof Exception)
 		{
-			$app = JFactory::getApplication();
 			JLog::add($data->getMessage(), JLog::ERROR);
 			$app->setHeader('status', $data->getCode());
-			$app->sendHeaders();
 		}
 
 		// Create the response object.
@@ -292,10 +285,12 @@ class FinderControllerIndexer extends JControllerLegacy
 		$response->buffer = JDEBUG ? ob_get_contents() : ob_end_clean();
 
 		// Send the JSON response.
+		$app->setHeader('Content-Type', $app->mimeType . '; charset=' . $app->charSet);
+		$app->sendHeaders();
 		echo json_encode($response);
 
 		// Close the application.
-		JFactory::getApplication()->close();
+		$app->close();
 	}
 }
 
@@ -315,18 +310,13 @@ class FinderIndexerResponse
 	 */
 	public function __construct($state)
 	{
-		static $log;
-
 		$params = JComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
 		{
-			if ($log == null)
-			{
-				$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
-				$options['text_file'] = 'indexer.php';
-				$log = JLog::addLogger($options);
-			}
+			$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
+			$options['text_file'] = 'indexer.php';
+			JLog::addLogger($options);
 		}
 
 		// The old token is invalid so send a new one.

--- a/administrator/components/com_finder/controllers/maps.php
+++ b/administrator/components/com_finder/controllers/maps.php
@@ -23,14 +23,12 @@ class FinderControllerMaps extends JControllerAdmin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  object  The model.
+	 * @return  JModelLegacy  The model.
 	 *
 	 * @since   1.6
 	 */
 	public function getModel($name = 'Maps', $prefix = 'FinderModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_finder/helpers/finder.php
+++ b/administrator/components/com_finder/helpers/finder.php
@@ -17,8 +17,10 @@ defined('_JEXEC') or die;
 class FinderHelper
 {
 	/**
-	 * @var		string	The extension name.
-	 * @since	2.5
+	 * The extension name.
+	 *
+	 * @var    string
+	 * @since  2.5
 	 */
 	public static $extension = 'com_finder';
 
@@ -64,8 +66,6 @@ class FinderHelper
 		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_finder');
-
-		return $result;
+		return JHelperContent::getActions('com_finder');
 	}
 }

--- a/administrator/components/com_finder/helpers/html/finder.php
+++ b/administrator/components/com_finder/helpers/html/finder.php
@@ -27,8 +27,6 @@ abstract class JHtmlFinder
 	 */
 	public static function typeslist()
 	{
-		$lang = JFactory::getLanguage();
-
 		// Load the finder types.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -44,7 +42,7 @@ abstract class JHtmlFinder
 		}
 		catch (RuntimeException $e)
 		{
-			return;
+			return array();
 		}
 
 		// Compile the options.
@@ -52,10 +50,9 @@ abstract class JHtmlFinder
 
 		foreach ($rows as $row)
 		{
-			$key = $lang->hasKey(FinderHelperLanguage::branchPlural($row->text))
-					? FinderHelperLanguage::branchPlural($row->text) : $row->text;
-			$string = JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_($key));
-			$options[] = JHtml::_('select.option', $row->value, $string);
+			$key = JFactory::getLanguage()->hasKey(FinderHelperLanguage::branchPlural($row->text))
+				? FinderHelperLanguage::branchPlural($row->text) : $row->text;
+			$options[] = JHtml::_('select.option', $row->value, JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_($key)));
 		}
 
 		return $options;
@@ -70,8 +67,6 @@ abstract class JHtmlFinder
 	 */
 	public static function mapslist()
 	{
-		$lang = JFactory::getLanguage();
-
 		// Load the finder types.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -87,7 +82,7 @@ abstract class JHtmlFinder
 		}
 		catch (RuntimeException $e)
 		{
-			return;
+			return array();
 		}
 
 		// Compile the options.
@@ -96,10 +91,9 @@ abstract class JHtmlFinder
 
 		foreach ($rows as $row)
 		{
-			$key = $lang->hasKey(FinderHelperLanguage::branchPlural($row->text))
-					? FinderHelperLanguage::branchPlural($row->text) : $row->text;
-			$string = JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_($key));
-			$options[] = JHtml::_('select.option', $row->value, $string);
+			$key = JFactory::getLanguage()->hasKey(FinderHelperLanguage::branchPlural($row->text))
+				? FinderHelperLanguage::branchPlural($row->text) : $row->text;
+			$options[] = JHtml::_('select.option', $row->value, JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_($key)));
 		}
 
 		return $options;
@@ -114,10 +108,9 @@ abstract class JHtmlFinder
 	 */
 	public static function statelist()
 	{
-		$options = array();
-		$options[] = JHtml::_('select.option', '1', JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_('JPUBLISHED')));
-		$options[] = JHtml::_('select.option', '0', JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_('JUNPUBLISHED')));
-
-		return $options;
+		return array(
+			JHtml::_('select.option', '1', JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_('JPUBLISHED'))),
+			JHtml::_('select.option', '0', JText::sprintf('COM_FINDER_ITEM_X_ONLY', JText::_('JUNPUBLISHED')))
+		);
 	}
 }

--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('FinderIndexer', __DIR__ . '/indexer.php');
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
 JLoader::register('FinderIndexerResult', __DIR__ . '/result.php');
@@ -161,7 +163,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 * @return  boolean  True on success.
 	 *
 	 * @since   2.5
-	 * @throws    Exception on error.
+	 * @throws  Exception on error.
 	 */
 	public function onStartIndex()
 	{
@@ -269,7 +271,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	 * @return  boolean  True on success.
 	 *
 	 * @since   2.5
-	 * @throws    Exception on database error.
+	 * @throws  Exception on database error.
 	 */
 	protected function change($id, $property, $value)
 	{
@@ -525,9 +527,8 @@ abstract class FinderIndexerAdapter extends JPlugin
 
 		// Get the total number of content items to index.
 		$this->db->setQuery($query);
-		$return = (int) $this->db->loadResult();
 
-		return $return;
+		return (int) $this->db->loadResult();
 	}
 
 	/**
@@ -551,7 +552,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 		$row = $this->db->loadAssoc();
 
 		// Convert the item to a result object.
-		$item = JArrayHelper::toObject($row, 'FinderIndexerResult');
+		$item = ArrayHelper::toObject($row, 'FinderIndexerResult');
 
 		// Set the item type.
 		$item->type_id = $this->type_id;
@@ -586,7 +587,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 		foreach ($rows as $row)
 		{
 			// Convert the item to a result object.
-			$item = JArrayHelper::toObject($row, 'FinderIndexerResult');
+			$item = ArrayHelper::toObject($row, 'FinderIndexerResult');
 
 			// Set the item type.
 			$item->type_id = $this->type_id;
@@ -622,9 +623,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	protected function getListQuery($query = null)
 	{
 		// Check if we can use the supplied SQL query.
-		$query = $query instanceof JDatabaseQuery ? $query : $this->db->getQuery(true);
-
-		return $query;
+		return $query instanceof JDatabaseQuery ? $query : $this->db->getQuery(true);
 	}
 
 	/**
@@ -644,9 +643,8 @@ abstract class FinderIndexerAdapter extends JPlugin
 			->from($this->db->quoteName('#__extensions'))
 			->where($this->db->quoteName('extension_id') . ' = ' . (int) $id);
 		$this->db->setQuery($query);
-		$type = $this->db->loadResult();
 
-		return $type;
+		return $this->db->loadResult();
 	}
 
 	/**
@@ -727,9 +725,8 @@ abstract class FinderIndexerAdapter extends JPlugin
 			->from($this->db->quoteName('#__finder_types'))
 			->where($this->db->quoteName('title') . ' = ' . $this->db->quote($this->type_title));
 		$this->db->setQuery($query);
-		$result = (int) $this->db->loadResult();
 
-		return $result;
+		return (int) $this->db->loadResult();
 	}
 
 	/**

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -74,7 +74,7 @@ class FinderIndexerHelper
 		$quotes = html_entity_decode('&#8216;&#8217;&#39;', ENT_QUOTES, 'UTF-8');
 
 		// Get the simple language key.
-		$lang = self::getPrimaryLanguage($lang);
+		$lang = static::getPrimaryLanguage($lang);
 
 		/*
 		 * Parsing the string input into terms is a multi-step process.
@@ -224,14 +224,12 @@ class FinderIndexerHelper
 		}
 
 		// Stem the token if we have a valid stemmer to use.
-		if (self::$stemmer instanceof FinderIndexerStemmer)
+		if (static::$stemmer instanceof FinderIndexerStemmer)
 		{
-			return self::$stemmer->stem($token, $lang);
+			return static::$stemmer->stem($token, $lang);
 		}
-		else
-		{
-			return $token;
-		}
+
+		return $token;
 	}
 
 	/**
@@ -303,14 +301,7 @@ class FinderIndexerHelper
 		}
 
 		// Check if the token is in the common array.
-		if (in_array($token, $data[$lang]))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return in_array($token, $data[$lang]);
 	}
 
 	/**
@@ -335,9 +326,8 @@ class FinderIndexerHelper
 
 		// Load all of the common terms for the language.
 		$db->setQuery($query);
-		$results = $db->loadColumn();
 
-		return $results;
+		return $db->loadColumn();
 	}
 
 	/**
@@ -440,22 +430,14 @@ class FinderIndexerHelper
 		// Load the finder plugin group.
 		JPluginHelper::importPlugin('finder');
 
-		try
-		{
-			// Trigger the event.
-			$results = $dispatcher->trigger('onPrepareFinderContent', array(&$item));
+		// Trigger the event.
+		$results = $dispatcher->trigger('onPrepareFinderContent', array(&$item));
 
-			// Check the returned results. This is for plugins that don't throw
-			// exceptions when they encounter serious errors.
-			if (in_array(false, $results))
-			{
-				throw new Exception($dispatcher->getError(), 500);
-			}
-		}
-		catch (Exception $e)
+		// Check the returned results. This is for plugins that don't throw
+		// exceptions when they encounter serious errors.
+		if (in_array(false, $results))
 		{
-			// Handle a caught exception.
-			throw $e;
+			throw new Exception($dispatcher->getError(), 500);
 		}
 
 		return true;

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -75,7 +75,7 @@ abstract class FinderIndexer
 	/**
 	 * The indexer state object.
 	 *
-	 * @var    object
+	 * @var    JObject
 	 * @since  2.5
 	 */
 	public static $state;
@@ -83,7 +83,7 @@ abstract class FinderIndexer
 	/**
 	 * The indexer profiler object.
 	 *
-	 * @var    object
+	 * @var    JProfiler
 	 * @since  2.5
 	 */
 	public static $profiler;
@@ -121,11 +121,9 @@ abstract class FinderIndexer
 
 			return new $class;
 		}
-		else
-		{
-			// Throw invalid format exception.
-			throw new RuntimeException(JText::sprintf('COM_FINDER_INDEXER_INVALID_DRIVER', $format));
-		}
+
+		// Throw invalid format exception.
+		throw new RuntimeException(JText::sprintf('COM_FINDER_INDEXER_INVALID_DRIVER', $format));
 	}
 
 	/**
@@ -138,9 +136,9 @@ abstract class FinderIndexer
 	public static function getState()
 	{
 		// First, try to load from the internal state.
-		if (!empty(self::$state))
+		if (!empty(static::$state))
 		{
-			return self::$state;
+			return static::$state;
 		}
 
 		// If we couldn't load from the internal state, try the session.
@@ -177,7 +175,7 @@ abstract class FinderIndexer
 		// Setup the profiler if debugging is enabled.
 		if (JFactory::getApplication()->get('debug'))
 		{
-			self::$profiler = JProfiler::getInstance('FinderIndexer');
+			static::$profiler = JProfiler::getInstance('FinderIndexer');
 		}
 
 		// Setup the stemmer.
@@ -187,9 +185,9 @@ abstract class FinderIndexer
 		}
 
 		// Set the state.
-		self::$state = $data;
+		static::$state = $data;
 
-		return self::$state;
+		return static::$state;
 	}
 
 	/**
@@ -210,11 +208,10 @@ abstract class FinderIndexer
 		}
 
 		// Set the new internal state.
-		self::$state = $data;
+		static::$state = $data;
 
 		// Set the new session state.
-		$session = JFactory::getSession();
-		$session->set('_finder.state', $data);
+		JFactory::getSession()->set('_finder.state', $data);
 
 		return true;
 	}
@@ -232,8 +229,7 @@ abstract class FinderIndexer
 		self::$state = null;
 
 		// Reset the session state to null.
-		$session = JFactory::getSession();
-		$session->set('_finder.state', null);
+		JFactory::getSession()->set('_finder.state', null);
 	}
 
 	/**
@@ -284,13 +280,14 @@ abstract class FinderIndexer
 	protected static function getSignature($item)
 	{
 		// Get the indexer state.
-		$state = self::getState();
+		$state = static::getState();
 
 		// Get the relevant configuration variables.
-		$config = array();
-		$config[] = $state->weights;
-		$config[] = $state->options->get('stem', 1);
-		$config[] = $state->options->get('stemmer', 'porter_en');
+		$config = array(
+			$state->weights,
+			$state->options->get('stem', 1),
+			$state->options->get('stemmer', 'porter_en')
+		);
 
 		return md5(serialize(array($item, $config)));
 	}
@@ -298,10 +295,8 @@ abstract class FinderIndexer
 	/**
 	 * Method to parse input, tokenize it, and then add it to the database.
 	 *
-	 * @param   mixed    $input    String or resource to use as input. A resource
-	 *                             input will automatically be chunked to conserve
-	 *                             memory. Strings will be chunked if longer than
-	 *                             2K in size.
+	 * @param   mixed    $input    String or resource to use as input. A resource input will automatically be chunked to conserve
+	 *                             memory. Strings will be chunked if longer than 2K in size.
 	 * @param   integer  $context  The context of the input. See context constants.
 	 * @param   string   $lang     The language of the input.
 	 * @param   string   $format   The format of the input.
@@ -373,7 +368,7 @@ abstract class FinderIndexer
 					$count += $this->addTokensToDb($tokens, $context);
 
 					// Check if we're approaching the memory limit of the token table.
-					if ($count > self::$state->options->get('memory_table_limit', 30000))
+					if ($count > static::$state->options->get('memory_table_limit', 30000))
 					{
 						$this->toggleTables(false);
 					}
@@ -428,7 +423,7 @@ abstract class FinderIndexer
 					$count += $this->addTokensToDb($tokens, $context);
 
 					// Check if we're approaching the memory limit of the token table.
-					if ($count > self::$state->options->get('memory_table_limit', 30000))
+					if ($count > static::$state->options->get('memory_table_limit', 30000))
 					{
 						$this->toggleTables(false);
 					}

--- a/administrator/components/com_finder/helpers/indexer/parser.php
+++ b/administrator/components/com_finder/helpers/indexer/parser.php
@@ -48,17 +48,15 @@ abstract class FinderIndexerParser
 		$class = 'FinderIndexerParser' . ucfirst($format);
 
 		// Check if a parser exists for the format.
-		if (file_exists($path))
-		{
-			// Instantiate the parser.
-			include_once $path;
-			$instances[$format] = new $class;
-		}
-		else
+		if (!file_exists($path))
 		{
 			// Throw invalid format exception.
 			throw new Exception(JText::sprintf('COM_FINDER_INDEXER_INVALID_PARSER', $format));
 		}
+
+		// Instantiate the parser.
+		include_once $path;
+		$instances[$format] = new $class;
 
 		return $instances[$format];
 	}

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -80,9 +80,7 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 	protected function process($input)
 	{
 		// Replace any amount of white space with a single space.
-		$input = preg_replace('#\s+#u', ' ', $input);
-
-		return $input;
+		return preg_replace('#\s+#u', ' ', $input);
 	}
 
 	/**
@@ -102,7 +100,6 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 	private function removeBlocks($input, $startTag, $endTag)
 	{
 		$return = '';
-		$blocks = array();
 		$offset = 0;
 		$startTagLength = strlen($startTag);
 		$endTagLength = strlen($endTag);

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
 JLoader::register('FinderIndexerTaxonomy', __DIR__ . '/taxonomy.php');
@@ -289,8 +290,7 @@ class FinderIndexerQuery
 		}
 
 		// Get the filters in the request.
-		$input = JFactory::getApplication()->input;
-		$t = $input->request->get('t', array(), 'array');
+		$t = JFactory::getApplication()->input->request->get('t', array(), 'array');
 
 		// Add the dynamic taxonomy filters if present.
 		if (!empty($this->filters))
@@ -379,9 +379,8 @@ class FinderIndexerQuery
 
 		// Sanitize the terms.
 		$results = array_unique($results);
-		JArrayHelper::toInteger($results);
 
-		return $results;
+		return ArrayHelper::toInteger($results);
 	}
 
 	/**
@@ -421,7 +420,7 @@ class FinderIndexerQuery
 		foreach ($results as $key => $value)
 		{
 			$results[$key] = array_unique($results[$key]);
-			JArrayHelper::toInteger($results[$key]);
+			$results[$key] = ArrayHelper::toInteger($results[$key]);
 		}
 
 		return $results;
@@ -462,7 +461,7 @@ class FinderIndexerQuery
 		foreach ($results as $key => $value)
 		{
 			$results[$key] = array_unique($results[$key]);
-			JArrayHelper::toInteger($results[$key]);
+			$results[$key] = ArrayHelper::toInteger($results[$key]);
 		}
 
 		return $results;
@@ -486,8 +485,7 @@ class FinderIndexerQuery
 		$db = JFactory::getDbo();
 
 		// Initialize user variables
-		$user = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
 
 		// Load the predefined filter.
 		$query = $db->getQuery(true)
@@ -521,7 +519,7 @@ class FinderIndexerQuery
 		// Remove duplicates and sanitize.
 		$filters = explode(',', $return->data);
 		$filters = array_unique($filters);
-		JArrayHelper::toInteger($filters);
+		$filters = ArrayHelper::toInteger($filters);
 
 		// Remove any values of zero.
 		if (array_search(0, $filters, true) !== false)
@@ -580,12 +578,11 @@ class FinderIndexerQuery
 	protected function processDynamicTaxonomy($filters)
 	{
 		// Initialize user variables
-		$user = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
 
 		// Remove duplicates and sanitize.
 		$filters = array_unique($filters);
-		JArrayHelper::toInteger($filters);
+		$filters = ArrayHelper::toInteger($filters);
 
 		// Remove any values of zero.
 		if (array_search(0, $filters, true) !== false)
@@ -682,8 +679,7 @@ class FinderIndexerQuery
 		// The value of 'today' is a special case that we need to handle.
 		if ($date1 === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 		{
-			$today = JFactory::getDate('now', $offset);
-			$date1 = $today->format('%Y-%m-%d');
+			$date1 = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 		}
 
 		// Try to parse the date string.
@@ -700,8 +696,7 @@ class FinderIndexerQuery
 		// The value of 'today' is a special case that we need to handle.
 		if ($date2 === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 		{
-			$today = JFactory::getDate('now', $offset);
-			$date2 = $today->format('%Y-%m-%d');
+			$date2 = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 		}
 
 		// Try to parse the date string.
@@ -808,8 +803,7 @@ class FinderIndexerQuery
 						// The value of 'today' is a special case that we need to handle.
 						if ($value === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 						{
-							$today = JFactory::getDate('now', $offset);
-							$value = $today->format('%Y-%m-%d');
+							$value = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 						}
 
 						// Try to parse the date string.

--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -207,12 +207,11 @@ class FinderIndexerResult
 	 */
 	public function __set($name, $value)
 	{
-		$this->elements[$name] = $value;
+		$this->setElement($name, $value);
 	}
 
 	/**
-	 * The magic get method is used to retrieve additional element values
-	 * from the elements array.
+	 * The magic get method is used to retrieve additional element values from the elements array.
 	 *
 	 * @param   string  $name  The name of the element.
 	 *
@@ -222,20 +221,11 @@ class FinderIndexerResult
 	 */
 	public function __get($name)
 	{
-		// Get the element value if set.
-		if (array_key_exists($name, $this->elements))
-		{
-			return $this->elements[$name];
-		}
-		else
-		{
-			return null;
-		}
+		return $this->getElement($name);
 	}
 
 	/**
-	 * The magic isset method is used to check the state of additional element
-	 * values in the elements array.
+	 * The magic isset method is used to check the state of additional element values in the elements array.
 	 *
 	 * @param   string  $name  The name of the element.
 	 *
@@ -249,8 +239,7 @@ class FinderIndexerResult
 	}
 
 	/**
-	 * The magic unset method is used to unset additional element values in the
-	 * elements array.
+	 * The magic unset method is used to unset additional element values in the elements array.
 	 *
 	 * @param   string  $name  The name of the element.
 	 *
@@ -279,10 +268,8 @@ class FinderIndexerResult
 		{
 			return $this->elements[$name];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**

--- a/administrator/components/com_finder/helpers/indexer/stemmer.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer.php
@@ -56,17 +56,15 @@ abstract class FinderIndexerStemmer
 		$class = 'FinderIndexerStemmer' . ucfirst($adapter);
 
 		// Check if a stemmer exists for the adapter.
-		if (file_exists($path))
-		{
-			// Instantiate the stemmer.
-			include_once $path;
-			$instances[$adapter] = new $class;
-		}
-		else
+		if (!file_exists($path))
 		{
 			// Throw invalid adapter exception.
 			throw new Exception(JText::sprintf('COM_FINDER_INDEXER_INVALID_STEMMER', $adapter));
 		}
+
+		// Instantiate the stemmer.
+		include_once $path;
+		$instances[$adapter] = new $class;
 
 		return $instances[$adapter];
 	}

--- a/administrator/components/com_finder/helpers/indexer/stemmer/fr.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer/fr.php
@@ -27,7 +27,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 	 * @var    array
 	 * @since  3.0
 	 */
-	private static $_stemRules = null;
+	private static $stemRules = null;
 
 	/**
 	 * Method to stem a token and return the root.
@@ -57,7 +57,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 		if (!isset($this->cache[$lang][$token]))
 		{
 			// Stem the token.
-			$result = static::_getStem($token);
+			$result = self::getStem($token);
 
 			// Add the token to the cache.
 			$this->cache[$lang][$token] = $result;
@@ -75,9 +75,9 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 	 */
 	protected static function getStemRules()
 	{
-		if (static::$_stemRules)
+		if (self::$stemRules)
 		{
-			return static::$_stemRules;
+			return self::$stemRules;
 		}
 
 		$vars = array();
@@ -134,9 +134,9 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 			'eya2i.', 'ya1i.', 'yo1i.', 'esu1.', 'ugi1.', 'tt1.', 'end0.'
 		);
 
-		static::$_stemRules = $vars;
+		self::$stemRules = $vars;
 
-		return static::$_stemRules;
+		return self::$stemRules;
 	}
 
 	/**
@@ -151,7 +151,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 	 *
 	 * @since   3.0
 	 */
-	private static function _getFirstRule($reversed_input, $rule_number)
+	private static function getFirstRule($reversed_input, $rule_number)
 	{
 		$vars = static::getStemRules();
 
@@ -181,7 +181,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 	 *
 	 * @since   3.0
 	 */
-	private static function _check($reversed_stem)
+	private static function check($reversed_stem)
 	{
 		$vars = static::getStemRules();
 
@@ -212,7 +212,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 	 *
 	 * @since   3.0
 	 */
-	private static function _getStem($input)
+	private static function getStem($input)
 	{
 		$vars = static::getStemRules();
 
@@ -223,7 +223,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 		// This loop goes through the rules' array until it finds an ending one (ending by '.') or the last one ('end0.')
 		while (true)
 		{
-			$rule_number = static::_getFirstRule($reversed_input, $rule_number);
+			$rule_number = self::getFirstRule($reversed_input, $rule_number);
 
 			if ($rule_number == -1)
 			{
@@ -238,7 +238,7 @@ class FinderIndexerStemmerFr extends FinderIndexerStemmer
 			{
 				$reversed_stem = utf8_decode($matches[4]) . substr($reversed_input, $matches[3], strlen($reversed_input) - $matches[3]);
 
-				if (self::_check($reversed_stem))
+				if (self::check($reversed_stem))
 				{
 					$reversed_input = $reversed_stem;
 

--- a/administrator/components/com_finder/helpers/indexer/stemmer/porter_en.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer/porter_en.php
@@ -27,7 +27,7 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 * @var    string
 	 * @since  2.5
 	 */
-	private static $_regex_consonant = '(?:[bcdfghjklmnpqrstvwxz]|(?<=[aeiou])y|^y)';
+	private static $regex_consonant = '(?:[bcdfghjklmnpqrstvwxz]|(?<=[aeiou])y|^y)';
 
 	/**
 	 * Regex for matching a vowel
@@ -35,7 +35,7 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 * @var    string
 	 * @since  2.5
 	 */
-	private static $_regex_vowel = '(?:[aeiou]|(?<![aeiou])y)';
+	private static $regex_vowel = '(?:[aeiou]|(?<![aeiou])y)';
 
 	/**
 	 * Method to stem a token and return the root.
@@ -66,12 +66,12 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 		{
 			// Stem the token.
 			$result = $token;
-			$result = self::_step1ab($result);
-			$result = self::_step1c($result);
-			$result = self::_step2($result);
-			$result = self::_step3($result);
-			$result = self::_step4($result);
-			$result = self::_step5($result);
+			$result = self::step1ab($result);
+			$result = self::step1c($result);
+			$result = self::step2($result);
+			$result = self::step3($result);
+			$result = self::step4($result);
+			$result = self::step5($result);
 
 			// Add the token to the cache.
 			$this->cache[$lang][$token] = $result;
@@ -89,37 +89,37 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step1ab($word)
+	private static function step1ab($word)
 	{
 		// Part a
 		if (substr($word, -1) == 's')
 		{
-			self::_replace($word, 'sses', 'ss')
-			or self::_replace($word, 'ies', 'i')
-			or self::_replace($word, 'ss', 'ss')
-			or self::_replace($word, 's', '');
+			self::replace($word, 'sses', 'ss')
+			or self::replace($word, 'ies', 'i')
+			or self::replace($word, 'ss', 'ss')
+			or self::replace($word, 's', '');
 		}
 
 		// Part b
-		if (substr($word, -2, 1) != 'e' or !self::_replace($word, 'eed', 'ee', 0))
+		if (substr($word, -2, 1) != 'e' or !self::replace($word, 'eed', 'ee', 0))
 		{
 			// First rule
-			$v = self::$_regex_vowel;
+			$v = self::$regex_vowel;
 
 			// Words ending with ing and ed
 			// Note use of && and OR, for precedence reasons
-			if (preg_match("#$v+#", substr($word, 0, -3)) && self::_replace($word, 'ing', '')
-				or preg_match("#$v+#", substr($word, 0, -2)) && self::_replace($word, 'ed', ''))
+			if (preg_match("#$v+#", substr($word, 0, -3)) && self::replace($word, 'ing', '')
+				or preg_match("#$v+#", substr($word, 0, -2)) && self::replace($word, 'ed', ''))
 			{
 				// If one of above two test successful
-				if (!self::_replace($word, 'at', 'ate') and !self::_replace($word, 'bl', 'ble') and !self::_replace($word, 'iz', 'ize'))
+				if (!self::replace($word, 'at', 'ate') and !self::replace($word, 'bl', 'ble') and !self::replace($word, 'iz', 'ize'))
 				{
 					// Double consonant ending
-					if (self::_doubleConsonant($word) and substr($word, -2) != 'll' and substr($word, -2) != 'ss' and substr($word, -2) != 'zz')
+					if (self::doubleConsonant($word) and substr($word, -2) != 'll' and substr($word, -2) != 'ss' and substr($word, -2) != 'zz')
 					{
 						$word = substr($word, 0, -1);
 					}
-					elseif (self::_m($word) == 1 and self::_cvc($word))
+					elseif (self::m($word) == 1 and self::cvc($word))
 					{
 						$word .= 'e';
 					}
@@ -139,13 +139,13 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step1c($word)
+	private static function step1c($word)
 	{
-		$v = self::$_regex_vowel;
+		$v = self::$regex_vowel;
 
 		if (substr($word, -1) == 'y' && preg_match("#$v+#", substr($word, 0, -1)))
 		{
-			self::_replace($word, 'y', 'i');
+			self::replace($word, 'y', 'i');
 		}
 
 		return $word;
@@ -160,46 +160,46 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step2($word)
+	private static function step2($word)
 	{
 		switch (substr($word, -2, 1))
 		{
 			case 'a':
-				self::_replace($word, 'ational', 'ate', 0)
-				or self::_replace($word, 'tional', 'tion', 0);
+				self::replace($word, 'ational', 'ate', 0)
+				or self::replace($word, 'tional', 'tion', 0);
 				break;
 			case 'c':
-				self::_replace($word, 'enci', 'ence', 0)
-				or self::_replace($word, 'anci', 'ance', 0);
+				self::replace($word, 'enci', 'ence', 0)
+				or self::replace($word, 'anci', 'ance', 0);
 				break;
 			case 'e':
-				self::_replace($word, 'izer', 'ize', 0);
+				self::replace($word, 'izer', 'ize', 0);
 				break;
 			case 'g':
-				self::_replace($word, 'logi', 'log', 0);
+				self::replace($word, 'logi', 'log', 0);
 				break;
 			case 'l':
-				self::_replace($word, 'entli', 'ent', 0)
-				or self::_replace($word, 'ousli', 'ous', 0)
-				or self::_replace($word, 'alli', 'al', 0)
-				or self::_replace($word, 'bli', 'ble', 0)
-				or self::_replace($word, 'eli', 'e', 0);
+				self::replace($word, 'entli', 'ent', 0)
+				or self::replace($word, 'ousli', 'ous', 0)
+				or self::replace($word, 'alli', 'al', 0)
+				or self::replace($word, 'bli', 'ble', 0)
+				or self::replace($word, 'eli', 'e', 0);
 				break;
 			case 'o':
-				self::_replace($word, 'ization', 'ize', 0)
-				or self::_replace($word, 'ation', 'ate', 0)
-				or self::_replace($word, 'ator', 'ate', 0);
+				self::replace($word, 'ization', 'ize', 0)
+				or self::replace($word, 'ation', 'ate', 0)
+				or self::replace($word, 'ator', 'ate', 0);
 				break;
 			case 's':
-				self::_replace($word, 'iveness', 'ive', 0)
-				or self::_replace($word, 'fulness', 'ful', 0)
-				or self::_replace($word, 'ousness', 'ous', 0)
-				or self::_replace($word, 'alism', 'al', 0);
+				self::replace($word, 'iveness', 'ive', 0)
+				or self::replace($word, 'fulness', 'ful', 0)
+				or self::replace($word, 'ousness', 'ous', 0)
+				or self::replace($word, 'alism', 'al', 0);
 				break;
 			case 't':
-				self::_replace($word, 'biliti', 'ble', 0)
-				or self::_replace($word, 'aliti', 'al', 0)
-				or self::_replace($word, 'iviti', 'ive', 0);
+				self::replace($word, 'biliti', 'ble', 0)
+				or self::replace($word, 'aliti', 'al', 0)
+				or self::replace($word, 'iviti', 'ive', 0);
 				break;
 		}
 
@@ -215,28 +215,28 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step3($word)
+	private static function step3($word)
 	{
 		switch (substr($word, -2, 1))
 		{
 			case 'a':
-				self::_replace($word, 'ical', 'ic', 0);
+				self::replace($word, 'ical', 'ic', 0);
 				break;
 			case 's':
-				self::_replace($word, 'ness', '', 0);
+				self::replace($word, 'ness', '', 0);
 				break;
 			case 't':
-				self::_replace($word, 'icate', 'ic', 0)
-				or self::_replace($word, 'iciti', 'ic', 0);
+				self::replace($word, 'icate', 'ic', 0)
+				or self::replace($word, 'iciti', 'ic', 0);
 				break;
 			case 'u':
-				self::_replace($word, 'ful', '', 0);
+				self::replace($word, 'ful', '', 0);
 				break;
 			case 'v':
-				self::_replace($word, 'ative', '', 0);
+				self::replace($word, 'ative', '', 0);
 				break;
 			case 'z':
-				self::_replace($word, 'alize', 'al', 0);
+				self::replace($word, 'alize', 'al', 0);
 				break;
 		}
 
@@ -252,58 +252,58 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step4($word)
+	private static function step4($word)
 	{
 		switch (substr($word, -2, 1))
 		{
 			case 'a':
-				self::_replace($word, 'al', '', 1);
+				self::replace($word, 'al', '', 1);
 				break;
 			case 'c':
-					self::_replace($word, 'ance', '', 1)
-				or self::_replace($word, 'ence', '', 1);
+					self::replace($word, 'ance', '', 1)
+				or self::replace($word, 'ence', '', 1);
 				break;
 			case 'e':
-				self::_replace($word, 'er', '', 1);
+				self::replace($word, 'er', '', 1);
 				break;
 			case 'i':
-				self::_replace($word, 'ic', '', 1);
+				self::replace($word, 'ic', '', 1);
 				break;
 			case 'l':
-				self::_replace($word, 'able', '', 1)
-				or self::_replace($word, 'ible', '', 1);
+				self::replace($word, 'able', '', 1)
+				or self::replace($word, 'ible', '', 1);
 				break;
 			case 'n':
-				self::_replace($word, 'ant', '', 1)
-				or self::_replace($word, 'ement', '', 1)
-				or self::_replace($word, 'ment', '', 1)
-				or self::_replace($word, 'ent', '', 1);
+				self::replace($word, 'ant', '', 1)
+				or self::replace($word, 'ement', '', 1)
+				or self::replace($word, 'ment', '', 1)
+				or self::replace($word, 'ent', '', 1);
 				break;
 			case 'o':
 				if (substr($word, -4) == 'tion' or substr($word, -4) == 'sion')
 				{
-					self::_replace($word, 'ion', '', 1);
+					self::replace($word, 'ion', '', 1);
 				}
 				else
 				{
-					self::_replace($word, 'ou', '', 1);
+					self::replace($word, 'ou', '', 1);
 				}
 				break;
 			case 's':
-				self::_replace($word, 'ism', '', 1);
+				self::replace($word, 'ism', '', 1);
 				break;
 			case 't':
-					self::_replace($word, 'ate', '', 1)
-				or self::_replace($word, 'iti', '', 1);
+					self::replace($word, 'ate', '', 1)
+				or self::replace($word, 'iti', '', 1);
 				break;
 			case 'u':
-				self::_replace($word, 'ous', '', 1);
+				self::replace($word, 'ous', '', 1);
 				break;
 			case 'v':
-				self::_replace($word, 'ive', '', 1);
+				self::replace($word, 'ive', '', 1);
 				break;
 			case 'z':
-				self::_replace($word, 'ize', '', 1);
+				self::replace($word, 'ize', '', 1);
 				break;
 		}
 
@@ -319,26 +319,26 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _step5($word)
+	private static function step5($word)
 	{
 		// Part a
 		if (substr($word, -1) == 'e')
 		{
-			if (self::_m(substr($word, 0, -1)) > 1)
+			if (self::m(substr($word, 0, -1)) > 1)
 			{
-				self::_replace($word, 'e', '');
+				self::replace($word, 'e', '');
 			}
-			elseif (self::_m(substr($word, 0, -1)) == 1)
+			elseif (self::m(substr($word, 0, -1)) == 1)
 			{
-				if (!self::_cvc(substr($word, 0, -1)))
+				if (!self::cvc(substr($word, 0, -1)))
 				{
-					self::_replace($word, 'e', '');
+					self::replace($word, 'e', '');
 				}
 			}
 		}
 
 		// Part b
-		if (self::_m($word) > 1 and self::_doubleConsonant($word) and substr($word, -1) == 'l')
+		if (self::m($word) > 1 and self::doubleConsonant($word) and substr($word, -1) == 'l')
 		{
 			$word = substr($word, 0, -1);
 		}
@@ -361,7 +361,7 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _replace(&$str, $check, $repl, $m = null)
+	private static function replace(&$str, $check, $repl, $m = null)
 	{
 		$len = 0 - strlen($check);
 
@@ -369,7 +369,7 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 		{
 			$substr = substr($str, 0, $len);
 
-			if (is_null($m) or self::_m($substr) > $m)
+			if (is_null($m) or self::m($substr) > $m)
 			{
 				$str = $substr . $repl;
 			}
@@ -396,10 +396,10 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _m($str)
+	private static function m($str)
 	{
-		$c = self::$_regex_consonant;
-		$v = self::$_regex_vowel;
+		$c = self::$regex_consonant;
+		$v = self::$regex_vowel;
 
 		$str = preg_replace("#^$c+#", '', $str);
 		$str = preg_replace("#$v+$#", '', $str);
@@ -419,9 +419,9 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _doubleConsonant($str)
+	private static function doubleConsonant($str)
 	{
-		$c = self::$_regex_consonant;
+		$c = self::$regex_consonant;
 
 		return preg_match("#$c{2}$#", $str, $matches) and $matches[0]{0} == $matches[0]{1};
 	}
@@ -435,10 +435,10 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 *
 	 * @since   2.5
 	 */
-	private static function _cvc($str)
+	private static function cvc($str)
 	{
-		$c = self::$_regex_consonant;
-		$v = self::$_regex_vowel;
+		$c = self::$regex_consonant;
+		$v = self::$regex_vowel;
 
 		return preg_match("#($c$v$c)$#", $str, $matches) and strlen($matches[1]) == 3 and $matches[1]{2} != 'w' and $matches[1]{2} != 'x'
 			and $matches[1]{2} != 'y';

--- a/administrator/components/com_finder/helpers/indexer/taxonomy.php
+++ b/administrator/components/com_finder/helpers/indexer/taxonomy.php
@@ -47,9 +47,9 @@ class FinderIndexerTaxonomy
 	public static function addBranch($title, $state = 1, $access = 1)
 	{
 		// Check to see if the branch is in the cache.
-		if (isset(self::$branches[$title]))
+		if (isset(static::$branches[$title]))
 		{
-			return self::$branches[$title]->id;
+			return static::$branches[$title]->id;
 		}
 
 		// Check to see if the branch is in the table.
@@ -68,9 +68,9 @@ class FinderIndexerTaxonomy
 		if (!empty($result) && $result->state == $state && $result->access == $access)
 		{
 			// The data matches, add the item to the cache.
-			self::$branches[$title] = $result;
+			static::$branches[$title] = $result;
 
-			return self::$branches[$title]->id;
+			return static::$branches[$title]->id;
 		}
 
 		/*
@@ -100,12 +100,12 @@ class FinderIndexerTaxonomy
 		}
 
 		// Store the branch.
-		self::storeNode($branch);
+		static::storeNode($branch);
 
 		// Add the branch to the cache.
-		self::$branches[$title] = $branch;
+		static::$branches[$title] = $branch;
 
-		return self::$branches[$title]->id;
+		return static::$branches[$title]->id;
 	}
 
 	/**
@@ -124,13 +124,13 @@ class FinderIndexerTaxonomy
 	public static function addNode($branch, $title, $state = 1, $access = 1)
 	{
 		// Check to see if the node is in the cache.
-		if (isset(self::$nodes[$branch][$title]))
+		if (isset(static::$nodes[$branch][$title]))
 		{
-			return self::$nodes[$branch][$title]->id;
+			return static::$nodes[$branch][$title]->id;
 		}
 
 		// Get the branch id, insert it if it does not exist.
-		$branchId = self::addBranch($branch);
+		$branchId = static::addBranch($branch);
 
 		// Check to see if the node is in the table.
 		$db = JFactory::getDbo();
@@ -148,9 +148,9 @@ class FinderIndexerTaxonomy
 		if (!empty($result) && $result->state == $state && $result->access == $access)
 		{
 			// The data matches, add the item to the cache.
-			self::$nodes[$branch][$title] = $result;
+			static::$nodes[$branch][$title] = $result;
 
-			return self::$nodes[$branch][$title]->id;
+			return static::$nodes[$branch][$title]->id;
 		}
 
 		/*
@@ -180,12 +180,12 @@ class FinderIndexerTaxonomy
 		}
 
 		// Store the node.
-		self::storeNode($node);
+		static::storeNode($node);
 
 		// Add the node to the cache.
-		self::$nodes[$branch][$title] = $node;
+		static::$nodes[$branch][$title] = $node;
 
-		return self::$nodes[$branch][$title]->id;
+		return static::$nodes[$branch][$title]->id;
 	}
 
 	/**
@@ -242,8 +242,7 @@ class FinderIndexerTaxonomy
 		$db = JFactory::getDbo();
 
 		// Set user variables
-		$user = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
 
 		// Create a query to get the taxonomy branch titles.
 		$query = $db->getQuery(true)
@@ -255,9 +254,8 @@ class FinderIndexerTaxonomy
 
 		// Get the branch titles.
 		$db->setQuery($query);
-		$results = $db->loadColumn();
 
-		return $results;
+		return $db->loadColumn();
 	}
 
 	/**
@@ -276,8 +274,7 @@ class FinderIndexerTaxonomy
 		$db = JFactory::getDbo();
 
 		// Set user variables
-		$user = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
+		$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
 
 		// Create a query to get the node.
 		$query = $db->getQuery(true)
@@ -293,9 +290,8 @@ class FinderIndexerTaxonomy
 
 		// Get the node.
 		$db->setQuery($query, 0, 1);
-		$result = $db->loadObject();
 
-		return $result;
+		return $db->loadObject();
 	}
 
 	/**

--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -33,10 +33,8 @@ class FinderHelperLanguage
 		{
 			return 'PLG_FINDER_QUERY_FILTER_BRANCH_P_' . $return;
 		}
-		else
-		{
-			return $branchName;
-		}
+
+		return $branchName;
 	}
 
 	/**
@@ -64,8 +62,7 @@ class FinderHelperLanguage
 	 */
 	public static function loadComponentLanguage()
 	{
-		$lang = JFactory::getLanguage();
-		$lang->load('com_finder', JPATH_SITE);
+		JFactory::getLanguage()->load('com_finder', JPATH_SITE);
 	}
 
 	/**

--- a/administrator/components/com_finder/models/filter.php
+++ b/administrator/components/com_finder/models/filter.php
@@ -50,7 +50,7 @@ class FinderModelFilter extends JModelAdmin
 	/**
 	 * Method to get the filter data.
 	 *
-	 * @return  mixed  The filter data.
+	 * @return  FinderTableFilter|boolean  The filter data or false on a failure.
 	 *
 	 * @since   2.5
 	 */
@@ -99,7 +99,7 @@ class FinderModelFilter extends JModelAdmin
 	 * @param   array    $data      Data for the form. [optional]
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not. [optional]
 	 *
-	 * @return  mixed  A JForm object on success, false on failure
+	 * @return  JForm|boolean  A JForm object on success, false on failure
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/models/filters.php
+++ b/administrator/components/com_finder/models/filters.php
@@ -22,7 +22,7 @@ class FinderModelFilters extends JModelList
 	 * @param   array  $config  An associative array of configuration settings. [optional]
 	 *
 	 * @since   2.5
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
@@ -116,7 +116,7 @@ class FinderModelFilters extends JModelList
 	 *
 	 * @since   2.5
 	 */
-	protected function populateState($ordering = null, $direction = null)
+	protected function populateState($ordering = 'a.title', $direction = 'asc')
 	{
 		// Load the filter state.
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
@@ -130,6 +130,6 @@ class FinderModelFilters extends JModelList
 		$this->setState('params', $params);
 
 		// List state information.
-		parent::populateState('a.title', 'asc');
+		parent::populateState($ordering, $direction);
 	}
 }

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -38,7 +38,7 @@ class FinderModelIndex extends JModelList
 	 * @param   array  $config  An associative array of configuration settings. [optional]
 	 *
 	 * @since   2.5
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
@@ -67,9 +67,7 @@ class FinderModelIndex extends JModelList
 	 */
 	protected function canDelete($record)
 	{
-		$user = JFactory::getUser();
-
-		return $user->authorise('core.delete', $this->option);
+		return JFactory::getUser()->authorise('core.delete', $this->option);
 	}
 
 	/**
@@ -83,9 +81,7 @@ class FinderModelIndex extends JModelList
 	 */
 	protected function canEditState($record)
 	{
-		$user = JFactory::getUser();
-
-		return $user->authorise('core.edit.state', $this->option);
+		return JFactory::getUser()->authorise('core.edit.state', $this->option);
 	}
 
 	/**
@@ -215,7 +211,7 @@ class FinderModelIndex extends JModelList
 	/**
 	 * Method to get the state of the Smart Search plug-ins.
 	 *
-	 * @return  array   Array of relevant plug-ins and whether they are enabled or not.
+	 * @return  array  Array of relevant plug-ins and whether they are enabled or not.
 	 *
 	 * @since   2.5
 	 */
@@ -229,10 +225,8 @@ class FinderModelIndex extends JModelList
 			->where($db->quoteName('folder') . ' IN(' . $db->quote('system') . ',' . $db->quote('content') . ')')
 			->where($db->quoteName('element') . ' = ' . $db->quote('finder'));
 		$db->setQuery($query);
-		$db->execute();
-		$plugins = $db->loadObjectList('name');
 
-		return $plugins;
+		return $db->loadObjectList('name');
 	}
 
 	/**
@@ -330,7 +324,7 @@ class FinderModelIndex extends JModelList
 	 *
 	 * @since   2.5
 	 */
-	protected function populateState($ordering = null, $direction = null)
+	protected function populateState($ordering = 'l.title', $direction = 'asc')
 	{
 		// Load the filter state.
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
@@ -347,7 +341,7 @@ class FinderModelIndex extends JModelList
 		$this->setState('params', $params);
 
 		// List state information.
-		parent::populateState('l.title', 'asc');
+		parent::populateState($ordering, $direction);
 	}
 
 	/**

--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -22,7 +22,7 @@ class FinderModelMaps extends JModelList
 	 * @param   array  $config  An associative array of configuration settings. [optional]
 	 *
 	 * @since   2.5
-	 * @see     JController
+	 * @see     JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
@@ -48,9 +48,7 @@ class FinderModelMaps extends JModelList
 	 */
 	protected function canDelete($record)
 	{
-		$user = JFactory::getUser();
-
-		return $user->authorise('core.delete', $this->option);
+		return JFactory::getUser()->authorise('core.delete', $this->option);
 	}
 
 	/**
@@ -64,9 +62,7 @@ class FinderModelMaps extends JModelList
 	 */
 	protected function canEditState($record)
 	{
-		$user = JFactory::getUser();
-
-		return $user->authorise('core.edit.state', $this->option);
+		return JFactory::getUser()->authorise('core.edit.state', $this->option);
 	}
 
 	/**
@@ -254,7 +250,7 @@ class FinderModelMaps extends JModelList
 	 *
 	 * @since   2.5
 	 */
-	protected function populateState($ordering = null, $direction = null)
+	protected function populateState($ordering = 'a.title', $direction = 'asc')
 	{
 		// Load the filter state.
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
@@ -271,7 +267,7 @@ class FinderModelMaps extends JModelList
 		$this->setState('params', $params);
 
 		// List state information.
-		parent::populateState('a.title', 'asc');
+		parent::populateState($ordering, $direction);
 	}
 
 	/**

--- a/administrator/components/com_finder/models/statistics.php
+++ b/administrator/components/com_finder/models/statistics.php
@@ -19,7 +19,7 @@ class FinderModelStatistics extends JModelLegacy
 	/**
 	 * Method to get the component statistics
 	 *
-	 * @return  object  The component statistics
+	 * @return  JObject  The component statistics
 	 *
 	 * @since   2.5
 	 */
@@ -60,7 +60,7 @@ class FinderModelStatistics extends JModelLegacy
 			->from($db->quoteName('#__finder_links') . ' AS a')
 			->join('INNER', $db->quoteName('#__finder_types') . ' AS t ON t.id = a.type_id')
 			->group('a.type_id, t.title')
-			->order($db->quoteName('type_title'), 'ASC');
+			->order($db->quoteName('type_title') . ' ASC');
 		$db->setQuery($query);
 		$data->type_list = $db->loadObjectList();
 

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Filter table class for the Finder package.
@@ -110,7 +111,7 @@ class FinderTableFilter extends JTable
 		$k = $this->_tbl_key;
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
 		$state = (int) $state;
 
@@ -197,15 +198,15 @@ class FinderTableFilter extends JTable
 	 */
 	public function store($updateNulls = false)
 	{
-		$date = JFactory::getDate();
-		$user = JFactory::getUser();
+		$date = JFactory::getDate()->toSql();
+		$userId = JFactory::getUser()->id;
 
-		$this->modified = $date->toSql();
+		$this->modified = $date;
 
 		if ($this->filter_id)
 		{
 			// Existing item
-			$this->modified_by = $user->get('id');
+			$this->modified_by = $userId;
 		}
 		else
 		{
@@ -213,12 +214,12 @@ class FinderTableFilter extends JTable
 			// so we don't touch it if it is set.
 			if (!(int) $this->created)
 			{
-				$this->created = $date->toSql();
+				$this->created = $date;
 			}
 
 			if (empty($this->created_by))
 			{
-				$this->created_by = $user->get('id');
+				$this->created_by = $userId;
 			}
 		}
 

--- a/administrator/components/com_finder/tables/map.php
+++ b/administrator/components/com_finder/tables/map.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Map table class for the Finder package.
  *
@@ -47,7 +49,7 @@ class FinderTableMap extends JTable
 		$k = $this->_tbl_key;
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$state = (int) $state;
 
 		// If there are no primary keys set check to see if the instance key is set.

--- a/administrator/components/com_finder/views/filter/view.html.php
+++ b/administrator/components/com_finder/views/filter/view.html.php
@@ -17,6 +17,34 @@ defined('_JEXEC') or die;
 class FinderViewFilter extends JViewLegacy
 {
 	/**
+	 * The filter object
+	 *
+	 * @var  FinderTableFilter
+	 */
+	protected $filter;
+
+	/**
+	 * The JForm object
+	 *
+	 * @var  JForm
+	 */
+	protected $form;
+
+	/**
+	 * The active item
+	 *
+	 * @var  object
+	 */
+	protected $item;
+
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
+	protected $state;
+
+	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
@@ -47,7 +75,7 @@ class FinderViewFilter extends JViewLegacy
 		// Configure the toolbar.
 		$this->addToolbar();
 
-		parent::display($tpl);
+		return parent::display($tpl);
 	}
 
 	/**
@@ -61,10 +89,8 @@ class FinderViewFilter extends JViewLegacy
 	{
 		JFactory::getApplication()->input->set('hidemainmenu', true);
 
-		$user = JFactory::getUser();
-		$userId = $user->get('id');
 		$isNew = ($this->item->filter_id == 0);
-		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
+		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == JFactory::getUser()->id);
 		$canDo = JHelperContent::getActions('com_finder');
 
 		// Configure the toolbar.

--- a/administrator/components/com_finder/views/filters/view.html.php
+++ b/administrator/components/com_finder/views/filters/view.html.php
@@ -17,6 +17,41 @@ defined('_JEXEC') or die;
 class FinderViewFilters extends JViewLegacy
 {
 	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
+	protected $items;
+
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * The HTML markup for the sidebar
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
+
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
+	protected $state;
+
+	/**
+	 * The total number of items
+	 *
+	 * @var  object
+	 */
+	protected $total;
+
+	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
@@ -48,7 +83,8 @@ class FinderViewFilters extends JViewLegacy
 		// Configure the toolbar.
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/views/index/view.html.php
+++ b/administrator/components/com_finder/views/index/view.html.php
@@ -19,6 +19,48 @@ JLoader::register('FinderHelperLanguage', JPATH_ADMINISTRATOR . '/components/com
 class FinderViewIndex extends JViewLegacy
 {
 	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
+	protected $items;
+
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * The state of core Smart Search plugins
+	 *
+	 * @var  array
+	 */
+	protected $pluginState;
+
+	/**
+	 * The HTML markup for the sidebar
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
+
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
+	protected $state;
+
+	/**
+	 * The total number of items
+	 *
+	 * @var  object
+	 */
+	protected $total;
+
+	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
@@ -53,7 +95,8 @@ class FinderViewIndex extends JViewLegacy
 		// Configure the toolbar.
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/views/maps/view.html.php
+++ b/administrator/components/com_finder/views/maps/view.html.php
@@ -19,6 +19,41 @@ JLoader::register('FinderHelperLanguage', JPATH_ADMINISTRATOR . '/components/com
 class FinderViewMaps extends JViewLegacy
 {
 	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
+	protected $items;
+
+	/**
+	 * The pagination object
+	 *
+	 * @var  JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * The HTML markup for the sidebar
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
+
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
+	protected $state;
+
+	/**
+	 * The total number of items
+	 *
+	 * @var  object
+	 */
+	protected $total;
+
+	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
@@ -53,7 +88,8 @@ class FinderViewMaps extends JViewLegacy
 		// Prepare the view.
 		$this->addToolbar();
 		$this->sidebar = JHtmlSidebar::render();
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**
@@ -68,7 +104,6 @@ class FinderViewMaps extends JViewLegacy
 		$canDo = JHelperContent::getActions('com_finder');
 
 		JToolbarHelper::title(JText::_('COM_FINDER_MAPS_TOOLBAR_TITLE'), 'zoom-in finder');
-		$toolbar = JToolbar::getInstance('toolbar');
 
 		if ($canDo->get('core.edit.state'))
 		{
@@ -83,7 +118,14 @@ class FinderViewMaps extends JViewLegacy
 		}
 
 		JToolbarHelper::divider();
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
+		JToolbar::getInstance('toolbar')->appendButton(
+			'Popup',
+			'bars',
+			'COM_FINDER_STATISTICS',
+			'index.php?option=com_finder&view=statistics&tmpl=component',
+			550,
+			350
+		);
 		JToolbarHelper::divider();
 		JToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_CONTENT_MAPS');
 

--- a/administrator/components/com_finder/views/statistics/view.html.php
+++ b/administrator/components/com_finder/views/statistics/view.html.php
@@ -17,6 +17,13 @@ defined('_JEXEC') or die;
 class FinderViewStatistics extends JViewLegacy
 {
 	/**
+	 * The index statistics
+	 *
+	 * @var  JObject
+	 */
+	protected $data;
+
+	/**
 	 * Method to display the view.
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
@@ -38,6 +45,6 @@ class FinderViewStatistics extends JViewLegacy
 			return false;
 		}
 
-		parent::display($tpl);
+		return parent::display($tpl);
 	}
 }


### PR DESCRIPTION
This PR is a general overview and cleanup of some code structure and doc blocks in the admin com_finder component. Changes of note:
- Doc blocks cleaned up some to follow standard
- Return the results of the view's `display()` methods to be consistent with the documented return
- Not using variables for items only referenced once
- Use `Joomla\Utilities\ArrayHelper` instead of `JArrayHelper`
- Removed `static $log` from methods instantiating a logger; `JLog::addLogger()` has no return value so the variable cannot be populated with data
- Use of the `JApplicationWeb` API in the indexer for building and sending the application response
- Support late static bindings in the indexer API classes, reference private members as `self::`
- Renamed private members with a leading underscore for code style compliance
### Testing Instructions

The admin com_finder component should continue to function correctly
