### PR TITLE
Corrected wordwrap titles in Latest Articles module with Beez3

### DIFF
--- a/templates/beez3/css/layout.css
+++ b/templates/beez3/css/layout.css
@@ -852,6 +852,10 @@ ul.menu ul ul ul ul a {
 	display: inline
 }
 
+ul.latestnews li {
+	word-wrap: break-word;
+}
+
 /* ++++++++++++++++++++++  Footer +++++++++++++++++++++++++ */
 #footer-outer
 {font-size:0.8em}


### PR DESCRIPTION
This PR fixes the layout of long titles in the **Latest Articles Module** of the **Beez3 template**
See similar PR: https://github.com/joomla/joomla-cms/pull/8318
# Testing Instructions

See similar issue: https://github.com/joomla/joomla-cms/pull/8312
Select the front-end template Beez3
## Before the PR

![mod_latestnews-beez-before](https://cloud.githubusercontent.com/assets/1217850/11015153/0cbba104-8553-11e5-9199-227841406351.png)
## After the PR

![mod_latestnews-beez-after](https://cloud.githubusercontent.com/assets/1217850/11015154/0cbebe3e-8553-11e5-8d72-e6d5dd89ffe9.png)
