### PR TITLE
Allow creating override for views located inside view folder of component

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -569,9 +569,20 @@ class TemplatesModelTemplate extends JModelForm
 
 			foreach ($components as $component)
 			{
-				$viewPath = JPath::clean($componentPath . '/' . $component . '/views/');
+				if (file_exists($componentPath . '/' . $component . '/views/'))
+				{
+					$viewPath = JPath::clean($componentPath . '/' . $component . '/views/');
+				}
+				elseif (file_exists($componentPath . '/' . $component . '/view/'))
+				{
+					$viewPath = JPath::clean($componentPath . '/' . $component . '/view/');
+				}
+				else
+				{
+					$viewPath = '';
+				}
 
-				if (file_exists($viewPath))
+				if ($viewPath)
 				{
 					$views = JFolder::folders($viewPath);
 

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -588,7 +588,11 @@ class TemplatesModelTemplate extends JModelForm
 
 					foreach ($views as $view)
 					{
-						$result['components'][$component][] = $this->getOverridesFolder($view, $viewPath);
+						// Only show the view has layout inside it
+						if (file_exists($viewPath . $view . '/tmpl'))
+						{
+							$result['components'][$component][] = $this->getOverridesFolder($view, $viewPath);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

At the moment, when you create a menu item, Joomla can detect **views** located both in **components/com_mycom/views** folder and **components/com_mycom/view**.

However, it only allows creating template override for views of a component has views located inside **components/com_mycom/views** folder only. 

This small PR improves it so that we can create template override for views located both in **views** and **view** folder of a component.
## Testing instructions

Right now, in Joomla core, I only see that com_config has views located inside view folder of component. 

Before this patch, you cannot create template override for com_config component.

After this patch, you will be able to create template override for com_config component.
