### PR TITLE
Menu manager pagination broken in 3.5.0 beta

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -698,7 +698,7 @@ class JModelList extends JModelLegacy
 			$name    = substr($request, 7);
 			$filters = $app->input->get('filter', array(), 'array');
 
-			if (isset($filters[$name]) && $filters[$name] !== '')
+			if (isset($filters[$name]))
 			{
 				$new_state = $filters[$name];
 			}


### PR DESCRIPTION
Simple fix for joomla#8456.

A copy of the original issue description

> ### Steps to reproduce the issue
> 
> Install Joomla 3.5.0 beta
> Open Administrator->Menus->Main menu
> Add at least 5 new menu items
> Change limit dropdown to "5"
> Open search tools, select "Published".
> Change to page 2, everything ok.
> Change back to page 1, everything ok.
> Open search tools again, select "- Select status-".
> Try going to page 2 again.
> ### Expected result
> 
> Page 2 shown
> ### Actual result
> 
> Page 1 shown again
> ### Additional comments
> 
> Please note that this is using 3.5.0 beta, so the changes regarding pagination included here do not fix this problem.

For details see that issue.
