### PR TITLE
[fix] Closes #8497 don't called behavior.core in grid.checkall

### DIFF
--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -122,6 +122,7 @@ abstract class JHtmlGrid
 	 */
 	public static function checkall($name = 'checkall-toggle', $tip = 'JGLOBAL_CHECK_ALL', $action = 'Joomla.checkAll(this)')
 	{
+		JHtml::_('behavior.core');
 		JHtml::_('bootstrap.tooltip');
 
 		return '<input type="checkbox" name="' . $name . '" value="" class="hasTooltip" title="' . JHtml::tooltipText($tip)


### PR DESCRIPTION
When using only grid.checkall and grid.id in list, but not using grid.sort or searchtools.sort, then checkbox grid.checkall does not select checkboxes, because this method does not call JHtml::_('behavior.core');
