### PR TITLE
Remove all unnecessary index.html files?

### DIFF
--- a/administrator/cache/index.html
+++ b/administrator/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/components/com_media/models/forms/index.html
+++ b/administrator/components/com_media/models/forms/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/language/overrides/index.html
+++ b/administrator/language/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/administrator/manifests/packages/index.html
+++ b/administrator/manifests/packages/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/bin/index.html
+++ b/bin/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/cache/index.html
+++ b/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/cli/index.html
+++ b/cli/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/components/index.html
+++ b/components/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/images/index.html
+++ b/images/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/includes/index.html
+++ b/includes/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/language/index.html
+++ b/language/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/language/overrides/index.html
+++ b/language/overrides/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/libraries/index.html
+++ b/libraries/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/logs/index.html
+++ b/logs/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/media/index.html
+++ b/media/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/modules/index.html
+++ b/modules/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/tmp/index.html
+++ b/tmp/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>


### PR DESCRIPTION
Can we **remove all index.html files** from Joomla because they are unnecessary?
If so, this PR will do so. It removes 20 "empty" index.html files that were used in the past to hide directory contents on wrongly configured servers that allowed "browse directory".
