### PR TITLE
TinyMCE IPV6 compatibility

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -709,12 +709,11 @@ class PlgEditorTinymce extends JPlugin
 
 		$script = '';
 
-				// Mootools b/c
-		$script .= '
-		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
-		';
-
+		// First line is for Mootools b/c
 		$script .= "
+		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
+		tinymce.suffix = '.min';
+		tinymce.baseURL = '" . JUri::root() . "media/editors/tinymce';
 		tinymce.init({
 		";
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -172,12 +172,12 @@ class PlgEditorTinymce extends JPlugin
 					}
 					else
 					{
-						$content_css = 'content_css : "' . JUri::root() . 'templates/system/css/editor.css",';
+						$content_css = 'content_css : "' . JUri::root(true) . 'templates/system/css/editor.css",';
 					}
 				}
 				else
 				{
-					$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/editor.css",';
+					$content_css = 'content_css : "' . JUri::root(true) . 'templates/' . $template . '/css/editor.css",';
 				}
 			}
 		}

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -13,6 +13,9 @@
 		<filename plugin="tinymce">tinymce.php</filename>
 		<folder>fields</folder>
 	</files>
+	<media destination="editors" folder="media">
+		<folder>tinymce</folder>
+	</media>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.ini</language>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.sys.ini</language>


### PR DESCRIPTION
#### Solves #8708 and also makes tinyMCE friendlier for concatenation scripts

Also the xml needs the media folder to be defined
#### Steps to reproduce the issue

When you load the administrator-Site with a raw IPv6-Adress, it's not possible to write or edit an article. The editor is not loaded and where it should be is only a white surface.
When I load the same administrator-Site with a normel internetadress (like www.testpage.org), everything works fine. 
=> So there is somehow a problem with the url to load the editor.
#### Expected result

There should be an editor in the edit-mode of an article.
#### Actual result

The editor is not loaded in the edit-mode of an article and where it should be is only a white surface.
#### Testing

Apply patch and repeat the above steps. TinyMCE should appear and function properly
