### PR TITLE
Fixed fatal error message on session timeout

### DIFF
--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -212,11 +212,10 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 *
 	 * @see     session_write_close()
 	 * @since   3.5
-	 * @throws  RuntimeException  If the session is saved without being started, or if the session is already closed.
 	 */
 	public function save()
 	{
-		// If running PHP 5.4, try to use the native API
+		// Verify if the session is active
 		if ((version_compare(PHP_VERSION, '5.4', 'ge') && PHP_SESSION_ACTIVE === session_status())
 			|| (version_compare(PHP_VERSION, '5.4', 'lt') && $this->started && isset($_SESSION) && $this->getId()))
 		{

--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -216,21 +216,21 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 */
 	public function save()
 	{
-		if (!$this->isStarted())
+		// If running PHP 5.4, try to use the native API
+		if ((version_compare(PHP_VERSION, '5.4', 'ge') && PHP_SESSION_ACTIVE === session_status())
+			|| (version_compare(PHP_VERSION, '5.4', 'lt') && $this->started && isset($_SESSION) && $this->getId()))
 		{
-			throw new RuntimeException('The session is not started.');
+			$session = JFactory::getSession();
+			$data    = $session->getData();
+
+			// Before storing it, let's serialize and encode the JRegistry object
+			$_SESSION['joomla'] = base64_encode(serialize($data));
+
+			session_write_close();
+
+			$this->closed  = true;
+			$this->started = false;
 		}
-
-		$session = JFactory::getSession();
-		$data    = $session->getData();
-
-		// Before storing it, let's serialize and encode the JRegistry object
-		$_SESSION['joomla'] = base64_encode(serialize($data));
-
-		session_write_close();
-
-		$this->closed  = true;
-		$this->started = false;
 	}
 
 	/**


### PR DESCRIPTION
This is a redo of PR #8808 based on the feedback by @mbabker 
### Test instructions
1. In the global configuration set the timeout to 1 minute
2. Go back to the administrator control panel
3. Wait 2 minutes
4. Click on any link
5. You are logged out and a fatal error is shown about the session
6. Apply the patch
7. Repeat steps 2 - 4
8. You are now logged out and no fatal error is shown

A signal for @wilsonge :)
