### PR TITLE
revert 301 redirect in Language Filter

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -397,12 +397,12 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$uri->setPath('index.php/' . $uri->getPath());
 				}
-				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')));
+				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')), 301);
 			}
 			else
 			{
 				$uri->setVar('lang', $this->lang_codes[$lang_code]->sef);
-				$this->app->redirect($uri->base() . 'index.php?' . $uri->getQuery());
+				$this->app->redirect($uri->base() . 'index.php?' . $uri->getQuery(), 301);
 			}
 		}
 


### PR DESCRIPTION
301 redirect has been lost during several changes, but it is more preferable status for redirection
