### PR TITLE
Expires date

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -436,7 +436,7 @@ class JApplicationWeb extends JApplicationBase
 		if (!$this->response->cachable)
 		{
 			// Expires in the past.
-			$this->setHeader('Expires', 'Mon, 1 Jan 2001 00:00:00 GMT', true);
+			$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 
 			// Always modified.
 			$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);


### PR DESCRIPTION
This (silly) PR modifies the Expires Header sent in the http request from 2001 to the date that Joomla was founded. There are no B/C issues in making this change. Other open source projects do similar things using significant dates in their history for this field instead of Jan 1 2001
