### PR TITLE
Remove link that 404's

### DIFF
--- a/administrator/components/com_config/controller/application/refreshhelp.php
+++ b/administrator/components/com_config/controller/application/refreshhelp.php
@@ -38,12 +38,7 @@ class ConfigControllerApplicationRefreshhelp extends JControllerBase
 		// Set FTP credentials, if given
 		JClientHelper::setCredentialsFromRequest('ftp');
 
-		if (($data = file_get_contents('http://help.joomla.org/helpsites.xml')) === false)
-		{
-			$this->app->enqueueMessage(JText::_('COM_CONFIG_ERROR_HELPREFRESH_FETCH'), 'error');
-			$this->app->redirect(JRoute::_('index.php?option=com_config', false));
-		}
-		elseif (!JFile::write(JPATH_BASE . '/help/helpsites.xml', $data))
+		if (!JFile::write(JPATH_BASE . '/help/helpsites.xml', $data))
 		{
 			$this->app->enqueueMessage(JText::_('COM_CONFIG_ERROR_HELPREFRESH_ERROR_STORE'), 'error');
 			$this->app->redirect(JRoute::_('index.php?option=com_config', false));


### PR DESCRIPTION
help.joomla.org only serves the 1.5 and 2.5 help screens. Me and Michael recently decommissioned all other files on this site. However even at that point this file didn't exist so I'm removing it as 'dead code'.

As far as I can tell this function is no longer used by core but was part of a legacy method in the old MVC structure pre Joomla 3.2.
