### PR TITLE
Missing Editor breaks the script on modal xtd button

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -19,6 +19,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $trashed   = $this->state->get('filter.state') == -2 ? true : false;
 $canOrder  = $user->authorise('core.edit.state', 'com_modules');
 $saveOrder = $listOrder == 'ordering';
+$editor    = JFactory::getApplication()->input->get('editor', '');
 
 if ($saveOrder)
 {
@@ -46,12 +47,12 @@ JFactory::getDocument()->addScriptDeclaration('
 		};
 
 		moduleIns = function(type, name) {
-			parent.window.jInsertEditorText("{loadmodule " + type + "," + name + "," + jQuery("#extra_class").val() + "}");
+			parent.window.jInsertEditorText("{loadmodule " + type + "," + name + "," + jQuery("#extra_class").val() + "}", "' . $editor . '");
 			parent.window.jModalClose();
 		}
 
 		modulePosIns = function(position) {
-			parent.window.jInsertEditorText("{loadposition " + position + "," + jQuery("#extra_class").val() + "}");
+			parent.window.jInsertEditorText("{loadposition " + position + "," + jQuery("#extra_class").val() + "}", "' . $editor . '");
 			parent.window.jModalClose();
 		}
 ');

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -19,7 +19,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $trashed   = $this->state->get('filter.state') == -2 ? true : false;
 $canOrder  = $user->authorise('core.edit.state', 'com_modules');
 $saveOrder = $listOrder == 'ordering';
-$editor    = JFactory::getApplication()->input->get('editor', '');
+$editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 
 if ($saveOrder)
 {

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -28,7 +28,7 @@ class PlgButtonModule extends JPlugin
 	 * Display the button
 	 *
 	 * @param   string  $name  The name of the button to add
-
+	 *
 	 * @since  3.5
 	 * @return array
 	 */

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -27,6 +27,8 @@ class PlgButtonModule extends JPlugin
 	/**
 	 * Display the button
 	 *
+	 * @param   string  $name  The name of the button to add
+
 	 * @since  3.5
 	 * @return array
 	 */
@@ -36,7 +38,8 @@ class PlgButtonModule extends JPlugin
 		 * Use the built-in element view to select the module.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor=' . $name . '&amp;' . JSession::getFormToken() . '=1';
+		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
+				. $name . '&amp;' . JSession::getFormToken() . '=1';
 
 		$button = new JObject;
 		$button->modal = true;

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 /**
- * Editor Module buton
+ * Editor Module button
  *
  * @since  3.5
  */
@@ -30,13 +30,13 @@ class PlgButtonModule extends JPlugin
 	 * @since  3.5
 	 * @return array
 	 */
-	public function onDisplay()
+	public function onDisplay($name)
 	{
 		/*
 		 * Use the built-in element view to select the module.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor=' . $name . '&amp;' . JSession::getFormToken() . '=1';
 
 		$button = new JObject;
 		$button->modal = true;


### PR DESCRIPTION
#### The problem

Select either none or code mirror as your editor
Edit an article
Try inserting a module by name or position
An error is logged in your browsers console
#### The fix

Pass a var to specify the editor’  id in the script
#### Test

Apply this patch and repeat the above procedure
