### PR TITLE
Fix CLI script using the session

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -106,8 +106,8 @@ class JSession implements IteratorAggregate
 	 */
 	public function __construct($store = 'none', array $options = array())
 	{
-        // Initialize the data variable, let's avoid fatal error if the session is not corretly started (ie in CLI).
-        $this->data = new \Joomla\Registry\Registry;
+		// Initialize the data variable, let's avoid fatal error if the session is not corretly started (ie in CLI).
+		$this->data = new \Joomla\Registry\Registry;
 
 		// Need to destroy any existing sessions started with session.auto_start
 		if (session_id())

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -106,6 +106,9 @@ class JSession implements IteratorAggregate
 	 */
 	public function __construct($store = 'none', array $options = array())
 	{
+        // Initialize the data variable, let's avoid fatal error if the session is not corretly started (ie in CLI).
+        $this->data = new \Joomla\Registry\Registry;
+
 		// Need to destroy any existing sessions started with session.auto_start
 		if (session_id())
 		{
@@ -579,8 +582,6 @@ class JSession implements IteratorAggregate
 		session_start();
 
 		// Ok let's unserialize the whole thing
-		$this->data = new \Joomla\Registry\Registry;
-
 		// Try loading data from the session
 		if (isset($_SESSION['joomla']) && !empty($_SESSION['joomla']))
 		{


### PR DESCRIPTION
Init the data pointer in method constructor, in order to avoid fatal error while running applications in CLI.
See #8755 for more details.

For what is worth, the whole behavior is wrong (even the old one), since we are working on a session flagged as "inactive" and we are getting all default values.
