### PR TITLE
Fixes #8220

### DIFF
--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -131,6 +131,7 @@ abstract class JHtmlFormbehavior
 			static::chosen($selector, $debug);
 
 			$displayData = array(
+				'url'            => $url,
 				'debug'          => $debug,
 				'options'        => $options,
 				'selector'       => $selector,


### PR DESCRIPTION
#### Oops, url is needed here

The url for the ajax chosen needs to be passed to to the layout.

Straight forward change, obvious mistake
