### PR TITLE
Menu text

### DIFF
--- a/administrator/language/en-GB/en-GB.com_menus.ini
+++ b/administrator/language/en-GB/en-GB.com_menus.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_MENUS="Menus"
-COM_MENUS_ADD_MENU_MODULE="Add a module for this menu type."
+COM_MENUS_ADD_MENU_MODULE="Add a module for this menu."
 COM_MENUS_ADVANCED_FIELDSET_LABEL="Advanced"
 COM_MENUS_BASIC_FIELDSET_LABEL="Options"
 COM_MENUS_BATCH_MENU_ITEM_CANNOT_CREATE="You are not allowed to create new menu items."
@@ -67,7 +67,7 @@ COM_MENUS_ITEM_FIELD_ANCHOR_CSS_LABEL="Link CSS Style"
 COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_DESC="An optional, custom description for the title attribute of the menu hyperlink."
 COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_LABEL="Link Title Attribute"
 COM_MENUS_ITEM_FIELD_ASSIGNED_DESC="Shows which menu the link will appear in."
-COM_MENUS_ITEM_FIELD_ASSIGNED_LABEL=" Menu Location"
+COM_MENUS_ITEM_FIELD_ASSIGNED_LABEL=" Menu"
 COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE="- No association -"
 COM_MENUS_ITEM_FIELD_BROWSERNAV_DESC="Target browser window when the menu item is selected."
 COM_MENUS_ITEM_FIELD_BROWSERNAV_LABEL="Target Window"


### PR DESCRIPTION
A question was raised during some training regarding the menu module and assigning links to a menu - what is a menu location? It really makes no sense to call a menu a menu location in this case.
## Before

![staging administration menus new item](https://cloud.githubusercontent.com/assets/1296369/11440217/a0e5759e-94f8-11e5-86c3-f3e566490275.png)
## After

![yzst](https://cloud.githubusercontent.com/assets/1296369/11440227/afde5930-94f8-11e5-8e8e-f898091a3697.png)
## Before

![ig0o](https://cloud.githubusercontent.com/assets/1296369/11440241/d0750932-94f8-11e5-8dab-57ac38ee33ac.png)
## After

![aozw](https://cloud.githubusercontent.com/assets/1296369/11440238/ca8aad7e-94f8-11e5-8f0c-7343784bdade.png)
