### PR TITLE
Exclude the sec read me from the final package as discussed eralier

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -123,6 +123,7 @@ $doNotPackage = array(
 	'phpunit.xml.dist',
 	'tests',
 	'travisci-phpunit.xml',
+	'libraries/joomla/crypt/README.md',
 );
 
 /*
@@ -247,3 +248,4 @@ system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_'
 system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip * > /dev/null');
 
 echo "Build of version $fullVersion complete!\n";
+'''

--- a/build/build.php
+++ b/build/build.php
@@ -248,4 +248,3 @@ system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_'
 system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip * > /dev/null');
 
 echo "Build of version $fullVersion complete!\n";
-'''


### PR DESCRIPTION
This execlud the new md file from the final package as discussed earlier.

//cc @wilsonge @bakual @rdeutz 

As discussed this can be merged on review ;)
### For The reason

This file needs to be removed from The final package as it Can ne accessed direct via URL and there is no reason to have this in the final package ;)

Btw should we add some kind of message to the unsecure classes too? (out of scope for this PR but if needed we can have a follow up)
