### PR TITLE
Add type hinting to JComponentRouterBase

### DIFF
--- a/libraries/cms/component/router/base.php
+++ b/libraries/cms/component/router/base.php
@@ -40,7 +40,7 @@ abstract class JComponentRouterBase implements JComponentRouterInterface
 	 *
 	 * @since   3.4
 	 */
-	public function __construct($app = null, $menu = null)
+	public function __construct(JApplicationCms $app = null, JMenu $menu = null)
 	{
 		if ($app)
 		{

--- a/libraries/cms/component/router/base.php
+++ b/libraries/cms/component/router/base.php
@@ -42,23 +42,8 @@ abstract class JComponentRouterBase implements JComponentRouterInterface
 	 */
 	public function __construct(JApplicationCms $app = null, JMenu $menu = null)
 	{
-		if ($app)
-		{
-			$this->app = $app;
-		}
-		else
-		{
-			$this->app = JFactory::getApplication('site');
-		}
-
-		if ($menu)
-		{
-			$this->menu = $menu;
-		}
-		else
-		{
-			$this->menu = $this->app->getMenu();
-		}
+		$this->app = $app ?: JFactory::getApplication('site');
+		$this->menu = $menu ?: $this->menu = $this->app->getMenu();
 	}
 
 	/**


### PR DESCRIPTION
Add type hinting to `JComponentRouterBase` and simplify assigns 
