### PR TITLE
Filter nullbyte (feeded via com_search) in Header

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -957,6 +957,7 @@ class JApplicationWeb extends JApplicationBase
 	 */
 	protected function header($string, $replace = true, $code = null)
 	{
+		$string = str_replace(chr(0), '', $string);
 		header($string, $replace, $code);
 	}
 


### PR DESCRIPTION
This PR filters fixes a problem with nullbyte that I found using com_search.
# Testing instructions
## Before the PR
### Search keyword with nullbyte %00

On the front-end use the Search Module or Search Component and search for a keyword containing a nullbyte %00, eg test%00

![com_search_before](https://cloud.githubusercontent.com/assets/1217850/11014749/bfa2ad3a-8544-11e5-8fdb-a2bf32086223.png)
### Joomla crashes on nullbyte %00

with error message:
**Warning:** Header may not contain NUL bytes in **/www/joomla-cms/libraries/joomla/application/web.php** on line **960**

![com_search_before2](https://cloud.githubusercontent.com/assets/1217850/11014767/4486f646-8545-11e5-880a-2a6b81b67449.png)
## After the PR

After this PR the nullbyte will be stripped from the Header and search will work correctly.

![com_search_after](https://cloud.githubusercontent.com/assets/1217850/11014747/bfa09c0c-8544-11e5-9c94-8fc7456f84a5.png)
