### PR TITLE
Allow filtering by tag in the frontend

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -709,6 +709,7 @@
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
+        <option value="tag">JTAG</option>
 		</field>
 
 		<field name="show_headings"

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -709,7 +709,7 @@
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
-        <option value="tag">JTAG</option>
+				<option value="tag">JTAG</option>
 		</field>
 
 		<field name="show_headings"

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -83,7 +83,7 @@ class ContentModelArticles extends JModelList
 		$value = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $value);
 
-		$value = $app->input->get('filter_tag', null, 'uint');
+		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		$orderCol = $app->input->get('filter_order', 'a.ordering');
@@ -524,7 +524,7 @@ class ContentModelArticles extends JModelList
 		// Filter by a single tag.
 		$tagId = $this->getState('filter.tag');
 
-		if (is_numeric($tagId))
+		if (!empty($tagId) && is_numeric($tagId))
 		{
 			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId)
 				->join(

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -49,7 +49,7 @@ class ContentModelArticles extends JModelList
 				'publish_down', 'a.publish_down',
 				'images', 'a.images',
 				'urls', 'a.urls',
-        'filter_tag'
+        			'filter_tag'
 			);
 		}
 
@@ -83,7 +83,7 @@ class ContentModelArticles extends JModelList
 		$value = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $value);
 
-    $value = $app->input->get('filter_tag', 0, 'uint');
+    		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		$orderCol = $app->input->get('filter_order', 'a.ordering');
@@ -521,7 +521,7 @@ class ContentModelArticles extends JModelList
 			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 
-    // Filter by a single tag.
+    		// Filter by a single tag.
 		$tagId = $this->getState('filter.tag');
 
 		if (is_numeric($tagId))

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -83,7 +83,7 @@ class ContentModelArticles extends JModelList
 		$value = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $value);
 
-		$value = $app->input->get('filter_tag', 0, 'uint');
+		$value = $app->input->get('filter_tag', null, 'uint');
 		$this->setState('filter.tag', $value);
 
 		$orderCol = $app->input->get('filter_order', 'a.ordering');

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -49,6 +49,7 @@ class ContentModelArticles extends JModelList
 				'publish_down', 'a.publish_down',
 				'images', 'a.images',
 				'urls', 'a.urls',
+        'filter_tag'
 			);
 		}
 
@@ -81,6 +82,9 @@ class ContentModelArticles extends JModelList
 
 		$value = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $value);
+
+    $value = $app->input->get('filter_tag', 0, 'uint');
+		$this->setState('filter.tag', $value);
 
 		$orderCol = $app->input->get('filter_order', 'a.ordering');
 
@@ -516,6 +520,19 @@ class ContentModelArticles extends JModelList
 		{
 			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
+
+    // Filter by a single tag.
+		$tagId = $this->getState('filter.tag');
+
+		if (is_numeric($tagId))
+		{
+			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId)
+				->join(
+					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
+					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
+				);
+		}    
 
 		// Add the list ordering clause.
 		$query->order($this->getState('list.ordering', 'a.ordering') . ' ' . $this->getState('list.direction', 'ASC'));

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -49,7 +49,7 @@ class ContentModelArticles extends JModelList
 				'publish_down', 'a.publish_down',
 				'images', 'a.images',
 				'urls', 'a.urls',
-        			'filter_tag'
+				'filter_tag'
 			);
 		}
 
@@ -83,7 +83,7 @@ class ContentModelArticles extends JModelList
 		$value = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $value);
 
-    		$value = $app->input->get('filter_tag', 0, 'uint');
+		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		$orderCol = $app->input->get('filter_order', 'a.ordering');
@@ -521,7 +521,7 @@ class ContentModelArticles extends JModelList
 			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}
 
-    		// Filter by a single tag.
+		// Filter by a single tag.
 		$tagId = $this->getState('filter.tag');
 
 		if (is_numeric($tagId))
@@ -532,7 +532,7 @@ class ContentModelArticles extends JModelList
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_content.article')
 				);
-		}    
+		}
 
 		// Add the list ordering clause.
 		$query->order($this->getState('list.ordering', 'a.ordering') . ' ' . $this->getState('list.direction', 'ASC'));

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -113,7 +113,7 @@ class ContentModelCategory extends JModelList
 
 		$this->setState('category.id', $pk);
 
-		$value = $app->input->get('filter_tag', null, 'uint');
+		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		// Load the parameters. Merge Global and Menu Item params into new object

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -113,7 +113,7 @@ class ContentModelCategory extends JModelList
 
 		$this->setState('category.id', $pk);
 
-		$value = $app->input->get('filter_tag', 0, 'uint');
+		$value = $app->input->get('filter_tag', null, 'uint');
 		$this->setState('filter.tag', $value);
 
 		// Load the parameters. Merge Global and Menu Item params into new object
@@ -249,7 +249,11 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.limit', $limit);
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
+<<<<<<< b7c50f7d83743ef42ab25c0d3ca2c5d2873146df
 			$model->setState('filter.tag', $this->getState('filter.tag'));
+=======
+      $model->setState('filter.tag', $this->getState('filter.tag'));
+>>>>>>> Add filter tag field to global settings. Set correct default value if no tag is provided
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -249,11 +249,7 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.limit', $limit);
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
-<<<<<<< b7c50f7d83743ef42ab25c0d3ca2c5d2873146df
 			$model->setState('filter.tag', $this->getState('filter.tag'));
-=======
-      $model->setState('filter.tag', $this->getState('filter.tag'));
->>>>>>> Add filter tag field to global settings. Set correct default value if no tag is provided
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -86,7 +86,8 @@ class ContentModelCategory extends JModelList
 				'hits', 'a.hits',
 				'publish_up', 'a.publish_up',
 				'publish_down', 'a.publish_down',
-				'author', 'a.author'
+				'author', 'a.author',
+        'filter_tag'
 			);
 		}
 
@@ -111,6 +112,9 @@ class ContentModelCategory extends JModelList
 		$pk  = $app->input->getInt('id');
 
 		$this->setState('category.id', $pk);
+
+    $value = $app->input->get('filter_tag', 0, 'uint');
+		$this->setState('filter.tag', $value);
 
 		// Load the parameters. Merge Global and Menu Item params into new object
 		$params = $app->getParams();
@@ -245,6 +249,7 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.limit', $limit);
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
+      $model->setState('filter.tag', $this->getState('filter.tag'));      
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -87,7 +87,7 @@ class ContentModelCategory extends JModelList
 				'publish_up', 'a.publish_up',
 				'publish_down', 'a.publish_down',
 				'author', 'a.author',
-        'filter_tag'
+        			'filter_tag'
 			);
 		}
 
@@ -113,7 +113,7 @@ class ContentModelCategory extends JModelList
 
 		$this->setState('category.id', $pk);
 
-    $value = $app->input->get('filter_tag', 0, 'uint');
+    		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		// Load the parameters. Merge Global and Menu Item params into new object
@@ -249,7 +249,7 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.limit', $limit);
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
-      $model->setState('filter.tag', $this->getState('filter.tag'));      
+      			$model->setState('filter.tag', $this->getState('filter.tag'));      
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -87,7 +87,7 @@ class ContentModelCategory extends JModelList
 				'publish_up', 'a.publish_up',
 				'publish_down', 'a.publish_down',
 				'author', 'a.author',
-        			'filter_tag'
+				'filter_tag'
 			);
 		}
 
@@ -113,7 +113,7 @@ class ContentModelCategory extends JModelList
 
 		$this->setState('category.id', $pk);
 
-    		$value = $app->input->get('filter_tag', 0, 'uint');
+		$value = $app->input->get('filter_tag', 0, 'uint');
 		$this->setState('filter.tag', $value);
 
 		// Load the parameters. Merge Global and Menu Item params into new object
@@ -249,7 +249,7 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.limit', $limit);
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
-      			$model->setState('filter.tag', $this->getState('filter.tag'));      
+			$model->setState('filter.tag', $this->getState('filter.tag'));
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -147,6 +147,7 @@
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
+        <option value="tag">JTAG</option>
 			</field>
 
 			<field name="show_headings" type="list"

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -147,7 +147,7 @@
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
-        <option value="tag">JTAG</option>
+        			<option value="tag">JTAG</option>
 			</field>
 
 			<field name="show_headings" type="list"

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -52,7 +52,6 @@ if (!empty($this->items))
 					</label>
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
 		        	<?php else :?>
-		          		<label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
 		    			<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
 		    				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
 		    				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -45,12 +45,20 @@ if (!empty($this->items))
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') != 'hide' || $this->params->get('show_pagination_limit')) :?>
 	<fieldset class="filters btn-toolbar clearfix">
 		<?php if ($this->params->get('filter_field') != 'hide') :?>
-			<div class="btn-group">
-				<label class="filter-search-lbl element-invisible" for="filter-search">
-					<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL') . '&#160;'; ?>
-				</label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
-			</div>
+      <div class="btn-group">
+        <?php if ($this->params->get('filter_field') != 'tag') :?>
+				  <label class="filter-search-lbl element-invisible" for="filter-search">
+					   <?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL') . '&#160;'; ?>
+				  </label>
+				  <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
+        <?php else :?>
+          <label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
+    			<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
+    				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
+    				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
+    			</select>
+        <?php endif; ?>
+    	</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>
 			<div class="btn-group pull-right">

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -45,20 +45,20 @@ if (!empty($this->items))
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') != 'hide' || $this->params->get('show_pagination_limit')) :?>
 	<fieldset class="filters btn-toolbar clearfix">
 		<?php if ($this->params->get('filter_field') != 'hide') :?>
-      <div class="btn-group">
-        <?php if ($this->params->get('filter_field') != 'tag') :?>
-				  <label class="filter-search-lbl element-invisible" for="filter-search">
-					   <?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL') . '&#160;'; ?>
-				  </label>
-				  <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
-        <?php else :?>
-          <label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
-    			<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
-    				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
-    				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
-    			</select>
-        <?php endif; ?>
-    	</div>
+		      	<div class="btn-group">
+		        	<?php if ($this->params->get('filter_field') != 'tag') :?>
+					<label class="filter-search-lbl element-invisible" for="filter-search">
+						<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL') . '&#160;'; ?>
+					</label>
+					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
+		        	<?php else :?>
+		          		<label class="selectlabel" for="filter_tag"><?php echo JText::_('JOPTION_SELECT_TAG'); ?></label>
+		    			<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
+		    				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
+		    				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
+		    			</select>
+		        	<?php endif; ?>
+		    	</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>
 			<div class="btn-group pull-right">

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Site
- * @subpackage  com_content
+ * @subpackage  Templates.beez3
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Site
- * @subpackage  Templates.beez3
+ * @subpackage  com_content
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -14,9 +14,9 @@ $app = JFactory::getApplication();
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.framework');
 
-$n         = count($this->items);
+$n = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
+$listDirn = $this->escape($this->state->get('list.direction'));
 
 ?>
 
@@ -34,11 +34,21 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<legend class="hidelabeltxt">
 			<?php echo JText::_('JGLOBAL_FILTER_LABEL'); ?>
 		</legend>
-
+		<?php if ($this->params->get('filter_field') != 'tag') :?>
 		<div class="filter-search">
-			<label class="filter-search-lbl" for="filter-search"><?php echo JText::_('COM_CONTENT_'.$this->params->get('filter_field').'_FILTER_LABEL').'&#160;'; ?></label>
-			<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" />
+			<label class="filter-search-lbl element-invisible" for="filter-search">
+				<?php echo JText::_('COM_CONTENT_'.$this->params->get('filter_field').'_FILTER_LABEL').'&#160;'; ?>
+			</label>
+			<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_'.$this->params->get('filter_field').'_FILTER_LABEL'); ?>" />
 		</div>
+		<?php else :?>
+		<div class="filter-search">
+			<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
+				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
+			</select>
+		</div>
+		<?php endif; ?>
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_pagination_limit')) : ?>
@@ -65,11 +75,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 				<?php if ($date = $this->params->get('list_show_date')) : ?>
 				<th class="list-date" id="tableOrdering2">
-					<?php if ($date == "created") : ?>
+					<?php if ($date == 'created') : ?>
 						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_'.$date.'_DATE', 'a.created', $listDirn, $listOrder); ?>
-					<?php elseif ($date == "modified") : ?>
+					<?php elseif ($date == 'modified') : ?>
 						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_'.$date.'_DATE', 'a.modified', $listDirn, $listOrder); ?>
-					<?php elseif ($date == "published") : ?>
+					<?php elseif ($date == 'published') : ?>
 						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_'.$date.'_DATE', 'a.publish_up', $listDirn, $listOrder); ?>
 					<?php endif; ?>
 				</th>
@@ -105,11 +115,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php if ($this->params->get('list_show_date')) : ?>
 					<td class="list-date">
 						<?php
-						echo JHtml::_(
-							'date', $article->displayDate, $this->escape(
-								$this->params->get('date_format', JText::_('DATE_FORMAT_LC3'))
-							)
-						); ?>
+							echo JHtml::_(
+									'date', $article->displayDate, $this->escape(
+											$this->params->get('date_format', JText::_('DATE_FORMAT_LC3'))
+									)
+							);
+						?>
 					</td>
 					<?php endif; ?>
 
@@ -117,8 +128,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<td class="list-author">
 						<?php if (!empty($article->author) || !empty($article->created_by_alias)) : ?>
 							<?php $author = $article->author ?>
-							<?php $author = ($article->created_by_alias ? $article->created_by_alias : $author);?>
-							<?php if (!empty($article->contact_link ) &&  $this->params->get('link_author') == true):?>
+							<?php $author = ($article->created_by_alias ? $article->created_by_alias : $author); ?>
+							<?php if (!empty($article->contact_link) &&  $this->params->get('link_author') == true):?>
 								<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $article->contact_link, $author)); ?>
 							<?php else :?>
 								<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
@@ -136,11 +147,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php else : ?>
 				<td>
 					<?php
-						echo $this->escape($article->title) . ' : ';
-						$menu   = JFactory::getApplication()->getMenu();
+						echo $this->escape($article->title).' : ';
+						$menu = JFactory::getApplication()->getMenu();
 						$active = $menu->getActive();
 						$itemId = $active->id;
-						$link   = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
+						$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid='.$itemId, false));
 						$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false)));
 					?>
 					<a href="<?php echo $link; ?>" class="register">
@@ -165,7 +176,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<div class="pagination">
 
 		<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-		 	<p class="counter">
+			 <p class="counter">
 				<?php echo $this->pagination->getPagesCounter(); ?>
 			</p>
 		<?php  endif; ?>


### PR DESCRIPTION
Resolves filtering by tags in the frontend. resolve #5998 

_How to test_
1. Create a fresh Joomla
2. Create some articles with tags
3. Create a new menu item -> articles -> category list
4. Select 'Tag' as filter field
5. Browse to the menu item in the frontend. 
6. Filter on any of the tags using the dropdown
