### PR TITLE
Updates keychain with the proper CLI bootstrap for the CMS.

### DIFF
--- a/bin/keychain.php
+++ b/bin/keychain.php
@@ -7,11 +7,51 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-define('_JEXEC', 1);
-define('JPATH_BASE', dirname(__FILE__));
+// Make sure we're being called from the command line, not a web interface
+if (PHP_SAPI !== 'cli')
+{
+	die('This is a command line only application.');
+}
 
-// Load the Joomla! Platform
-require_once realpath('../libraries/import.php');
+// We are a valid entry point.
+define('_JEXEC', 1);
+
+// Load system defines
+if (file_exists(dirname(__DIR__) . '/defines.php'))
+{
+	require_once dirname(__DIR__) . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', dirname(__DIR__));
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+// Get the framework.
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+// Import the configuration.
+require_once JPATH_CONFIGURATION . '/configuration.php';
+
+// System configuration.
+$config = new JConfig;
+
+// Configure error reporting to maximum for CLI output.
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Load Library language
+$lang = JFactory::getLanguage();
+
+// Try the finder_cli file in the current language (without allowing the loading of the file in the default language)
+$lang->load('finder_cli', JPATH_SITE, null, false, false)
+
+// Fallback to the finder_cli file in the default language
+|| $lang->load('finder_cli', JPATH_SITE, null, true);
 
 /**
  * Keychain Manager.


### PR DESCRIPTION
Copies the proper CLI bootstrap for the CMS from /joomla-cms/cli/finder_indexer.php
Addresses issues from #8765 

Testing
1. add patch
  https://docs.joomla.org/Testing_Joomla!_patches
2. Attempt to access the file by calling: your-joomla-domain.com/bin/keychain.php with any Browser
3. Observe the notice "This is a command line only application." ( step 3 completes testing for issues in #8765 )
4. Use the keychain through CLI, with no change in behavior [see documentation](https://github.com/eBaySF/joomla-platform/wiki/Keychain#keychain-management-utility)
