### PR TITLE
[Accessibility] Joomla Article - Tag: Add 'Search' & 'Clear text' button near search text field

### DIFF
--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -27,6 +27,12 @@ $n = count($this->items);
 
 ?>
 
+<script type="text/javascript">
+	var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+</script>
+
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
 	<fieldset class="filters btn-toolbar">
@@ -36,6 +42,12 @@ $n = count($this->items);
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+				<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+					<span class="icon-remove"></span>
+				</button>
+				<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+					<span class="icon-search"></span>
+				</button>
 			</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -41,98 +41,110 @@ $bscolumns = min($columns, floor(12 / $bsspans));
 $n = count($this->items);
 ?>
 
+<script type="text/javascript">
+	var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+</script>
+
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-	<fieldset class="filters btn-toolbar">
-		<?php if ($this->params->get('filter_field')) : ?>
-			<div class="btn-group">
-				<label class="filter-search-lbl element-invisible" for="filter-search">
-					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
-				</label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
-			</div>
-		<?php endif; ?>
-		<?php if ($this->params->get('show_pagination_limit')) : ?>
-			<div class="btn-group pull-right">
-				<label for="limit" class="element-invisible">
-					<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
-				</label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-		<?php endif; ?>
+		<fieldset class="filters btn-toolbar">
+			<?php if ($this->params->get('filter_field')) : ?>
+				<div class="btn-group">
+					<label class="filter-search-lbl element-invisible" for="filter-search">
+						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
+					</label>
+					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+					<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+						<span class="icon-remove"></span>
+					</button>
+					<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+						<span class="icon-search"></span>
+					</button>
+				</div>
+			<?php endif; ?>
+			<?php if ($this->params->get('show_pagination_limit')) : ?>
+				<div class="btn-group pull-right">
+					<label for="limit" class="element-invisible">
+						<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
+					</label>
+					<?php echo $this->pagination->getLimitBox(); ?>
+				</div>
+			<?php endif; ?>
 
-		<input type="hidden" name="filter_order" value="" />
-		<input type="hidden" name="filter_order_Dir" value="" />
-		<input type="hidden" name="limitstart" value="" />
-		<input type="hidden" name="task" value="" />
-		<div class="clearfix"></div>
-	</fieldset>
+			<input type="hidden" name="filter_order" value="" />
+			<input type="hidden" name="filter_order_Dir" value="" />
+			<input type="hidden" name="limitstart" value="" />
+			<input type="hidden" name="task" value="" />
+			<div class="clearfix"></div>
+		</fieldset>
 	<?php endif; ?>
 
-<?php if ($this->items == false || $n == 0) : ?>
-	<p><?php echo JText::_('COM_TAGS_NO_TAGS'); ?></p>
-<?php else : ?>
-	<?php foreach ($this->items as $i => $item) : ?>
-		<?php if ($n == 1 || $i == 0 || $bscolumns == 1 || $i % $bscolumns == 0) : ?>
-			<ul class="thumbnails">
+	<?php if ($this->items == false || $n == 0) : ?>
+		<p><?php echo JText::_('COM_TAGS_NO_TAGS'); ?></p>
+	<?php else : ?>
+		<?php foreach ($this->items as $i => $item) : ?>
+			<?php if ($n == 1 || $i == 0 || $bscolumns == 1 || $i % $bscolumns == 0) : ?>
+				<ul class="thumbnails">
+			<?php endif; ?>
+			<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
+			<li class="cat-list-row<?php echo $i % 2; ?>" >
+			<h3>
+				<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . '-' . $item->alias)); ?>">
+					<?php echo $this->escape($item->title); ?>
+				</a>
+			</h3>
 		<?php endif; ?>
-		<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
- 			<li class="cat-list-row<?php echo $i % 2; ?>" >
-				<h3>
-					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . '-' . $item->alias)); ?>">
-						<?php echo $this->escape($item->title); ?>
-					</a>
-				</h3>
-		<?php endif; ?>
-		<?php if ($this->params->get('all_tags_show_tag_image') && !empty($item->images)) : ?>
-			<?php $images  = json_decode($item->images); ?>
-			<span class="tag-body">
+			<?php if ($this->params->get('all_tags_show_tag_image') && !empty($item->images)) : ?>
+				<?php $images  = json_decode($item->images); ?>
+				<span class="tag-body">
 			<?php if (!empty($images->image_intro)): ?>
 				<?php $imgfloat = (empty($images->float_intro)) ? $this->params->get('float_intro') : $images->float_intro; ?>
 				<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image">
 					<img
-				<?php if ($images->image_intro_caption) : ?>
-					<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
-				<?php endif; ?>
-				src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+						<?php if ($images->image_intro_caption) : ?>
+							<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
+						<?php endif; ?>
+						src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
 				</div>
 			<?php endif; ?>
 			</span>
-		<?php endif; ?>
-		<div class="caption">
-			<?php if ($this->params->get('all_tags_show_tag_description', 1)) : ?>
-				<span class="tag-body">
+			<?php endif; ?>
+			<div class="caption">
+				<?php if ($this->params->get('all_tags_show_tag_description', 1)) : ?>
+					<span class="tag-body">
 					<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('tag_list_item_maximum_characters')); ?>
 				</span>
-			<?php endif; ?>
-			<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
-				<span class="list-hits badge badge-info">
+				<?php endif; ?>
+				<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
+					<span class="list-hits badge badge-info">
 					<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
 				</span>
+				<?php endif; ?>
+			</div>
+			</li>
+
+			<?php if (($i == 0 && $n == 1) || $i == $n - 1 || $bscolumns == 1 || (($i + 1) % $bscolumns == 0)) : ?>
+				</ul>
 			<?php endif; ?>
-		</div>
-	</li>
 
-		<?php if (($i == 0 && $n == 1) || $i == $n - 1 || $bscolumns == 1 || (($i + 1) % $bscolumns == 0)) : ?>
-			</ul>
-		<?php endif; ?>
+		<?php endforeach; ?>
+	<?php endif;?>
 
-	<?php endforeach; ?>
-<?php endif;?>
-
-<?php // Add pagination links ?>
-<?php if (!empty($this->items)) : ?>
+	<?php // Add pagination links ?>
+	<?php if (!empty($this->items)) : ?>
 	<?php if (($this->params->def('show_pagination', 2) == 1  || ($this->params->get('show_pagination') == 2)) && ($this->pagination->pagesTotal > 1)) : ?>
-	<div class="pagination">
+		<div class="pagination">
 
-		<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-			<p class="counter pull-right">
-				<?php echo $this->pagination->getPagesCounter(); ?>
-			</p>
-		<?php endif; ?>
+			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+				<p class="counter pull-right">
+					<?php echo $this->pagination->getPagesCounter(); ?>
+				</p>
+			<?php endif; ?>
 
-		<?php echo $this->pagination->getPagesLinks(); ?>
-	</div>
+			<?php echo $this->pagination->getPagesLinks(); ?>
+		</div>
 	<?php endif; ?>
 </form>
 <?php endif; ?>


### PR DESCRIPTION
A Solution for issue #5563

**The issue:**
Mobile users could have problems to use the form for searching tags and their articles, because it has no buttons.

**My solution:**
Like the issue maker wanted it, I added one button for entering the form field and one button for clearing the input of the field.

**Testing instructions:**
- Go to the searching form for tags "/all-tags"
- Without the patch you see only an input form field and you submit it with pushing enter
- With the patch you see nice new buttons
- Try them out!
- Do the same with the other form where you search the articles of one tag, e.g. "/all-tags/4-green"

**Expected result:**
Two new buttons can be used for submitting the form and clearing the input.
The clear button works only when the form got submitted once, because the form field submits immediately, when the user clicks out of it.

Worked as a group on that issue: @icampus @kathastaden @flow87 @xsability 
