### PR TITLE
fixed wordwrap long (user)name com_users

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -96,7 +96,7 @@ $loggeduser = JFactory::getUser();
 							<?php endif; ?>
 						</td>
 						<td>
-							<div class="name">
+							<div class="name break-word">
 							<?php if ($canEdit) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->id); ?>" title="<?php echo JText::sprintf('COM_USERS_EDIT_USER', $this->escape($item->name)); ?>">
 									<?php echo $this->escape($item->name); ?></a>
@@ -118,7 +118,7 @@ $loggeduser = JFactory::getUser();
 								<?php echo JText::_('COM_USERS_DEBUG_USER');?></a></div>
 							<?php endif; ?>
 						</td>
-						<td>
+						<td class="break-word">
 							<?php echo $this->escape($item->username); ?>
 						</td>
 						<td class="center">
@@ -144,7 +144,7 @@ $loggeduser = JFactory::getUser();
 								<?php echo nl2br($item->group_names); ?>
 							<?php endif; ?>
 						</td>
-						<td class="hidden-phone">
+						<td class="hidden-phone break-word">
 							<?php echo JStringPunycode::emailToUTF8($this->escape($item->email)); ?>
 						</td>
 						<td class="hidden-phone">

--- a/administrator/templates/hathor/html/com_users/users/default.php
+++ b/administrator/templates/hathor/html/com_users/users/default.php
@@ -133,7 +133,7 @@ $loggeduser = JFactory::getUser();
 						<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 					<?php endif; ?>
 				</td>
-				<td>
+				<td class="break-word">
 					<div class="fltrt">
 						<?php echo JHtml::_('users.filterNotes', $item->note_count, $item->id); ?>
 						<?php echo JHtml::_('users.notes', $item->note_count, $item->id); ?>
@@ -154,7 +154,7 @@ $loggeduser = JFactory::getUser();
 						<?php echo JText::_('COM_USERS_DEBUG_USER');?></a></div></div></div>
 					<?php endif; ?>
 				</td>
-				<td class="center">
+				<td class="center break-word">
 					<?php echo $this->escape($item->username); ?>
 				</td>
 				<td class="center">
@@ -178,7 +178,7 @@ $loggeduser = JFactory::getUser();
 						<?php echo nl2br($item->group_names); ?>
 					<?php endif; ?>
 				</td>
-				<td class="center">
+				<td class="center break-word">
 					<?php echo $this->escape($item->email); ?>
 				</td>
 				<td class="center">


### PR DESCRIPTION
This PR fixes the layout for **long usernames** and **long names**  and **long email addresses** in the User Manager (Users > Manage) of **com_users** for both the **Isis** and the **Hathor** templates.
# Testing Instructions

Create a new user with **a really long name**, username and email address, that do not contain spaces or hyphens. E.g. use the longest name of a village in Wales, Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.
## Before the PR
### with Isis template

![com_user_isis_before](https://cloud.githubusercontent.com/assets/1217850/11021182/c41045b2-8639-11e5-8b1b-dd21609d41f4.png)
### with Hathor template

![com_user_hathor_before](https://cloud.githubusercontent.com/assets/1217850/11021181/c40f6cf0-8639-11e5-8860-12a408b15764.png)
## After the PR
### with Isis template

This PR should fix the layout

![com_user_isis_after](https://cloud.githubusercontent.com/assets/1217850/11021183/c411b08c-8639-11e5-9c5f-46a36a59b899.png)
### with Hathor template

This PR should fix the layout

![com_user_hathor_after](https://cloud.githubusercontent.com/assets/1217850/11021184/c4122ab2-8639-11e5-831f-040b69eef7a1.png)
