### PR TITLE
Fix missing component's language key in com_config validation

### DIFF
--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -86,12 +86,8 @@ class ConfigModelComponent extends ConfigModelForm
 		}
 
 		$lang = JFactory::getLanguage();
-
-		$lang->load($component, JPATH_ADMINISTRATOR, null, false, true)
-		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
-
-		$lang->load($component . '.sys', JPATH_ADMINISTRATOR, null, false, true)
-		|| $lang->load($component . '.sys', JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
+		$lang->load($option, JPATH_BASE, null, false, true)
+		|| $lang->load($option, JPATH_BASE . "/components/$option", null, false, true);
 
 		return $form;
 	}

--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -58,6 +58,7 @@ class ConfigModelComponent extends ConfigModelForm
 	public function getForm($data = array(), $loadData = true)
 	{
 		$state = $this->getState();
+		$component = $state->get('component.option');
 
 		if ($path = $state->get('component.path'))
 		{
@@ -67,7 +68,7 @@ class ConfigModelComponent extends ConfigModelForm
 		else
 		{
 			// Add the search path for the admin component config.xml file.
-			JForm::addFormPath(JPATH_ADMINISTRATOR . '/components/' . $state->get('component.option'));
+			JForm::addFormPath(JPATH_ADMINISTRATOR . '/components/' . $component);
 		}
 
 		// Get the form.
@@ -83,6 +84,14 @@ class ConfigModelComponent extends ConfigModelForm
 		{
 			return false;
 		}
+
+		$lang = JFactory::getLanguage();
+
+		$lang->load($component, JPATH_ADMINISTRATOR, null, false, true)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
+
+		$lang->load($component . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+		|| $lang->load($component . '.sys', JPATH_ADMINISTRATOR . '/components/' . $component, null, false, true);
 
 		return $form;
 	}

--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -58,7 +58,7 @@ class ConfigModelComponent extends ConfigModelForm
 	public function getForm($data = array(), $loadData = true)
 	{
 		$state = $this->getState();
-		$component = $state->get('component.option');
+		$option = $state->get('component.option');
 
 		if ($path = $state->get('component.path'))
 		{
@@ -68,7 +68,7 @@ class ConfigModelComponent extends ConfigModelForm
 		else
 		{
 			// Add the search path for the admin component config.xml file.
-			JForm::addFormPath(JPATH_ADMINISTRATOR . '/components/' . $component);
+			JForm::addFormPath(JPATH_ADMINISTRATOR . '/components/' . $option);
 		}
 
 		// Get the form.


### PR DESCRIPTION
In back-end, when we edit a component's configuration, if we validate a field by using JFormRule and the validation fails, the field's label and the custom error message are not displayed because the language files of the component are not loaded.

Please make this small change to see this problem.
1. Open administrator/components/com_banners/config.xml
2. Add `validation="email"` to `purchase_type` field, the result looks like this:
   
   ```
   <field
       id="purchase_type"
       name="purchase_type"
       type="list"
       label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
       description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       default="0"
       validate="email"
       >
   ```
3. Edit Banners's configuration, save and you get this error message:

`Invalid field: COM_BANNERS_FIELD_PURCHASETYPE_LABEL`
1. If you add `message` attribute for custom error message and use a language key which only exists in Banners component, like this
   
   ```
   <field
       id="purchase_type"
       name="purchase_type"
       type="list"
       label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
       description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       default="0"
       validate="email"
       message="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
       >
   ```
   
   When you save the configuration, you get

```
Error
COM_BANNERS_FIELD_PURCHASETYPE_DESC
```

The problem is in validateField() of JForm (libraries/joomla/form/form.php), it doesn't load the language files of Banners component. This pull request is trying to do it.

Apply this commit, try again for the 2 cases above and you will get:

`Invalid field: Purchase Type`

```
Error
Select the type of purchase in the list.
```
