### PR TITLE
Do not create a tab for fieldsets inside of repeatable fields.

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -47,12 +47,18 @@ JFactory::getDocument()->addScriptDeclaration(
 		<div class="span10">
 			<ul class="nav nav-tabs" id="configTabs">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
+					<?php if ((isset($fieldSet->repeat) && $fieldSet->repeat == true)) : ?>
+						<?php continue; ?>
+					<?php endif; ?>
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
 					<li><a href="#<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($label); ?></a></li>
 				<?php endforeach; ?>
 			</ul>
 			<div class="tab-content">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
+					<?php if ((isset($fieldSet->repeat) && $fieldSet->repeat == true)) : ?>
+						<?php continue; ?>
+					<?php endif; ?>
 					<div class="tab-pane" id="<?php echo $name; ?>">
 						<?php
 						if (isset($fieldSet->description) && !empty($fieldSet->description))


### PR DESCRIPTION
The 'repeatable' field type has a problem when used in a config form. Because the `repeatable` type has an extra 'fieldset' inside the the main 'field' tag and because `JForm::getFieldsets` does not exclude these specially nested 'fieldsets' and because this particular form's template doesn't use the `joomla.edit.params` layout (which includes a special exemption for `fieldset` tags with the `repeatable` attribute set to 'true'), when you place a 'repeatable' in a config form, you will get an extra tab that you didn't want. You can test this by inserting a 'repeatable' field in any config form. For example:

``` xml
<field name="test" type="repeatable" label="Test" default="{'test':['']}">
    <fieldset name="test_modal" hidden="true" repeat="true">
        <field name="test" type="text" label="Test" />
    </fieldset>
</field>
```

paste this code in some appropriate location inside of any component's `config.xml` and then go to the administrator and look at the form. There should be an extra tab with nothing in it. This is the tab for the 'test_modal' fieldset. Apply this patch and it will go away.

This patch is kind of a quick fix for this issue. It solves the problem and shouldn't have any side-effects. In the longer term (because other things may be affected) more changes would be nice, including:
-  The config form should be changed to make use of the `joomla.edit.params` layout.
-  `JForm::getFieldsets` should (at least optionally) omit 'fieldset' tags nested within 'field' tags. This breaks BC but it was a kind of break of BC when 'fieldsets' began to be nested within 'field' tags in the first place because that was certainly not the expectation when `JForm::getFieldsets` was written.
- Possibly rethink the 'repeatable' field type. Although it serves a valuable purpose, almost everything about it is a mess. The xml to set it up is not so easy to remember, the layout of the fields on the rendered form is a bit limiting, the fact that you must 'save' the modal and then remember to 'save' the actual form can be confusing, using the stored values of the sub-fields is not as easy as it should be... Well, it's probably too late to do anything about any of that anyway. 
