### PR TITLE
Parse the returned text to make sure HTML entities show correctly.

### DIFF
--- a/installation/template/js/installation.js
+++ b/installation/template/js/installation.js
@@ -305,7 +305,7 @@ var Installation = function(_container, _base) {
             if (r) {
                 Joomla.replaceTokens(r.token);
                 if (r.error === false) {
-                    $el.val(r.data.text);
+                    $el.val($("<div/>").html(r.data.text).text());
                     $el.attr('onclick', '').unbind('click');
                     $el.attr('disabled', 'disabled');
                     // Stop keep alive requests


### PR DESCRIPTION
## Problem

As shown in the screenshot, HTML entities are not converted because of the AJAX call.
<img width="583" alt="screen shot 2015-11-05 at 20 57 50" src="https://cloud.githubusercontent.com/assets/359377/10979974/ec41de60-83ff-11e5-846b-deb58fe8c223.png">
## Solution

This PR parses the returned string as HTML and then puts it out so it shows as correct text
<img width="617" alt="screen shot 2015-11-05 at 20 50 39" src="https://cloud.githubusercontent.com/assets/359377/10980017/2b78e876-8400-11e5-9f96-52ec9bb7cfec.png">
## Test
1. Get a clean copy of the Joomla staging branch or [download it here](https://github.com/joomla/joomla-cms/archive/staging.zip)
2. Go through the installation process in German
3. After reaching the last page when the installation is complete click on the button `Verzeichnis „installation” löschen`
4. You will see the resulting text `Das Verzeichnis &bdquo;installation&ldquo; wurde gelöscht!`
5. Setup a clean installation again
6. Replace the file installation/template/js/installation.js with the file attached here or just replace line 308 as shown in the file change
7. Go through the installation process in German again
8. After reaching the last page when the installation is complete click on the button `Verzeichnis „installation” löschen`
9. You will see the resulting text `Das Verzeichnis „installation” wurde gelöscht!`
10. All is good now.
