### PR TITLE
added componentlayout for Article Single Item

### DIFF
--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -31,7 +31,9 @@
 		<fieldset name="basic"
 			label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL">
 
-		<field name="article_layout" type="componentlayout"
+		<field 
+			name="article_layout" 
+			type="componentlayout"
 			label="JFIELD_ALT_LAYOUT_LABEL"
 			description="JFIELD_ALT_COMPONENT_LAYOUT_DESC"
 			useglobal="true"

--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -31,6 +31,13 @@
 		<fieldset name="basic"
 			label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL">
 
+		<field name="article_layout" type="componentlayout"
+			label="JFIELD_ALT_LAYOUT_LABEL"
+			description="JFIELD_ALT_COMPONENT_LAYOUT_DESC"
+			useglobal="true"
+			extension="com_content" view="article"
+		/>
+
 		<field
 			name="show_title"
 			type="radio"


### PR DESCRIPTION
### Description

When we create any new Joomla! Menu with : Articles => Single Article, we cant set the layout for it. It will load always default.php 
#### Before

![article_before](https://cloud.githubusercontent.com/assets/1936565/11613621/c890eaaa-9c51-11e5-8faf-30a976583bd8.png)
### Desired Output

If we add these patch, its allow to set the alternative layout for article details page. So i can see all layouts for article details page and set any one to load for specific page or menu item.
#### After

![article_after](https://cloud.githubusercontent.com/assets/1936565/11613622/d4c32658-9c51-11e5-9ebe-1f985ea33b52.png)
### Comment

Though its already been checked in view.html.php for article. 
