### PR TITLE
Smart Search: Only index published articles

### DIFF
--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -140,6 +140,12 @@ class PlgFinderContent extends FinderIndexerAdapter
 		// We only want to handle articles here.
 		if ($context == 'com_content.article' || $context == 'com_content.form')
 		{
+			// Handle only articles that are published
+			if ($row->published != 1)
+			{
+				return false;
+			}
+
 			// Check if the access levels are different.
 			if (!$isNew && $this->old_access != $row->access)
 			{


### PR DESCRIPTION
This PR fixes the Smart Search indexing of articles: currently an article is always saved, even if you save it with status Trashed or Unpublished. With this PR **an article** will only be **indexed by Smart Search** when its **status is Published**.
# Testing instructions

Enable Smart Search plugin & Index the content.
## Before this PR
### Create a new article

Content > Article > [new], add some specific keywords to search for later on, 
set **Status** to **Trashed** and save.

![com_finder_deleted_is_indexed](https://cloud.githubusercontent.com/assets/1217850/11014524/377a172c-853a-11e5-91f1-0228b9d01aeb.png)
### Search article in **Smart Search: Indexed Content**

Go to the Smart Search and search for the specific keywords to test that the Trashed article has been indexed as well.

![com_finder_deleted_is_indexed-2](https://cloud.githubusercontent.com/assets/1217850/11014523/3779f92c-853a-11e5-88b9-155d8c854c93.png)
## After this PR

After this PR only articles with Status Published should be indexed upon saving.
Redo the previous steps with some other specific keywords and test that only articles with state
**Published** are indexed upon saving.
