### PR TITLE
Fix if feeds are displayed reversed/ASC

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -189,7 +189,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 
 		if ($feed_display_order == 'asc')
 		{
-			$newsfeed->items = array_reverse($newsfeed->items);
+			$this->rssDoc->reverseItems();
 		}
 
 		// Escape strings for HTML output

--- a/libraries/joomla/feed/feed.php
+++ b/libraries/joomla/feed/feed.php
@@ -326,4 +326,17 @@ class JFeed implements ArrayAccess
 
 		return $this;
 	}
+
+	/** Method to reverse the items if display is set to 'oldest first'
+	 *
+	 * @return JFeed
+	 */
+	public function reverseItems()
+	{
+		if (is_array($this->entries) && !empty($this->entries))
+		{
+			$this->entries = array_reverse($this->entries);
+		}
+		return $this;
+	}
 }


### PR DESCRIPTION
This is a fix for / related to #7727 
#### Testinstructions:
- Create a feed in Backend/News Feeds
- Create a menu item to show that single feed and set in tab 'Feed display options' the 'Feed Display Order' to 'Oldest first'
#### Before Patch:
- The feed is still ordered as 'Newes first' and there is a `Warning: array_reverse() expects parameter 1 to be array, null given in.....` 
#### After Patch:
- The warning is gone and the feed is shown as 'Oldest first'
