### PR TITLE
Add Event onAfterRenderModule

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -255,6 +255,9 @@ abstract class JModuleHelper
 			}
 		}
 
+		// Call the plugins to be able to change the module before rendering it
+		$app->triggerEvent('onAfterRenderModule', array(&$module, &$attribs));
+
 		// Revert the scope
 		$app->scope = $scope;
 


### PR DESCRIPTION
Allows the plugins to catch the module object (content and params) before it renders into the page. This is very useful for design purposes
