### PR TITLE
Remove "?limitstart=0" in pagination

### DIFF
--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -786,11 +786,14 @@ class JPagination
 			$data->start->base = '0';
 			$data->start->link = JRoute::_($params . '&' . $this->prefix);
 			$data->previous->base = $page;
-			if($page != '0'){
-	                    $data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
-	                } else {
-	                    $data->previous->link = JRoute::_($params . '&' . $this->prefix);
-	                }
+			if($page != '0')
+			{
+				$data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
+			}
+			else
+			{
+				$data->previous->link = JRoute::_($params . '&' . $this->prefix);
+			}
 		}
 
 		// Set the next and end data objects.
@@ -820,11 +823,14 @@ class JPagination
 			if ($i != $this->pagesCurrent || $this->viewall)
 			{
 				$data->pages[$i]->base = $offset;
-				if ($offset == '0') {
-		                    $data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix);
-		                } else {
-		                    $data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
-		                }
+				if ($offset == '0')
+				{
+					$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix);
+				}
+				else
+				{
+					$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+				}
 			}
 			else
 			{

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -786,7 +786,7 @@ class JPagination
 			$data->start->base = '0';
 			$data->start->link = JRoute::_($params . '&' . $this->prefix);
 			$data->previous->base = $page;
-			if($page != '0')
+			if ($page != '0')
 			{
 				$data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
 			}

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -784,9 +784,13 @@ class JPagination
 			// @todo remove code: $page = $page == 0 ? '' : $page;
 
 			$data->start->base = '0';
-			$data->start->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=0');
+			$data->start->link = JRoute::_($params . '&' . $this->prefix);
 			$data->previous->base = $page;
-			$data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
+			if($page != '0'){
+	                    $data->previous->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
+	                } else {
+	                    $data->previous->link = JRoute::_($params . '&' . $this->prefix);
+	                }
 		}
 
 		// Set the next and end data objects.
@@ -816,7 +820,11 @@ class JPagination
 			if ($i != $this->pagesCurrent || $this->viewall)
 			{
 				$data->pages[$i]->base = $offset;
-				$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+				if ($offset == '0') {
+		                    $data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix);
+		                } else {
+		                    $data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+		                }
 			}
 			else
 			{


### PR DESCRIPTION
This patch remove "?limitstart=0" in pagination from "Page 1", "Back" and "Start" page.
