### PR TITLE
Always save session data inside the database

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -529,8 +529,14 @@ class JSession implements IteratorAggregate
 		// Initialise the session
 		$this->_setCounter();
 		$this->_setTimers();
+
 		// Perform security checks
-		$this->_validate();
+		if(!$this->_validate())
+        {
+            // Destroy the session if it's not valid
+            $this->destroy();
+        }
+
 		if ($this->_dispatcher instanceof JEventDispatcher)
 		{
 			$this->_dispatcher->trigger('onAfterSessionStart');
@@ -672,8 +678,14 @@ class JSession implements IteratorAggregate
 		session_regenerate_id(true);
 		$this->_start();
 		$this->_state = 'active';
-		$this->_validate();
-		$this->_setCounter();
+
+        if(!$this->_validate())
+        {
+            // Destroy the session if it's not valid
+            $this->destroy();
+        }
+
+        $this->_setCounter();
 		return true;
 	}
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -571,8 +571,6 @@ class JSession implements IteratorAggregate
 		 * Write and Close handlers are called after destructing objects since PHP 5.0.5.
 		 * Thus destructors can use sessions but session handler can't use objects.
 		 * So we are moving session closure before destructing objects.
-		 *
-		 * Replace with session_register_shutdown() when dropping compatibility with PHP 5.3
 		 */
 		register_shutdown_function(array($this, 'close'));
 		session_cache_limiter('none');
@@ -723,12 +721,6 @@ class JSession implements IteratorAggregate
 	 */
 	public function close()
 	{
-		if ($this->_state !== 'active')
-		{
-			// @TODO :: generated error here
-			return false;
-		}
-
 		$session = JFactory::getSession();
 		$data    = $session->getData();
 


### PR DESCRIPTION
This PR fixes the "You are not authorized to.." issue we are experiencing this days

This is a VERY weird issue, given some randomness introduced by the way we flush sessions (check this code in [ApplicationCms](https://github.com/joomla/joomla-cms/blob/3.4.x/libraries/cms/application/cms.php#L747) )
So long story short:
- if the session is expired
- if the session flushing is not triggered

The session is flagged as _expired_ and its updated value won't be stored inside the database. This leads to the user having an "invalid" session but still logged in.
By always saving the data inside the database, we are 100% that even if the session wasn't flushed the user will be logged out at the next page load.

For what is worth, such code is VERY bad, since on very loaded sites it introduces a race condition.
We should really improve such code (maybe moving it inside a system plugin triggered on timely basis?)
