### PR TITLE
Change recaptcha default version to 2.0

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -24,7 +24,7 @@
 		<field
 			name="version"
 			type="list"
-			default="1.0"
+			default="2.0"
 			label="PLG_RECAPTCHA_VERSION_LABEL"
 			description="PLG_RECAPTCHA_VERSION_DESC"
 			size="1">


### PR DESCRIPTION
On a new install, the default choose for the ReCAPTCHA plugin is version 1.0. But there is also a this warning: 

```
You have selected Version 1.0. All new sites should be using Version 2.0. Version 1.0 is only maintained to provide support for Global Site keys which are no longer available from Google.
```

So why we don't change the default to version 2.0?
Or was there a certain reason that version 1.0 is still default?
### Test instructions
1. Go to Plugins -> Recaptcha (make sure you didn't save the plugin before. If you did, clean the parameter field in the database)
2. Notice that version 1.0 is default select
3. Apply patch and notice that 2.0 is now default selected
