### PR TITLE
Language associations improvements

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -99,13 +99,6 @@ class CategoriesHelper
 	 */
 	public static function getAssociations($pk, $extension = 'com_content')
 	{
-		$langAssociations = JLanguageAssociations::getAssociations($extension, '#__categories', 'com_categories.item', $pk, 'id', 'alias', '');
-		$associations = array();
-		foreach ($langAssociations as $langAssociation)
-		{
-			$associations[$langAssociation->language] = $langAssociation->id;
-		}
-
-		return $associations;
+		return JLanguageAssociations::getAssociations($extension, '#__categories', 'com_categories.item', $pk, 'id', null, null, true);
 	}
 }

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -324,32 +324,6 @@ class CategoriesModelCategories extends JModelList
 	 */
 	public function getAssoc()
 	{
-		static $assoc = null;
-
-		if (!is_null($assoc))
-		{
-			return $assoc;
-		}
-
-		$extension = $this->getState('filter.extension');
-
-		$assoc = JLanguageAssociations::isEnabled();
-		$extension = explode('.', $extension);
-		$component = array_shift($extension);
-		$cname = str_replace('com_', '', $component);
-
-		if (!$assoc || !$component || !$cname)
-		{
-			$assoc = false;
-		}
-		else
-		{
-			$hname = $cname . 'HelperAssociation';
-			JLoader::register($hname, JPATH_SITE . '/components/' . $component . '/helpers/association.php');
-
-			$assoc = class_exists($hname) && !empty($hname::$category_association);
-		}
-
-		return $assoc;
+		return JLanguageAssociations::allowsAssociations($this->getState('filter.extension'));
 	}
 }

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -1227,32 +1227,6 @@ class CategoriesModelCategory extends JModelAdmin
 	 */
 	public function getAssoc()
 	{
-		static $assoc = null;
-
-		if (!is_null($assoc))
-		{
-			return $assoc;
-		}
-
-		$extension = $this->getState('category.extension');
-
-		$assoc = JLanguageAssociations::isEnabled();
-		$extension = explode('.', $extension);
-		$component = array_shift($extension);
-		$cname = str_replace('com_', '', $component);
-
-		if (!$assoc || !$component || !$cname)
-		{
-			$assoc = false;
-		}
-		else
-		{
-			$hname = $cname . 'HelperAssociation';
-			JLoader::register($hname, JPATH_SITE . '/components/' . $component . '/helpers/association.php');
-
-			$assoc = class_exists($hname) && !empty($hname::$category_association);
-		}
-
-		return $assoc;
+		return JLanguageAssociations::allowsAssociations($this->getState('category.extension'));
 	}
 }

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -316,13 +316,7 @@ class MenusHelper
 	 */
 	public static function getAssociations($pk)
 	{
-		$langAssociations = JLanguageAssociations::getAssociations('com_menus', '#__menu', 'com_menus.item', $pk, 'id', '', '');
-		$associations = array();
-		foreach ($langAssociations as $langAssociation)
-		{
-			$associations[$langAssociation->language] = $langAssociation->id;
-		}
-
-		return $associations;
+		return JLanguageAssociations::getAssociations('com_menus', '#__menu', 'com_menus.item', $pk, 'id', null, null, true);
 	}
+
 }

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -138,7 +138,7 @@ class JLanguageAssociations
 	/**
 	 * Get the associations links.
 	 *
-	 * @param   boolean  $addFallbackLinks  If we want the last resort to add the fallback language homepage link or global default homepage.
+	 * @param   boolean  $addFallbackLinks  If it should return, as last resort, the fallback language homepage link or, if doesn't exist, the global default homepage.
 	 *
 	 * @return  array  The associated items links.
 	 *

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -36,7 +36,8 @@ class JLanguageAssociations
 	 *
 	 * @throws  Exception
 	 */
-	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid', $onlyIds = false)
+	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid',
+		$onlyIds = false)
 	{
 		// To avoid doing duplicate database queries.
 		static $multilanguageAssociations = array();
@@ -138,7 +139,8 @@ class JLanguageAssociations
 	/**
 	 * Get the associations links.
 	 *
-	 * @param   boolean  $addFallbackLinks  If it should return, as last resort, the fallback language homepage link or, if doesn't exist, the global default homepage.
+	 * @param   boolean  $addFallbackLinks  If it should return, as last resort, the fallback language homepage link
+	 *                                      or, if doesn't exist, the global default homepage.
 	 *
 	 * @return  array  The associated items links.
 	 *
@@ -232,7 +234,7 @@ class JLanguageAssociations
 									$item = $menu->getItem($homepages['*']->id);
 								}
 								$associationLinks[$i] = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
-								
+
 								// If not in home this is a fall back link for the language switcher.
 								if (!$isHome)
 								{
@@ -245,8 +247,8 @@ class JLanguageAssociations
 			}
 		}
 
-		// Final check in return array.
-		// If don't want the fallback assocaition links. remove then (we don't need it in language filter alternate meta tags, but we need it in the alanguage switcher).
+		// Remove the the fallback association links if needed (we don't need it in language filter alternate meta tags,
+		// but we need it for the language switcher).
 		$associations = array_merge($associationLinks);
 		if (count($associations) > 0)
 		{

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -23,13 +23,14 @@ class JLanguageAssociations
 	 *
 	 * @param   string   $extension   The name of the component.
 	 * @param   string   $tablename   The name of the table.
-	 * @param   string   $context     The context
+	 * @param   string   $context     The context.
 	 * @param   integer  $id          The primary key value.
 	 * @param   string   $pk          The name of the primary key in the given $table.
-	 * @param   string   $aliasField  If the table has an alias field set it here. Null to not use it
-	 * @param   string   $catField    If the table has a catid field set it here. Null to not use it
+	 * @param   string   $aliasField  If the table has an alias field set it here. Null to not use it.
+	 * @param   string   $catField    If the table has a catid field set it here. Null to not use it.
+	 * @param   boolean  $onlyIds     If the method should only return the ids.
 	 *
-	 * @return  array                The associated items
+	 * @return  array                The associated items.
 	 *
 	 * @since   3.1
 	 *
@@ -132,6 +133,236 @@ class JLanguageAssociations
 		}
 
 		return $associations;
+	}
+
+	/**
+	 * Get the associations links.
+	 *
+	 * @param   boolean  $lastHome  If we want the last resort to be the language homepage link.
+	 *
+	 * @return  array  The associated items links.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getAssociationsLinks($lastHome = false)
+	{
+		// To avoid doing duplicate processing.
+		static $associationLinks = null;
+
+		$app  = JFactory::getApplication();
+		$menu = $app->getMenu();
+
+		// If not yet fetched, fetch the associations array.
+		if (is_null($associationLinks))
+		{
+			$associationLinks = array();
+
+			// If multilanguage is enabled.
+			if (JLanguageMultilang::isEnabled())
+			{
+				// Check what languages fullfill the requirements.
+				$homepages        = JLanguageMultilang::getSiteHomePages();
+				$languages        = array_intersect_key(JLanguageHelper::getLanguages('lang_code'), JLanguageMultilang::getSiteLangs(), $homepages);
+				$levels           = JFactory::getUser()->getAuthorisedViewLevels();
+
+				foreach ($languages as $i => $language)
+				{
+					// Do not display language without authorized access level in the language.
+					if (isset($language->access) && $language->access && !in_array($language->access, $levels))
+					{
+						unset($languages[$i]);
+						continue;
+					}
+					// Do not display language without authorized access level in the home menu item id.
+					if (isset($homepages[$i]->level) && $homepages[$i]->level && !in_array($homepages[$i]->level, $levels))
+					{
+						unset($languages[$i]);
+						continue;
+					}
+					// Set the home id for the language.
+					$languages[$i]->homeid = $homepages[$i]->id;
+				}
+
+				// If any language left to process.
+				if (count($languages) > 0)
+				{
+					$lang             = JFactory::getLanguage();
+					$langTag          = $lang->getTag();
+					$activeMenu       = $menu->getActive();
+					$isHome           = (isset($activeMenu) && $languages[$langTag]->homeid == $activeMenu->id);
+					$cassociations    = array();
+					$associations     = array();
+
+					// If is not the homepage, multilanguage associations are enable and associations is enabled load the associations.
+					if (!$isHome && self::isEnabled())
+					{
+						// Load component associations.
+						$cassociations = self::getComponentAssociations($app->input->get('option'));
+
+						// Load menu associations (only if there is an active menu).
+						if (isset($activeMenu))
+						{
+							$associations = self::getAssociations('com_menus', '#__menu', 'com_menus.item', $activeMenu->id, 'id', null, null, true);
+						}
+					}
+
+					$internalUri = '';
+					// For each language get the association link.
+					foreach ($languages as $i => $language)
+					{
+						switch (true)
+						{
+							// If current URI is the home page the associations are the homepages in all languages.
+							case ($isHome):
+								$item = $menu->getItem($language->homeid);
+								$associationLinks[$language->lang_code] = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+								break;
+
+							// If the current language return current language link.
+							case ($i === $langTag):
+								$associationLinks[$i] = JUri::getInstance()->toString(array('path', 'query'));
+								break;
+
+							// If there is a menu item association for the current URI the association is that association in this language.
+							case (isset($activeMenu) && isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
+								$associationLinks[$i] = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+								break;
+
+							// If there is a component association (ex: category) for the current URI the association is that association in this language.
+							case (isset($cassociations[$i])):
+								$associationLinks[$i] = JRoute::_($cassociations[$i] . '&lang=' . $language->sef);
+								break;
+
+							// If current URI is a component without menu item (no active menu, ex: /en/component/content/),
+							// associated URI for this language will be the version of the component in the language (ex: /fr/component/content/).
+							case (!isset($activeMenu)):
+								if (empty($internalUri))
+								{
+									$internalUri = http_build_query($app->getRouter()->getVars(array_diff_key($app->getRouter()->getVars(), array('lang' => ''))));
+								}
+								$associationLinks[$i] = JRoute::_('index.php?' . $internalUri . '&lang=' . $language->sef);
+								break;
+
+							// If no association ... set to this language home page menu item id or (if not exists) to the default global menu id to be treated after.
+							default:
+								$associationLinks[$i] = ($item = $menu->getItem($language->homeid)) ? $language->homeid : $homepages['*']->id;
+								break;
+						}
+					}
+				}
+			}
+		}
+
+		// Change the last item in the array. Needed to not repeat the whole process two times
+		// in each page load (language filter alternate meta and the language switcher module links).
+		$associations = array_merge($associationLinks);
+		foreach ($associationLinks as $i => $associationLink)
+		{
+			// If is the homepage item id setted above.
+			if (is_numeric($associationLink))
+			{
+				// If we want as a last resort that the association link is the language homepage (used in language switcher module links).
+				if ($lastHome)
+				{
+					$item = $menu->getItem($associationLink);
+					$associations[$i] = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $i);
+				}
+				// If no association ... unset the association link for this language (used in language filter alternate meta tags).
+				else
+				{
+					unset($associations[$i]);
+				}
+			}
+		}
+
+		return $associations;
+	}
+
+	/**
+	 * Get the component associations.
+	 *
+	 * @param   string  $component  The name of the component or extension id.
+	 *
+	 * @return  array  The associated items.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getComponentAssociations($component = 'com_content')
+	{
+		static $associations = array();
+
+		// It was called by the extension id, not the component name. Gets the component name.
+		if (strpos($component, '.') !== false)
+		{
+			$component = array_shift(explode('.', $component));
+		}
+
+		// If tested before, don't test again. Return the previous result.
+		if (isset($associations[$component]))
+		{
+			return $associations[$component];
+		}
+
+		// Set it as an empty array by default.
+		$associations[$component] = array();
+
+		// If component allows associations return the associations.
+		if (self::isEnabled())
+		{
+			$className = JString::ucfirst(JString::str_ireplace('com_', '', $component)) . 'HelperAssociation';
+			if (!(class_exists($className) && is_callable(array($className, 'getAssociations'))))
+			{
+				JLoader::register($className, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+			}
+			if (class_exists($className) && is_callable(array($className, 'getAssociations')))
+			{
+				$associations[$component] = call_user_func(array($className, 'getAssociations'));
+			}
+		}
+
+		return $associations[$component];
+	}
+
+	/**
+	 * Check if a component allows language associations.
+	 *
+	 * @param   string  $component  The name of the component or extension id.
+	 *
+	 * @return  boolean  True if component allows associations; false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function allowsAssociations($component = 'com_content')
+	{
+		static $associations = array();
+
+		// It was called by the extension id, not the component name. Gets the component name.
+		if (strpos($component, '.') !== false)
+		{
+			$component = array_shift(explode('.', $component));
+		}
+
+		// If tested before, don't test again. Return the previous result.
+		if (isset($associations[$component]))
+		{
+			return $associations[$component];
+		}
+
+		// Set it as false by default.
+		$associations[$component] = false;
+
+		// If language associations are enabled check if there is a associations class in the component folder.
+		if (self::isEnabled())
+		{
+			$className = JString::ucfirst(JString::str_ireplace('com_', '', $component)) . 'HelperAssociation';
+			if (!(class_exists($className) && is_callable(array($className, 'getAssociations'))))
+			{
+				JLoader::register($className, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+			}
+			$associations[$component] = class_exists($className) && is_callable(array($className, 'getAssociations'));
+		}
+
+		return $associations[$component];
 	}
 
 	/**

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -170,9 +170,6 @@ class JLanguageAssociations
 					$menu                 = $app->getMenu();
 					$activeMenu           = $menu->getActive();
 					$isHome               = (isset($activeMenu) && $languages[$langTag]->homeid == $activeMenu->id);
-					$languageFilterPlugin = JPluginHelper::getPlugin('system', 'languagefilter');
-					$languageFilterParams = new Registry($languageFilterPlugin->params);
-					$removeDefaultPrefix  = $languageFilterParams->get('remove_default_prefix', 0);
 
 					// If is not the homepage, multilanguage associations are enable and associations is enabled load the associations.
 					if (!$isHome && self::isEnabled())
@@ -235,14 +232,13 @@ class JLanguageAssociations
 									$item = $menu->getItem($homepages['*']->id);
 								}
 								$associationLinks[$i] = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
-								$languagesWithFallback[$i] = 1;
+								
+								// If not in home this is a fall back link for the language switcher.
+								if (!$isHome)
+								{
+									$languagesWithFallback[$i] = 1;
+								}
 								break;
-						}
-
-						// Removes the default prefix when enabled in the language filter.
-						if ($i === $langTag && $removeDefaultPrefix)
-						{
-							$associationLinks[$i] = preg_replace('#^/' . $language->sef . '/#', '/', $associationLinks[$i], 1);
 						}
 					}
 				}
@@ -256,7 +252,7 @@ class JLanguageAssociations
 		{
 			if (!$addFallbackLinks)
 			{
-				$associations = array_intersect_key($associationLinks, $languagesWithFallback);
+				$associations = array_diff_key($associationLinks, $languagesWithFallback);
 			}
 		}
 

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -127,7 +127,7 @@ class JLanguageMultilang
 
 	/**
 	 * Get available languages. A available language is published, the language extension is enabled,
-	 * has a homepage menu item, the user can view the language and the homepage and the directory of the language exists.	 
+	 * has a homepage menu item, the user can view the language and the homepage, and the ini language file exists.	 
 	 *
 	 * @return  array  An array with all available languages.
 	 *

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -124,4 +124,46 @@ class JLanguageMultilang
 
 		return $multilangSiteHomePages;
 	}
+
+	/**
+	 * Get available languages. A available language is published, the language extension is enabled,
+	 * has a homepage menu item, the user can view the language and the homepage and the directory of the language exists.	 
+	 *
+	 * @return  array  An array with all available languages.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getAvailableLanguages()
+	{
+		static $languages = null;
+
+		if (is_null($languages))
+		{
+			// Check what languages fullfill the requirements.
+			$homepages = JLanguageMultilang::getSiteHomePages();
+			$languages = array_intersect_key(JLanguageHelper::getLanguages('lang_code'), JLanguageMultilang::getSiteLangs(), $homepages);
+			$levels    = JFactory::getUser()->getAuthorisedViewLevels();
+
+			foreach ($languages as $i => $language)
+			{
+				// Do not display language without authorized access level in the language.
+				if (isset($language->access) && $language->access && !in_array($language->access, $levels))
+				{
+					unset($languages[$i]);
+					continue;
+				}
+				// Do not display language without authorized access level in the home menu item id.
+				if (isset($homepages[$i]->level) && $homepages[$i]->level && !in_array($homepages[$i]->level, $levels))
+				{
+					unset($languages[$i]);
+					continue;
+				}
+				// Set the home id for the language.
+				$languages[$i]->homeid = $homepages[$i]->id;
+			}
+		}
+
+		return $languages;
+	}
+}
 }

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -140,8 +140,8 @@ class JLanguageMultilang
 		if (is_null($languages))
 		{
 			// Check what languages fullfill the requirements.
-			$homepages = JLanguageMultilang::getSiteHomePages();
-			$languages = array_intersect_key(JLanguageHelper::getLanguages('lang_code'), JLanguageMultilang::getSiteLangs(), $homepages);
+			$homepages = self::getSiteHomePages();
+			$languages = array_intersect_key(JLanguageHelper::getLanguages('lang_code'), self::getSiteLangs(), $homepages);
 			$levels    = JFactory::getUser()->getAuthorisedViewLevels();
 
 			foreach ($languages as $i => $language)

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -112,6 +112,7 @@ class JLanguageMultilang
 			$query = $db->getQuery(true)
 				->select('language')
 				->select('id')
+				->select('level')
 				->from($db->quoteName('#__menu'))
 				->where('home = 1')
 				->where('published = 1')

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -152,12 +152,21 @@ class JLanguageMultilang
 					unset($languages[$i]);
 					continue;
 				}
+
 				// Do not display language without authorized access level in the home menu item id.
 				if (isset($homepages[$i]->level) && $homepages[$i]->level && !in_array($homepages[$i]->level, $levels))
 				{
 					unset($languages[$i]);
 					continue;
 				}
+
+				// Do not display languages without an ini file.
+				if (!is_file(JPATH_SITE . '/language/' . $language->lang_code . '/' . $language->lang_code . '.ini'))
+				{
+					unset($languages['lang_code'][$index]);
+					continue;
+				}
+
 				// Set the home id for the language.
 				$languages[$i]->homeid = $homepages[$i]->id;
 			}

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -175,4 +175,3 @@ class JLanguageMultilang
 		return $languages;
 	}
 }
-}

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -163,7 +163,7 @@ class JLanguageMultilang
 				// Do not display languages without an ini file.
 				if (!is_file(JPATH_SITE . '/language/' . $language->lang_code . '/' . $language->lang_code . '.ini'))
 				{
-					unset($languages['lang_code'][$index]);
+					unset($languages[$i]);
 					continue;
 				}
 

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -112,7 +112,7 @@ class JLanguageMultilang
 			$query = $db->getQuery(true)
 				->select('language')
 				->select('id')
-				->select('level')
+				->select('access')
 				->from($db->quoteName('#__menu'))
 				->where('home = 1')
 				->where('published = 1')
@@ -154,7 +154,7 @@ class JLanguageMultilang
 				}
 
 				// Do not display language without authorized access level in the home menu item id.
-				if (isset($homepages[$i]->level) && $homepages[$i]->level && !in_array($homepages[$i]->level, $levels))
+				if (isset($homepages[$i]->access) && $homepages[$i]->access && !in_array($homepages[$i]->access, $levels))
 				{
 					unset($languages[$i]);
 					continue;

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
-
 /**
  * Helper for mod_languages
  *
@@ -30,116 +28,40 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-		$user      = JFactory::getUser();
+		// If multilanguage is not active return an empty array.
+		// There can be no languages if language filter is published but no languages are available.
+		if (!JLanguageMultilang::isEnabled())
+		{
+			return array();
+		}
+
+		// Prefetch variables
 		$lang      = JFactory::getLanguage();
-		$languages = JLanguageHelper::getLanguages();
-		$app       = JFactory::getApplication();
-		$menu      = $app->getMenu();
+		$langTag   = $lang->getTag();
+		$langRtl   = $lang->isRtl();
+		$languages = JLanguageMultilang::getAvailableLanguages();
 
-		// Get menu home items
-		$homes = array();
-		$homes['*'] = $menu->getDefault('*');
+		// If there are languages, load the association links.
+		$associationLinks = JLanguageAssociations::getAssociationsLinks(true);
 
-		foreach ($languages as $item)
+		// Get the if language is rtl and the association link for each language.
+		foreach ($languages as $i => $language)
 		{
-			$default = $menu->getDefault($item->lang_code);
+			$language->active = ($language->lang_code == $langTag);
 
-			if ($default && $default->language == $item->lang_code)
+			// If language already loaded language get the rtl from current JLanguage metadata.
+			if ($language->active)
 			{
-				$homes[$item->lang_code] = $default;
+				$language->rtl = $langRtl;
 			}
-		}
-
-		// Load associations
-		$assoc = JLanguageAssociations::isEnabled();
-
-		if ($assoc)
-		{
-			$active = $menu->getActive();
-
-			if ($active)
-			{
-				$associations = MenusHelper::getAssociations($active->id);
-			}
-
-			// Load component associations
-			$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
-			JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
-
-			if (class_exists($class) && is_callable(array($class, 'getAssociations')))
-			{
-				$cassociations = call_user_func(array($class, 'getAssociations'));
-			}
-		}
-
-		$levels    = $user->getAuthorisedViewLevels();
-		$sitelangs = JLanguageMultilang::getSiteLangs();
-		$multilang = JLanguageMultilang::isEnabled();
-
-		// Filter allowed languages
-		foreach ($languages as $i => &$language)
-		{
-			// Do not display language without frontend UI
-			if (!array_key_exists($language->lang_code, $sitelangs))
-			{
-				unset($languages[$i]);
-			}
-			// Do not display language without specific home menu
-			elseif (!isset($homes[$language->lang_code]))
-			{
-				unset($languages[$i]);
-			}
-			// Do not display language without authorized access level
-			elseif (isset($language->access) && $language->access && !in_array($language->access, $levels))
-			{
-				unset($languages[$i]);
-			}
+			// If language not loaded fetch rtl from metadata directly for performance.
 			else
 			{
-				$language->active = ($language->lang_code == $lang->getTag());
-
-				// Fetch language rtl
-				// If loaded language get from current JLanguage metadata
-				if ($language->active)
-				{
-					$language->rtl = $lang->isRtl();
-				}
-				// If not loaded language fetch metadata directly for performance
-				else
-				{
-					$languageMetadata = JLanguage::getMetadata($language->lang_code);
-					$language->rtl    = $languageMetadata['rtl'];
-				}
-
-				if ($multilang)
-				{
-					if (isset($cassociations[$language->lang_code]))
-					{
-						$language->link = JRoute::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
-					}
-					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
-					{
-						$itemid = $associations[$language->lang_code];
-						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
-					}
-					else
-					{
-						if ($language->active)
-						{
-							$language->link = JUri::getInstance()->toString(array('path', 'query'));
-						}
-						else
-						{
-							$itemid = isset($homes[$language->lang_code]) ? $homes[$language->lang_code]->id : $homes['*']->id;
-							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
-						}
-					}
-				}
-				else
-				{
-					$language->link = JRoute::_('&Itemid=' . $homes['*']->id);
-				}
+				$languageMetadata = JLanguage::getMetadata($language->lang_code);
+				$language->rtl    = $languageMetadata['rtl'];
 			}
+
+			$language->link = $associationLinks[$language->lang_code];
 		}
 
 		return $languages;

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -28,9 +28,15 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-		// If multilanguage is not active return an empty array.
-		// There can be no languages if language filter is published but no languages are available.
+		// If multilanguage is not active (language filter disabled) return an empty array.
 		if (!JLanguageMultilang::isEnabled())
+		{
+			return array();
+		}
+
+		// There can also be no languages if language filter is published but no languages are available.
+		$languages = JLanguageMultilang::getAvailableLanguages();
+		if (count($languages) == 0)
 		{
 			return array();
 		}
@@ -39,7 +45,6 @@ abstract class ModLanguagesHelper
 		$lang      = JFactory::getLanguage();
 		$langTag   = $lang->getTag();
 		$langRtl   = $lang->isRtl();
-		$languages = JLanguageMultilang::getAvailableLanguages();
 
 		// If there are languages, load the association links.
 		$associationLinks = JLanguageAssociations::getAssociationsLinks(true);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -604,106 +604,32 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		$doc = JFactory::getDocument();
 
-		if ($this->app->isSite() && $this->params->get('alternate_meta') && $doc->getType() == 'html')
+		if ($this->app->isSite() && $this->params->get('item_associations', 0) && $this->params->get('alternate_meta', 0) && $doc->getType() == 'html')
 		{
-			$languages = $this->lang_codes;
-			$homes = JLanguageMultilang::getSiteHomePages();
-			$menu = $this->app->getMenu();
-			$active = $menu->getActive();
-			$levels = JFactory::getUser()->getAuthorisedViewLevels();
-			$remove_default_prefix = $this->params->get('remove_default_prefix', 0);
-			$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
-			$is_home = false;
-
-			if ($active)
-			{
-				$active_link = JRoute::_($active->link . '&Itemid=' . $active->id, false);
-				$current_link = JUri::getInstance()->toString(array('path', 'query'));
-
-				// Load menu associations
-				if ($active_link == $current_link)
-				{
-					$associations = MenusHelper::getAssociations($active->id);
-				}
-
-				// Check if we are on the homepage
-				$is_home = ($active->home
-					&& ($active_link == $current_link || $active_link == $current_link . 'index.php' || $active_link . '/' == $current_link));
-			}
-
-			// Load component associations.
-			$option = $this->app->input->get('option');
-			$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
-			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
-
-			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
-			{
-				$cassociations = call_user_func(array($cName, 'getAssociations'));
-			}
-
-			// For each language...
-			foreach ($languages as $i => &$language)
-			{
-				switch (true)
-				{
-					// Language without frontend UI || Language without specific home menu || Language without authorized access level
-					case (!array_key_exists($i, JLanguageMultilang::getSiteLangs())):
-					case (!isset($homes[$i])):
-					case (isset($language->access) && $language->access && !in_array($language->access, $levels)):
-						unset($languages[$i]);
-						break;
-
-					// Home page
-					case ($is_home):
-						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $homes[$i]->id);
-						break;
-
-					// Current language link
-					case ($i == $this->current_lang):
-						$language->link = JUri::getInstance()->toString(array('path', 'query'));
-						break;
-
-					// Component association
-					case (isset($cassociations[$i])):
-						$language->link = JRoute::_($cassociations[$i] . '&lang=' . $language->sef);
-						break;
-
-					// Menu items association
-					// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
-					case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
-						$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
-						break;
-
-					// Too bad...
-					default:
-						unset($languages[$i]);
-				}
-			}
+			// Load the association links.
+			$assocLinks = JLanguageAssociations::getAssociationsLinks(false);
 
 			// If there are at least 2 of them, add the rel="alternate" links to the <head>
-			if (count($languages) > 1)
+			if (count($assocLinks) > 1)
 			{
-				// Remove the sef from the default language if "Remove URL Language Code" is on
-				if (isset($languages[$this->default_lang]) && $remove_default_prefix)
+				$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
+
+				// Add the language alternate links meta tags to the head.
+				foreach ($assocLinks as $langCode => $assocLink)
 				{
-					$languages[$this->default_lang]->link
-									= preg_replace('|/' . $languages[$this->default_lang]->sef . '/|', '/', $languages[$this->default_lang]->link, 1);
+					$doc->addHeadLink($server . $assocLink, 'alternate', 'rel', array('hreflang' => $langCode));
 				}
 
-				foreach ($languages as $i => &$language)
-				{
-					$doc->addHeadLink($server . $language->link, 'alternate', 'rel', array('hreflang' => $i));
-				}
-
-				// Add x-default language tag
-				if ($this->params->get('xdefault', 1))
+				// Add x-default language tag.
+				if ((boolean) $this->params->get('xdefault', true))
 				{
 					$xdefault_language = $this->params->get('xdefault_language', $this->default_lang);
 					$xdefault_language = ( $xdefault_language == 'default' ) ? $this->default_lang : $xdefault_language;
-					if (isset($languages[$xdefault_language]))
+
+					if (!empty($assocLinks[$xdefault_language]))
 					{
 						// Use a custom tag because addHeadLink is limited to one URI per tag
-						$doc->addCustomTag('<link href="' . $server . $languages[$xdefault_language]->link . '" rel="alternate" hreflang="x-default" />');
+						$doc->addCustomTag('<link href="' . $server . $assocLinks[$xdefault_language] . '" rel="alternate" hreflang="x-default" />');
 					}
 				}
 			}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
-JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
-
 /**
  * Joomla! Language Filter Plugin.
  *
@@ -557,7 +555,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				if ($assoc)
 				{
-					$associations = MenusHelper::getAssociations($active->id);
+					$associations = JLanguageAssociations::getAssociations('com_menus', '#__menu', 'com_menus.item', $active->id, 'id', null, null, true);
 				}
 
 				if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -610,15 +610,15 @@ class PlgSystemLanguageFilter extends JPlugin
 			// If there are at least 2 of them, add the rel="alternate" links to the <head>
 			if (count($assocLinks) > 1)
 			{
-				$langTag = JFactory::getLanguage()->getTag();
-				$server  = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
+				$langTag     = JFactory::getLanguage()->getTag();
+				$defaultLang = $this->default_lang;
+				$server      = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
 
 				// Remove the sef from the default language if "Remove URL Language Code" is on
-				if (isset($assocLinks[$this->default_lang]) && $this->params->get('remove_default_prefix', 0))
+				if (isset($assocLinks[$defaultLang]) && $this->params->get('remove_default_prefix', 0))
 				{
-					$assocLinks[$this->default_lang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$this->default_lang]->sef . '/#',
-						'/$1', $assocLinks[$this->default_lang], 1);
-					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php(|/)$#', '/', $assocLinks[$this->default_lang], 1);
+					$assocLinks[$defaultLang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$defaultLang]->sef . '/#', '/$1', $assocLinks[$defaultLang], 1);
+					$assocLinks[$defaultLang] = preg_replace('#^/index\.php(|/)$#', '/', $assocLinks[$defaultLang], 1);
 				}
 
 				// Add the language alternate links meta tags to the head, but not for the current language.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -610,7 +610,8 @@ class PlgSystemLanguageFilter extends JPlugin
 			// If there are at least 2 of them, add the rel="alternate" links to the <head>
 			if (count($assocLinks) > 1)
 			{
-				$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
+				$langTag = JFactory::getLanguage()->getTag();
+				$server  = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
 
 				// Remove the sef from the default language if "Remove URL Language Code" is on
 				if (isset($assocLinks[$this->default_lang]) && $this->params->get('remove_default_prefix', 0))
@@ -619,10 +620,13 @@ class PlgSystemLanguageFilter extends JPlugin
 					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php$#', '/', $assocLinks[$this->default_lang], 1);
 				}
 
-				// Add the language alternate links meta tags to the head.
+				// Add the language alternate links meta tags to the head, but not for the current language.
 				foreach ($assocLinks as $langCode => $assocLink)
 				{
-					$doc->addHeadLink($server . $assocLink, 'alternate', 'rel', array('hreflang' => $langCode));
+					if ($langCode !== $langTag)
+					{
+						$doc->addHeadLink($server . $assocLink, 'alternate', 'rel', array('hreflang' => $langCode));
+					}
 				}
 
 				// Add x-default language tag.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -614,6 +614,13 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
 
+				// Remove the sef from the default language if "Remove URL Language Code" is on
+				if (isset($assocLinks[$this->default_lang]) && $this->params->get('remove_default_prefix', 0))
+				{
+					$assocLinks[$this->default_lang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$this->default_lang]->sef . '/#', '/$1', $assocLinks[$this->default_lang], 1);
+					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php$#', '/', $assocLinks[$this->default_lang], 1);
+				}
+
 				// Add the language alternate links meta tags to the head.
 				foreach ($assocLinks as $langCode => $assocLink)
 				{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -616,7 +616,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				// Remove the sef from the default language if "Remove URL Language Code" is on
 				if (isset($assocLinks[$this->default_lang]) && $this->params->get('remove_default_prefix', 0))
 				{
-					$assocLinks[$this->default_lang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$this->default_lang]->sef . '/#', '/$1', $assocLinks[$this->default_lang], 1);
+					$assocLinks[$this->default_lang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$this->default_lang]->sef . '/#',
+						'/$1', $assocLinks[$this->default_lang], 1);
 					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php(|/)$#', '/', $assocLinks[$this->default_lang], 1);
 				}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -617,7 +617,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				if (isset($assocLinks[$this->default_lang]) && $this->params->get('remove_default_prefix', 0))
 				{
 					$assocLinks[$this->default_lang] = preg_replace('#^/(|index\.php/)' . $this->lang_codes[$this->default_lang]->sef . '/#', '/$1', $assocLinks[$this->default_lang], 1);
-					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php$#', '/', $assocLinks[$this->default_lang], 1);
+					$assocLinks[$this->default_lang] = preg_replace('#^/index\.php(|/)$#', '/', $assocLinks[$this->default_lang], 1);
 				}
 
 				// Add the language alternate links meta tags to the head, but not for the current language.


### PR DESCRIPTION
#### Description

This PR takes similar languages associations code from language filter, mod languages and some helpers and centralize it in `JLanguageAssociations`.
It also ...
###### Does some improvements

The components without menu item id now will have an alternate language association too.
For instance, the if current URI is a component without menu item (ex: /en/component/users/), the associated language URI will be the version of the component page in the other language (ex: /fr/component/users/).
###### Corrects some bugs
1. If you have 2 languages (published and public) but one was the home menu item id with a higher view level. It shouldn't appear in the language meta tags nor in mod languages flags/text.
2. If you have 2 languages (published and public) and the 2 home item menus (also published and public) but the language ini folder/file does not exist. It shouldn't appear in the language filter nor in mod languages flags/text.
###### Performance

Also there is a very slight performance improvement in a multilanguage site, because the language switcher and the language filter plugin now use the same method to get the languages associations, instead of doing that two times in each page.
##### New method JLanguageMultilang::getAvailableLanguages()

Besides the new methods in `JLanguageAssociations`, this introduces a new method `JLanguageMultilang::getAvailableLanguages()` that is different from the `JLanguageHelper::getLanguages()`.

`JLanguageHelper::getLanguages()` only gets the content languages that are published.

`JLanguageMultilang::getAvailableLanguages()` uses `JLanguageHelper::getLanguages()` to get the content languages published and them does some checks to check if that language is really available to the user, it checks:
- if the language extension exists and is enabled. Though `JLanguageMultilang::getSiteLangs()`
- if the user has view level rights to that published language
- if the language has a published homepage. Though `JLanguageMultilang::getSiteHomePages()`
- if the user has view level rights to that published homepage
- if there is a ini file for that language

And also returns the language object with the language menu item homepage id.

See https://github.com/andrepereiradasilva/joomla-cms/blob/language-association-improvement/libraries/cms/language/multilang.php#L136-L176
#### How to test
1. Install latest staging with multilanguage. Language filter on, 2 or more languages with language homepages and language switcher module on.
2. Install this patch.
3. Make some language associations.
4. Test language associations with or without language published, different view levels, etc. Also, different language filter plugin options.
   Check if the language switcher and the alternate meta code in the head are as they should.
5. Check if bugs described above are corrected.
6. Check if component without menu items now have the language association (ex: /en/component/users/).
#### Observations

Improvements, suggestions and code revisions are welcome.

@infograf768, please check this one, when you have time.
