### PR TITLE
Correcting Permissions tooltips display

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -259,7 +259,7 @@ class JFormFieldRules extends JFormField
 				$html[] = '<tr>';
 				$html[] = '<td headers="actions-th' . $group->value . '">';
 				$html[] = '<label for="' . $this->id . '_' . $action->name . '_' . $group->value . '" class="hasTooltip" title="'
-					. htmlspecialchars(JText::_($action->title) . ' ' . JText::_($action->description), ENT_COMPAT, 'UTF-8') . '">';
+					. JHtml::_('tooltipText', JText::_($action->title), JText::_($action->description)) . '">';
 				$html[] = JText::_($action->title);
 				$html[] = '</label>';
 				$html[] = '</td>';


### PR DESCRIPTION
Test: display the Permissions tab for any component or global.

Before this patch the title and the content of the tip are incorrectly displayed this way:

![screen shot 2015-10-26 at 08 38 03](https://cloud.githubusercontent.com/assets/869724/10724048/790b85ae-7bc1-11e5-8694-4783de662840.png)

After patch, we get:

![screen shot 2015-10-26 at 08 36 50](https://cloud.githubusercontent.com/assets/869724/10724065/a2e02290-7bc1-11e5-9d6a-dd23df9e3680.png)

When the PR https://github.com/joomla/joomla-cms/pull/8150 will be merged, we will get:

![screen shot 2015-10-26 at 09 09 08](https://cloud.githubusercontent.com/assets/869724/10724076/c427889e-7bc1-11e5-81a9-a06e97b3b039.png)

Note: htmlspecialchars is already modified in https://github.com/joomla/joomla-cms/pull/8150
