### PR TITLE
Remove class="active" from non-menu item

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 
 <ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 	<?php if ($params->get('showHere', 1)) : ?>
-		<li class="active">
+		<li>
 			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
 		</li>
 	<?php else : ?>

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7126,6 +7126,9 @@ h6 {
 .breadcrumb {
 	margin: 10px 0;
 }
+.breadcrumb > li {
+	color: #999;
+}
 .img_caption .left {
 	float: left;
 	margin-right: 1em;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -227,6 +227,9 @@ h6 { font-size: 12px; line-height: 14px; }
 .breadcrumb {
 	margin: 10px 0;
 }
+.breadcrumb > li {
+   color: #999;
+}
 /* Caption fixes */
 .img_caption .left {
 	float: left;


### PR DESCRIPTION
Removed the class="active" from line 17 which is text.  In the standard Joomla! install it says "you are here".  This should not be active, only the menu item for the page you are on should be active.  You can see an example here: http://eoindemo.demojoomla.com/index.php/bread-crumbs-content

Issue posted here: https://github.com/joomla/joomla-cms/issues/8593#issuecomment-172546422

Protostar needs to be updated with this CSS 

.breadcrumb > li {
    color: #999;
}

This change may break backwards compatibility with other templates.  I have fixed Protostar.

Protostar pull request here: https://github.com/joomla/joomla-cms/pull/8930
