### PR TITLE
Remove administrator deprecated JVersion calls

### DIFF
--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -77,8 +77,8 @@ $version = new JVersion;
 								<?php echo $language->name; ?>
 
 								<?php // Display a Note if language pack version is not equal to Joomla version ?>
-								<?php if (substr($language->version, 0, 3) != $version->RELEASE
-									|| substr($language->version, 0, 5) != $version->RELEASE . "." . $version->DEV_LEVEL) : ?>
+								<?php if (substr($language->version, 0, 3) != $version::RELEASE
+									|| substr($language->version, 0, 5) != $version->getShortVersion()) : ?>
 									<div class="small"><?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?></div>
 								<?php endif; ?>
 							</label>

--- a/administrator/modules/mod_version/helper.php
+++ b/administrator/modules/mod_version/helper.php
@@ -25,20 +25,19 @@ abstract class ModVersionHelper
 	 */
 	public static function getVersion(&$params)
 	{
-		$format  = $params->get('format', 'short');
-		$product = $params->get('product', 0);
-		$method  = 'get' . ucfirst($format) . "Version";
+		$version = new JVersion;
+		$versionText = $version->getShortVersion();
 
-		// Get the joomla version
-		$instance = new JVersion;
-		$version  = call_user_func(array($instance, $method));
-
-		if ($format == 'short' && !empty($product))
+		if ($params->get('format', 'short') === 'long')
 		{
-			// Add the product name to short format only (in long format it's included)
-			$version = $instance->PRODUCT . ' ' . $version;
+			$versionText = str_replace($version::PRODUCT . ' ', '', $version->getLongVersion());
 		}
 
-		return $version;
+		if (!empty($params->get('product', 0)))
+		{
+			$versionText = $version::PRODUCT . ' ' . $versionText;
+		}
+
+		return $versionText;
 	}
 }

--- a/administrator/templates/hathor/html/com_installer/languages/default.php
+++ b/administrator/templates/hathor/html/com_installer/languages/default.php
@@ -65,8 +65,8 @@ $version = new JVersion;
 							<?php echo $language->name; ?>
 
 							<?php // Display a Note if language pack version is not equal to Joomla version ?>
-							<?php if (substr($language->version, 0, 3) != $version->RELEASE
-									|| substr($language->version, 0, 5) != $version->RELEASE . "." . $version->DEV_LEVEL) : ?>
+							<?php if (substr($language->version, 0, 3) != $version::RELEASE
+									|| substr($language->version, 0, 5) != $version->getShortVersion()) : ?>
 								<div class="small"><?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?></div>
 							<?php endif; ?>
 						</td>

--- a/build/helpTOC.php
+++ b/build/helpTOC.php
@@ -52,7 +52,7 @@ class MediawikiCli extends JApplicationCli
 	{
 		// Get the version data for the script
 		$version     = new JVersion;
-		$helpVersion = str_replace('.', '', $version->RELEASE);
+		$helpVersion = str_replace('.', '', $version::RELEASE);
 		$namespace   = 'Help' . $helpVersion . ':';
 
 		// Set up options for JMediawiki
@@ -63,7 +63,7 @@ class MediawikiCli extends JApplicationCli
 
 		// Get the category members (local hack)
 		$this->out('Fetching data from docs wiki', true);
-		$categoryMembers = $mediawiki->categories->getCategoryMembers('Category:Help_screen_' . $version->RELEASE, null, 'max');
+		$categoryMembers = $mediawiki->categories->getCategoryMembers('Category:Help_screen_' . $version::RELEASE, null, 'max');
 
 		$members = array();
 

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -91,8 +91,8 @@ $version = new JVersion;
 									/> <?php echo $language->name; ?>
 
 									<?php // Display a Note if language pack version is not equal to Joomla version ?>
-									<?php if (substr($language->version, 0, 3) != $version->RELEASE
-											|| substr($language->version, 0, 5) != $version->RELEASE . "." . $version->DEV_LEVEL) : ?>
+									<?php if (substr($language->version, 0, 3) != $version::RELEASE
+											|| substr($language->version, 0, 5) != $version->getShortVersion()) : ?>
 										<div class="small"><?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?></div>
 									<?php endif; ?>
 							</label>

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -148,7 +148,7 @@ class JUpdaterCollection extends JUpdateAdapter
 				$ver = new JVersion;
 
 				// Lower case and remove the exclamation mark
-				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
+				$product = strtolower(JFilterInput::getInstance()->clean($ver::PRODUCT, 'cmd'));
 
 				/*
 				 * Set defaults, the extension file should clarify in case but it may be only available in one version
@@ -166,7 +166,7 @@ class JUpdaterCollection extends JUpdateAdapter
 				// Set this to ourself as a default
 				if (!isset($values['targetplatformversion']))
 				{
-					$values['targetplatformversion'] = $ver->RELEASE;
+					$values['targetplatformversion'] = $ver::RELEASE;
 				}
 
 				// Set this to ourselves as a default

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -95,7 +95,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				$ver = new JVersion;
 
 				// Lower case and remove the exclamation mark
-				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
+				$product = strtolower(JFilterInput::getInstance()->clean($ver::PRODUCT, 'cmd'));
 
 				/*
 				 * Check that the product matches and that the version matches (optionally a regexp)
@@ -107,8 +107,8 @@ class JUpdaterExtension extends JUpdateAdapter
 				 */
 				if ($product == $this->currentUpdate->targetplatform['NAME']
 					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
 					if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum, '>='))

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -303,9 +303,9 @@ class JUpdate extends JObject
 				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
 				if (isset($this->currentUpdate->targetplatform->name)
 					&& $product == $this->currentUpdate->targetplatform->name
-					&& preg_match('/' . $this->currentUpdate->targetplatform->version . '/', $ver->RELEASE)
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver->DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver->DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
+					&& preg_match('/' . $this->currentUpdate->targetplatform->version . '/', $ver::RELEASE)
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $ver::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $ver::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
 					if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum->_data, '>='))

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -298,7 +298,7 @@ class JUpdate extends JObject
 			// Closing update, find the latest version and check
 			case 'UPDATE':
 				$ver = new JVersion;
-				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
+				$product = strtolower(JFilterInput::getInstance()->clean($ver::PRODUCT, 'cmd'));
 
 				// Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
 				if (isset($this->currentUpdate->targetplatform->name)

--- a/tests/unit/suites/libraries/cms/version/JVersionTest.php
+++ b/tests/unit/suites/libraries/cms/version/JVersionTest.php
@@ -70,7 +70,7 @@ class JVersionTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetShortVersion()
 	{
-		$this->assertEquals($this->object::RELEASE . '.' . $this->object::DEV_LEVEL, $this->object->getShortVersion());
+		$this->assertEquals($this->object->RELEASE . '.' . $this->object->DEV_LEVEL, $this->object->getShortVersion());
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/version/JVersionTest.php
+++ b/tests/unit/suites/libraries/cms/version/JVersionTest.php
@@ -70,7 +70,7 @@ class JVersionTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetShortVersion()
 	{
-		$this->assertEquals($this->object->RELEASE . '.' . $this->object->DEV_LEVEL, $this->object->getShortVersion());
+		$this->assertEquals($this->object::RELEASE . '.' . $this->object::DEV_LEVEL, $this->object->getShortVersion());
 	}
 
 	/**


### PR DESCRIPTION
#### Description

This PR removes the usage of deprecated JVersion methods inside admin mod_version (the one that puts the joomla version in the bottom right corner of the admin panel) and from install languages.
The old usage was deprecated in https://github.com/joomla/joomla-cms/pull/7217

https://github.com/joomla/joomla-cms/pull/8935, https://github.com/joomla/joomla-cms/pull/8925 and https://github.com/joomla/joomla-cms/pull/8932 removes most of deprecated log messages in Joomla core.
#### How to test.
- Install patch.
- Check if in the bottom right corner of your joomla admin panel if version is ok
- Go to modules, select "Administrator" modules and edit the "Joomla Version".
- Test the 3 options and check if they are all ok.
- Check also if in the debug console there is no deprecated message

Part 2:
- Go to install languages
- Check there are no JVersion deprecated messages and everything works fine
