### PR TITLE
blog.xml for article layout override from category

### DIFF
--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -226,7 +226,15 @@
 					<option value="4">J4</option>
 					<option value="5">J5</option>
 				</field>
-
+				
+				<field 
+					name="article_layout" type="componentlayout"
+					label="JFIELD_ALT_LAYOUT_LABEL"
+					description="JFIELD_ALT_COMPONENT_LAYOUT_DESC"
+					useglobal="true"
+					extension="com_content" view="article"
+				/>
+				
 				<field
 					name="spacer1"
 					type="spacer"


### PR DESCRIPTION
# Description
Joomla has the ability to set the articles details page layout from category menu item. but it wasn't implemented. just add these xml and its gonna work perfect.

## Before
![image](https://cloud.githubusercontent.com/assets/1936565/11498289/cd421112-9848-11e5-8833-88b2e349c557.png)

## After

![image](https://cloud.githubusercontent.com/assets/1936565/11498305/ec68f4ac-9848-11e5-8de2-3d2d4de86a72.png)
