### PR TITLE
PostgreSQL - wrong group by com_contacts

### DIFF
--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -226,10 +226,26 @@ class ContactModelContacts extends JModelList
 					$db->quoteName(
 						array(
 							'a.id',
-							'ul.name',
-							'l.title',
-							'uc.name',
-							'ag.title',
+							'a.name',
+							'a.alias',
+							'a.checked_out',
+							'a.checked_out_time',
+							'a.catid',
+							'a.user_id',
+							'a.published',
+							'a.access',
+							'a.created',
+							'a.created_by',
+							'a.ordering',
+							'a.featured',
+							'a.language',
+							'a.publish_up',
+							'a.publish_down',
+							'ul.name' ,
+							'ul.email',
+							'l.title' ,
+							'uc.name' ,
+							'ag.title' ,
 							'c.title'
 						)
 					)


### PR DESCRIPTION
#### Steps to reproduce the issue

on a (empty) multilanguage site
administration->contacts->contacts
#### Actual result

sql error
![j35 administration -contacts](https://cloud.githubusercontent.com/assets/181681/10904634/19e1fc84-8215-11e5-80be-1a33f07f6910.png)
#### After patch

work as expected
![j35 administration contacts-f](https://cloud.githubusercontent.com/assets/181681/10904708/87c4643a-8215-11e5-99f8-7561992a4912.png)
#### Comments

wrong  group by clause for postgresql,mssql
