### PR TITLE
Multilingual Status Module center heading

### DIFF
--- a/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
@@ -100,7 +100,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 				<th>
 					<?php echo JText::_('JDETAILS'); ?>
 				</th>
-				<th>
+				<th class="center">
 					<?php echo JText::_('JSTATUS'); ?>
 				</th>
 			</tr>


### PR DESCRIPTION
This is a cosmetic change to center the heading for a column where the data is centred
## Before

![mm-before](https://cloud.githubusercontent.com/assets/1296369/11767146/ac721e76-a19b-11e5-945f-35af69176c0e.png)
## After

![mm-after](https://cloud.githubusercontent.com/assets/1296369/11767147/b08bb3dc-a19b-11e5-901e-325906d200da.png)
