### PR TITLE
Harden CSRF token generation (Fix #8710)

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -219,7 +219,7 @@ class JSession implements IteratorAggregate
 		// Create a token
 		if ($token === null || $forceNew)
 		{
-			$token = $this->_createToken(12);
+			$token = $this->_createToken();
 			$this->set('session.token', $token);
 		}
 

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -766,17 +766,7 @@ class JSession implements IteratorAggregate
 	 */
 	protected function _createToken($length = 32)
 	{
-		static $chars = '0123456789abcdef';
-		$max = strlen($chars) - 1;
-		$token = '';
-		$name = $this->_handler->getName();
-
-		for ($i = 0; $i < $length; ++$i)
-		{
-			$token .= $chars[(rand(0, $max))];
-		}
-
-		return md5($token . $name);
+		return JUserHelper::genRandomPassword($length);
 	}
 
 	/**


### PR DESCRIPTION
Unless there's a reason CSRF tokens cannot contain [A-Z][a-z][0-9] then proxying to `JUserHelper::genRandomPassword()` (which is using `random_bytes()` in its generation of random strings) is good enough here.
### Testing instructions

CSRF validation should still pass on forms
