### PR TITLE
Update to use JMicrodata library rather than hard coded values

### DIFF
--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -72,7 +72,7 @@ $params = $this->params;
 						<div class="category-name">
 							<?php $title = $this->escape($item->category_title); ?>
 							<?php if ($params->get('link_category') && $item->catslug) : ?>
-								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" ' . echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 							<?php else : ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span ' . echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
@@ -149,10 +149,10 @@ $params = $this->params;
 							<div class="parent-category-name">
 								<?php $title = $this->escape($item->parent_title); ?>
 								<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
-									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" ' . echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span '. echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span ' . echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 								<?php endif; ?>
 							</div>
 						</dd>
@@ -162,10 +162,10 @@ $params = $this->params;
 							<div class="category-name">
 								<?php $title = $this->escape($item->category_title); ?>
 								<?php if ($params->get('link_category') && $item->catslug) : ?>
-									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" ' . echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span '. echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
+									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span ' . echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 								<?php endif; ?>
 							</div>
 						</dd>

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -12,25 +12,31 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 $params = $this->params;
 ?>
-
+<?php $microdata = new JMicrodata('Article'); ?>
+<?php $microdata2 = new JMicrodata('Person'); ?>
 <div id="archive-items">
 	<?php foreach ($this->items as $i => $item) : ?>
 		<?php $info = $item->params->get('info_block_position', 0); ?>
-		<div class="row<?php echo $i % 2; ?>" itemscope itemtype="https://schema.org/Article">
+		<div class="row<?php echo $i % 2; ?>" <?php echo $microdata->displayScope(); ?>>
 			<div class="page-header">
-				<h2 itemprop="name">
+				<h2>
 					<?php if ($params->get('link_titles')) : ?>
-						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>" itemprop="url">
-							<?php echo $this->escape($item->title); ?>
+						<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>"
+						<?php echo $microdata->property('url')->display(); ?>>
+							<span <?php echo $microdata->property('name')->display(); ?>>
+								<?php echo $this->escape($item->title); ?>
+							</span>
 						</a>
 					<?php else: ?>
-						<?php echo $this->escape($item->title); ?>
+						<span <?php echo $microdata->property('name')->display(); ?>>
+							<?php echo $this->escape($item->title); ?>
+						</span>
 					<?php endif; ?>
 				</h2>
 				<?php if ($params->get('show_author') && !empty($item->author )) : ?>
-					<div class="createdby" itemprop="author" itemscope itemtype="https://schema.org/Person">
+					<div class="createdby" <?php echo $microdata->property('author')->display();?> <?php echo $microdata2->displayScope(); ?>>
 					<?php $author = ($item->created_by_alias) ? $item->created_by_alias : $item->author; ?>
-					<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
+					<?php $author = '<span' . echo $microdata2->property('name')->display(); . '>' . $author . '</span>'; ?>
 						<?php if (!empty($item->contact_link) && $params->get('link_author') == true) : ?>
 							<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author, array('itemprop' => 'url'))); ?>
 						<?php else: ?>
@@ -53,10 +59,10 @@ $params = $this->params;
 						<div class="parent-category-name">
 							<?php $title = $this->escape($item->parent_title); ?>
 							<?php if ($params->get('link_parent_category') && !empty($item->parent_slug)) : ?>
-								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" ' . echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 							<?php else : ?>
-								<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
+								<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span ' . echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 							<?php endif; ?>
 						</div>
 					</dd>
@@ -66,10 +72,10 @@ $params = $this->params;
 						<div class="category-name">
 							<?php $title = $this->escape($item->category_title); ?>
 							<?php if ($params->get('link_category') && $item->catslug) : ?>
-								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 							<?php else : ?>
-								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
+								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span ' . echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 							<?php endif; ?>
 						</div>
 					</dd>
@@ -79,7 +85,7 @@ $params = $this->params;
 					<dd>
 						<div class="published">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
+							<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" <?php echo $microdata->property('datePublished')->display(); ?>>
 								<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>
@@ -91,7 +97,7 @@ $params = $this->params;
 						<dd>
 							<div class="modified">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
+								<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" <?php echo $microdata->property('dateModified')->display(); ?>>
 									<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -101,7 +107,7 @@ $params = $this->params;
 						<dd>
 							<div class="create">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
+								<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" <?php echo $microdata->property('dateCreated')->display(); ?>>
 									<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -112,7 +118,7 @@ $params = $this->params;
 						<dd>
 							<div class="hits">
 								<span class="icon-eye-open"></span> 
-								<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $item->hits; ?>" />
+								<meta <?php echo $microdata->property('interactionCount')->display(); ?> content="UserPageVisits:<?php echo $item->hits; ?>" />
 								<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 							</div>
 						</dd>
@@ -129,7 +135,7 @@ $params = $this->params;
 		<?php // Content is generated by content plugin event "onContentBeforeDisplay" ?>
 		<?php echo $item->event->beforeDisplayContent; ?>
 		<?php if ($params->get('show_intro')) :?>
-			<div class="intro" itemprop="articleBody"> <?php echo JHtml::_('string.truncateComplex', $item->introtext, $params->get('introtext_limit')); ?> </div>
+			<div class="intro" <?php echo $microdata->property('articleBody')->display(); ?>> <?php echo JHtml::_('string.truncateComplex', $item->introtext, $params->get('introtext_limit')); ?> </div>
 		<?php endif; ?>
 
 		<?php if ($useDefList && ($info == 1 || $info == 2)) : ?>
@@ -143,10 +149,10 @@ $params = $this->params;
 							<div class="parent-category-name">
 								<?php $title = $this->escape($item->parent_title); ?>
 								<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
-									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
+									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span '. echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 								<?php endif; ?>
 							</div>
 						</dd>
@@ -156,10 +162,10 @@ $params = $this->params;
 							<div class="category-name">
 								<?php $title = $this->escape($item->category_title); ?>
 								<?php if ($params->get('link_category') && $item->catslug) : ?>
-									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" '. echo $microdata->property('genre')->display(); . '>' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
+									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span '. echo $microdata->property('genre')->display(); . '>' . $title . '</span>'); ?>
 								<?php endif; ?>
 							</div>
 						</dd>
@@ -168,7 +174,7 @@ $params = $this->params;
 						<dd>
 							<div class="published">
 								<span class="icon-calendar"></span>
-								<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
+								<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" <?php echo $microdata->property('datePublished')->display(); ?>>
 									<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
 							</div>
@@ -180,7 +186,7 @@ $params = $this->params;
 					<dd>
 						<div class="create">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
+							<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" <?php echo $microdata->property('dateCreated')->display(); ?>>
 								<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>
@@ -190,7 +196,7 @@ $params = $this->params;
 					<dd>
 						<div class="modified">
 							<span class="icon-calendar"></span>
-							<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
+							<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" <?php echo $microdata->property('dateModified')->display(); ?>>
 								<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
 						</div>
@@ -200,7 +206,7 @@ $params = $this->params;
 					<dd>
 						<div class="hits">
 							<span class="icon-eye-open"></span> 
-							<meta content="UserPageVisits:<?php echo $item->hits; ?>" itemprop="interactionCount" />
+							<meta content="UserPageVisits:<?php echo $item->hits; ?>" <?php echo $microdata->property('interactionCount')->display(); ?> />
 							<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 						</div>
 					</dd>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -20,8 +20,9 @@ $user    = JFactory::getUser();
 $info    = $params->get('info_block_position', 0);
 JHtml::_('behavior.caption');
 ?>
-<div class="item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
-	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? JFactory::getConfig()->get('language') : $this->item->language; ?>" />
+<?php $microdata = new JMicrodata('Article'); ?>
+<div class="item-page<?php echo $this->pageclass_sfx; ?>" <?php echo $microdata->displayScope();?>>
+	<meta <?php echo $microdata->property('inLanguage')->display(); ?> content="<?php echo ($this->item->language === '*') ? JFactory::getConfig()->get('language') : $this->item->language; ?>" />
 	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
@@ -45,11 +46,11 @@ JHtml::_('behavior.caption');
 	<?php endif; ?>
 	<?php if ($params->get('show_title') || $params->get('show_author')) : ?>
 	<div class="page-header">
-		<h2 itemprop="name">
-			<?php if ($params->get('show_title')) : ?>
+		<?php if ($params->get('show_title')) : ?>
+		<h2 <?php echo $microdata->property('name')->display(); ?>>
 				<?php echo $this->escape($this->item->title); ?>
-			<?php endif; ?>
 		</h2>
+		<?php endif; ?>
 		<?php if ($this->item->state == 0) : ?>
 			<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>
@@ -99,7 +100,7 @@ JHtml::_('behavior.caption');
 	<?php if ($images->image_fulltext_caption):
 		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
 	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
+	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" <?php echo $microdata->property('image')->display(); ?>/> </div>
 	<?php endif; ?>
 	<?php
 	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
@@ -109,7 +110,7 @@ JHtml::_('behavior.caption');
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<div itemprop="articleBody">
+	<div <?php echo $microdata->property('articleBody')->display(); ?>>
 		<?php echo $this->item->text; ?>
 	</div>
 

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -13,7 +13,9 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 JHtml::_('behavior.caption');
 ?>
-<div class="blog<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Blog">
+<?php $microdata = new JMicrodata('Blog'); ?>
+<?php $microdata2 = new JMicrodata('BlogPosting'); ?>
+<div class="blog<?php echo $this->pageclass_sfx; ?>" <?php echo $microdata->displayScope();?>>
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
@@ -55,7 +57,7 @@ JHtml::_('behavior.caption');
 		<div class="items-leading clearfix">
 			<?php foreach ($this->lead_items as &$item) : ?>
 				<div class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>"
-					itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+					<?php echo $microdata2->displayScope(); ?> <?php echo $microdata2->property('blogPost')->display(); ?>>
 					<?php
 					$this->item = & $item;
 					echo $this->loadTemplate('item');
@@ -80,7 +82,7 @@ JHtml::_('behavior.caption');
 			<?php endif; ?>
 			<div class="span<?php echo round((12 / $this->columns)); ?>">
 				<div class="item column-<?php echo $rowcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?>"
-					itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+					<?php echo $microdata2->displayScope(); ?> <?php echo $microdata2->property('blogPost')->display(); ?>>
 					<?php
 					$this->item = & $item;
 					echo $this->loadTemplate('item');

--- a/components/com_content/views/featured/tmpl/default.php
+++ b/components/com_content/views/featured/tmpl/default.php
@@ -16,7 +16,9 @@ JHtml::_('behavior.caption');
 // If the page class is defined, add to class as suffix.
 // It will be a separate class if the user starts it with a space
 ?>
-<div class="blog-featured<?php echo $this->pageclass_sfx;?>" itemscope itemtype="https://schema.org/Blog">
+<?php $microdata = new JMicrodata('Blog'); ?>
+<?php $microdata2 = new JMicrodata('BlogPosting'); ?>
+<div class="blog-featured<?php echo $this->pageclass_sfx;?>" <?php echo $microdata->displayScope();?>>
 <?php if ($this->params->get('show_page_heading') != 0) : ?>
 <div class="page-header">
 	<h1>
@@ -30,7 +32,7 @@ JHtml::_('behavior.caption');
 <div class="items-leading clearfix">
 	<?php foreach ($this->lead_items as &$item) : ?>
 		<div class="leading-<?php echo $leadingcount; ?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> clearfix" 
-			itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+			<?php echo $microdata2->displayScope(); ?> <?php echo $microdata2->property('blogPost')->display(); ?>>
 			<?php
 				$this->item = &$item;
 				echo $this->loadTemplate('item');
@@ -59,7 +61,7 @@ JHtml::_('behavior.caption');
 		<div class="items-row cols-<?php echo (int) $this->columns;?> <?php echo 'row-' . $row; ?> row-fluid">
 		<?php endif; ?>
 			<div class="item column-<?php echo $rowcount;?><?php echo $item->state == 0 ? ' system-unpublished' : null; ?> span<?php echo round((12 / $this->columns));?>"
-				itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+				<?php echo $microdata2->displayScope(); ?> <?php echo $microdata2->property('blogPost')->display(); ?>>
 			<?php
 					$this->item = &$item;
 					echo $this->loadTemplate('item');

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <?php foreach ($list as $item) :  ?>
 	<li <?php echo $microdata->displayScope();?>>
 		<a href="<?php echo $item->link; ?>" <?php echo $microdata->property('url')->display(); ?>>
-			<span <?php echo $microdata->content('')->property('name')->display();?>>
+			<span <?php echo $microdata->property('name')->display();?>>
 				<?php echo $item->title; ?>
 			</span>
 		</a>

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -9,11 +9,12 @@
 
 defined('_JEXEC') or die;
 ?>
+<?php $microdata = new JMicrodata('Article'); ?>
 <ul class="latestnews<?php echo $moduleclass_sfx; ?>">
 <?php foreach ($list as $item) :  ?>
-	<li itemscope itemtype="https://schema.org/Article">
-		<a href="<?php echo $item->link; ?>" itemprop="url">
-			<span itemprop="name">
+	<li <?php echo $microdata->displayScope();?>>
+		<a href="<?php echo $item->link; ?>" <?php echo $microdata->property('url')->display(); ?>>
+			<span <?php echo $microdata->content('')->property('name')->display();?>>
 				<?php echo $item->title; ?>
 			</span>
 		</a>


### PR DESCRIPTION
We have the JMicrodata library, lets actually use it.

Testing
1. Add patch
  https://docs.joomla.org/Testing_Joomla!_patches
2. modify the template to remove any overrides for `com_content` or `mod_articles_latest` (you can't test if you have an override, since you would just be testing the override)
3. Add a latest articles module to site display
4. add some articles, arcived articles and blog layout menu types for displaying on the site side
5. Check that microdata values are still applied using a microdata validation tool
  https://developers.google.com/structured-data/testing-tool/
