### PR TITLE
Use strict verification of legacy Joomla MD5 hash (Fix #8326)

### DIFF
--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -148,7 +148,7 @@ class JCryptPasswordSimple implements JCryptPassword
 		// Check if the hash is a Joomla hash.
 		if (preg_match('#[a-z0-9]{32}:[A-Za-z0-9]{32}#', $hash) === 1)
 		{
-			return md5($password . substr($hash, 33)) == substr($hash, 0, 32);
+			return md5($password . substr($hash, 33)) === substr($hash, 0, 32);
 		}
 
 		return false;


### PR DESCRIPTION
This class was never actually used for password verification, however, it should correctly validate hashes.
