### PR TITLE
com_installer moved filters Update & Discover

### DIFF
--- a/administrator/components/com_installer/models/discover.php
+++ b/administrator/components/com_installer/models/discover.php
@@ -51,6 +51,7 @@ class InstallerModelDiscover extends InstallerModel
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
+		$this->setState('list.ordering', 'name');
 
 		parent::populateState('name', 'asc');
 	}

--- a/administrator/components/com_installer/models/forms/filter_discover.xml
+++ b/administrator/components/com_installer/models/forms/filter_discover.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset addfieldpath="/administrator/components/com_installer/models/fields"/>
+
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                hint="JSEARCH_FILTER"
+                />
+
+        <field
+                name="client_id"
+                type="location"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
+        </field>
+
+        <field
+                name="type"
+                type="type"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_TYPE_SELECT</option>
+        </field>
+
+        <field
+                name="group"
+                type="folder"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_FOLDER_SELECT</option>
+        </field>
+
+    </fields>
+    <fields name="list">
+        <field
+                name="limit"
+                type="limitbox"
+                class="input-mini"
+                default="25"
+                onchange="this.form.submit();"
+                />
+    </fields>
+</form>

--- a/administrator/components/com_installer/models/forms/filter_update.xml
+++ b/administrator/components/com_installer/models/forms/filter_update.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset addfieldpath="/administrator/components/com_installer/models/fields"/>
+
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                hint="JSEARCH_FILTER"
+                />
+
+        <field
+                name="client_id"
+                type="location"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
+        </field>
+
+        <field
+                name="type"
+                type="type"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_TYPE_SELECT</option>
+        </field>
+
+        <field
+                name="group"
+                type="folder"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_FOLDER_SELECT</option>
+        </field>
+
+    </fields>
+    <fields name="list">
+        <field
+                name="limit"
+                type="limitbox"
+                class="input-mini"
+                default="25"
+                onchange="this.form.submit();"
+                />
+    </fields>
+</form>

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -75,6 +75,7 @@ class InstallerModelUpdate extends JModelList
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
+		$this->setState('list.ordering', 'name');
 
 		parent::populateState('name', 'asc');
 	}

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -34,22 +34,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php if ($this->ftp) : ?>
 		<?php echo $this->loadTemplate('ftp'); ?>
 	<?php endif; ?>
-
-	<!-- Begin Filters -->
-	<div id="filter-bar" class="btn-toolbar">
-		<div class="btn-group pull-right hidden-phone">
-			<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>
-			<?php echo $this->pagination->getLimitBox(); ?>
-		</div>
-		<div class="filter-search btn-group pull-left">
-			<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_INSTALLER_FILTER_LABEL'); ?>" />
-		</div>
-		<div class="btn-group pull-left">
-			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-		</div>
-	</div>
-	<div class="clearfix"> </div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 	<!-- Begin Content -->
 		<?php if (count($this->items)) : ?>

--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -30,9 +30,11 @@ class InstallerViewDiscover extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state      = $this->get('State');
-		$this->items      = $this->get('Items');
+		$this->state = $this->get('State');
+		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
+		$this->filterForm = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		parent::display($tpl);
 	}
@@ -54,45 +56,6 @@ class InstallerViewDiscover extends InstallerViewDefault
 		JToolbarHelper::divider();
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=discover');
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'),
-			'filter_client_id',
-			JHtml::_(
-				'select.options',
-				array('0' => 'JSITE', '1' => 'JADMINISTRATOR'),
-				'value',
-				'text',
-				$this->state->get('filter.client_id'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'),
-			'filter_type',
-			JHtml::_(
-				'select.options',
-				InstallerHelper::getExtensionTypes(),
-				'value',
-				'text',
-				$this->state->get('filter.type'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'),
-			'filter_group',
-			JHtml::_(
-				'select.options',
-				array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))),
-				'value',
-				'text',
-				$this->state->get('filter.group'),
-				true
-			)
-		);
 
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_DISCOVER');

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -30,20 +30,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php if ($this->ftp) : ?>
 		<?php echo $this->loadTemplate('ftp'); ?>
 	<?php endif; ?>
-	<div id="filter-bar" class="btn-toolbar">
-		<div class="btn-group pull-right hidden-phone">
-			<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>
-			<?php echo $this->pagination->getLimitBox(); ?>
-		</div>
-		<div class="filter-search btn-group pull-left">
-			<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_INSTALLER_FILTER_LABEL'); ?>" />
-		</div>
-		<div class="btn-group pull-left">
-			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-			<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-		</div>
-	</div>
-	<div class="clearfix"> </div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 	<!-- Begin Content -->
 		<?php if (count($this->items)) : ?>

--- a/administrator/components/com_installer/views/update/view.html.php
+++ b/administrator/components/com_installer/views/update/view.html.php
@@ -56,6 +56,9 @@ class InstallerViewUpdate extends InstallerViewDefault
 		$this->state = $this->get('State');
 		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
+		$this->filterForm = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
+
 		$paths = new stdClass;
 		$paths->first = '';
 
@@ -85,30 +88,6 @@ class InstallerViewUpdate extends InstallerViewDefault
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=manage');
 
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'),
-			'filter_client_id',
-			JHtml::_('select.options', array('0' => 'JSITE', '1' => 'JADMINISTRATOR'), 'value', 'text', $this->state->get('filter.client_id'), true)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'),
-			'filter_type',
-			JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'),
-			'filter_group',
-			JHtml::_(
-				'select.options',
-				array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))),
-				'value',
-				'text',
-				$this->state->get('filter.group'),
-				true
-			)
-		);
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATE');
 	}


### PR DESCRIPTION
New PR to replace "com_installer Update & Discover - Moved Filters #7717 " that had a merge conflict.
Please see #7717 for details & testing instructions.

---

This PR moves Filters from left sidebar to Search Tools.
# Testing instructions

You have to install some old extensions for which newer versions are available. Make sure that you install extensions with different Type / Folder / Client so that you can test the various settings of the Filters.

For my **tests with Update** I chose the following extensions because I use them often and I had some old versions available:
Name            | Type      | Version   | Folder    | Client
Akeeba Backup       | Component | 4.0.5     | N/A       | Administrator
DJ-ImageSlider Package  | Package   | 2.2.4     | N/A       | Site
JCE Editor      | Component | 2.4.3     | N/A       | Administrator
JCE MediaBox (J2.5 - 3) | Plugin    | 1.1.17    | system    | Site

For my **test with Discover** I copied the templateDetails.xml of an admin and a site template,
and the .xml manifest file of an authentication Plugin,
and changed those to get some fake extensions that Joomla could discover to install.
## Before this PR
### Extensions > Manage > **Update**
1. Left sidebar has 3 filter options (Select: Location, Type, Folder) that cannot be reset easily to original state with one button.

![extension-update](https://cloud.githubusercontent.com/assets/1217850/9313876/c3a89052-4525-11e5-9c9b-30f92de28c0e.png)
### Extensions > Manage > **Discover**
1. Left sidebar has 3 filter options (Select: Location, Type, Folder) that cannot be reset easily to original state with one button.

![extension-discover](https://cloud.githubusercontent.com/assets/1217850/9313875/c3a7654c-4525-11e5-9275-1aac9216aa61.png)
### Extensions > Manage > **Discover** & clicked on [Discover] button
1. Left sidebar has 3 filter options (Select: Location, Type, Folder) that cannot be reset easily to original state with one button.

![extension-discover-before](https://cloud.githubusercontent.com/assets/1217850/9313874/c3a6cd76-4525-11e5-86a1-bd06ccf3c909.png)
## After this PR
### Extensions > Manage > **Update**
1. The Filters have been moved from sidebar to Search Tools in middle column. All filters can be reset with the "Clear" button.
   **Note:** the Filters work okay because the lists are filtered on basis of those filters. However the filters do not keep their chosen value. I hope that someone else understands the problem and can fix that.

![extension-update-after](https://cloud.githubusercontent.com/assets/1217850/9313879/c3aaa298-4525-11e5-8f3e-880141d6b19f.png)
### Extensions > Manage > **Discover**
1. The Filters have been moved from sidebar to Search Tools in middle column. All filters can be reset with the "Clear" button.

![extension-discover-after](https://cloud.githubusercontent.com/assets/1217850/9313878/c3a9a294-4525-11e5-99b4-bd516856cae5.png)
### Extensions > Manage > **Discover** & Search Tools + Select Type Option has been clicked
1. The Filters have been moved from sidebar to Search Tools in middle column. All filters can be reset with the "Clear" button.
   **Note:** these Filters work okay **and** they keep their chosen value.

![extension-discover-after-selected](https://cloud.githubusercontent.com/assets/1217850/9313877/c3a897d2-4525-11e5-827b-b834b132646c.png)
