### PR TITLE
Mod languages ative languages absolute URI fix

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -112,7 +112,7 @@ abstract class ModLanguagesHelper
 					{
 						if ($language->active)
 						{
-							$language->link = JUri::getInstance()->toString(array('scheme', 'host', 'port', 'path', 'query'));
+							$language->link = JUri::getInstance()->toString(array('path', 'query'));
 						}
 						else
 						{


### PR DESCRIPTION
### Description

Problem: Mod languages uses an absolute URI in the ative language flag image link and site root relative URI for the other languages.

This patch converts the absolute URI in the ative language URI to site root relative URI.
### How to test

After the patch the ative language URI in mod languages flag image link should be relative to site root.
### B/C

None.
