### PR TITLE
remove width: 220px for  select element due to overflow issue

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -989,7 +989,7 @@ input[type="file"] {
 	line-height: 28px;
 }
 select {
-	width: 220px;
+	width: 100%;
 	border: 1px solid #ccc;
 	background-color: #fff;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -989,7 +989,7 @@ input[type="file"] {
 	line-height: 28px;
 }
 select {
-	width: 220px;
+	width: 100%;
 	border: 1px solid #ccc;
 	background-color: #fff;
 }

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -161,7 +161,7 @@ input[type="file"] {
 
 // Make select elements obey height by applying a border
 select {
-  width: 100%; // default input width + 10px of padding that doesn't get applied
+  width: 220px; // default input width + 10px of padding that doesn't get applied
   border: 1px solid @inputBorder;
   background-color: @inputBackground; // Chrome on Linux and Mobile Safari need background-color
 }

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -161,7 +161,7 @@ input[type="file"] {
 
 // Make select elements obey height by applying a border
 select {
-  width: 220px; // default input width + 10px of padding that doesn't get applied
+  width: 100%; // default input width + 10px of padding that doesn't get applied
   border: 1px solid @inputBorder;
   background-color: @inputBackground; // Chrome on Linux and Mobile Safari need background-color
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1004,6 +1004,7 @@ input[type="file"] {
 	line-height: 28px;
 }
 select {
+	width: 100%;
 	border: 1px solid #ccc;
 	background-color: #fff;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1004,7 +1004,6 @@ input[type="file"] {
 	line-height: 28px;
 }
 select {
-	width: 220px;
 	border: 1px solid #ccc;
 	background-color: #fff;
 }

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -644,3 +644,7 @@ body.modal-open {
 #finder-search .in.collapse {
 	overflow: visible;
 }
+
+select {
+	width: 100% !important;
+}


### PR DESCRIPTION
This PR fixes select element overflow issue as illustrated in included screenshots. Testing has been performed on latest Chrome and Firefox latest.

**1. Select Overflow**
![select_overflow_issue_screenshot from 2016-01-29 13 29 01](https://cloud.githubusercontent.com/assets/815186/12684888/14fc2046-c68f-11e5-98d3-c426dedda5e4.png)

**2. Firefox tested fix**
![firefox_tested_fix_screenshot from 2016-01-29 13 35 04](https://cloud.githubusercontent.com/assets/815186/12684886/14f4f99c-c68f-11e5-94c1-42b1dc48af50.png)

**3. Chrome tested fix**
![chrome_tested_fix_screenshot from 2016-01-29 13 31 21](https://cloud.githubusercontent.com/assets/815186/12684887/14f8bec4-c68f-11e5-9bdd-0c74db6c5346.png)
