### PR TITLE
Regression: Firefox autocomplete off does not work anymore

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -40,7 +40,7 @@ $fieldsets = $this->form->getFieldsets();
 			<div class="control-label"><?php echo $field->label; ?></div>
 			<div class="controls">
 				<?php if ($field->fieldname == 'password2') : ?>
-					<?php // Disables autocomplete ?> <input type="text" style="display:none">
+					<?php // Disables autocomplete ?> <input type="password" style="display:none">
 				<?php endif; ?>
 				<?php echo $field->input; ?>
 			</div>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -60,7 +60,7 @@ $fieldsets = $this->form->getFieldsets();
 						</div>
 						<div class="controls">
 							<?php if ($field->fieldname == 'password') : ?>
-								<?php // Disables autocomplete ?> <input type="text" style="display:none">
+								<?php // Disables autocomplete ?> <input type="password" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -70,7 +70,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 						</div>
 						<div class="controls">
 							<?php if ($field->fieldname == 'password1') : ?>
-								<?php // Disables autocomplete ?> <input type="text" style="display:none">
+								<?php // Disables autocomplete ?> <input type="password" style="display:none">
 							<?php endif; ?>
 							<?php echo $field->input; ?>
 						</div>

--- a/installation/model/forms/database.xml
+++ b/installation/model/forms/database.xml
@@ -22,6 +22,7 @@
 			/>
 			<field name="db_pass" type="password" id="db_pass" class="inputbox"
 				label="INSTL_DATABASE_PASSWORD_LABEL"
+				autocomplete="off"
 				filter="raw"
 			/>
 			<field name="db_name" type="text" id="db_name" class="inputbox"

--- a/installation/view/database/tmpl/default.php
+++ b/installation/view/database/tmpl/default.php
@@ -59,6 +59,7 @@ defined('_JEXEC') or die;
 			<?php echo $this->form->getLabel('db_pass'); ?>
 		</div>
 		<div class="controls">
+			<?php // Disables autocomplete ?> <input type="password" style="display:none">
 			<?php echo $this->form->getInput('db_pass'); ?>
 			<p class="help-block">
 				<?php echo JText::_('INSTL_DATABASE_PASSWORD_DESC'); ?>

--- a/installation/view/site/tmpl/default.php
+++ b/installation/view/site/tmpl/default.php
@@ -78,6 +78,7 @@ defined('_JEXEC') or die;
 					<?php echo $this->form->getLabel('admin_password'); ?>
 				</div>
 				<div class="controls">
+					<?php // Disables autocomplete ?> <input type="password" style="display:none">
 					<?php echo $this->form->getInput('admin_password'); ?>
 					<p class="help-block"><?php echo JText::_('INSTL_ADMIN_PASSWORD_DESC'); ?></p>
 				</div>
@@ -87,6 +88,7 @@ defined('_JEXEC') or die;
 					<?php echo $this->form->getLabel('admin_password2'); ?>
 				</div>
 				<div class="controls">
+					<?php // Disables autocomplete ?> <input type="password" style="display:none">
 					<?php echo $this->form->getInput('admin_password2'); ?>
 				</div>
 			</div>


### PR DESCRIPTION
This corrects https://github.com/joomla/joomla-cms/pull/7094#issuecomment-165232604
It also adds autocomplete off for the passwords fields in installation (site and database)

To test, same instructions as https://github.com/joomla/joomla-cms/pull/7094
The password field is filled even when it is only optional thus forcing to enter a value in the Confirm Password field. As this is not expected by the user, the error "Invalid field: Confirm Password" displays.

To test:
3 instances:
1. Edit a user (editing yourself as superuser) through User Manager.
2. Editing your own profile in back-end
3.Editing your own profile in front-end

In these 3 cases, you will see that the password field contains a value.

Patch and retest, then save any user parameter without touching at the passwords fields. Now should be OK.

This patch also 
1.adds `autocomplete off` to the database password field when installing Joomla as it picks the Username field when not set such.
2. solves `autocomplete off` for Firefox for site passwords when installing Joomla

Note: to test, the password has to be saved first (Firefox message) in a former new installation.

@ggppdk @fontanil
Thank you for testing
