### PR TITLE
Height of a form field type editor -> the Tiny MCE plugin overrides custom settings

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -218,7 +218,7 @@ class PlgEditorTinymce extends JPlugin
 		// Flip for performance, so we can direct check for the key isset($access[$key])
 		$access = array_flip($access);
 
-		$html_height = $this->params->get('html_height', '550');
+		$html_height = $this->params->get('html_height', '');
 		$html_width  = $this->params->get('html_width', '');
 
 		if ($html_width == 750)

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -176,7 +176,7 @@
 				label="PLG_TINY_FIELD_LABEL_ADVANCEDPARAMS"
 			>
 				<field name="html_height" type="text"
-					default="550"
+					default=""
 					description="PLG_TINY_FIELD_HTMLHEIGHT_DESC"
 					label="PLG_TINY_FIELD_HTMLHEIGHT_LABEL"
 				/>


### PR DESCRIPTION
The XML code I have in my extensions for the form field type editor did not use my defined height of 100px it always shows the standard height of 550px -

<field name="name"
  type="editor"
  label="Description"
  height="100" />

I think that this is a bug in the Tiny MCE plugin. This plugin sets 550px as height in the setting parameters and that overrides the height definition in the custom XML forms.

How to test:
1. Open Component | Newsfeed| New and check, that the height of the editor is 550px.
2. Set the value of a custom form field with the type editor for the height to 100px. For example: Open the file JOOMLA\administrator\components\com_newsfeeds\models\forms\newsfeed.xml  and set in a height for the editor of 100px.
3. Open Extension | Plugin | Tiny MCE -> Advanced and delete the value for the html-height
4. Open again Component | Newsfeed| New and see, that the height of the editor is still 550px. I would expect that this height is now 100px!!
Check the patch:
1. After you completed steps 1 to 4 apply the patch.
2. Again, open Component | Newsfeed| New and see, that the height of the editor is now 100px.
3. Open after that the settings of other Joomla! core components and check that the height of this are still 550px.
