### PR TITLE
Fix unit for session expiration

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -32,12 +32,12 @@ class JSession implements IteratorAggregate
 	protected $_state = 'inactive';
 
 	/**
-	 * Maximum age of unused session in minutes
+	 * Maximum age of unused session in seconds
 	 *
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $_expire = 15;
+	protected $_expire = 900;
 
 	/**
 	 * The session store object.
@@ -198,9 +198,9 @@ class JSession implements IteratorAggregate
 	}
 
 	/**
-	 * Get expiration time in minutes
+	 * Get expiration time in seconds
 	 *
-	 * @return  integer  The session expiration time in minutes
+	 * @return  integer  The session expiration time in seconds
 	 *
 	 * @since   11.1
 	 */


### PR DESCRIPTION
fixes #8843

Docs and therefore source code too claims that `JSession::getExpire` returns expiration in minutes. But it is initialised as seconds. See [here](https://github.com/joomla/joomla-cms/blob/9e948130acb79d189255625df47c0b57afc00534/libraries/cms/application/cms.php#L718) and [here](https://github.com/joomla/joomla-cms/blob/3cfe5ab695825b5ed8edf22a8c227c7974968de9/libraries/joomla/factory.php#L595).

If session lifetime is set to 30 minutes in backend, it returns 1800.

Also, it is used to set `session.gc_maxlifetime` in [here](https://github.com/joomla/joomla-cms/blob/ea1abff73885def195d5bbe30b34b0a9d117013f/libraries/joomla/session/session.php#L906), which takes seconds.

So it works well, just description is misleading.
