### PR TITLE
Search Term Analysis - wordwrap long titles

### DIFF
--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -86,7 +86,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			<tbody>
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
-					<td>
+					<td class="pull-left break-word">
 						<?php echo $this->escape($item->search_term); ?>
 					</td>
 					<td>


### PR DESCRIPTION
This PR fixes the **layout for long keyword searches** in **Search Term Analysis** in the **Isis template**
# Testing Instructions
## Before the PR

Go to Components > Search 
Make sure that under [Options] the "Gather Search Statistics" has been switched on to "Yes".
Go to the front-end and search for a really long keyword without spaces and hyphen - 
In the back-end go to Components > Search to see that the long keyword searches messes up the layout.

![search-term-analysis-wordwrap-isis-before](https://cloud.githubusercontent.com/assets/1217850/11020316/ea81bb0e-861b-11e5-8eb9-857b093db2ac.png)
## After the PR

This PR should fix the layout

![search-term-analysis-wordwrap-isis-after](https://cloud.githubusercontent.com/assets/1217850/11020317/ea82b70c-861b-11e5-9248-003aff2d9f47.png)
