### PR TITLE
fixes layout long titles + text in protostar

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -546,7 +546,6 @@ a:focus {
 }
 p {
 	margin: 0 0 9px;
-	word-wrap: break-word;
 }
 .lead {
 	margin-bottom: 18px;
@@ -622,7 +621,6 @@ h6 {
 	line-height: 18px;
 	color: inherit;
 	text-rendering: optimizelegibility;
-	word-wrap: break-word;
 }
 h1 small,
 h2 small,
@@ -7058,6 +7056,7 @@ h4,
 h5,
 h6 {
 	margin: 12px 0;
+	word-wrap: break-word;
 }
 h1 {
 	font-size: 26px;
@@ -7087,6 +7086,9 @@ h6 {
 	padding-bottom: 17px;
 	margin: 20px 0 18px 0;
 	border-bottom: 1px solid #eeeeee;
+}
+p {
+	word-wrap: break-word;
 }
 .item-title {
 	margin-bottom: 9px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -546,6 +546,7 @@ a:focus {
 }
 p {
 	margin: 0 0 9px;
+	word-wrap: break-word;
 }
 .lead {
 	margin-bottom: 18px;
@@ -621,6 +622,7 @@ h6 {
 	line-height: 18px;
 	color: inherit;
 	text-rendering: optimizelegibility;
+	word-wrap: break-word;
 }
 h1 small,
 h2 small,

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -185,7 +185,7 @@ h6 { font-size: 12px; line-height: 14px; }
 	border-bottom: 1px solid #eeeeee;
 }
 /* Single Item */
-p{
+p {
 	word-wrap: break-word;
 }
 .item-title {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -169,7 +169,8 @@ body.site.fluid{
 /* Headings */
 
 h1, h2, h3, h4, h5, h6 {
-  margin: (@baseLineHeight / 1.5) 0;
+  	margin: (@baseLineHeight / 1.5) 0;
+	word-wrap: break-word;
 }
 h1 { font-size: 26px; line-height: 28px; }
 h2 { font-size: 22px; line-height: 24px; }
@@ -184,6 +185,9 @@ h6 { font-size: 12px; line-height: 14px; }
 	border-bottom: 1px solid #eeeeee;
 }
 /* Single Item */
+p{
+	word-wrap: break-word;
+}
 .item-title {
 	margin-bottom:9px;
 }


### PR DESCRIPTION
This PR fixes the layout of long article titles & text articles in the Protostar template. If an article or text has content without spaces or a hyphen - it will continue on the same line, messing up the layout.
btw: I was not intending to use such long titles myself but I can imagine issues with words/sentences in the Thai & Welsh languages.
# Testing Procedure
## Before the PR
### Create a new article

Content > Article > [New]
Use a **very long title** + article text that has no spaces or hyphens -

![long_title_before1](https://cloud.githubusercontent.com/assets/1217850/11014639/31fc9e0e-8540-11e5-9c39-8ab4dd11c259.png)
### Back-end with Isis template looks ok

In the list of Articles the Isis administrator template will nicely break the title onto multiple lines.

![long_title_before2](https://cloud.githubusercontent.com/assets/1217850/11014640/3213fa7c-8540-11e5-8c3f-3bd7edecdfa6.png)
### Front-end with Protostar template looks weird

However the front-end view of the Protostar template does not break the title and text, and those both mess up the layout.

![long_title_before1b](https://cloud.githubusercontent.com/assets/1217850/11014642/321efcc4-8540-11e5-9c05-08e69b3ac4d3.png)
## After the PR

I've added **word-wrap: break-word;** to  **h1, h2, h3, h4, h5, h6** and **p** so that the layout looks better. I've added it to templates/protostar/less/template.less and manually to templates/protostar/css/template.css (however it should be done with compiling instead)

![long_title_after](https://cloud.githubusercontent.com/assets/1217850/11014641/321ed956-8540-11e5-8e45-fd53ea1bd2ea.png)
