### PR TITLE
Run the stats plugin only on cpanel

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -45,8 +45,10 @@ class PlgSystemStats extends JPlugin
 	 */
 	public function onAfterInitialise()
 	{
-		// Only run this in admin
-		if (!$this->app->isAdmin())
+		$option = JFactory::getApplication()->input->get('option', 'com_cpanel');
+
+		// Only run this in admin on the start
+		if (!$this->app->isAdmin() || $option != 'com_cpanel')
 		{
 			return;
 		}

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -45,10 +45,8 @@ class PlgSystemStats extends JPlugin
 	 */
 	public function onAfterInitialise()
 	{
-		$option = JFactory::getApplication()->input->get('option', 'com_cpanel');
-
 		// Only run this in admin on the start
-		if (!$this->app->isAdmin() || $option != 'com_cpanel')
+		if (!$this->app->isAdmin() || $this->app->input->get('option', 'com_cpanel') != 'com_cpanel')
 		{
 			return;
 		}


### PR DESCRIPTION
Hello,

with Joomla! 3.5 there is a new plugin for collecting stats. The problem here is, that after an update every user is forced to send the stats once before he/she/it can deactivate the plugin.

That could be a problem for some companies which don't allow such a behavior.

This patch extends the plugin, so that the plugin does not collect the data directly after the update but not until the user goes to "cpanel" (= the frontpage of the administration).
So Joomla! still gets its data (at the latest after the next login), but the (experienced) user can deactivate the plugin without sending data once.
