### PR TITLE
BEEZ: Allowing smartsearch Advanced search to collapse

### DIFF
--- a/templates/beez3/css/layout.css
+++ b/templates/beez3/css/layout.css
@@ -1067,3 +1067,18 @@ div.current {
 #searchForm .searchintro {
 	padding: 0 0 0 250px;
 }
+.collapse {
+	position: relative;
+	height: 0;
+	overflow: hidden;
+	-webkit-transition: height .35s ease;
+	-moz-transition: height .35s ease;
+	-o-transition: height .35s ease;
+	transition: height .35s ease;
+}
+.collapse.in {
+	height: auto;
+}
+#finder-search .in.collapse {
+	overflow: visible;
+}


### PR DESCRIPTION
This solves https://github.com/joomla/joomla-cms/issues/8482
Before patch clicking on advanced search does not force it to collapse.

<b>After patch: Collapsed</b>

![screen shot 2015-11-19 at 10 06 18](https://cloud.githubusercontent.com/assets/869724/11266496/3accc45a-8ea5-11e5-8b83-7f2d0e288d84.png)

<b>After patch: Not collapsed</b>

![screen shot 2015-11-19 at 09 54 22](https://cloud.githubusercontent.com/assets/869724/11266512/506a285c-8ea5-11e5-8047-1af66d15b1e5.png)
