### PR TITLE
PostgreSQL - tag similar module error

### DIFF
--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -135,7 +135,7 @@ abstract class ModTagssimilarHelper
 
 		if ($ordering == 'random' || $ordering == 'countrandom')
 		{
-			$query->order('RAND()');
+			$query->order($query->Rand());
 		}
 
 		$db->setQuery($query, 0, $maximum);


### PR DESCRIPTION
#### Steps to reproduce the issue

Set the tag similar module parameter Order Results to random

Click on Similar Tags item from the fronted left menu All Modules
#### Actual result

you got a generic error message
#### After Patch

no error message
#### Addictional Comments

similar to #8238
# LetsUseTheApiThanWeCanSuccess

was used `RAND()`  instead of  the api `$query->Rand()`
