### PR TITLE
indexer does not work properly in languages with different decimal notation thanks @chrisdavenport

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -597,7 +597,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. str_replace(',', '.', (string) $token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 			);

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -603,7 +603,7 @@ class FinderIndexerDriverPostgresql extends FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. str_replace(',', '.', (string) $token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 			);

--- a/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
@@ -568,7 +568,7 @@ class FinderIndexerDriverSqlsrv extends FinderIndexer
 				. $db->quote($token->stem) . ', '
 				. (int) $token->common . ', '
 				. (int) $token->phrase . ', '
-				. (float) $token->weight . ', '
+				. str_replace(',', '.', (string) $token->weight) . ', '
 				. (int) $context . ', '
 				. $db->quote($token->language)
 			);


### PR DESCRIPTION
[#34056] indexer does not work properly in languages with different decimal notation

== Reproduce

Have a joomla site in a language that uses comma instead of a dot for decimal places (ex: Portuguese).

Turn on search indexer content plugin.

Edit a content item in the frontend and save.
It will appear an sql error like this

Column count doesn't match value count at row 1 SQL=INSERT INTO `29i8c_finder_tokens` (`term`,`stem`,`common`,`phrase`,`weight`,`context`,`language`) VALUES ('a', 'a', 0, 0, 0,0667, 1, 'pt')

Note the "0,0667" it should be "0.0667" and the error is there.

---

Redo this PR by @chrisdavenport: https://github.com/joomla/joomla-cms/pull/4116
