### PR TITLE
Not require logout after update from J3.4.7 or earlier

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -635,8 +635,8 @@ class JSession implements IteratorAggregate
 			$this->data = unserialize($data);
 		}
 
-		// Temporary, PARTIAL, data migration of existing session data to avoid logout on update from J < 3.4.7
-		if (isset($_SESSION['__default']) && !empty($_SESSION['__default']))
+		// Migrate existing session data to avoid logout on update from J < 3.4.7
+		if (!empty($_SESSION['__default']))
 		{
 			$migratableKeys = array("user", "session.token", "session.counter", "session.timer.start", "session.timer.last", "session.timer.now");
 
@@ -655,12 +655,8 @@ class JSession implements IteratorAggregate
 				}
 			}
 
-			/**
-			 * Finally, empty the __default key since we no longer need it. Don't unset it completely, we need this
-			 * for the administrator/components/com_admin/script.php to detect upgraded sessions and perform a full
-			 * session cleanup.
-			 */
-			$_SESSION['__default'] = array();
+			$this->data->set('__default.registry', new Joomla\Registry\Registry);
+			unset($_SESSION['__default']);
 		}
 
 		return true;


### PR DESCRIPTION
Updates in J3.4.8 makes all the users logout after successful update. The actual error was however not resolved and this can be achieved without the user's logout. This patch will be helpful for those who update from J3.4.7 or before, as J3.4.8 would have already logged out everyone so those updating from J3.4.8 won't notice any difference. The actual error was however not resolved and this can be achieved without the user's logout. This patch will be helpful for those who update from J3.4.7 or before, as J3.4.8 would have already logged out everyone so those updating from J3.4.8 won't notice any difference.

This is a redo of PR #8782 against **staging** as it was outdated and was based over 3.4.7 release.
