### PR TITLE
Use static scripts for editor none

### DIFF
--- a/media/editors/none/none.js
+++ b/media/editors/none/none.js
@@ -1,0 +1,33 @@
+/**
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license	    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Editor None
+ */
+function insertAtCursor(myField, myValue)
+{
+	if (document.selection)
+	{
+		// IE support
+		myField.focus();
+		sel = document.selection.createRange();
+		sel.text = myValue;
+	} else if (myField.selectionStart || myField.selectionStart == '0')
+	{
+		// MOZILLA/NETSCAPE support
+		var startPos = myField.selectionStart;
+		var endPos = myField.selectionEnd;
+		myField.value = myField.value.substring(0, startPos)
+			+ myValue
+			+ myField.value.substring(endPos, myField.value.length);
+	} else {
+		myField.value += myValue;
+	}
+}
+
+function jInsertEditorText(text, editor)
+{
+	insertAtCursor(document.getElementById(editor), text);
+}

--- a/media/editors/none/none.min.js
+++ b/media/editors/none/none.min.js
@@ -1,0 +1,1 @@
+function insertAtCursor(e,t){if(document.selection)e.focus(),sel=document.selection.createRange(),sel.text=t;else if(e.selectionStart||"0"==e.selectionStart){var n=e.selectionStart,s=e.selectionEnd;e.value=e.value.substring(0,n)+t+e.value.substring(s,e.value.length)}else e.value+=t}function jInsertEditorText(e,t){insertAtCursor(document.getElementById(t),e)}

--- a/plugins/editors/none/none.php
+++ b/plugins/editors/none/none.php
@@ -20,36 +20,15 @@ class PlgEditorNone extends JPlugin
 	 * Method to handle the onInitEditor event.
 	 *  - Initialises the Editor
 	 *
-	 * @return  string	JavaScript Initialization string
+	 * @return  void
 	 *
 	 * @since 1.5
 	 */
 	public function onInit()
 	{
-		$txt =	"<script type=\"text/javascript\">
-					function insertAtCursor(myField, myValue)
-					{
-						if (document.selection)
-						{
-							// IE support
-							myField.focus();
-							sel = document.selection.createRange();
-							sel.text = myValue;
-						} else if (myField.selectionStart || myField.selectionStart == '0')
-						{
-							// MOZILLA/NETSCAPE support
-							var startPos = myField.selectionStart;
-							var endPos = myField.selectionEnd;
-							myField.value = myField.value.substring(0, startPos)
-								+ myValue
-								+ myField.value.substring(endPos, myField.value.length);
-						} else {
-							myField.value += myValue;
-						}
-					}
-				</script>";
+		JHtml::script('media/editors/none/none.min.js', false, false, false, false, true);
 
-		return $txt;
+		return null;
 	}
 
 	/**
@@ -94,24 +73,12 @@ class PlgEditorNone extends JPlugin
 	 *
 	 * @param   string  $id  The id of the editor field
 	 *
-	 * @return  boolean  returns true when complete
+	 * @return  void
 	 */
 	public function onGetInsertMethod($id)
 	{
-		static $done = false;
 
-		// Do this only once.
-		if (!$done)
-		{
-			$doc = JFactory::getDocument();
-			$js = "\tfunction jInsertEditorText(text, editor)
-			{
-				insertAtCursor(document.getElementById(editor), text);
-			}";
-			$doc->addScriptDeclaration($js);
-		}
-
-		return true;
+		return null;
 	}
 
 	/**
@@ -150,9 +117,9 @@ class PlgEditorNone extends JPlugin
 			$height .= 'px';
 		}
 
-		$buttons = $this->_displayButtons($id, $buttons, $asset, $author);
-		$editor  = "<textarea name=\"$name\" id=\"$id\" cols=\"$col\" rows=\"$row\" style=\"width: $width; height: $height;\">$content</textarea>"
-			. $buttons;
+		$editor = '<textarea name="' . $name . '" id="' . $id . '" cols="' . $col . '" rows="' . $row
+				. '" style="width: ' . $width . '; height: ' . $height . ';">' . $content . '</textarea>'
+				. $this->_displayButtons($id, $buttons, $asset, $author);
 
 		return $editor;
 	}


### PR DESCRIPTION
#### Static scripts are way cooler
#### What does this PR fix?

Try this:
Select none as default editor for your current user
Then try to edit an article
Observe the source of the generated HTML page and you will find some inline scripts in the head and above textarea input
#### Testing

Apply this PR with patch tester and follow the above steps
A none.min.js is added in the header of the page
Make sure that the buttons bellow the editor still function as usual as well as the saving of the article
