### PR TITLE
En-gb creation date

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -2,7 +2,7 @@
 <metafile version="3.5" client="administrator">
 	<name>English (en-GB)</name>
 	<version>3.5.0</version>
-	<creationDate>2013-03-07</creationDate>
+	<creationDate>November 2015</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -2,7 +2,7 @@
 <metafile version="3.5" client="site">
 	<name>English (en-GB)</name>
 	<version>3.5.0</version>
-	<creationDate>2013-03-07</creationDate>
+	<creationDate>November 2015</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>


### PR DESCRIPTION
The creation date in the en-gb.xml file has never been update. This looks "odd" on a site with multiple languages installed as the other languages update the creation date with each release.

This PR set the creation date for en-gb to November 2015
## Before

![rri5](https://cloud.githubusercontent.com/assets/1296369/11117109/fac86240-892e-11e5-9a7c-0389fd7a4e07.png)
## After

![ploj](https://cloud.githubusercontent.com/assets/1296369/11117085/d2b00c2c-892e-11e5-911f-c7cd1e6745df.png)
