### PR TITLE
Fix pagination in user components and com_users (with enabled filters)

### DIFF
--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -70,22 +70,6 @@ class UsersModelUsers extends JModelList
 			$this->context .= '.' . $layout;
 		}
 
-		// Load the filter state.
-		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
-		$this->setState('filter.search', $search);
-
-		$active = $this->getUserStateFromRequest($this->context . '.filter.active', 'filter_active');
-		$this->setState('filter.active', $active);
-
-		$state = $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state');
-		$this->setState('filter.state', $state);
-
-		$groupId = $this->getUserStateFromRequest($this->context . '.filter.group_id', 'filter_group_id', null, 'int');
-		$this->setState('filter.group_id', $groupId);
-
-		$range = $this->getUserStateFromRequest($this->context . '.filter.range', 'filter_range');
-		$this->setState('filter.range', $range);
-
 		$groups = json_decode(base64_decode($app->input->get('groups', '', 'BASE64')));
 
 		if (isset($groups))

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -555,7 +555,6 @@ class JModelList extends JModelLegacy
 								break;
 
 							case 'limit':
-							case 'start':
 								$limit = $inputFilter->clean($value, 'int');
 								break;
 


### PR DESCRIPTION
Sometimes pagination in JModelList don`t work. Usually it happens when you are on first page and has no active filters (if it present) in frontend. Reason that list.start state is cleared in populateState method.

Second commit fix pagination in users list com_users when you activate some filters.
