### PR TITLE
Add JMicrodata to popular articles module for schema.org microdata

### DIFF
--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -9,11 +9,15 @@
 
 defined('_JEXEC') or die;
 ?>
+<?php $microdata = new JMicrodata('Article'); ?>
 <ul class="mostread<?php echo $moduleclass_sfx; ?>">
 <?php foreach ($list as $item) : ?>
-	<li>
-		<a href="<?php echo $item->link; ?>">
-			<?php echo $item->title; ?></a>
+	<li <?php echo $microdata->displayScope();?>>
+		<a href="<?php echo $item->link; ?>" <?php echo $microdata->property('url')->display(); ?>>
+			<span <?php echo $microdata->property('name')->display();?>>
+				<?php echo $item->title; ?>
+			</span>
+		</a>
 	</li>
 <?php endforeach; ?>
 </ul>


### PR DESCRIPTION
We have the JMicrodata library, lets actually use it.

Testing
1. Add patch
  https://docs.joomla.org/Testing_Joomla!_patches
2. Add a popular articles module to display
3. Check that microdata values are applied using a microdata validation tool
  https://developers.google.com/structured-data/testing-tool/
