### PR TITLE
Valid default date for User Notes Review

### DIFF
--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -68,7 +68,7 @@
 			type="calendar"
 			label="COM_USERS_FIELD_REVIEW_TIME_LABEL"
 			description="COM_USERS_FIELD_REVIEW_TIME_DESC"
-			default="0000-00-00"
+			default="NOW"
 			format="%Y-%m-%d"
 			/>
 


### PR DESCRIPTION
If you create a User Note the default value for the Review Date is invalid and displayed as -001-11-30 with a tooltip of Monday 30 November -001. This also results in a value of "-" being displayed in the column for Review Date in the list view

This simple view changes the default value for this field from 0000-00-00 to NOW according to the documented option published at https://docs.joomla.org/Calendar_form_field_type
