### PR TITLE
Fix error in script.php for the stats plugin

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -77,6 +77,8 @@ class JoomlaInstallerScript
 			$params['lastrun'] = '';
 		}
 
+		$params = json_encode($params);
+
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__extensions'))
 			->set($db->quoteName('params') . ' = ' . $db->quote($params))


### PR DESCRIPTION
### How to test
- set error reporting to max
- install last nigly build via "Install from URL" https://developer.joomla.org/cms-packages/Joomla_3.5.0-beta-Beta-Update_Package.zip
- you go an error (array to string conversation)
- use this package: http://www.jah-tz.de/downloads/download.php?file=Joomla_3.5.0-beta-Beta-Update_Package_script_stats.zip&folder=media/joomla/
- error is gone
