### PR TITLE
Duplicated input jform[catid] if enable_category

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -161,9 +161,6 @@ JFactory::getDocument()->addScriptDeclaration("
 
 					<input type="hidden" name="task" value="" />
 					<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
-					<?php if ($this->params->get('enable_category', 0) == 1) :?>
-					<input type="hidden" name="jform[catid]" value="<?php echo $this->params->get('catid', 1); ?>" />
-					<?php endif; ?>
 				</div>
 			</div>
 			<?php echo JHtml::_('form.token'); ?>


### PR DESCRIPTION
Duplicated input name jform[catid] if enable_category is enabled:
Menus: New Item
Menu Item Type: Create Article
Options: Default Category to yes

---

Url:index.php?option=com_content&view=form&layout=edit

![cattura](https://cloud.githubusercontent.com/assets/7433268/11326887/7d648398-9175-11e5-93f0-69d34ee58900.PNG)
