### PR TITLE
Modal category searchtools optimization

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -31,45 +31,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 <form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
 	<fieldset class="filter clearfix">
-		<div class="btn-toolbar">
-			<div class="btn-group pull-left">
-				<label for="filter_search">
-					<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
-				</label>
-			</div>
-			<div class="btn-group pull-left">
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('COM_CATEGORIES_ITEMS_SEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_CATEGORIES_ITEMS_SEARCH_FILTER'); ?>" />
-			</div>
-			<div class="btn-group pull-left">
-				<button type="submit" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">
-					<span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
-				<button type="button" class="btn hasTooltip" data-placement="bottom" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();">
-					<span class="icon-remove"></span><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
-			</div>
-			<div class="clearfix"></div>
-		</div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<hr class="hr-condensed" />
-		<div class="filters pull-left">
-			<select name="filter_access" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
-			</select>
-
-			<select name="filter_published" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
-			</select>
-
-			<?php if ($this->state->get('filter.forcedLanguage')) : ?>
-				<input type="hidden" name="forcedLanguage" value="<?php echo $this->escape($this->state->get('filter.forcedLanguage')); ?>" />
-				<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
-			<?php else : ?>
-				<select name="filter_language" class="input-medium" onchange="this.form.submit()">
-					<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
-					<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
-				</select>
-			<?php endif; ?>
-		</div>
 	</fieldset>
 
 	<?php if (empty($this->items)) : ?>
@@ -161,8 +124,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="boxchecked" value="0" />
-	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-	<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 
 </form>


### PR DESCRIPTION
Bring up **all relevant filters** to the **modal category field**.
The template code is simplified while enjoying the factorization of **JLayoutHelper**.

![category_modal_exemple-01](https://cloud.githubusercontent.com/assets/16225234/11690931/25a51678-9e99-11e5-9936-d4149d67cb9f.png)
## Testing

To test the modal category field ( you can do what is indicated at #8185; listed below ) :
1. Change the file :
   _administrator/components/com_content/models/forms/article.xml_
   45 - : `<field name="catid" type="categoryedit"`
   45 + : `<field name="catid" type="modal_category"`
2. open an article to use the field : 
   ![category_modal_exemple-on-article-01](https://cloud.githubusercontent.com/assets/16225234/11690876/efc8394a-9e98-11e5-9292-af92a7f3b1c9.png)
