### PR TITLE
JForm: Fix `/administrator` hardcoded in xml for addfieldpath, addrulepath etc

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1881,6 +1881,8 @@ class JForm
 		// Add the field paths.
 		foreach ($paths as $path)
 		{
+			// We resolve '/administrator' to the correct backend directory, so that xml attribute works seamlessly.
+			$path = preg_replace('|^([\\\/])?administrator|', JPATH_ADMINISTRATOR_DIR, $path);
 			$path = JPATH_ROOT . '/' . ltrim($path, '/\\');
 			self::addFieldPath($path);
 		}
@@ -1892,6 +1894,8 @@ class JForm
 		// Add the form paths.
 		foreach ($paths as $path)
 		{
+			// We resolve '/administrator' to the correct backend directory, so that xml attribute works seamlessly.
+			$path = preg_replace('|^([\\\/])?administrator|', JPATH_ADMINISTRATOR_DIR, $path);
 			$path = JPATH_ROOT . '/' . ltrim($path, '/\\');
 			self::addFormPath($path);
 		}
@@ -1903,6 +1907,8 @@ class JForm
 		// Add the rule paths.
 		foreach ($paths as $path)
 		{
+			// We resolve '/administrator' to the correct backend directory, so that xml attribute works seamlessly.
+			$path = preg_replace('|^([\\\/])?administrator|', JPATH_ADMINISTRATOR_DIR, $path);
 			$path = JPATH_ROOT . '/' . ltrim($path, '/\\');
 			self::addRulePath($path);
 		}


### PR DESCRIPTION
`JForm` to allow using `/administrator` in addfieldpath, addrulepath, addformpath and still resolve it to the alternate folder name for administrator application.

**This depends on #8721**

Does not break B/C. XML declaration need not any change. They can still continue to use /administrator for that purpose.
