### PR TITLE
com_search - Fix long titles + text in search results

### DIFF
--- a/templates/beez3/css/layout.css
+++ b/templates/beez3/css/layout.css
@@ -435,6 +435,15 @@ input[type="radio"]:checked + label:before {
 	padding: 10px 15px 5px 5px
 }
 
+/* Com_search break long titles & text */
+dt.result-title {
+	word-wrap: break-word;
+}
+
+dd.result-text {
+	word-wrap: break-word;
+}
+
 .advanced-search-tip {
 	background: #FEFDE2;
 	border-radius: 3px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7491,6 +7491,12 @@ code {
 	font-weight: bold;
 	padding: 1px 4px;
 }
+dt.result-title {
+	word-wrap: break-word;
+}
+dd.result-text {
+	word-wrap: break-word;
+}
 body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -615,6 +615,15 @@ code {
 	padding:1px 4px;
 }
 
+/* Com_search break long titles & text */
+dt.result-title {
+	word-wrap: break-word;
+}
+
+dd.result-text {
+	word-wrap: break-word;
+}
+
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
   overflow: hidden;


### PR DESCRIPTION
This PR fixes the layout for **long titles** and **long text** in the search results of **com_search** for both the **Protostar** and the **Beez3** template
# Testing Instructions

Create a new article with a long title and long article text as described in https://github.com/joomla/joomla-cms/pull/8312
## Before the PR
### with Protostar template

On the front-end use Joomla's Search functionality and search for the article with the long title,
to see that the long title & text mess up the layout.

![com_search_results-before-title-before](https://cloud.githubusercontent.com/assets/1217850/11020380/9b6a3afc-861e-11e5-8bf4-2d6fb9b7b0a2.png)
### with Beez3 template

In the back-end change the default template to Beez3
On the front-end use Joomla's Search functionality and search for the article with the long title,
to see that the long title & text mess up the layout.

![com_search_results-before-title-beez3-before](https://cloud.githubusercontent.com/assets/1217850/11020379/9b69db16-861e-11e5-9d26-82b6a0fbd580.png)
## After the PR
### with Protostar template

This PR should fix the layout

![com_search_results-before-title-after](https://cloud.githubusercontent.com/assets/1217850/11020381/9b6a2d8c-861e-11e5-87a2-292644e56166.png)
### with Beez3 template

This PR should fix the layout

![com_search_results-before-title-beez3-after](https://cloud.githubusercontent.com/assets/1217850/11020382/9b6b9fc8-861e-11e5-8838-46b99d051f82.png)
