### PR TITLE
Use Popovers instead of Tooltips if a title and description is present

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -165,6 +165,131 @@ body.modal-open {
 	font-size: 1.2em;
 	line-height: 1.6em;
 }
+.popover {
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 1010;
+	display: none;
+	max-width: 276px;
+	padding: 1px;
+	text-align: left;
+	background-color: #ffffff;
+	-webkit-background-clip: padding-box;
+	-moz-background-clip: padding;
+	background-clip: padding-box;
+	border: 1px solid #ccc;
+	border: 1px solid rgba(0,0,0,0.2);
+	-webkit-border-radius: 6px;
+	-moz-border-radius: 6px;
+	border-radius: 6px;
+	-webkit-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	-moz-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	white-space: normal;
+}
+.popover.top {
+	margin-top: -10px;
+}
+.popover.right {
+	margin-left: 10px;
+}
+.popover.bottom {
+	margin-top: 10px;
+}
+.popover.left {
+	margin-left: -10px;
+}
+.popover-title {
+	margin: 0;
+	padding: 8px 14px;
+	font-size: 14px;
+	font-weight: normal;
+	line-height: 18px;
+	background-color: #f7f7f7;
+	border-bottom: 1px solid #ebebeb;
+	-webkit-border-radius: 5px 5px 0 0;
+	-moz-border-radius: 5px 5px 0 0;
+	border-radius: 5px 5px 0 0;
+}
+.popover-title:empty {
+	display: none;
+}
+.popover-content {
+	padding: 9px 14px;
+}
+.popover .arrow,
+.popover .arrow:after {
+	position: absolute;
+	display: block;
+	width: 0;
+	height: 0;
+	border-color: transparent;
+	border-style: solid;
+}
+.popover .arrow {
+	border-width: 11px;
+}
+.popover .arrow:after {
+	border-width: 10px;
+	content: "";
+}
+.popover.top .arrow {
+	left: 50%;
+	margin-left: -11px;
+	border-bottom-width: 0;
+	border-top-color: #999;
+	border-top-color: rgba(0,0,0,0.25);
+	bottom: -11px;
+}
+.popover.top .arrow:after {
+	bottom: 1px;
+	margin-left: -10px;
+	border-bottom-width: 0;
+	border-top-color: #ffffff;
+}
+.popover.right .arrow {
+	top: 50%;
+	left: -11px;
+	margin-top: -11px;
+	border-left-width: 0;
+	border-right-color: #999;
+	border-right-color: rgba(0,0,0,0.25);
+}
+.popover.right .arrow:after {
+	left: 1px;
+	bottom: -10px;
+	border-left-width: 0;
+	border-right-color: #ffffff;
+}
+.popover.bottom .arrow {
+	left: 50%;
+	margin-left: -11px;
+	border-top-width: 0;
+	border-bottom-color: #999;
+	border-bottom-color: rgba(0,0,0,0.25);
+	top: -11px;
+}
+.popover.bottom .arrow:after {
+	top: 1px;
+	margin-left: -10px;
+	border-top-width: 0;
+	border-bottom-color: #ffffff;
+}
+.popover.left .arrow {
+	top: 50%;
+	right: -11px;
+	margin-top: -11px;
+	border-right-width: 0;
+	border-left-color: #999;
+	border-left-color: rgba(0,0,0,0.25);
+}
+.popover.left .arrow:after {
+	right: 1px;
+	border-right-width: 0;
+	border-left-color: #ffffff;
+	bottom: -10px;
+}
 @font-face {
 	font-family: 'IcoMoon';
 	src: url('../../../../media/jui/fonts/IcoMoon.eot');

--- a/administrator/templates/hathor/css/template_rtl.css
+++ b/administrator/templates/hathor/css/template_rtl.css
@@ -1289,6 +1289,7 @@ div.btn-toolbar {
 	float: left;
 }
 
+.popover,
 .tooltip-inner {
 	text-align: right;
 }

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -11,6 +11,9 @@
 @import "modals.less";
 //@import "../../../../media/jui/less/modals.joomla.less";
 
+// Bootstrap Popovers
+@import "../../../../media/jui/less/popovers.less";
+
 // Icon Font
 @import "icomoon.less";
 

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1671,6 +1671,7 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
 }
@@ -8872,8 +8873,17 @@ body {
 #mediamanager-form .dimensions {
 	direction: ltr;
 }
+.popover,
 .tooltip-inner {
 	text-align: right;
+}
+.popover.top .arrow,
+.popover.bottom .arrow {
+	margin-right: -11px;
+}
+.popover.top .arrow:after,
+.popover.bottom .arrow:after {
+	margin-right: -10px;
 }
 @media (max-width: 480px) {
 	.btn-toolbar .btn-wrapper {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1671,6 +1671,7 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
 }

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -29,9 +29,24 @@ $title = '';
 
 if (!empty($description))
 {
-	JHtml::_('bootstrap.tooltip');
-	$classes[] = 'hasTooltip';
-	$title     = ' title="' . JHtml::tooltipText(trim($text, ':'), $description, 0) . '"';
+	if ($text && $text != $description)
+	{
+		JHtml::_('bootstrap.popover');
+		$classes[] = 'hasPopover';
+		$title     = ' title="' . htmlspecialchars(trim($text, ':')) . '"'
+			. ' data-content="'. htmlspecialchars($description) . '"';
+
+		if (JFactory::getLanguage()->isRtl() && !$position)
+		{
+			$position = ' data-placement="left" ';
+		}
+	}
+	else
+	{
+		JHtml::_('bootstrap.tooltip');
+		$classes[] = 'hasTooltip';
+		$title     = ' title="' . JHtml::tooltipText(trim($text, ':'), $description, 0) . '"';
+	}
 }
 
 if ($required)

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -11,10 +11,12 @@ defined('JPATH_BASE') or die;
 
 $data = $displayData;
 
-$metatitle = JHtml::tooltipText(JText::_($data->tip ? $data->tip : $data->title), JText::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN'), 0);
-JHtml::_('bootstrap.tooltip');
+$title = htmlspecialchars(JText::_($data->tip ? $data->tip : $data->title));
+JHtml::_('bootstrap.popover');
 ?>
-<a href="#" onclick="return false;" class="js-stools-column-order hasTooltip" data-order="<?php echo $data->order; ?>" data-direction="<?php echo strtoupper($data->direction); ?>" data-name="<?php echo JText::_($data->title); ?>" title="<?php echo $metatitle; ?>">
+<a href="#" onclick="return false;" class="js-stools-column-order hasPopover"
+   data-order="<?php echo $data->order; ?>" data-direction="<?php echo strtoupper($data->direction); ?>" data-name="<?php echo JText::_($data->title); ?>"
+   title="<?php echo $title; ?>" data-content="<?php echo htmlspecialchars(JText::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')); ?>" data-placement="top">
 <?php if (!empty($data->icon)) : ?><span class="<?php echo $data->icon; ?>"></span><?php endif; ?>
 <?php if (!empty($data->title)) : ?><?php echo JText::_($data->title); ?><?php endif; ?>
 <?php if ($data->order == $data->selected) : ?><span class="<?php echo $data->orderIcon; ?>"></span><?php endif; ?>

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -72,7 +72,7 @@ abstract class JHtmlGrid
 	public static function sort($title, $order, $direction = 'asc', $selected = '', $task = null, $new_direction = 'asc', $tip = '')
 	{
 		JHtml::_('behavior.core');
-		JHtml::_('bootstrap.tooltip');
+		JHtml::_('bootstrap.popover');
 
 		$direction = strtolower($direction);
 		$icon = array('arrow-up-3', 'arrow-down-3');
@@ -88,7 +88,8 @@ abstract class JHtmlGrid
 		}
 
 		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\');return false;"'
-			. ' class="hasTooltip" title="' . JHtml::tooltipText(($tip ? $tip : $title), 'JGLOBAL_CLICK_TO_SORT_THIS_COLUMN') . '">';
+			. ' class="hasPopover" title="' . htmlspecialchars(JText::_($tip ? $tip : $title)) . '"'
+			. ' data-content="' . htmlspecialchars(JText::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '" data-placement="top">';
 
 		if (isset($title['0']) && $title['0'] == '<')
 		{

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -585,8 +585,17 @@ body {
 #mediamanager-form .dimensions {
 	direction: ltr;
 }
+.popover,
 .tooltip-inner {
 	text-align: right;
+}
+.popover.top .arrow,
+.popover.bottom .arrow {
+	margin-right: -11px;
+}
+.popover.top .arrow:after,
+.popover.bottom .arrow:after {
+	margin-right: -10px;
 }
 @media (max-width: 480px) {
 	.btn-toolbar .btn-wrapper {

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -586,10 +586,20 @@ direction:rtl;
 #mediamanager-form .dimensions {
 	direction: ltr;
 }
-/* Tooltip */
+/* Tooltip/Popover */
+.popover,
 .tooltip-inner {
 	text-align: right;
 }
+.popover.top .arrow,
+.popover.bottom .arrow {
+	margin-right: -11px;
+}
+.popover.top .arrow:after,
+.popover.bottom .arrow:after {
+	margin-right: -10px;
+}
+
 /* Media queries */
 @media (max-width: 480px) {
 	.btn-toolbar .btn-wrapper {

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -690,6 +690,7 @@ legend + .control-group {
 }
 
 /*Fix for tooltips wrong positioning*/
+.control-label .hasPopover,
 .control-label .hasTooltip {
   display: inline-block;
 }

--- a/templates/beez3/css/general.css
+++ b/templates/beez3/css/general.css
@@ -438,6 +438,133 @@ span.optional
 	width: 60px;
 }
 
+/* ##########################  popover  ########################### */
+.popover {
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 1010;
+	display: none;
+	max-width: 276px;
+	padding: 1px;
+	text-align: left;
+	background-color: #fff;
+	-webkit-background-clip: padding-box;
+	-moz-background-clip: padding;
+	background-clip: padding-box;
+	border: 1px solid #ccc;
+	border: 1px solid rgba(0,0,0,0.2);
+	-webkit-border-radius: 6px;
+	-moz-border-radius: 6px;
+	border-radius: 6px;
+	-webkit-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	-moz-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	white-space: normal;
+}
+.popover.top {
+	margin-top: -10px;
+}
+.popover.right {
+	margin-left: 10px;
+}
+.popover.bottom {
+	margin-top: 10px;
+}
+.popover.left {
+	margin-left: -10px;
+}
+.popover-title {
+	margin: 0;
+	padding: 8px 14px;
+	font-size: 14px;
+	font-weight: normal;
+	line-height: 18px;
+	background-color: #f7f7f7;
+	border-bottom: 1px solid #ebebeb;
+	-webkit-border-radius: 5px 5px 0 0;
+	-moz-border-radius: 5px 5px 0 0;
+	border-radius: 5px 5px 0 0;
+}
+.popover-title:empty {
+	display: none;
+}
+.popover-content {
+	padding: 9px 14px;
+}
+.popover .arrow,
+.popover .arrow:after {
+	position: absolute;
+	display: block;
+	width: 0;
+	height: 0;
+	border-color: transparent;
+	border-style: solid;
+}
+.popover .arrow {
+	border-width: 11px;
+}
+.popover .arrow:after {
+	border-width: 10px;
+	content: "";
+}
+.popover.top .arrow {
+	left: 50%;
+	margin-left: -11px;
+	border-bottom-width: 0;
+	border-top-color: #999;
+	border-top-color: rgba(0,0,0,0.25);
+	bottom: -11px;
+}
+.popover.top .arrow:after {
+	bottom: 1px;
+	margin-left: -10px;
+	border-bottom-width: 0;
+	border-top-color: #fff;
+}
+.popover.right .arrow {
+	top: 50%;
+	left: -11px;
+	margin-top: -11px;
+	border-left-width: 0;
+	border-right-color: #999;
+	border-right-color: rgba(0,0,0,0.25);
+}
+.popover.right .arrow:after {
+	left: 1px;
+	bottom: -10px;
+	border-left-width: 0;
+	border-right-color: #fff;
+}
+.popover.bottom .arrow {
+	left: 50%;
+	margin-left: -11px;
+	border-top-width: 0;
+	border-bottom-color: #999;
+	border-bottom-color: rgba(0,0,0,0.25);
+	top: -11px;
+}
+.popover.bottom .arrow:after {
+	top: 1px;
+	margin-left: -10px;
+	border-top-width: 0;
+	border-bottom-color: #fff;
+}
+.popover.left .arrow {
+	top: 50%;
+	right: -11px;
+	margin-top: -11px;
+	border-right-width: 0;
+	border-left-color: #999;
+	border-left-color: rgba(0,0,0,0.25);
+}
+.popover.left .arrow:after {
+	right: 1px;
+	border-right-width: 0;
+	border-left-color: #fff;
+	bottom: -10px;
+}
+
 /* Bootstrap overrides anhiliation
  * @since 3.2
  */

--- a/templates/beez3/css/template_rtl.css
+++ b/templates/beez3/css/template_rtl.css
@@ -513,6 +513,7 @@ ul.menu li ul li ul li ul li ul {
 .tooltip.left {
 	margin-left: 3px;
 }
+.popover,
 .tooltip-inner {
 	text-align: right;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1689,6 +1689,7 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
 }

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -402,7 +402,7 @@ figcaption {
 
 // Category collapse
 .categories-list .collapse {
-	margin: 0 0 0 20px;
+	margin-left: 20px;
 }
 @media (max-width: 480px) {
 	.item-info > span {

--- a/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormFieldTest.php
@@ -210,9 +210,10 @@ class JFormFieldTest extends TestCaseDatabase
 				'id'         => 'title_id-lbl',
 				'tag'        => 'label',
 				'attributes' => array(
-						'for'   => 'title_id',
-						'class' => 'hasTooltip required',
-						'title' => '<strong>Title</strong><br />The title.'
+					'for'          => 'title_id',
+					'class'        => 'hasPopover required',
+					'title'        => 'Title',
+					'data-content' => 'The title.',
 					),
 				'content'    => 'regexp:/Title.*\*/',
 				'child'      => array(
@@ -370,9 +371,10 @@ class JFormFieldTest extends TestCaseDatabase
 				'id'         => 'myId-lbl',
 				'tag'        => 'label',
 				'attributes' => array(
-						'for'   => 'myId',
-						'class' => 'hasTooltip',
-						'title' => '<strong>My Title</strong><br />The description.'
+					'for'          => 'myId',
+					'class'        => 'hasPopover',
+					'title'        => 'My Title',
+					'data-content' => 'The description.',
 					),
 				'content'    => 'regexp:/My Title/'
 			);

--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -1214,9 +1214,10 @@ class JFormTest extends TestCaseDatabase
 				'id'         => 'title_id-lbl',
 				'tag'        => 'label',
 				'attributes' => array(
-						'for'   => 'title_id',
-						'class' => 'hasTooltip required',
-						'title' => '<strong>Title</strong><br />The title.'
+					'for'          => 'title_id',
+					'class'        => 'hasPopover required',
+					'title'        => 'Title',
+					'data-content' => 'The title.',
 					),
 				'content'    => 'regexp:/Title.*\*/',
 				'child'      => array(

--- a/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/TestHelpers/JHtmlField-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldTest_DataSet
 				'name' => 'myName',
 				'value' => 'The text field.',
 				'title' => 'My Title',
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title</label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasPopover" title="My Title" data-content="The description.">My Title</label>',
 				'unexisting' => null,
 			),
 			'<field name="myName" type="text" id="myId" label="My Title" description="The description."  value="Text Field" />',
@@ -111,7 +111,7 @@ class JHtmlFieldTest_DataSet
 		'RequiredLabel' => array(
 			array(
 				'required' => true,
-				'label' => '<label id="myId-lbl" for="myId" class="hasTooltip required" title="&lt;strong&gt;My Title&lt;/strong&gt;&lt;br /&gt;The description.">My Title<span class="star">&#160;*</span></label>',
+				'label' => '<label id="myId-lbl" for="myId" class="hasPopover required" title="My Title" data-content="The description.">My Title<span class="star">&#160;*</span></label>',
 			),
 			'<field name="myName" type="text" id="myId" required="true" label="My Title" description="The description." />',
 			'',


### PR DESCRIPTION
Inspired by https://github.com/joomla/joomla-cms/pull/8150
This PR uses the Bootstrap "popover" method to display a tooltip when there is a title and description present in a form.
To test, you can have a look at an article edit form. The "Title" field doesn't have a description, thus a regular tooltip is shown. The alias does have both, thus the popover will be used.

In backend this worked fine for me. In frontend, the placement was looking bad because it goes that far right. Not sure why it behaves different there.
I tried with position it on top, but then it got cut in backend for the alias, so that isn't ideal either. And I think it actually looks better when placed right there.
