### PR TITLE
Fixed logic bug in JPath::isOwner

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -238,7 +238,7 @@ class JPath
 		// Try to find a writable directory
 		$dir = false;
 
-		foreach (array('/tmp', $ssp, $jtp) as $currentDir)
+		foreach (array($jtp, $ssp, '/tmp') as $currentDir)
 		{
 			if (is_writable($currentDir))
 			{

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -236,9 +236,17 @@ class JPath
 		$jtp = JPATH_SITE . '/tmp';
 
 		// Try to find a writable directory
-		$dir = is_writable('/tmp') ? '/tmp' : false;
-		$dir = (!$dir && is_writable($ssp)) ? $ssp : false;
-		$dir = (!$dir && is_writable($jtp)) ? $jtp : false;
+		$dir = false;
+
+		foreach (array('/tmp', $ssp, $jtp) as $currentDir)
+		{
+			if (is_writable($currentDir))
+			{
+				$dir = $currentDir;
+
+				break;
+			}
+		}
 
 		if ($dir)
 		{


### PR DESCRIPTION
## Issue

There's a logic bug in JPath::isOwner causing false results of the ownership check. Let's assume:
- /tmp is unwriteable
- session.save_path is writeable

Expected result: session.save_path is used as $dir

Actual result: As $dir is a string, !$dir becomes a boolean false and the whole check returns false. This causes that the correct $dir is overwritten with a false in line 241.

I found this issue because I was trying to save a configuration.php with chmod 444 on a webspace with an unwriteable /tmp and a writeable session.save_path. Because of the logic bug, isOwner doesn't return true as expected and Joomla fails to execute a chmod 644 which would allow us to update the file.
## Solution

I fixed the logic bug and improved the readablity by converting the code into a foreach loop.
## Testing

That's a bit harder. You need a server with:
- /tmp unwriteable for PHP (i.e. because it's not included in the open_basedir)
- session.save_path writeable

If you have such a machine. Change the chmod of the configuration.php to 444 and try to save the global configuration. You'll get an errror message.

Apply the patch, try to save the configuration.php again, now it works as expected.
