### PR TITLE
Fixes #8381 - JForm::getFieldAttribute

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -316,7 +316,7 @@ class JForm
 		$element = $this->findField($name, $group);
 
 		// If the element exists and the attribute exists for the field return the attribute value.
-		if (($element instanceof SimpleXMLElement) && ((string) $element[$attribute]))
+		if (($element instanceof SimpleXMLElement) && strlen((string) $element[$attribute]))
 		{
 			return (string) $element[$attribute];
 		}


### PR DESCRIPTION
Fixes #8381 Currently returns false when attribute value is "0", this fix makes it return "0" only.
