### PR TITLE
Regression: Revert the tabs in the com_media/images layout

### DIFF
--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -35,136 +35,122 @@ JFactory::getDocument()->addScriptDeclaration(
 	"
 );
 ?>
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active"><a href="#browse_tab" data-toggle="tab"><?php echo JText::_('COM_MEDIA_BROWSE_FILES') ?></a></li>
-		<li><a href="#upload_tab" data-toggle="tab"><?php echo JText::_('COM_MEDIA_UPLOAD') ?></a></li>
-	</ul>
-
-	<div class="tab-content">
-		<div class="tab-pane active" id="browse_tab">
-			<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
-				<div id="messages" style="display: none;">
-					<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
+<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
+	<div id="messages" style="display: none;">
+		<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
+	</div>
+	<div class="well">
+		<div class="row">
+			<div class="span12 control-group">
+				<div class="control-label">
+					<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY') ?></label>
 				</div>
-				<div class="well">
-					<div class="row">
-						<div class="span12 control-group">
-							<div class="control-label">
-								<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY') ?></label>
-							</div>
-							<div class="controls">
-								<?php echo $this->folderList; ?>
-								<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP') ?>"><?php echo JText::_('COM_MEDIA_UP') ?></button>
-							</div>
-						</div>
-						<div class="pull-right">
-							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
-							<button class="btn button-cancel" type="button" <?php if (!$this->state->get('field.id')) :
-							// This is for Mootools compatibility ?>onclick="parent.jModalClose();"<?php endif;?> data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
-						</div>
-					</div>
+				<div class="controls">
+					<?php echo $this->folderList; ?>
+					<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP') ?>"><?php echo JText::_('COM_MEDIA_UP') ?></button>
 				</div>
-
-				<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
-
-				<div class="well">
-					<div class="row">
-						<div class="span6 control-group">
-							<div class="control-label">
-								<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
-							</div>
-							<div class="controls">
-								<input type="text" id="f_url" value="" />
-							</div>
-						</div>
-						<?php if (!$this->state->get('field.id')):?>
-							<div class="span6 control-group">
-								<div class="control-label">
-									<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
-								</div>
-								<div class="controls">
-									<select size="1" id="f_align">
-										<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET') ?></option>
-										<option value="left"><?php echo JText::_('JGLOBAL_LEFT') ?></option>
-										<option value="center"><?php echo JText::_('JGLOBAL_CENTER') ?></option>
-										<option value="right"><?php echo JText::_('JGLOBAL_RIGHT') ?></option>
-									</select>
-								</div>
-							</div>
-						<?php endif;?>
-					</div>
-					<?php if (!$this->state->get('field.id')):?>
-						<div class="row">
-							<div class="span6 control-group">
-								<div class="control-label">
-									<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
-								</div>
-								<div class="controls">
-									<input type="text" id="f_alt" value="" />
-								</div>
-							</div>
-							<div class="span6 control-group">
-								<div class="control-label">
-									<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE') ?></label>
-								</div>
-								<div class="controls">
-									<input type="text" id="f_title" value="" />
-								</div>
-							</div>
-						</div>
-						<div class="row">
-							<div class="span6 control-group">
-								<div class="control-label">
-									<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>
-								</div>
-								<div class="controls">
-									<input type="text" id="f_caption" value="" />
-								</div>
-							</div>
-							<div class="span6 control-group">
-								<div class="control-label">
-									<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL') ?></label>
-								</div>
-								<div class="controls">
-									<input type="text" list="d_caption_class" id="f_caption_class" value="" />
-									<datalist id="d_caption_class">
-										<option value="text-left">
-										<option value="text-center">
-										<option value="text-right">
-									</datalist>
-								</div>
-							</div>
-						</div>
-					<?php endif;?>
-
-					<input type="hidden" id="dirPath" name="dirPath" />
-					<input type="hidden" id="f_file" name="f_file" />
-					<input type="hidden" id="tmpl" name="component" />
-
-				</div>
-			</form>
-		</div>
-		<div class="tab-pane" id="upload_tab">
-			<?php if ($user->authorise('core.create', 'com_media')) : ?>
-				<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
-					<div id="uploadform" class="well">
-						<fieldset id="upload-noflash" class="actions">
-							<div class="control-group">
-								<div class="control-label">
-									<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
-								</div>
-								<div class="controls">
-									<input type="file" id="upload-file" name="Filedata[]" multiple /><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
-									<p class="help-block"><?php echo $this->config->get('upload_maxsize') == '0' ? JText::_('COM_MEDIA_UPLOAD_FILES_NOLIMIT') : JText::sprintf('COM_MEDIA_UPLOAD_FILES', $this->config->get('upload_maxsize')); ?></p>
-								</div>
-							</div>
-						</fieldset>
-						<?php JFactory::getSession()->set('com_media.return_url', 'index.php?option=com_media&view=images&tmpl=component&fieldid=' . $input->getCmd('fieldid', '') . '&e_name=' . $input->getCmd('e_name') . '&asset=' . $input->getCmd('asset') . '&author=' . $input->getCmd('author')); ?>
-					</div>
-				</form>
-			<?php endif; ?>
-
+			</div>
+			<div class="pull-right">
+				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+				<button class="btn button-cancel" type="button" <?php if (!$this->state->get('field.id')) :
+				// This is for Mootools compatibility ?>onclick="parent.jModalClose();"<?php endif;?> data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
+			</div>
 		</div>
 	</div>
-</div>
+
+	<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
+
+	<div class="well">
+		<div class="row">
+			<div class="span6 control-group">
+				<div class="control-label">
+					<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
+				</div>
+				<div class="controls">
+					<input type="text" id="f_url" value="" />
+				</div>
+			</div>
+			<?php if (!$this->state->get('field.id')):?>
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
+					</div>
+					<div class="controls">
+						<select size="1" id="f_align">
+							<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET') ?></option>
+							<option value="left"><?php echo JText::_('JGLOBAL_LEFT') ?></option>
+							<option value="center"><?php echo JText::_('JGLOBAL_CENTER') ?></option>
+							<option value="right"><?php echo JText::_('JGLOBAL_RIGHT') ?></option>
+						</select>
+					</div>
+				</div>
+			<?php endif;?>
+		</div>
+		<?php if (!$this->state->get('field.id')):?>
+			<div class="row">
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
+					</div>
+					<div class="controls">
+						<input type="text" id="f_alt" value="" />
+					</div>
+				</div>
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE') ?></label>
+					</div>
+					<div class="controls">
+						<input type="text" id="f_title" value="" />
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>
+					</div>
+					<div class="controls">
+						<input type="text" id="f_caption" value="" />
+					</div>
+				</div>
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL') ?></label>
+					</div>
+					<div class="controls">
+						<input type="text" list="d_caption_class" id="f_caption_class" value="" />
+						<datalist id="d_caption_class">
+							<option value="text-left">
+							<option value="text-center">
+							<option value="text-right">
+						</datalist>
+					</div>
+				</div>
+			</div>
+		<?php endif;?>
+
+		<input type="hidden" id="dirPath" name="dirPath" />
+		<input type="hidden" id="f_file" name="f_file" />
+		<input type="hidden" id="tmpl" name="component" />
+
+	</div>
+</form>
+<?php if ($user->authorise('core.create', 'com_media')) : ?>
+	<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
+		<div id="uploadform" class="well">
+			<fieldset id="upload-noflash" class="actions">
+				<div class="control-group">
+					<div class="control-label">
+						<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
+					</div>
+					<div class="controls">
+						<input type="file" id="upload-file" name="Filedata[]" multiple /><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
+						<p class="help-block"><?php echo $this->config->get('upload_maxsize') == '0' ? JText::_('COM_MEDIA_UPLOAD_FILES_NOLIMIT') : JText::sprintf('COM_MEDIA_UPLOAD_FILES', $this->config->get('upload_maxsize')); ?></p>
+					</div>
+				</div>
+			</fieldset>
+			<?php JFactory::getSession()->set('com_media.return_url', 'index.php?option=com_media&view=images&tmpl=component&fieldid=' . $input->getCmd('fieldid', '') . '&e_name=' . $input->getCmd('e_name') . '&asset=' . $input->getCmd('asset') . '&author=' . $input->getCmd('author')); ?>
+		</div>
+	</form>
+<?php endif; ?>


### PR DESCRIPTION
#### Do not force Bootstrap

For B/C no bootstrap tabs should be forced by default
### Testing

Apply patch
Set admin template to isis
Edit an article, insert an image through tinyMCE image button 
The modal should have tabs select, upload
Repeat for the intro image
Repeat the same steps for Hathor
No tabs should be available there

Do the same for the front end templates Protostar (should have tabs) and Beez (no tabs)
