### PR TITLE
Flush sessions on Joomla update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -36,6 +36,10 @@ class JoomlaInstallerScript
 		$this->updateDatabase();
 		$this->clearRadCache();
 		$this->updateAssets();
+
+        // VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD
+        // LOGOUT ALL THE USERS
+        $this->flushSessions();
 	}
 
 	/**
@@ -1478,4 +1482,35 @@ class JoomlaInstallerScript
 
 		return true;
 	}
+
+    /**
+     * If we migrated the session from the previous system, flush all the active sessions.
+     * Otherwise users will be logged in, but not able to do anything since they don't have
+     * a valid session
+     *
+     * @return  boolean
+     */
+    public function flushSessions()
+    {
+        // No default namespace? No need to flush the sessions
+        if(!isset($_SESSION['__default']))
+        {
+            return true;
+        }
+
+        $db = JFactory::getDbo();
+
+        try
+        {
+            $db->truncateTable($db->qn('#__sessions'));
+        }
+        catch(Exception $e)
+        {
+            echo JText::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br />';
+
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -589,8 +589,8 @@ class JSession implements IteratorAggregate
 			$this->data = unserialize($data);
 		}
 
-		// Migrate existing session data to avoid logout on update from J < 3.4.7
-		if (isset($_SESSION['__default']))
+		// Temporary, PARTIAL, data migration of existing session data to avoid logout on update from J < 3.4.7
+		if (isset($_SESSION['__default']) && !empty($_SESSION['__default']))
 		{
 			$migratableKeys = array("user", "session.token", "session.counter", "session.timer.start", "session.timer.last", "session.timer.now");
 
@@ -609,6 +609,11 @@ class JSession implements IteratorAggregate
 					unset($_SESSION['__default'][$migratableKey]);
 				}
 			}
+
+			// Finally, empty the __default key since we no longer need it. Don't unset it completely, we need this
+			// for the administrator/components/com_admin/script.php to detect upgraded sessions and perform a full
+			// session cleanup.
+			$_SESSION['__default'] = array();
 		}
 
 		return true;


### PR DESCRIPTION
After updating Joomla, we have to flush session if we migrated data session.
Otherwise the user will be stuck in a limbo, were he is logged in but he can't do anything
