### PR TITLE
Fix JavaScript error in TinyMCE button plugins

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1010,7 +1010,7 @@ class PlgEditorTinymce extends JPlugin
 							});";
 					if ($onclick && ($button->get('modal') || $href))
 					{
-						$tempConstructor .= ",
+						$tempConstructor .= "
 						" . $onclick . "
 							";
 					}


### PR DESCRIPTION
To test it install OneDrive extension and enable editor buttons plugins.
Go to article edit view and hit OneDrive button. Check you browser console to see the error.
https://www.perfect-web.co/joomla-extensions/microsoft-onedrive-gallery-file

When button plugin has onclick property with JavaScript code it is being added after
editor.windowManager.open({...});
So there can not be a coma (,) between above code and onclick code define in plugin.
Below is code rendered by TinyMCE plugin which contains a coma (line before SkyDriveButton...) which leads to JavaScript error

```
editor.addButton("OneDriveFile", {
    text: "OneDrive File",
    title: "OneDrive File",
    icon: "none icon-flag-2", 
    onclick: function () {
        editor.windowManager.open({
            title : "OneDrive File",
            url : 'http://localhost/administrator/index.php',
            buttons: [{ text : "Close", onclick: "close" }] 
        });,
        SkyDriveButton.browseFile('tinymce');
        return false;
    }
});
```
