### PR TITLE
Fix undefined variable $skin and minimize code in TinyMCE

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -53,6 +53,7 @@ class PlgEditorTinymce extends JPlugin
 
 		// List the skins
 		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		$skin     = 'skin : "lightgray",';
 
 		// Set the selected skin
 		if ($app->isSite())
@@ -60,10 +61,6 @@ class PlgEditorTinymce extends JPlugin
 			if ((int) $this->params->get('skin', 0) < count($skindirs))
 			{
 				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin', 0)]) . '",';
-			}
-			else
-			{
-				$skin = 'skin : "lightgray",';
 			}
 		}
 
@@ -73,10 +70,6 @@ class PlgEditorTinymce extends JPlugin
 			if ((int) $this->params->get('skin_admin', 0) < count($skindirs))
 			{
 				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin_admin', 0)]) . '",';
-			}
-			else
-			{
-				$skin = 'skin : "lightgray",';
 			}
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -53,25 +53,10 @@ class PlgEditorTinymce extends JPlugin
 
 		// List the skins
 		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-		$skin     = 'skin : "lightgray",';
 
-		// Set the selected skin
-		if ($app->isSite())
-		{
-			if ((int) $this->params->get('skin', 0) < count($skindirs))
-			{
-				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin', 0)]) . '",';
-			}
-		}
-
-		// Set the selected administrator skin
-		elseif ($app->isAdmin())
-		{
-			if ((int) $this->params->get('skin_admin', 0) < count($skindirs))
-			{
-				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin_admin', 0)]) . '",';
-			}
-		}
+		$index = (int) $this->params->get($app->isAdmin() ? 'skin_admin' : 'skin', 0);
+		$skin  = isset($skindirs[$index]) ? basename($skindirs[$index]) : 'lightgray';
+		$skin  = 'skin : "' . $skin . '",';
 
 		$entity_encoding = $this->params->get('entity_encoding', 'raw');
 		$langMode        = $this->params->get('lang_mode', 0);


### PR DESCRIPTION
This fixes two things: 
- First, undefined variable $skins in the switch cases at the end of this method when `isSite` and `isAdmin` both fails (please don't say this can't happen). 
- Second, minimize the code by providing fallback value once.
