### PR TITLE
Fixed layout long titles + text in beez3 template

### DIFF
--- a/templates/beez3/css/layout.css
+++ b/templates/beez3/css/layout.css
@@ -20,6 +20,7 @@ body h1,body h2,body h3,body h4,body h5,body h6 {
 	font-weight: normal;
 	color: inherit;
 	text-rendering: optimizelegibility;
+	word-wrap: break-word;
 }
 
 body h1 {
@@ -57,6 +58,7 @@ body p,body ol,body ul,body dl,body address {
 	margin-bottom: 1.5em;
 	font-size: 1.0em;
 	line-height: 1.5em;
+	word-wrap: break-word;
 }
 
 small {


### PR DESCRIPTION
This PR fixes the layout of long article titles & text articles in the Beez3 template.
Similar problem as this PR for Protostar template: https://github.com/joomla/joomla-cms/pull/8312
# Testing Instruction
## Before the PR
### Create a new article

Content > Article > [New]
Use a **very long title** + article text that has no spaces or hyphens -
See instruction of: https://github.com/joomla/joomla-cms/pull/8312
And set the Beez3 template as Default Template:
Extensions > Templates > select "Beez3 - Default" & set as default (or click on the star)
### Front-end with Beez3 template looks weird

The front-end view of the Beez template does not break the title and text, and those both mess up the layout.

![long_title_beez_before1](https://cloud.githubusercontent.com/assets/1217850/11014994/bd9fa4d6-854c-11e5-9a44-cb10eeec65cc.png)
## After the PR

I've added **word-wrap: break-word;** to  **body h1,body h2,body h3,body h4,body h5,body h6 {** and **body p,body ol,body ul,body dl,body address {** of  /templates/beez3/css/layout.css

![long_title_beez_after](https://cloud.githubusercontent.com/assets/1217850/11014993/bd985f3c-854c-11e5-9a2f-1c6793432e08.png)
