### PR TITLE
Remove automatic HTML comments for layouts until we get it working properly

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -117,20 +117,10 @@ class JLayoutFile extends JLayoutBase
 			return $layoutOutput;
 		}
 
-		if (JDEBUG)
-		{
-			$layoutOutput .= "<!-- Start layout: " . $path . " -->\n";
-		}
-
 		ob_start();
 		include $path;
 		$layoutOutput .= ob_get_contents();
 		ob_end_clean();
-
-		if (JDEBUG)
-		{
-			$layoutOutput .= "<!-- End layout: " . $path . " -->\n";
-		}
 
 		return $layoutOutput;
 	}


### PR DESCRIPTION
This reverts a new feature added in https://github.com/joomla/joomla-cms/pull/8234

Some layout output is used directly in JS functions and this feature breaks them. Example:

https://github.com/joomla/joomla-cms/blob/staging/layouts/joomla/modal/main.php#L68-L73

To see the error try to edit any menu item with debug enabled from joomla configuration. It causes a JS error that breaks edit page. After applying this PR everything works again.
