### PR TITLE
Don't load tags layouts unless there are tags (Part 2)

### DIFF
--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -49,7 +49,7 @@ jimport('joomla.html.html.bootstrap');
 		</form>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags)) : ?>
+	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>

--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -45,7 +45,7 @@ $cparams = JComponentHelper::getParams('com_media');
 		</form>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags)) : ?>
+	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>

--- a/templates/beez3/html/com_content/article/default.php
+++ b/templates/beez3/html/com_content/article/default.php
@@ -171,7 +171,7 @@ endif;
 	<?php echo $this->item->text; ?>
 
 <?php // TAGS ?>
-<?php if ($params->get('show_tags', 1) && !empty($this->item->tags)) : ?>
+<?php if ($params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 	<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 	<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 <?php endif; ?>


### PR DESCRIPTION
Same as https://github.com/joomla/joomla-cms/pull/3275 but for remaining cases.

The affected layouts are:
- Single Contact page in Protostar and Beez
- Single Article page in Beez

Testing:
Make sure tags are shown when there are some assigned. You should actually see no change.
Testing instructions from PR 3275 can be used as well:

> 1. Test the tags layout is shown in the frontend by viewing an article without tags. Adding a `die;` at the top of the layout (https://github.com/joomla/joomla-cms/blob/staging/layouts/joomla/content/tags.php) should kill your page.
> #### APPLY PR
> 1. Check your article without tags. The page should load happily now because the JLayout isn't being loaded.
> 2. Check an article with tags and ensure the tags still show as expected in the frontend (don't forget to remove the die)
