### PR TITLE
Create Categories on-the-fly on Contact edit form

### DIFF
--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -384,7 +384,7 @@ class ContactModelContact extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 
-		require_once JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php';
+		JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
 
 		// Cast catid to integer for comparison
 		$catid = (int) $data['catid'];

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -384,6 +384,31 @@ class ContactModelContact extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 
+		require_once JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php';
+
+		// Cast catid to integer for comparison
+		$catid = (int) $data['catid'];
+
+		// Check if New Category exists
+		if ($catid > 0)
+		{
+			$catid = CategoriesHelper::validateCategoryId($data['catid'], 'com_contact');
+		}
+
+		// Save New Category
+		if ($catid == 0)
+		{
+			$table = array();
+			$table['title'] = $data['catid'];
+			$table['parent_id'] = 1;
+			$table['extension'] = 'com_contact';
+			$table['language'] = $data['language'];
+			$table['published'] = 1;
+
+			// Create new category and get catid back
+			$data['catid'] = CategoriesHelper::createCategory($table);
+		}
+
 		// Alter the name for save as copy
 		if ($input->get('task') == 'save2copy')
 		{

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -69,6 +69,8 @@
 			label="JCATEGORY"
 			description="JFIELD_CATEGORY_DESC"
 			required="true"
+			allowAdd="true"
+			default=""
 		/>
 
 		<field name="access"


### PR DESCRIPTION
This PR adds a **new functionality** to the **Contact edit** form that makes it possible to **create & assign** a **new Category** on the fly. See also PR #8623.
# Testing Instructions

This PR uses some code in com_categories from PR #8623.
**Please install PR #8623 before testing this PR.**
## Before the PR

Go to Components > Contacts > [New]
Create a new Contact (Title) and select an existing Category. 

![contact1](https://cloud.githubusercontent.com/assets/1217850/11689915/5033c7a4-9e94-11e5-80d9-491cfcb5310d.png)
## After the PR

Go to Components > Contacts > [New]
Create a new Contact (Title) and **click on the Category dropdown**. 

![contact2](https://cloud.githubusercontent.com/assets/1217850/11689914/50315190-9e94-11e5-9717-00cfaf7b0905.png)

The Category dropdown now has an option to add a new Category name.

![contact3](https://cloud.githubusercontent.com/assets/1217850/11689912/502efd82-9e94-11e5-9e1b-3b2f8e26f47d.png)

Don't forget to **click on <Enter>** to select your **newly created Category**.
When you save the Contact, the new category will be created.

![contact4](https://cloud.githubusercontent.com/assets/1217850/11689913/50312256-9e94-11e5-8595-ace422e22d6f.png)

After save the new Category will be in the category list (a hyphen is added in front of it).
