### PR TITLE
Global Check-in: differentiate by colour

### DIFF
--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -43,7 +43,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			</thead>
 			<tbody>
 				<?php $i = 0; ?>
-				<?php foreach ($this->items as $table => $count): ?>
+				<?php foreach ($this->items as $table => $count) : ?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center"><?php echo JHtml::_('grid.id', $i, $table); ?></td>
 						<td>
@@ -51,7 +51,13 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 								<?php echo JText::sprintf('COM_CHECKIN_TABLE', $table); ?>
 							</label>
 						</td>
-						<td><span class="label label-info"><?php echo $count; ?></span></td>
+						<td>
+							<?php if ($count > 0) : ?>
+								<span class="label label-warning"><?php echo $count; ?></span>
+							<?php else : ?>
+								<span class="label label-info"><?php echo $count; ?></span>
+							<?php endif; ?>
+						</td>
 					</tr>
 					<?php $i++; ?>
 				<?php endforeach; ?>


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/8811
Test: checkout some items.

After patch, the display uses a different colour when items > 0
![screen shot 2015-12-30 at 10 19 14](https://cloud.githubusercontent.com/assets/869724/12048726/04304264-aedf-11e5-8872-510ddaa18b29.png)
