### PR TITLE
Some useful extra validation added e.g validate-date

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -191,6 +191,24 @@ var JFormValidator = function() {
  	 	 	var regex = /^[a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
  	 	 	return regex.test(value);
  	 	});
+		setHandler('natural-number', function(value, element) {
+		    value = punycode.toASCII(value);
+ 	 	 	var regex = /^[1-9]\d*$/;
+ 	 	 	return regex.test(value);
+ 	 	});
+		setHandler('whole-number', function(value, element) {
+			value = punycode.toASCII(value);
+ 	 	 	var regex = /^[0-9]{1,9}$/;
+ 	 	 	return regex.test(value);
+ 	 	});
+		setHandler('date', function(value, element) {
+ 	 	 	var regex = /^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/;
+ 	 	 	return regex.test(value);
+ 	 	});
+		setHandler('datetime', function(value, element) {
+ 	 	 	var regex = /^(\d{4})(\/|\-)(\d{1,2})(\/|\-)(\d{1,2})\s(\d{1,2})(\/|\:)(\d{1,2})(\/|\:)(\d{1,2})$/;
+ 	 	 	return regex.test(value);
+ 	 	});
  	 	// Attach to forms with class 'form-validate'
  	 	var forms = jQuery('form.form-validate');
  	 	for (var i = 0, l = forms.length; i < l; i++) {


### PR DESCRIPTION
Now you can validate your date and numeric fields.

For e.g
If you have a date field in your Joomla's form and the user enters a wrong date then you will get a fatal error on the page. So its better to validate the date field before saving.

Field 1- YYYY/MM/DD can be validate using class "validate-date"
Field 2- YYYY/MM/DD H:I:S can be validate using class "validate-datetime" 

These changes have been added to "validate-uncompressed.js". To test this you will need to minify this file and replace the content of "validate.js" with this.

Let me know if any other information is needed.
