### PR TITLE
Protostar Contact display corrections

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8562,7 +8562,14 @@ body {
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }

--- a/components/com_contact/views/contact/tmpl/default_articles.php
+++ b/components/com_contact/views/contact/tmpl/default_articles.php
@@ -16,7 +16,7 @@ require_once JPATH_SITE . '/components/com_content/helpers/route.php';
 <div class="contact-articles">
 	<ul class="nav nav-tabs nav-stacked">
 		<?php foreach ($this->item->articles as $article) :	?>
-			<li>
+			<li class="break-word">
 				<?php echo JHtml::_('link', JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)), htmlspecialchars($article->title, ENT_COMPAT, 'UTF-8')); ?>
 			</li>
 		<?php endforeach; ?>

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -437,7 +437,14 @@ body {
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -447,7 +447,14 @@ direction:rtl;
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7511,3 +7511,7 @@ body.modal-open {
 #finder-search .in.collapse {
 	overflow: visible;
 }
+.break-word {
+	word-break: break-all;
+	word-wrap: break-word;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -641,3 +641,9 @@ body.modal-open {
 #finder-search .in.collapse {
 	overflow: visible;
 }
+
+/* Break word for articles titles */
+.break-word {
+	word-break: break-all;
+	word-wrap: break-word;
+}


### PR DESCRIPTION
This PR corrects 2 issues concerning Single Contact display in Protostar.

Create a contact and link it to a user who has created some articles. Fill all fields. Make sure parameters are set to display all fields. Also Enable User - Profile plugin and fill fields for that user.
Create a Single contact menu item and make sure all fields are set to display.

A. RTL display (to test change en-GB.xml to `<rtl>1</rtl>`). Thanks @Bakual  for that part.

-----------------------------------before patch

![before_rtl](https://cloud.githubusercontent.com/assets/869724/11653887/a2ce21f6-9da1-11e5-965d-3d6bbf6a4f50.png)

-----------------------------------After patch

![after_rtl](https://cloud.githubusercontent.com/assets/869724/11653891/ac00a190-9da1-11e5-9a0c-0d345004ade5.png)

B. Long article title issue. Screenshots in RTL but it is same in LTR.

-----------------------------------------before patch

![before_longname](https://cloud.githubusercontent.com/assets/869724/11653907/cfbbd406-9da1-11e5-9fe4-1b9f30481198.png)

-------------------------------------------After patch

![after_longname](https://cloud.githubusercontent.com/assets/869724/11653911/d96a04d2-9da1-11e5-89e0-d857fcdbe0b9.png)
