### PR TITLE
Fixed long title for Hathor in Smart Search: Indexed Content

### DIFF
--- a/administrator/templates/hathor/html/com_finder/index/default.php
+++ b/administrator/templates/hathor/html/com_finder/index/default.php
@@ -130,7 +130,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				<th class="center">
 					<?php echo JHtml::_('grid.id', $i, $item->link_id); ?>
 				</th>
-				<td>
+				<td class="pull-left break-word">
 					<?php if ((int) $item->publish_start_date or (int) $item->publish_end_date or (int) $item->start_date or (int) $item->end_date) : ?>
 					<img src="<?php echo JUri::root();?>/media/system/images/calendar.png" style="border:1px;float:right" class="hasTooltip" title="<?php echo JHtml::tooltipText(JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date), '', 0); ?>" />
 					<?php endif; ?>


### PR DESCRIPTION
This PR fixes the **layout for long titles** in **Smart Search: Indexed Content** in the **Hathor template**
See similar PR for the Isis template: https://github.com/joomla/joomla-cms/pull/8316
# Testing Instructions
## Before the PR

Create a new article with a long title as described in https://github.com/joomla/joomla-cms/pull/8312
Set in Extensions > Templates > the Hathor template as default admin template.
Go to Components > Smart Search > Indexed Content
to see that the long title messes up the layout.

![com_finder-longtitle-hathor](https://cloud.githubusercontent.com/assets/1217850/11020578/9db7213a-8623-11e5-93ec-dc43de59a4f4.png)
## After the PR

This PR should fix the layout

![com_finder-longtitle-hathor-after](https://cloud.githubusercontent.com/assets/1217850/11020577/9db51958-8623-11e5-8db3-f10c140a9917.png)
