### PR TITLE
Deal with fatal when XML Form can't be found

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -877,9 +877,14 @@ class UsersModelUser extends JModelAdmin
 
 		if (empty($userId))
 		{
-			$result = array();
+			$result   = array();
+			$form     = $this->getForm();
+			$groupIDs = array();
 
-			$groupsIDs = $this->getForm()->getValue('groups');
+			if ($form)
+			{
+				$groupsIDs = $form->getValue('groups');
+			}
 
 			if (!empty($groupsIDs))
 			{


### PR DESCRIPTION
When the XML Form can't be found then `getForm` returns false in that case you currently when saving a fatal error

```
Fatal error: Call to a member function getValue() on boolean in ROOT/administrator/components/com_users/models/user.php on line 876
```

I do not even know how to replicate this (the error was posted privately to me in skype). But this at least stops the fatal error even if it doesn't solve the root of the problem
