### PR TITLE
Remove usage of deprecated JArrayHelper from com_finder

### DIFF
--- a/administrator/components/com_finder/controllers/filter.php
+++ b/administrator/components/com_finder/controllers/filter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Indexer controller class for Finder.
  *
@@ -144,7 +146,7 @@ class FinderControllerFilter extends JControllerForm
 		// Get and sanitize the filter data.
 		$validData['data'] = $input->post->get('t', array(), 'array');
 		$validData['data'] = array_unique($validData['data']);
-		JArrayHelper::toInteger($validData['data']);
+		$validData['data'] = ArrayHelper::toInteger($validData['data']);
 
 		// Remove any values of zero.
 		if (array_search(0, $validData['data'], true))

--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('FinderIndexer', __DIR__ . '/indexer.php');
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
 JLoader::register('FinderIndexerResult', __DIR__ . '/result.php');
@@ -551,7 +553,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 		$row = $this->db->loadAssoc();
 
 		// Convert the item to a result object.
-		$item = JArrayHelper::toObject($row, 'FinderIndexerResult');
+		$item = ArrayHelper::toObject((array) $row, 'FinderIndexerResult');
 
 		// Set the item type.
 		$item->type_id = $this->type_id;
@@ -586,7 +588,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 		foreach ($rows as $row)
 		{
 			// Convert the item to a result object.
-			$item = JArrayHelper::toObject($row, 'FinderIndexerResult');
+			$item = ArrayHelper::toObject((array) $row, 'FinderIndexerResult');
 
 			// Set the item type.
 			$item->type_id = $this->type_id;

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
 JLoader::register('FinderIndexerTaxonomy', __DIR__ . '/taxonomy.php');
@@ -379,7 +380,7 @@ class FinderIndexerQuery
 
 		// Sanitize the terms.
 		$results = array_unique($results);
-		JArrayHelper::toInteger($results);
+		$results = ArrayHelper::toInteger($results);
 
 		return $results;
 	}
@@ -421,7 +422,7 @@ class FinderIndexerQuery
 		foreach ($results as $key => $value)
 		{
 			$results[$key] = array_unique($results[$key]);
-			JArrayHelper::toInteger($results[$key]);
+			$results[$key] = ArrayHelper::toInteger($results[$key]);
 		}
 
 		return $results;
@@ -462,7 +463,7 @@ class FinderIndexerQuery
 		foreach ($results as $key => $value)
 		{
 			$results[$key] = array_unique($results[$key]);
-			JArrayHelper::toInteger($results[$key]);
+			$results[$key] = ArrayHelper::toInteger($results[$key]);
 		}
 
 		return $results;
@@ -521,7 +522,7 @@ class FinderIndexerQuery
 		// Remove duplicates and sanitize.
 		$filters = explode(',', $return->data);
 		$filters = array_unique($filters);
-		JArrayHelper::toInteger($filters);
+		$filters = ArrayHelper::toInteger($filters);
 
 		// Remove any values of zero.
 		if (array_search(0, $filters, true) !== false)
@@ -585,7 +586,7 @@ class FinderIndexerQuery
 
 		// Remove duplicates and sanitize.
 		$filters = array_unique($filters);
-		JArrayHelper::toInteger($filters);
+		$filters = ArrayHelper::toInteger($filters);
 
 		// Remove any values of zero.
 		if (array_search(0, $filters, true) !== false)

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Filter table class for the Finder package.
@@ -110,7 +111,7 @@ class FinderTableFilter extends JTable
 		$k = $this->_tbl_key;
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
 		$state = (int) $state;
 

--- a/administrator/components/com_finder/tables/map.php
+++ b/administrator/components/com_finder/tables/map.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Map table class for the Finder package.
  *
@@ -47,7 +49,7 @@ class FinderTableMap extends JTable
 		$k = $this->_tbl_key;
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$state = (int) $state;
 
 		// If there are no primary keys set check to see if the instance key is set.

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 // Register dependent classes.
 define('FINDER_PATH_INDEXER', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer');
 JLoader::register('FinderIndexerHelper', FINDER_PATH_INDEXER . '/helper.php');
@@ -979,7 +981,7 @@ class FinderModelSearch extends JModelList
 
 		// Sanitize the link ids.
 		$links = array_unique($links);
-		JArrayHelper::toInteger($links);
+		$links = ArrayHelper::toInteger($links);
 
 		// Push the link ids into cache.
 		$this->store($store, $links);


### PR DESCRIPTION
This is one from the series of edits in which we try to remove usage of deprecated JArrayHelper from the entire Joomla core system. Taking one extension/library at a time for easy tests.
