### PR TITLE
Remove a useless mootools call

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -14,7 +14,6 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.calendar');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
-JHtml::_('behavior.modal', 'a.modal_jform_contenthistory');
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');


### PR DESCRIPTION
#### Front end article editing still loads mootools

This happens due to a hardcoded call for content history (versions).
#### Testing

Select protostar as your front end template
Edit an article in the front end and observe that mootools are still present.
Apply patch and reload the page, no mootools but versions button still functions
Rename the file `templates/protostar/html/layouts/joomla/form/field/contenthistory.php` to something else and retry. You should get mootools again and when clicking on the versions button a mootools modal should appear (ad functions as usual)

@zero-24 @wilsonge @roland-d this would be nice to make it into 3.5
