### PR TITLE
Deprecate JAdministrationHelper instead JApplicationHelper

### DIFF
--- a/administrator/includes/helper.php
+++ b/administrator/includes/helper.php
@@ -12,7 +12,9 @@ defined('_JEXEC') or die;
  * Joomla! Administrator Application helper class.
  * Provide many supporting API functions.
  *
- * @since  1.5
+ * @since       1.5
+ *
+ * @deprecated  4.0 Deprecated without replacement
  */
 class JAdministratorHelper
 {

--- a/libraries/cms/application/helper.php
+++ b/libraries/cms/application/helper.php
@@ -12,9 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Application helper functions
  *
- * @since       1.5
- *
- * @deprecated  4.0 Deprecated without replacement
+ * @since  1.5
  */
 class JApplicationHelper
 {


### PR DESCRIPTION
According to our drunken @wilsonge, https://github.com/joomla/joomla-cms/pull/8075 deprecated the wrong class.
Fixing that on his request :smile: 
