### PR TITLE
editor button->onclick, SyntaxError: expected expression, got ','

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1066,7 +1066,7 @@ class PlgEditorTinymce extends JPlugin
 							});";
 					if ($onclick && ($button->get('modal') || $href))
 					{
-						$tempConstructor .= ",
+						$tempConstructor .= "
 						" . $onclick . "
 							";
 					}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1066,14 +1066,14 @@ class PlgEditorTinymce extends JPlugin
 							});";
 					if ($onclick && ($button->get('modal') || $href))
 					{
-						$tempConstructor .= "
+						$tempConstructor .= "\r\n
 						" . $onclick . "
 							";
 					}
 				}
 				else
 				{
-					$tempConstructor .= "
+					$tempConstructor .= "\r\n
 						" . $onclick . "
 							";
 				}


### PR DESCRIPTION
tinymce is concatenating button callback with , and it generates the SyntaxError.

It is fixed removing ,

To test it, a callback can be added to any of the current editors-xtd plugins. For instance, in plugins/editors-xtd/image/image.php, line 62:

```
$button->onclick = 'alert("test")';
```

When the patch is applied, there is no console error, editor loads fine and when you click on the button it shows 'test'
