### PR TITLE
Featured ordering select

### DIFF
--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -90,14 +90,14 @@
 			default="a.title ASC"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="fp.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="fp.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
 			<option value="a.state ASC">JSTATUS_ASC</option>
 			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
+			<option value="fp.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="fp.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
@@ -106,10 +106,10 @@
 			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>
 			<option value="a.hits DESC">JGLOBAL_HITS_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>
 		<field
 			name="limit"


### PR DESCRIPTION
The order of options in the dropdown select boxes should match the order that the items are displayed in the grid.
This simple PR changes the order for the the options in the com_content featured view ordering select list to match the ordering in the grid.
There is no functional change it is purely cosmetic
## before

![screen shot 2015-12-17 at 06 07 32](https://issues.joomla.org/uploads/1/90594a2143dfd21ae9cebe0471bfe96f.png)
## after

![screen shot 2015-12-17 at 06 07 44](https://issues.joomla.org/uploads/1/765c5dc154c49643a611a00c505d86a4.png)
