### PR TITLE
moved filters of User Notes to Search Tools

### DIFF
--- a/administrator/components/com_users/models/forms/filter_notes.xml
+++ b/administrator/components/com_users/models/forms/filter_notes.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fieldset addfieldpath="/administrator/components/com_installer/models/fields"/>
+
+	<fields name="filter">
+		<field
+				name="search"
+				type="text"
+				hint="JSEARCH_FILTER"
+				/>
+
+		<field
+				name="published"
+				type="status"
+				onchange="this.form.submit();"
+				>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+
+		<field
+				name="category_id"
+				type="category"
+				extension="com_users"
+				onchange="this.form.submit();"
+				>
+			<option value="">JOPTION_SELECT_CATEGORY</option>
+		</field>
+
+	</fields>
+	<fields name="list">
+		<field
+				name="sortTable"
+				type="list"
+				label="JGLOBAL_SORT_BY"
+				description="JFIELD_ORDERING_DESC"
+				onchange="Joomla.orderTable();"
+				default="a.id DESC"
+				>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="u.name">COM_USERS_USER_HEADING</option>
+			<option value="a.subject">COM_USERS_SUBJECT_HEADING</option>
+			<option value="c.title">COM_USERS_CATEGORY_HEADING</option>
+			<option value="a.state">JSTATUS</option>
+			<option value="a.review_time">COM_USERS_REVIEW_HEADING</option>
+			<option value="a.id">JGRID_HEADING_ID</option>
+		</field>
+
+		<field
+				name="directionTable"
+				type="list"
+				label="JGLOBAL_ORDER_DIRECTION_LABEL"
+				description="JGLOBAL_ORDER_DIRECTION_DESC"
+				onchange="Joomla.orderTable();"
+				>
+			<option value="">JFIELD_ORDERING_DESC</option>
+			<option value="asc">JGLOBAL_ORDER_ASCENDING</option>
+			<option value="desc">JGLOBAL_ORDER_DESCENDING</option>
+		</field>
+
+		<field
+				name="limit"
+				type="limitbox"
+				class="input-mini"
+				default="25"
+				onchange="this.form.submit();"
+				/>
+	</fields>
+</form>

--- a/administrator/components/com_users/models/notes.php
+++ b/administrator/components/com_users/models/notes.php
@@ -106,7 +106,7 @@ class UsersModelNotes extends JModelList
 		}
 
 		// Filter by published state
-		$published = $this->getState('filter.state');
+		$published = $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{
@@ -139,7 +139,7 @@ class UsersModelNotes extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$orderCol = $this->state->get('list.ordering');
+		$orderCol = $this->state->get('list.ordering', 'a.review_time');
 		$orderDirn = $this->state->get('list.direction');
 		$query->order($db->escape($orderCol . ' ' . $orderDirn));
 

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -21,8 +21,8 @@ $sortFields = $this->getSortFields();
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.orderTable = function()
 	{
-		table = document.getElementById("sortTable");
-		direction = document.getElementById("directionTable");
+		table = document.getElementById("list_sortTable");
+		direction = document.getElementById("list_directionTable");
 		order = table.options[table.selectedIndex].value;
 		if (order != "' . $listOrder . '")
 		{
@@ -45,35 +45,8 @@ JFactory::getDocument()->addScriptDeclaration('
 <?php else : ?>
 	<div id="j-main-container">
 <?php endif;?>
-		<div id="filter-bar" class="btn-toolbar">
-			<div class="filter-search btn-group pull-left">
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_IN_NOTE_TITLE'); ?>" />
-			</div>
-			<div class="btn-group">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="directionTable" class="element-invisible"><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></label>
-				<select name="directionTable" id="directionTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JFIELD_ORDERING_DESC'); ?></option>
-					<option value="asc" <?php if ($listDirn == 'asc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_ASCENDING'); ?></option>
-					<option value="desc" <?php if ($listDirn == 'desc') echo 'selected="selected"'; ?>><?php echo JText::_('JGLOBAL_ORDER_DESCENDING');  ?></option>
-				</select>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="sortTable" class="element-invisible"><?php echo JText::_('JGLOBAL_SORT_BY'); ?></label>
-				<select name="sortTable" id="sortTable" class="input-medium" onchange="Joomla.orderTable()">
-					<option value=""><?php echo JText::_('JGLOBAL_SORT_BY');?></option>
-					<?php echo JHtml::_('select.options', $sortFields, 'value', 'text', $listOrder); ?>
-				</select>
-			</div>
-		</div>
-		<div class="clearfix"> </div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">
 				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>

--- a/administrator/components/com_users/views/notes/view.html.php
+++ b/administrator/components/com_users/views/notes/view.html.php
@@ -62,10 +62,12 @@ class UsersViewNotes extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Initialise view variables.
-		$this->items      = $this->get('Items');
+		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
-		$this->state      = $this->get('State');
-		$this->user       = $this->get('User');
+		$this->state = $this->get('State');
+		$this->user = $this->get('User');
+		$this->filterForm = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		UsersHelper::addSubmenu('notes');
 
@@ -144,18 +146,6 @@ class UsersViewNotes extends JViewLegacy
 		JToolbarHelper::help('JHELP_USERS_USER_NOTES');
 
 		JHtmlSidebar::setAction('index.php?option=com_users&view=notes');
-
-		JHtmlSidebar::addFilter(
-			JText::_('JOPTION_SELECT_PUBLISHED'),
-			'filter_published',
-			JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true)
-		);
-
-		JHtmlSidebar::addFilter(
-			JText::_('JOPTION_SELECT_CATEGORY'),
-			'filter_category_id',
-			JHtml::_('select.options', JHtml::_('category.options', 'com_users'), 'value', 'text', $this->state->get('filter.category_id'))
-		);
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the filters from sidebar to Search Tools
and adds Ordering + Direction dropdown + List Limit options to the Search Tools area.
## Test instructions
### Before the PR

Users > User Notes
When you want to unset the filters on the left, you'll have to be unset them individually.

![com_users-notes-before](https://cloud.githubusercontent.com/assets/1217850/10926022/82283e24-8293-11e5-985f-dea375b16b7b.png)
### After the PR

Users > User Notes
When you want to unset the 2 filters, just click on the Clear button.

![com_users-notes-after](https://cloud.githubusercontent.com/assets/1217850/10926023/8229a142-8293-11e5-8abc-c7581c772541.png)
