### PR TITLE
The Modal Category Field doesn't work if edit=false (Ref #8180)

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -157,7 +157,7 @@ class JFormFieldModal_Category extends JFormField
 				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
-		
+
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
 			'modalCategory-' . $this->id,
@@ -170,7 +170,7 @@ class JFormFieldModal_Category extends JFormField
 					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
-		
+
 		// Clear category button
 		if ($allowClear)
 		{

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -156,21 +156,21 @@ class JFormFieldModal_Category extends JFormField
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
 				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
 				. '</a>';
-
-			$html[] = JHtml::_(
-				'bootstrap.renderModal',
-				'modalCategory-' . $this->id,
-				array(
-					'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-					'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
-					'width' => '800px',
-					'height' => '300px',
-					'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-				)
-			);
 		}
-
+		
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'modalCategory-' . $this->id,
+			array(
+				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+				'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
+				'width' => '800px',
+				'height' => '300px',
+				'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
+		
 		// Clear category button
 		if ($allowClear)
 		{


### PR DESCRIPTION
#### Steps to reproduce the issue

Create a form with a modal category field

To test the issue you can change the file
administrator/components/com_content/models/forms/article.xml
45:         <field name="catid" type="categoryedit"

45:     <field name="catid" type="modal_category"
and open an article
![cattura2](https://cloud.githubusercontent.com/assets/12718836/10795081/56a419d0-7d98-11e5-93a8-66f2edea1805.PNG)
#### Expected result

When you click on the select button the modal popup should open
#### Actual result

When you click on the select button nothing happens

see 
