### PR TITLE
moved filters of Banners Tracks to Search Tools

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/models/forms/filter_tracks.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fields name="filter">
+        <field
+                name="search"
+                type="text"
+                hint="JSEARCH_FILTER"
+                class="js-stools-search-string"
+                />
+        <field
+                name="client_id"
+                type="bannerclient"
+                extension="com_content"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_BANNERS_SELECT_CLIENT</option>
+        </field>
+        <field
+                name="category_id"
+                type="category"
+                extension="com_banners"
+                onchange="this.form.submit();"
+                >
+            <option value="">JOPTION_SELECT_CATEGORY</option>
+        </field>
+        <field
+                name="type"
+                type="list"
+                default="0"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_BANNERS_SELECT_TYPE</option>
+            <option value="1">COM_BANNERS_TYPE1</option>
+            <option value="2">COM_BANNERS_TYPE2</option>
+        </field>
+
+    </fields>
+
+    <fields name="list">
+        <field
+                name="sortTable"
+                type="list"
+                label="JGLOBAL_SORT_BY"
+                description="JFIELD_ORDERING_DESC"
+                onchange="Joomla.orderTable();"
+                default="a.id DESC"
+                >
+            <option value="">JGLOBAL_SORT_BY</option>
+            <option value="b.name">COM_BANNERS_HEADING_NAME</option>
+            <option value="cl.name">COM_BANNERS_HEADING_CLIENT</option>
+            <option value="track_type">COM_BANNERS_HEADING_TYPE</option>
+            <option value="count">COM_BANNERS_HEADING_COUNT</option>
+            <option value="track_date">JDATE</option>
+        </field>
+
+        <field
+                name="directionTable"
+                type="list"
+                label="JGLOBAL_ORDER_DIRECTION_LABEL"
+                description="JGLOBAL_ORDER_DIRECTION_DESC"
+                onchange="Joomla.orderTable();"
+                >
+            <option value="">JFIELD_ORDERING_DESC</option>
+            <option value="asc">JGLOBAL_ORDER_ASCENDING</option>
+            <option value="desc">JGLOBAL_ORDER_DESCENDING</option>
+        </field>
+
+        <field
+                name="limit"
+                type="limitbox"
+                class="input-mini"
+                default="25"
+                onchange="this.form.submit();"
+                />
+    </fields>
+</form>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -22,8 +22,8 @@ $sortFields = $this->getSortFields();
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()
 	{
-		table = document.getElementById("sortTable");
-		direction = document.getElementById("directionTable");
+		table = document.getElementById("list_sortTable");
+		direction = document.getElementById("list_directionTable");
 		order = table.options[table.selectedIndex].value;
 		if (order != "' . $listOrder . '")
 		{
@@ -57,27 +57,9 @@ JFactory::getDocument()->addScriptDeclaration('
 				<label class="filter-hide-lbl" for="filter_end"><?php echo JText::_('COM_BANNERS_END_LABEL'); ?></label>
 				<?php echo JHtml::_('calendar', $this->state->get('filter.end'), 'filter_end', 'filter_end', '%Y-%m-%d', array('size' => 10, 'onchange' => "this.form.fireEvent('submit');this.form.submit()")); ?>
 			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
-				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php echo $listDirn == 'asc' ? 'selected="selected"' : ''; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php echo $listDirn == 'desc' ? 'selected="selected"' : ''; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING'); ?></option>
-				</select>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
-				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY'); ?></option>
-					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
-				</select>
-			</div>
 		</div>
 		<div class="clearfix"></div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">
 				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>

--- a/administrator/components/com_banners/views/tracks/view.html.php
+++ b/administrator/components/com_banners/views/tracks/view.html.php
@@ -48,9 +48,11 @@ class BannersViewTracks extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->items      = $this->get('Items');
+		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
-		$this->state      = $this->get('State');
+		$this->state = $this->get('State');
+		$this->filterForm = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -103,29 +105,6 @@ class BannersViewTracks extends JViewLegacy
 
 		JHtmlSidebar::setAction('index.php?option=com_banners&view=tracks');
 
-		JHtmlSidebar::addFilter(
-			JText::_('COM_BANNERS_SELECT_CLIENT'),
-			'filter_client_id',
-			JHtml::_('select.options', BannersHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'))
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('JOPTION_SELECT_CATEGORY'),
-			'filter_category_id',
-			JHtml::_('select.options', JHtml::_('category.options', 'com_banners'), 'value', 'text', $this->state->get('filter.category_id'))
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('COM_BANNERS_SELECT_TYPE'),
-			'filter_type',
-			JHtml::_(
-				'select.options',
-				array(JHtml::_('select.option', 1, JText::_('COM_BANNERS_IMPRESSION')), JHtml::_('select.option', 2, JText::_('COM_BANNERS_CLICK'))),
-				'value',
-				'text',
-				$this->state->get('filter.type')
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the filters from sidebar to Search Tools
and adds Ordering + Direction dropdown options to Search Tools area.
## Test instructions
### Before the PR

Components > Banners > Tracks
When you want to unset the filters on the left, you'll have to be unset them individually.

![com_banners-tracks-before](https://cloud.githubusercontent.com/assets/1217850/10925420/5d5fba4a-828e-11e5-8566-cedd9e401104.png)
### After the PR

Components > Banners > Tracks
When you want to unset the 3 filters, just click on the Clear button.

![com_banners-tracks-after](https://cloud.githubusercontent.com/assets/1217850/10925421/5d6192ca-828e-11e5-8dd9-4bba07a64e13.png)
