### PR TITLE
Use hash_equals() for constant-time string comparison

### DIFF
--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -254,8 +254,11 @@ class JCrypt
 	}
 
 	/**
-	 * A timing safe comparison method. This defeats hacking
-	 * attempts that use timing based attack vectors.
+	 * A timing safe comparison method.
+	 *
+	 * This defeats hacking attempts that use timing based attack vectors.
+	 *
+	 * NOTE: Length will leak.
 	 *
 	 * @param   string  $known    A known string to check against.
 	 * @param   string  $unknown  An unknown string to check.
@@ -266,6 +269,12 @@ class JCrypt
 	 */
 	public static function timingSafeCompare($known, $unknown)
 	{
+		// Prefer PHP's hash_equals function (PHP 5.6+) if available
+		if (function_exists('hash_equals'))
+		{
+			return hash_equals((string) $known, (string) $unknown);
+		}
+
 		// Prevent issues if string length is 0
 		$known .= chr(0);
 		$unknown .= chr(0);


### PR DESCRIPTION
This is attempt number 3 to merge this.  See previous PR's:
- https://github.com/joomla/joomla-cms/pull/4206
- https://github.com/joomla/joomla-cms/pull/7754
