### PR TITLE
Include missing 'registry' in the session migratable keys during J3.4.7 update

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -633,7 +633,7 @@ class JSession implements IteratorAggregate
 		// Migrate existing session data to avoid logout on update from J < 3.4.7
 		if (isset($_SESSION['__default']))
 		{
-			$migratableKeys = array("user", "session.token", "session.counter", "session.timer.start", "session.timer.last", "session.timer.now");
+			$migratableKeys = array("user", "session.token", "session.counter", "session.timer.start", "session.timer.last", "session.timer.now", "registry");
 
 			foreach ($migratableKeys as $migratableKey)
 			{


### PR DESCRIPTION
The `$_SESSION['__default']['registry']` is responsible for the `userState` 
as in `$app->setUserState('some.key.for.state', 'value');`

Not migrating this value, as well as not even initializing this value as blank results in `userState` inaccessible until the user log-out and login again. 

[JApplicationCms::setUserState()](https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/application/cms.php#L1125) requires the `registry` value set in order to be able to update user state.

**Affected areas** include sitewide pagination, filters, editing content etc.

This commit includes that key as a migratable key.

**TESTING**
- Install Joomla 3.4.5 / 3.4.6 with sample data
- Go to Article manager.
- Filter the list using some filters, more that one filter would be better.
- Navigate to any other page.
- Go back to Article manager, the filters are still applied. (as expected)
- Now update to Joomla 3.4.7 directly 
- Go back to Article manager, **the filters are reset** (not expected)
- Apply some filters again. (Will be applied, but won't persist)

Repeat the process (starting with Joomla 3.4.5 / 3.4.6 again) but this time update with this patch included in the update package.
