### PR TITLE
Corrected wordwrap long titles latest articles

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7502,3 +7502,6 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+li {
+	word-wrap: break-word;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -631,3 +631,7 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+
+li {
+	word-wrap: break-word;
+}


### PR DESCRIPTION
This PR fixes the layout of long titles in the **Latest Articles Module** of the **Protostar template**
Thanks @waader for spotting this issue!
# Testing Instructions

See similar issue: https://github.com/joomla/joomla-cms/pull/8312
## Before the PR

![mod_latestnews-before](https://cloud.githubusercontent.com/assets/1217850/11015115/997d5134-8551-11e5-951a-146413d40f8a.png)
## After the PR

![mod_latestnews-after](https://cloud.githubusercontent.com/assets/1217850/11015114/997c01a8-8551-11e5-9304-87d03026c0ff.png)
