### PR TITLE
Avoid calling base renderer on render

### DIFF
--- a/libraries/cms/layout/base.php
+++ b/libraries/cms/layout/base.php
@@ -287,12 +287,14 @@ class JLayoutBase implements JLayout
 	 *
 	 * @param   boolean  $debug  Enable / Disable debug
 	 *
-	 * @return  void
+	 * @return  self
 	 *
 	 * @since   3.5
 	 */
 	public function setDebug($debug)
 	{
 		$this->options->set('debug', (boolean) $debug);
+
+		return $this;
 	}
 }

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -95,7 +95,7 @@ class JLayoutFile extends JLayoutBase
 		$this->clearDebugMessages();
 
 		// Inherit base output from parent class
-		$layoutOutput = parent::render($displayData);
+		$layoutOutput = '';
 
 		// Automatically merge any previously data set if $displayData is an array
 		if (is_array($displayData))


### PR DESCRIPTION
If people copies the current behavior in `JLayoutFile` it can led to unexpected results. And in fact is merging data twice. That's not causing an issue because array_merge will replace the data with the same data but is better to avoid it.

I also changed `setDebug()` method so it's chainable
