### PR TITLE
Create Categories on-the-fly on Banner edit form

### DIFF
--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -486,6 +486,31 @@ class BannersModelBanner extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 
+		require_once JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php';
+
+		// Cast catid to integer for comparison
+		$catid = (int) $data['catid'];
+
+		// Check if New Category exists
+		if ($catid > 0)
+		{
+			$catid = CategoriesHelper::validateCategoryId($data['catid'], 'com_banners');
+		}
+
+		// Save New Category
+		if ($catid == 0)
+		{
+			$table = array();
+			$table['title'] = $data['catid'];
+			$table['parent_id'] = 1;
+			$table['extension'] = 'com_banners';
+			$table['language'] = $data['language'];
+			$table['published'] = 1;
+
+			// Create new category and get catid back
+			$data['catid'] = CategoriesHelper::createCategory($table);
+		}
+
 		// Alter the name for save as copy
 		if ($input->get('task') == 'save2copy')
 		{

--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -486,7 +486,7 @@ class BannersModelBanner extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 
-		require_once JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php';
+		JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
 
 		// Cast catid to integer for comparison
 		$catid = (int) $data['catid'];

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -20,7 +20,10 @@
 		<field name="catid" type="categoryedit" extension="com_banners"
 			label="JCATEGORY" description="COM_BANNERS_FIELD_CATEGORY_DESC"
 			required="true"
-			addfieldpath="/administrator/components/com_categories/models/fields" />
+			addfieldpath="/administrator/components/com_categories/models/fields"
+			allowAdd="true"
+			default=""
+		/>
 
 		<field name="state" type="list"
 			label="JSTATUS" description="COM_BANNERS_FIELD_STATE_DESC"

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)


### PR DESCRIPTION
This PR adds a **new functionality** to the **Banner edit** form that makes it possible to **create & assign** a **new Category** on the fly. See also PR #8623.
# Testing Instructions

This PR uses some code in com_categories from PR #8623.
**Please install PR #8623 before testing this PR.**
## Before the PR

Go to Components > Banners > [New]
Create a new banner (Title) and select an existing Category. 

![banners1](https://cloud.githubusercontent.com/assets/1217850/11687336/624b1f90-9e86-11e5-89bb-4adf934215fe.png)
## After the PR

Go to Components > Banners > [New]
Create a new banner (Title) and **click on the Category dropdown**. 

![banners2](https://cloud.githubusercontent.com/assets/1217850/11687335/624b2f58-9e86-11e5-8b62-a4ac87122bd4.png)

The Category dropdown now has an option to add a new Category name.

![banners3](https://cloud.githubusercontent.com/assets/1217850/11687337/6250db24-9e86-11e5-838e-40e6d8d7ba43.png)

Don't forget to **click on <Enter>** to select your **newly created Category**.
When you save the Banner, the new category will be created.

![banners4](https://cloud.githubusercontent.com/assets/1217850/11687338/62532550-9e86-11e5-9a88-1fa366bb88af.png)

After save the new Category will be in the category list (a hyphen is added in front of it).
