### PR TITLE
Syntax errors in file /com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__redirect_links` ADD header smallint(3) NOT NULL DEFAULT 301;
-ALTER TABLE `#__redirect_links` MODIFY new_url varchar(255);
+ALTER TABLE `#__redirect_links` ADD `header` smallint(3) NOT NULL DEFAULT 301;
+ALTER TABLE `#__redirect_links` MODIFY `new_url` varchar(255);

--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__redirect_links` ADD `header` smallint(3) NOT NULL DEFAULT 301;
+ALTER TABLE `#__redirect_links` ADD COLUMN `header` smallint(3) NOT NULL DEFAULT 301;
 ALTER TABLE `#__redirect_links` MODIFY `new_url` varchar(255);


### PR DESCRIPTION
PR for issue  #8786
Original issue description

> IMHO file https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql contains MySQL syntax errors :
> is
> 
> ``` SQL
> ALTER TABLE `#__redirect_links` ADD header smallint(3) NOT NULL DEFAULT 301;
> ALTER TABLE `#__redirect_links` MODIFY new_url varchar(255);
> ```
> 
> should be
> 
> ``` sql
> ALTER TABLE `#__redirect_links` ADD `header` smallint(3) NOT NULL DEFAULT 301;
> ALTER TABLE `#__redirect_links` MODIFY `new_url` varchar(255);
> ```
> 
> related: https://github.com/joomla/joomla-cms/issues/6333
