### PR TITLE
Deprecate JHtmlRules

### DIFF
--- a/libraries/cms/html/rules.php
+++ b/libraries/cms/html/rules.php
@@ -9,10 +9,13 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JLog::add('JHtmlRules is deprecated.', JLog::WARNING, 'deprecated');
+
 /**
  * Extended Utility class for all HTML drawing classes.
  *
- * @since  1.6
+ * @since       1.6
+ * @deprecated  4.0
  */
 abstract class JHtmlRules
 {
@@ -30,6 +33,7 @@ abstract class JHtmlRules
 	 * @see     JAccess
 	 * @see     JFormFieldRules
 	 * @since   1.6
+	 * @deprecated  4.0
 	 */
 	public static function assetFormWidget($actions, $assetId = null, $parent = null, $control = 'jform[rules]', $idPrefix = 'jform_rules')
 	{
@@ -144,6 +148,7 @@ abstract class JHtmlRules
 	 * @return  integer  The id of the parent asset
 	 *
 	 * @since   1.6
+	 * @deprecated  4.0
 	 */
 	protected static function _getParentAssetId($assetId)
 	{
@@ -166,6 +171,7 @@ abstract class JHtmlRules
 	 * @return  array  Array of user groups
 	 *
 	 * @since   1.6
+	 * @deprecated  4.0
 	 */
 	protected static function _getUserGroups()
 	{
@@ -209,6 +215,7 @@ abstract class JHtmlRules
 	 * @return  array  An associative  array of permissions and images
 	 *
 	 * @since   1.6
+	 * @deprecated  4.0
 	 */
 	protected static function _getImagesArray()
 	{


### PR DESCRIPTION
This HTML helper is a remnant from the 1.6 beta period before the ACL widget on component edit screens was refactored to the form it retained through the end of the 2.5 series.  This pull request deprecates this unused (and moderately broken, the 2.5 style markup is still used) helper.
