### PR TITLE
removed unnecessary label + description fields in filter xml

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -4,16 +4,12 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_BANNERS_SEARCH_IN_TITLE"
-			description="COM_BANNERS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,9 +17,7 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
 			extension="com_banners"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_CATEGORY</option>
@@ -31,8 +25,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -41,9 +33,7 @@
         <field
                 name="client_id"
                 type="bannerclient"
-                label="COM_BANNERS_FILTER_CLIENT"
                 extension="com_content"
-                description="COM_BANNERS_FILTER_CLIENT_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">COM_BANNERS_SELECT_CLIENT</option>
@@ -53,9 +43,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -84,8 +72,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_BANNERS_LIST_LIMIT"
-			description="COM_BANNERS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_banners/models/forms/filter_clients.xml
+++ b/administrator/components/com_banners/models/forms/filter_clients.xml
@@ -4,23 +4,19 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_BANNERS_SEARCH_IN_TITLE"
-			description="COM_BANNERS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
 		<field
 			name="state"
 			type="status"
-			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>
-		<field name="purchase_type" type="list"
-			label="COM_BANNERS_FILTER_PURCHASETYPE_LABEL"
-			description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
+		<field
+			name="purchase_type"
+			type="list"
 			default="0"
 			onchange="this.form.submit();"
 		>
@@ -36,9 +32,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -63,8 +57,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_BANNERS_LIST_LIMIT"
-			description="COM_BANNERS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_banners/models/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/models/forms/filter_tracks.xml
@@ -40,8 +40,6 @@
         <field
                 name="sortTable"
                 type="list"
-                label="JGLOBAL_SORT_BY"
-                description="JFIELD_ORDERING_DESC"
                 onchange="Joomla.orderTable();"
                 default="a.id DESC"
                 >
@@ -56,8 +54,6 @@
         <field
                 name="directionTable"
                 type="list"
-                label="JGLOBAL_ORDER_DIRECTION_LABEL"
-                description="JGLOBAL_ORDER_DIRECTION_DESC"
                 onchange="Joomla.orderTable();"
                 >
             <option value="">JFIELD_ORDERING_DESC</option>

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -4,15 +4,12 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_CATEGORIES_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="COM_CATEGORIES_FILTER_PUBLISHED"
-			description="COM_CATEGORIES_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -20,8 +17,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -29,8 +24,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -40,8 +33,6 @@
 			name="tag"
 			type="tag"
 			mode="nested"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -52,9 +43,7 @@
                 first="1"
                 last="10"
                 step="1"
-                label="JOPTION_FILTER_LEVEL"
                 languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_MAX_LEVELS</option>
@@ -64,9 +53,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
 			>
@@ -89,8 +76,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_CATEGORIES_LIST_LIMIT"
-			description="COM_CATEGORIES_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_contact/models/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/models/forms/filter_contacts.xml
@@ -4,15 +4,11 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_CONTACT_FILTER_SEARCH_DESC"
-			description="COM_CONTACT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -20,9 +16,7 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
 			extension="com_contact"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			published="0,1,2"
 			>
@@ -31,8 +25,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,8 +32,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,8 +41,6 @@
 			name="tag"
 			type="tag"
 			mode="nested"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -62,8 +50,6 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_CONTACT_LIST_FULL_ORDERING"
-			description="COM_CONTACT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -92,8 +78,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_CONTACT_LIST_LIMIT"
-			description="COM_CONTACT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -4,15 +4,11 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_CONTENT_FILTER_SEARCH_DESC"
-			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="COM_CONTENT_FILTER_PUBLISHED"
-			description="COM_CONTENT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -20,9 +16,7 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
 			extension="com_content"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			published="0,1,2"
 			>
@@ -31,8 +25,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,8 +32,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,8 +41,6 @@
 			name="tag"
 			type="tag"
 			mode="nested"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -60,8 +48,6 @@
         <field
                 name="author_id"
                 type="author"
-                label="COM_CONTENT_FILTER_AUTHOR"
-                description="COM_CONTENT_FILTER_AUTHOR_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_AUTHOR</option>
@@ -72,9 +58,7 @@
                 first="1"
                 last="10"
                 step="1"
-                label="JOPTION_FILTER_LEVEL"
                 languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_MAX_LEVELS</option>
@@ -84,8 +68,6 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -120,8 +102,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -4,16 +4,12 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_CONTENT_FILTER_SEARCH_DESC"
-			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="COM_CONTENT_FILTER_PUBLISHED"
-			description="COM_CONTENT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,9 +17,7 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
 			extension="com_content"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_CATEGORY</option>
@@ -31,8 +25,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,8 +32,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,8 +41,6 @@
 			name="tag"
 			type="tag"
 			mode="nested"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -60,8 +48,6 @@
         <field
                 name="author_id"
                 type="author"
-                label="COM_CONTENT_FILTER_AUTHOR"
-                description="COM_CONTENT_FILTER_AUTHOR_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_AUTHOR</option>
@@ -72,9 +58,7 @@
                 first="1"
                 last="10"
                 step="1"
-                label="JOPTION_FILTER_LEVEL"
                 languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_MAX_LEVELS</option>
@@ -84,8 +68,6 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.title ASC"
 			>
@@ -116,8 +98,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_finder/models/forms/filter_filters.xml
+++ b/administrator/components/com_finder/models/forms/filter_filters.xml
@@ -4,15 +4,12 @@
         <field
                 name="search"
                 type="text"
-                label="COM_FINDER_FILTER_SEARCH_DESC"
                 hint="JSEARCH_FILTER"
                 />
         <field
                 name="state"
                 type="status"
                 filter="*,0,1"
-                label="COM_FINDER_FILTER_PUBLISHED"
-                description="COM_FINDER_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -24,8 +21,6 @@
                 type="limitbox"
                 class="input-mini"
                 default="25"
-                label="COM_FINDER_LIST_LIMIT"
-                description="COM_FINDER_LIST_LIMIT_DESC"
                 onchange="this.form.submit();"
                 />
     </fields>

--- a/administrator/components/com_finder/models/forms/filter_index.xml
+++ b/administrator/components/com_finder/models/forms/filter_index.xml
@@ -4,15 +4,12 @@
         <field
                 name="search"
                 type="text"
-                label="COM_FINDER_FILTER_SEARCH_DESC"
                 hint="JSEARCH_FILTER"
                 />
         <field
                 name="state"
                 type="status"
                 filter="*,0,1"
-                label="COM_FINDER_FILTER_PUBLISHED"
-                description="COM_FINDER_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -22,8 +19,6 @@
                 type="sql"
                 default="0"
                 query="SELECT id AS value, title AS type FROM #__finder_types ORDER BY title"
-                label="JOPTION_FILTER_CATEGORY"
-                description="JOPTION_FILTER_CATEGORY_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">COM_FINDER_MAPS_SELECT_TYPE</option>
@@ -35,8 +30,6 @@
                 type="limitbox"
                 class="input-mini"
                 default="25"
-                label="COM_FINDER_LIST_LIMIT"
-                description="COM_FINDER_LIST_LIMIT_DESC"
                 onchange="this.form.submit();"
                 />
     </fields>

--- a/administrator/components/com_finder/models/forms/filter_maps.xml
+++ b/administrator/components/com_finder/models/forms/filter_maps.xml
@@ -6,15 +6,12 @@
         <field
                 name="search"
                 type="text"
-                label="COM_FINDER_FILTER_SEARCH_DESC"
                 hint="JSEARCH_FILTER"
                 />
         <field
                 name="state"
                 type="status"
                 filter="*,0,1"
-                label="COM_FINDER_FILTER_PUBLISHED"
-                description="COM_FINDER_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -36,8 +33,6 @@
                 type="limitbox"
                 class="input-mini"
                 default="25"
-                label="COM_FINDER_LIST_LIMIT"
-                description="COM_FINDER_LIST_LIMIT_DESC"
                 onchange="this.form.submit();"
                 />
     </fields>

--- a/administrator/components/com_installer/models/forms/filter_manage.xml
+++ b/administrator/components/com_installer/models/forms/filter_manage.xml
@@ -20,8 +20,6 @@
         <field
                 name="status"
                 type="extensionstatus"
-                label="COM_PLUGINS_FILTER_PUBLISHED"
-                description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_installer/models/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/models/forms/filter_updatesites.xml
@@ -20,8 +20,6 @@
         <field
                 name="enabled"
                 type="list"
-                label="COM_PLUGINS_FILTER_PUBLISHED"
-                description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_languages/models/forms/filter_languages.xml
+++ b/administrator/components/com_languages/models/forms/filter_languages.xml
@@ -28,8 +28,6 @@
 		<field
 				name="sortTable"
 				type="list"
-				label="JGLOBAL_SORT_BY"
-				description="JFIELD_ORDERING_DESC"
 				onchange="Joomla.orderTable();"
 				default="a.id DESC"
 				>
@@ -48,8 +46,6 @@
 		<field
 				name="directionTable"
 				type="list"
-				label="JGLOBAL_ORDER_DIRECTION_LABEL"
-				description="JGLOBAL_ORDER_DIRECTION_DESC"
 				onchange="Joomla.tableOrdering();"
 				>
 			<option value="">JGLOBAL_ORDER_DIRECTION_LABEL</option>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -3,16 +3,12 @@
 	<field
 		name="menutype"
 		type="menu"
-		label="COM_MENUS_FILTER_CATEGORY"
-		description="JOPTION_FILTER_CATEGORY_DESC"
 		onchange="this.form.submit();"
 	/>
 	<fields name="filter">
 		<field
 			name="search"
 			type="text"
-			label="COM_MENUS_FILTER_SEARCH_DESC"
-			description="COM_MENUS_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
@@ -20,8 +16,6 @@
 			name="published"
 			type="status"
 			filter="*,0,1,-2"
-			label="COM_MENUS_FILTER_PUBLISHED"
-			description="COM_MENUS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -29,8 +23,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -38,8 +30,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,9 +41,7 @@
                 first="1"
                 last="10"
                 step="1"
-                label="JOPTION_FILTER_LEVEL"
                 languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_MAX_LEVELS</option>
@@ -63,9 +51,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
 			>
@@ -92,8 +78,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_MENUS_LIST_LIMIT"
-			description="COM_MENUS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_modules/models/forms/filter_modules.xml
+++ b/administrator/components/com_modules/models/forms/filter_modules.xml
@@ -16,8 +16,6 @@
 		<field
 			name="search"
 			type="text"
-			label="JSEARCH_FILTER_LABEL"
-			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 
@@ -34,7 +32,6 @@
 		<field
 			name="position"
 			type="modulesposition"
-			label="COM_MODULES_FIELD_POSITION_LABEL"
 			onchange="this.form.submit();"
 		>
 			<option value="">COM_MODULES_OPTION_SELECT_POSITION</option>
@@ -43,7 +40,6 @@
 		<field
 			name="module"
 			type="ModulesModule"
-			label="COM_MODULES_OPTION_SELECT_MODULE"
 			onchange="this.form.submit();"
 		>
 			<option value="">COM_MODULES_OPTION_SELECT_MODULE</option>
@@ -52,8 +48,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -62,8 +56,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -77,9 +69,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="ordering ASC"
 		>
@@ -109,8 +99,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_MODULES_LIST_LIMIT"
-			description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 

--- a/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
@@ -4,14 +4,11 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_NEWSFEEDS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="COM_NEWSFEEDS_FILTER_PUBLISHED"
-			description="COM_NEWSFEEDS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -19,9 +16,7 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
 			extension="com_newsfeeds"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_CATEGORY</option>
@@ -29,8 +24,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -38,8 +31,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -49,8 +40,6 @@
 			name="tag"
 			type="tag"
 			mode="nested"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -60,8 +49,6 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_NEWSFEEDS_LIST_FULL_ORDERING"
-			description="COM_NEWSFEEDS_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -90,8 +77,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_NEWSFEEDS_LIST_LIMIT"
-			description="COM_NEWSFEEDS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_plugins/models/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/models/forms/filter_plugins.xml
@@ -28,8 +28,6 @@
         <field
                 name="access"
                 type="accesslevel"
-                label="JOPTION_FILTER_ACCESS"
-                description="JOPTION_FILTER_ACCESS_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,8 +38,6 @@
         <field
                 name="sortTable"
                 type="list"
-                label="JGLOBAL_SORT_BY"
-                description="JFIELD_ORDERING_DESC"
                 onchange="Joomla.orderTable();"
                 default="a.id DESC"
                 >
@@ -58,8 +54,6 @@
         <field
                 name="directionTable"
                 type="list"
-                label="JGLOBAL_ORDER_DIRECTION_LABEL"
-                description="JGLOBAL_ORDER_DIRECTION_DESC"
                 onchange="Joomla.orderTable();"
                 >
             <option value="">JFIELD_ORDERING_DESC</option>

--- a/administrator/components/com_redirect/models/forms/filter_links.xml
+++ b/administrator/components/com_redirect/models/forms/filter_links.xml
@@ -4,14 +4,11 @@
         <field
                 name="search"
                 type="text"
-                label="COM_REDIRECT_FILTER_SEARCH_DESC"
                 hint="JSEARCH_FILTER"
                 />
         <field
                 name="state"
                 type="status"
-                label="COM_REDIRECT_FILTER_PUBLISHED"
-                description="COM_REDIRECT_FILTER_PUBLISHED_DESC"
                 onchange="this.form.submit();"
                 >
             <option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -23,8 +20,6 @@
                 type="limitbox"
                 class="input-mini"
                 default="25"
-                label="COM_REDIRECT_LIST_LIMIT"
-                description="COM_REDIRECT_LIST_LIMIT_DESC"
                 onchange="this.form.submit();"
                 />
     </fields>

--- a/administrator/components/com_tags/models/forms/filter_tags.xml
+++ b/administrator/components/com_tags/models/forms/filter_tags.xml
@@ -4,14 +4,11 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_TAGS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
-			label="COM_TAGS_FILTER_PUBLISHED"
-			description="COM_TAGS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -19,8 +16,6 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -28,8 +23,6 @@
 		<field
 			name="language"
 			type="contentlanguage"
-			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -40,8 +33,6 @@
 		<field
             name="fullordering"
 			type="list"
-			label="COM_TAGS_LIST_FULL_ORDERING"
-			description="COM_TAGS_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -64,8 +55,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_TAGS_LIST_LIMIT"
-			description="COM_TAGS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_users/models/forms/filter_notes.xml
+++ b/administrator/components/com_users/models/forms/filter_notes.xml
@@ -31,8 +31,6 @@
 		<field
 				name="sortTable"
 				type="list"
-				label="JGLOBAL_SORT_BY"
-				description="JFIELD_ORDERING_DESC"
 				onchange="Joomla.orderTable();"
 				default="a.id DESC"
 				>
@@ -48,8 +46,6 @@
 		<field
 				name="directionTable"
 				type="list"
-				label="JGLOBAL_ORDER_DIRECTION_LABEL"
-				description="JGLOBAL_ORDER_DIRECTION_DESC"
 				onchange="Joomla.orderTable();"
 				>
 			<option value="">JFIELD_ORDERING_DESC</option>

--- a/administrator/components/com_users/models/forms/filter_users.xml
+++ b/administrator/components/com_users/models/forms/filter_users.xml
@@ -4,16 +4,12 @@
 		<field
 			name="search"
 			type="text"
-			label="COM_USERS_SEARCH_USERS"
-			description="COM_USERS_SEARCH_IN_NAME"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>
 		<field
 			name="state"
 			type="userstate"
-			label="COM_USERS_FILTER_STATE"
-			description="COM_USERS_FILTER_STATE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_STATE</option>
@@ -21,8 +17,6 @@
 		<field
 			name="active"
 			type="useractive"
-			label="COM_USERS_FILTER_ACTIVE"
-			description="COM_USERS_FILTER_ACTIVE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_ACTIVE</option>
@@ -30,8 +24,6 @@
 		<field
 			name="group_id"
 			type="usergrouplist"
-			label="COM_USERS_FILTER_GROUP"
-			description="COM_USERS_FILTER_GROUP_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_USERGROUP</option>
@@ -39,8 +31,6 @@
 		<field
 			name="range"
 			type="registrationdaterange"
-			label="COM_USERS_OPTION_FILTER_DATE"
-			description="COM_USERS_OPTION_FILTER_DATE"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_FILTER_DATE</option>
@@ -50,8 +40,6 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.title ASC"
 			>
@@ -78,8 +66,6 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>


### PR DESCRIPTION
This PR **removes the unnecessary fields** of the **filter xml files** that are used by **Search Tools**

Most /models/filter_somename.xml files contained a **label + description field** that is **not used** by the **Search Tools filters**. 

Example: administrator/components/com_content/models/forms/filter_articles.xml
contains:

```
        <field
            name="published"
            type="status"
            label="COM_CONTENT_FILTER_PUBLISHED"
            description="COM_CONTENT_FILTER_PUBLISHED_DESC"
            onchange="this.form.submit();"
            >
            <option value="">JOPTION_SELECT_PUBLISHED</option>
        </field>
```

The **label="COM_CONTENT_FILTER_PUBLISHED"** and the **description="COM_CONTENT_FILTER_PUBLISHED_DESC"** are not used. This PR removes those.

The label of the Search Tool Filter label "- Select Status -" is created by the **<option value="">JOPTION_SELECT_PUBLISHED</option>** option and is not removed by this PR.
# Test Instruction
- **All Search Tool filter fields** + **ordering & list limit dropdowns** should **work correctly**, **before and after** installing the patch. 
- All labels should still be correctly displayed. 
- No untranslated COM_SOMECOMPONENT_FILTER_FIELD should be displayed

![filterxml-removed-labels](https://cloud.githubusercontent.com/assets/1217850/11020739/968cb1c6-8629-11e5-9aa3-583e3ccbcae7.png)

The Search Tools filter options should be tested for the following components:
- Components > Banners (Banners, Clients & Tracks)
- Content > Categories
- Components > Contacts
- Content > Articles
- Content > Featured Articles
- Content > Smart Search (Indexed Content, Content Maps, Search Filters)
- Extensions > Manage (Manage & Update Sites)
- Extensions > Languages
- Menus > some menu
- Extensions > Modules
- Component > Newsfeeds
- Extensions > Plugins
- Components > Redirects
- Components > Tags
- Users > Manage (Users & User Notes)
