### PR TITLE
Fix hits counter

### DIFF
--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -101,6 +101,15 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
+		if ($vName == 'article' && $cachable && true)
+		{
+			// Get/Create the model
+			if ($model = $this->getModel($vName))
+			{
+				$model->hit();
+			}
+		}
+
 		parent::display($cachable, $safeurlparams);
 
 		return $this;

--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -101,7 +101,7 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
-		if ($vName == 'article' && $cachable && true)
+		if ($vName == 'article' && $cachable)
 		{
 			// Get/Create the model
 			if ($model = $this->getModel($vName))

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -170,13 +170,6 @@ class ContentViewArticle extends JViewLegacy
 		$results = $dispatcher->trigger('onContentAfterDisplay', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->afterDisplayContent = trim(implode("\n", $results));
 
-		// Increment the hit counter of the article.
-		if (!$this->params->get('intro_only') && $offset == 0)
-		{
-			$model = $this->getModel();
-			$model->hit();
-		}
-
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($this->item->params->get('pageclass_sfx'));
 


### PR DESCRIPTION
# Executive summary

These change allows to count hits for an article also when cache is switched on
# Backwards compatibility

Full b/c, no problems are expected
# Translation impact

none
# Why

If you switch cache on hits for an article are not counted right. The counter will be increased for the first time the article is requested. For the time the article come directly from the cache hits are not counted, this makes the statistic useless.
# Testing instruction
## To reproduce the error
- Install a fresh version of Joomla
- Create an article with an intro and full text, we need a read more button
- Make it a featured article so that you can see the article on the home page
- Notice that the counter is 0 (check this in the backend!)
- Click on the read more button and go back
- Notice that the counter is 1
- Click again and go back
- Counter === 2
- Switch on cache
- Click on the read more button and go back
- Counter === 3
- Click on the read more button and go back
- Counter === 3 (ups)

You can now wait the cache time and click and the counter will increase. If you are not so patient you can clear the cache and click then and the counter will increase
## Expected behavior

Every time you click on an article to counter should increase if cache is set on or off shouldn’t make a difference.
# Apply patch and testing
- Switch cache off
- check the hit counter value => N
- Click on the read more button and go back
- Counter === N+1
- Switch on cache
- Click on the read more button and go back
- Counter === N+2
- Click on the read more button and go back
- Counter === N+3

Bingo :-)

All counter checks should be made in the backend the frontend is caching values if caching is on.
