### PR TITLE
Support multiple recaptcha's on 1 page

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -57,7 +57,12 @@ class PlgCaptchaRecaptcha extends JPlugin
 		}
 		else
 		{
+			$theme = $this->params->get('theme2', 'light');
 			$file	= 'https://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()->getTag();
+			JFactory::getDocument()->addScriptDeclaration('jQuery(document).ready(function($) {$(window).load(function() {'
+				. 'grecaptcha.render("' . $id . '", {sitekey: "' . $pubkey . '", theme: "' . $theme . '"});'
+				. '});});'
+			);
 		}
 
 		JHtml::_('script', $file);


### PR DESCRIPTION
#### Issue

Now you can't have multiple recaptcha's on a single page. Also 3rt party support doesn't work correct.
#### How To Reproduce

1) Install Kunena, enable recaptcha on joomla and kunena, also setup category correct, and enable public write option on kunena config.
also set option captcha for guests and users 

2) Create a new topic on kunena, or reply topic.
3) You will not see any recaptcha
#### After Fix

You see recaptcha on new topic, also you can now have multiple recapcha's. like one a topic with multiple replies.
