### PR TITLE
Clear Cache: Allowing sorting for all columns

### DIFF
--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -38,6 +38,20 @@ class CacheModelCache extends JModelList
 	protected $_pagination = null;
 
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *
+	 * @since   3.5
+	 */
+	public function __construct($config = array())
+	{
+		parent::__construct($config);
+
+		$this->filter_fields = array('group', 'count', 'size');
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.


### PR DESCRIPTION
To test, implement caching in Global Configuration.

This PR allows sorting by Number of Files and Size in the Clear Cache page.
Before the PR one can only sort by Cache Group.

After patch you will for example get for Size
![screen shot 2016-01-14 at 17 26 47](https://cloud.githubusercontent.com/assets/869724/12330185/0f450a8e-bae4-11e5-9167-d28cb8fbb195.png)
:
