### PR TITLE
Force the Travis badge to the staging branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cm
 
 Build Status
 ---------------------
-Travis-CI: [![Build Status](https://travis-ci.org/joomla/joomla-cms.png)](https://travis-ci.org/joomla/joomla-cms)
+Travis-CI: [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)
 Jenkins: [![Build Status](http://build.joomla.org/job/cms/badge/icon)](http://build.joomla.org/job/cms/)
 
 What is this?


### PR DESCRIPTION
Current Travis badge will show failing if any branch is failing. (which just looks wrong and like the whole project is a failure) this fixes the issue by only showing the staging branch status.
