### PR TITLE
Add the size param to Recaptcha plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -29,6 +29,10 @@ PLG_RECAPTCHA_THEME_LIGHT="Light"
 PLG_RECAPTCHA_THEME_DARK="Dark"
 PLG_RECAPTCHA_LANG_LABEL="Language"
 PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
+PLG_RECAPTCHA_SIZE_LABEL="Size"
+PLG_RECAPTCHA_SIZE_DESC="Select the size for the reCAPTCHA field"
+PLG_RECAPTCHA_THEME_NORMAL="Normal"
+PLG_RECAPTCHA_THEME_COMPACT="Compact"
 
 ; Error messages
 PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="reCAPTCHA plugin needs a secret key to be set in its parameters. Please contact a site administrator."

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -30,7 +30,7 @@ PLG_RECAPTCHA_THEME_DARK="Dark"
 PLG_RECAPTCHA_LANG_LABEL="Language"
 PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
 PLG_RECAPTCHA_SIZE_LABEL="Size"
-PLG_RECAPTCHA_SIZE_DESC="Select the size for the reCAPTCHA field"
+PLG_RECAPTCHA_SIZE_DESC="Select the size for the reCAPTCHA field."
 PLG_RECAPTCHA_THEME_NORMAL="Normal"
 PLG_RECAPTCHA_THEME_COMPACT="Compact"
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -54,7 +54,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 			$file	= 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
 
 			JFactory::getDocument()->addScriptDeclaration('jQuery( document ).ready(function()
-				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '", size: "' . $size . '",' . $this->_getLanguage() . 'tabindex: 0});});');
+				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $this->_getLanguage() . 'tabindex: 0});});');
 		}
 		else
 		{

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -50,10 +50,11 @@ class PlgCaptchaRecaptcha extends JPlugin
 			JHtml::_('jquery.framework');
 
 			$theme	= $this->params->get('theme', 'clean');
+			$size	= $this->params->get('size', 'normal');
 			$file	= 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
 
 			JFactory::getDocument()->addScriptDeclaration('jQuery( document ).ready(function()
-				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $this->_getLanguage() . 'tabindex: 0});});');
+				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '", size: "' . $size . '",' . $this->_getLanguage() . 'tabindex: 0});});');
 		}
 		else
 		{
@@ -86,7 +87,10 @@ class PlgCaptchaRecaptcha extends JPlugin
 		else
 		{
 			return '<div id="' . $id . '" ' . str_replace('class="', 'class="g-recaptcha ', $class) .
-					' data-sitekey="' . $this->params->get('public_key', '') . '" data-theme="' . $this->params->get('theme2', 'light') . '"></div>';
+					' data-sitekey="' . $this->params->get('public_key', '') .
+					'" data-theme="' . $this->params->get('theme2', 'light') .
+					'" data-size="' . $this->params->get('size', 'normal') .
+					'"></div>';
 		}
 	}
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -50,7 +50,6 @@ class PlgCaptchaRecaptcha extends JPlugin
 			JHtml::_('jquery.framework');
 
 			$theme	= $this->params->get('theme', 'clean');
-			$size	= $this->params->get('size', 'normal');
 			$file	= 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
 
 			JFactory::getDocument()->addScriptDeclaration('jQuery( document ).ready(function()

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -84,6 +84,21 @@
 			<option
 				value="dark">PLG_RECAPTCHA_THEME_DARK</option>
 		</field>
+
+		<field
+			name="size"
+			type="list"
+			default="normal"
+			label="PLG_RECAPTCHA_SIZE_LABEL"
+			description="PLG_RECAPTCHA_SIZE_DESC"
+			required="false"
+			showon="version:2.0"
+			filter="">
+			<option
+				value="normal">PLG_RECAPTCHA_THEME_NORMAL</option>
+			<option
+				value="compact">PLG_RECAPTCHA_THEME_COMPACT</option>
+		</field>
 		</fieldset>
 	</fields>
 	</config>


### PR DESCRIPTION
## Description

This PR enable users to set a size to the Recaptcha 2.0 plugin (compact or normal).
As you can see on the google documentation : https://developers.google.com/recaptcha/docs/display
## Example
- Before (the field was in normal size): 

![registrationformbefore](https://cloud.githubusercontent.com/assets/11151445/12355519/8bfd2886-bb9d-11e5-8667-1820516530a3.png)
- After (the field **can** be in compact size):

![registrationformafter](https://cloud.githubusercontent.com/assets/11151445/12355543/a2356d34-bb9d-11e5-890e-a2ae1130a207.png)
## Test

You can test each mode by changing the configuration of the plugin : 

![configrecaptcha](https://cloud.githubusercontent.com/assets/11151445/12355551/b3c5a780-bb9d-11e5-9cb3-476ee825f518.png)
