### PR TITLE
Changed title to use header_class

### DIFF
--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -13,7 +13,7 @@ $item_heading = $params->get('item_heading', 'h4');
 ?>
 <?php if ($params->get('item_title')) : ?>
 
-	<<?php echo $item_heading; ?> class="newsflash-title<?php echo $params->get('moduleclass_sfx'); ?>">
+	<<?php echo $item_heading; ?> class="newsflash-title<?php echo $params->get('header_class'); ?>">
 	<?php if ($params->get('link_titles') && $item->link != '') : ?>
 		<a href="<?php echo $item->link; ?>">
 			<?php echo $item->title; ?>


### PR DESCRIPTION
BUG: The module classes was added to the header class tag.
Changed this to use header_class instead.
