### PR TITLE
Fix: Post Install Messages sort order

### DIFF
--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -31,7 +31,7 @@ class PostinstallModelMessages extends FOFModel
 		$oldState = $this->getState('filter_order_Dir', 'DESC');
 
 		// Set the filter_order_dir to bypass the check in fof
-		// As this is bad in fof please make sure the state is "filter_order_Dir" else it don't work :(
+		// As this is hard coded in fof please make sure the state is "filter_order_Dir" else it don't work
 		$this->setState('filter_order_Dir', 'DESC');
 
 		$query = parent::buildQuery($overrideLimits);

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -27,13 +27,6 @@ class PostinstallModelMessages extends FOFModel
 	 */
 	public function buildQuery($overrideLimits = false)
 	{
-		// Save the old filter order dir
-		$oldState = $this->getState('filter_order_Dir', 'DESC');
-
-		// Set the filter_order_dir to bypass the check in fof
-		// As this is hard coded in fof please make sure the state is "filter_order_Dir" else it don't work
-		$this->setState('filter_order_Dir', 'DESC');
-
 		$query = parent::buildQuery($overrideLimits);
 
 		$db = $this->getDbo();
@@ -45,9 +38,6 @@ class PostinstallModelMessages extends FOFModel
 		// Force filter only enabled messages
 		$published = $this->getState('published', 1, 'int');
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));
-
-		// Reset to the old state
-		$this->setState('filter_order_Dir', $oldState);
 
 		return $query;
 	}
@@ -135,6 +125,9 @@ class PostinstallModelMessages extends FOFModel
 	{
 		$unset_keys          = array();
 		$language_extensions = array();
+
+		// Order the results DESC so the newest is on the top.
+		$resultArray = array_reverse($resultArray);
 
 		foreach ($resultArray as $key => $item)
 		{

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -28,10 +28,11 @@ class PostinstallModelMessages extends FOFModel
 	public function buildQuery($overrideLimits = false)
 	{
 		// Save the old filter order dir
-		$oldState = $this->getState('filter_order_dir', 'DESC');
+		$oldState = $this->getState('filter_order_Dir', 'DESC');
 
 		// Set the filter_order_dir to bypass the check in fof
-		$this->setState('filter_order_dir', 'DESC');
+		// As this is bad in fof please make sure the state is "filter_order_Dir" else it don't work :(
+		$this->setState('filter_order_Dir', 'DESC');
 
 		$query = parent::buildQuery($overrideLimits);
 
@@ -46,7 +47,7 @@ class PostinstallModelMessages extends FOFModel
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));
 
 		// Reset to the old state
-		$this->setState('filter_order_dir', $oldState);
+		$this->setState('filter_order_Dir', $oldState);
 
 		return $query;
 	}

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -44,7 +44,7 @@ class PostinstallModelMessages extends FOFModel
 		// Force filter only enabled messages
 		$published = $this->getState('published', 1, 'int');
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));
-		
+
 		// Reset to the old state
 		$this->setState('filter_order_dir', $oldState);
 

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -27,6 +27,12 @@ class PostinstallModelMessages extends FOFModel
 	 */
 	public function buildQuery($overrideLimits = false)
 	{
+		// Save the old filter order dir
+		$oldState = $this->getState('filter_order_dir', 'DESC');
+
+		// Set the filter_order_dir to bypass the check in fof
+		$this->setState('filter_order_dir', 'DESC');
+
 		$query = parent::buildQuery($overrideLimits);
 
 		$db = $this->getDbo();
@@ -38,6 +44,9 @@ class PostinstallModelMessages extends FOFModel
 		// Force filter only enabled messages
 		$published = $this->getState('published', 1, 'int');
 		$query->where($db->qn('enabled') . ' = ' . $db->q($published));
+		
+		// Reset to the old state
+		$this->setState('filter_order_dir', $oldState);
 
 		return $query;
 	}


### PR DESCRIPTION
### Issue

> The Messages are displayed in ascending ID which means that the oldest ones are at the top. I know there are only 3 right now but it makes more sense to me that the newest message is always at the top (ORDER BY postinstall_message_id DESC )
> 
> I did try to fix this myself but only managed to ADD it to the ORDER by not change it.

Fixing: https://github.com/joomla/joomla-cms/issues/8382
### How to test
- Install staging
- see there are postinstall messages
- see that the 3.2.0 one is on the top
- apply this patch using com_patchtester
- see there are now the newest on the top.

Thanks @brianteeman 
