### PR TITLE
Smartsearch: collation issue when searching in back-end index

### DIFF
--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -198,7 +198,7 @@ class FinderModelIndex extends JModelList
 		if ($this->getState('filter.search') != '')
 		{
 			$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($this->getState('filter.search')), true) . '%'));
-			$query->where('l.title LIKE ' . $search . ' OR l.url LIKE ' . $search . ' OR l.indexdate LIKE  ' . $search);
+			$query->where('l.title LIKE ' . $search . ' OR l.url LIKE ' . $search);
 		}
 
 		// Handle the list ordering.

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -194,11 +194,20 @@ class FinderModelIndex extends JModelList
 			$query->where('l.published = ' . (int) $this->getState('filter.state'));
 		}
 
-		// Check the search phrase.
+			// Check the search phrase.
 		if ($this->getState('filter.search') != '')
 		{
 			$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($this->getState('filter.search')), true) . '%'));
-			$query->where('l.title LIKE ' . $search . ' OR l.url LIKE ' . $search);
+
+			// Do not filter by indexdate if $search contains non-ascii characters
+			if (preg_match('/[^\x00-\x7F]/', $search))
+			{
+				$query->where('l.title LIKE ' . $search . ' OR l.url LIKE ' . $search);
+			}
+			else
+			{
+				$query->where('l.title LIKE ' . $search . ' OR l.url LIKE ' . $search . ' OR l.indexdate LIKE  ' . $search);
+			}
 		}
 
 		// Handle the list ordering.


### PR DESCRIPTION
This solves https://github.com/joomla/joomla-cms/issues/8298

Create an article with title in Hebrew
 ביו 
then purge and run smartsearch indexer (I used snowball as indexer)
When done, enter the title in the search box (still in the indexer page): 
![screen shot 2015-11-06 at 17 31 15](https://cloud.githubusercontent.com/assets/869724/11002303/45af37b6-84ac-11e5-8cf8-53215348e500.png)

we get 

```
500 Illegal mix of collations for operation 'like' SQL=SELECT COUNT() FROM `#__finder_links` AS l INNER JOIN `#__finder_types` AS t ON t.id = l.type_id WHERE l.type_id = 4 AND l.title LIKE '%ביו%' OR l.url LIKE '%ביו%' OR l.indexdate LIKE '%ביו%' Illegal mix of collations for operation 'like' SQL=SELECT l.,t.title AS t_title FROM `#__finder_links` AS l INNER JOIN `#__finder_types` AS t ON t.id = l.type_id WHERE l.type_id = 4 AND l.title LIKE '%ביו%' OR l.url LIKE '%ביו%' OR l.indexdate LIKE '%ביו%' LIMIT 0, 20 Illegal mix of collations for operation 'like' SQL=SELECT COUNT() FROM `#__finder_links` AS l INNER JOIN `#__finder_types` AS t ON t.id = l.type_id WHERE l.type_id = 4 AND l.title LIKE '%ביו%' OR l.url LIKE '%ביו%' OR l.indexdate LIKE '%ביו%' Illegal mix of collations for operation 'like' SQL=SELECT COUNT() FROM `#__finder_links` AS l INNER JOIN `#__finder_types` AS t ON t.id = l.type_id WHERE l.type_id = 4 AND l.title LIKE '%ביו%' OR l.url LIKE '%ביו%' OR l.indexdate LIKE '%ביו%'
```

the issue comes from the fact that the search query includes the `indexdate` while it is anyway useless here.
See: http://stackoverflow.com/questions/18629094/illegal-mix-of-collations-for-operation-like-while-searching-with-ignited-data for explanation.

After getting the 500, logout, login again and patch.
try again.
You should get :
![screen shot 2015-11-07 at 08 58 21](https://cloud.githubusercontent.com/assets/869724/11014223/c20c2f40-852d-11e5-87e1-ba767f68f67b.png)
