### PR TITLE
Login module: fixed graphic glitches by making it responsive

### DIFF
--- a/templates/beez3/css/layout.css
+++ b/templates/beez3/css/layout.css
@@ -541,6 +541,11 @@ fieldset.filters {
 	background: #f5f5f5
 }
 
+#login-form input[type="text"], input[type="password"], input[type="submit"] {
+	width: 100%;
+	box-sizing: border-box
+}
+
 form ul {
 	list-style-type: none;
 	margin: 0;


### PR DESCRIPTION
The standard login module presents graphic glitches when used with the template Beez3 depending on the device resolution.
It happens under several resolutions, but you can test with your own smartphone using a landscape (horizontal) orientation.
Alternatively, you can test it using “Google Chrome Development Tools”, by enabling “Toggle Device mode”. I have selected “Google Nexus 5” device for the test.

On these conditions, the login module overlaps the content area.

![mobile](https://cloud.githubusercontent.com/assets/1609992/12079655/f3cc994c-b238-11e5-8ee5-48bd146427fb.png)

On desktop computer the module does not overlap, but depending on the size of the system fonts, the input fields may assume different indentations, resulting in a poor quality design.

![desktop](https://cloud.githubusercontent.com/assets/1609992/12079657/fd3a05dc-b238-11e5-932c-474ba9ee013d.png)

This is how the login module looks like in the mobile **after** this patch

![mobile-after](https://cloud.githubusercontent.com/assets/1609992/12079660/086971fe-b239-11e5-888a-5321d4c8d474.png)

The desktop layout also benefits from this patch:

![desktop-after](https://cloud.githubusercontent.com/assets/1609992/12079671/35caab22-b239-11e5-87ca-6955d488195a.png)
