### PR TITLE
Batch modal too small to show all options

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3926,7 +3926,7 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
+	min-height: 450px;
 	padding: 1%;
 }
 .modal-body iframe {


### PR DESCRIPTION
#### Steps to reproduce the issue

When you click on Batch button, for instance in Menu Manager, it shows the batch dialog with three Select controls. They look fine, but when you click on any of Select controls, items are shown below modal-footer.

In the worst case, the second line of controls options are totally hidden.
#### Expected result

All Select controls have to work.
#### Actual result

Not possible to select options.
#### System information (as much as possible)

J 3.5 Beta
#### Additional comments

".modal-body {min-height: 450px;}" is a viable workaround (instead of max-height). All options can be selected in Menu Manager, Content Manager or Module Manager. Please, test these three cases.
