### PR TITLE
Revert part of #8012 as it breaks multi-language functionality

### DIFF
--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -140,7 +140,7 @@ class JMenuSite extends JMenu
 				if (JLanguageMultilang::isEnabled())
 				{
 					$attributes[] = 'language';
-					$values[]     = array($this->language->getTag(), '*');
+					$values[]     = array(JFactory::getLanguage()->getTag(), '*');
 				}
 			}
 			elseif ($values[$key] === null)


### PR DESCRIPTION
Reverting this change because $this->language contains the old language object while JFactory::getLanguage() holds the current language object with the language chosen by the user.

This is a PR for issue #8218 

To test see issue 8218, just a second click is no longer needed.
