### PR TITLE
Simplifying #8918 and solving Notice

### DIFF
--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -659,14 +659,9 @@ class JControllerForm extends JControllerLegacy
 				return false;
 			}
 
-			// Reset the ID and then treat the request as for Apply.
+			// Reset the ID, the multilingual associations and then treat the request as for Apply.
 			$data[$key] = 0;
-
-			// Reset multilingual associations if necessary
-			if (isset($data['associations']) && array_sum($data['associations']) != 0)
-			{
-				$data['associations'] = array();
-			}
+			$data['associations'] = array();
 			$task = 'apply';
 		}
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1201,7 +1201,7 @@ abstract class JModelAdmin extends JModelForm
 
 		$this->setState($this->getName() . '.new', $isNew);
 
-		if ($this->associationsContext && JLanguageAssociations::isEnabled())
+		if ($this->associationsContext && JLanguageAssociations::isEnabled() && !empty($data['associations']))
 		{
 			$associations = $data['associations'];
 


### PR DESCRIPTION
This simplifies https://github.com/joomla/joomla-cms/pull/8918 as we do not need to check is we have associations.
Test instructions there.

Also, it solves a Notice that has been present for ever when Save as Copy a menu item with associations and in present staging when save as copy any item with associations.

`PHP Notice:  Undefined index: associations in ROOT/libraries/legacy/model/admin.php on line 1206`

PR has to be applied to last staging.

@wilsonge @andrepereiradasilva @fontanil
