### PR TITLE
Deprecate JCryptPassword

### DIFF
--- a/libraries/joomla/crypt/password.php
+++ b/libraries/joomla/crypt/password.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform Password Hashing Interface
  *
- * @since  12.2
+ * @since       12.2
+ * @deprecated  4.0  Use PHP 5.5's native password hashing API
  */
 interface JCryptPassword
 {
@@ -33,6 +34,7 @@ interface JCryptPassword
 	 * @return  string  The hashed password.
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function create($password, $type = null);
 
@@ -45,6 +47,7 @@ interface JCryptPassword
 	 * @return  boolean  True if the password is valid, false otherwise.
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function verify($password, $hash);
 
@@ -56,6 +59,7 @@ interface JCryptPassword
 	 * @return  void
 	 *
 	 * @since   12.3
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function setDefaultType($type);
 
@@ -65,6 +69,7 @@ interface JCryptPassword
 	 * @return  void
 	 *
 	 * @since   12.3
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function getDefaultType();
 }

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -12,19 +12,22 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform Password Crypter
  *
- * @since  12.2
+ * @since       12.2
+ * @deprecated  4.0  Use PHP 5.5's native password hashing API
  */
 class JCryptPasswordSimple implements JCryptPassword
 {
 	/**
 	 * @var    integer  The cost parameter for hashing algorithms.
 	 * @since  12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	protected $cost = 10;
 
 	/**
 	 * @var    string   The default hash type
 	 * @since  12.3
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	protected $defaultType = '$2y$';
 
@@ -38,6 +41,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 *
 	 * @since   12.2
 	 * @throws  InvalidArgumentException
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function create($password, $type = null)
 	{
@@ -88,6 +92,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * @return  void
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function setCost($cost)
 	{
@@ -102,6 +107,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * @return  string  The string of random characters.
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	protected function getSalt($length)
 	{
@@ -121,6 +127,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * @return  boolean  True if the password is valid, false otherwise.
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function verify($password, $hash)
 	{
@@ -162,6 +169,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * @return  void
 	 *
 	 * @since   12.3
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function setDefaultType($type)
 	{
@@ -177,6 +185,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * @return   string  $type  The default type
 	 *
 	 * @since   12.3
+	 * @deprecated  4.0  Use PHP 5.5's native password hashing API
 	 */
 	public function getDefaultType()
 	{


### PR DESCRIPTION
This API is unused in the Joomla application stack and a native PHP alternative exists in PHP 5.5 (and polyfilled to 5.3.7).  Drop it at 4.0.
