### PR TITLE
Using JInput to get server information

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -905,22 +905,26 @@ class JSession implements IteratorAggregate
 			}
 		}
 
+		$httpForwardedFor = $this->_input->server->getString('HTTP_X_FORWARDED_FOR', '');
+
 		// Record proxy forwarded for in the session in case we need it later
-		if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+		if (!empty($httpForwardedFor))
 		{
-			$this->set('session.client.forwarded', $_SERVER['HTTP_X_FORWARDED_FOR']);
+			$this->set('session.client.forwarded', $httpForwardedFor);
 		}
 
+		$remoteAddress = $this->_input->server->getString('REMOTE_ADDR', '');
+
 		// Check for client address
-		if (in_array('fix_adress', $this->_security) && isset($_SERVER['REMOTE_ADDR']))
+		if (in_array('fix_adress', $this->_security) && !empty($remoteAddress))
 		{
 			$ip = $this->get('session.client.address');
 
 			if ($ip === null)
 			{
-				$this->set('session.client.address', $_SERVER['REMOTE_ADDR']);
+				$this->set('session.client.address', $remoteAddress);
 			}
-			elseif ($_SERVER['REMOTE_ADDR'] !== $ip)
+			elseif ($remoteAddress !== $ip)
 			{
 				$this->_state = 'error';
 
@@ -928,16 +932,18 @@ class JSession implements IteratorAggregate
 			}
 		}
 
+		$userAgent = $this->_input->server->getString('HTTP_USER_AGENT', '');
+
 		// Check for clients browser
-		if (in_array('fix_browser', $this->_security) && isset($_SERVER['HTTP_USER_AGENT']))
+		if (in_array('fix_browser', $this->_security) && !empty($userAgent))
 		{
 			$browser = $this->get('session.client.browser');
 
 			if ($browser === null)
 			{
-				$this->set('session.client.browser', $_SERVER['HTTP_USER_AGENT']);
+				$this->set('session.client.browser', $userAgent);
 			}
-			elseif ($_SERVER['HTTP_USER_AGENT'] !== $browser)
+			elseif ($userAgent !== $browser)
 			{
 				// @todo remove code: $this->_state = 'error';
 				// @todo remove code: return false;

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -62,8 +62,11 @@ class JUri extends Uri
 			// Are we obtaining the URI from the server?
 			if ($uri == 'SERVER')
 			{
+				$input = JFactory::getApplication()->input;
+				$serverSSLVar = $input->server->getString('HTTPS', '');
+
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if (isset($serverSSLVar) && !empty($serverSSLVar) && (strtolower($serverSSLVar) != 'off'))
 				{
 					$https = 's://';
 				}
@@ -78,11 +81,14 @@ class JUri extends Uri
 				 * are present, we will assume we are running on apache.
 				 */
 
-				if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI']))
+				$phpSelf = $input->server->getString('PHP_SELF', '');
+				$requestUri = $input->server->getString('REQUEST_URI', '');
+
+				if (!empty($phpSelf && !empty($requestUri)))
 				{
 					// To build the entire URI we need to prepend the protocol, and the http host
 					// to the URI string.
-					$theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+					$theURI = 'http' . $https . $input->server->getString('HTTP_HOST') . $requestUri;
 				}
 				else
 				{
@@ -93,12 +99,13 @@ class JUri extends Uri
 					 *
 					 * IIS uses the SCRIPT_NAME variable instead of a REQUEST_URI variable... thanks, MS
 					 */
-					$theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
+					$theURI   = 'http' . $https . $input->server->getString('HTTP_HOST') . $input->server->getString('SCRIPT_NAME');
+					$queryString = $input->server->getString('QUERY_STRING', '');
 
 					// If the query string exists append it to the URI string
-					if (isset($_SERVER['QUERY_STRING']) && !empty($_SERVER['QUERY_STRING']))
+					if (isset($queryString) && !empty($queryString))
 					{
-						$theURI .= '?' . $_SERVER['QUERY_STRING'];
+						$theURI .= '?' . $queryString;
 					}
 				}
 
@@ -152,19 +159,21 @@ class JUri extends Uri
 			else
 			{
 				static::$base['prefix'] = $uri->toString(array('scheme', 'host', 'port'));
+				$input = JFactory::getApplication()->input;
+				$requestUri = $input->server->getString('REQUEST_URI', '');
 
-				if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI']))
+				if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($requestUri))
 				{
 					// PHP-CGI on Apache with "cgi.fix_pathinfo = 0"
 
 					// We shouldn't have user-supplied PATH_INFO in PHP_SELF in this case
 					// because PHP will not work with PATH_INFO at all.
-					$script_name = $_SERVER['PHP_SELF'];
+					$script_name = $input->server->getString('PHP_SELF', '');
 				}
 				else
 				{
 					// Others
-					$script_name = $_SERVER['SCRIPT_NAME'];
+					$script_name = $input->server->getString('SCRIPT_NAME', '');
 				}
 
 				static::$base['path'] = rtrim(dirname($script_name), '/\\');

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -84,7 +84,7 @@ class JUri extends Uri
 				$phpSelf = $input->server->getString('PHP_SELF', '');
 				$requestUri = $input->server->getString('REQUEST_URI', '');
 
-				if (!empty($phpSelf && !empty($requestUri)))
+				if (!empty($phpSelf) && !empty($requestUri))
 				{
 					// To build the entire URI we need to prepend the protocol, and the http host
 					// to the URI string.

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -62,7 +62,7 @@ class JUri extends Uri
 			// Are we obtaining the URI from the server?
 			if ($uri == 'SERVER')
 			{
-				$input = JFactory::getApplication()->input;
+				$input = new JInput;
 				$serverSSLVar = $input->server->getString('HTTPS', '');
 
 				// Determine if the request was over SSL (HTTPS).
@@ -159,7 +159,7 @@ class JUri extends Uri
 			else
 			{
 				static::$base['prefix'] = $uri->toString(array('scheme', 'host', 'port'));
-				$input = JFactory::getApplication()->input;
+				$input = new JInput;
 				$requestUri = $input->server->getString('REQUEST_URI', '');
 
 				if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($requestUri))

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1357,10 +1357,10 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testIsSSLConnection()
 	{
-		$this->assertFalse($this->object->isSslConnection());
+		$this->assertFalse($this->class->isSslConnection());
 
-		$this->object->input->server->set('HTTPS', 'on');
+		$this->class->input->server->set('HTTPS', 'on');
 
-		$this->assertTrue($this->object->isSslConnection());
+		$this->assertTrue($this->class->isSslConnection());
 	}
 }


### PR DESCRIPTION
This ports back some fixes from the framework to grab data from JInput rather than $_SERVER which adds an additional layer of sanity checks to the data.

There's no easy way to test this. Just browse around and ensure that any thing URL and session related continue to work as usual.
