### PR TITLE
Regression: Joomla installation broken when Email Configuration is on

### DIFF
--- a/installation/controller/install/email.php
+++ b/installation/controller/install/email.php
@@ -28,7 +28,6 @@ class InstallationControllerInstallEmail extends JControllerBase
 		// Overrides application config and set the configuration.php file so the send function will work
 		JFactory::$config = null;
 		JFactory::getConfig(JPATH_SITE . '/configuration.php');
-		JFactory::$session = null;
 	}
 
 	/**


### PR DESCRIPTION
Solves https://github.com/joomla/joomla-cms/issues/8972

When installing Joomla! and setting Email Configuration to Yes, installation does not go further and reloads page 3 after sending the mail.
The issue looks related to the changes in the session handling.

This patch takes off `JFactory::$session = null;` which was added in https://github.com/joomla/joomla-cms/pull/1992 when the session was handling differently.

To test issue install a new staging. Then patch and test again.

@mbabker @bertmert 
Thanks you for checking.
