### PR TITLE
Fix inconsistent code in JTable. Fix #6901

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1037,8 +1037,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 */
 	public function checkOut($userId, $pk = null)
 	{
+		$checkedOutField = $this->getColumnAlias('checked_out');
+		$checkedOutTimeField = $this->getColumnAlias('checked_out_time');
+
 		// If there is no checked_out or checked_out_time field, just return true.
-		if (!property_exists($this, 'checked_out') || !property_exists($this, 'checked_out_time'))
+		if (!property_exists($this, $checkedOutField) || !property_exists($this, $checkedOutTimeField))
 		{
 			return true;
 		}
@@ -1073,15 +1076,15 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// Check the row out by primary key.
 		$query = $this->_db->getQuery(true)
 			->update($this->_tbl)
-			->set($this->_db->quoteName($this->getColumnAlias('checked_out')) . ' = ' . (int) $userId)
-			->set($this->_db->quoteName($this->getColumnAlias('checked_out_time')) . ' = ' . $this->_db->quote($time));
+			->set($this->_db->quoteName($checkedOutField) . ' = ' . (int) $userId)
+			->set($this->_db->quoteName($checkedOutTimeField) . ' = ' . $this->_db->quote($time));
 		$this->appendPrimaryKeys($query, $pk);
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 
 		// Set table values in the object.
-		$this->checked_out      = (int) $userId;
-		$this->checked_out_time = $time;
+		$this->$checkedOutField      = (int) $userId;
+		$this->$checkedOutTimeField = $time;
 
 		return true;
 	}
@@ -1100,8 +1103,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 */
 	public function checkIn($pk = null)
 	{
+		$checkedOutField = $this->getColumnAlias('checked_out');
+		$checkedOutTimeField = $this->getColumnAlias('checked_out_time');
+
 		// If there is no checked_out or checked_out_time field, just return true.
-		if (!property_exists($this, 'checked_out') || !property_exists($this, 'checked_out_time'))
+		if (!property_exists($this, $checkedOutField) || !property_exists($this, $checkedOutTimeField))
 		{
 			return true;
 		}
@@ -1133,8 +1139,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// Check the row in by primary key.
 		$query = $this->_db->getQuery(true)
 			->update($this->_tbl)
-			->set($this->_db->quoteName($this->getColumnAlias('checked_out')) . ' = 0')
-			->set($this->_db->quoteName($this->getColumnAlias('checked_out_time')) . ' = ' . $this->_db->quote($this->_db->getNullDate()));
+			->set($this->_db->quoteName($checkedOutField) . ' = 0')
+			->set($this->_db->quoteName($checkedOutTimeField) . ' = ' . $this->_db->quote($this->_db->getNullDate()));
 		$this->appendPrimaryKeys($query, $pk);
 		$this->_db->setQuery($query);
 
@@ -1142,8 +1148,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$this->_db->execute();
 
 		// Set table values in the object.
-		$this->checked_out      = 0;
-		$this->checked_out_time = '';
+		$this->$checkedOutField      = 0;
+		$this->$checkedOutTimeField = '';
 
 		return true;
 	}
@@ -1202,8 +1208,10 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 */
 	public function hit($pk = null)
 	{
+		$hitsField = $this->getColumnAlias('hits');
+
 		// If there is no hits field, just return true.
-		if (!property_exists($this, 'hits'))
+		if (!property_exists($this, $hitsField))
 		{
 			return true;
 		}
@@ -1235,7 +1243,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// Check the row in by primary key.
 		$query = $this->_db->getQuery(true)
 			->update($this->_tbl)
-			->set($this->_db->quoteName($this->getColumnAlias('hits')) . ' = (' . $this->_db->quoteName($this->getColumnAlias('hits')) . ' + 1)');
+			->set($this->_db->quoteName($hitsField) . ' = (' . $this->_db->quoteName($hitsField) . ' + 1)');
 		$this->appendPrimaryKeys($query, $pk);
 		$this->_db->setQuery($query);
 		$this->_db->execute();
@@ -1266,7 +1274,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// Handle the non-static case.
 		if (isset($this) && ($this instanceof JTable) && is_null($against))
 		{
-			$against = $this->get('checked_out');
+			$checkedOutField = $this->getColumnAlias('checked_out');
+			$against = $this->get($checkedOutField);
 		}
 
 		// The item is not checked out or is checked out by the same user.
@@ -1565,17 +1574,20 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			$pks = array($pk);
 		}
 
+		$publishedField = $this->getColumnAlias('published');
+		$checkedOutField = $this->getColumnAlias('checked_out');
+
 		foreach ($pks as $pk)
 		{
 			// Update the publishing state for rows with the given primary keys.
 			$query = $this->_db->getQuery(true)
 				->update($this->_tbl)
-				->set($this->_db->quoteName($this->getColumnAlias('published')) . ' = ' . (int) $state);
+				->set($this->_db->quoteName($publishedField) . ' = ' . (int) $state);
 
 			// Determine if there is checkin support for the table.
 			if (property_exists($this, 'checked_out') || property_exists($this, 'checked_out_time'))
 			{
-				$query->where('(' . $this->getColumnAlias('checked_out') . ' = 0 OR ' . $this->getColumnAlias('checked_out') . ' = ' . (int) $userId . ')');
+				$query->where('(' . $this->_db->quoteName($checkedOutField) . ' = 0 OR ' . $this->_db->quoteName($checkedOutField) . ' = ' . (int) $userId . ')');
 				$checkin = true;
 			}
 			else
@@ -1618,7 +1630,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 			if ($ours)
 			{
-				$publishedField = $this->getColumnAlias('published');
 				$this->$publishedField = $state;
 			}
 		}


### PR DESCRIPTION
## PR Summary

Our **JTable** class suppose to allow developers to use column alias for the following common columns: **checked_out**, **checked_out_time**, **hits** (for example, in my custom database table, I can use **view_count** field instead of **hits** and use setColumnAlias to map that field with the original hits field)

However, there are places in the class, the columns name are hardcoded instead of using it's alias (if it is set). That makes the following methods checkIn, checkOut, publish, hit won't work properly if someone uses custom columns name in his database table despite that he set the alias properly.

This PR simply fix that mistakes. I also move the  getColumnAlias out of the for loop in publish method, so it should has litle performance improvement, too
## Testing instructions

I think this PR just need code review from maintainers. The modification will affect check in, checkout, publish methods, so if you want to help testing this change, you can login to backend of your site, create an article, try to publish, checkin, checkout it and make sure everything still works as expected. 
