### PR TITLE
Only access appscdn.joomla.org over ssl/https

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -66,7 +66,7 @@ JFactory::getDocument()->addScriptDeclaration(
 	Joomla.submitbuttonInstallWebInstaller = function() {
 		var form = document.getElementById("adminForm");
 
-		form.install_url.value = "http://appscdn.joomla.org/webapps/jedapps/webinstaller.xml";
+		form.install_url.value = "https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml";
 
 		Joomla.submitbutton4();
 	};

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -63,7 +63,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	{
 		var form = document.getElementById('adminForm');
 
-		form.install_url.value = 'http://appscdn.joomla.org/webapps/jedapps/webinstaller.xml';
+		form.install_url.value = 'https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml';
 
 		Joomla.submitbutton4();
 	};


### PR DESCRIPTION
The current method connects to http://appscdn.joomla.org/webapps/jedapps/webinstaller.xml

If your site is currently configured over a SSL/https url then the "Add from web" installer no longer loads due to the security of modern web browsers 

This changes the url to use the https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml url - note the S in the protocol is the only thing changing 

Without this change you get these kind of issues:

![image 2016-01-22 at 10 25 39 pm](https://cloud.githubusercontent.com/assets/400092/12525067/84b9e2b4-c159-11e5-8a16-05e58897ecb0.png)
