### PR TITLE
regression: fix for #8367

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8146,7 +8146,7 @@ body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;
 }
-.modal-body {
+.field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8146,7 +8146,7 @@ body.modal-open {
 	overflow: hidden;
 	-ms-overflow-style: none;
 }
-.modal-body {
+.field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1297,7 +1297,7 @@ body.modal-open {
 }
 
 /*Corrects the modals padding*/
-.modal-body {
+.field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7498,7 +7498,7 @@ body.modal-open {
 #users-profile-custom label {
 	display: inline;
 }
-.modal-body {
+.field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
 }

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -627,7 +627,7 @@ body.modal-open {
 }
 
 /*Corrects the modals padding*/
-.modal-body {
+.field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
 }


### PR DESCRIPTION
## fix for #8367
#### Issue

When trying to batch copy articles, I can't select anything from the category dropdown because it is hidden behind the modal footer.
#### Testing

With isis as the template try in the list of articles to batch some articles.
Drop downs should be visible
Edit an article and try inserting an image in the tab images and links
The modal should be ok as well (especially for mobile devices)
