### PR TITLE
2 suspicious code fragments

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -707,7 +707,7 @@ class TemplatesModelTemplate extends JModelForm
 	{
 		$return = false;
 
-		if (empty($htmlPath) || empty($htmlPath))
+		if (empty($overridePath) || empty($htmlPath))
 		{
 			return $return;
 		}

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -496,7 +496,7 @@ abstract class JUserHelper
 			case 'sha256':
 				$encrypted = ($salt) ? hash('sha256', $plaintext . $salt) . ':' . $salt : hash('sha256', $plaintext);
 
-				return ($show_encrypt) ? '{SHA256}' . $encrypted : '{SHA256}' . $encrypted;
+				return ($show_encrypt) ? '{SHA256}' . $encrypted : $encrypted;
 
 			case 'md5-hex':
 			default:


### PR DESCRIPTION
1) It looks strange that $htmlPath is checked twice. It seems that another variable should be checked instead, possibly $overridePath.

2) 
Both parts of ternary operation are identical.
return ($show_encrypt) ? '{SHA256}' . $encrypted : '{SHA256}' . $encrypted;

It seems that it should be like this:
return ($show_encrypt) ? '{MD5}' . $encrypted : $encrypted;

Possible defect was found by AppChecker static analyzer (http://cnpo.ru/en/solutions/appchecker.php).
