### PR TITLE
[bug] Multilanguage: Save as Copy should not transfer the associations to the new item

### DIFF
--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -665,7 +665,7 @@ class JControllerForm extends JControllerLegacy
 			// Reset multilingual associations if necessary
 			if (isset($data['associations']) && array_sum($data['associations']) != 0)
 			{
-				$data['associations'] = '';
+				$data['associations'] = array();
 			}
 			$task = 'apply';
 		}

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -661,6 +661,12 @@ class JControllerForm extends JControllerLegacy
 
 			// Reset the ID and then treat the request as for Apply.
 			$data[$key] = 0;
+
+			// Reset multilingual associations if necessary
+			if (isset($data['associations']) && array_sum($data['associations']) != 0)
+			{
+				$data['associations'] = '';
+			}
 			$task = 'apply';
 		}
 


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/8907

Test: 
install a basic multilingual site with the staging branch.
Enable item associations in the language filter plugin.
Associate some items (article, categories, contact, etc.)

Before patch
When using "Save as Copy" when editing an item with associations, the associations are transferred to the newly created copy instead of letting the original item with its associations.

After patch, the original item is untouched.
