### PR TITLE
Regression: Correcting fatal error in mod_version

### DIFF
--- a/administrator/modules/mod_version/helper.php
+++ b/administrator/modules/mod_version/helper.php
@@ -25,15 +25,16 @@ abstract class ModVersionHelper
 	 */
 	public static function getVersion(&$params)
 	{
-		$version = new JVersion;
+		$version     = new JVersion;
 		$versionText = $version->getShortVersion();
+		$product     = $params->get('product', 0);
 
 		if ($params->get('format', 'short') === 'long')
 		{
 			$versionText = str_replace($version::PRODUCT . ' ', '', $version->getLongVersion());
 		}
 
-		if (!empty($params->get('product', 0)))
+		if (!empty($product))
 		{
 			$versionText = $version::PRODUCT . ' ' . $versionText;
 		}


### PR DESCRIPTION
Solves https://github.com/joomla/joomla-cms/issues/9002
( ! ) Fatal error: Can't use method return value in write context in ROOT/administrator/modules/mod_version/helper.php on line 36

To test enable the administrator mod_version module, admin loads with error, patch and reload page.
