### PR TITLE
use jpath_base not jexec in layouts

### DIFF
--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 // Create a shortcut for params.
 $params = $displayData->params;

--- a/layouts/joomla/content/blog_style_default_links.php
+++ b/layouts/joomla/content/blog_style_default_links.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($displayData->get('link_items') as $item) : ?>

--- a/layouts/joomla/content/categories_default.php
+++ b/layouts/joomla/content/categories_default.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 ?>
 <?php if ($displayData->params->get('show_page_heading')) : ?>

--- a/layouts/joomla/content/categories_default_items.php
+++ b/layouts/joomla/content/categories_default_items.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $class = ' class="first"';
 JHtml::_('bootstrap.tooltip');

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 $params  = $displayData->params;
 ?>
 <?php $images = json_decode($displayData->images); ?>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 ?>
 <fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : 'form-horizontal'; ?>">

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+defined('JPATH_BASE') or die;
+
 $params = $displayData['params'];
 $item = $displayData['item'];
 ?>

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 // JLayout for standard handling of associations fields in the administrator items edit screens.
 echo $displayData->getForm()->renderFieldset('item_associations');

--- a/layouts/joomla/edit/details.php
+++ b/layouts/joomla/edit/details.php
@@ -9,7 +9,7 @@
  * @deprecated  3.2
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;;
 
 $app = JFactory::getApplication();
 

--- a/layouts/joomla/edit/details.php
+++ b/layouts/joomla/edit/details.php
@@ -9,7 +9,7 @@
  * @deprecated  3.2
  */
 
-defined('JPATH_BASE') or die;;
+defined('JPATH_BASE') or die;
 
 $app = JFactory::getApplication();
 

--- a/layouts/joomla/edit/fieldset.php
+++ b/layouts/joomla/edit/fieldset.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $app = JFactory::getApplication();
 $form = $displayData->getForm();

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 // JLayout for standard handling of the edit modules:
 

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $app       = JFactory::getApplication();
 $form      = $displayData->getForm();

--- a/layouts/joomla/edit/metadata.php
+++ b/layouts/joomla/edit/metadata.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $form = $displayData->getForm();
 

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $app       = JFactory::getApplication();
 $form      = $displayData->getForm();

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $app = JFactory::getApplication();
 $form = $displayData->getForm();

--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $buttons = $displayData;
 

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $button = $displayData;
 

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/formbehavior/ajaxchosen.php
+++ b/layouts/joomla/html/formbehavior/ajaxchosen.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/formbehavior/chosen.php
+++ b/layouts/joomla/html/formbehavior/chosen.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/sortablelist.php
+++ b/layouts/joomla/html/sortablelist.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 /**
  * Layout variables

--- a/layouts/joomla/html/tag.php
+++ b/layouts/joomla/html/tag.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 use Joomla\Registry\Registry;
 

--- a/layouts/joomla/links/groupclose.php
+++ b/layouts/joomla/links/groupclose.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 	</ul>

--- a/layouts/joomla/links/groupopen.php
+++ b/layouts/joomla/links/groupopen.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <h2 class="nav-header"><?php echo JFilterOutput::ampReplace(JText::_($displayData)); ?></h2>
 <ul class="j-links-group nav nav-list">

--- a/layouts/joomla/links/groupsclose.php
+++ b/layouts/joomla/links/groupsclose.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 </div>

--- a/layouts/joomla/links/groupseparator.php
+++ b/layouts/joomla/links/groupseparator.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <div class="j-links-separator"></div>

--- a/layouts/joomla/links/groupsopen.php
+++ b/layouts/joomla/links/groupsopen.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <div class="j-links-groups">

--- a/layouts/joomla/links/link.php
+++ b/layouts/joomla/links/link.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $id      = empty($displayData['id']) ? '' : (' id="' . $displayData['id'] . '"');
 $target  = empty($displayData['target']) ? '' : (' target="' . $displayData['target'] . '"');

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $id      = empty($displayData['id']) ? '' : (' id="' . $displayData['id'] . '"');
 $target  = empty($displayData['target']) ? '' : (' target="' . $displayData['target'] . '"');

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $msgList = $displayData['msgList'];
 

--- a/layouts/joomla/tinymce/buttons.php
+++ b/layouts/joomla/tinymce/buttons.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JLog::add('The layout joomla.tinymce.buttons is deprecated, use joomla.editors.buttons instead.', JLog::WARNING, 'deprecated');
 echo JLayoutHelper::render('joomla.editors.buttons', $displayData);

--- a/layouts/joomla/tinymce/buttons/button.php
+++ b/layouts/joomla/tinymce/buttons/button.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JLog::add('The layout joomla.tinymce.buttons.button is deprecated, use joomla.editors.buttons.button instead.', JLog::WARNING, 'deprecated');
 echo JLayoutHelper::render('joomla.editors.buttons.button', $displayData);

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $data = $displayData;
 

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $name = $displayData;
 

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <div class="btn-wrapper" <?php echo $displayData['id']; ?>>
 	<?php echo $displayData['action']; ?>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/confirm.php
+++ b/layouts/joomla/toolbar/confirm.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/containerclose.php
+++ b/layouts/joomla/toolbar/containerclose.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 </div>

--- a/layouts/joomla/toolbar/containeropen.php
+++ b/layouts/joomla/toolbar/containeropen.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 <div class="btn-toolbar" id="<?php echo $displayData['id']; ?>">

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/iconclass.php
+++ b/layouts/joomla/toolbar/iconclass.php
@@ -7,6 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 ?>
 icon-<?php echo $displayData['icon']; ?>

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -7,4 +7,4 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $icon = empty($displayData['icon']) ? 'generic' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);
 ?>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.framework');
 

--- a/layouts/libraries/cms/html/bootstrap/addtab.php
+++ b/layouts/libraries/cms/html/bootstrap/addtab.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $id = empty($displayData['id']) ? '' : $displayData['id'];
 $active = empty($displayData['active']) ? '' : $displayData['active'];

--- a/layouts/libraries/cms/html/bootstrap/addtabscript.php
+++ b/layouts/libraries/cms/html/bootstrap/addtabscript.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $selector = empty($displayData['selector']) ? '' : $displayData['selector'];
 $id = empty($displayData['id']) ? '' : $displayData['id'];

--- a/layouts/libraries/cms/html/bootstrap/endtab.php
+++ b/layouts/libraries/cms/html/bootstrap/endtab.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 ?>
 

--- a/layouts/libraries/cms/html/bootstrap/endtabset.php
+++ b/layouts/libraries/cms/html/bootstrap/endtabset.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 ?>
 

--- a/layouts/libraries/cms/html/bootstrap/starttabset.php
+++ b/layouts/libraries/cms/html/bootstrap/starttabset.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $selector = empty($displayData['selector']) ? '' : $displayData['selector'];
 

--- a/layouts/libraries/cms/html/bootstrap/starttabsetscript.php
+++ b/layouts/libraries/cms/html/bootstrap/starttabsetscript.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+defined('JPATH_BASE') or die;
 
 $selector = empty($displayData['selector']) ? '' : $displayData['selector'];
 


### PR DESCRIPTION
This PR standardises on using jpath_base in the layouts. 
We currently have a mix of both jpath_base and jexec and in one case (readmore) none at all

see #8384
