### PR TITLE
FeedFix: If xmlreader failed: retry with JHttp and additional useragent-string…

### DIFF
--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -41,24 +41,26 @@ class JFeedFactory
 		// Open the URI within the stream reader.
 		if (!@$reader->open($uri, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
 		{
-			// If allow_url_fopen is enabled
-			if (ini_get('allow_url_fopen'))
+			// Retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
+
+			// Adding a valid user agent string, otherwise some feed-servers returning a error
+			$options 	= new \joomla\Registry\Registry();
+			$options->set('userAgent','Mozilla/5.0 (Windows NT 6.1; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0');
+
+			$connector 	= JHttpFactory::getHttp($options);
+			$feed 		= $connector->get($uri);
+
+			if($feed->code != 200)
 			{
-				// This is an error
 				throw new RuntimeException('Unable to open the feed.');
 			}
-			else
-			{
-				// Retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
-				$connector = JHttpFactory::getHttp();
-				$feed = $connector->get($uri);
 
-				// Set the value to the XMLReader parser
-				if (!$reader->xml($feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
-				{
-					throw new RuntimeException('Unable to parse the feed.');
-				}
+			// Set the value to the XMLReader parser
+			if (!$reader->xml($feed->body, null, LIBXML_NOERROR | LIBXML_ERR_NONE | LIBXML_NOWARNING))
+			{
+				throw new RuntimeException('Unable to parse the feed.');
 			}
+
 		}
 
 		try

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -44,13 +44,13 @@ class JFeedFactory
 			// Retry with JHttpFactory that allow using CURL and Sockets as alternative method when available
 
 			// Adding a valid user agent string, otherwise some feed-servers returning a error
-			$options 	= new \joomla\Registry\Registry();
-			$options->set('userAgent','Mozilla/5.0 (Windows NT 6.1; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0');
+			$options 	= new \joomla\Registry\Registry;
+			$options->set('userAgent', 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0');
 
 			$connector 	= JHttpFactory::getHttp($options);
 			$feed 		= $connector->get($uri);
 
-			if($feed->code != 200)
+			if ($feed->code != 200)
 			{
 				throw new RuntimeException('Unable to open the feed.');
 			}


### PR DESCRIPTION
… (for those feed-servers who need that header)
see #8127 
### Testinstructions:

Publish a feed module with feed url http://govexec.com/rss/contracting/
(that feed gives a 500 error if no user agent string in header is provided)
#### Before applying patch:

PHP's xmlparser fails, module shows a 'Feed not found.' message
#### After applying patch:

Feed is received and showed in module
