### PR TITLE
Performance gain - new featured article

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -238,7 +238,7 @@ class ContentModelArticle extends JModelAdmin
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$table->ordering = $table->getNextOrder('catid = ' . (int) $table->catid . ' AND state >= 0');
 		}
 	}
 
@@ -641,10 +641,12 @@ class ContentModelArticle extends JModelAdmin
 
 				// Featuring.
 				$tuples = array();
+				$ordering = $table->getNextOrder();
 
 				foreach ($new_featured as $pk)
 				{
-					$tuples[] = $pk . ', 0';
+					$tuples[] = $pk . ', ' . $ordering;
+					$ordering++;
 				}
 
 				if (count($tuples))
@@ -665,8 +667,6 @@ class ContentModelArticle extends JModelAdmin
 			$this->setError($e->getMessage());
 			return false;
 		}
-
-		$table->reorder();
 
 		$this->cleanCache();
 


### PR DESCRIPTION
Follow up 
- https://developer.joomla.org/joomlacode-archive/issue-32329.html
- https://github.com/joomla/joomla-cms/issues/8189
- https://github.com/joomla/joomla-cms/pull/8563
#### How to reproduce the issue

this issue arise when you create a new article (featured) in a category of 100 or more  articles
when you save a new one you should notice that it takes a lot of time
#### How to test

1) You need to have 100 articles in one category

2) at the begin  of  `prepareTable()`  https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/article.php#L222 add 

``` PHP
JDEBUG ? $time=microtime(true) : null;
JDEBUG ? JLog::addLogger(array('text_file' => 'testPR8576.php', ), JLog::INFO) : null;
```

 at the end https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/article.php#L243 add

``` PHP
JDEBUG ? JLog::add('prepareTable():'.round(microtime(true) - $time, 3), JLog::INFO) : null;
```

3) we do the same on `featured()` https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/article.php#L595 add

``` PHP
JDEBUG ? $time=microtime(true) : null;
```

and 

``` PHP
JDEBUG ? JLog::add('Featured():'.round(microtime(true) - $time, 3), JLog::INFO) : null;
```

at the end

4) enable the debug plugin

5) create a new featured article in the category with 100 articles

repeat 5) two or 3 times

in the logs folder open testPR8576.php  you'll see how much time cost 
#### Apply the pacth

and redo the same hack 2), 3) as before 
repeat 5) two or 3 times 
reopen testPR8576.php you should notice the gain

![logimage](https://cloud.githubusercontent.com/assets/181681/12657702/026dedf4-c605-11e5-905f-7a91d900e32b.PNG)
#### performance gain measurements

i've runned a cli script that create 100 featured articles in 1 category without the patch
![bulk100](https://cloud.githubusercontent.com/assets/181681/11494080/5a44452a-97ff-11e5-822c-bfe4f9739f2d.PNG)

it takes something like 500 seconds

i've runned the same script as before with the patch applyed
![bulk100p](https://cloud.githubusercontent.com/assets/181681/11494120/9854b12e-97ff-11e5-8e21-20f947069cc7.PNG)

as you can see now takes only something like 70 seconds
#### Comments

the  `$table->reorder()` was insanely invoked in the artcle model
and this cause to run a lot of unncessary updates for the `ordering` field on the `#__ content` , `#__content_frontapage` tables
