### PR TITLE
We have a specific alert when deleting Menus

### DIFF
--- a/administrator/components/com_menus/views/menus/view.html.php
+++ b/administrator/components/com_menus/views/menus/view.html.php
@@ -99,7 +99,7 @@ class MenusViewMenus extends JViewLegacy
 		if ($canDo->get('core.delete'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'menus.delete', 'JTOOLBAR_DELETE');
+			JToolbarHelper::deleteList('COM_MENUS_MENU_CONFIRM_DELETE', 'menus.delete', 'JTOOLBAR_DELETE');
 		}
 
 		JToolbarHelper::custom('menus.rebuild', 'refresh.png', 'refresh_f2.png', 'JTOOLBAR_REBUILD', false);


### PR DESCRIPTION
When doing #8995 I inadvertently changed the existing Alert when deleting Menus.
We have an existing string:
`COM_MENUS_MENU_CONFIRM_DELETE="Are you sure you want to delete these menus?
Confirming will delete the selected menu types, all their menu items and the associated menu modules."`

Can be merged on review.
