### PR TITLE
Debug console - Profile Information tooltip info

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -582,13 +582,13 @@ class PlgSystemDebug extends JPlugin
 			$bars[] = (object) array(
 				'width' => round($mark->time / ($totalTime / 100), 4),
 				'class' => $barClass,
-				'tip' => $mark->tip
+				'tip' => $mark->tip . ' ' . round($mark->time , 1) . ' ms'
 			);
 
 			$barsMem[] = (object) array(
 				'width' => round($mark->memory / ($totalMem / 100), 4),
 				'class' => $barClassMem,
-				'tip' => $mark->tip
+				'tip' => $mark->tip . ' ' . round($mark->memory , 3) .'  MB',
 			);
 
 			$htmlMarks[] = '<div>' . str_replace('label-time', $labelClass, str_replace('label-memory', $labelClassMem, $mark->html)) . '</div>';

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -582,13 +582,13 @@ class PlgSystemDebug extends JPlugin
 			$bars[] = (object) array(
 				'width' => round($mark->time / ($totalTime / 100), 4),
 				'class' => $barClass,
-				'tip' => $mark->tip . ' ' . round($mark->time , 1) . ' ms'
+				'tip' => $mark->tip . ' ' . round($mark->time, 1) . ' ms'
 			);
 
 			$barsMem[] = (object) array(
 				'width' => round($mark->memory / ($totalMem / 100), 4),
 				'class' => $barClassMem,
-				'tip' => $mark->tip . ' ' . round($mark->memory , 3) .'  MB',
+				'tip' => $mark->tip . ' ' . round($mark->memory, 3) . '  MB',
 			);
 
 			$htmlMarks[] = '<div>' . str_replace('label-time', $labelClass, str_replace('label-memory', $labelClassMem, $mark->html)) . '</div>';


### PR DESCRIPTION
Goto -> Profile Information 
move along the bars Time and Memory 
the tooltip report only the Application name afterInitialise

![beforep](https://cloud.githubusercontent.com/assets/181681/11712329/a67c9ae4-9f2c-11e5-88da-55ae558728d9.png)

Add time and memory info on each tooltip

![afterp](https://cloud.githubusercontent.com/assets/181681/11712345/b9a18274-9f2c-11e5-869b-6de579c8e409.png)
