### PR TITLE
Remove JLayoutFile deprecated methods from inside JLayoutFile class

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -73,7 +73,7 @@ class JLayoutFile extends JLayoutBase
 		$this->setOptions($options);
 
 		// Main properties
-		$this->setLayout($layoutId);
+		$this->setLayoutId($layoutId);
 		$this->basePath = $basePath;
 
 		// Init Enviroment
@@ -466,7 +466,7 @@ class JLayoutFile extends JLayoutBase
 		$this->options->set('component', $component);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**
@@ -501,7 +501,7 @@ class JLayoutFile extends JLayoutBase
 		$this->options->set('client', $client);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**


### PR DESCRIPTION
#### Description

This PR removes the usage of deprecated methods inside jlayout file class.
This was generating a lot of deprecated warnings on the log console.

Followed deprecated warning instructions:
- `refreshIncludePaths()` replaced by `clearIncludePaths()`
- `setLayout(arg)` replaced by `setLayoutId(arg)`

https://github.com/joomla/joomla-cms/pull/8935, https://github.com/joomla/joomla-cms/pull/8925 and https://github.com/joomla/joomla-cms/pull/8932 removes most of deprecated log messages in Joomla core.
#### How to test.

Check code diff.
