### PR TITLE
Optimizing JMenu::getItems()

### DIFF
--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -261,6 +261,7 @@ class JMenu
 		$items = array();
 		$attributes = (array) $attributes;
 		$values = (array) $values;
+		$count = count($attributes);
 
 		foreach ($this->_items as $item)
 		{
@@ -271,7 +272,7 @@ class JMenu
 
 			$test = true;
 
-			for ($i = 0, $count = count($attributes); $i < $count; $i++)
+			for ($i = 0; $i < $count; $i++)
 			{
 				if (is_array($values[$i]))
 				{


### PR DESCRIPTION
This is related to #8863. I looked into JMenu::getItems() to see if this could be optimized further. While this is a small optimization, it still means that the count operation only has to be run once instead of for each menu item. The number of attributes does not change during this method call, so we can move this to the beginning of the method instead of it being part of the for-loop.

Thanks @volandku for this one, too.
