### PR TITLE
Update filter order in Update Sites

### DIFF
--- a/administrator/components/com_installer/models/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/models/forms/filter_updatesites.xml
@@ -10,14 +10,6 @@
                 />
 
         <field
-                name="client_id"
-                type="location"
-                onchange="this.form.submit();"
-                >
-            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
-        </field>
-
-        <field
                 name="enabled"
                 type="list"
                 label="COM_PLUGINS_FILTER_PUBLISHED"
@@ -29,6 +21,14 @@
             <option value="1">JPUBLISHED</option>
         </field>
 
+        <field
+                name="client_id"
+                type="location"
+                onchange="this.form.submit();"
+                >
+            <option value="">COM_INSTALLER_VALUE_CLIENT_SELECT</option>
+        </field>
+    
         <field
                 name="type"
                 type="type"


### PR DESCRIPTION
The advanced search filters should be ordered to match the column ordering
This simple cosmetic change swaps the order of the status and location filters in the  Extensions: Update Sites
