### PR TITLE
SEF plugin, wrong canonical generation

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -38,7 +38,7 @@ class PlgSystemSef extends JPlugin
 		$uri     = JUri::getInstance();
 		$domain  = $this->params->get('domain');
 
-		if ($domain === null || $domain === '')
+		if ($domain === false || $domain === '')
 		{
 			$domain = $uri->toString(array('scheme', 'host', 'port'));
 		}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -45,7 +45,7 @@ class PlgSystemSef extends JPlugin
 
 		$link = $domain . JRoute::_('index.php?' . http_build_query($router->getVars()), false);
 
-		if ($uri->toString() !== $link)
+		if (rawurldecode($uri->toString()) !== $link)
 		{
 			$doc->addHeadLink(htmlspecialchars($link), 'canonical');
 		}


### PR DESCRIPTION
modified test : the canonical link should only be added if the site domain parameter is set.
before patch it does the opposite.
see further down for the correct results.
