### PR TITLE
Allow numeric characters in format variable (Ref #8259)

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -723,7 +723,7 @@ abstract class JFactory
 		$lang = self::getLanguage();
 
 		$input = self::getApplication()->input;
-		$type = $input->get('format', 'html', 'word');
+		$type = $input->get('format', 'html', 'cmd');
 
 		$version = new JVersion;
 


### PR DESCRIPTION
This change will allow document types to accept extensions with
alphanumeric characters such as m4v, mp3, and mp4. Because the JDocument class is loaded from JFactory, it becomes exceedingly difficult to override this behavior in extensions. 

---

In the JFactory class the format variable retrieved from the request uses the 'word' filter which strips out all numeric characters from the variable value and leaves only alpha characters. In order to add document types for video files such as m4v, mp4, etc... this change is needed to JDocument types which include numeric characters. Consider this example:

``` php
$link = JRoute::_('index.php?option=com_video&format=m4v&id=y2VLUEh6crVq4hfV');
```

The router for the custom component returns a link in the form:

```
http://mysite.com/videos/y2VLUEh6crVq4hfV.m4v
```

However, following that link you will receive a view not found error message because the "type" variable will be returned as "mv" instead of "m4v" as the filter variable for JInput will strip out the numeric characters.
