### PR TITLE
Possibility to remove filters individually when using the searchtools layout helper

### DIFF
--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -13,13 +13,26 @@ $data = $displayData;
 
 // Load the form filters
 $filters = $data['view']->filterForm->getGroup('filter');
+
+// Remove the search filter
+unset($filters['filter_search']);
+
+// Introduced 'removedFilters' (array) option that lets remove filters
+if (isset($data['options']['removedFilters']))
+{
+    foreach ($data['options']['removedFilters'] as $removedFilters){
+        if (isset($filters[$removedFilters]))
+        {
+            unset($filters[$removedFilters]);
+        }
+    }
+}
+
 ?>
 <?php if ($filters) : ?>
 	<?php foreach ($filters as $fieldName => $field) : ?>
-		<?php if ($fieldName != 'filter_search') : ?>
 			<div class="js-stools-field-filter">
 				<?php echo $field->input; ?>
 			</div>
-		<?php endif; ?>
 	<?php endforeach; ?>
 <?php endif; ?>

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -20,12 +20,10 @@ unset($filters['filter_search']);
 // Introduced 'removedFilters' (array) option that lets remove filters
 if (isset($data['options']['removedFilters']))
 {
-    foreach ($data['options']['removedFilters'] as $removedFilters){
-        if (isset($filters[$removedFilters]))
-        {
-            unset($filters[$removedFilters]);
-        }
-    }
+	foreach ($data['options']['removedFilters'] as $removedFilters)
+	{
+        	unset($filters[$removedFilters]);
+	}
 }
 
 ?>

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -22,7 +22,7 @@ if (isset($data['options']['removedFilters']))
 {
 	foreach ($data['options']['removedFilters'] as $removedFilters)
 	{
-        	unset($filters[$removedFilters]);
+		unset($filters[$removedFilters]);
 	}
 }
 


### PR DESCRIPTION
Bring up a **'removedFilters' (array) option** to the **searchtools layout helper** that allows to remove filters individually.

# Testing

To test it you can change the file:
*administrator/components/com_content/views/articles/tmpl/default.php*

on line 48:
```php
echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
```
by: 
```php
echo JLayoutHelper::render('joomla.searchtools.default', array(
        'view' => $this,
        'options' => array(
                'removedFilters' => array()
        )
)); 
```

**Then**, add names of the searchtools fields you want to remove to the 'removedFilters' option array :
```php
        'options' => array(
                'removedFilters' => array('filter_published', 'filter_category_id')
        )
```

and observe the result (filters removed) on the searchtools of:
*/administrator/index.php?option=com_content&view=articles*

<br />

![capture du 2015-12-22 16 39 14ok](https://cloud.githubusercontent.com/assets/16225234/11958855/9a868432-a8ca-11e5-87c2-bcc41c258e68.png)
*(screenshot: searchtools with all filters)*

<br />

![capture du 2015-12-22 16 34 10](https://cloud.githubusercontent.com/assets/16225234/11958740/e5971ff0-a8c9-11e5-8f3f-ef30d555ac19.png)
*(screenshot: searchtools with 'status' and 'category' filters removed)*
