### PR TITLE
Look ma no addScriptDeclaration

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -112,15 +112,8 @@ $stickyBar = 0;
 
 if ($stickyToolbar)
 {
-	$stickyBar = 1;
+	$stickyBar = 'true';
 }
-
-$doc->addScriptDeclaration(
-	"
-	window.isisStickyToolbar = $stickyBar;
-	window.isisOffsetTop = $offset;
-	"
-);
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -315,5 +308,6 @@ $doc->addScriptDeclaration(
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
+<div id="isisJsData" data-tmpl-sticky="<?php echo $stickyBar; ?>" data-tmpl-offset="<?php echo $offset; ?>"></div>
 </body>
 </html>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -239,7 +239,7 @@ if ($stickyToolbar)
 	<!-- Subheader -->
 	<a class="btn btn-subhead" data-toggle="collapse" data-target=".subhead-collapse"><?php echo JText::_('TPL_ISIS_TOOLBAR'); ?>
 		<span class="icon-wrench"></span></a>
-	<div class="subhead-collapse collapse">
+	<div class="subhead-collapse collapse" id="isisJsData" data-tmpl-sticky="<?php echo $stickyBar; ?>" data-tmpl-offset="<?php echo $offset; ?>">
 		<div class="subhead">
 			<div class="container-fluid">
 				<div id="container-collapse" class="container-collapse"></div>
@@ -308,6 +308,5 @@ if ($stickyToolbar)
 	<!-- End Status Module -->
 <?php endif; ?>
 <jdoc:include type="modules" name="debug" style="none" />
-<div id="isisJsData" data-tmpl-sticky="<?php echo $stickyBar; ?>" data-tmpl-offset="<?php echo $offset; ?>"></div>
 </body>
 </html>

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -61,7 +61,8 @@
 		var navTop;
 		var isFixed = false;
 
-		if (window.isisStickyToolbar == 1) {
+
+		if ($('#isisJsData').data('tmpl-sticky') == true) {
 			processScrollInit();
 			processScroll();
 
@@ -71,7 +72,7 @@
 
 		function processScrollInit() {
 			if ($('.subhead').length) {
-				navTop = $('.subhead').length && $('.subhead').offset().top - window.isisOffsetTop;
+				navTop = $('.subhead').length && $('.subhead').offset().top - $('#isisJsData').data('tmpl-offset');
 
 				// Fix the container top
 				$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -62,7 +62,7 @@
 		var isFixed = false;
 
 
-		if ($('#isisJsData').data('tmpl-sticky') == true) {
+		if (document.getElementById('isisJsData').getAttribute('data-tmpl-sticky') == "true") {
 			processScrollInit();
 			processScroll();
 
@@ -72,7 +72,7 @@
 
 		function processScrollInit() {
 			if ($('.subhead').length) {
-				navTop = $('.subhead').length && $('.subhead').offset().top - $('#isisJsData').data('tmpl-offset');
+				navTop = $('.subhead').length && $('.subhead').offset().top - parseInt(document.getElementById('isisJsData').getAttribute('data-tmpl-offset'));
 
 				// Fix the container top
 				$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -62,7 +62,7 @@
 		var isFixed = false;
 
 
-		if (document.getElementById('isisJsData').getAttribute('data-tmpl-sticky') == "true") {
+		if (document.getElementById('isisJsData') && document.getElementById('isisJsData').getAttribute('data-tmpl-sticky') == "true") {
 			processScrollInit();
 			processScroll();
 


### PR DESCRIPTION
#### A better way to pass PHP vars to Javascript

Instead of using addScriptDeclaratio() which comes with much computation power we can use data attributes to pass all the vars. Then we collect them easily from the javascript.

As an example Isis passes two variables that control the toolbar buttons (if it is sticky and the height of the menu). Now these vars are injected in a null div and collected from the static script.
#### Testing

Apply the patch and play with the different options that isis provides in it’s configuration.
