### PR TITLE
don't load finder label instead of make it invisible

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -24,28 +24,30 @@ $output = '<input type="text" name="q" id="mod-finder-searchword" class="search-
 	. $params->get('field_size', 20) . '" value="' . htmlspecialchars(JFactory::getApplication()->input->get('q', '', 'string')) . '"'
 	. ' placeholder="' . JText::_('MOD_FINDER_SEARCH_VALUE') . '"/>';
 
-$showLabel  = $params->get('show_label', 1);
-$labelClass = (!$showLabel ? 'element-invisible ' : '') . 'finder' . $suffix;
-$label      = '<label for="mod-finder-searchword" class="' . $labelClass . '">' . $params->get('alt_label', JText::_('JSEARCH_FILTER_SUBMIT')) . '</label>';
 
-switch ($params->get('label_pos', 'left'))
+if ($params->get('show_label', 1))
 {
-	case 'top' :
-		$output = $label . '<br />' . $output;
-		break;
+	$label = '<label for="mod-finder-searchword" class="finder' . $suffix . '">' . $params->get('alt_label', JText::_('JSEARCH_FILTER_SUBMIT')) . '</label>';
 
-	case 'bottom' :
-		$output .= '<br />' . $label;
-		break;
+	switch ($params->get('label_pos', 'left'))
+	{
+		case 'top' :
+			$output = $label . '<br />' . $output;
+			break;
 
-	case 'right' :
-		$output .= $label;
-		break;
+		case 'bottom' :
+			$output .= '<br />' . $label;
+			break;
 
-	case 'left' :
-	default :
-		$output = $label . $output;
-		break;
+		case 'right' :
+			$output .= $label;
+			break;
+
+		case 'left' :
+		default :
+			$output = $label . $output;
+			break;
+	}
 }
 
 if ($params->get('show_button'))


### PR DESCRIPTION
This PR make sure the label of the mod_finder don't load. Before it was only invisible via the class `element-invisible`. But if you're template.css don't contain this class, the label won't hide.
## Test instructions

1) Make a mod_finder module and hide the label via the parameter "Search Field Label"
2) Go to the front-end, inspect the source (right click -> inspect element), and notice the label is only invisible:

```
<label for="mod-finder-searchword" class="finder">Search</label>
```

3) Apply the patch, and notice the label is not load any more.
