### PR TITLE
More unneeded mootools calls

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -14,7 +14,6 @@ require_once JPATH_ROOT . '/components/com_contact/helpers/route.php';
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.framework', true);
 JHtml::_('formbehavior.chosen', 'select');
 
 $input     = JFactory::getApplication()->input;

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -20,7 +20,6 @@ require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.framework', true);
 JHtml::_('formbehavior.chosen', 'select');
 
 $function  = $app->input->getCmd('function', 'jSelectArticle');

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -14,7 +14,6 @@ require_once JPATH_ROOT . '/components/com_newsfeeds/helpers/route.php';
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
-JHtml::_('behavior.framework', true);
 
 $input     = JFactory::getApplication()->input;
 $function  = JFactory::getApplication()->input->getCmd('function', 'jSelectNewsfeed');

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('behavior.framework', true);
 JHtml::_('behavior.combobox');
 JHtml::_('formbehavior.chosen', 'select');
 


### PR DESCRIPTION
#### More unneeded mootools calls
#### Testing

On a fresh installation go to global config and make sure that Mouse-over Edit Icons for is set to Modules
Go to the left panel on the modules and select Site

With go to front end and try to edit a module. Try to save it. Everything should function as usual.

There are also 3 more calls for mootools on some modal pages which I don’t have an easy way for testing. BUT by checking the other scripts loaded there and the content of those pages it is obvious that mootools is not required. So request for review on those, unless someone can get some testing instructions...
