### PR TITLE
Fix Undefined index: dbconnectioncollation on in sysinfo

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -142,20 +142,21 @@ class AdminModelSysInfo extends JModelLegacy
 			return $this->info;
 		}
 
-		$version    = new JVersion;
-		$platform   = new JPlatform;
-		$db         = $this->getDbo();
+		$version  = new JVersion;
+		$platform = new JPlatform;
+		$db       = $this->getDbo();
 
 		$this->info = array(
-			'php'         => php_uname(),
-			'dbversion'   => $db->getVersion(),
-			'dbcollation' => $db->getCollation(),
-			'phpversion'  => phpversion(),
-			'server'      => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : getenv('SERVER_SOFTWARE'),
-			'sapi_name'   => php_sapi_name(),
-			'version'     => $version->getLongVersion(),
-			'platform'    => $platform->getLongVersion(),
-			'useragent'   => isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : ""
+			'php'                   => php_uname(),
+			'dbversion'             => $db->getVersion(),
+			'dbcollation'           => $db->getCollation(),
+			'dbconnectioncollation' => $db->getConnectionCollation(),
+			'phpversion'            => phpversion(),
+			'server'                => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : getenv('SERVER_SOFTWARE'),
+			'sapi_name'             => php_sapi_name(),
+			'version'               => $version->getLongVersion(),
+			'platform'              => $platform->getLongVersion(),
+			'useragent'             => isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : ""
 		);
 
 		return $this->info;


### PR DESCRIPTION
### How to test
- install current staging (wich is now 3.5)
- go to the System Information (System --> System Information)
- see the `Undefined index: dbconnectioncollation` error
- apply this patch
- see that the issue is gone.

Kudos goes to @t-arapi see: https://github.com/joomla/joomla-cms/pull/8176
