### PR TITLE
Redo of #4563

### DIFF
--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.Administrator
+ * @package     Messages
  * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
@@ -14,9 +14,9 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.modal');
 
-JFactory::getDocument()->addScriptDeclaration("
+JFactory::getDocument()->addScriptDeclaration(
+	"
 		Joomla.submitbutton = function(task)
 		{
 			if (task == 'config.cancel' || document.formvalidator.isValid(document.getElementById('config-form')))
@@ -24,49 +24,17 @@ JFactory::getDocument()->addScriptDeclaration("
 				Joomla.submitform(task, document.getElementById('config-form'));
 			}
 		};
-");
+	"
+);
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
+<form action="<?php echo JRoute::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
 	<fieldset>
-		<div>
-			<div class="modal-header">
-				<h3><?php echo JText::_('COM_MESSAGES_MY_SETTINGS');?></h3>
-			</div>
-			<div class="modal-body">
-				<button class="btn btn-primary" type="submit" onclick="Joomla.submitform('config.save', this.form);window.top.setTimeout('window.parent.jModalClose()', 700);">
-					<?php echo JText::_('JSAVE');?></button>
-				<button class="btn" type="button" onclick="window.parent.jModalClose();">
-					<?php echo JText::_('JCANCEL');?></button>
-				<hr />
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('lock'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('lock'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('mail_on_new'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('mail_on_new'); ?>
-					</div>
-				</div>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('auto_purge'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('auto_purge'); ?>
-					</div>
-				</div>
+		<?php echo $this->form->renderField('lock'); ?>
+		<?php echo $this->form->renderField('mail_on_new'); ?>
+		<?php echo $this->form->renderField('auto_purge'); ?>
+	</fieldset>
+	<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
 
-			</div>
-		</div>
-		</fieldset>
-		<input type="hidden" name="task" value="" />
-		<?php echo JHtml::_('form.token'); ?>
-
+	<input type="hidden" name="task" value="" />
+	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Messages
+ * @package     Joomla.Administrator
  * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.

--- a/administrator/components/com_messages/views/message/tmpl/default.php
+++ b/administrator/components/com_messages/views/message/tmpl/default.php
@@ -8,7 +8,8 @@
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.framework');
+
+JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  Messages
+ * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_messages
+ * @subpackage  Messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -19,33 +19,44 @@ JHtml::_('formbehavior.chosen', 'select');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-?>
 
+JFactory::getDocument()->addStyleDeclaration(
+	"
+	@media (min-width: 768px) {
+		div.modal {
+			left: none;
+			width: 500px;
+			margin-left: -250px;
+		}
+	}
+	"
+);
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_messages&view=messages'); ?>" method="post" name="adminForm" id="adminForm">
-<?php if (!empty( $this->sidebar)) : ?>
+	<?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 	</div>
 	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
-		<div id="filter-bar" class="btn-toolbar">
-			<div class="filter-search btn-group pull-left">
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_MESSAGES_SEARCH_IN_SUBJECT'); ?>" />
+		<?php else : ?>
+		<div id="j-main-container">
+			<?php endif;?>
+			<div id="filter-bar" class="btn-toolbar">
+				<div class="filter-search btn-group pull-left">
+					<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_MESSAGES_SEARCH_IN_SUBJECT'); ?>" />
+				</div>
+				<div class="btn-group pull-left">
+					<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
+					<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
+				</div>
+				<div class="btn-group pull-left hidden-phone">
+					<select name="filter_state" onchange="this.form.submit()">
+						<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
+						<?php echo JHtml::_('select.options', MessagesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
+					</select>
+				</div>
 			</div>
-			<div class="btn-group pull-left">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-			</div>
-			<div class="btn-group pull-left hidden-phone">
-				<select name="filter_state" onchange="this.form.submit()">
-					<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-					<?php echo JHtml::_('select.options', MessagesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
-				</select>
-			</div>
-		</div>
-		<div class="clearfix"> </div>
+			<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">
 				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
@@ -104,7 +115,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				</tbody>
 			</table>
 		<?php endif; ?>
-
 		<div>
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  Messages
+ * @subpackage  com_messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -89,7 +89,9 @@ class MessagesViewMessages extends JViewLegacy
 			'',
 			'<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
 			. JText::_('JCANCEL')
-			. '</button><button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
+			. '</button>'
+			. '<button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true"'
+			. ' onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
 			. JText::_('JSAVE')
 			. '</button>'
 		);

--- a/administrator/components/com_messages/views/messages/view.html.php
+++ b/administrator/components/com_messages/views/messages/view.html.php
@@ -1,14 +1,13 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_messages
+ * @subpackage  Messages
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
-JHtml::_('behavior.modal');
 
 /**
  * View class for a list of messages.
@@ -42,7 +41,6 @@ class MessagesViewMessages extends JViewLegacy
 		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode("\n", $errors));
-
 			return false;
 		}
 
@@ -62,7 +60,6 @@ class MessagesViewMessages extends JViewLegacy
 	{
 		$state = $this->get('State');
 		$canDo = JHelperContent::getActions('com_messages');
-
 		JToolbarHelper::title(JText::_('COM_MESSAGES_MANAGER_MESSAGES'), 'envelope inbox');
 
 		if ($canDo->get('core.create'))
@@ -78,13 +75,24 @@ class MessagesViewMessages extends JViewLegacy
 		}
 
 		JToolbarHelper::divider();
-		$bar = JToolbar::getInstance('toolbar');
-
-		// Instantiate a new JLayoutFile instance and render the layout
-		JHtml::_('behavior.modal', 'a.messagesSettings');
-		$layout = new JLayoutFile('toolbar.mysettings');
-
-		$bar->appendButton('Custom', $layout->render(array()), 'upload');
+		$bar = JToolBar::getInstance('toolbar');
+		$bar->appendButton(
+			'Popup',
+			'cog',
+			'COM_MESSAGES_TOOLBAR_MY_SETTINGS',
+			'index.php?option=com_messages&amp;view=config&amp;tmpl=component',
+			500,
+			250,
+			0,
+			0,
+			'',
+			'',
+			'<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
+			. JText::_('JCANCEL')
+			. '</button><button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
+			. JText::_('JSAVE')
+			. '</button>'
+		);
 
 		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))
 		{


### PR DESCRIPTION
#### The PR #4563 was broken into two parts

 in order to get it merged in the messages repo. But that didn’t happen so I just did that missing part here.

In short this PR drops the mootools modal for the config modal of the component messages.
To test simply check that the modal still operates and the configuration gets saved in com_messages
