### PR TITLE
change layout for override edit

### DIFF
--- a/administrator/components/com_languages/views/override/tmpl/edit.php
+++ b/administrator/components/com_languages/views/override/tmpl/edit.php
@@ -49,6 +49,24 @@ JFactory::getDocument()->addScriptDeclaration('
 				<legend><?php echo empty($this->item->key) ? JText::_('COM_LANGUAGES_VIEW_OVERRIDE_EDIT_NEW_OVERRIDE_LEGEND') : JText::_('COM_LANGUAGES_VIEW_OVERRIDE_EDIT_EDIT_OVERRIDE_LEGEND'); ?></legend>
 				<div class="control-group">
 					<div class="control-label">
+						<?php echo $this->form->getLabel('language'); ?>
+					</div>
+					<div class="controls">
+						<?php echo $this->form->getInput('language'); ?>
+					</div>
+				</div>
+
+				<div class="control-group">
+					<div class="control-label">
+						<?php echo $this->form->getLabel('client'); ?>
+					</div>
+					<div class="controls">
+						<?php echo $this->form->getInput('client'); ?>
+					</div>
+				</div>
+
+				<div class="control-group">
+					<div class="control-label">
 						<?php echo $this->form->getLabel('key'); ?>
 					</div>
 					<div class="controls">
@@ -75,24 +93,6 @@ JFactory::getDocument()->addScriptDeclaration('
 					</div>
 				</div>
 				<?php endif; ?>
-
-					<div class="control-group">
-						<div class="control-label">
-							<?php echo $this->form->getLabel('language'); ?>
-						</div>
-						<div class="controls">
-							<?php echo $this->form->getInput('language'); ?>
-						</div>
-					</div>
-
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $this->form->getLabel('client'); ?>
-					</div>
-					<div class="controls">
-						<?php echo $this->form->getInput('client'); ?>
-					</div>
-				</div>
 
 				<div class="control-group">
 					<div class="control-label">


### PR DESCRIPTION
It always annoys me when I go to create a language override that I forget to filter site/admin before I click new and then I cant find the Constant I want to change.

This PR is purely cosmetic and makes the position of the language / location more prominent
## Before

![before](https://cloud.githubusercontent.com/assets/1296369/11216448/1db0c488-8d43-11e5-8fe8-5e96b2af6828.png)
## After

![after](https://cloud.githubusercontent.com/assets/1296369/11216446/19ed951a-8d43-11e5-8a9a-6229f27e36e9.png)
