### PR TITLE
Fix id attribute generation to be unique within the HTML document

### DIFF
--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -12,39 +12,43 @@ defined('_JEXEC') or die;
 JLoader::register('JHtmlUsers', JPATH_COMPONENT . '/helpers/html/users.php');
 JHtml::register('users.spacer', array('JHtmlUsers', 'spacer'));
 
-
 $fieldsets = $this->form->getFieldsets();
-if (isset($fieldsets['core']))   unset($fieldsets['core']);
-if (isset($fieldsets['params'])) unset($fieldsets['params']);
 
-foreach ($fieldsets as $group => $fieldset): // Iterate through the form fieldsets
-	$fields = $this->form->getFieldset($group);
-	if (count($fields)):
+if (isset($fieldsets['core']))
+{
+	unset($fieldsets['core']);
+}
+
+if (isset($fieldsets['params']))
+{
+	unset($fieldsets['params']);
+}
 ?>
-
-<fieldset id="users-profile-custom" class="users-profile-custom-<?php echo $group; ?>">
-	<?php // If the fieldset has a label set, display it as the legend. ?>
-	<?php if (isset($fieldset->label)): ?>
-	<legend><?php echo JText::_($fieldset->label); ?></legend>
-	<?php endif; ?>
-	<dl class="dl-horizontal">
-	<?php foreach ($fields as $field) :
-		if (!$field->hidden && $field->type != 'Spacer') : ?>
-		<dt><?php echo $field->title; ?></dt>
-		<dd>
-			<?php if (JHtml::isRegistered('users.' . $field->id)) : ?>
-				<?php echo JHtml::_('users.' . $field->id, $field->value); ?>
-			<?php elseif (JHtml::isRegistered('users.' . $field->fieldname)) : ?>
-				<?php echo JHtml::_('users.' . $field->fieldname, $field->value); ?>
-			<?php elseif (JHtml::isRegistered('users.' . $field->type)) : ?>
-				<?php echo JHtml::_('users.' . $field->type, $field->value); ?>
-			<?php else : ?>
-				<?php echo JHtml::_('users.value', $field->value); ?>
+<?php foreach ($fieldsets as $group => $fieldset) : ?>
+	<?php $fields = $this->form->getFieldset($group); ?>
+	<?php if (count($fields)) : ?>
+		<fieldset id="users-profile-custom-<?php echo $group; ?>" class="users-profile-custom-<?php echo $group; ?>">
+			<?php if (isset($fieldset->label) && strlen($legend = trim(JText::_($fieldset->label)))) : ?>
+				<legend><?php echo $legend; ?></legend>
 			<?php endif; ?>
-		</dd>
-		<?php endif; ?>
-	<?php endforeach; ?>
-	</dl>
-</fieldset>
+			<dl class="dl-horizontal">
+				<?php foreach ($fields as $field) : ?>
+					<?php if (!$field->hidden && $field->type !== 'Spacer') : ?>
+						<dt><?php echo $field->title; ?></dt>
+						<dd>
+							<?php if (JHtml::isRegistered('users.' . $field->id)) : ?>
+								<?php echo JHtml::_('users.' . $field->id, $field->value); ?>
+							<?php elseif (JHtml::isRegistered('users.' . $field->fieldname)) : ?>
+								<?php echo JHtml::_('users.' . $field->fieldname, $field->value); ?>
+							<?php elseif (JHtml::isRegistered('users.' . $field->type)) : ?>
+								<?php echo JHtml::_('users.' . $field->type, $field->value); ?>
+							<?php else : ?>
+								<?php echo JHtml::_('users.value', $field->value); ?>
+							<?php endif; ?>
+						</dd>
+					<?php endif; ?>
+				<?php endforeach; ?>
+			</dl>
+		</fieldset>
 	<?php endif; ?>
 <?php endforeach; ?>


### PR DESCRIPTION
This pr fixes the generation of the id attribute for each fieldset by adding a group name prefix similar to the class.

Reference:
http://www.w3.org/TR/html401/struct/global.html#adef-id

Note:
If I'm not mistaken, the class "should be" the same for all fieldsets. I did not remove the group to keep it bc.

Furthermore I've reformatted some code blocks to match the code sniffer rules and added a more strict check to the legend rendering method of each fieldset.

Background:
If one overrides a translatable string with an empty string, the legend tag would be rendered without a text which could lead to a messed up styling of the form in general.
