### PR TITLE
PostgreSQL - new flash module error

### DIFF
--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -70,12 +70,13 @@ abstract class ModArticlesNewsHelper
 
 		if (trim($ordering) == 'rand()')
 		{
-			$model->setState('list.direction', '');
+			$model->setState('list.ordering', JFactory::getDbo()->getQuery(true)->Rand());
 		}
 		else
 		{
 			$direction = $params->get('direction', 1) ? 'DESC' : 'ASC';
 			$model->setState('list.direction', $direction);
+			$model->setState('list.ordering', $ordering);
 		}
 
 		// Retrieve Content


### PR DESCRIPTION
#### Steps to reproduce the issue

Set the Articles - Newsflash module parameter Order  Result to Random

Click on News fash item from the fronted left menu All Modules
#### Actual result

you got an error message
#### Addictional Comments

similar to #8238,#8240,#8242,#8043
