### PR TITLE
Update application.xml required fields

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -9,7 +9,6 @@
 			default="2"
 			label="COM_CONFIG_FIELD_CACHE_LABEL"
 			description="COM_CONFIG_FIELD_CACHE_DESC"
-			required="true"
 			filter="integer">
 			<option value="0">COM_CONFIG_FIELD_VALUE_CACHE_OFF</option>
 			<option value="1">COM_CONFIG_FIELD_VALUE_CACHE_CONSERVATIVE</option>
@@ -399,8 +398,7 @@
 			type="timezone"
 			default="UTC"
 			label="COM_CONFIG_FIELD_SERVER_TIMEZONE_LABEL"
-			description="COM_CONFIG_FIELD_SERVER_TIMEZONE_DESC"
-			required="true">
+			description="COM_CONFIG_FIELD_SERVER_TIMEZONE_DESC">
 			<option value="UTC">JLIB_FORM_VALUE_TIMEZONE_UTC</option>
 		</field>
 	</fieldset>
@@ -428,7 +426,6 @@
 			default="mail"
 			label="COM_CONFIG_FIELD_MAIL_MAILER_LABEL"
 			description="COM_CONFIG_FIELD_MAIL_MAILER_DESC"
-			required="true"
 			filter="word">
 			<option value="mail">COM_CONFIG_FIELD_VALUE_PHP_MAIL</option>
 			<option value="sendmail">COM_CONFIG_FIELD_VALUE_SENDMAIL</option>
@@ -747,7 +744,6 @@
 			default="none"
 			label="COM_CONFIG_FIELD_SESSION_HANDLER_LABEL"
 			description="COM_CONFIG_FIELD_SESSION_HANDLER_DESC"
-			required="true"
 			filter="word" />
 
 		<field
@@ -863,7 +859,6 @@
 			default="tinymce"
 			label="COM_CONFIG_FIELD_DEFAULT_EDITOR_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_EDITOR_DESC"
-			required="false"
 			filter="cmd" />
 
 		<field
@@ -873,7 +868,6 @@
 			default="0"
 			label="COM_CONFIG_FIELD_DEFAULT_CAPTCHA_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_CAPTCHA_DESC"
-			required="true"
 			filter="cmd">
 			<option value="0">JOPTION_DO_NOT_USE</option>
 		</field>
@@ -884,7 +878,6 @@
 			default="1"
 			label="COM_CONFIG_FIELD_DEFAULT_ACCESS_LEVEL_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_ACCESS_LEVEL_DESC"
-			required="true"
 			filter="integer" />
 
 		<field
@@ -952,8 +945,7 @@
 			name="helpurl"
 			type="helpsite"
 			label="COM_CONFIG_FIELD_HELP_SERVER_LABEL"
-			description="COM_CONFIG_FIELD_HELP_SERVER_DESC"
-			required="true" />
+			description="COM_CONFIG_FIELD_HELP_SERVER_DESC" />
 	</fieldset>
 
 	<fieldset
@@ -964,7 +956,6 @@
 			type="text"
 			label="COM_CONFIG_FIELD_COOKIE_DOMAIN_LABEL"
 			description="COM_CONFIG_FIELD_COOKIE_DOMAIN_DESC"
-			required="false"
 			filter="string"
 			size="40" />
 
@@ -973,7 +964,6 @@
 			type="text"
 			label="COM_CONFIG_FIELD_COOKIE_PATH_LABEL"
 			description="COM_CONFIG_FIELD_COOKIE_PATH_DESC"
-			required="false"
 			filter="string"
 			size="40" />
 	</fieldset>

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -215,6 +215,7 @@
 			type="text"
 			label="COM_CONFIG_FIELD_DATABASE_HOST_LABEL"
 			description="COM_CONFIG_FIELD_DATABASE_HOST_DESC"
+			required="true"
 			filter="string"
 			size="30" />
 
@@ -223,6 +224,7 @@
 			type="text"
 			label="COM_CONFIG_FIELD_DATABASE_USERNAME_LABEL"
 			description="COM_CONFIG_FIELD_DATABASE_USERNAME_DESC"
+			required="true"
 			filter="string"
 			size="30" />
 
@@ -231,6 +233,7 @@
 			type="text"
 			label="COM_CONFIG_FIELD_DATABASE_NAME_LABEL"
 			description="COM_CONFIG_FIELD_DATABASE_NAME_DESC"
+			required="true"
 			filter="string"
 			size="30" />
 


### PR DESCRIPTION
In Global Configuration we have several fields that are marked as required in the xml and as a result have a \* next to the label. 

When they are a select field this is useless as there is always a value eg Help Server and there is no way to ever not have a value. 

There appears to be no real logic in which fields are marked as required. For example Mailer type is required but Database type is not required - of course it is require but its a select that always has a value.

This PR removes the required=true for all fields where there is no way for the user ever to have no data
This PR also removes the few cases where required=false is set. (We should set it for all or none)
