### PR TITLE
Debug Language: Star (*) is OK in lang constant

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -905,7 +905,7 @@ class JLanguage
 				}
 
 				// Check that the line passes the necessary format.
-				if (!preg_match('#^[A-Z][A-Z0-9_\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
+				if (!preg_match('#^[A-Z][A-Z0-9_\*\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
 				{
 					$errors[] = $realNumber;
 					continue;


### PR DESCRIPTION
As of today, a language constant containing a star will trigger a parse error when debug language is on.
Some extensions like sobibro do use stars in their constants.

```
SP.PERMISSIONS.DELETE_*="delete any"
```

It is not mandatory to throw an error if there is a star as the translation works fine
This patch prevents the parse error.

To test, modify a string, for example in en-GB.config.ini:
Change
`COM_CONFIG_DEBUG_SETTINGS="Debug Settings"`
to
`COM_CONFIG_DEBUG_SETTINGS*="Debug Settings"`
Then modify in ROOT/administrator/components/com_config/view/application/tmpl/default_debug.php

`$this->name = JText::_('COM_CONFIG_DEBUG_SETTINGS');`
to
`$this->name = JText::_('COM_CONFIG_DEBUG_SETTINGS*');`

Go to Global Configuration => System and enable Debug Language

The translation works.
Look at the bottom of the page: there is an error in Parsing Error in language files (it shows red)

Patch and test again.
No more parsing error.

@Radek-Suski 
@baijianpeng
