### PR TITLE
Update random_compat and PHPUnit to latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ Desktop.ini
 /libraries/vendor/paragonie/random_compat/README.md
 /libraries/vendor/paragonie/random_compat/SECURITY.md
 /libraries/vendor/paragonie/random_compat/composer.json
+/libraries/vendor/paragonie/random_compat/phpunit.sh
+/libraries/vendor/paragonie/random_compat/phpunit.xml.dist
 /libraries/vendor/paragonie/random_compat/tests
 /libraries/vendor/phpmailer/phpmailer/docs
 /libraries/vendor/phpmailer/phpmailer/examples

--- a/composer.lock
+++ b/composer.lock
@@ -605,20 +605,23 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "1.0.10",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "2fa50aa2f17066fa74ba00d943e8cee1a98284af"
+                "reference": "e6f80ab77885151908d0ec743689ca700886e8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/2fa50aa2f17066fa74ba00d943e8cee1a98284af",
-                "reference": "2fa50aa2f17066fa74ba00d943e8cee1a98284af",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/e6f80ab77885151908d0ec743689ca700886e8b0",
+                "reference": "e6f80ab77885151908d0ec743689ca700886e8b0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
@@ -646,7 +649,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2015-10-23 13:21:37"
+            "time": "2016-01-29 16:19:52"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -1420,16 +1423,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.11",
+            "version": "4.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bdd199472410fd7e32751f9c814c7e06f2c21bd5"
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bdd199472410fd7e32751f9c814c7e06f2c21bd5",
-                "reference": "bdd199472410fd7e32751f9c814c7e06f2c21bd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea76b17bced0500a28098626b84eda12dbcf119c",
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c",
                 "shasum": ""
             },
             "require": {
@@ -1488,7 +1491,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-07 10:39:46"
+            "time": "2015-12-12 07:45:58"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/libraries/vendor/composer/ClassLoader.php
+++ b/libraries/vendor/composer/ClassLoader.php
@@ -147,7 +147,7 @@ class ClassLoader
      * appending or prepending to the ones previously set for this namespace.
      *
      * @param string       $prefix  The prefix/namespace, with trailing '\\'
-     * @param array|string $paths   The PSR-0 base directories
+     * @param array|string $paths   The PSR-4 base directories
      * @param bool         $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException

--- a/libraries/vendor/composer/autoload_files.php
+++ b/libraries/vendor/composer/autoload_files.php
@@ -7,6 +7,6 @@ $baseDir = dirname(dirname($vendorDir));
 
 return array(
     'e40631d46120a9c38ea139981f8dab26' => $vendorDir . '/ircmaxell/password-compat/lib/password.php',
-    '5255c38a0faeba867671b61dfda6d864' => $vendorDir . '/paragonie/random_compat/lib/random.php',
     'bd9634f2d41831496de0d3dfe4c94881' => $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
+    '5255c38a0faeba867671b61dfda6d864' => $vendorDir . '/paragonie/random_compat/lib/random.php',
 );

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -670,53 +670,6 @@
         ]
     },
     {
-        "name": "paragonie/random_compat",
-        "version": "1.0.10",
-        "version_normalized": "1.0.10.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/paragonie/random_compat.git",
-            "reference": "2fa50aa2f17066fa74ba00d943e8cee1a98284af"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/paragonie/random_compat/zipball/2fa50aa2f17066fa74ba00d943e8cee1a98284af",
-            "reference": "2fa50aa2f17066fa74ba00d943e8cee1a98284af",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.2.0"
-        },
-        "suggest": {
-            "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-        },
-        "time": "2015-10-23 13:21:37",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "files": [
-                "lib/random.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Paragon Initiative Enterprises",
-                "email": "security@paragonie.com",
-                "homepage": "https://paragonie.com"
-            }
-        ],
-        "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-        "keywords": [
-            "csprng",
-            "pseudorandom",
-            "random"
-        ]
-    },
-    {
         "name": "symfony/polyfill-util",
         "version": "v1.0.0",
         "version_normalized": "1.0.0.0",
@@ -933,5 +886,55 @@
         ],
         "description": "lessphp is a compiler for LESS written in PHP.",
         "homepage": "http://leafo.net/lessphp/"
+    },
+    {
+        "name": "paragonie/random_compat",
+        "version": "1.1.6",
+        "version_normalized": "1.1.6.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/paragonie/random_compat.git",
+            "reference": "e6f80ab77885151908d0ec743689ca700886e8b0"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/paragonie/random_compat/zipball/e6f80ab77885151908d0ec743689ca700886e8b0",
+            "reference": "e6f80ab77885151908d0ec743689ca700886e8b0",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.2.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "4.*|5.*"
+        },
+        "suggest": {
+            "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+        },
+        "time": "2016-01-29 16:19:52",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "lib/random.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Paragon Initiative Enterprises",
+                "email": "security@paragonie.com",
+                "homepage": "https://paragonie.com"
+            }
+        ],
+        "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+        "keywords": [
+            "csprng",
+            "pseudorandom",
+            "random"
+        ]
     }
 ]

--- a/libraries/vendor/paragonie/random_compat/lib/random.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random.php
@@ -50,7 +50,7 @@ if (PHP_VERSION_ID < 70000) {
          * In order of preference:
          *   1. Use libsodium if available.
          *   2. fread() /dev/urandom if available (never on Windows)
-         *   3. mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)
+         *   3. mcrypt_create_iv($bytes, MCRYPT_DEV_URANDOM)
          *   4. COM('CAPICOM.Utilities.1')->GetRandom()
          *   5. openssl_random_pseudo_bytes() (absolute last resort)
          * 
@@ -58,25 +58,53 @@ if (PHP_VERSION_ID < 70000) {
          */
         if (extension_loaded('libsodium')) {
             // See random_bytes_libsodium.php
-            require_once $RandomCompatDIR.'/random_bytes_libsodium.php';
+            if (PHP_VERSION_ID >= 50300 && function_exists('\\Sodium\\randombytes_buf')) {
+                require_once $RandomCompatDIR.'/random_bytes_libsodium.php';
+            } elseif (method_exists('Sodium', 'randombytes_buf')) {
+                require_once $RandomCompatDIR.'/random_bytes_libsodium_legacy.php';
+            }
         }
-        if (
-            !function_exists('random_bytes') && 
-            DIRECTORY_SEPARATOR === '/' &&
-            @is_readable('/dev/urandom')
-        ) {
+        /**
+         * Reading directly from /dev/urandom:
+         */
+        if (DIRECTORY_SEPARATOR === '/') {
             // DIRECTORY_SEPARATOR === '/' on Unix-like OSes -- this is a fast
             // way to exclude Windows.
-            // 
-            // Error suppression on is_readable() in case of an open_basedir or 
-            // safe_mode failure. All we care about is whether or not we can 
-            // read it at this point. If the PHP environment is going to panic 
-            // over trying to see if the file can be read in the first place,
-            // that is not helpful to us here.
-            
-            // See random_bytes_dev_urandom.php
-            require_once $RandomCompatDIR.'/random_bytes_dev_urandom.php';
+            $RandomCompatUrandom = true;
+            $RandomCompat_basedir = ini_get('open_basedir');
+            if (!empty($RandomCompat_basedir)) {
+                $RandomCompat_open_basedir = explode(
+                    PATH_SEPARATOR,
+                    strtolower($RandomCompat_basedir)
+                );
+                $RandomCompatUrandom = in_array(
+                    '/dev',
+                    $RandomCompat_open_basedir
+                );
+                $RandomCompat_open_basedir = null;
+            }
+            if (
+                !function_exists('random_bytes') && 
+                $RandomCompatUrandom &&
+                @is_readable('/dev/urandom')
+            ) {
+                // Error suppression on is_readable() in case of an open_basedir
+                // or safe_mode failure. All we care about is whether or not we
+                // can read it at this point. If the PHP environment is going to 
+                // panic over trying to see if the file can be read in the first 
+                // place, that is not helpful to us here.
+
+                // See random_bytes_dev_urandom.php
+                require_once $RandomCompatDIR.'/random_bytes_dev_urandom.php';
+            }
+            // Unset variables after use
+            $RandomCompatUrandom = null;
+            $RandomCompat_basedir = null;
         }
+        
+        /**
+         * mcrypt_create_iv()
+         */
         if (
             !function_exists('random_bytes') &&
             PHP_VERSION_ID >= 50307 &&
@@ -90,17 +118,29 @@ if (PHP_VERSION_ID < 70000) {
             extension_loaded('com_dotnet') &&
             class_exists('COM')
         ) {
-            try {
-                $RandomCompatCOMtest = new COM('CAPICOM.Utilities.1');
-                if (method_exists($RandomCompatCOMtest, 'GetRandom')) {
-                    // See random_bytes_com_dotnet.php
-                    require_once $RandomCompatDIR.'/random_bytes_com_dotnet.php';
+            $RandomCompat_disabled_classes = preg_split(
+                '#\s*,\s*#', 
+                strtolower(ini_get('disable_classes'))
+            );
+            
+            if (!in_array('com', $RandomCompat_disabled_classes)) {
+                try {
+                    $RandomCompatCOMtest = new COM('CAPICOM.Utilities.1');
+                    if (method_exists($RandomCompatCOMtest, 'GetRandom')) {
+                        // See random_bytes_com_dotnet.php
+                        require_once $RandomCompatDIR.'/random_bytes_com_dotnet.php';
+                    }
+                } catch (com_exception $e) {
+                    // Don't try to use it.
                 }
-            } catch (com_exception $e) {
-                // Don't try to use it.
             }
+            $RandomCompat_disabled_classes = null;
             $RandomCompatCOMtest = null;
         }
+        
+        /**
+         * openssl_random_pseudo_bytes()
+         */
         if (
             !function_exists('random_bytes') && 
             extension_loaded('openssl') &&
@@ -110,19 +150,23 @@ if (PHP_VERSION_ID < 70000) {
                     DIRECTORY_SEPARATOR === '/' &&
                     PHP_VERSION_ID >= 50300
                 ) ||
-                // Windows with PHP >= 5.3.4
-                PHP_VERSION_ID >= 50304
+                // Windows with PHP >= 5.4.1
+                PHP_VERSION_ID >= 50401
             )
         ) {
             // See random_bytes_openssl.php
             require_once $RandomCompatDIR.'/random_bytes_openssl.php';
         }
+        
+        /**
+         * throw new Exception
+         */
         if (!function_exists('random_bytes')) {
             /**
              * We don't have any more options, so let's throw an exception right now
              * and hope the developer won't let it fail silently.
              */
-            function random_bytes()
+            function random_bytes($length)
             {
                 throw new Exception(
                     'There is no suitable CSPRNG installed on your system'

--- a/libraries/vendor/paragonie/random_compat/lib/random_bytes_dev_urandom.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random_bytes_dev_urandom.php
@@ -62,16 +62,21 @@ function random_bytes($bytes)
                 $fp = false;
             }
         }
-        /**
-         * stream_set_read_buffer() does not exist in HHVM
-         * 
-         * If we don't set the stream's read buffer to 0, PHP will
-         * internally buffer 8192 bytes, which can waste entropy
-         * 
-         * stream_set_read_buffer returns 0 on success
-         */
-        if (!empty($fp) && function_exists('stream_set_read_buffer')) {
-            stream_set_read_buffer($fp, RANDOM_COMPAT_READ_BUFFER);
+        if (!empty($fp)) {
+            /**
+             * stream_set_read_buffer() does not exist in HHVM
+             * 
+             * If we don't set the stream's read buffer to 0, PHP will
+             * internally buffer 8192 bytes, which can waste entropy
+             * 
+             * stream_set_read_buffer returns 0 on success
+             */
+            if (function_exists('stream_set_read_buffer')) {
+                stream_set_read_buffer($fp, RANDOM_COMPAT_READ_BUFFER);
+            }
+            if (function_exists('stream_set_chunk_size')) {
+                stream_set_chunk_size($fp, RANDOM_COMPAT_READ_BUFFER);
+            }
         }
     }
     try {
@@ -132,6 +137,6 @@ function random_bytes($bytes)
      * If we reach here, PHP has failed us.
      */
     throw new Exception(
-        'PHP failed to generate random data.'
+        'Error reading from source device'
     );
 }

--- a/libraries/vendor/paragonie/random_compat/lib/random_bytes_libsodium.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random_bytes_libsodium.php
@@ -79,6 +79,6 @@ function random_bytes($bytes)
      * If we reach here, PHP has failed us.
      */
     throw new Exception(
-        'PHP failed to generate random data.'
+        'Could not gather sufficient random data'
     );
 }

--- a/libraries/vendor/paragonie/random_compat/lib/random_bytes_mcrypt.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random_bytes_mcrypt.php
@@ -67,6 +67,6 @@ function random_bytes($bytes)
      * If we reach here, PHP has failed us.
      */
     throw new Exception(
-        'PHP failed to generate random data.'
+        'Could not gather sufficient random data'
     );
 }

--- a/libraries/vendor/paragonie/random_compat/lib/random_bytes_openssl.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random_bytes_openssl.php
@@ -71,6 +71,6 @@ function random_bytes($bytes)
      * If we reach here, PHP has failed us.
      */
     throw new Exception(
-        'PHP failed to generate random data.'
+        'Could not gather sufficient random data'
     );
 }


### PR DESCRIPTION
As advertised in title
### Testing instructions

Install still works, the random_compat library has the `random_bytes()` backport which is used in the installer to generate the site's secret.  Or creating a new user without specifying a password should cause a random password to be generated using the same method.
