### PR TITLE
Fix Jform::bind method JObject handling

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -126,40 +126,7 @@ class JForm
 			return false;
 		}
 
-		// Convert the input to an array.
-		if (is_object($data))
-		{
-			if ($data instanceof Registry)
-			{
-				// Handle a Registry.
-				$data = $data->toArray();
-			}
-			elseif ($data instanceof JObject)
-			{
-				// Handle a JObject. Getting just the properties won't work. We need to convert any nested JObject too.
-				$data = JArrayHelper::fromObject($data);
-			}
-			else
-			{
-				// Handle other types of objects.
-				$data = (array) $data;
-			}
-		}
-
-		// Process the input data.
-		foreach ($data as $k => $v)
-		{
-			if ($this->findField($k))
-			{
-				// If the field exists set the value.
-				$this->data->set($k, $v);
-			}
-			elseif (is_object($v) || JArrayHelper::isAssociative($v))
-			{
-				// If the value is an object or an associative array hand it off to the recursive bind level method.
-				$this->bindLevel($k, $v);
-			}
-		}
+		$this->bindLevel(null, $data);
 
 		return true;
 	}
@@ -177,20 +144,39 @@ class JForm
 	protected function bindLevel($group, $data)
 	{
 		// Ensure the input data is an array.
-		settype($data, 'array');
+		if (is_object($data))
+		{
+			if ($data instanceof Registry)
+			{
+				// Handle a Registry.
+				$data = $data->toArray();
+			}
+			elseif ($data instanceof JObject)
+			{
+				// Handle a JObject.
+				$data = $data->getProperties();
+			}
+			else
+			{
+				// Handle other types of objects.
+				$data = (array) $data;
+			}
+		}
 
 		// Process the input data.
 		foreach ($data as $k => $v)
 		{
+			$level = $group ? $group . '.' . $k : $k;
+
 			if ($this->findField($k, $group))
 			{
 				// If the field exists set the value.
-				$this->data->set($group . '.' . $k, $v);
+				$this->data->set($level, $v);
 			}
 			elseif (is_object($v) || JArrayHelper::isAssociative($v))
 			{
-				// If the value is an object or an associative array, hand it off to the recursive bind level method
-				$this->bindLevel($group . '.' . $k, $v);
+				// If the value is an object or an associative array, hand it off to the recursive bind level method.
+				$this->bindLevel($level, $v);
 			}
 		}
 	}


### PR DESCRIPTION
Currently it converts all nested objects to array silently (see #3737). Some components relying on old behavior (prior to #3737) may expect object type values for the form fields.
This fix does not process the entire nested structure, instead converts only binding levels to array for internal iterations.
