### PR TITLE
Avoid duplicated language load calls

### DIFF
--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -252,10 +252,16 @@ abstract class ModulesHelper
 		$lang = JFactory::getLanguage();
 		$path = $clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 
-		$lang->load('tpl_' . $template . '.sys', $path, null, false, false)
-		||	$lang->load('tpl_' . $template . '.sys', $path . '/templates/' . $template, null, false, false)
-		||	$lang->load('tpl_' . $template . '.sys', $path, $lang->getDefault(), false, false)
-		||	$lang->load('tpl_' . $template . '.sys', $path . '/templates/' . $template, $lang->getDefault(), false, false);
+		$loaded = $lang->getPaths('tpl_' . $template . '.sys');
+
+		// Only load the template's language file if it hasn't been already
+		if (!$loaded)
+		{
+			$lang->load('tpl_' . $template . '.sys', $path, null, false, false)
+			||	$lang->load('tpl_' . $template . '.sys', $path . '/templates/' . $template, null, false, false)
+			||	$lang->load('tpl_' . $template . '.sys', $path, $lang->getDefault(), false, false)
+			||	$lang->load('tpl_' . $template . '.sys', $path . '/templates/' . $template, $lang->getDefault(), false, false);
+		}
 
 		$langKey = strtoupper('TPL_' . $template . '_POSITION_' . $position);
 		$text = JText::_($langKey);


### PR DESCRIPTION
From @mbabker :

> With the extra check in there to load the default language if the $lang param doesn’t match the default, it ends up with a lot of duplicated calls… plus in the case of that method specifically, it was trying to load the template’s language file for every module position in the template, so that forces the helper to only try loading the template language file once per template instead of letting JLanguage deal with it

Before:
![before](https://cloud.githubusercontent.com/assets/1119272/10872060/252a2164-80fa-11e5-9fdb-92d34fda2b7b.png)

After:
![after](https://cloud.githubusercontent.com/assets/1119272/10872062/2c07f72c-80fa-11e5-8f74-7e457486f5e7.png)
