### PR TITLE
Fix #8683 Relative URLs are not converted to absolute URLs in atom feed

### DIFF
--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -178,7 +178,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 			if ($data->items[$i]->description != "")
 			{
 				$feed .= "		<summary type=\"html\">" . htmlspecialchars($this->_relToAbs($data->items[$i]->description), ENT_COMPAT, 'UTF-8') . "</summary>\n";
-				$feed .= "		<content type=\"html\">" . htmlspecialchars($data->items[$i]->description, ENT_COMPAT, 'UTF-8') . "</content>\n";
+				$feed .= "		<content type=\"html\">" . htmlspecialchars($this->_relToAbs($data->items[$i]->description), ENT_COMPAT, 'UTF-8') . "</content>\n";
 			}
 
 			if (empty($data->items[$i]->category) === false)


### PR DESCRIPTION
Issue #8683

This PR fixes a problem with relative URLs in atom feeds.
Prior to this commit relative URLs were only converted to absolute URLs in the **summary tag** and not in the **content tag**.

With the proposed change, relative URLs are also converted to absolute URLs in the **content tag**.
## How to test
1. Create an article including relative URLs and/or embedded images.
2. Access the atom feed URL that includes this article.
3. Notice that the relative URLs are converted to absolute URLs only in the **summary tag** and not in the **content tag**.
4. Apply this PR
5. Access the atom feed again and notice that relative URLs are converted in both the **summary** and the **content tag**.
