### PR TITLE
Multilanguage: joomla installation without localised content ignored

### DIFF
--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -163,25 +163,30 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 					$error = true;
 				}
 
-				if (!$error)
-				{
-					$tableCategory = $model->addCategory($siteLang);
+				$installContent = (int) $data['installLocalisedContent'];
 
-					if ($tableCategory === false)
+				if ($installContent)
+				{
+					if (!$error)
 					{
-						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
-						$error = true;
+						$tableCategory = $model->addCategory($siteLang);
+
+						if ($tableCategory === false)
+						{
+							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
+							$error = true;
+						}
 					}
-				}
 
-				if (!$error)
-				{
-					$categoryId = $tableCategory->id;
-
-					if (!$model->addArticle($siteLang, $categoryId))
+					if (!$error)
 					{
-						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
-						$error = true;
+						$categoryId = $tableCategory->id;
+
+						if (!$model->addArticle($siteLang, $categoryId))
+						{
+							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
+							$error = true;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Ths PR to solve https://github.com/joomla/joomla-cms/issues/8192
![screen shot 2015-10-29 at 17 02 18](https://cloud.githubusercontent.com/assets/869724/10824041/e6b4708a-7e5e-11e5-8a56-48a58f12c7f8.png)

To test, verify that installing Joomla as a multilanguage site can be done with and without localised content.
