### PR TITLE
XTD buttons should use bootstrap modals instead of mootools

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -25,6 +25,30 @@ JHtml::_('formbehavior.chosen', 'select');
 $function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$editor    = $app->input->getCmd('editor', '');
+
+/*
+ * Javascript to insert the link
+ * View element calls jSelectArticle when an article is clicked
+ * jSelectArticle creates the link tag, sends it to the editor,
+ * and closes the select frame.
+ */
+JFactory::getDocument()->addScriptDeclaration(
+	"
+		function jSelectArticle(id, title, catid, object, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			window.parent.jInsertEditorText(tag, '" . $editor . "');
+			window.parent.jModalClose();
+		}
+	"
+);
+
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1');?>"
       method="post" name="adminForm" id="adminForm" class="form-inline">
@@ -136,7 +160,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<td>
-						<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+						<a href="javascript:void(0)" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 							<?php echo $this->escape($item->title); ?></a>
 					</td>
 					<td class="center">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -18,11 +18,34 @@ if ($app->isSite())
 
 require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
-JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 $function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$editor    = $app->input->getCmd('editor', '');
+
+/*
+ * Javascript to insert the link
+ * View element calls jSelectArticle when an article is clicked
+ * jSelectArticle creates the link tag, sends it to the editor,
+ * and closes the select frame.
+ */
+JFactory::getDocument()->addScriptDeclaration(
+	"
+		function jSelectArticle(id, title, catid, object, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			window.parent.jInsertEditorText(tag, '" . $editor . "');
+			window.parent.jModalClose();
+		}
+	"
+);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function='.$function.'&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">
@@ -101,7 +124,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>');">
+					<a class="pointer" href="javascript:void(0)" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>');">
 						<?php echo $this->escape($item->title); ?></a>
 				</th>
 				<td class="center">

--- a/administrator/templates/isis/html/layouts/joomla/editors/buttons.php
+++ b/administrator/templates/isis/html/layouts/joomla/editors/buttons.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$buttons = $displayData;
+
+// Override jModalClose and SqueezeBox.close for B/C
+JFactory::getDocument()->addScriptDeclaration(
+	"
+		if (jModalClose === undefined && typeof(jModalClose) != 'function') {
+			var jModalClose;
+			jModalClose = function() {
+				jQuery('.modal.in ').modal('hide');
+			}
+		} else {
+			var oldClose = jModalClose;
+			jModalClose = function() {
+				oldClose.apply(this, arguments);
+				jQuery('.modal.in ').modal('hide');
+			};
+		}
+		if (SqueezeBox != undefined) {
+			var oldSqueezeBox = SqueezeBox.close;
+			SqueezeBox.close = function() {
+				oldSqueezeBox.apply(this, arguments);
+				jQuery('.modal.in ').modal('hide');
+			}
+		} else {
+			var SqueezeBox = {};
+			SqueezeBox.close = function() {
+				jQuery('.modal.in ').modal('hide');
+			}
+		}
+	"
+);
+
+?>
+<div id="editor-xtd-buttons" class="btn-toolbar pull-left">
+	<?php if ($buttons) : ?>
+		<?php foreach ($buttons as $button) : ?>
+			<?php echo JLayoutHelper::render('joomla.editors.buttons.button', $button); ?>
+		<?php endforeach; ?>
+		<?php foreach ($buttons as $button) : ?>
+			<?php echo JLayoutHelper::render('joomla.editors.buttons.modal', $button); ?>
+		<?php endforeach; ?>
+	<?php endif; ?>
+</div>

--- a/administrator/templates/isis/html/layouts/joomla/editors/buttons/button.php
+++ b/administrator/templates/isis/html/layouts/joomla/editors/buttons/button.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$button = $displayData;
+
+?>
+<?php if ($button->get('name')) : ?>
+	<?php
+		$class    = ($button->get('class')) ? $button->get('class') : null;
+		$class   .= ($button->get('modal')) ? ' modal-button' : null;
+		$href     = '#' . str_replace(' ', '', $button->get('text')) . 'Modal';
+		$link     = ($button->get('link')) ? JUri::base() . $button->get('link') : null;
+		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
+		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+	?>
+	<a href="<?php echo $href; ?>" role="button" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+		<span class="icon-<?php echo $button->get('name'); ?>"></span> <?php echo $button->get('text'); ?>
+	</a>
+<?php endif;

--- a/administrator/templates/isis/html/layouts/joomla/editors/buttons/modal.php
+++ b/administrator/templates/isis/html/layouts/joomla/editors/buttons/modal.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$button = $displayData;
+
+$class    = ($button->get('class')) ? $button->get('class') : null;
+$class   .= ($button->get('modal')) ? ' modal-button' : null;
+$href     = '#' . str_replace(' ', '', $button->get('text')) . 'Modal';
+$link     = ($button->get('link')) ? JUri::base() . $button->get('link') : null;
+$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
+$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+// Load modal popup behavior
+if ($button->get('modal'))
+{
+	echo JHtml::_(
+		'bootstrap.renderModal',
+		str_replace(' ', '', $button->get('text')) . 'Modal',
+		array(
+			'url'    => $link,
+			'title'  => $title,
+			'height' => '300px',
+			'width'  => '800px',
+			'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+				. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+		)
+	);
+}

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -34,32 +34,11 @@ class PlgButtonArticle extends JPlugin
 	public function onDisplay($name)
 	{
 		/*
-		 * Javascript to insert the link
-		 * View element calls jSelectArticle when an article is clicked
-		 * jSelectArticle creates the link tag, sends it to the editor,
-		 * and closes the select frame.
-		 */
-		$js = "
-		function jSelectArticle(id, title, catid, object, link, lang)
-		{
-			var hreflang = '';
-			if (lang !== '')
-			{
-				var hreflang = ' hreflang = \"' + lang + '\"';
-			}
-			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
-			jInsertEditorText(tag, '" . $name . "');
-			jModalClose();
-		}";
-
-		$doc = JFactory::getDocument();
-		$doc->addScriptDeclaration($js);
-
-		/*
 		 * Use the built-in element view to select the article.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;editor='
+				. $name . '&amp;' . JSession::getFormToken() . '=1';
 
 		$button = new JObject;
 		$button->modal = true;

--- a/templates/protostar/html/layouts/joomla/editors/buttons.php
+++ b/templates/protostar/html/layouts/joomla/editors/buttons.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$buttons = $displayData;
+
+// Override jModalClose and SqueezeBox.close for B/C
+JFactory::getDocument()->addScriptDeclaration(
+	"
+		if (jModalClose === undefined && typeof(jModalClose) != 'function') {
+			var jModalClose;
+			jModalClose = function() {
+				jQuery('.modal.in ').modal('hide');
+			}
+		} else {
+			var oldClose = jModalClose;
+			jModalClose = function() {
+				oldClose.apply(this, arguments);
+				jQuery('.modal.in ').modal('hide');
+			};
+		}
+		if (SqueezeBox != undefined) {
+			var oldSqueezeBox = SqueezeBox.close;
+			SqueezeBox.close = function() {
+				oldSqueezeBox.apply(this, arguments);
+				jQuery('.modal.in ').modal('hide');
+			}
+		} else {
+			var SqueezeBox = {};
+			SqueezeBox.close = function() {
+				jQuery('.modal.in ').modal('hide');
+			}
+		}
+	"
+);
+
+?>
+<div id="editor-xtd-buttons" class="btn-toolbar pull-left">
+	<?php if ($buttons) : ?>
+		<?php foreach ($buttons as $button) : ?>
+			<?php echo JLayoutHelper::render('joomla.editors.buttons.button', $button); ?>
+		<?php endforeach; ?>
+		<?php foreach ($buttons as $button) : ?>
+			<?php echo JLayoutHelper::render('joomla.editors.buttons.modal', $button); ?>
+		<?php endforeach; ?>
+	<?php endif; ?>
+</div>

--- a/templates/protostar/html/layouts/joomla/editors/buttons/button.php
+++ b/templates/protostar/html/layouts/joomla/editors/buttons/button.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$button = $displayData;
+
+?>
+<?php if ($button->get('name')) : ?>
+	<?php
+		$class    = ($button->get('class')) ? $button->get('class') : null;
+		$class   .= ($button->get('modal')) ? ' modal-button' : null;
+		$href     = '#' . str_replace(' ', '', $button->get('text')) . 'Modal';
+		$link     = ($button->get('link')) ? JUri::base() . $button->get('link') : null;
+		$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
+		$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+	?>
+	<a href="<?php echo $href; ?>" role="button" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+		<span class="icon-<?php echo $button->get('name'); ?>"></span> <?php echo $button->get('text'); ?>
+	</a>
+<?php endif;

--- a/templates/protostar/html/layouts/joomla/editors/buttons/modal.php
+++ b/templates/protostar/html/layouts/joomla/editors/buttons/modal.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$button = $displayData;
+
+$class    = ($button->get('class')) ? $button->get('class') : null;
+$class   .= ($button->get('modal')) ? ' modal-button' : null;
+$href     = '#' . str_replace(' ', '', $button->get('text')) . 'Modal';
+$link     = ($button->get('link')) ? JUri::base() . $button->get('link') : null;
+$onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
+$title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
+
+// Load modal popup behavior
+if ($button->get('modal'))
+{
+	echo JHtml::_(
+		'bootstrap.renderModal',
+		str_replace(' ', '', $button->get('text')) . 'Modal',
+		array(
+			'url'    => $link,
+			'title'  => $title,
+			'height' => '300px',
+			'width'  => '800px',
+			'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+				. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+		)
+	);
+}


### PR DESCRIPTION
#### XTD buttons with bootstrap modal
##### What is this?

XTD Buttons (the ones under the editor) are tightly coupled to mootools modal. We can do it in a better way: using bootstrap modals.
#### B/C

The functionality will not change with this PR. There are overrides both for jModalClose and SqueezeBox.Close functions to close the modal. There is though a possibility that buttons that rely on Mootools functions to stop working (mootools won’t be available). Also any plugins doing javascript calculations for the modal dimensions will render on a predefined modal size (hey we are suppose to do that with css, we are in the responsive era…)
#### Performance

Again: dropping Mootools is performance gain!
#### Testing

Set as your default editor either none or code mirror
Edit an article in Isis and in Protostar
Ensure that all buttons work as expected
Please try this also with 3pd buttons
