### PR TITLE
Solves breadcrumb space problem (See #8205)

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -48,11 +48,7 @@ JHtml::_('bootstrap.tooltip');
 			// Render all but last item - along with separator ?>
 			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 				<?php if (!empty($item->link)) : ?>
-					<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway">
-						<span itemprop="name">
-							<?php echo $item->name; ?>
-						</span>
-					</a>
+					<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway"><span itemprop="name"><?php echo $item->name; ?></span></a>
 				<?php else : ?>
 					<span itemprop="name">
 						<?php echo $item->name; ?>


### PR DESCRIPTION
### Test instructions

1- Use a fresh joomla install with sample content
2- On chrome go to one article and mouseover the breadcrumb link
3- It should only underline the text on mouseover (not any extra spaces)

See #8205 
