### PR TITLE
remove nowrap

### DIFF
--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -48,14 +48,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
 					</th>
 					<?php foreach ($this->actions as $key => $action) : ?>
-					<th width="5%" class="nowrap center">
+					<th width="5%" class="center">
 						<span class="hasTooltip" title="<?php echo JHtml::tooltipText($key, $action[1]); ?>"><?php echo JText::_($key); ?></span>
 					</th>
 					<?php endforeach; ?>
-					<th width="5%" class="nowrap center">
+					<th width="5%" class="center">
 						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
 					</th>
-					<th width="1%" class="nowrap center">
+					<th width="1%" class="center">
 						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>


### PR DESCRIPTION
The debug users view and debug groups view are different because one has the column headings set to nowrap and the other does not.

This PR makes them both the same (no nowrap) and as a result the debuggroup view will fit better on the screen and not break the interface

To test this you will need to enable Debug System in the global config
## before

![hpc8](https://cloud.githubusercontent.com/assets/1296369/11239575/d2fe3662-8de4-11e5-8972-762381fa3959.png)
## after

![arsi](https://cloud.githubusercontent.com/assets/1296369/11239619/086e836a-8de5-11e5-9c84-f9648832618b.png)
