### PR TITLE
Fix using en-GB as default language on odd cases

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -328,9 +328,13 @@ class JApplicationAdministrator extends JApplicationCms
 
 		if (!($result instanceof Exception))
 		{
-			$lang = $this->input->getCmd('lang', 'en-GB');
-			$lang = preg_replace('/[^A-Z-]/i', '', $lang);
-			$this->setUserState('application.lang', $lang);
+			$lang = $this->input->getCmd('lang');
+
+			if (strlen($lang)>0)
+			{
+				$lang = preg_replace('/[^A-Z-]/i', '', $lang);
+				$this->setUserState('application.lang', $lang);
+			}
 
 			static::purgeMessages();
 		}

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -330,7 +330,7 @@ class JApplicationAdministrator extends JApplicationCms
 		{
 			$lang = $this->input->getCmd('lang');
 
-			if (strlen($lang)>0)
+			if (strlen($lang) > 0)
 			{
 				$lang = preg_replace('/[^A-Z-]/i', '', $lang);
 				$this->setUserState('application.lang', $lang);

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -328,11 +328,11 @@ class JApplicationAdministrator extends JApplicationCms
 
 		if (!($result instanceof Exception))
 		{
-			$lang = $this->input->getCmd('lang', null);
+			$lang = $this->input->getCmd('lang');
+			$lang = preg_replace('/[^A-Z-]/i', '', $lang);
 
-			if (!is_null($lang))
+			if ($lang)
 			{
-				$lang = preg_replace('/[^A-Z-]/i', '', $lang);
 				$this->setUserState('application.lang', $lang);
 			}
 

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -328,9 +328,9 @@ class JApplicationAdministrator extends JApplicationCms
 
 		if (!($result instanceof Exception))
 		{
-			$lang = $this->input->getCmd('lang');
+			$lang = $this->input->getCmd('lang', null);
 
-			if (strlen($lang) > 0)
+			if (!is_null($lang))
 			{
 				$lang = preg_replace('/[^A-Z-]/i', '', $lang);
 				$this->setUserState('application.lang', $lang);


### PR DESCRIPTION
fixes #8906 

Fixes showing administrator side always in `en-GB` if `$_POST` has no `lang` key.
