### PR TITLE
Addding a package manifest for english language pack

### DIFF
--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<extension type="package" version="3.4" method="upgrade">
+	<name>English (en-GB) Language Pack</name>
+	<packagename>en-GB</packagename>
+	<version>3.5.0.1</version>
+	<creationDate>2013-03-07</creationDate>
+	<author>Joomla! Project</author>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<copyright>Copyright (C) 2005 - 2015 Joomla.fr and Open Source Matters, Inc. All rights reserved.</copyright>
+	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
+	<url>https://crowdin.com/project/joomla-cms</url>
+	<packager>Joomla! Project</packager>
+	<packagerurl>www.joomla.org</packagerurl>
+	<description>en-GB language pack</description>
+	<files>
+		<folder type="language" client="site" id="en-GB">site_en-GB</folder>
+		<folder type="language" client="administrator" id="en-GB">admin_en-GB</folder>
+	</files>
+	<updateservers>
+		<server type="collection" priority="1" name="Accredited Joomla! Translations">
+			http://update.joomla.org/language/translationlist_3.xml
+		</server>
+	</updateservers>
+</extension>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<extension type="package" version="3.4" method="upgrade">
+<extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
 	<version>3.5.0.1</version>
@@ -7,7 +7,7 @@
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<copyright>Copyright (C) 2005 - 2015 Joomla.fr and Open Source Matters, Inc. All rights reserved.</copyright>
+	<copyright>Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<url>https://crowdin.com/project/joomla-cms</url>
 	<packager>Joomla! Project</packager>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -9,7 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
-	<url>https://crowdin.com/project/joomla-cms</url>
+	<url>https://github.com/joomla/joomla-cms</url>
 	<packager>Joomla! Project</packager>
 	<packagerurl>www.joomla.org</packagerurl>
 	<description>en-GB language pack</description>


### PR DESCRIPTION
This is something to discuss.
When language packs are created, they need to include a package manifest file. This file is documented on https://docs.joomla.org/J3.x:Making_a_Language_Pack_for_Joomla.
Since the english language is already installed, and can't be uninstalled, there is no need for such a manifest file withing core. That's why it is missing.
However when translating using Crowdin (or similar tools), that file has to be present as otherwise it can't be translated.

I would love to have the "example" package manifest file within core, so changes could be done here and synced with Crowdin automatically.

Just adding the package doesn't seem to generate any side effects. I wasn't able to discover it or uninstall the language from withing the extension manager.

This PR just adds a package manifest file for en-GB.
It also contains the version numbering scheme that is expected to be used by translations.
It also contains a link to Crowdin, again doesn't really matter what we put in there as it's just an example for translators. For Crowdin, there just needs to be something written in it.

@horus68 @infograf768 @imanickam What do you think?
