### PR TITLE
Avoid sending data to blocked users

### DIFF
--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -54,7 +54,8 @@ class PlgContentJoomla extends JPlugin
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
 			->from($db->quoteName('#__users'))
-			->where($db->quoteName('sendEmail') . ' = 1');
+			->where($db->quoteName('sendEmail') . ' = 1')
+			->where($db->quoteName('block') . ' = 0');
 		$db->setQuery($query);
 		$users = (array) $db->loadColumn();
 


### PR DESCRIPTION
### Info

This patch alters the behavior of plg_content_joomla so that blocked users won't recieve system emails anymore.
### Instructions

Apply patch and create an article in the frontend. Blocked users should not recieve system emails anymore, even if the option is enabled.
### B/C

Fixes a probably undesired behavior.
