### PR TITLE
Regression: correcting #8665

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -81,7 +81,7 @@
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
-			<option value="association DESC" requries="associations">JASSOCIATIONS_DESC</option>
+			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
 			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>


### PR DESCRIPTION
Just a typo to correct to avoid displaying associations when the parameter is not set in the languagefilter plugin.
Solves https://github.com/joomla/joomla-cms/issues/8665

before patch:
![screen shot 2015-12-13 at 18 05 27](https://cloud.githubusercontent.com/assets/869724/11768184/0fcf7f6c-a1c5-11e5-8fa7-bbea76f67a06.png)

After patch
![screen shot 2015-12-13 at 18 06 20](https://cloud.githubusercontent.com/assets/869724/11768185/17d746d6-a1c5-11e5-888e-4566966c3432.png)
