### PR TITLE
Security Issue with login: password shown in browser

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -72,6 +72,8 @@ class UsersControllerUser extends UsersController
 		{
 			// Login failed !
 			$data['remember'] = (int) $options['remember'];
+			$data['password'] = '';
+			$data['secretkey'] = '';
 			$app->setUserState('users.login.form.data', $data);
 			$app->redirect(JRoute::_('index.php?option=com_users&view=login', false));
 		}

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -71,8 +71,9 @@ class UsersControllerUser extends UsersController
 		if (true !== $app->login($credentials, $options))
 		{
 			// Login failed !
-			// Clear password and secret key before sending the login form back to the user.
+			// Clear user name, password and secret key before sending the login form back to the user.
 			$data['remember'] = (int) $options['remember'];
+			$data['username'] = '';
 			$data['password'] = '';
 			$data['secretkey'] = '';
 			$app->setUserState('users.login.form.data', $data);

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -71,6 +71,7 @@ class UsersControllerUser extends UsersController
 		if (true !== $app->login($credentials, $options))
 		{
 			// Login failed !
+			// Clear password and secret key before sending the login form back to the user.
 			$data['remember'] = (int) $options['remember'];
 			$data['password'] = '';
 			$data['secretkey'] = '';


### PR DESCRIPTION
If the user supplies either an unknown user name or a wrong password or a wrong secret key the com_users login form is shown (probably again) and it contains not only the user name typed in but also the password and (if activated) the secret key. The latter two should never be sent back to the user's browser for security reasons as is the case with the registration form when you enter e.g. a user name already in use or an email address already used with any other registration.

Test instructions: locate the login form at any page in the frontend and enter any invalid login information. After sending this data to the server you'll be shown the com_users login form containing the login information you just entered (the password field contains only dots but when you look into the HTML code you'll see the password you entered in clear text).
