### PR TITLE
RTL: correcting Protostar display Contact details

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8562,7 +8562,14 @@ body {
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }

--- a/media/jui/css/bootstrap-rtl.css
+++ b/media/jui/css/bootstrap-rtl.css
@@ -437,7 +437,14 @@ body {
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }

--- a/media/jui/less/bootstrap-rtl.less
+++ b/media/jui/less/bootstrap-rtl.less
@@ -447,7 +447,14 @@ direction:rtl;
 }
 .dl-horizontal dt {
 	float: right;
+	text-align: left;
+	clear: right;
 }
+.dl-horizontal dd {
+	margin-left: 0;
+	margin-right: 180px;
+}
+.dl-horizontal dt
 .profile> ul {
 	margin: 9px 25px 0 0;
 }


### PR DESCRIPTION
Create a contact, fill all fields. Make sure parameters are set to display all fields. 
Create a Single contact menu item and make sure all fields are set to display.

Change ROOT/language/en-GB/en-GB.xml to `<rtl>1</rtl>`) to display in RTL. Display the menu item in frontend.

-----------------------------------before patch

![before_rtl](https://cloud.githubusercontent.com/assets/869724/11653887/a2ce21f6-9da1-11e5-965d-3d6bbf6a4f50.png)

-----------------------------------After patch

![after_rtl](https://cloud.githubusercontent.com/assets/869724/11653891/ac00a190-9da1-11e5-9a0c-0d345004ade5.png)

@fontanil @Bakual 
