### PR TITLE
Fix missing component's language key in com_config validation

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1980,6 +1980,26 @@ class JForm
 			// Does the field have a defined error message?
 			$message = (string) $element['message'];
 
+			$app = JFactory::getApplication();
+			$lang = JFactory::getLanguage();
+			$option = $app->input->get('option', null);
+
+			// If we are editing a component's configuration in back-end,
+			// load that component's .ini and .sys.ini language files.
+			if (!$app->isSite() && $option == 'com_config' && !$lang->hasKey($message))
+			{
+				$component = $app->input->post->get('component', null);
+
+				if (!empty($component))
+				{
+					$lang->load($component, JPATH_ADMINISTRATOR, null, false, true)
+					|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
+
+					$lang->load($component . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+					|| $lang->load($component . '.sys', JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
+				}
+			}
+
 			if ($message)
 			{
 				$message = JText::_($element['message']);


### PR DESCRIPTION
In back-end, when we edit a component's configuration, if we validate a field by using JFormRule and the validation fails, the field's label and the custom error message are not displayed because the language files of the component are not loaded.

Please make this small change to see this problem.
1. Open administrator/components/com_banners/config.xml
2. Add `validation="email"` to `purchase_type` field, the result looks like this:
   
   ```
   <field
       id="purchase_type"
       name="purchase_type"
       type="list"
       label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
       description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       default="0"
       validation="email"
       >
   ```
3. Edit Banners's configuration, save and you get this error message:

`Invalid field: COM_BANNERS_FIELD_PURCHASETYPE_LABEL`
1. If you add `message` attribute for custom error message and use a language key which only exists in Banners component, like this
   
   ```
   <field
       id="purchase_type"
       name="purchase_type"
       type="list"
       label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
       description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       default="0"
       validate="email"
       message="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       >
   ```
   
   When you save the configuration, you get

```
Error
COM_BANNERS_FIELD_PURCHASETYPE_DESC
```

The problem is in validateField() of JForm (libraries/joomla/form/form.php), it doesn't load the language files of Banners component. This pull request is trying to do it.

Apply this commit, try again for the 2 cases above and you will get:

`Invalid field: Purchase Type`

```
Error
Select the type of purchase in the list.
```

I don't like this solution. But it is the only way I've found out. If you have a better solution to solve this problem. Please submit another pull request. Thanks!
