### PR TITLE
Fixes #8484 stats alert in modals

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -94,6 +94,11 @@ class PlgSystemStats extends JPlugin
 			return;
 		}
 
+		if (JUri::getInstance()->getVar("tmpl") === "component")
+		{
+			return;
+		}
+
 		JHtml::_('jquery.framework');
 		JHtml::script('plg_system_stats/stats.js', false, true, false);
 	}


### PR DESCRIPTION
#### Fixes #8484
#### Too many alerts
#### Problem

Go to admin area on a newly installed joomla
Don’t respond on the message about stats
Edit/create an article
Click on the button to insert an image
#### Actual result

![screenshot 2015-11-18 21 23 20](https://cloud.githubusercontent.com/assets/3889375/11251828/b94e7644-8e3b-11e5-8b39-c52c09703d30.png)
#### Expected result

Normal window
#### Testing

Apply patch and repeat the above steps. No messages should render inside the modals
