### PR TITLE
Backport FW filter package changes: allow arrays process by clean()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d500f4784ce37841dad0b29e32660849",
-    "content-hash": "800b07fe877fd7416bf7c046ad42a55a",
+    "hash": "871fd29fff6b6d203c23bf28b5c25f0e",
+    "content-hash": "49979472d61e44eba9b2d42a6ab04886",
     "packages": [
         {
             "name": "ircmaxell/password-compat",
@@ -230,30 +230,29 @@
         },
         {
             "name": "joomla/filter",
-            "version": "1.1.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filter.git",
-                "reference": "ed6d695a81e71508782ab8d711498c684465b041"
+                "reference": "45a504f0cd6fa2312a0260955e957435ca2cedc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/ed6d695a81e71508782ab8d711498c684465b041",
-                "reference": "ed6d695a81e71508782ab8d711498c684465b041",
+                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/45a504f0cd6fa2312a0260955e957435ca2cedc9",
+                "reference": "45a504f0cd6fa2312a0260955e957435ca2cedc9",
                 "shasum": ""
             },
             "require": {
+                "joomla/string": "~1.3",
                 "php": ">=5.3.10"
             },
             "require-dev": {
                 "joomla/language": "~1.0",
-                "joomla/string": "~1.0",
                 "phpunit/phpunit": "4.*",
                 "squizlabs/php_codesniffer": "1.*"
             },
             "suggest": {
-                "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`.",
-                "joomla/string": "Required only if you want to use `OutputFilter::stringURLSafe` and `OutputFilter::stringURLUnicodeSlug`."
+                "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
             },
             "type": "joomla-package",
             "extra": {
@@ -278,7 +277,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-12-12 21:46:44"
+            "time": "2016-01-08 17:27:47"
         },
         {
             "name": "joomla/input",

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * JFilterInput is a class for filtering input from any data source
  *

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -243,6 +243,8 @@ class JFilterInput
 
 				if (is_array($source))
 				{
+					$result = array();
+
 					// Itterate through the array
 					foreach ($source as $eachString)
 					{
@@ -263,6 +265,8 @@ class JFilterInput
 
 				if (is_array($source))
 				{
+					$result = array();
+
 					// Itterate through the array
 					foreach ($source as $eachString)
 					{
@@ -284,6 +288,8 @@ class JFilterInput
 
 				if (is_array($source))
 				{
+					$result = array();
+
 					// Itterate through the array
 					foreach ($source as $eachString)
 					{
@@ -301,32 +307,141 @@ class JFilterInput
 
 			case 'BOOL':
 			case 'BOOLEAN':
-				$result = (bool) $source;
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (bool) $eachString;
+					}
+				}
+				else
+				{
+					$result = (bool) $source;
+				}
+
 				break;
 
 			case 'WORD':
-				$result = (string) preg_replace('/[^A-Z_]/i', '', $source);
+				$pattern = '/[^A-Z_]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'ALNUM':
-				$result = (string) preg_replace('/[^A-Z0-9]/i', '', $source);
+				$pattern = '/[^A-Z0-9]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'CMD':
-				$result = (string) preg_replace('/[^A-Z0-9_\.-]/i', '', $source);
-				$result = ltrim($result, '.');
+				$pattern = '/[^A-Z0-9_\.-]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$cleaned  = (string) preg_replace($pattern, '', $eachString);
+						$result[] = ltrim($cleaned, '.');
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+					$result = ltrim($result, '.');
+				}
+
 				break;
 
 			case 'BASE64':
-				$result = (string) preg_replace('/[^A-Z0-9\/+=]/i', '', $source);
+				$pattern = '/[^A-Z0-9\/+=]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'STRING':
-				$result = (string) $this->_remove($this->_decode((string) $source));
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) $this->remove($this->decode((string) $eachString));
+					}
+				}
+				else
+				{
+					$result = (string) $this->remove($this->decode((string) $source));
+				}
+
 				break;
 
 			case 'HTML':
-				$result = (string) $this->_remove((string) $source);
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) $this->remove((string) $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) $this->remove((string) $source);
+				}
+
 				break;
 
 			case 'ARRAY':
@@ -338,6 +453,8 @@ class JFilterInput
 
 				if (is_array($source))
 				{
+					$result = array();
+
 					// Itterate through the array
 					foreach ($source as $eachString)
 					{
@@ -354,13 +471,46 @@ class JFilterInput
 				break;
 
 			case 'TRIM':
-				$result = (string) trim($source);
-				$result = JString::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = JString::trim($result, chr(0xC2) . chr(0xA0));
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$cleaned  = (string) trim($eachString);
+						$cleaned  = StringHelper::trim($cleaned, chr(0xE3) . chr(0x80) . chr(0x80));
+						$result[] = StringHelper::trim($cleaned, chr(0xC2) . chr(0xA0));
+					}
+				}
+				else
+				{
+					$result = (string) trim($source);
+					$result = StringHelper::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
+					$result = StringHelper::trim($result, chr(0xC2) . chr(0xA0));
+				}
+
 				break;
 
 			case 'USERNAME':
-				$result = (string) preg_replace('/[\x00-\x1F\x7F<>"\'%&]/', '', $source);
+				$pattern = '/[\x00-\x1F\x7F<>"\'%&]/';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'RAW':
@@ -441,9 +591,12 @@ class JFilterInput
 		$attrSubSet[0] = strtolower($attrSubSet[0]);
 		$attrSubSet[1] = strtolower($attrSubSet[1]);
 
-		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style') || (strpos($attrSubSet[1], 'javascript:') !== false) ||
-			(strpos($attrSubSet[1], 'behaviour:') !== false) || (strpos($attrSubSet[1], 'vbscript:') !== false) ||
-			(strpos($attrSubSet[1], 'mocha:') !== false) || (strpos($attrSubSet[1], 'livescript:') !== false));
+		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style') 
+			|| (strpos($attrSubSet[1], 'javascript:') !== false)
+			|| (strpos($attrSubSet[1], 'behaviour:') !== false)
+			|| (strpos($attrSubSet[1], 'vbscript:') !== false)
+			|| (strpos($attrSubSet[1], 'mocha:') !== false)
+			|| (strpos($attrSubSet[1], 'livescript:') !== false));
 	}
 
 	/**

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -103,7 +103,7 @@ class JFilterInput
 		'script',
 		'style',
 		'title',
-		'xml'
+		'xml',
 	);
 
 	/**
@@ -117,7 +117,7 @@ class JFilterInput
 		'background',
 		'codebase',
 		'dynsrc',
-		'lowsrc'
+		'lowsrc',
 	);
 
 	/**
@@ -234,27 +234,69 @@ class JFilterInput
 			$source = $this->stripUSC($source);
 		}
 
-		// Handle the type constraint
+		// Handle the type constraint cases
 		switch (strtoupper($type))
 		{
 			case 'INT':
 			case 'INTEGER':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
-				$result = @ (int) $matches[0];
+				$pattern = '/[-+]?[0-9]+/';
+
+				if (is_array($source))
+				{
+					// Itterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (int) $matches[0] : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (int) $matches[0] : 0;
+				}
+
 				break;
 
 			case 'UINT':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
-				$result = @ abs((int) $matches[0]);
+				$pattern = '/[-+]?[0-9]+/';
+
+				if (is_array($source))
+				{
+					// Itterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? abs((int) $matches[0]) : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
+				}
+
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				// Only use the first floating point value
-				preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source, $matches);
-				$result = @ (float) $matches[0];
+				$pattern = '/[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?/';
+
+				if (is_array($source))
+				{
+					// Itterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (float) $matches[0] : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (float) $matches[0] : 0;
+				}
+
 				break;
 
 			case 'BOOL':
@@ -293,8 +335,22 @@ class JFilterInput
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_match($pattern, (string) $source, $matches);
-				$result = @ (string) $matches[0];
+
+				if (is_array($source))
+				{
+					// Itterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (string) $matches[0] : '';
+					}
+				}
+				else
+				{
+					preg_match($pattern, $source, $matches);
+					$result = isset($matches[0]) ? (string) $matches[0] : '';
+				}
+
 				break;
 
 			case 'TRIM':
@@ -336,7 +392,7 @@ class JFilterInput
 					}
 					else
 					{
-						// Not an array or string.. return the passed parameter
+						// Not an array or string... return the passed parameter
 						$result = $source;
 					}
 				}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -203,9 +203,9 @@ class JFilterInput
 	 *
 	 * @param   mixed   $source  Input string/array-of-string to be 'cleaned'
 	 * @param   string  $type    The return type for the variable:
-	 *                           INT:       An integer,
-	 *                           UINT:      An unsigned integer,
-	 *                           FLOAT:     A floating point number,
+	 *                           INT:       An integer, or an array of integers,
+	 *                           UINT:      An unsigned integer, or an array of unsigned integers,
+	 *                           FLOAT:     A floating point number, or an array of floating point numbers,
 	 *                           BOOLEAN:   A boolean value,
 	 *                           WORD:      A string containing A-Z or underscores only (not case sensitive),
 	 *                           ALNUM:     A string containing A-Z or 0-9 only (not case sensitive),
@@ -214,7 +214,7 @@ class JFilterInput
 	 *                           STRING:    A fully decoded and sanitised string (default),
 	 *                           HTML:      A sanitised string,
 	 *                           ARRAY:     An array,
-	 *                           PATH:      A sanitised file path,
+	 *                           PATH:      A sanitised file path, or an array of sanitised file paths,
 	 *                           TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
 	 *                           USERNAME:  Do not use (use an application specific filter),
 	 *                           RAW:       The raw string is returned with no filtering,

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -593,7 +593,7 @@ class JFilterInput
 		$attrSubSet[0] = strtolower($attrSubSet[0]);
 		$attrSubSet[1] = strtolower($attrSubSet[1]);
 
-		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style') 
+		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style')
 			|| (strpos($attrSubSet[1], 'javascript:') !== false)
 			|| (strpos($attrSubSet[1], 'behaviour:') !== false)
 			|| (strpos($attrSubSet[1], 'vbscript:') !== false)

--- a/libraries/vendor/composer/ClassLoader.php
+++ b/libraries/vendor/composer/ClassLoader.php
@@ -147,7 +147,7 @@ class ClassLoader
      * appending or prepending to the ones previously set for this namespace.
      *
      * @param string       $prefix  The prefix/namespace, with trailing '\\'
-     * @param array|string $paths   The PSR-0 base directories
+     * @param array|string $paths   The PSR-4 base directories
      * @param bool         $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException

--- a/libraries/vendor/composer/autoload_real.php
+++ b/libraries/vendor/composer/autoload_real.php
@@ -42,14 +42,14 @@ class ComposerAutoloaderInit205c915b9c7d3e718e7c95793ee67ffe
 
         $includeFiles = require __DIR__ . '/autoload_files.php';
         foreach ($includeFiles as $fileIdentifier => $file) {
-            composerRequire205c915b9c7d3e718e7c95793ee67ffe($fileIdentifier, $file);
+            composerRequire0efb534ee20646bcb987f4359c38b3aa($fileIdentifier, $file);
         }
 
         return $loader;
     }
 }
 
-function composerRequire205c915b9c7d3e718e7c95793ee67ffe($fileIdentifier, $file)
+function composerRequire0efb534ee20646bcb987f4359c38b3aa($fileIdentifier, $file)
 {
     if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
         require $file;

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -261,60 +261,6 @@
         ]
     },
     {
-        "name": "joomla/filter",
-        "version": "1.1.5",
-        "version_normalized": "1.1.5.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/filter.git",
-            "reference": "ed6d695a81e71508782ab8d711498c684465b041"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/filter/zipball/ed6d695a81e71508782ab8d711498c684465b041",
-            "reference": "ed6d695a81e71508782ab8d711498c684465b041",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.10"
-        },
-        "require-dev": {
-            "joomla/language": "~1.0",
-            "joomla/string": "~1.0",
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*"
-        },
-        "suggest": {
-            "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`.",
-            "joomla/string": "Required only if you want to use `OutputFilter::stringURLSafe` and `OutputFilter::stringURLUnicodeSlug`."
-        },
-        "time": "2014-12-12 21:46:44",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Filter\\": "src/",
-                "Joomla\\Filter\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Filter Package",
-        "homepage": "https://github.com/joomla-framework/filter",
-        "keywords": [
-            "filter",
-            "framework",
-            "joomla"
-        ]
-    },
-    {
         "name": "joomla/compat",
         "version": "1.2.0",
         "version_normalized": "1.2.0.0",
@@ -933,5 +879,58 @@
         ],
         "description": "lessphp is a compiler for LESS written in PHP.",
         "homepage": "http://leafo.net/lessphp/"
+    },
+    {
+        "name": "joomla/filter",
+        "version": "1.2.0",
+        "version_normalized": "1.2.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/filter.git",
+            "reference": "45a504f0cd6fa2312a0260955e957435ca2cedc9"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/filter/zipball/45a504f0cd6fa2312a0260955e957435ca2cedc9",
+            "reference": "45a504f0cd6fa2312a0260955e957435ca2cedc9",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/string": "~1.3",
+            "php": ">=5.3.10"
+        },
+        "require-dev": {
+            "joomla/language": "~1.0",
+            "phpunit/phpunit": "4.*",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "suggest": {
+            "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
+        },
+        "time": "2016-01-08 17:27:47",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Filter\\": "src/",
+                "Joomla\\Filter\\Tests\\": "Tests/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Filter Package",
+        "homepage": "https://github.com/joomla-framework/filter",
+        "keywords": [
+            "filter",
+            "framework",
+            "joomla"
+        ]
     }
 ]

--- a/libraries/vendor/joomla/filter/src/InputFilter.php
+++ b/libraries/vendor/joomla/filter/src/InputFilter.php
@@ -2,11 +2,13 @@
 /**
  * Part of the Joomla Framework Filter Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Filter;
+
+use Joomla\String\StringHelper;
 
 /**
  * InputFilter is a class for filtering input from any data source
@@ -23,6 +25,7 @@ class InputFilter
 	 *
 	 * @var    InputFilter[]
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	protected static $instances = array();
 
@@ -94,7 +97,7 @@ class InputFilter
 		'script',
 		'style',
 		'title',
-		'xml'
+		'xml',
 	);
 
 	/**
@@ -108,11 +111,11 @@ class InputFilter
 		'background',
 		'codebase',
 		'dynsrc',
-		'lowsrc'
+		'lowsrc',
 	);
 
 	/**
-	 * Constructor for inputFilter class. Only first parameter is required.
+	 * Constructor for InputFilter class.
 	 *
 	 * @param   array    $tagsArray   List of user-defined tags
 	 * @param   array    $attrArray   List of user-defined attributes
@@ -142,9 +145,9 @@ class InputFilter
 	 *
 	 * @param   mixed   $source  Input string/array-of-string to be 'cleaned'
 	 * @param   string  $type    The return type for the variable:
-	 *                           INT:       An integer,
-	 *                           UINT:      An unsigned integer,
-	 *                           FLOAT:     A floating point number,
+	 *                           INT:       An integer, or an array of integers,
+	 *                           UINT:      An unsigned integer, or an array of unsigned integers,
+	 *                           FLOAT:     A floating point number, or an array of floating point numbers,
 	 *                           BOOLEAN:   A boolean value,
 	 *                           WORD:      A string containing A-Z or underscores only (not case sensitive),
 	 *                           ALNUM:     A string containing A-Z or 0-9 only (not case sensitive),
@@ -153,7 +156,7 @@ class InputFilter
 	 *                           STRING:    A fully decoded and sanitised string (default),
 	 *                           HTML:      A sanitised string,
 	 *                           ARRAY:     An array,
-	 *                           PATH:      A sanitised file path,
+	 *                           PATH:      A sanitised file path, or an array of sanitised file paths,
 	 *                           TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
 	 *                           USERNAME:  Do not use (use an application specific filter),
 	 *                           RAW:       The raw string is returned with no filtering,
@@ -166,27 +169,75 @@ class InputFilter
 	 */
 	public function clean($source, $type = 'string')
 	{
-		// Handle the type constraint
+		// Handle the type constraint cases
 		switch (strtoupper($type))
 		{
 			case 'INT':
 			case 'INTEGER':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
-				$result = isset($matches[0]) ? (int) $matches[0] : 0;
+				$pattern = '/[-+]?[0-9]+/';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (int) $matches[0] : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (int) $matches[0] : 0;
+				}
+
 				break;
 
 			case 'UINT':
-				// Only use the first integer value
-				preg_match('/-?[0-9]+/', (string) $source, $matches);
-				$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
+				$pattern = '/[-+]?[0-9]+/';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? abs((int) $matches[0]) : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? abs((int) $matches[0]) : 0;
+				}
+
 				break;
 
 			case 'FLOAT':
 			case 'DOUBLE':
-				// Only use the first floating point value
-				preg_match('/-?[0-9]+(\.[0-9]+)?/', (string) $source, $matches);
-				$result = isset($matches[0]) ? (float) $matches[0] : 0;
+				$pattern = '/[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?/';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (float) $matches[0] : 0;
+					}
+				}
+				else
+				{
+					preg_match($pattern, (string) $source, $matches);
+					$result = isset($matches[0]) ? (float) $matches[0] : 0;
+				}
+
 				break;
 
 			case 'BOOL':
@@ -195,28 +246,121 @@ class InputFilter
 				break;
 
 			case 'WORD':
-				$result = (string) preg_replace('/[^A-Z_]/i', '', $source);
+				$pattern = '/[^A-Z_]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'ALNUM':
-				$result = (string) preg_replace('/[^A-Z0-9]/i', '', $source);
+				$pattern = '/[^A-Z0-9]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'CMD':
-				$result = (string) preg_replace('/[^A-Z0-9_\.-]/i', '', $source);
-				$result = ltrim($result, '.');
+				$pattern = '/[^A-Z0-9_\.-]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$cleaned  = (string) preg_replace($pattern, '', $eachString);
+						$result[] = ltrim($cleaned, '.');
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+					$result = ltrim($result, '.');
+				}
+
 				break;
 
 			case 'BASE64':
-				$result = (string) preg_replace('/[^A-Z0-9\/+=]/i', '', $source);
+				$pattern = '/[^A-Z0-9\/+=]/i';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'STRING':
-				$result = (string) $this->remove($this->decode((string) $source));
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) $this->remove($this->decode((string) $eachString));
+					}
+				}
+				else
+				{
+					$result = (string) $this->remove($this->decode((string) $source));
+				}
+
 				break;
 
 			case 'HTML':
-				$result = (string) $this->remove((string) $source);
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) $this->remove((string) $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) $this->remove((string) $source);
+				}
+
 				break;
 
 			case 'ARRAY':
@@ -225,18 +369,66 @@ class InputFilter
 
 			case 'PATH':
 				$pattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/][A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
-				preg_match($pattern, (string) $source, $matches);
-				$result = isset($matches[0]) ? (string) $matches[0] : '';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						preg_match($pattern, (string) $eachString, $matches);
+						$result[] = isset($matches[0]) ? (string) $matches[0] : '';
+					}
+				}
+				else
+				{
+					preg_match($pattern, $source, $matches);
+					$result = isset($matches[0]) ? (string) $matches[0] : '';
+				}
+
 				break;
 
 			case 'TRIM':
-				$result = (string) trim($source);
-				$result = trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
-				$result = trim($result, chr(0xC2) . chr(0xA0));
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$cleaned  = (string) trim($eachString);
+						$cleaned  = StringHelper::trim($cleaned, chr(0xE3) . chr(0x80) . chr(0x80));
+						$result[] = StringHelper::trim($cleaned, chr(0xC2) . chr(0xA0));
+					}
+				}
+				else
+				{
+					$result = (string) trim($source);
+					$result = StringHelper::trim($result, chr(0xE3) . chr(0x80) . chr(0x80));
+					$result = StringHelper::trim($result, chr(0xC2) . chr(0xA0));
+				}
+
 				break;
 
 			case 'USERNAME':
-				$result = (string) preg_replace('/[\x00-\x1F\x7F<>"\'%&]/', '', $source);
+				$pattern = '/[\x00-\x1F\x7F<>"\'%&]/';
+
+				if (is_array($source))
+				{
+					$result = array();
+
+					// Iterate through the array
+					foreach ($source as $eachString)
+					{
+						$result[] = (string) preg_replace($pattern, '', $eachString);
+					}
+				}
+				else
+				{
+					$result = (string) preg_replace($pattern, '', $source);
+				}
+
 				break;
 
 			case 'RAW':
@@ -268,7 +460,7 @@ class InputFilter
 					}
 					else
 					{
-						// Not an array or string.. return the passed parameter
+						// Not an array or string... return the passed parameter
 						$result = $source;
 					}
 				}

--- a/libraries/vendor/joomla/filter/src/OutputFilter.php
+++ b/libraries/vendor/joomla/filter/src/OutputFilter.php
@@ -2,14 +2,14 @@
 /**
  * Part of the Joomla Framework Filter Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Filter;
 
 use Joomla\Language\Language;
-use Joomla\String\String;
+use Joomla\String\StringHelper;
 
 /**
  * OutputFilter
@@ -32,7 +32,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function objectHTMLSafe(&$mixed, $quote_style = ENT_QUOTES, $exclude_keys = '')
+	public static function objectHtmlSafe(&$mixed, $quote_style = ENT_QUOTES, $exclude_keys = '')
 	{
 		if (is_object($mixed))
 		{
@@ -66,7 +66,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function linkXHTMLSafe($input)
+	public static function linkXhtmlSafe($input)
 	{
 		$regex = 'href="([^"]*(&(amp;){0})[^"]*)*?"';
 
@@ -74,9 +74,7 @@ class OutputFilter
 			"#$regex#i",
 			function($m)
 			{
-				$rx = '&(?!amp;)';
-
-				return preg_replace('#' . $rx . '#', '&amp;', $m[0]);
+				return preg_replace('#&(?!amp;)#', '&amp;', $m[0]);
 			},
 			$input
 		);
@@ -92,16 +90,15 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function stringURLSafe($string)
+	public static function stringUrlSafe($string)
 	{
 		// Remove any '-' from the string since they will be used as concatenaters
 		$str = str_replace('-', ' ', $string);
 
-		$lang = Language::getInstance();
-		$str = $lang->transliterate($str);
+		$str = Language::getInstance()->transliterate($str);
 
 		// Trim white spaces at beginning and end of alias and make lowercase
-		$str = trim(String::strtolower($str));
+		$str = trim(StringHelper::strtolower($str));
 
 		// Remove any duplicate whitespace, and ensure all characters are alphanumeric
 		$str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);
@@ -121,7 +118,7 @@ class OutputFilter
 	 *
 	 * @since   1.0
 	 */
-	public static function stringURLUnicodeSlug($string)
+	public static function stringUrlUnicodeSlug($string)
 	{
 		// Replace double byte whitespaces by single byte (East Asian languages)
 		$str = preg_replace('/\xE3\x80\x80/', ' ', $string);
@@ -138,7 +135,7 @@ class OutputFilter
 		$str = str_replace('?', '', $str);
 
 		// Trim white spaces at beginning and end of alias and make lowercase
-		$str = trim(String::strtolower($str));
+		$str = trim(StringHelper::strtolower($str));
 
 		// Remove any duplicate whitespace and replace whitespaces by hyphens
 		$str = preg_replace('#\x20+#', '-', $str);
@@ -154,8 +151,7 @@ class OutputFilter
 	 * @return  string  Processed string.
 	 *
 	 * @since   1.0
-	 *
-	 * @todo There must be a better way???
+	 * @todo    There must be a better way???
 	 */
 	public static function ampReplace($text)
 	{

--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -104,10 +104,46 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				-789,
 				'From generic cases'
 			),
+			'int_11' => array(
+				'int',
+				'',
+				0,
+				'From generic cases'
+			),
+			'int_12' => array(
+				'int',
+				array(1, 3, 9),
+				array(1, 3, 9),
+				'From generic cases'
+			),
+			'int_13' => array(
+				'int',
+				array(1, 'ab-123ab', '-ab123.456ab'),
+				array(1, -123, 123),
+				'From generic cases'
+			),
 			'uint_1' => array(
 				'uint',
 				-789,
 				789,
+				'From generic cases'
+			),
+			'uint_2' => array(
+				'uint',
+				'',
+				0,
+				'From generic cases'
+			),
+			'uint_3' => array(
+				'uint',
+				array(-1, -3, -9),
+				array(1, 3, 9),
+				'From generic cases'
+			),
+			'uint_4' => array(
+				'uint',
+				array(1, 'ab-123ab', '-ab123.456ab'),
+				array(1, 123, 123),
 				'From generic cases'
 			),
 			'float_01' => array(
@@ -162,6 +198,36 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'float',
 				'abc-12. 456',
 				-12,
+				'From generic cases'
+			),
+			'float_09' => array(
+				'float',
+				'',
+				0,
+				'From generic cases'
+			),
+			'float_10' => array(
+				'float',
+				'27.3e-34',
+				27.3e-34,
+				'From generic cases'
+			),
+			'float_11' => array(
+				'float',
+				array(1.0, 3.1, 6.2),
+				array(1.0, 3.1, 6.2),
+				'From generic cases'
+			),
+			'float_12' => array(
+				'float',
+				array(1.0, 'abc-12. 456', 'abc-12.456abc'),
+				array(1.0, -12, -12.456),
+				'From generic cases'
+			),
+			'float_13' => array(
+				'float',
+				array(1.0, 'abcdef-7E-10', '+27.3E-34', '+27.3e-34'),
+				array(1.0, -7E-10, 27.3E-34, 27.3e-34),
 				'From generic cases'
 			),
 			'bool_0' => array(

--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -45,7 +45,7 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'From generic cases'
 			),
 			'integer' => array(
-				'int',
+				'integer',
 				$input,
 				123456789,
 				'From generic cases'
@@ -284,6 +284,12 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				true,
 				'From generic cases'
 			),
+			'bool_8' => array(
+				'bool',
+				array('false', null, true, false, 1, 0, ''),
+				array(true, false, true, false, true, false, false),
+				'From generic cases'
+			),
 			'word_01' => array(
 				'word',
 				$input,
@@ -320,6 +326,12 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'word',
 				'From generic cases'
 			),
+			'word_07' => array(
+				'word',
+				array('w123o', '4567r89d'),
+				array('wo', 'rd'),
+				'From generic cases'
+			),
 			'alnum_01' => array(
 				'alnum',
 				$input,
@@ -338,16 +350,34 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'abc',
 				'From generic cases'
 			),
-			'cmd' => array(
+			'alnum_04' => array(
+				'alnum',
+				array('~!@#$%^abc', '&*()_+def'),
+				array('abc', 'def'),
+				'From generic cases'
+			),
+			'cmd_string' => array(
 				'cmd',
 				$input,
 				'-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz',
 				'From generic cases'
 			),
-			'base64' => array(
+			'cmd_array' => array(
+				'cmd',
+				array($input, $input),
+				array('-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz', '-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz'),
+				'From generic cases'
+			),
+			'base64_string' => array(
 				'base64',
 				$input,
 				'+/0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+				'From generic cases'
+			),
+			'base64_array' => array(
+				'base64',
+				array($input, $input),
+				array('+/0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', '+/0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'),
 				'From generic cases'
 			),
 			'array' => array(
@@ -370,8 +400,20 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 			),
 			'path_03' => array(
 				'path',
+				'',
+				'',
+				'From generic cases'
+			),
+			'path_04' => array(
+				'path',
 				'/images/system',
 				'/images/system',
+				'From generic cases'
+			),
+			'path_05' => array(
+				'path',
+				array('images/system', '/var/www/html/index.html'),
+				array('images/system', '/var/www/html/index.html'),
 				'From generic cases'
 			),
 			'user_01' => array(
@@ -384,6 +426,30 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'username',
 				'fred',
 				'fred',
+				'From generic cases'
+			),
+			'user_03' => array(
+				'username',
+				array('&<f>r%e\'d', '$user69'),
+				array('fred', '$user69'),
+				'From generic cases'
+			),
+			'trim_01' => array(
+				'trim',
+				'nonbreaking nonbreaking',
+				'nonbreaking nonbreaking',
+				'From generic cases'
+			),
+			'trim_02' => array(
+				'trim',
+				'multi　multi',
+				'multi　multi',
+				'From generic cases'
+			),
+			'trim_03' => array(
+				'trim',
+				array('nonbreaking nonbreaking', 'multi　multi'),
+				array('nonbreaking nonbreaking', 'multi　multi'),
 				'From generic cases'
 			),
 			'string_01' => array(
@@ -414,6 +480,30 @@ class JFilterInputTest extends PHPUnit_Framework_TestCase
 				'string',
 				'this is a "test\' of "odd number" of quotes',
 				'this is a "test\' of "odd number" of quotes',
+				'From generic cases'
+			),
+			'string_array' => array(
+				'string',
+				array('this is a "test\' of "odd number" of quotes', 'executed in an array'),
+				array('this is a "test\' of "odd number" of quotes', 'executed in an array'),
+				'From generic cases'
+			),
+			'raw_01' => array(
+				'raw',
+				'<script type="text/javascript">alert("foo");</script>',
+				'<script type="text/javascript">alert("foo");</script>',
+				'From generic cases'
+			),
+			'raw_02' => array(
+				'raw',
+				'<p>This is a test of a html <b>snippet</b></p>',
+				'<p>This is a test of a html <b>snippet</b></p>',
+				'From generic cases'
+			),
+			'raw_03' => array(
+				'raw',
+				'0123456789',
+				'0123456789',
 				'From generic cases'
 			),
 			'unknown_01' => array(


### PR DESCRIPTION
Updates the CMS Framework package to [framework/filter 1.2.0](https://github.com/joomla-framework/filter/commit/45a504f0cd6fa2312a0260955e957435ca2cedc9) with Composer

Backports Framework changes: Allow arrays of numbers to be processed by clean() and associated tests.
joomla-framework/filter#13
Backports additional changes from [framework/filter 1.2.0](https://github.com/joomla-framework/filter/commit/45a504f0cd6fa2312a0260955e957435ca2cedc9)
- Add array support to most filters
  - Fixes Array to String conversion notices in clean() for most cases
- Updates pcre patterns for numbers
  - Fixes floats case to properly handle exponent type floats rather than just decimal floats
- Adds new general cases to test and verify the array filter functionality
- Code style: fixes missing comma at end of array lists.
  *Fixes PHP7 issues

Testing
https://docs.joomla.org/Testing_Joomla!_patches
Do a general check that the various existing forms in the CMS function as expected.
