### PR TITLE
Isis template: no preview for media field due to undefined variable

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/form/field/media.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/media.php
@@ -59,7 +59,6 @@ switch ($preview)
 	case 'yes': // Deprecated parameter value
 	case 'true':
 	case 'show':
-		break;
 	case 'tooltip':
 	default:
 		$showPreview = true;

--- a/templates/protostar/html/layouts/joomla/form/field/media.php
+++ b/templates/protostar/html/layouts/joomla/form/field/media.php
@@ -59,7 +59,6 @@ switch ($preview)
 	case 'yes': // Deprecated parameter value
 	case 'true':
 	case 'show':
-		break;
 	case 'tooltip':
 	default:
 		$showPreview = true;


### PR DESCRIPTION
If field media has attribute _preview_ set to _true_, php complains about _$showPreview_ not being declared and hence no preview is being shown.

> Notice: Undefined variable: showPreview in /var/www/joomla/administrator/templates/isis/html/layouts/joomla/form/field/media.php on line 72

Looks like in the case switch in `administrator/templates/isis/html/layouts/joomla/form/field/media.php` there is a _break_ that is not supposed to be there, since leaving _$showPreview_ undefined in some cases.
