### PR TITLE
Unset limitstart=0 for com_content

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -33,6 +33,12 @@ class ContentRouter extends JComponentRouterBase
 		$params = JComponentHelper::getParams('com_content');
 		$advanced = $params->get('sef_advanced_link', 0);
 
+		// Unset limitstart=0 since it's pointless
+		if (isset($query['limitstart']) && $query['limitstart'] == 0)
+		{
+			unset($query['limitstart']);
+		}
+
 		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid']))
 		{


### PR DESCRIPTION
Because it seems to be a popular request to get rid of the `limitstart=0`, I hereby remove it from com_content.

To test, create a list of articles in frontend where you can move to page two of the list.
Check the link for page 1, it has `limitstart=0` as part of the URL.
After applying this PR it will no longer be there.
Check that the link to page 1 still works.

Since com_content doesn't use user states to store the last visited page, this should have no side effects.
