### PR TITLE
com_installer Update Sites Moved Filters v2

### DIFF
--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -52,8 +52,8 @@ class InstallerHelper
 		);
 		JHtmlSidebar::addEntry(
 		JText::_('COM_INSTALLER_SUBMENU_WARNINGS'),
-					'index.php?option=com_installer&view=warnings',
-		$vName == 'warnings'
+			'index.php?option=com_installer&view=warnings',
+			$vName == 'warnings'
 		);
 		JHtmlSidebar::addEntry(
 			JText::_('COM_INSTALLER_SUBMENU_LANGUAGES'),

--- a/administrator/components/com_installer/models/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/models/forms/filter_updatesites.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset addfieldpath="/administrator/components/com_installer/models/fields"/>
+
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                hint="JSEARCH_FILTER"
+                />
+
+        <field
+                name="client_id"
+                type="location"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
+        </field>
+
+        <field
+                name="enabled"
+                type="list"
+                label="COM_PLUGINS_FILTER_PUBLISHED"
+                description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_PUBLISHED</option>
+            <option value="0">JUNPUBLISHED</option>
+            <option value="1">JPUBLISHED</option>
+        </field>
+
+        <field
+                name="type"
+                type="type"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_TYPE_SELECT</option>
+        </field>
+
+        <field
+                name="group"
+                type="folder"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_FOLDER_SELECT</option>
+        </field>
+
+    </fields>
+    <fields name="list">
+        <field
+                name="limit"
+                type="limitbox"
+                class="input-mini"
+                default="25"
+                onchange="this.form.submit();"
+                />
+    </fields>
+</form>

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -72,6 +72,8 @@ class InstallerModelUpdatesites extends InstallerModel
 		$group = $this->getUserStateFromRequest($this->context . '.filter.group', 'filter_group', '');
 		$this->setState('filter.group', $group);
 
+		$this->setState('list.ordering', 'name');
+
 		parent::populateState('name', 'asc');
 	}
 

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -26,20 +26,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php else : ?>
 			<div id="j-main-container">
 		<?php endif; ?>
-			<div id="filter-bar" class="btn-toolbar">
-				<div class="btn-group pull-right hidden-phone">
-					<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
-					<?php echo $this->pagination->getLimitBox(); ?>
-				</div>
-				<div class="filter-search btn-group pull-left">
-					<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_INSTALLER_FILTER_LABEL'); ?>" />
-				</div>
-				<div class="btn-group pull-left">
-					<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-					<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-				</div>
-			</div>
-			<div class="clearfix"> </div>
+			<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
 			<?php if (count($this->items)) : ?>
 			<table class="table table-striped">
 				<thead>

--- a/administrator/components/com_installer/views/updatesites/view.html.php
+++ b/administrator/components/com_installer/views/updatesites/view.html.php
@@ -42,9 +42,11 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model
-		$this->state      = $this->get('State');
-		$this->items      = $this->get('Items');
+		$this->state = $this->get('State');
+		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
+		$this->filterForm = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -87,48 +89,7 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 		}
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=updatesites');
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'),
-			'filter_client_id',
-			JHtml::_('select.options', array('0' => 'JSITE', '1' => 'JADMINISTRATOR'), 'value', 'text', $this->state->get('filter.client_id'), true)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_STATE_SELECT'),
-			'filter_enabled',
-			JHtml::_(
-				'select.options',
-				array('0' => 'JDISABLED', '1' => 'JENABLED'),
-				'value',
-				'text',
-				$this->state->get('filter.enabled'),
-				true
-			)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'),
-			'filter_type',
-			JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'),
-			'filter_group',
-			JHtml::_(
-				'select.options',
-				array_merge(
-					InstallerHelper::getExtensionGroupes(),
-					array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))
-				),
-				'value',
-				'text',
-				$this->state->get('filter.group'),
-				true
-			)
-		);
-
+		
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATESITES');
 	}

--- a/administrator/components/com_installer/views/updatesites/view.html.php
+++ b/administrator/components/com_installer/views/updatesites/view.html.php
@@ -89,7 +89,7 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 		}
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=updatesites');
-		
+
 		parent::addToolbar();
 		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATESITES');
 	}


### PR DESCRIPTION
PR to replace "com_installer Update Sites - Moved sidebar Filters #7707 " to correct a merge conflict.
Please see #7707 for details & testing instructions.

---

This PR moves Filters from left sidebar to Search Tools.
# Testing instructions
## Before this PR

Extensions > Manage > **Update Sites**
1. Left sidebar has 4 filter options (Select: Location, Status, Type, Folder) that cannot be reset easily to original state with one button.

![extension-updatesites-before](https://cloud.githubusercontent.com/assets/1217850/9296029/419202a4-4482-11e5-9af3-b21941f64282.png)
## After this PR

Extensions > Manage > **Update Sites**
1. The Filters have been moved from sidebar to Search Tools in middle column. All filters can be reset with the "Clear" button.

![extension-updatesites-after](https://cloud.githubusercontent.com/assets/1217850/9296030/419227f2-4482-11e5-9dc4-a13453f7260c.png)
