### PR TITLE
Extended Media form field type

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -624,6 +624,7 @@ JLIB_MEDIA_ERROR_WARNIEXSS="Possible IE XSS Attack found."
 JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Illegal or invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
+JLIB_MEDIA_ERROR_WARNNOUPLOADRIGHTS="You do not have permission to upload files."
 
 JLIB_NO_EDITOR_PLUGIN_PUBLISHED="Unable to display an editor because no editor plugin is published."
 


### PR DESCRIPTION
The Media field form type was extended with two attributes and a new functionality:

**component** - The component can be defined from which the default image path is retrieved.

Example: _component="com_example"_

The default image path can then be defined in the manifest file of the extension. The name value to use is _image_path_.

**mode** - If the mode is strict and the user does not have upload rights, then a notice instead of the select button is loaded. This is useful to limit the access of the user only for a specific folder if he has upload rights (new com_media has to be modified to check for the used mode).

Example: _mode="strict"_

**Placeholders for upload path**

The path in the directory parameter can now contain the following placeholders: 

{PLACEHOLDER}

_username_ - The user name of the logged-in user.
_userid_ - The ID of the logged-in user.
_date() format characters_ - Default value transformation (see list here: http://php.net/manual/en/function.date.php)

Example: {username}, {userid}, {Y} or {Ymd}

**Complete example:**

```
<field name="image-upload" type="media" directory="{d}-{m}-{Y}/{username}-{userid}" component="com_example" mode="strict" />
```

In this example the upload path would consist of the date (day-month-year) and the username plus id (user-42). The default image path will be loaded from com_example (if available, else com_media) and the mode is set to strict which means that users without upload permission right will not be possible to load the modal window.

Small changed behavior: If the the selected folder does not exist, then this folder ist still used and not the root folder. This is necessary with the addtion of placeholders which create dynamic paths.
