### PR TITLE
PostgreSQL - tag popular module error

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -36,16 +36,6 @@ abstract class ModTagsPopularHelper
 		$nowDate     = JFactory::getDate()->toSql();
 		$nullDate    = $db->quote($db->getNullDate());
 
-		if ($order_value == 'rand()')
-		{
-			$order_direction = '';
-		}
-		else
-		{
-			$order_value     = $db->quoteName($order_value);
-			$order_direction = $params->get('order_direction', 1) ? 'DESC' : 'ASC';
-		}
-
 		$query = $db->getQuery(true)
 			->select(
 				array(
@@ -81,8 +71,18 @@ abstract class ModTagsPopularHelper
 		}
 
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
-			->join('INNER', $db->quoteName('#__ucm_content', 'c') . ' ON ' . $db->quoteName('m.core_content_id') . ' = ' . $db->quoteName('c.core_content_id'))
-			->order($order_value . ' ' . $order_direction);
+		->join('INNER', $db->qn('#__ucm_content', 'c') . ' ON ' . $db->qn('m.core_content_id') . ' = ' . $db->qn('c.core_content_id'));
+
+		if ($order_value == 'random')
+		{
+			$query->order($query->Rand());
+		}
+		else
+		{
+			$order_value     = $db->quoteName($order_value);
+			$order_direction = $params->get('order_direction', 1) ? 'DESC' : 'ASC';
+			$query->order($order_value . ' ' . $order_direction);
+		}
 
 		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));
 
@@ -93,6 +93,7 @@ abstract class ModTagsPopularHelper
 			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate
 				. ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $db->quote($nowDate) . ')');
 		$db->setQuery($query, 0, $maximum);
+
 		try
 		{
 			$results = $db->loadObjectList();

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -73,7 +73,7 @@ abstract class ModTagsPopularHelper
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
 		->join('INNER', $db->qn('#__ucm_content', 'c') . ' ON ' . $db->qn('m.core_content_id') . ' = ' . $db->qn('c.core_content_id'));
 
-		if ($order_value == 'random')
+		if ($order_value == 'rand()')
 		{
 			$query->order($query->Rand());
 		}

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -62,7 +62,7 @@
 					<option
 						value="count">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_COUNT</option>
 					<option
-						value="rand()">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_RANDOM</option>
+						value="random">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_RANDOM</option>
 				</field>
 				<field
 					name="order_direction"

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -62,7 +62,7 @@
 					<option
 						value="count">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_COUNT</option>
 					<option
-						value="random">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_RANDOM</option>
+						value="rand()">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_RANDOM</option>
 				</field>
 				<field
 					name="order_direction"


### PR DESCRIPTION
#### Steps to reproduce the issue

Set the tag popular module parameter Order  to random

Click on Popular Tags item from the fronted left menu All Modules
#### Actual result

you got a sql error message
![popular tags](https://cloud.githubusercontent.com/assets/181681/10882426/d9b40454-816a-11e5-96f0-f8a1c2f0d16a.png)
#### How to tests

Apply the pacth
#### Addictional Comments

similar to #8238,#8240
was used `RAND()`  instead of  the api `$query->Rand()`
