### PR TITLE
Changing the selector type to avoid inconsistency

### DIFF
--- a/plugins/system/languagefilter/languagefilter.xml
+++ b/plugins/system/languagefilter/languagefilter.xml
@@ -54,11 +54,10 @@
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
-				<field name="lang_cookie" type="radio"
+				<field name="lang_cookie" type="list"
 					description="PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_DESC"
 					label="PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_LABEL"
 					default="0"
-					class="btn-group btn-group-yesno"
 				>
 					<option value="1">PLG_SYSTEM_LANGUAGEFILTER_OPTION_YEAR</option>
 					<option value="0">PLG_SYSTEM_LANGUAGEFILTER_OPTION_SESSION</option>


### PR DESCRIPTION
#### Steps to reproduce the issue

Go to the language filter plugin
In the backend, go to:
Extensions->Plugins->System - Language Filter 
#### Actual result

The selector for the "Cookie Lifetime" (Year/Session) is a radio btn type with: 
<code>class="btn-group btn-group-yesno"</code> then 'success' (green) for "Year" and 'danger' (red) for "Session"
![before](https://cloud.githubusercontent.com/assets/1972717/10738526/302b75ce-7bee-11e5-94fc-a3a4b50105e1.png)
#### Expected result

As it is not a kind of yes/no selector and to be consistent, I think we should use a <code>type="list"</code> instead of the <code>type="radio"</code>
![after](https://cloud.githubusercontent.com/assets/1972717/10738559/57f177ca-7bee-11e5-94c5-4a777ef96a4f.png)
