### PR TITLE
Debug Permissions Report more readable

### DIFF
--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -72,9 +72,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<td colspan="15">
 						<div>
 							<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>
-							<span class="btn disabled btn-micro btn-warning"><span class="icon-white icon-ban-circle"></span></span> <?php echo JText::_('COM_USERS_DEBUG_IMPLICIT_DENY');?>
-							<span class="btn disabled btn-micro btn-success"><span class="icon-white icon-ok"></span></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');?>
-							<span class="btn disabled btn-micro btn-danger"><span class="icon-white icon-remove"></span></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_DENY');?>
+							<span class="icon-white icon-ban-circle"></span> <?php echo JText::_('COM_USERS_DEBUG_IMPLICIT_DENY');?>
+							<span class="icon-white icon-ok"></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');?>
+							<span class="icon-white icon-remove"></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_DENY');?>
 						</div>
 					</td>
 				</tr>
@@ -106,9 +106,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							endif;
 							?>
 						<td class="center">
-							<span class="btn disabled btn-micro <?php echo $button; ?>">
-								<span class="icon-white <?php echo $class; ?>"></span>
-							</span>
+							<span class="icon-white <?php echo $class; ?>"></span>
 						</td>
 						<?php endforeach; ?>
 						<td class="center">

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -71,9 +71,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<td colspan="15">
 						<div>
 							<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>
-							<span class="btn disabled btn-micro btn-warning"><span class="icon-white icon-ban-circle"></span></span> <?php echo JText::_('COM_USERS_DEBUG_IMPLICIT_DENY');?>
-							<span class="btn disabled btn-micro btn-success"><span class="icon-white icon-ok"></span></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');?>
-							<span class="btn disabled btn-micro btn-danger"><span class="icon-white icon-remove"></span></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_DENY');?>
+							<span class="icon-white icon-ban-circle"></span> <?php echo JText::_('COM_USERS_DEBUG_IMPLICIT_DENY');?>
+							<span class="icon-white icon-ok"></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');?>
+							<span class="icon-white icon-remove"></span> <?php echo JText::_('COM_USERS_DEBUG_EXPLICIT_DENY');?>
 						</div>
 					</td>
 				</tr>
@@ -105,9 +105,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							endif;
 							?>
 						<td class="center">
-							<span class="btn disabled btn-micro <?php echo $button; ?>">
-								<span class="icon-white <?php echo $class; ?>"></span>
-							</span>
+							<span class="icon-white <?php echo $class; ?>"></span>
 						</td>
 						<?php endforeach; ?>
 						<td class="center">


### PR DESCRIPTION
#### Steps to reproduce the issue

Global configuration set Debug System to Yes
Users-> Manage  and click on the Debug Permissions Report link on user item
#### Actual result

is very ugly imho
![j35 administration debug permissions report for user 959 super user](https://cloud.githubusercontent.com/assets/181681/10863583/244478f4-7fd2-11e5-9369-138c43603c83.png)
#### Apply the patch

less ugly
![j35 administration debug permissions report for user 959 super user-after](https://cloud.githubusercontent.com/assets/181681/10863589/4f9cb5fc-7fd2-11e5-9be7-116115c11306.png)
#### Additional comments

The same on "maquillage" for Users-> Groups  and click on the Debug Permissions Report link on group item
