### PR TITLE
JPATH_BASE and redundant _JDEFINES in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,15 +21,12 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
  * define() is used in the installation folder rather than "const" to not error for PHP 5.2 and lower
  */
 define('_JEXEC', 1);
+define('JPATH_BASE', __DIR__);
 
-if (file_exists(__DIR__ . '/defines.php'))
+if (file_exists(JPATH_BASE . '/defines.php'))
 {
-	include_once __DIR__ . '/defines.php';
-}
-
-if (!defined('_JDEFINES'))
-{
-	define('JPATH_BASE', __DIR__);
+	include_once JPATH_BASE . '/defines.php';
+} else {
 	require_once JPATH_BASE . '/includes/defines.php';
 }
 

--- a/index.php
+++ b/index.php
@@ -26,7 +26,9 @@ define('JPATH_BASE', __DIR__);
 if (file_exists(JPATH_BASE . '/defines.php'))
 {
 	include_once JPATH_BASE . '/defines.php';
-} else {
+}
+else
+{
 	require_once JPATH_BASE . '/includes/defines.php';
 }
 


### PR DESCRIPTION
You're wrong. Where sense define custom JPATH_BASE in custom defines.php? Then, if move plugins/modules/etc dir, site will be broken and joomla update process not will be worked correctly. Also .css and .js from many plugins and modules, whatever, load from root "/" url.

Custom JPATH_BASE in custom defines.php - ok... If you copy /includes/defines.php to /defines.php and not defined _JDEFINES requires in index.php, then defines.php will be included twice an get error. Why define redundant _JDEFINES constant and make error, when you can just use "if(){}else{}" construction? when defines.php must be once included in any case!

You're wrong.
https://github.com/joomla/joomla-cms/pull/8281
