### PR TITLE
Remove deprecated getJSObject and replace it with json_encode

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -296,7 +296,7 @@ abstract class JHtmlBehavior
 		$opt['onShow']    = (isset($params['onShow'])) ? '\\' . $params['onShow'] : null;
 		$opt['onHide']    = (isset($params['onHide'])) ? '\\' . $params['onHide'] : null;
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 		// Include jQuery
 		JHtml::_('jquery.framework');
@@ -393,7 +393,7 @@ abstract class JHtmlBehavior
 			$opt['size']      = array('x' => '\\jQuery(window).width() - 80', 'y' => '\\jQuery(window).height() - 80');
 		}
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 		// Attach modal behavior to document
 		$document
@@ -493,7 +493,7 @@ abstract class JHtmlBehavior
 		$opt['onClick']  = (array_key_exists('onClick', $params)) ? '\\' . $params['onClick']
 		: '\\function(node){  window.open(node.data.url, node.data.target != null ? node.data.target : \'_self\'); }';
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 		// Setup root node
 		$rt['text']     = (array_key_exists('text', $root)) ? $root['text'] : 'Root';
@@ -503,7 +503,8 @@ abstract class JHtmlBehavior
 		$rt['icon']     = (array_key_exists('icon', $root)) ? $root['icon'] : null;
 		$rt['openicon'] = (array_key_exists('openicon', $root)) ? $root['openicon'] : null;
 		$rt['data']     = (array_key_exists('data', $root)) ? $root['data'] : null;
-		$rootNode = JHtml::getJSObject($rt);
+		
+		$rootNode = json_encode(array_filter((array) $rt, function ($item) { return !is_null($item); }));
 
 		$treeName = (array_key_exists('treeName', $params)) ? $params['treeName'] : '';
 

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -51,7 +51,7 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['offset'] = isset($params['offset']) ? $params['offset'] : 10;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			// Attach affix to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -159,7 +159,7 @@ abstract class JHtmlBootstrap
 			$opt['interval'] = isset($params['interval']) ? (int) $params['interval'] : 5000;
 			$opt['pause']    = isset($params['pause']) ? $params['pause'] : 'hover';
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			// Attach the carousel to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -347,7 +347,7 @@ abstract class JHtmlBootstrap
 		$opt['delay']     = isset($params['delay']) ? $params['delay'] : null;
 		$opt['container'] = isset($params['container']) ? $params['container'] : 'body';
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 		// Attach the popover to the document
 		JFactory::getDocument()->addScriptDeclaration(
@@ -386,7 +386,7 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['offset'] = isset($params['offset']) ? (int) $params['offset'] : 10;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			// Attach ScrollSpy to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -449,7 +449,7 @@ abstract class JHtmlBootstrap
 			$onHide           = isset($params['onHide']) ? (string) $params['onHide'] : null;
 			$onHidden         = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			// Build the script.
 			$script = array();
@@ -530,7 +530,7 @@ abstract class JHtmlBootstrap
 			$opt['updater']     = isset($params['updater']) ? (string) $params['updater'] : null;
 			$opt['highlighter'] = isset($params['highlighter']) ? (int) $params['highlighter'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			// Attach typehead to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -584,7 +584,7 @@ abstract class JHtmlBootstrap
 			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
 			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			$opt['active'] = isset($params['active']) ? (string) $params['active'] : '';
 

--- a/libraries/cms/html/sliders.php
+++ b/libraries/cms/html/sliders.php
@@ -106,7 +106,7 @@ abstract class JHtmlSliders
 			$opt['opacity'] = (isset($params['opacityTransition']) && ($params['opacityTransition'])) ? 'true' : 'false';
 			$opt['alwaysHide'] = (isset($params['allowAllClose']) && (!$params['allowAllClose'])) ? 'false' : 'true';
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			$js = "window.addEvent('domready', function(){ new Fx.Accordion($$('div#" . $group
 				. ".pane-sliders > .panel > h3.pane-toggler'), $$('div#" . $group . ".pane-sliders > .panel > div.pane-slider'), " . $options

--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -86,7 +86,7 @@ abstract class JHtmlTabs
 			$opt['titleSelector']       = "dt.tabs";
 			$opt['descriptionSelector'] = "dd.tabs";
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode(array_filter((array) $opt, function ($item) { return !is_null($item); }));
 
 			$js = '	window.addEvent(\'domready\', function(){
 						$$(\'dl#' . $group . '.tabs\').each(function(tabs){


### PR DESCRIPTION
#### Description

This PR removes deprecated getJSObject (used for javascript).
This removes a lot of deprecated messages from Joomla core.

https://github.com/joomla/joomla-cms/pull/8935, https://github.com/joomla/joomla-cms/pull/8925 and https://github.com/joomla/joomla-cms/pull/8932 removes most of deprecated log messages in Joomla core.
#### How to test
1. Install patch
2. Check javascript is working properly.
#### Observations

`getJSObject` has some more operations than just json_encode (see https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/html/html.php#L1064-L1109), but the deprecated message just says: `JHtml::getJSObject is deprecated. Use json_encode instead.`

I tried to just replace one by another and most convertions didn't work (they throw javascript errors) because the json also saves the null values, so i had to strip the null values from the arrays before using json_encode.
