### PR TITLE
Add is_array check on head document

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -116,9 +116,12 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			$buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
 
-			if ($temp = JArrayHelper::toString($linkAtrr['attribs']))
+			if (is_array($linkAtrr['attribs']))
 			{
-				$buffer .= ' ' . $temp;
+				if ($temp = ArrayHelper::toString($linkAtrr['attribs']))
+				{
+					$buffer .= ' ' . $temp;
+				}
 			}
 
 			$buffer .= ' />' . $lnEnd;
@@ -141,7 +144,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 			if (is_array($strAttr['attribs']))
 			{
-				if ($temp = JArrayHelper::toString($strAttr['attribs']))
+				if ($temp = ArrayHelper::toString($strAttr['attribs']))
 				{
 					$buffer .= ' ' . $temp;
 				}

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -116,7 +116,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			$buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
 
-			if ($temp = ArrayHelper::toString($linkAtrr['attribs']))
+			if ($temp = JArrayHelper::toString($linkAtrr['attribs']))
 			{
 				$buffer .= ' ' . $temp;
 			}
@@ -141,7 +141,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 			if (is_array($strAttr['attribs']))
 			{
-				if ($temp = ArrayHelper::toString($strAttr['attribs']))
+				if ($temp = JArrayHelper::toString($strAttr['attribs']))
 				{
 					$buffer .= ' ' . $temp;
 				}


### PR DESCRIPTION
#### Issue https://github.com/joomla/joomla-cms/issues/8923

Error: Argument 1 passed to Joomla\Utilities\ArrayHelper::toString() must be of the type array, string given, called in \libraries\joomla\document\renderer\html\head.php on line 119 and defined in libraries/vendor/joomla/utilities/src/ArrayHelper.php on line 104
#### Fix

add an is_array check
