### PR TITLE
language plugin

### DIFF
--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -608,7 +608,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (449, 'plg_authentication_cookie', 'plugin', 'cookie', 'authentication', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (450, 'plg_twofactorauth_yubikey', 'plugin', 'yubikey', 'twofactorauth', 0, 0, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (451, 'plg_search_tags', 'plugin', 'tags', 'search', 0, 1, 1, 0, '', '{"search_limit":"50","show_tagged_items":"1"}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(452, 'plg_system_updatenotification', 'plugin', 'updatenotification', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(452, 'plg_system_updatenotification', 'plugin', 'updatenotification', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (453, 'plg_editors-xtd_module', 'plugin', 'module', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -997,7 +997,7 @@ SELECT 450, 'plg_twofactorauth_yubikey', 'plugin', 'yubikey', 'twofactorauth', 0
 UNION ALL
 SELECT 451, 'plg_search_tags', 'plugin', 'tags', 'search', 0, 1, 1, 0, '', '{"search_limit":"50","show_tagged_items":"1"}', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 452, 'plg_system_updatenotification', 'plugin', 'updatenotification', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 452, 'plg_system_updatenotification', 'plugin', 'updatenotification', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
 SELECT 453, 'plg_editors-xtd_module', 'plugin', 'module', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -168,8 +168,8 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			// Build the options array.
 			foreach ($items as $link)
 			{
-				$level = str_repeat('- ', $link->level - 1);
-				$groups[$menuType][] = JHtml::_('select.option', $level . $link->value, $link->text, 'value', 'text', in_array($link->type, $this->disable));
+				$levelPrefix = str_repeat('- ', max(0, $link->level - 1));
+				$groups[$menuType][] = JHtml::_('select.option', $link->value, $levelPrefix . $link->text, 'value', 'text', in_array($link->type, $this->disable));
 			}
 		}
 		// Build groups for all menu types.
@@ -184,9 +184,9 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 				// Build the options array.
 				foreach ($menu->links as $link)
 				{
-					$level = str_repeat('- ', $link->level - 1);
+					$levelPrefix = str_repeat('- ', $link->level - 1);
 					$groups[$menu->menutype][] = JHtml::_(
-						'select.option', $link->value, $level . $link->text, 'value', 'text',
+						'select.option', $link->value, $levelPrefix . $link->text, 'value', 'text',
 						in_array($link->type, $this->disable)
 					);
 				}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -169,7 +169,12 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			foreach ($items as $link)
 			{
 				$levelPrefix = str_repeat('- ', max(0, $link->level - 1));
-				$groups[$menuType][] = JHtml::_('select.option', $link->value, $levelPrefix . $link->text, 'value', 'text', in_array($link->type, $this->disable));
+				$groups[$menuType][] = JHtml::_('select.option',
+								$link->value, $levelPrefix . $link->text,
+								'value',
+								'text',
+								in_array($link->type, $this->disable)
+							);
 			}
 		}
 		// Build groups for all menu types.

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -766,7 +766,7 @@ class PlgEditorTinymce extends JPlugin
 			// Plugins
 			plugins : \"$plugins\",
 			// Toolbar
-			toolbar1: \"$toolbar1 | $toolbar5 | code\",
+			toolbar1: \"$toolbar1 | code\",
 			removed_menuitems: \"newdocument\",
 			// URL
 			relative_urls : $relative_urls,

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -621,10 +621,11 @@ class PlgEditorTinymce extends JPlugin
 		$elements = implode(',', $elements);
 
 		// Prepare config variables
-		$toolbar1 = implode(' ', $toolbar1_add);
-		$toolbar2 = implode(' ', $toolbar2_add);
-		$toolbar3 = implode(' ', $toolbar3_add);
-		$toolbar4 = implode(' ', $toolbar4_add);
+		$toolbar1 = implode(' ', $toolbar1_add) . ' | '
+			. implode(' ', $toolbar2_add) . ' | '
+			. implode(' ', $toolbar3_add) . ' | '
+			. implode(' ', $toolbar4_add) . ' | '
+			. implode(" | ", $btnsNames);
 		$toolbar5 = implode(" | ", $btnsNames);
 
 		// The buttons script
@@ -669,8 +670,7 @@ class PlgEditorTinymce extends JPlugin
 			theme : \"$theme\",
 			schema: \"html5\",
 			menubar: false,
-			toolbar1: \"bold italics underline strikethrough | undo redo | bullist numlist\",
-			toolbar2: \"$toolbar5 | code\",
+			toolbar1: \"bold italics underline strikethrough | undo redo | bullist numlist | $toolbar5 | code\",
 			plugins: \"code\",
 			// Cleanup/Output
 			inline_styles : true,
@@ -694,8 +694,8 @@ class PlgEditorTinymce extends JPlugin
 
 			case 1:
 			default: /* Advanced mode*/
-				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist";
-				$toolbar2 = "outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
+			$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
+				. "| outdent indent | undo redo | link unlink anchor image | hr table | subscript superscript | charmap";
 				JFactory::getDocument()->addScriptDeclaration(
 					"
 		tinyMCE.init({
@@ -718,11 +718,9 @@ class PlgEditorTinymce extends JPlugin
 			$smallButtons
 			invalid_elements : \"$invalid_elements\",
 			// Plugins
-			plugins : \"table link image code hr charmap autolink lists importcss\",
+			plugins : \"table link image code hr charmap autolink lists importcss code\",
 			// Toolbar
-			toolbar1: \"$toolbar1\",
-			toolbar2: \"$toolbar2\",
-			toolbar3: \"$toolbar5 | code\",
+			toolbar1: \"$toolbar1 | $toolbar5 | code\",
 			removed_menuitems: \"newdocument\",
 			// URL
 			relative_urls : $relative_urls,
@@ -768,11 +766,7 @@ class PlgEditorTinymce extends JPlugin
 			// Plugins
 			plugins : \"$plugins\",
 			// Toolbar
-			toolbar1: \"$toolbar1\",
-			toolbar2: \"$toolbar2\",
-			toolbar3: \"$toolbar3\",
-			toolbar4: \"$toolbar4\",
-			toolbar5: \"$toolbar5 | code\",
+			toolbar1: \"$toolbar1 | $toolbar5 | code\",
 			removed_menuitems: \"newdocument\",
 			// URL
 			relative_urls : $relative_urls,


### PR DESCRIPTION
hi,

i work on a big site, the site has on http 15000 likes, we changed to https.

the problem from joomla comes now. like facebook requested i must put og url to http, what i did.

we use falang, falang use /plugins/system/languagefilter/languagefilter.php

and this makes

example.com/de   canonical to    /de/

for all subpages it set hiself as page canonical.

the problem is facebook consider canonical AND og url, if they both different, Facebook is completly confused, so i can remove over a code the canonical over the theme.php BUT!!  if i want to set a 

301  from /de  to /de/ then i get an error, over the htacess.

any clean suggestions how to resolve that?

ty.
