### PR TITLE
Prevent (unharmful) fatal error on session expire

### DIFF
--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -216,11 +216,6 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 */
 	public function save()
 	{
-		if (!$this->isStarted())
-		{
-			throw new RuntimeException('The session is not started.');
-		}
-
 		$session = JFactory::getSession();
 		$data    = $session->getData();
 


### PR DESCRIPTION
If the session expires, it's no longer "valid" and an uncaught exception is thrown, resulting in the following:

```
Fatal error: Uncaught exception 'RuntimeException' with message 'The session is not started.' in /Users/tampe125/git/joomla-cms/libraries/joomla/session/handler/native.php on line 221
RuntimeException: The session is not started. in /Users/tampe125/git/joomla-cms/libraries/joomla/session/handler/native.php on line 221
```

Since this is the last thing performed, there no harm is done.
I think we should always save data to session, no matter what, however I'd like @mbabker to take a look at this. Since the code was already there, maybe there is an hidden reason for that?
