### PR TITLE
Serialize the user object

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -16,7 +16,7 @@ use Joomla\Registry\Registry;
  *
  * @since  11.1
  */
-class JUser extends JObject
+class JUser extends JObject implements Serializable
 {
 	/**
 	 * A cached switch for if this user has root access rights.
@@ -813,12 +813,6 @@ class JUser extends JObject
 			return false;
 		}
 
-		// Reset the user object in the session on a successful save
-		if ($result === true && JFactory::getUser()->id == $this->id)
-		{
-			JFactory::getSession()->set('user', $this);
-		}
-
 		return $result;
 	}
 
@@ -898,5 +892,50 @@ class JUser extends JObject
 		}
 
 		return true;
+	}
+
+	/**
+	 * Method to serialize the input.
+	 *
+	 * @return  string  The serialized input.
+	 *
+	 * @since   3.5
+	 */
+	public function serialize()
+	{
+		return serialize(array($this->id));
+	}
+
+	/**
+	 * Method to unserialize the user object.
+	 *
+	 * @param   string  $input  The serialized input.
+	 *
+	 * @return  JUser
+	 *
+	 * @since   3.5
+	 */
+	public function unserialize($input)
+	{
+		// Get the user id from the serialized data.
+		list($id) = unserialize($input);
+
+		// Initialise some variables
+		$this->userHelper = new JUserWrapperHelper;
+		$this->_params    = new Registry;
+
+		// Load the user if it exists
+		if (!empty($id))
+		{
+			$this->load($id);
+		}
+		else
+		{
+			// Initialise
+			$this->id = 0;
+			$this->sendEmail = 0;
+			$this->aid = 0;
+			$this->guest = 1;
+		}
 	}
 }


### PR DESCRIPTION
## Overview

This small PR has a large number of benefits - it reduces the amount of user data stored in the database in the session table, it ensures the the user object is fully updated every page load removing some hackish code required for forcing password resets. Finally it solves the age old problem we have in Joomla of user groups not properly updating when they are changed by an admin or extension like Admin Tools. This comes at a slight overhead of reloading the user object on every page load.
## Testing

Create a super admin and a second regular user. Log into that account into the frontend and browse around. Then log into the backend as the super admin and flag the normal users account as requiring a password reset. As soon as the frontend user goes to the next page they should be taken and only be able to access the profile edit page. Then reset password for the normal user and browse the site as usual again.

This ensures that the serialization replaces the "hack" implemented for the Password Reset code successfully.

As a bonus you can also test things like akeeba subs. I have not tested this myself but I think this should solve the age old problem we've had in Joomla that when a user's groups are changed it's not applied until the user logs out and logs back in again (e.g. the reverted https://github.com/joomla/joomla-cms/pull/3972)
## Performance

The user object is now reloaded at the start of every page. This is going to introduce a performance hit as the system is now going to reload the user from the database and the user groups assigned on every page load (around 10-20ms). For what it's worth though this is consistent with various other PHP Frameworks out there like Lavarel
## Backwards Compatibility

There are no major b/c breaks. The serialization is ONLY done when the session gets closed and when it is kicked up again. There _will_ be a b/c break if you are directly editing the database to change the database information. But imho if you are doing this then you pretty much get what you deserve - because you shouldn't even be relying on the data being stored there because of the different session handlers available.
