### PR TITLE
Correct Styling for Breadcrumb after Pull Request

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3710,6 +3710,7 @@ input[type="submit"].btn.btn-mini {
 	*display: inline;
 	*zoom: 1;
 	text-shadow: 0 1px 0 #fff;
+	color: #999;
 }
 .breadcrumb > li > .divider {
 	padding: 0 5px;


### PR DESCRIPTION
I have created a pull request https://github.com/joomla/joomla-cms/pull/8929 to remove the class "active" from the "you are here" text and leave it only on the menu item of the page you are on.  The issue is explained better here.  https://github.com/joomla/joomla-cms/issues/8593#issuecomment-172546422

After making this request I have updated the protostar template so the "you are here" text is still the same colour as previous.

The original change may break backwards compatibility with other templates.
