### PR TITLE
Pull in Symfony's PHP 5.6 polyfill to consistently use hash_equals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,11 @@ Desktop.ini
 /libraries/vendor/psr/log/.gitignore
 /libraries/vendor/psr/log/composer.json
 /libraries/vendor/psr/log/README.md
+/libraries/vendor/symfony/polyfill-php56/composer.json
+/libraries/vendor/symfony/polyfill-php56/README.md
+/libraries/vendor/symfony/polyfill-util/composer.json
+/libraries/vendor/symfony/polyfill-util/README.md
+/libraries/vendor/symfony/polyfill-util/TestListener.php
 /libraries/vendor/symfony/yaml/Tests
 /libraries/vendor/symfony/yaml/.gitignore
 /libraries/vendor/symfony/yaml/CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "leafo/lessphp": "0.3.9",
         "paragonie/random_compat": "~1.0",
         "phpmailer/phpmailer": "5.2.9",
+        "symfony/polyfill-php56": "~1.0",
         "symfony/yaml": "2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c197264a007954a2f516b254701041d1",
-    "content-hash": "e9bfab93fa1da2901bef86c28a318b57",
+    "hash": "95f124c32e010ff993d660ee0c98188b",
+    "content-hash": "49979472d61e44eba9b2d42a6ab04886",
     "packages": [
         {
             "name": "ircmaxell/password-compat",
@@ -738,6 +738,114 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "symfony/polyfill-php56",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php56.git",
+                "reference": "a6bd4770a6967517e6610529e14afaa3111094a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/a6bd4770a6967517e6610529e14afaa3111094a3",
+                "reference": "a6bd4770a6967517e6610529e14afaa3111094a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-util": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php56\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
+        },
+        {
+            "name": "symfony/polyfill-util",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-util.git",
+                "reference": "4271c55cbc0a77b2641f861b978123e46b3da969"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4271c55cbc0a77b2641f861b978123e46b3da969",
+                "reference": "4271c55cbc0a77b2641f861b978123e46b3da969",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Util\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony utilities for portability of PHP codes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compat",
+                "compatibility",
+                "polyfill",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
         },
         {
             "name": "symfony/yaml",

--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -142,31 +142,8 @@ class JCrypt
 	 */
 	public static function timingSafeCompare($known, $unknown)
 	{
-		// Prefer PHP's hash_equals function (PHP 5.6+) if available
-		if (function_exists('hash_equals'))
-		{
-			return hash_equals((string) $known, (string) $unknown);
-		}
-
-		// Prevent issues if string length is 0
-		$known .= chr(0);
-		$unknown .= chr(0);
-
-		$knownLength = static::safeStrlen($known);
-		$unknownLength = static::safeStrlen($unknown);
-
-		// Set the result to the difference between the lengths
-		$result = $knownLength - $unknownLength;
-
-		// Note that we ALWAYS iterate over the user-supplied length to prevent leaking length info.
-		for ($i = 0; $i < $unknownLength; $i++)
-		{
-			// Using % here is a trick to prevent notices. It's safe, since if the lengths are different, $result is already non-0
-			$result |= (ord($known[$i % $knownLength]) ^ ord($unknown[$i]));
-		}
-
-		// They are only identical strings if $result is exactly 0...
-		return $result === 0;
+		// This function is native in PHP as of 5.6 and backported via the symfony/polyfill-56 library
+		return hash_equals((string) $known, (string) $unknown);
 	}
 
 	/**

--- a/libraries/vendor/composer/autoload_files.php
+++ b/libraries/vendor/composer/autoload_files.php
@@ -8,4 +8,5 @@ $baseDir = dirname(dirname($vendorDir));
 return array(
     $vendorDir . '/ircmaxell/password-compat/lib/password.php',
     $vendorDir . '/paragonie/random_compat/lib/random.php',
+    $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
 );

--- a/libraries/vendor/composer/autoload_psr4.php
+++ b/libraries/vendor/composer/autoload_psr4.php
@@ -6,6 +6,8 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname(dirname($vendorDir));
 
 return array(
+    'Symfony\\Polyfill\\Util\\' => array($vendorDir . '/symfony/polyfill-util'),
+    'Symfony\\Polyfill\\Php56\\' => array($vendorDir . '/symfony/polyfill-php56'),
     'Symfony\\Component\\Yaml\\' => array($vendorDir . '/symfony/yaml'),
     'Joomla\\Utilities\\Tests\\' => array($vendorDir . '/joomla/utilities/Tests'),
     'Joomla\\Utilities\\' => array($vendorDir . '/joomla/utilities/src'),

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -813,5 +813,117 @@
             "pseudorandom",
             "random"
         ]
+    },
+    {
+        "name": "symfony/polyfill-util",
+        "version": "v1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-util.git",
+            "reference": "4271c55cbc0a77b2641f861b978123e46b3da969"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4271c55cbc0a77b2641f861b978123e46b3da969",
+            "reference": "4271c55cbc0a77b2641f861b978123e46b3da969",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3"
+        },
+        "time": "2015-11-04 20:28:58",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Util\\": ""
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony utilities for portability of PHP codes",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compat",
+            "compatibility",
+            "polyfill",
+            "shim"
+        ]
+    },
+    {
+        "name": "symfony/polyfill-php56",
+        "version": "v1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-php56.git",
+            "reference": "a6bd4770a6967517e6610529e14afaa3111094a3"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/a6bd4770a6967517e6610529e14afaa3111094a3",
+            "reference": "a6bd4770a6967517e6610529e14afaa3111094a3",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3",
+            "symfony/polyfill-util": "~1.0"
+        },
+        "time": "2015-11-04 20:28:58",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Php56\\": ""
+            },
+            "files": [
+                "bootstrap.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compatibility",
+            "polyfill",
+            "portable",
+            "shim"
+        ]
     }
 ]

--- a/libraries/vendor/symfony/polyfill-php56/LICENSE
+++ b/libraries/vendor/symfony/polyfill-php56/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2015 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/libraries/vendor/symfony/polyfill-php56/Php56.php
+++ b/libraries/vendor/symfony/polyfill-php56/Php56.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Php56;
+
+use Symfony\Polyfill\Util\Binary;
+
+/**
+ * @internal
+ */
+final class Php56
+{
+    const LDAP_ESCAPE_FILTER = 1;
+    const LDAP_ESCAPE_DN = 2;
+
+    public static function hash_equals($knownString, $userInput)
+    {
+        if (!is_string($knownString)) {
+            trigger_error('Expected known_string to be a string, '.gettype($knownString).' given', E_USER_WARNING);
+
+            return false;
+        }
+
+        if (!is_string($userInput)) {
+            trigger_error('Expected user_input to be a string, '.gettype($userInput).' given', E_USER_WARNING);
+
+            return false;
+        }
+
+        $knownLen = Binary::strlen($knownString);
+        $userLen = Binary::strlen($userInput);
+
+        if ($knownLen !== $userLen) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $knownLen; ++$i) {
+            $result |= ord($knownString[$i]) ^ ord($userInput[$i]);
+        }
+
+        return 0 === $result;
+    }
+
+    /**
+     * Stub implementation of the {@link ldap_escape()} function of the ldap
+     * extension.
+     *
+     * Escape strings for safe use in LDAP filters and DNs.
+     *
+     * @author Chris Wright <ldapi@daverandom.com>
+     *
+     * @param string $subject
+     * @param string $ignore
+     * @param int    $flags
+     *
+     * @return string
+     *
+     * @see http://stackoverflow.com/a/8561604
+     */
+    public static function ldap_escape($subject, $ignore = '', $flags = 0)
+    {
+        static $charMaps = null;
+
+        if (null === $charMaps) {
+            $charMaps = array(
+                self::LDAP_ESCAPE_FILTER => array('\\', '*', '(', ')', "\x00"),
+                self::LDAP_ESCAPE_DN => array('\\', ',', '=', '+', '<', '>', ';', '"', '#'),
+            );
+
+            $charMaps[0] = array();
+
+            for ($i = 0; $i < 256; ++$i) {
+                $charMaps[0][chr($i)] = sprintf('\\%02x', $i);
+            }
+
+            for ($i = 0, $l = count($charMaps[self::LDAP_ESCAPE_FILTER]); $i < $l; ++$i) {
+                $chr = $charMaps[self::LDAP_ESCAPE_FILTER][$i];
+                unset($charMaps[self::LDAP_ESCAPE_FILTER][$i]);
+                $charMaps[self::LDAP_ESCAPE_FILTER][$chr] = $charMaps[0][$chr];
+            }
+
+            for ($i = 0, $l = count($charMaps[self::LDAP_ESCAPE_DN]); $i < $l; ++$i) {
+                $chr = $charMaps[self::LDAP_ESCAPE_DN][$i];
+                unset($charMaps[self::LDAP_ESCAPE_DN][$i]);
+                $charMaps[self::LDAP_ESCAPE_DN][$chr] = $charMaps[0][$chr];
+            }
+        }
+
+        // Create the base char map to escape
+        $flags = (int) $flags;
+        $charMap = array();
+
+        if ($flags & self::LDAP_ESCAPE_FILTER) {
+            $charMap += $charMaps[self::LDAP_ESCAPE_FILTER];
+        }
+
+        if ($flags & self::LDAP_ESCAPE_DN) {
+            $charMap += $charMaps[self::LDAP_ESCAPE_DN];
+        }
+
+        if (!$charMap) {
+            $charMap = $charMaps[0];
+        }
+
+        // Remove any chars to ignore from the list
+        $ignore = (string) $ignore;
+
+        for ($i = 0, $l = strlen($ignore); $i < $l; ++$i) {
+            unset($charMap[$ignore[$i]]);
+        }
+
+        // Do the main replacement
+        $result = strtr($subject, $charMap);
+
+        // Encode leading/trailing spaces if self::LDAP_ESCAPE_DN is passed
+        if ($flags & self::LDAP_ESCAPE_DN) {
+            if ($result[0] === ' ') {
+                $result = '\\20'.substr($result, 1);
+            }
+
+            if ($result[strlen($result) - 1] === ' ') {
+                $result = substr($result, 0, -1).'\\20';
+            }
+        }
+
+        return $result;
+    }
+}

--- a/libraries/vendor/symfony/polyfill-php56/bootstrap.php
+++ b/libraries/vendor/symfony/polyfill-php56/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Polyfill\Php56 as p;
+
+if (PHP_VERSION_ID < 50600) {
+    if (!function_exists('hash_equals')) {
+        function hash_equals($knownString, $userInput) { return p\Php56::hash_equals($knownString, $userInput); }
+    }
+    if (extension_loaded('ldap') && !function_exists('ldap_escape')) {
+        define('LDAP_ESCAPE_FILTER', 1);
+        define('LDAP_ESCAPE_DN', 2);
+
+        function ldap_escape($subject, $ignore = '', $flags = 0) { return p\Php56::ldap_escape($subject, $ignore, $flags); }
+    }
+}

--- a/libraries/vendor/symfony/polyfill-util/Binary.php
+++ b/libraries/vendor/symfony/polyfill-util/Binary.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+if (extension_loaded('mbstring')) {
+    class Binary extends BinaryOnFuncOverload {}
+} else {
+    class Binary extends BinaryNoFuncOverload {}
+}

--- a/libraries/vendor/symfony/polyfill-util/BinaryNoFuncOverload.php
+++ b/libraries/vendor/symfony/polyfill-util/BinaryNoFuncOverload.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class BinaryNoFuncOverload
+{
+    public static function strlen($s)
+    {
+        return strlen($s);
+    }
+
+    public static function strpos($haystack, $needle, $offset = 0)
+    {
+        return strpos($haystack, $needle, $offset);
+    }
+
+    public static function strrpos($haystack, $needle, $offset = 0)
+    {
+        return strrpos($haystack, $needle, $offset);
+    }
+
+    public static function substr($string, $start, $length = PHP_INT_MAX)
+    {
+        return substr($string, $start, $length);
+    }
+
+    public static function stripos($s, $needle, $offset = 0)
+    {
+        return stripos($s, $needle, $offset);
+    }
+
+    public static function stristr($s, $needle, $part = false)
+    {
+        return stristr($s, $needle, $part);
+    }
+
+    public static function strrchr($s, $needle, $part = false)
+    {
+        return strrchr($s, $needle, $part);
+    }
+
+    public static function strripos($s, $needle, $offset = 0)
+    {
+        return strripos($s, $needle, $offset);
+    }
+
+    public static function strstr($s, $needle, $part = false)
+    {
+        return strstr($s, $needle, $part);
+    }
+}

--- a/libraries/vendor/symfony/polyfill-util/BinaryOnFuncOverload.php
+++ b/libraries/vendor/symfony/polyfill-util/BinaryOnFuncOverload.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Polyfill\Util;
+
+/**
+ * Binary safe version of string functions overloaded when MB_OVERLOAD_STRING is enabled.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class BinaryOnFuncOverload
+{
+    public static function strlen($s)
+    {
+        return mb_strlen($s, '8bit');
+    }
+
+    public static function strpos($haystack, $needle, $offset = 0)
+    {
+        return mb_strpos($haystack, $needle, $offset, '8bit');
+    }
+
+    public static function strrpos($haystack, $needle, $offset = 0)
+    {
+        return mb_strrpos($haystack, $needle, $offset, '8bit');
+    }
+
+    public static function substr($string, $start, $length = 2147483647)
+    {
+        return mb_substr($string, $start, $length, '8bit');
+    }
+
+    public static function stripos($s, $needle, $offset = 0)
+    {
+        return mb_stripos($s, $needle, $offset, '8bit');
+    }
+
+    public static function stristr($s, $needle, $part = false)
+    {
+        return mb_stristr($s, $needle, $part, '8bit');
+    }
+
+    public static function strrchr($s, $needle, $part = false)
+    {
+        return mb_strrchr($s, $needle, $part, '8bit');
+    }
+
+    public static function strripos($s, $needle, $offset = 0)
+    {
+        return mb_strripos($s, $needle, $offset, '8bit');
+    }
+
+    public static function strstr($s, $needle, $part = false)
+    {
+        return mb_strstr($s, $needle, $part, '8bit');
+    }
+}

--- a/libraries/vendor/symfony/polyfill-util/LICENSE
+++ b/libraries/vendor/symfony/polyfill-util/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2015 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
This pull request introduces Symfony's new Polyfill libraries to the CMS code stack.  This enables `JCrypt:: timingSafeCompare()` to always use the `hash_equals()` function and in older PHP versions where it isn't present it falls back to their polyfill library, which given the overall state of JCrypt I feel like is going to be better structured than our own method.
### Full API additions

The [5.6 polyfill](https://github.com/symfony/polyfill-php56) library supports backports for PHP's native `hash_equals()` and `ldap_escape()` functions.  The [util polyfill](https://github.com/symfony/polyfill-util) library introduces a class set with several binary-safe string functions.
### Testing Instructions

The only user facing space that uses `JCrypt:: timingSafeCompare()` is in `JUserHelper::verifyPassword()` if a MD5 or SHA256 password hash are used.  So for those looking to test this, you'd need to load an MD5 style hash from early 3.0 or 2.5 releases into your database and login with that.  Preferably with a PHP 5.5 or earlier system.
