### PR TITLE
JLayout system improvements / fixes

### DIFF
--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -289,7 +289,7 @@ class JLayoutBase implements JLayout
 	 *
 	 * @return  void
 	 *
-	 * @since   3.2
+	 * @since   3.5
 	 */
 	public function setDebug($debug)
 	{

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -28,6 +28,14 @@ class JLayoutBase implements JLayout
 	protected $options = null;
 
 	/**
+	 * Data for the layout
+	 *
+	 * @var    array
+	 * @since  3.5
+	 */
+	protected $data = array();
+
+	/**
 	 * Debug information messages
 	 *
 	 * @var    array
@@ -123,7 +131,7 @@ class JLayoutBase implements JLayout
 	/**
 	 * Method to render the layout.
 	 *
-	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
+	 * @param   mixed  $displayData  Data to be used inside the layout file to build displayed output
 	 *
 	 * @return  string  The necessary HTML to display the layout
 	 *
@@ -131,6 +139,12 @@ class JLayoutBase implements JLayout
 	 */
 	public function render($displayData)
 	{
+		// Automatically merge any previously data set if $displayData is an array
+		if (is_array($displayData))
+		{
+			$displayData = array_merge($this->data, $displayData);
+		}
+
 		return '';
 	}
 
@@ -143,6 +157,11 @@ class JLayoutBase implements JLayout
 	 */
 	public function renderDebugMessages()
 	{
+		if (!$this->isDebugEnabled())
+		{
+			return '';
+		}
+
 		return implode($this->debugMessages, "\n");
 	}
 
@@ -151,12 +170,137 @@ class JLayoutBase implements JLayout
 	 *
 	 * @param   string  $message  Message to save
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
 	 */
 	public function addDebugMessage($message)
 	{
-		$this->debugMessages[] = $message;
+		if ($this->isDebugEnabled())
+		{
+			$this->debugMessages[] = $message;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Clear the debug messages array
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function clearDebugMessages()
+	{
+		$this->debugMessages = array();
+
+		return $this;
+	}
+
+	/**
+	 * Render a layout with debug info
+	 *
+	 * @param   mixed  $data  Data passed to the layout
+	 *
+	 * @return  string
+	 *
+	 * @since    3.5
+	 */
+	public function debug($data = array())
+	{
+		$this->setDebug(true);
+
+		$output = $this->render($data);
+
+		$this->setDebug(false);
+
+		return $output;
+	}
+
+	/**
+	 * Method to get the value from the data array
+	 *
+	 * @param   string  $key           Key to search for in the data array
+	 * @param   mixed   $defaultValue  Default value to return if the key is not set
+	 *
+	 * @return  mixed   Value from the data array | defaultValue if doesn't exist
+	 *
+	 * @since   3.5
+	 */
+	public function get($key, $defaultValue = null)
+	{
+		return isset($this->data[$key]) ? $this->data[$key] : $defaultValue;
+	}
+
+	/**
+	 * Get the data being rendered
+	 *
+	 * @return  array
+	 *
+	 * @since   3.5
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * Check if debug mode is enabled
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5
+	 */
+	public function isDebugEnabled()
+	{
+		return $this->getOptions()->get('debug', false) === true;
+	}
+
+	/**
+	 * Method to set a value in the data array. Example: $layout->set('items', $items);
+	 *
+	 * @param   string  $key    Key for the data array
+	 * @param   mixed   $value  Value to assign to the key
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function set($key, $value)
+	{
+		$this->data[(string) $key] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Set the the data passed the layout
+	 *
+	 * @param   array  $data  Array with the data for the layout
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function setData(array $data)
+	{
+		$this->data = $data;
+
+		return $this;
+	}
+
+	/**
+	 * Change the debug mode
+	 *
+	 * @param   boolean  $debug  Enable / Disable debug
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function setDebug($debug)
+	{
+		$this->options->set('debug', (boolean) $debug);
 	}
 }

--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -157,11 +157,6 @@ class JLayoutBase implements JLayout
 	 */
 	public function renderDebugMessages()
 	{
-		if (!$this->isDebugEnabled())
-		{
-			return '';
-		}
-
 		return implode($this->debugMessages, "\n");
 	}
 
@@ -176,10 +171,7 @@ class JLayoutBase implements JLayout
 	 */
 	public function addDebugMessage($message)
 	{
-		if ($this->isDebugEnabled())
-		{
-			$this->debugMessages[] = $message;
-		}
+		$this->debugMessages[] = $message;
 
 		return $this;
 	}

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -19,6 +19,13 @@ defined('JPATH_PLATFORM') or die;
 class JLayoutFile extends JLayoutBase
 {
 	/**
+	 * Cached layout paths
+	 *
+	 * @var  array
+	 */
+	protected static $cache = array();
+
+	/**
 	 * @var    string  Dot separated path to the layout file, relative to base path
 	 * @since  3.0
 	 */
@@ -76,25 +83,46 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @since   3.0
 	 */
-	public function render($displayData)
+	public function render($displayData = array())
 	{
-		$layoutOutput = '';
+		$this->clearDebugMessages();
+
+		// Inherit base output from parent class
+		$layoutOutput = parent::render($displayData);
+
+		// Automatically merge any previously data set if $displayData is an array
+		if (is_array($displayData))
+		{
+			$displayData = array_merge($this->data, $displayData);
+		}
 
 		// Check possible overrides, and build the full path to layout file
 		$path = $this->getPath();
 
-		if ($this->options->get('debug', false))
+		if ($this->isDebugEnabled())
 		{
 			echo "<pre>" . $this->renderDebugMessages() . "</pre>";
 		}
 
-		// If there exists such a layout file, include it and collect its output
-		if (!empty($path))
+		// Nothing to show
+		if (empty($path))
 		{
-			ob_start();
-			include $path;
-			$layoutOutput = ob_get_contents();
-			ob_end_clean();
+			return $layoutOutput;
+		}
+
+		if (JDEBUG)
+		{
+			$layoutOutput .= "<!-- Start layout: " . $path . " -->\n";
+		}
+
+		ob_start();
+		include $path;
+		$layoutOutput .= ob_get_contents();
+		ob_end_clean();
+
+		if (JDEBUG)
+		{
+			$layoutOutput .= "<!-- End layout: " . $path . " -->\n";
 		}
 
 		return $layoutOutput;
@@ -111,49 +139,83 @@ class JLayoutFile extends JLayoutBase
 	{
 		JLoader::import('joomla.filesystem.path');
 
-		if (is_null($this->fullPath) && !empty($this->layoutId))
+		$layoutId     = $this->getLayoutId();
+		$includePaths = $this->getIncludePaths();
+		$suffixes     = $this->getSuffixes();
+
+		$this->addDebugMessage('<strong>Layout:</strong> ' . $this->layoutId);
+
+		if (!$layoutId)
 		{
-			$this->addDebugMessage('<strong>Layout:</strong> ' . $this->layoutId);
+			$this->addDebugMessage('<strong>There is no active layout</strong>');
 
-			// Refresh paths
-			$this->refreshIncludePaths();
+			return null;
+		}
 
-			$this->addDebugMessage('<strong>Include Paths:</strong> ' . print_r($this->includePaths, true));
+		if (!$includePaths)
+		{
+			$this->addDebugMessage('<strong>There are no folders to search for layouts:</strong> ' . $layoutId);
 
-			$suffixes = $this->options->get('suffixes', array());
+			return null;
+		}
 
-			// Search for suffixed versions. Example: tags.j31.php
-			if (!empty($suffixes))
+		$hash = md5(
+			json_encode(
+				array(
+					'paths'    => $includePaths,
+					'suffixes' => $suffixes
+				)
+			)
+		);
+
+		if (!empty(static::$cache[$layoutId][$hash]))
+		{
+			$this->addDebugMessage('<strong>Cached path:</strong> ' . static::$cache[$layoutId][$hash]);
+
+			return static::$cache[$layoutId][$hash];
+		}
+
+		$this->addDebugMessage('<strong>Include Paths:</strong> ' . print_r($includePaths, true));
+
+		// Search for suffixed versions. Example: tags.j31.php
+		if ($suffixes)
+		{
+			$this->addDebugMessage('<strong>Suffixes:</strong> ' . print_r($suffixes, true));
+
+			foreach ($suffixes as $suffix)
 			{
-				$this->addDebugMessage('<strong>Suffixes:</strong> ' . print_r($suffixes, true));
+				$rawPath  = str_replace('.', '/', $this->layoutId) . '.' . $suffix . '.php';
+				$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
 
-				foreach ($suffixes as $suffix)
+				if ($foundLayout = JPath::find($this->includePaths, $rawPath))
 				{
-					$rawPath  = str_replace('.', '/', $this->layoutId) . '.' . $suffix . '.php';
-					$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
+					$this->addDebugMessage('<strong>Found layout:</strong> ' . $this->fullPath);
 
-					if ($this->fullPath = JPath::find($this->includePaths, $rawPath))
-					{
-						$this->addDebugMessage('<strong>Found layout:</strong> ' . $this->fullPath);
+					static::$cache[$layoutId][$hash] = $foundLayout;
 
-						return $this->fullPath;
-					}
+					return static::$cache[$layoutId][$hash];
 				}
-			}
-
-			// Standard version
-			$rawPath  = str_replace('.', '/', $this->layoutId) . '.php';
-			$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
-
-			$this->fullPath = JPath::find($this->includePaths, $rawPath);
-
-			if ($this->fullPath)
-			{
-				$this->addDebugMessage('<strong>Found layout:</strong> ' . $this->fullPath);
 			}
 		}
 
-		return $this->fullPath;
+		// Standard version
+		$rawPath  = str_replace('.', '/', $this->layoutId) . '.php';
+		$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
+
+		$foundLayout = JPath::find($this->includePaths, $rawPath);
+
+		if (!$foundLayout)
+		{
+			$this->addDebugMessage('<strong>Unable to find layout: </strong> ' . $layoutId);
+
+			return null;
+		}
+
+		$this->addDebugMessage('<strong>Found layout:</strong> ' . $foundLayout);
+
+		static::$cache[$layoutId][$hash] = $foundLayout;
+
+		return static::$cache[$layoutId][$hash];
 	}
 
 	/**
@@ -161,13 +223,15 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $path  The path to search for layouts
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
 	 */
 	public function addIncludePath($path)
 	{
 		$this->addIncludePaths($path);
+
+		return $this;
 	}
 
 	/**
@@ -175,23 +239,136 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $paths  The path or array of paths to search for layouts
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
 	 */
 	public function addIncludePaths($paths)
 	{
-		if (!empty($paths))
+		if (empty($paths))
 		{
-			if (is_array($paths))
-			{
-				$this->includePaths = array_unique(array_merge($paths, $this->includePaths));
-			}
-			else
-			{
-				array_unshift($this->includePaths, $paths);
-			}
+			return $this;
 		}
+
+		$includePaths = $this->getIncludePaths();
+
+		if (is_array($paths))
+		{
+			$includePaths = array_unique(array_merge($paths, $includePaths));
+		}
+		else
+		{
+			array_unshift($includePaths, $paths);
+		}
+
+		$this->setIncludePaths($includePaths);
+
+		return $this;
+	}
+
+	/**
+	 * Clear the include paths
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function clearIncludePaths()
+	{
+		$this->includePaths = array();
+
+		return $this;
+	}
+
+	/**
+	 * Get the active include paths
+	 *
+	 * @return  array
+	 *
+	 * @since   3.5
+	 */
+	public function getIncludePaths()
+	{
+		if (empty($this->includePaths))
+		{
+			$this->includePaths = $this->getDefaultIncludePaths();
+		}
+
+		return $this->includePaths;
+	}
+
+	/**
+	 * Get the active layout id
+	 *
+	 * @return  string
+	 *
+	 * @since   3.5
+	 */
+	public function getLayoutId()
+	{
+		return $this->layoutId;
+	}
+
+	/**
+	 * Get the active suffixes
+	 *
+	 * @return  array
+	 *
+	 * @since   3.5
+	 */
+	public function getSuffixes()
+	{
+		return $this->getOptions()->get('suffixes', array());
+	}
+
+	/**
+	 * Load the automatically generated language suffixes.
+	 * Example: array('es-ES', 'es', 'ltr')
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function loadLanguageSuffixes()
+	{
+		$lang = JFactory::getLanguage();
+
+		$langTag = $lang->getTag();
+		$langParts = explode('-', $langTag);
+
+		$suffixes = array($langTag, $langParts[0]);
+		$suffixes[] = $lang->isRTL() ? 'rtl' : 'ltr';
+
+		$this->setSuffixes($suffixes);
+
+		return $this;
+	}
+
+	/**
+	 * Load the automatically generated version suffixes.
+	 * Example: array('j311', 'j31', 'j3')
+	 *
+	 * @return  self
+	 *
+	 * @since   1.0
+	 */
+	public function loadVersionSuffixes()
+	{
+		$cmsVersion = new JVersion;
+
+		// Example j311
+		$fullVersion = 'j' . str_replace('.', '', $cmsVersion->getShortVersion());
+
+		// Create suffixes like array('j311', 'j31', 'j3')
+		$suffixes = array(
+			$fullVersion,
+			substr($fullVersion, 0, 3),
+			substr($fullVersion, 0, 2),
+		);
+
+		$this->setSuffixes(array_unique($suffixes));
+
+		return $this;
 	}
 
 	/**
@@ -199,13 +376,15 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $path  The path to remove from the layout search
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
 	 */
 	public function removeIncludePath($path)
 	{
 		$this->removeIncludePaths($path);
+
+		return $this;
 	}
 
 	/**
@@ -213,7 +392,7 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $paths  The path or array of paths to remove for the layout search
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
 	 */
@@ -225,6 +404,8 @@ class JLayoutFile extends JLayoutBase
 
 			$this->includePaths = array_diff($this->includePaths, $paths);
 		}
+
+		return $this;
 	}
 
 	/**
@@ -241,14 +422,11 @@ class JLayoutFile extends JLayoutBase
 		// By default we will validate the active component
 		$component = ($option !== null) ? $option : $this->options->get('component', null);
 
-		if (!empty($component))
+		// Valid option format
+		if (!empty($component) && substr_count($component, 'com_'))
 		{
-			// Valid option format
-			if (substr_count($component, 'com_'))
-			{
-				// Latest check: component exists and is enabled
-				return JComponentHelper::isEnabled($component);
-			}
+			// Latest check: component exists and is enabled
+			return JComponentHelper::isEnabled($component);
 		}
 
 		return false;
@@ -334,72 +512,132 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @param   string  $layoutId  Layout to render
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
+	 *
+	 * @deprecated  3.5  Use setLayoutId()
 	 */
 	public function setLayout($layoutId)
 	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JLayoutFile::setLayoutId() instead.', JLog::WARNING, 'deprecated');
+
+		return $this->setLayoutId($layoutId);
+	}
+
+	/**
+	 * Set the active layout id
+	 *
+	 * @param   string  $layoutId  Layout identifier
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function setLayoutId($layoutId)
+	{
 		$this->layoutId = $layoutId;
 		$this->fullPath = null;
+
+		return $this;
 	}
 
 	/**
 	 * Refresh the list of include paths
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.2
+	 *
+	 * @deprecated  3.5  Use JLayoutFile::clearIncludePaths()
 	 */
 	protected function refreshIncludePaths()
 	{
+		// Log usage of deprecated function
+		JLog::add(__METHOD__ . '() is deprecated, use JLayoutFile::clearIncludePaths() instead.', JLog::WARNING, 'deprecated');
+
+		$this->clearIncludePaths();
+
+		return $this;
+	}
+
+	/**
+	 * Get the default array of include paths
+	 *
+	 * @return  array
+	 *
+	 * @since   3.5
+	 */
+	public function getDefaultIncludePaths()
+	{
 		// Reset includePaths
-		$this->includePaths = array();
+		$paths = array();
 
-		// (1 - lower priority) Frontend base layouts
-		$this->addIncludePaths(JPATH_ROOT . '/layouts');
-
-		// (2) Standard Joomla! layouts overriden
-		$this->addIncludePaths(JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts');
+		// (1 - 	highest priority) Received a custom high priority path
+		if (!is_null($this->basePath))
+		{
+			$paths[] = rtrim($this->basePath, DIRECTORY_SEPARATOR);
+		}
 
 		// Component layouts & overrides if exist
 		$component = $this->options->get('component', null);
 
 		if (!empty($component))
 		{
+			// (2) Component template overrides path
+			$paths[] = JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts/' . $component;
+
 			// (3) Component path
 			if ($this->options->get('client') == 0)
 			{
-				$this->addIncludePaths(JPATH_SITE . '/components/' . $component . '/layouts');
+				$paths[] = JPATH_SITE . '/components/' . $component . '/layouts';
 			}
 			else
 			{
-				$this->addIncludePaths(JPATH_ADMINISTRATOR . '/components/' . $component . '/layouts');
+				$paths[] = JPATH_ADMINISTRATOR . '/components/' . $component . '/layouts';
 			}
-
-			// (4) Component template overrides path
-			$this->addIncludePath(JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts/' . $component);
 		}
 
-		// (5 - highest priority) Received a custom high priority path ?
-		if (!is_null($this->basePath))
-		{
-			$this->addIncludePath(rtrim($this->basePath, DIRECTORY_SEPARATOR));
-		}
+		// (4) Standard Joomla! layouts overriden
+		$paths[] = JPATH_THEMES . '/' . JFactory::getApplication()->getTemplate() . '/html/layouts';
+
+		// (5 - lower priority) Frontend base layouts
+		$paths[] = JPATH_ROOT . '/layouts';
+
+		return $paths;
 	}
 
 	/**
-	 * Change the debug mode
+	 * Set the include paths to search for layouts
 	 *
-	 * @param   boolean  $debug  Enable / Disable debug
+	 * @param   array  $paths  Array with paths to search in
 	 *
-	 * @return  void
+	 * @return  self
 	 *
-	 * @since   3.2
+	 * @since   3.5
 	 */
-	public function setDebug($debug)
+	public function setIncludePaths($paths)
 	{
-		$this->options->set('debug', (boolean) $debug);
+		$this->includePaths = (array) $paths;
+
+		return $this;
+	}
+
+	/**
+	 * Set suffixes to search layouts
+	 *
+	 * @param   mixed  $suffixes  String with a single suffix or 'auto' | 'none' or array of suffixes
+	 *
+	 * @return  self
+	 *
+	 * @since   3.5
+	 */
+	public function setSuffixes(array $suffixes)
+	{
+		$this->options->set('suffixes', $suffixes);
+
+		return $this;
 	}
 
 	/**

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -21,24 +21,31 @@ class JLayoutFile extends JLayoutBase
 	/**
 	 * Cached layout paths
 	 *
-	 * @var  array
+	 * @var    array
+	 * @since  3.5
 	 */
 	protected static $cache = array();
 
 	/**
-	 * @var    string  Dot separated path to the layout file, relative to base path
+	 * Dot separated path to the layout file, relative to base path
+	 *
+	 * @var    string
 	 * @since  3.0
 	 */
 	protected $layoutId = '';
 
 	/**
-	 * @var    string  Base path to use when loading layout files
+	 * Base path to use when loading layout files
+	 *
+	 * @var    string
 	 * @since  3.0
 	 */
 	protected $basePath = null;
 
 	/**
-	 * @var    string  Full path to actual layout files, after possible template override check
+	 * Full path to actual layout files, after possible template override check
+	 *
+	 * @var    string
 	 * @since  3.0.3
 	 */
 	protected $fullPath = null;
@@ -350,7 +357,7 @@ class JLayoutFile extends JLayoutBase
 	 *
 	 * @return  self
 	 *
-	 * @since   1.0
+	 * @since   3.5
 	 */
 	public function loadVersionSuffixes()
 	{
@@ -574,7 +581,7 @@ class JLayoutFile extends JLayoutBase
 		// Reset includePaths
 		$paths = array();
 
-		// (1 - 	highest priority) Received a custom high priority path
+		// (1 - highest priority) Received a custom high priority path
 		if (!is_null($this->basePath))
 		{
 			$paths[] = rtrim($this->basePath, DIRECTORY_SEPARATOR);

--- a/libraries/cms/layout/helper.php
+++ b/libraries/cms/layout/helper.php
@@ -27,6 +27,30 @@ class JLayoutHelper
 	public static $defaultBasePath = '';
 
 	/**
+	 * Method to render a layout with debug info
+	 *
+	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
+	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
+	 * @param   string  $basePath     Base path to use when loading layout files
+	 * @param   mixed   $options      Optional custom options to load. Registry or array format
+	 *
+	 * @return  string
+	 *
+	 * @since   3.5
+	 */
+	public static function debug($layoutFile, $displayData = null, $basePath = '', $options = null)
+	{
+		$basePath = empty($basePath) ? self::$defaultBasePath : $basePath;
+
+		// Make sure we send null to JLayoutFile if no path set
+		$basePath = empty($basePath) ? null : $basePath;
+		$layout = new JLayoutFile($layoutFile, $basePath, $options);
+		$renderedLayout = $layout->debug($displayData);
+
+		return $renderedLayout;
+	}
+
+	/**
 	 * Method to render the layout.
 	 *
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path


### PR DESCRIPTION
This PR tries to improve & fix some issues in the curre JLayout system
# Index
1. [Fixes](#1)  
   1.1. [[fix] Custom include paths cannot be used.](#1.1)
2. [Improvements](#2)  
   2.1. [[imp] Add method to clear include paths](#2.1) (_clearIncludePaths()_)  
   2.2. [[imp] Add method to get active include paths](#2.2) (_getIncludePaths()_)  
   2.3. [[imp] Make JLayout methods chainable when possible.](#2.3)  
   2.4. [[imp] Allow to set data variables before rendering the layout](#2.4)  
   2,5. [[imp] Add method to clear the debug messages](#2.5) (_clearDebugMessages()_)  
   2.6. [[imp] Add a cache system to avoid duplicates file searches](#2.6)  
   2.7. [[imp] Add HTML comment to the start & end of layouts when Joomla debug mode is enabled](#2.7)  
   2.8. [[imp] Add support for automatic language suffixes](#2.8)  
   2.9. [[imp] Add support for automatic version suffixes](#2.9)  
   2.10. [[imp] Add a method to get the active layout id](#2.10)  
   2.11. [[imp] Add a method to get the active suffixes](#2.11)  
   2.12. [[imp] Add a method to check if debug is enabled](#2.12)  
   2.13. [[imp] Add fast methods to debug layouts](#2.13)  
   ~~2.14. [[imp] Avoid adding debug messages if debug is disabled](#2.14)~~  
## <a name="1"></a>1. Fixes
### <a name="1.1"></a>1.1. [fix] Custom include paths cannot be used.

Currently there is a fix that makes that includePaths cannot be changed by developers. See https://github.com/joomla/joomla-cms/issues/3451

This was caused because the refreshIncludePaths() method was called always on render method. Not the logic attached to load the default include paths is only triggered when there are no includePaths explicilty defined.

Now you can use different methods to set the include paths:

``` php
$layout = new JLayoutFile('mylibrary.item');

// Explicitly set the array of include paths
$layout->setIncludePaths(array(JPATH_LIBRARIES . '/mylibrary/layouts'));

// Add a layout folder on top of the default includePaths
$layout->addIncludePath(JPATH_LIBRARIES . '/mylibrary/layouts');

// Add more than one folder on top of the default include paths
$layout->addIncludePaths(
    array(
        JPATH_LIBRARIES . '/mylibrary/layouts',
        JPATH_SITE . '/layouts'
    )
);
```
## <a name="2"></a>2. Improvements
### <a name="2.1"></a>2.1. [imp] Add method to clear include paths

Now there is a method to clear the list of include paths. Usage:

``` php
$layout = new JLayoutFile('mylibrary.item');

// Clear any existing include path
$layout->clearIncludePaths();

// Add our own paths
$layout->addIncludePaths(
    array(
        JPATH_LIBRARIES . '/mylibrary/layouts',
        JPATH_SITE . '/layouts'
    )
);

// Note that you don't need to clear include paths to replace them. This would be faster:
$layout->setIncludePaths(
    array(
        JPATH_LIBRARIES . '/mylibrary/layouts',
        JPATH_SITE . '/layouts'
    )
);
```
### <a name="2.2"></a>2.2. [imp] Add method to get active include paths

Now we can get the list of active paths that are going to be used to render a layout:

``` php
$layout = new JLayoutFile('mylibrary.item');

// Get the active include paths. If they are not set default include paths will be returned
$defaultPaths = $layout->getIncludePaths();

// Replace include paths
$layout->setIncludePaths(
    array(
        JPATH_LIBRARIES . '/mylibrary/layouts',
        JPATH_SITE . '/layouts'
    )
);

// Get the list of new paths assigned
$newPaths = $layout->getIncludePaths();
```
### <a name="2.3"></a>2.3. [imp] Make JLayout methods chainable when possible.

This allows a more dynamic way of setup layouts. Examples:

``` php
$layout = new JLayoutFile('mylibrary.item');

// Set our custom include paths
$layout->setIncludePaths(array(JPATH_LIBRARIES . '/mylibrary/layouts')
    // Enable debug
    ->setDebug(true)
    // Load our prefixes
    ->setSuffixes(array('bs3', 'bs2'));

// Render the layout
echo $layout->render(array('item' => $item));
```
### <a name="2.4"></a>2.4. [imp] Allow to set data variables before rendering the layout

Most rendering systems include a way to dynamically set & set data. Now you can do it like:

``` php
$layout = new JLayoutFile('mylibrary.item');

// Set a data value
$layout->set('name', 'Roberto');

// Sample of how it can be used
if ($useTooltips)
{
    $layout->set('tooltip', 'I hate tooltips');
}

// Check if a data value has been set. It will return the value if set or the default value if not set
// public function get($key, $defaultValue = null)
$age = (int) $layout->get('age', 0);

// You can still pass additional data on render and this data will be merged
$data = array(
    'sex' => 'almost never',
    'height' => 2.05
)

// Layout will receive: name, tooltip, sex & height values 
echo $layout->render($data);
```

Note that to be able to use the set & get methods the data passed to layouts has to be ALWAYS AN ARRAY. Otherwise the system will only use the data received in the render method to keep B/C.
### <a name="2.5"></a>2.5. [imp] Add method to clear the debug messages

Now debug messages can be cleared dynamically with `$layout->clearDebugMessages()`. Now that method is only used internally but may be useful even if it's only to people extending JLayoutFile
### <a name="2.6"></a>2.6. [imp] Add a cache system to avoid duplicates file searches

Now all the file searches are cached by the system so if the same layout is searched in the same include paths and with the same suffixes it will return a cached path.
### <a name="2.7"></a>2.7. [imp] Add HTML comment to the start & end of layouts when Joomla debug mode is enabled.

This was a proposal by @javigomez and I found it really useful for frontenders I've been working with. When debug mode is enabled from backend joomla configuration all the layouts will have an HTML comment before and one HTML after.

Something like:

``` html
<!-- Start layout: /home/roberto/www/jcms3x/layouts/joomla/content/info_block/block.php -->
<dl class="article-info muted">
    <dt class="article-info-term"> Details </dt>
</dl>
<!-- End layout: /home/roberto/www/jcms3x/layouts/joomla/content/info_block/block.php -->
```
### <a name="2.8"></a>2.8. [imp] Add support for automatic language suffixes

Now there is a method to automatically load suffixes based on the active language. Usage:

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Load the language suffixes
$layout->loadLanguageSuffixes();

// Render the layout
$layout->render(array());

/*
When en-GB language is enabled this will be the suffixes applied
Suffixes: Array
(
    [0] => en-GB
    [1] => en
    [2] => ltr
)
*/

/*
Sample file search:
Searching layout for: joomla/content/info_block/block.en-GB.php
Searching layout for: joomla/content/info_block/block.en.php
Searching layout for: joomla/content/info_block/block.ltr.php
Searching layout for: joomla/content/info_block/block.php
*/
```
### <a name="2.9"></a>2.9. [imp] Add support for automatic version suffixes

I added also a method to generate automatic suffixes based on the version of the system. Usage:

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Load the version suffixes
$layout->loadVersionSuffixes();

// Render the layout
$layout->render(array());

/*
Suffixes loaded for latest Joomla:
Suffixes: Array
(
    [0] => j350
    [1] => j35
    [2] => j3
)
*/

/*
Sample file search:
Searching layout for: joomla/content/info_block/block.j350.php
Searching layout for: joomla/content/info_block/block.j35.php
Searching layout for: joomla/content/info_block/block.j3.php
Searching layout for: joomla/content/info_block/block.php
*/
```
### <a name="2.10"></a>2.10. [imp] Add a method to get the active layout id

Sometimes is useful to know the id of the layout being rendered. I added a method to do it. Sample usage:

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Will print joomla.content.info_block.block
echo $layout->getLayoutId();
```

I have also deprecated the old `setLayout()` method in favour of `setLayoutId()` so describes better what it does.
### <a name="2.11"></a>2.11. [imp] Add a method to get the active suffixes

Returns an array of loaded suffixes. Sample usage:

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Load version suffixes
$layout->loadVersionSuffixes();

// Print the active suffixes
print_r($layout->getSuffixes());

/*
Array
(
    [0] => j350
    [1] => j35
    [2] => j3
)
*/
```
### <a name="2.12"></a>2.12. [imp] Add a method to check if debug is enabled

Now there is also a method to check if debug is enabled. It makes sense mainly for internal use. Sample usage:

``` php
public function addDebugMessage($message)
{
    if ($this->isDebugEnabled())
    {
        $this->debugMessages[] = $message;
    }

    return $this;
}
```

Also there is now a method to change debug mode without adding the debug setting to the options :

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Enable debug mode
$layout->setDebug(true);

echo $layout->render(array());
```
### <a name="2.13"></a>2.13. [imp] Add fast methods to debug layouts

Additionally there are new methods to fastly debug a layout.

``` php
$layout = new JLayoutFile('joomla.content.info_block.block');

// Standard rendering
echo $layout->render($data);

// Render with debug information
echo $layout->debug($data);
```

There is also a new method in the `JLayoutHelper` class:

``` php
echo JLayoutHelper::debug('joomla.content.info_block.block', $data);
```

So only replacing the render with debug you see the output with the debug info. 
### <a name="2.14"></a>~~2.14. [imp] Avoid adding debug messages if debug is disabled~~

**This has been removed because it causes tests to fail and there is no time before v3.5**

This was a request from @alex-filat 

Now the debug messages are only added and returned when debug is enabled.
