### PR TITLE
Correct year in comments

### DIFF
--- a/administrator/components/com_config/controller/application/sendtestmail.php
+++ b/administrator/components/com_config/controller/application/sendtestmail.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_config
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;

--- a/media/system/js/sendtestmail.js
+++ b/media/system/js/sendtestmail.js
@@ -1,6 +1,6 @@
 /**
  * @package         Joomla.JavaScript
- * @copyright       Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright       Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license         GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
#### Description

Some files merged recently have the year 2015 in copyright. It should be 2016.
#### How to test

Just check code difference.
