### PR TITLE
Depricated catslug note - mod_articles_popular

### DIFF
--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -78,6 +78,8 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug = $item->id . ':' . $item->alias;
+			// Catslug is depricated and will be removed in 4.0. Use catid instead.
+			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -78,7 +78,6 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug = $item->id . ':' . $item->alias;
-			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))
 			{

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -78,6 +78,7 @@ abstract class ModArticlesPopularHelper
 		foreach ($items as &$item)
 		{
 			$item->slug = $item->id . ':' . $item->alias;
+
 			// Catslug is depricated and will be removed in 4.0. Use catid instead.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -79,7 +79,7 @@ abstract class ModArticlesPopularHelper
 		{
 			$item->slug = $item->id . ':' . $item->alias;
 
-			// Catslug is depricated and will be removed in 4.0. Use catid instead.
+			// Catslug is deprecated and will be removed in 4.0. Use catid instead.
 			$item->catslug = $item->catid . ':' . $item->category_alias;
 
 			if ($access || in_array($item->access, $authorised))


### PR DESCRIPTION
This PR just add deprecated note for unnecessary $catslug parameter because it's not used anywhere.
