### PR TITLE
Fixed long title in Smart Search: Indexed Content

### DIFF
--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -113,7 +113,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<td>
 						<?php echo JHtml::_('jgrid.published', $item->published, $i, 'index.', $canChange, 'cb'); ?>
 					</td>
-					<td>
+					<td class="pull-left break-word">
 						<label for="cb<?php echo $i ?>">
 							<strong>
 								<?php echo $this->escape($item->title); ?>


### PR DESCRIPTION
This PR fixes the **layout for long titles** in **Smart Search: Indexed Content** in the **Isis template**
# Testing Instructions
## Before the PR

Create a new article with a long title as described in https://github.com/joomla/joomla-cms/pull/8312
Go to Components > Smart Search > Indexed Content
to see that the long title messes up the layout.

![com_finder-longtitle](https://cloud.githubusercontent.com/assets/1217850/11014948/03d30d3c-854b-11e5-972a-6a047a016a5f.png)
## After the PR

This PR should fix the layout

![com_finder-longtitle-after](https://cloud.githubusercontent.com/assets/1217850/11014947/03d2eea6-854b-11e5-8b05-9cf1e37c78ef.png)
