### PR TITLE
Remove usage of deprecated JArrayHelper from com_cache

### DIFF
--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -19,7 +19,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * An Array of CacheItems indexed by cache group ID
 	 *
-	 * @var Array
+	 * @var array
 	 */
 	protected $_data = array();
 
@@ -83,8 +83,7 @@ class CacheModelCache extends JModelList
 					$ordering = $this->getState('list.ordering');
 					$direction = ($this->getState('list.direction') == 'asc') ? 1 : (-1);
 
-					jimport('joomla.utilities.arrayhelper');
-					$this->_data = JArrayHelper::sortObjects($data, $ordering, $direction);
+					$this->_data = Joomla\Utilities\ArrayHelper::sortObjects($data, $ordering, $direction);
 
 					// Apply custom pagination.
 					if ($this->_total > $this->getState('list.limit') && $this->getState('list.limit'))


### PR DESCRIPTION
This is one from the series of edits in which we try to remove usage of deprecated JArrayHelper from the entire Joomla core system. Taking one extension/library at a time for easy tests.
