### PR TITLE
removed functions can't included in code coverage

### DIFF
--- a/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/utilities/JArrayHelperTest.php
@@ -1387,7 +1387,6 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider  getTestFromObjectData
 	 * @covers  JArrayHelper::fromObject
-	 * @covers  JArrayHelper::_fromObject
 	 * @since   11.1
 	 */
 	public function testFromObject($input, $recurse, $regex, $expect, $defaults)
@@ -1552,7 +1551,6 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider getTestSortObjectData
 	 * @covers  JArrayHelper::sortObjects
-	 * @covers  JArrayHelper::_sortObjects
 	 * @since   11.1
 	 */
 	public function testSortObjects($input, $key, $direction, $casesensitive, $locale, $expect, $message, $defaults, $swappableKeys = array())


### PR DESCRIPTION
removed functions:
_sortObjects
_fromObject

these functions are removed with commit 012d28b19c2194ea8bf769e3ffcc45c81847e013 from 2014

I agree that it strange, why we find out a year later?
