### PR TITLE
Removed unused lines from count items

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -147,10 +147,6 @@ class CategoriesModelCategories extends JModelList
 		$query = $db->getQuery(true);
 		$user = JFactory::getUser();
 
-		// Determine for which component the category manager retrieves its categories (for item count)
-		$jinput	= JFactory::getApplication()->input;
-		$countitemhelper = JPATH_ADMINISTRATOR . "/components/" . $jinput->get('extension') . '/helpers/countitems.php';
-
 		// Select the required fields from the table.
 		$query->select(
 			$this->getState(
@@ -285,6 +281,7 @@ class CategoriesModelCategories extends JModelList
 
 		// Load Helper file of the component for which com_categories displays the categories
 		$classname = ucfirst(substr($extension, 4)) . 'Helper';
+
 		if (class_exists($classname) && method_exists($classname, 'countItems'))
 		{
 			// Get the SQL to extend the com_category $query object with item count (published, unpublished, trashed)


### PR DESCRIPTION
While debugging another issue I found these lines to not be used and thus can be removed.

@pe7er Can you confirm this can be removed?
### Test instructions

Load the category list and check that the category counters work as before.
