### PR TITLE
Revert "allow PHP7 to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ php:
   - 5.6
   - 7.0
 
-matrix:
-  allow_failures:
-    - php: 7.0
-
 services:
   - memcached
   - redis-server


### PR DESCRIPTION
Reverts joomla/joomla-cms#8494

It works now again: https://github.com/travis-ci/travis-ci/issues/5111#issuecomment-158091632

example: https://travis-ci.org/joomla-extensions/jstats-server/jobs/92060601
