### PR TITLE
Multilanguage: display associations tab only when available for a component when editing a category

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -20,6 +20,8 @@ $app = JFactory::getApplication();
 $input = $app->input;
 
 $assoc = JLanguageAssociations::isEnabled();
+// Are associations implemented for this extension?
+$extensionassoc = array_key_exists('item_associations', $this->form->getFieldsets());
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)
@@ -67,7 +69,7 @@ $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php if ($assoc) : ?>
+		<?php if ($assoc && $extensionassoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>


### PR DESCRIPTION
See: https://github.com/joomla/joomla-cms/issues/8231
Test:
Install a multilanguage site and enable Associations in the languagefilter plugin.
Edit/create a Banners Category. The Associations tab is displayed with an empty content as associations are NOT used for this component.
Result:
![screen shot 2015-11-02 at 16 35 28](https://cloud.githubusercontent.com/assets/869724/10885871/c79c15da-817f-11e5-88e8-9a71f3d40c3e.png)

Patch and retest, you will get:
![screen shot 2015-11-02 at 16 37 05](https://cloud.githubusercontent.com/assets/869724/10885925/01d5b08a-8180-11e5-9bd5-aa372f200237.png)

Check that the Associations tab is still available for Articles categories:
![screen shot 2015-11-02 at 16 38 23](https://cloud.githubusercontent.com/assets/869724/10885952/2b0776b4-8180-11e5-9bfa-3f73dd4bda93.png)
