### PR TITLE
Add a value to language forum string

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_menu.ini
+++ b/administrator/language/en-GB/en-GB.mod_menu.ini
@@ -53,7 +53,7 @@ MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM="Official Support Forum"
 ; the string below will be used if the localised sample data contains a URL for the desired community forum or if the 'Custom Support Forum' field parameter in the Administrator Menu module contains a URL
 MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM="Custom Support Forum"
 ; The string below will be used if MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE has a value, i.e the # of the specific language forum in forum.joomla.org. Use something like 'Official english forum'.
-MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official language forums"
+MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official Language Forums"
 MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE="511"
 MOD_MENU_HELP_TRANSLATIONS="Joomla! Translations"
 MOD_MENU_HELP_XCHANGE="Stack Exchange"

--- a/administrator/language/en-GB/en-GB.mod_menu.ini
+++ b/administrator/language/en-GB/en-GB.mod_menu.ini
@@ -52,9 +52,9 @@ MOD_MENU_HELP_SHOP="Joomla! Shop"
 MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM="Official Support Forum"
 ; the string below will be used if the localised sample data contains a URL for the desired community forum or if the 'Custom Support Forum' field parameter in the Administrator Menu module contains a URL
 MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM="Custom Support Forum"
-; the string below will be used if MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE has a value, i.e the # of the specific language forum in forum.joomla.org
-MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official [language] forum"
-MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE=""
+; The string below will be used if MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE has a value, i.e the # of the specific language forum in forum.joomla.org. Use something like 'Official english forum'.
+MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official language forums"
+MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE="511"
 MOD_MENU_HELP_TRANSLATIONS="Joomla! Translations"
 MOD_MENU_HELP_XCHANGE="Stack Exchange"
 MOD_MENU_HOME_DEFAULT="Home"


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/8171 for the initial discussion.

The issue we have is that in Crowdin (and probably other translation tools) we can't translate strings where there is nothing to translate. So empty strings can't be translated.

This particular string here goes beyond translating as it also decides if a menuitem in the help menu is shown or not. However I don't see a reason why we can't always show the link to the language forums.
#### Testing

After applying this PR, you now see a new menuitem in the help menu pointing to the language forums.
