### PR TITLE
Fixed expired session bug

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -754,6 +754,7 @@ class JApplicationCms extends JApplicationWeb
 
 		// Remove expired sessions from the database.
 		$time = time();
+		$checkSessionNeeded = false;
 
 		if ($time % 2)
 		{
@@ -765,13 +766,14 @@ class JApplicationCms extends JApplicationWeb
 
 			$db->setQuery($query);
 			$db->execute();
+			$checkSessionNeeded = true;
 		}
 
 		// Get the session handler from the configuration.
 		$handler = $this->get('session_handler', 'none');
 
 		if (($handler != 'database' && ($time % 2 || $session->isNew()))
-			|| ($handler == 'database' && $session->isNew()))
+			|| ($handler == 'database' && ($session->isNew() || $checkSessionNeeded)))
 		{
 			$this->checkSession();
 		}


### PR DESCRIPTION
@mbabker when you have a chance - please review my another code here, its related with closed PR https://github.com/joomla/joomla-cms/pull/8834
It will fixed problem too.

description:
When session time was expired and we open site page, it getting data from expired session data which store in DB, so page has an old form token, and, after, expired data deletes from db here https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/application/cms.php#L758-L768, so next any pages have new token and, when we call ajax from page with old token, we get invalid token message, because user data session was recreated with new token.
