### PR TITLE
Added event onUserBeforeAuthenticate.

### DIFF
--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -676,3 +676,6 @@ JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to 
 JLIB_UTIL_ERROR_DOMIT="DommitDocument is deprecated. Use DomDocument instead."
 JLIB_UTIL_ERROR_LOADING_FEED_DATA="Error loading feed data."
 JLIB_UTIL_ERROR_XML_LOAD="Failed loading XML file."
+JLIB_LOGIN_DENIED="Access denied!"
+JLIB_LOGIN_EXPIRED="Your session has expired."
+JLIB_LOGIN_AUTHORISATION="You are not authorised to login on this website."

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -806,11 +806,25 @@ class JApplicationCms extends JApplicationWeb
 		// Get the global JAuthentication object.
 		jimport('joomla.user.authentication');
 
+		// Import the user and authentication plugin groups.
+		JPluginHelper::importPlugin('authentication');
+		JPluginHelper::importPlugin('user');
+
+		$results    = $this->triggerEvent('onUserBeforeAuthenticate', array($credentials, &$options));
+
+		if (in_array(false, $results, true))
+		{
+			// If silent is set, just return false.
+			if (array_key_exists('silent', $options) and $options['silent'] === true)
+			{
+				return false;
+			}
+
+			return JError::raiseWarning('102003', JText::_('JLIB_LOGIN_DENIED'));
+		}
+
 		$authenticate = JAuthentication::getInstance();
 		$response = $authenticate->authenticate($credentials, $options);
-
-		// Import the user plugin group.
-		JPluginHelper::importPlugin('user');
 
 		if ($response->status === JAuthentication::STATUS_SUCCESS)
 		{
@@ -818,13 +832,13 @@ class JApplicationCms extends JApplicationWeb
 			 * Validate that the user should be able to login (different to being authenticated).
 			 * This permits authentication plugins blocking the user.
 			 */
-			$authorisations = $authenticate->authorise($response, $options);
+			$authorisations = $this->triggerEvent('onUserAuthorisation', array($response, &$options));
 
 			foreach ($authorisations as $authorisation)
 			{
 				$denied_states = array(JAuthentication::STATUS_EXPIRED, JAuthentication::STATUS_DENIED);
 
-				if (in_array($authorisation->status, $denied_states))
+				if (in_array($authorisation->status, $denied_states, true))
 				{
 					// Trigger onUserAuthorisationFailure Event.
 					$this->triggerEvent('onUserAuthorisationFailure', array((array) $authorisation));
@@ -868,12 +882,12 @@ class JApplicationCms extends JApplicationWeb
 			 */
 			$user = JFactory::getUser();
 
-			if ($response->type == 'Cookie')
+			if ($response->type === 'Cookie')
 			{
 				$user->set('cookieLogin', true);
 			}
 
-			if (in_array(false, $results, true) == false)
+			if (in_array(false, $results, true) === false)
 			{
 				$options['user'] = $user;
 				$options['responseType'] = $response->type;

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -322,6 +322,7 @@ class JAuthentication extends JObject
 	 * @return  array[JAuthenticationResponse]  results of authorisation
 	 *
 	 * @since  11.2
+	 * @deprecated 4.0
 	 */
 	public static function authorise($response, $options = array())
 	{


### PR DESCRIPTION
Added an event that can be useful for developers who would like to protect the front-end of their websites. They will be able to use this event to do the login process more secure.

The changes...
- Added event **onUserBeforeAuthenticate**. This event will be handled before _onUserAuthenticate_. It returns boolean. If it returns **false**, the system will interrupt the process of authentication. 
- Replaced **_$authenticate->authorise...**_ with **_$this->triggerEvent('onUserAuthorisation'...**_. It was a static method used as not static. It was only used in the method _"login,"_ so we can replace it with _triggerEvent_. You can deprecate  _JAuthentication::authorise_ in Joomla! v4.0.
- Now, the variable **_$options**_ is going to be passed by reference. So, we will be able to change its values. We will be able to change the value of option **'silent'** in the plugins.

If you would like, you can test the changes with this plugin [User - Face Control](https://github.com/ITPrism/Plugin-User-FaceControl).
