### PR TITLE
Fixing list states in JModelList

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -555,11 +555,8 @@ class JModelList extends JModelLegacy
 								break;
 
 							case 'limit':
-								$limit = $inputFilter->clean($value, 'int');
-								break;
-
-							case 'start':
 								$value = $inputFilter->clean($value, 'int');
+								$limit = $value;
 								break;
 
 							case 'select':

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -621,7 +621,7 @@ class JModelList extends JModelLegacy
 				$this->setState('list.direction', $oldDirection);
 			}
 
-			$value = $app->getUserStateFromRequest($this->context . '.limitstart', 'limitstart', 0);
+			$value = $app->getUserStateFromRequest($this->context . '.limitstart', 'limitstart', 0, 'int');
 			$limitstart = ($limit != 0 ? (floor($value / $limit) * $limit) : 0);
 			$this->setState('list.start', $limitstart);
 		}


### PR DESCRIPTION
### Issue

Current code in JModelList->populateState is wrong for the limit and start case.
#### limit

In this case, the `$value` is cleaned properly and saved into `$limit`. However a bit further down the uncleaned value is stored into the states: `$this->setState('list.' . $name, $value);`. Obviously the cleaned value should be saved here. Which means we need to overwrite `$value` with the cleaned value and then also store it into `$limit`.
#### start

This case isn't needed at all. Some more lines further down this state is already handled by the following code:

```
$value = $app->getUserStateFromRequest($this->context . '.limitstart', 'limitstart', 0);
$limitstart = ($limit != 0 ? (floor($value / $limit) * $limit) : 0);
$this->setState('list.start', $limitstart);
```

Effectively overwriting the value stored in the "start" case. So I simply removed that case.
