### PR TITLE
JApplicationSite getTemplate returns an incomplete class after a set…

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -800,8 +800,8 @@ final class JApplicationSite extends JApplicationCms
 		{
 			$this->template = new stdClass;
 			$this->template->template = $template;
-		        $this->template->id=null;
-            		$this->template->home=0;
+		        $this->template->id = null;
+            		$this->template->home = 0;
 
 			if ($styleParams instanceof Registry)
 			{

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -800,8 +800,8 @@ final class JApplicationSite extends JApplicationCms
 		{
 			$this->template = new stdClass;
 			$this->template->template = $template;
-		        $this->template->id = null;
-            		$this->template->home = 0;
+			$this->template->id = null;
+			$this->template->home = 0;
 
 			if ($styleParams instanceof Registry)
 			{

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -800,6 +800,8 @@ final class JApplicationSite extends JApplicationCms
 		{
 			$this->template = new stdClass;
 			$this->template->template = $template;
+		        $this->template->id=null;
+            		$this->template->home=0;
 
 			if ($styleParams instanceof Registry)
 			{


### PR DESCRIPTION
…Template

$app = JFactory::getApplication();
    $t=$app->getTemplate(true);
    var_dump($t);

results in
object(stdClass)#582 (4) {
** ["id"]=>
string(2) "7"
["home"]=>
string(1) "1"**
["template"]=>
string(10) "protostar"
["params"]=>
object[....]
}

But after a setTemplate, the same call has a different type of result

$app = JFactory::getApplication();
$app->setTemplate('beez3',null);
    $t=$app->getTemplate(true);

results in
object(stdClass)#865 (2) {
["template"]=>
string(10) "rt_anacron"
["params"]=>
..........
}