### PR TITLE
Protostar: Getting rid of scroll bar in smartsearch Advanced search

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7502,3 +7502,12 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+#search-results {
+	clear: both;
+}
+#finder-filter-window {
+	overflow: visible;
+}
+#finder-search .in.collapse {
+	overflow: visible;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -626,8 +626,18 @@ body.modal-open {
 	display: inline;
 }
 
-/*Corrects the modals padding*/
+/* Corrects the modals padding */
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
+}
+/* Getting rid of scroll bar in smartsearch Advanced search */
+#search-results {
+	clear: both;
+}
+#finder-filter-window {
+	overflow: visible;
+}
+#finder-search .in.collapse {
+	overflow: visible;
 }


### PR DESCRIPTION
Before patch, to see the contents of the dropdowns, we have to scroll. The scroll bar changes depending on the length of the dropdown. 

<b>Before patch</b>

![protostar_smartsearch_before](https://cloud.githubusercontent.com/assets/869724/11265299/9643998a-8e9b-11e5-8236-9343ef7eea13.png)

<b>After patch</b>

![protostar_smartsearch_after](https://cloud.githubusercontent.com/assets/869724/11265303/a604e2e8-8e9b-11e5-992d-e9a68255016a.png)

Note: I also solved this issue for Beez in the recently merged PR ( https://github.com/joomla/joomla-cms/pull/8480 )
