### PR TITLE
fix stripe in smart search

### DIFF
--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -113,7 +113,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<td>
 						<?php echo JHtml::_('jgrid.published', $item->published, $i, 'index.', $canChange, 'cb'); ?>
 					</td>
-					<td class="pull-left break-word">
+					<td class="break-word">
 						<label for="cb<?php echo $i ?>">
 							<strong>
 								<?php echo $this->escape($item->title); ?>


### PR DESCRIPTION
The class pull-left is breaking the striping for the index in smart search
(make sure you have indexed some content before testing)

(I only included the VERY long title to show that the break-word still works)
## Before

![jqgm](https://cloud.githubusercontent.com/assets/1296369/11451524/055deb28-95c1-11e5-877c-67e58963ebbf.png)
## After

![after](https://cloud.githubusercontent.com/assets/1296369/11451519/dc29300a-95c0-11e5-84dd-8d8e30529d07.png)
