### PR TITLE
Proper modal close overrides for tinyMCE

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -406,9 +406,6 @@ abstract class JHtmlBehavior
 			});
 		});
 		function jModalClose() {
-			if (jQuery('.mce-window').length ){
-				tinyMCE.activeEditor.windowManager.close();
-			}
 			SqueezeBox.close();
 		}"
 		);

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -912,28 +912,37 @@ class PlgEditorTinymce extends JPlugin
 		}
 		";
 
-			if (!empty($btnsNames))
-			{
-				JFactory::getDocument()->addScriptDeclaration(
-					"
-		function jModalClose() {
-			tinyMCE.activeEditor.windowManager.close();
-		}
-		var SqueezeBox;
-		if (SqueezeBox != undefined)
+		if (!empty($btnsNames))
 		{
-			var otherStr = 'SqueezeBox.close', otherCallback;
-			otherCallback = new Function(otherStr);
-			otherCallback.call(SqueezeBox.close);
+			JFactory::getDocument()->addScriptDeclaration(
+				"
+		if (jModalClose === undefined && typeof(jModalClose) != 'function') {
+			var jModalClose;
+			jModalClose = function() {
+				tinyMCE.activeEditor.windowManager.close();
+			}
+		} else {
+			var oldClose = jModalClose;
+			jModalClose = function() {
+				oldClose.apply(this, arguments);
+				tinyMCE.activeEditor.windowManager.close();
+			};
+		}
+		if (SqueezeBox != undefined) {
+			var oldSqueezeBox = SqueezeBox.close;
+			SqueezeBox.close = function() {
+				oldSqueezeBox.apply(this, arguments);
+				tinyMCE.activeEditor.windowManager.close();
+			}
 		} else {
 			var SqueezeBox = {};
-			SqueezeBox.close = function(){
+			SqueezeBox.close = function() {
 				tinyMCE.activeEditor.windowManager.close();
 			}
 		}
 			"
-				);
-			}
+			);
+		}
 
 			JFactory::getDocument()->addScriptDeclaration($script);
 			JFactory::getDocument()->addStyleDeclaration(".mce-in { padding: 5px 10px !important;}");


### PR DESCRIPTION
#### This is covered in tinyMCE

Since we moved the XTD buttons in the tinyMCE's toolbar, some overrides for jmodalclose and squeezebox.close functions are required. This is done here
#### Testing {UPDATED}

To test the functionality of the overrides you will need to comment out and change some lines (temporarily)
So for the case that Mootools are not loaded:
Select ISIS as the template
1. CASE 1 (No mootools using jModalClose)
   Edit an article
   Use the xtd buttons to insert an article. (should close the tinymce modal)
2. CASE 2 (No mootools using SqueezeBox.close)
   Change line 52 of plugins/editors-xtd/article/article.php to `SqueezeBox.close();`
   Retest (tinymce modal should close)

Now change template to HATHOR
1. CASE 3 (Mootools present using jModalClose)
   Edit an article
   Use the xtd buttons to insert an article. (should close the tinymce modal)
2. CASE 4 (Mootools present using SqueezeBox.close)
   In the file administrator/components/com_media/views/images/tmpl/default.php change all `jModalClose()` to `SqueezeBox.close()` on lines 54-56.
   Try inserting an image (through images and links sidebar) and see if the modal closes correctly.
