### PR TITLE
Creating new article unnecessarily load versions

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -58,7 +58,7 @@ JFactory::getDocument()->addScriptDeclaration("
 					<span class="icon-cancel"></span><?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
-			<?php if ($params->get('save_history', 0)) : ?>
+			<?php if ($params->get('save_history', 0) && $this->item->id) : ?>
 			<div class="btn-group">
 				<?php echo $this->form->getInput('contenthistory'); ?>
 			</div>


### PR DESCRIPTION
To test: When creating a new article check that the version history isn't loaded anymore.
Also ensure that when editing an article the versions are loaded as before.
