### PR TITLE
Update sysinfo.php

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -69,6 +69,7 @@ class AdminModelSysInfo extends JModelLegacy
 	protected $privateSettings = array(
 		'phpInfoArray' => array(
 			'CONTEXT_DOCUMENT_ROOT',
+			'Cookie',
 			'DOCUMENT_ROOT',
 			'extension_dir',
 			'Host',


### PR DESCRIPTION
In the NEW download of sysinfo the values of "sensitive" data is replaced with XXXX

In the section "Apache Environment" the value for HTTP_COOKIE is replaced with XXXX
In the section "HTTP Headers Information" the value for Cookie is NOT replaced

As they both contain the same information then we should be consistent in either replacing the value for both or displaying it for both

This PR removes the value of the cookie in the  "HTTP Headers Information" section in the downloaded system information.

To test simply download the System information and verfiy that the value of the Cookie is replaced with XXX
