### PR TITLE
Missing return argument

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -156,7 +156,7 @@ class JDocumentHTML extends JDocument
 	{
 		if (empty($data) || !is_array($data))
 		{
-			return;
+			return $this;
 		}
 
 		$this->title        = (isset($data['title']) && !empty($data['title'])) ? $data['title'] : $this->title;


### PR DESCRIPTION
The method is declared to return JDocumentHTML, but contains a void return statement.
Currently the return value is ignored everywhere, therefore this patch won't have any side effects and can be merged safely.
