### PR TITLE
regression: Make tinyMCE's buttons behave

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -983,12 +983,14 @@ class PlgEditorTinymce extends JPlugin
 	/**
 	 * Get the XTD buttons and render them inside tinyMCE
 	 *
+	 * @param   string  $excluded  the buttons that should be hidden
+	 *
 	 * @return array
 	 */
-	private function tinyButtons($buttons)
+	private function tinyButtons($excluded)
 	{
 		// Get the available buttons
-		$buttons = $this->_subject->getButtons($this->_name, $buttons);
+		$buttons = $this->_subject->getButtons($this->_name, $excluded);
 
 		// Init the arrays for the buttons
 		$tinyBtns  = array();

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -786,12 +786,11 @@ class PlgEditorTinymce extends JPlugin
 
 			$script = '';
 
-			// Mootools b/c
-			$script .= '
-		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
-		';
-
+			// First line is for Mootools b/c
 			$script .= "
+		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
+		tinymce.suffix = '.min';
+		tinymce.baseURL = '" . JUri::root() . "media/editors/tinymce';
 		tinymce.init({
 		";
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -46,6 +46,80 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onInit()
 	{
+		JHtml::script($this->_basePath . '/tinymce.min.js', false, false, false, false, false);
+
+		return;
+	}
+
+	/**
+	 * TinyMCE WYSIWYG Editor - get the editor content
+	 *
+	 * @param   string  $editor  The name of the editor
+	 *
+	 * @return  string
+	 */
+	public function onGetContent($editor)
+	{
+		return 'tinyMCE.activeEditor.getContent();';
+	}
+
+	/**
+	 * TinyMCE WYSIWYG Editor - set the editor content
+	 *
+	 * @param   string  $editor  The name of the editor
+	 * @param   string  $html    The html to place in the editor
+	 *
+	 * @return  string
+	 */
+	public function onSetContent($editor, $html)
+	{
+		return 'tinyMCE.activeEditor.setContent(' . $html . ');';
+	}
+
+	/**
+	 * TinyMCE WYSIWYG Editor - copy editor content to form field
+	 *
+	 * @param   string  $editor  The name of the editor
+	 *
+	 * @return  string
+	 */
+	public function onSave($editor)
+	{
+		return 'if (tinyMCE.get("' . $editor . '").isHidden()) {tinyMCE.get("' . $editor . '").show()};';
+	}
+
+	/**
+	 * Inserts html code into the editor
+	 *
+	 * @param   string  $name  The name of the editor
+	 *
+	 * @return  void
+	 *
+	 * @deprecated 3.5 tinyMCE (API v4) will get the content automatically from the text area
+	 */
+	public function onGetInsertMethod($name)
+	{
+		return;
+	}
+
+	/**
+	 * Display the editor area.
+	 *
+	 * @param   string   $name     The name of the editor area.
+	 * @param   string   $content  The content of the field.
+	 * @param   string   $width    The width of the editor area.
+	 * @param   string   $height   The height of the editor area.
+	 * @param   int      $col      The number of columns for the editor area.
+	 * @param   int      $row      The number of rows for the editor area.
+	 * @param   boolean  $buttons  True and the editor buttons will be displayed.
+	 * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
+	 * @param   string   $asset    The object asset
+	 * @param   object   $author   The author.
+	 *
+	 * @return  string
+	 */
+	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
+	{
 		$app      = JFactory::getApplication();
 		$language = JFactory::getLanguage();
 		$mode     = (int) $this->params->get('mode', 1);
@@ -617,9 +691,9 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		// We shall put the XTD button inside tinymce
-		$buttons = $this->tinyButtons();
-		$btnsNames = $buttons['names'];
-		$tinyBtns  = $buttons['script'];
+		$btns = $this->tinyButtons($buttons);
+		$btnsNames = $btns['names'];
+		$tinyBtns  = $btns['script'];
 
 		// Drag and drop Images
 		$allowImgPaste = "false";
@@ -687,8 +761,6 @@ class PlgEditorTinymce extends JPlugin
 		// See if mobileVersion is activated
 		$mobileVersion = $this->params->get('mobile', 0);
 
-		JHtml::script($this->_basePath . '/tinymce.min.js', false, false, false, false, false);
-
 		/**
 		 * Shrink the buttons if not on a mobile or if mobile view is off.
 		 * If mobile view is on force into simple mode and enlarge the buttons
@@ -709,7 +781,7 @@ class PlgEditorTinymce extends JPlugin
 
 		$script = '';
 
-				// Mootools b/c
+		// Mootools b/c
 		$script .= '
 		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
 		';
@@ -767,10 +839,10 @@ class PlgEditorTinymce extends JPlugin
 
 			case 1:
 			default: /* Advanced mode*/
-			$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
-				. "| outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
+				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
+					. "| outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
 
-			$script .= "
+				$script .= "
 			valid_elements : \"$valid_elements\",
 			extended_valid_elements : \"$elements\",
 			invalid_elements : \"$invalid_elements\",
@@ -790,7 +862,7 @@ class PlgEditorTinymce extends JPlugin
 				break;
 
 			case 2: /* Extended mode*/
-			$script .= "
+				$script .= "
 			valid_elements : \"$valid_elements\",
 			extended_valid_elements : \"$elements\",
 			invalid_elements : \"$invalid_elements\",
@@ -839,7 +911,7 @@ class PlgEditorTinymce extends JPlugin
 		if (!empty($btnsNames))
 		{
 			JFactory::getDocument()->addScriptDeclaration(
-					"
+				"
 		function jModalClose() {
 			tinyMCE.activeEditor.windowManager.close();
 		}
@@ -862,78 +934,6 @@ class PlgEditorTinymce extends JPlugin
 		JFactory::getDocument()->addScriptDeclaration($script);
 		JFactory::getDocument()->addStyleDeclaration(".mce-in { padding: 5px 10px !important;}");
 
-		return;
-	}
-
-	/**
-	 * TinyMCE WYSIWYG Editor - get the editor content
-	 *
-	 * @param   string  $editor  The name of the editor
-	 *
-	 * @return  string
-	 */
-	public function onGetContent($editor)
-	{
-		return 'tinyMCE.activeEditor.getContent();';
-	}
-
-	/**
-	 * TinyMCE WYSIWYG Editor - set the editor content
-	 *
-	 * @param   string  $editor  The name of the editor
-	 * @param   string  $html    The html to place in the editor
-	 *
-	 * @return  string
-	 */
-	public function onSetContent($editor, $html)
-	{
-		return 'tinyMCE.activeEditor.setContent(' . $html . ');';
-	}
-
-	/**
-	 * TinyMCE WYSIWYG Editor - copy editor content to form field
-	 *
-	 * @param   string  $editor  The name of the editor
-	 *
-	 * @return  string
-	 */
-	public function onSave($editor)
-	{
-		return 'if (tinyMCE.get("' . $editor . '").isHidden()) {tinyMCE.get("' . $editor . '").show()};';
-	}
-
-	/**
-	 * Inserts html code into the editor
-	 *
-	 * @param   string  $name  The name of the editor
-	 *
-	 * @return  void
-	 *
-	 * @deprecated 3.5 tinyMCE (API v4) will get the content automatically from the text area
-	 */
-	public function onGetInsertMethod($name)
-	{
-		return;
-	}
-
-	/**
-	 * Display the editor area.
-	 *
-	 * @param   string   $name     The name of the editor area.
-	 * @param   string   $content  The content of the field.
-	 * @param   string   $width    The width of the editor area.
-	 * @param   string   $height   The height of the editor area.
-	 * @param   int      $col      The number of columns for the editor area.
-	 * @param   int      $row      The number of rows for the editor area.
-	 * @param   boolean  $buttons  True and the editor buttons will be displayed.
-	 * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
-	 * @param   string   $asset    The object asset
-	 * @param   object   $author   The author.
-	 *
-	 * @return  string
-	 */
-	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
-	{
 		if (empty($id))
 		{
 			$id = $name;
@@ -985,10 +985,10 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return array
 	 */
-	private function tinyButtons()
+	private function tinyButtons($buttons)
 	{
 		// Get the available buttons
-		$buttons = $this->_subject->getButtons($this->_name, true);
+		$buttons = $this->_subject->getButtons($this->_name, $buttons);
 
 		// Init the arrays for the buttons
 		$tinyBtns  = array();

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -225,7 +225,7 @@ class PlgEditorTinymce extends JPlugin
 				// If it is not a URL, assume it is a file name in the current template folder
 				else
 				{
-					$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/' . $content_css_custom . '",';
+					$content_css = 'content_css : "' . JUri::root(true) . '/templates/' . $template . '/css/' . $content_css_custom . '",';
 
 					// Issue warning notice if the file is not found (but pass name to $content_css anyway to avoid TinyMCE error
 					if (!file_exists($templates_path . '/' . $template . '/css/' . $content_css_custom))
@@ -251,12 +251,12 @@ class PlgEditorTinymce extends JPlugin
 						}
 						else
 						{
-							$content_css = 'content_css : "' . JUri::root() . 'templates/system/css/editor.css",';
+							$content_css = 'content_css : "' . JUri::root(true) . '/templates/system/css/editor.css",';
 						}
 					}
 					else
 					{
-						$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/editor.css",';
+						$content_css = 'content_css : "' . JUri::root(true) . '/templates/' . $template . '/css/editor.css",';
 					}
 				}
 			}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -120,678 +120,683 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
 	{
-		$app      = JFactory::getApplication();
-		$language = JFactory::getLanguage();
-		$mode     = (int) $this->params->get('mode', 1);
-		$theme    = 'modern';
+		static $declaredJs = false;
 
-		// List the skins
-		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-
-		// Set the selected skin
-		if ($app->isSite())
+		if (!$declaredJs)
 		{
-			if ((int) $this->params->get('skin', 0) < count($skindirs))
+			$app      = JFactory::getApplication();
+			$language = JFactory::getLanguage();
+			$mode     = (int) $this->params->get('mode', 1);
+			$theme    = 'modern';
+			$idField  = str_replace('[', '_', substr($name, 0, -1));
+
+			// List the skins
+			$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+
+			// Set the selected skin
+			if ($app->isSite())
 			{
-				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin', 0)]) . '",';
-			}
-			else
-			{
-				$skin = 'skin : "lightgray",';
-			}
-		}
-
-		// Set the selected administrator skin
-		elseif ($app->isAdmin())
-		{
-			if ((int) $this->params->get('skin_admin', 0) < count($skindirs))
-			{
-				$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin_admin', 0)]) . '",';
-			}
-			else
-			{
-				$skin = 'skin : "lightgray",';
-			}
-		}
-
-		$entity_encoding = $this->params->get('entity_encoding', 'raw');
-		$langMode        = $this->params->get('lang_mode', 0);
-		$langPrefix      = $this->params->get('lang_code', 'en');
-
-		if ($langMode)
-		{
-			if (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . $language->getTag() . ".js"))
-			{
-				$langPrefix = $language->getTag();
-			}
-			elseif (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . ".js"))
-			{
-				$langPrefix = substr($language->getTag(), 0, strpos($language->getTag(), '-'));
-			}
-			else
-			{
-				$langPrefix = "en";
-			}
-		}
-
-		$text_direction = 'ltr';
-
-		if ($language->isRtl())
-		{
-			$text_direction = 'rtl';
-		}
-
-		$use_content_css    = $this->params->get('content_css', 1);
-		$content_css_custom = $this->params->get('content_css_custom', '');
-
-		/*
-		 * Lets get the default template for the site application
-		 */
-		$db    = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('template')
-			->from('#__template_styles')
-			->where('client_id=0 AND home=' . $db->quote('1'));
-
-		$db->setQuery($query);
-		try
-		{
-			$template = $db->loadResult();
-		}
-		catch (RuntimeException $e)
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
-
-			return;
-		}
-
-		$content_css    = '';
-		$templates_path = JPATH_SITE . '/templates';
-
-		// Loading of css file for 'styles' dropdown
-		if ($content_css_custom)
-		{
-			// If URL, just pass it to $content_css
-			if (strpos($content_css_custom, 'http') !== false)
-			{
-				$content_css = 'content_css : "' . $content_css_custom . '",';
-			}
-
-			// If it is not a URL, assume it is a file name in the current template folder
-			else
-			{
-				$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/' . $content_css_custom . '",';
-
-				// Issue warning notice if the file is not found (but pass name to $content_css anyway to avoid TinyMCE error
-				if (!file_exists($templates_path . '/' . $template . '/css/' . $content_css_custom))
+				if ((int) $this->params->get('skin', 0) < count($skindirs))
 				{
-					$msg = sprintf(JText::_('PLG_TINY_ERR_CUSTOMCSSFILENOTPRESENT'), $content_css_custom);
-					JLog::add($msg, JLog::WARNING, 'jerror');
-				}
-			}
-		}
-		else
-		{
-			// Process when use_content_css is Yes and no custom file given
-			if ($use_content_css)
-			{
-				// First check templates folder for default template
-				// if no editor.css file in templates folder, check system template folder
-				if (!file_exists($templates_path . '/' . $template . '/css/editor.css'))
-				{
-					// If no editor.css file in system folder, show alert
-					if (!file_exists($templates_path . '/system/css/editor.css'))
-					{
-						JLog::add(JText::_('PLG_TINY_ERR_EDITORCSSFILENOTPRESENT'), JLog::WARNING, 'jerror');
-					}
-					else
-					{
-						$content_css = 'content_css : "' . JUri::root() . 'templates/system/css/editor.css",';
-					}
+					$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin', 0)]) . '",';
 				}
 				else
 				{
-					$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/editor.css",';
+					$skin = 'skin : "lightgray",';
 				}
 			}
-		}
 
-		$relative_urls = $this->params->get('relative_urls', '1');
-
-		if ($relative_urls)
-		{
-			// Relative
-			$relative_urls = "true";
-		}
-		else
-		{
-			// Absolute
-			$relative_urls = "false";
-		}
-
-		$newlines = $this->params->get('newlines', 0);
-
-		if ($newlines)
-		{
-			// Break
-			$forcenewline = "force_br_newlines : true, force_p_newlines : false, forced_root_block : '',";
-		}
-		else
-		{
-			// Paragraph
-			$forcenewline = "force_br_newlines : false, force_p_newlines : true, forced_root_block : 'p',";
-		}
-
-		$invalid_elements  = $this->params->get('invalid_elements', 'script,applet,iframe');
-		$extended_elements = $this->params->get('extended_elements', '');
-		$valid_elements    = $this->params->get('valid_elements', '');
-
-		// Advanced Options
-		$access = JFactory::getUser()->getAuthorisedViewLevels();
-
-		// Flip for performance, so we can direct check for the key isset($access[$key])
-		$access = array_flip($access);
-
-		$html_height = $this->params->get('html_height', '550');
-		$html_width  = $this->params->get('html_width', '');
-
-		if ($html_width == 750)
-		{
-			$html_width = '';
-		}
-
-		// Image advanced options
-		$image_advtab = $this->params->get('image_advtab', 1);
-
-		if (isset($access[$image_advtab]))
-		{
-			$image_advtab = "true";
-		}
-		else
-		{
-			$image_advtab = "false";
-		}
-
-		// The param is true for vertical resizing only, false or both
-		$resizing = $this->params->get('resizing', '1');
-		$resize_horizontal = $this->params->get('resize_horizontal', '1');
-
-		if ($resizing || $resizing == 'true')
-		{
-			if ($resize_horizontal || $resize_horizontal == 'true')
+			// Set the selected administrator skin
+			elseif ($app->isAdmin())
 			{
-				$resizing = 'resize: "both",';
-			}
-			else
-			{
-				$resizing = 'resize: true,';
-			}
-		}
-		else
-		{
-			$resizing = 'resize: false,';
-		}
-
-		$toolbar1_add   = array();
-		$toolbar2_add   = array();
-		$toolbar3_add   = array();
-		$toolbar4_add   = array();
-		$elements       = array();
-		$plugins        = array(
-			'autolink',
-			'lists',
-			'image',
-			'charmap',
-			'print',
-			'preview',
-			'anchor',
-			'pagebreak',
-			'code',
-			'save',
-			'textcolor',
-			'colorpicker',
-			'importcss');
-		$toolbar1_add[] = 'bold';
-		$toolbar1_add[] = 'italic';
-		$toolbar1_add[] = 'underline';
-		$toolbar1_add[] = 'strikethrough';
-
-		// Alignment buttons
-		$alignment = $this->params->get('alignment', 1);
-
-		if (isset($access[$alignment]))
-		{
-			$toolbar1_add[] = '|';
-			$toolbar1_add[] = 'alignleft';
-			$toolbar1_add[] = 'aligncenter';
-			$toolbar1_add[] = 'alignright';
-			$toolbar1_add[] = 'alignjustify';
-		}
-
-		$toolbar1_add[] = '|';
-		$toolbar1_add[] = 'styleselect';
-		$toolbar1_add[] = '|';
-		$toolbar1_add[] = 'formatselect';
-
-		// Fonts
-		$fonts = $this->params->get('fonts', 1);
-
-		if (isset($access[$fonts]))
-		{
-			$toolbar1_add[] = 'fontselect';
-			$toolbar1_add[] = 'fontsizeselect';
-		}
-
-		// Search & replace
-		$searchreplace = $this->params->get('searchreplace', 1);
-
-		if (isset($access[$searchreplace]))
-		{
-			$plugins[]      = 'searchreplace';
-			$toolbar2_add[] = 'searchreplace';
-		}
-
-		$toolbar2_add[] = '|';
-		$toolbar2_add[] = 'bullist';
-		$toolbar2_add[] = 'numlist';
-		$toolbar2_add[] = '|';
-		$toolbar2_add[] = 'outdent';
-		$toolbar2_add[] = 'indent';
-		$toolbar2_add[] = '|';
-		$toolbar2_add[] = 'undo';
-		$toolbar2_add[] = 'redo';
-		$toolbar2_add[] = '|';
-
-		// Insert date and/or time plugin
-		$insertdate = $this->params->get('insertdate', 1);
-
-		if (isset($access[$insertdate]))
-		{
-			$plugins[]      = 'insertdatetime';
-			$toolbar4_add[] = 'inserttime';
-		}
-
-		// Link plugin
-		$link = $this->params->get('link', 1);
-
-		if (isset($access[$link]))
-		{
-			$plugins[]      = 'link';
-			$toolbar2_add[] = 'link';
-			$toolbar2_add[] = 'unlink';
-		}
-
-		$toolbar2_add[] = 'anchor';
-		$toolbar2_add[] = 'image';
-		$toolbar2_add[] = '|';
-		$toolbar2_add[] = 'code';
-
-		// Colors
-		$colors = $this->params->get('colors', 1);
-
-		if (isset($access[$colors]))
-		{
-			$toolbar2_add[] = '|';
-			$toolbar2_add[] = 'forecolor,backcolor';
-		}
-
-		// Fullscreen
-		$fullscreen = $this->params->get('fullscreen', 1);
-
-		if (isset($access[$fullscreen]))
-		{
-			$plugins[]      = 'fullscreen';
-			$toolbar2_add[] = '|';
-			$toolbar2_add[] = 'fullscreen';
-		}
-
-		// Table
-		$table = $this->params->get('table', 1);
-
-		if (isset($access[$table]))
-		{
-			$plugins[]      = 'table';
-			$toolbar3_add[] = 'table';
-			$toolbar3_add[] = '|';
-		}
-
-		$toolbar3_add[] = 'subscript';
-		$toolbar3_add[] = 'superscript';
-		$toolbar3_add[] = '|';
-		$toolbar3_add[] = 'charmap';
-
-		// Emotions
-		$smilies = $this->params->get('smilies', 1);
-
-		if (isset($access[$smilies]))
-		{
-			$plugins[]      = 'emoticons';
-			$toolbar3_add[] = 'emoticons';
-		}
-
-		// Media plugin
-		$media = $this->params->get('media', 1);
-
-		if (isset($access[$media]))
-		{
-			$plugins[]      = 'media';
-			$toolbar3_add[] = 'media';
-		}
-
-		// Horizontal line
-		$hr = $this->params->get('hr', 1);
-
-		if (isset($access[$hr]))
-		{
-			$plugins[]      = 'hr';
-			$elements[]     = 'hr[id|title|alt|class|width|size|noshade]';
-			$toolbar3_add[] = 'hr';
-		}
-		else
-		{
-			$elements[] = 'hr[id|class|title|alt]';
-		}
-
-		// RTL/LTR buttons
-		$directionality = $this->params->get('directionality', 1);
-
-		if (isset($access[$directionality]))
-		{
-			$plugins[] = 'directionality';
-			$toolbar3_add[] = 'ltr rtl';
-		}
-
-		if ($extended_elements != "")
-		{
-			$elements = explode(',', $extended_elements);
-		}
-
-		$toolbar4_add[] = 'cut';
-		$toolbar4_add[] = 'copy';
-
-		// Paste
-		$paste = $this->params->get('paste', 1);
-
-		if (isset($access[$paste]))
-		{
-			$plugins[]      = 'paste';
-			$toolbar4_add[] = 'paste';
-		}
-
-		$toolbar4_add[] = '|';
-
-		// Visualchars
-		$visualchars = $this->params->get('visualchars', 1);
-
-		if (isset($access[$visualchars]))
-		{
-			$plugins[]      = 'visualchars';
-			$toolbar4_add[] = 'visualchars';
-		}
-
-		// Visualblocks
-		$visualblocks = $this->params->get('visualblocks', 1);
-
-		if (isset($access[$visualblocks]))
-		{
-			$plugins[]      = 'visualblocks';
-			$toolbar4_add[] = 'visualblocks';
-		}
-
-		// Non-breaking
-		$nonbreaking = $this->params->get('nonbreaking', 1);
-
-		if (isset($access[$nonbreaking]))
-		{
-			$plugins[]      = 'nonbreaking';
-			$toolbar4_add[] = 'nonbreaking';
-		}
-
-		// Blockquote
-		$blockquote = $this->params->get('blockquote', 1);
-
-		if (isset($access[$blockquote]))
-		{
-			$toolbar4_add[] = 'blockquote';
-		}
-
-		// Template
-		$template = $this->params->get('template', 1);
-
-		if (isset($access[$template]))
-		{
-			$plugins[]      = 'template';
-			$toolbar4_add[] = 'template';
-
-			// Note this check for the template_list.js file will be removed in Joomla 4.0
-			if (is_file(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js"))
-			{
-				// If using the legacy file we need to include and input the files the new way
-				$str = file_get_contents(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js");
-
-				// Find from one [ to the last ]
-				preg_match_all('/\[.*\]/', $str, $matches);
-
-				$templates = "templates: [";
-
-				// Set variables
-				foreach ($matches['0'] as $match)
+				if ((int) $this->params->get('skin_admin', 0) < count($skindirs))
 				{
-					preg_match_all('/\".*\"/', $match, $values);
-					$result = trim($values["0"]["0"], '"');
-					$final_result = explode(',', $result);
-					$templates .= "{title: '" . trim($final_result['0'], ' " ') . "', description: '"
-						. trim($final_result['2'], ' " ') . "', url: '" . JUri::root() . trim($final_result['1'], ' " ') . "'},";
+					$skin = 'skin : "' . basename($skindirs[(int) $this->params->get('skin_admin', 0)]) . '",';
+				}
+				else
+				{
+					$skin = 'skin : "lightgray",';
+				}
+			}
+
+			$entity_encoding = $this->params->get('entity_encoding', 'raw');
+			$langMode        = $this->params->get('lang_mode', 0);
+			$langPrefix      = $this->params->get('lang_code', 'en');
+
+			if ($langMode)
+			{
+				if (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . $language->getTag() . ".js"))
+				{
+					$langPrefix = $language->getTag();
+				}
+				elseif (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . ".js"))
+				{
+					$langPrefix = substr($language->getTag(), 0, strpos($language->getTag(), '-'));
+				}
+				else
+				{
+					$langPrefix = "en";
+				}
+			}
+
+			$text_direction = 'ltr';
+
+			if ($language->isRtl())
+			{
+				$text_direction = 'rtl';
+			}
+
+			$use_content_css    = $this->params->get('content_css', 1);
+			$content_css_custom = $this->params->get('content_css_custom', '');
+
+			/*
+			 * Lets get the default template for the site application
+			 */
+			$db    = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('template')
+				->from('#__template_styles')
+				->where('client_id=0 AND home=' . $db->quote('1'));
+
+			$db->setQuery($query);
+			try
+			{
+				$template = $db->loadResult();
+			}
+			catch (RuntimeException $e)
+			{
+				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+
+				return;
+			}
+
+			$content_css    = '';
+			$templates_path = JPATH_SITE . '/templates';
+
+			// Loading of css file for 'styles' dropdown
+			if ($content_css_custom)
+			{
+				// If URL, just pass it to $content_css
+				if (strpos($content_css_custom, 'http') !== false)
+				{
+					$content_css = 'content_css : "' . $content_css_custom . '",';
 				}
 
-				$templates .= "],";
-			}
-			else
-			{
-				$templates = 'templates: [';
-
-				foreach (glob(JPATH_ROOT . '/media/editors/tinymce/templates/*.html') as $filename)
+				// If it is not a URL, assume it is a file name in the current template folder
+				else
 				{
-					$filename = basename($filename, '.html');
+					$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/' . $content_css_custom . '",';
 
-					if ($filename !== 'index')
+					// Issue warning notice if the file is not found (but pass name to $content_css anyway to avoid TinyMCE error
+					if (!file_exists($templates_path . '/' . $template . '/css/' . $content_css_custom))
 					{
-						$lang = JFactory::getLanguage();
-						$title = $filename;
-						$description = ' ';
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
-						{
-							$title = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
-						}
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
-						{
-							$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
-						}
-
-						$templates .= '{title: \'' . $title . '\', description: \'' . $description . '\', url:\''
-							. JUri::root() . 'media/editors/tinymce/templates/' . $filename . '.html\'},';
+						$msg = sprintf(JText::_('PLG_TINY_ERR_CUSTOMCSSFILENOTPRESENT'), $content_css_custom);
+						JLog::add($msg, JLog::WARNING, 'jerror');
 					}
 				}
-
-				$templates .= '],';
 			}
-		}
-		else
-		{
-			$templates = '';
-		}
+			else
+			{
+				// Process when use_content_css is Yes and no custom file given
+				if ($use_content_css)
+				{
+					// First check templates folder for default template
+					// if no editor.css file in templates folder, check system template folder
+					if (!file_exists($templates_path . '/' . $template . '/css/editor.css'))
+					{
+						// If no editor.css file in system folder, show alert
+						if (!file_exists($templates_path . '/system/css/editor.css'))
+						{
+							JLog::add(JText::_('PLG_TINY_ERR_EDITORCSSFILENOTPRESENT'), JLog::WARNING, 'jerror');
+						}
+						else
+						{
+							$content_css = 'content_css : "' . JUri::root() . 'templates/system/css/editor.css",';
+						}
+					}
+					else
+					{
+						$content_css = 'content_css : "' . JUri::root() . 'templates/' . $template . '/css/editor.css",';
+					}
+				}
+			}
 
-		// Print
-		$print = $this->params->get('print', 1);
+			$relative_urls = $this->params->get('relative_urls', '1');
 
-		if (isset($access[$print]))
-		{
-			$plugins[] = 'print';
+			if ($relative_urls)
+			{
+				// Relative
+				$relative_urls = "true";
+			}
+			else
+			{
+				// Absolute
+				$relative_urls = "false";
+			}
+
+			$newlines = $this->params->get('newlines', 0);
+
+			if ($newlines)
+			{
+				// Break
+				$forcenewline = "force_br_newlines : true, force_p_newlines : false, forced_root_block : '',";
+			}
+			else
+			{
+				// Paragraph
+				$forcenewline = "force_br_newlines : false, force_p_newlines : true, forced_root_block : 'p',";
+			}
+
+			$invalid_elements  = $this->params->get('invalid_elements', 'script,applet,iframe');
+			$extended_elements = $this->params->get('extended_elements', '');
+			$valid_elements    = $this->params->get('valid_elements', '');
+
+			// Advanced Options
+			$access = JFactory::getUser()->getAuthorisedViewLevels();
+
+			// Flip for performance, so we can direct check for the key isset($access[$key])
+			$access = array_flip($access);
+
+			$html_height = $this->params->get('html_height', '550');
+			$html_width  = $this->params->get('html_width', '');
+
+			if ($html_width == 750)
+			{
+				$html_width = '';
+			}
+
+			// Image advanced options
+			$image_advtab = $this->params->get('image_advtab', 1);
+
+			if (isset($access[$image_advtab]))
+			{
+				$image_advtab = "true";
+			}
+			else
+			{
+				$image_advtab = "false";
+			}
+
+			// The param is true for vertical resizing only, false or both
+			$resizing          = $this->params->get('resizing', '1');
+			$resize_horizontal = $this->params->get('resize_horizontal', '1');
+
+			if ($resizing || $resizing == 'true')
+			{
+				if ($resize_horizontal || $resize_horizontal == 'true')
+				{
+					$resizing = 'resize: "both",';
+				}
+				else
+				{
+					$resizing = 'resize: true,';
+				}
+			}
+			else
+			{
+				$resizing = 'resize: false,';
+			}
+
+			$toolbar1_add   = array();
+			$toolbar2_add   = array();
+			$toolbar3_add   = array();
+			$toolbar4_add   = array();
+			$elements       = array();
+			$plugins        = array(
+				'autolink',
+				'lists',
+				'image',
+				'charmap',
+				'print',
+				'preview',
+				'anchor',
+				'pagebreak',
+				'code',
+				'save',
+				'textcolor',
+				'colorpicker',
+				'importcss');
+			$toolbar1_add[] = 'bold';
+			$toolbar1_add[] = 'italic';
+			$toolbar1_add[] = 'underline';
+			$toolbar1_add[] = 'strikethrough';
+
+			// Alignment buttons
+			$alignment = $this->params->get('alignment', 1);
+
+			if (isset($access[$alignment]))
+			{
+				$toolbar1_add[] = '|';
+				$toolbar1_add[] = 'alignleft';
+				$toolbar1_add[] = 'aligncenter';
+				$toolbar1_add[] = 'alignright';
+				$toolbar1_add[] = 'alignjustify';
+			}
+
+			$toolbar1_add[] = '|';
+			$toolbar1_add[] = 'styleselect';
+			$toolbar1_add[] = '|';
+			$toolbar1_add[] = 'formatselect';
+
+			// Fonts
+			$fonts = $this->params->get('fonts', 1);
+
+			if (isset($access[$fonts]))
+			{
+				$toolbar1_add[] = 'fontselect';
+				$toolbar1_add[] = 'fontsizeselect';
+			}
+
+			// Search & replace
+			$searchreplace = $this->params->get('searchreplace', 1);
+
+			if (isset($access[$searchreplace]))
+			{
+				$plugins[]      = 'searchreplace';
+				$toolbar2_add[] = 'searchreplace';
+			}
+
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'bullist';
+			$toolbar2_add[] = 'numlist';
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'outdent';
+			$toolbar2_add[] = 'indent';
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'undo';
+			$toolbar2_add[] = 'redo';
+			$toolbar2_add[] = '|';
+
+			// Insert date and/or time plugin
+			$insertdate = $this->params->get('insertdate', 1);
+
+			if (isset($access[$insertdate]))
+			{
+				$plugins[]      = 'insertdatetime';
+				$toolbar4_add[] = 'inserttime';
+			}
+
+			// Link plugin
+			$link = $this->params->get('link', 1);
+
+			if (isset($access[$link]))
+			{
+				$plugins[]      = 'link';
+				$toolbar2_add[] = 'link';
+				$toolbar2_add[] = 'unlink';
+			}
+
+			$toolbar2_add[] = 'anchor';
+			$toolbar2_add[] = 'image';
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'code';
+
+			// Colors
+			$colors = $this->params->get('colors', 1);
+
+			if (isset($access[$colors]))
+			{
+				$toolbar2_add[] = '|';
+				$toolbar2_add[] = 'forecolor,backcolor';
+			}
+
+			// Fullscreen
+			$fullscreen = $this->params->get('fullscreen', 1);
+
+			if (isset($access[$fullscreen]))
+			{
+				$plugins[]      = 'fullscreen';
+				$toolbar2_add[] = '|';
+				$toolbar2_add[] = 'fullscreen';
+			}
+
+			// Table
+			$table = $this->params->get('table', 1);
+
+			if (isset($access[$table]))
+			{
+				$plugins[]      = 'table';
+				$toolbar3_add[] = 'table';
+				$toolbar3_add[] = '|';
+			}
+
+			$toolbar3_add[] = 'subscript';
+			$toolbar3_add[] = 'superscript';
+			$toolbar3_add[] = '|';
+			$toolbar3_add[] = 'charmap';
+
+			// Emotions
+			$smilies = $this->params->get('smilies', 1);
+
+			if (isset($access[$smilies]))
+			{
+				$plugins[]      = 'emoticons';
+				$toolbar3_add[] = 'emoticons';
+			}
+
+			// Media plugin
+			$media = $this->params->get('media', 1);
+
+			if (isset($access[$media]))
+			{
+				$plugins[]      = 'media';
+				$toolbar3_add[] = 'media';
+			}
+
+			// Horizontal line
+			$hr = $this->params->get('hr', 1);
+
+			if (isset($access[$hr]))
+			{
+				$plugins[]      = 'hr';
+				$elements[]     = 'hr[id|title|alt|class|width|size|noshade]';
+				$toolbar3_add[] = 'hr';
+			}
+			else
+			{
+				$elements[] = 'hr[id|class|title|alt]';
+			}
+
+			// RTL/LTR buttons
+			$directionality = $this->params->get('directionality', 1);
+
+			if (isset($access[$directionality]))
+			{
+				$plugins[]      = 'directionality';
+				$toolbar3_add[] = 'ltr rtl';
+			}
+
+			if ($extended_elements != "")
+			{
+				$elements = explode(',', $extended_elements);
+			}
+
+			$toolbar4_add[] = 'cut';
+			$toolbar4_add[] = 'copy';
+
+			// Paste
+			$paste = $this->params->get('paste', 1);
+
+			if (isset($access[$paste]))
+			{
+				$plugins[]      = 'paste';
+				$toolbar4_add[] = 'paste';
+			}
+
 			$toolbar4_add[] = '|';
-			$toolbar4_add[] = 'print';
-			$toolbar4_add[] = 'preview';
-		}
 
-		// Spellchecker
-		$spell = $this->params->get('spell', 0);
+			// Visualchars
+			$visualchars = $this->params->get('visualchars', 1);
 
-		if (isset($access[$spell]))
-		{
-			$plugins[]      = 'spellchecker';
-			$toolbar4_add[] = '|';
-			$toolbar4_add[] = 'spellchecker';
-		}
-
-		// Wordcount
-		$wordcount = $this->params->get('wordcount', 1);
-
-		if (isset($access[$wordcount]))
-		{
-			$plugins[] = 'wordcount';
-		}
-
-		// Advlist
-		$advlist = $this->params->get('advlist', 1);
-
-		if (isset($access[$advlist]))
-		{
-			$plugins[] = 'advlist';
-		}
-
-		// Autosave
-		$autosave = $this->params->get('autosave', 1);
-
-		if (isset($access[$autosave]))
-		{
-			$plugins[] = 'autosave';
-		}
-
-		// Context menu
-		$contextmenu = $this->params->get('contextmenu', 1);
-
-		if (isset($access[$contextmenu]))
-		{
-			$plugins[] = 'contextmenu';
-		}
-
-		$custom_plugin = $this->params->get('custom_plugin', '');
-
-		if ($custom_plugin != "")
-		{
-			$plugins[] = $custom_plugin;
-		}
-
-		$custom_button = $this->params->get('custom_button', '');
-
-		if ($custom_button != "")
-		{
-			$toolbar4_add[] = $custom_button;
-		}
-
-		// We shall put the XTD button inside tinymce
-		$btns = $this->tinyButtons($buttons);
-		$btnsNames = $btns['names'];
-		$tinyBtns  = $btns['script'];
-
-		// Drag and drop Images
-		$allowImgPaste = "false";
-		$dragDropPlg   = '';
-		$dragdrop      = $this->params->get('drag_drop', 1);
-		$user          = JFactory::getUser();
-
-		if ($dragdrop && $user->authorise('core.create', 'com_media'))
-		{
-			$allowImgPaste = "true";
-			$isSubDir      = '';
-			$session       = JFactory::getSession();
-			$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
-				. $session->getName() . '=' . $session->getId()
-				. '&' . JSession::getFormToken() . '=1'
-				. '&asset=image&format=json';
-
-			if (JFactory::getApplication()->isSite())
+			if (isset($access[$visualchars]))
 			{
-				$uploadUrl = htmlentities($uploadUrl, null, 'UTF-8', null);
+				$plugins[]      = 'visualchars';
+				$toolbar4_add[] = 'visualchars';
 			}
 
-			// Is Joomla installed in subdirectory
-			if (JUri::root(true) != '/')
+			// Visualblocks
+			$visualblocks = $this->params->get('visualblocks', 1);
+
+			if (isset($access[$visualblocks]))
 			{
-				$isSubDir = JUri::root(true);
+				$plugins[]      = 'visualblocks';
+				$toolbar4_add[] = 'visualblocks';
 			}
 
-			// Get specific path
-			$tempPath = $this->params->get('path', '');
+			// Non-breaking
+			$nonbreaking = $this->params->get('nonbreaking', 1);
 
-			if (!empty($tempPath))
+			if (isset($access[$nonbreaking]))
 			{
-				$tempPath = rtrim($tempPath, '/');
-				$tempPath = ltrim($tempPath, '/');
+				$plugins[]      = 'nonbreaking';
+				$toolbar4_add[] = 'nonbreaking';
 			}
 
-			$dragDropPlg = 'jdragdrop';
+			// Blockquote
+			$blockquote = $this->params->get('blockquote', 1);
 
-			JText::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
-			JFactory::getDocument()->addScriptDeclaration(
-				"
+			if (isset($access[$blockquote]))
+			{
+				$toolbar4_add[] = 'blockquote';
+			}
+
+			// Template
+			$template = $this->params->get('template', 1);
+
+			if (isset($access[$template]))
+			{
+				$plugins[]      = 'template';
+				$toolbar4_add[] = 'template';
+
+				// Note this check for the template_list.js file will be removed in Joomla 4.0
+				if (is_file(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js"))
+				{
+					// If using the legacy file we need to include and input the files the new way
+					$str = file_get_contents(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js");
+
+					// Find from one [ to the last ]
+					preg_match_all('/\[.*\]/', $str, $matches);
+
+					$templates = "templates: [";
+
+					// Set variables
+					foreach ($matches['0'] as $match)
+					{
+						preg_match_all('/\".*\"/', $match, $values);
+						$result       = trim($values["0"]["0"], '"');
+						$final_result = explode(',', $result);
+						$templates .= "{title: '" . trim($final_result['0'], ' " ') . "', description: '"
+							. trim($final_result['2'], ' " ') . "', url: '" . JUri::root() . trim($final_result['1'], ' " ') . "'},";
+					}
+
+					$templates .= "],";
+				}
+				else
+				{
+					$templates = 'templates: [';
+
+					foreach (glob(JPATH_ROOT . '/media/editors/tinymce/templates/*.html') as $filename)
+					{
+						$filename = basename($filename, '.html');
+
+						if ($filename !== 'index')
+						{
+							$lang        = JFactory::getLanguage();
+							$title       = $filename;
+							$description = ' ';
+
+							if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
+							{
+								$title = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
+							}
+
+							if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
+							{
+								$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
+							}
+
+							$templates .= '{title: \'' . $title . '\', description: \'' . $description . '\', url:\''
+								. JUri::root() . 'media/editors/tinymce/templates/' . $filename . '.html\'},';
+						}
+					}
+
+					$templates .= '],';
+				}
+			}
+			else
+			{
+				$templates = '';
+			}
+
+			// Print
+			$print = $this->params->get('print', 1);
+
+			if (isset($access[$print]))
+			{
+				$plugins[]      = 'print';
+				$toolbar4_add[] = '|';
+				$toolbar4_add[] = 'print';
+				$toolbar4_add[] = 'preview';
+			}
+
+			// Spellchecker
+			$spell = $this->params->get('spell', 0);
+
+			if (isset($access[$spell]))
+			{
+				$plugins[]      = 'spellchecker';
+				$toolbar4_add[] = '|';
+				$toolbar4_add[] = 'spellchecker';
+			}
+
+			// Wordcount
+			$wordcount = $this->params->get('wordcount', 1);
+
+			if (isset($access[$wordcount]))
+			{
+				$plugins[] = 'wordcount';
+			}
+
+			// Advlist
+			$advlist = $this->params->get('advlist', 1);
+
+			if (isset($access[$advlist]))
+			{
+				$plugins[] = 'advlist';
+			}
+
+			// Autosave
+			$autosave = $this->params->get('autosave', 1);
+
+			if (isset($access[$autosave]))
+			{
+				$plugins[] = 'autosave';
+			}
+
+			// Context menu
+			$contextmenu = $this->params->get('contextmenu', 1);
+
+			if (isset($access[$contextmenu]))
+			{
+				$plugins[] = 'contextmenu';
+			}
+
+			$custom_plugin = $this->params->get('custom_plugin', '');
+
+			if ($custom_plugin != "")
+			{
+				$plugins[] = $custom_plugin;
+			}
+
+			$custom_button = $this->params->get('custom_button', '');
+
+			if ($custom_button != "")
+			{
+				$toolbar4_add[] = $custom_button;
+			}
+
+			// We shall put the XTD button inside tinymce
+			$btns      = $this->tinyButtons($buttons);
+			$btnsNames = $btns['names'];
+			$tinyBtns  = $btns['script'];
+
+			// Drag and drop Images
+			$allowImgPaste = "false";
+			$dragDropPlg   = '';
+			$dragdrop      = $this->params->get('drag_drop', 1);
+			$user          = JFactory::getUser();
+
+			if ($dragdrop && $user->authorise('core.create', 'com_media'))
+			{
+				$allowImgPaste = "true";
+				$isSubDir      = '';
+				$session       = JFactory::getSession();
+				$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
+					. $session->getName() . '=' . $session->getId()
+					. '&' . JSession::getFormToken() . '=1'
+					. '&asset=image&format=json';
+
+				if (JFactory::getApplication()->isSite())
+				{
+					$uploadUrl = htmlentities($uploadUrl, null, 'UTF-8', null);
+				}
+
+				// Is Joomla installed in subdirectory
+				if (JUri::root(true) != '/')
+				{
+					$isSubDir = JUri::root(true);
+				}
+
+				// Get specific path
+				$tempPath = $this->params->get('path', '');
+
+				if (!empty($tempPath))
+				{
+					$tempPath = rtrim($tempPath, '/');
+					$tempPath = ltrim($tempPath, '/');
+				}
+
+				$dragDropPlg = 'jdragdrop';
+
+				JText::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
+				JFactory::getDocument()->addScriptDeclaration(
+					"
 		var setCustomDir    = '" . $isSubDir . "';
 		var mediaUploadPath = '" . $tempPath . "';
 		var uploadUri       = '" . $uploadUrl . "';
 				"
-			);
-		}
+				);
+			}
 
-		// Prepare config variables
-		$plugins  = implode(',', $plugins);
-		$elements = implode(',', $elements);
+			// Prepare config variables
+			$plugins  = implode(',', $plugins);
+			$elements = implode(',', $elements);
 
-		// Prepare config variables
-		$toolbar1 = implode(' ', $toolbar1_add) . ' | '
-			. implode(' ', $toolbar2_add) . ' | '
-			. implode(' ', $toolbar3_add) . ' | '
-			. implode(' ', $toolbar4_add) . ' | '
-			. implode(" | ", $btnsNames);
-		$toolbar5 = implode(" | ", $btnsNames);
+			// Prepare config variables
+			$toolbar1 = implode(' ', $toolbar1_add) . ' | '
+				. implode(' ', $toolbar2_add) . ' | '
+				. implode(' ', $toolbar3_add) . ' | '
+				. implode(' ', $toolbar4_add) . ' | '
+				. implode(" | ", $btnsNames);
+			$toolbar5 = implode(" | ", $btnsNames);
 
-		// The buttons script
-		$tinyBtns = implode("; ", $tinyBtns);
+			// The buttons script
+			$tinyBtns = implode("; ", $tinyBtns);
 
-		// See if mobileVersion is activated
-		$mobileVersion = $this->params->get('mobile', 0);
+			// See if mobileVersion is activated
+			$mobileVersion = $this->params->get('mobile', 0);
 
-		/**
-		 * Shrink the buttons if not on a mobile or if mobile view is off.
-		 * If mobile view is on force into simple mode and enlarge the buttons
-		 **/
-		if (!$this->app->client->mobile)
-		{
-			$smallButtons = 'toolbar_items_size: "small",';
-		}
-		elseif ($mobileVersion == false)
-		{
-			$smallButtons = '';
-		}
-		else
-		{
-			$smallButtons = '';
-			$mode         = 0;
-		}
+			/**
+			 * Shrink the buttons if not on a mobile or if mobile view is off.
+			 * If mobile view is on force into simple mode and enlarge the buttons
+			 **/
+			if (!$this->app->client->mobile)
+			{
+				$smallButtons = 'toolbar_items_size: "small",';
+			}
+			elseif ($mobileVersion == false)
+			{
+				$smallButtons = '';
+			}
+			else
+			{
+				$smallButtons = '';
+				$mode         = 0;
+			}
 
-		$script = '';
+			$script = '';
 
-		// Mootools b/c
-		$script .= '
+			// Mootools b/c
+			$script .= '
 		window.getSize = window.getSize || function(){return {x: jQuery(window).width(), y: jQuery(window).height()};};
 		';
 
-		$script .= "
+			$script .= "
 		tinymce.init({
 		";
 
-		// General
-		$script .= "
+			// General
+			$script .= "
 			directionality: \"$text_direction\",
 			selector: \"textarea.mce_editable\",
 			language : \"$langPrefix\",
@@ -802,8 +807,8 @@ class PlgEditorTinymce extends JPlugin
 			schema: \"html5\",
 			";
 
-		// Cleanup/Output
-		$script .= "
+			// Cleanup/Output
+			$script .= "
 			inline_styles : true,
 			gecko_spellcheck : true,
 			entity_encoding : \"$entity_encoding\",
@@ -811,14 +816,14 @@ class PlgEditorTinymce extends JPlugin
 			$smallButtons
 		";
 
-		// URL
-		$script .= "
+			// URL
+			$script .= "
 			relative_urls : $relative_urls,
 			remove_script_host : false,
 		";
 
-		// Layout
-		$script .= "
+			// Layout
+			$script .= "
 			$content_css
 			document_base_url : \"" . JUri::root() . "\",
 			setup: function (editor) {
@@ -826,23 +831,23 @@ class PlgEditorTinymce extends JPlugin
 			},
 			paste_data_images: $allowImgPaste,
 		";
-		switch ($mode)
-		{
-			case 0: /* Simple mode*/
-				$script .= "
+			switch ($mode)
+			{
+				case 0: /* Simple mode*/
+					$script .= "
 			menubar: false,
 			toolbar1: \"bold italics underline strikethrough | undo redo | bullist numlist | $toolbar5 | code\",
 			plugins: \"$dragDropPlg code\",
 		});
 		";
-				break;
+					break;
 
-			case 1:
-			default: /* Advanced mode*/
-				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
-					. "| outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
+				case 1:
+				default: /* Advanced mode*/
+					$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
+						. "| outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
 
-				$script .= "
+					$script .= "
 			valid_elements : \"$valid_elements\",
 			extended_valid_elements : \"$elements\",
 			invalid_elements : \"$invalid_elements\",
@@ -859,10 +864,10 @@ class PlgEditorTinymce extends JPlugin
 			width : \"$html_width\"
 		});
 			";
-				break;
+					break;
 
-			case 2: /* Extended mode*/
-				$script .= "
+				case 2: /* Extended mode*/
+					$script .= "
 			valid_elements : \"$valid_elements\",
 			extended_valid_elements : \"$elements\",
 			invalid_elements : \"$invalid_elements\",
@@ -898,20 +903,20 @@ class PlgEditorTinymce extends JPlugin
 			width : \"$html_width\",
 		});
 		";
-				break;
-		}
+					break;
+			}
 
-		$script .= "
+			$script .= "
 		function jInsertEditorText( text, editor )
 		{
 			tinyMCE.activeEditor.execCommand('mceInsertContent', false, text);
 		}
 		";
 
-		if (!empty($btnsNames))
-		{
-			JFactory::getDocument()->addScriptDeclaration(
-				"
+			if (!empty($btnsNames))
+			{
+				JFactory::getDocument()->addScriptDeclaration(
+					"
 		function jModalClose() {
 			tinyMCE.activeEditor.windowManager.close();
 		}
@@ -928,11 +933,14 @@ class PlgEditorTinymce extends JPlugin
 			}
 		}
 			"
-			);
-		}
+				);
+			}
 
-		JFactory::getDocument()->addScriptDeclaration($script);
-		JFactory::getDocument()->addStyleDeclaration(".mce-in { padding: 5px 10px !important;}");
+			JFactory::getDocument()->addScriptDeclaration($script);
+			JFactory::getDocument()->addStyleDeclaration(".mce-in { padding: 5px 10px !important;}");
+
+			$declaredJs = true;
+		}
 
 		if (empty($id))
 		{

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -13,6 +13,9 @@
 		<filename plugin="tinymce">tinymce.php</filename>
 		<folder>fields</folder>
 	</files>
+	<media destination="editors" folder="media">
+		<folder>tinymce</folder>
+	</media>
 	<languages>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.ini</language>
 		<language tag="en-GB">en-GB.plg_editors_tinymce.sys.ini</language>


### PR DESCRIPTION
#### Moving code from onInit() to OnDisplay()

The reason for this is that only the function onDisplay contains all the needed variables to correctly setup the initialisation script. Solves https://github.com/joomla/joomla-cms/issues/8712
#### Testing

Edit a category with editor set to tinymce. The buttons ReadMore and Pagebreak SHOULD NOT display, but they do.
Apply patch retry editing a category. The buttons ReadMore and Pagebreak DO NOT display.
