### PR TITLE
Switch update server to HTTPS Closes #8186

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-10-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-10-29.sql
@@ -1,0 +1,4 @@
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/core/list.xml' WHERE `name` = 'Joomla! Core' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/jed/list.xml' WHERE `name` = 'Joomla! Extension Directory' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/language/translationlist_3.xml' WHERE `name` = 'Accredited Joomla! Translations' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE `name` = 'Joomla! Update Component Update Site' AND `type` = 'extension';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-29.sql
@@ -1,0 +1,4 @@
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/core/list.xml' WHERE "name" = 'Joomla! Core' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/jed/list.xml' WHERE "name" = 'Joomla! Extension Directory' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/language/translationlist_3.xml' WHERE "name" = 'Accredited Joomla! Translations' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE "name" = 'Joomla! Update Component Update Site' AND "type" = 'extension';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-10-29.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-10-29.sql
@@ -1,0 +1,4 @@
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/core/list.xml' WHERE [name] = 'Joomla! Core' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/jed/list.xml' WHERE [name] = 'Joomla! Extension Directory' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/language/translationlist_3.xml' WHERE [name] = 'Accredited Joomla! Translations' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE [name] = 'Joomla! Update Component Update Site' AND [type] = 'extension';

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -26,7 +26,7 @@
 		</languages>
 	</administration>
 	<updateservers>
-		<server type="extension" name="Joomla! Update Component Update Site">http://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
+		<server type="extension" name="Joomla! Update Component Update Site">https://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
 	</updateservers>
 </extension>
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -37,12 +37,12 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			// "Minor & Patch Release for Current version AND Next Major Release".
 			case 'sts':
 			case 'next':
-				$updateURL = 'http://update.joomla.org/core/sts/list_sts.xml';
+				$updateURL = 'https://update.joomla.org/core/sts/list_sts.xml';
 				break;
 
 			// "Testing"
 			case 'testing':
-				$updateURL = 'http://update.joomla.org/core/test/list_test.xml';
+				$updateURL = 'https://update.joomla.org/core/test/list_test.xml';
 				break;
 
 			// "Custom"
@@ -66,7 +66,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			 * case 'nochange':
 			 */
 			default:
-				$updateURL = 'http://update.joomla.org/core/list.xml';
+				$updateURL = 'https://update.joomla.org/core/list.xml';
 		}
 
 		$db = $this->getDbo();

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -48,7 +48,7 @@
 	</fileset>
 
 	<updateservers>
-		<server type="collection">http://update.joomla.org/core/list.xml</server>
-		<server type="collection">http://update.joomla.org/jed/list.xml</server>
+		<server type="collection">https://update.joomla.org/core/list.xml</server>
+		<server type="collection">https://update.joomla.org/jed/list.xml</server>
 	</updateservers>
 </extension>

--- a/components/com_users/controllers/profile.json.php
+++ b/components/com_users/controllers/profile.json.php
@@ -33,7 +33,7 @@ class UsersControllerProfile extends UsersController
 		// Set FTP credentials, if given
 		JClientHelper::setCredentialsFromRequest('ftp');
 
-		if (($data = file_get_contents('http://update.joomla.org/helpsites/helpsites.xml')) === false)
+		if (($data = file_get_contents('https://update.joomla.org/helpsites/helpsites.xml')) === false)
 		{
 			throw new Exception(JText::_('COM_CONFIG_ERROR_HELPREFRESH_FETCH'), 500);
 		}

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1783,10 +1783,10 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 --
 
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
-(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
-(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0),
+(3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1708,10 +1708,10 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 -- Dumping data for table #__update_sites
 --
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
-(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
-(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0),
+(3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 SELECT setval('#__update_sites_update_site_id_seq', 5, false);
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2720,13 +2720,13 @@ CREATE TABLE [#__update_sites](
 SET IDENTITY_INSERT [#__update_sites] ON;
 
 INSERT INTO [#__update_sites] ([update_site_id], [name], [type], [location], [enabled], [last_check_timestamp])
-SELECT 1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0
+SELECT 1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0
 UNION ALL
-SELECT 2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0
+SELECT 2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0
 UNION ALL
-SELECT 3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0
+SELECT 3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0
 UNION ALL
-SELECT 4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0;
+SELECT 4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0;
 
 SET IDENTITY_INSERT [#__update_sites] OFF;
 


### PR DESCRIPTION
### Issue

Our update server now supports SSL connections.  The CMS should be updated to query `update.joomla.org` via HTTPS.

See: https://github.com/joomla/joomla-cms/issues/8186
### How to test
##### First test
- install https://github.com/zero-24/joomla-cms/archive/updateServerHTTPS.zip as normal joomla
- go to the backend -> Extension -> Manage --> Update Sites
- confirm we have for update.joomla.org links https and not http

<s>
##### Seccond test (don't work for some strange reason?!>
- install 3.4.5
- go to the Backend -> Extension -> Manage --> Update Sites
- see we have http links to update.joomla.org
- apply this patch
- go to Backend -> Extension -> Manage -> Database
- press the ``fix` button
- go to the backend -> Extension -> Manage --> Update Sites
- confirm we have for update.joomla.org links https and not http</s>
