### PR TITLE
Ensure we have a instance of JApplicationCms

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -91,7 +91,8 @@ class PlgUserJoomla extends JPlugin
 		if ($isnew)
 		{
 			// TODO: Suck in the frontend registration emails here as well. Job for a rainy day.
-			if ($this->app instanceof JApplicationCms && $this->app->isAdmin())
+			// The method check here ensures that if running as a CLI Application we don't get any errors
+			if (method_exists($this->app, 'isAdmin') && $this->app->isAdmin())
 			{
 				if ($mail_to_user)
 				{

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -91,7 +91,7 @@ class PlgUserJoomla extends JPlugin
 		if ($isnew)
 		{
 			// TODO: Suck in the frontend registration emails here as well. Job for a rainy day.
-			if ($this->app->isAdmin())
+			if ($this->app instanceof JApplicationCms && $this->app->isAdmin())
 			{
 				if ($mail_to_user)
 				{


### PR DESCRIPTION
This allows the creation of users via CLI scripts that currently error because the application object is an instance of JApplicationCli and the `isAdmin` method doesn't exist.

You can test by ensuring that creating a user in the frontend and backend of Joomla work as expected. If you want to have bonus brownie points you can _create your own_ CLI script that will now create users succesfully
