### PR TITLE
Fix JUri::root() assignment from backend app constuctor

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -45,7 +45,7 @@ class JApplicationAdministrator extends JApplicationCms
 		parent::__construct($input, $config, $client);
 
 		// Set the root in the URI based on the application name
-		JUri::root(null, dirname(JUri::base(true)));
+		JUri::root(null, rtrim(dirname(JUri::base(true)), '/'));
 	}
 
 	/**

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -45,7 +45,7 @@ class JApplicationAdministrator extends JApplicationCms
 		parent::__construct($input, $config, $client);
 
 		// Set the root in the URI based on the application name
-		JUri::root(null, str_ireplace('/' . $this->getName(), '', JUri::base(true)));
+		JUri::root(null, dirname(JUri::base(true)));
 	}
 
 	/**


### PR DESCRIPTION
This may not seem any important but I'd say it still is breaking. Try running Joomla in a subdirectory `administrator` under your web root, and open backend. It would break.

```
example.com/administrator/administrator/index.php
```

`dirname` will work on all platforms as `JUri::base(true)` always uses `/` as the path separator. Also there is no trailing slash in the return value of  `JUri::base(true)` 
