### PR TITLE
Fix installer for PDO MySQL on PHP 7

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -714,7 +714,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 *
 	 * @since   12.2
 	 */
-	protected function getAlterDbCharacterSet($dbName)
+	public function getAlterDbCharacterSet($dbName)
 	{
 		$charset = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
 


### PR DESCRIPTION
The installation model `InstallationModelDatabase` calls this method directly so this method needs to be made public
