### PR TITLE
Create Categories on-the-fly on Newsfeed edit form

### DIFF
--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -30,9 +30,14 @@
 				JTRASHED</option>
 		</field>
 
-		<field name="catid" type="categoryedit" extension="com_newsfeeds"
-			label="JCATEGORY" description="COM_NEWSFEEDS_FIELD_CATEGORY_DESC"
-			required="true"
+		<field	name="catid"
+				type="categoryedit"
+				extension="com_newsfeeds"
+				label="JCATEGORY"
+				description="COM_NEWSFEEDS_FIELD_CATEGORY_DESC"
+				required="true"
+				allowAdd="true"
+				default=""
 		>
 		</field>
 

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -302,6 +302,31 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	{
 		$input = JFactory::getApplication()->input;
 
+		JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
+
+		// Cast catid to integer for comparison
+		$catid = (int) $data['catid'];
+
+		// Check if New Category exists
+		if ($catid > 0)
+		{
+			$catid = CategoriesHelper::validateCategoryId($data['catid'], 'com_newsfeeds');
+		}
+
+		// Save New Category
+		if ($catid == 0)
+		{
+			$table = array();
+			$table['title'] = $data['catid'];
+			$table['parent_id'] = 1;
+			$table['extension'] = 'com_newsfeeds';
+			$table['language'] = $data['language'];
+			$table['published'] = 1;
+
+			// Create new category and get catid back
+			$data['catid'] = CategoriesHelper::createCategory($table);
+		}
+
 		// Alter the name for save as copy
 		if ($input->get('task') == 'save2copy')
 		{

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
 
 $app = JFactory::getApplication();
 $input = $app->input;


### PR DESCRIPTION
This PR adds a **new functionality** to the **Newsfeed edit** form that makes it possible to **create & assign** a **new Category** on the fly. See also PR #8623.
# Testing Instructions

This PR uses some code in com_categories from PR #8623.
**Please install PR #8623 before testing this PR.**
## Before the PR

Go to Components > Newsfeeds > [New]
Create a new Newsfeed (Title) + link and select an existing Category. 

![newsfeed1](https://cloud.githubusercontent.com/assets/1217850/11690890/f7e25b1a-9e98-11e5-8b3d-1a0b12c6eec9.png)
## After the PR

Go to Components > Newsfeeds > [New]
Create a new Newsfeed (Title) + link and **click on the Category dropdown**. 

![newsfeed2](https://cloud.githubusercontent.com/assets/1217850/11690892/f7e5f48c-9e98-11e5-81dc-5271ad865277.png)

The Category dropdown now has an option to add a new Category name.

![newsfeed3](https://cloud.githubusercontent.com/assets/1217850/11690889/f7e1c47a-9e98-11e5-8757-91d2d2b205f9.png)

Don't forget to **click on <Enter>** to select your **newly created Category**.
When you save the Newsfeed, the new category will be created.

![newsfeed4](https://cloud.githubusercontent.com/assets/1217850/11690891/f7e38a6c-9e98-11e5-9c0f-07ee6292800e.png)

After save the new Category will be in the category list (a hyphen is added in front of it).
