### PR TITLE
Fix a failure in the URL of News Feeds if the Feed-Provider sends Spaces in the Link to the Feed

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -114,7 +114,7 @@ else
 					<a href="<?php echo $this->rssDoc[$i]->uri; ?>" target="_blank">
 					<?php  echo $this->rssDoc[$i]->title; ?></a>
 				<?php else : ?>
-					<h3><?php  echo '<a target="_blank" href="' . $this->rssDoc[$i]->uri . '">' . $this->rssDoc[$i]->title . '</a>'; ?></h3>
+					<h3><?php  echo '<a target="_blank" href="' . trim($this->rssDoc[$i]->uri) . '">' . $this->rssDoc[$i]->title . '</a>'; ?></h3>
 				<?php  endif; ?>
 				<?php if ($this->params->get('show_item_description') && !empty($text)) : ?>
 					<div class="feed-item-description">

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -102,20 +102,28 @@ else
 	<!-- Show items -->
 	<?php if (!empty($this->rssDoc[0])) { ?>
 	<ol>
-		<?php for ($i = 0; $i < $this->item->numarticles; $i++) { ?>
-	<?php if (empty($this->rssDoc[$i])) { break; } ?>
-	<?php
-		$uri = !empty($this->rssDoc[$i]->guid) || !is_null($this->rssDoc[$i]->guid) ? $this->rssDoc[$i]->guid : $this->rssDoc[$i]->uri;
-		$uri = substr($uri, 0, 4) != 'http' ? $this->item->link : $uri;
-		$text = !empty($this->rssDoc[$i]->content) || !is_null($this->rssDoc[$i]->content) ? $this->rssDoc[$i]->content : $this->rssDoc[$i]->description;
-	?>
+	<?php for ($i = 0; $i < $this->item->numarticles; $i++)
+	{
+		if (empty($this->rssDoc[$i]))
+		{
+			break;
+		}
+		?>
+		<?php
+			$uri   = !empty($this->rssDoc[$i]->guid) || !is_null($this->rssDoc[$i]->guid) ? trim($this->rssDoc[$i]->guid) : trim($this->rssDoc[$i]->uri);
+			$uri   = substr($uri, 0, 4) != 'http' ? $this->item->link : $uri;
+			$text  = !empty($this->rssDoc[$i]->content) || !is_null($this->rssDoc[$i]->content) ? trim($this->rssDoc[$i]->content) : trim($this->rssDoc[$i]->description);
+			$title = trim($this->rssDoc[$i]->title);
+		?>
 			<li>
-				<?php if (!empty($this->rssDoc[$i]->uri)) : ?>
-					<a href="<?php echo $this->rssDoc[$i]->uri; ?>" target="_blank">
-					<?php  echo $this->rssDoc[$i]->title; ?></a>
+				<?php if (!empty($uri)) : ?>
+					<h3 class="feed-link">
+					<a href="<?php echo htmlspecialchars($uri); ?>" target="_blank">
+					<?php echo $title; ?></a></h3>
 				<?php else : ?>
-					<h3><?php  echo '<a target="_blank" href="' . trim($this->rssDoc[$i]->uri) . '">' . $this->rssDoc[$i]->title . '</a>'; ?></h3>
+					<h3 class="feed-link"><?php  echo $title; ?></h3>
 				<?php  endif; ?>
+
 				<?php if ($this->params->get('show_item_description') && !empty($text)) : ?>
 					<div class="feed-item-description">
 					<?php if ($this->params->get('show_feed_image', 0) == 0)

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -94,17 +94,18 @@ else
 			}
 			?>
 			<?php
-				$uri  = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? $feed[$i]->uri : $feed[$i]->guid;
-				$uri  = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;
-				$text = !empty($feed[$i]->content) ||  !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
+				$uri   = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
+				$uri   = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;
+				$text  = !empty($feed[$i]->content) ||  !is_null($feed[$i]->content) ? trim($feed[$i]->content) : trim($feed[$i]->description);
+				$title = trim($feed[$i]->title);
 			?>
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<span class="feed-link">
 						<a href="<?php echo htmlspecialchars($uri); ?>" target="_blank">
-						<?php echo $feed[$i]->title; ?></a></span>
+						<?php echo $title; ?></a></span>
 					<?php else : ?>
-						<span class="feed-link"><?php  echo $feed[$i]->title; ?></span>
+						<span class="feed-link"><?php  echo $title; ?></span>
 					<?php  endif; ?>
 
 					<?php if ($params->get('rssitemdesc') && !empty($text)) : ?>


### PR DESCRIPTION
1. Go to Components|News Feeds|Feeds and create a new News Feed with the Link to 
   https://www.datev.de/web/de/rss/nachrichten-steuern-und-recht.rss and call it Datev
   ![datev2](https://cloud.githubusercontent.com/assets/9974686/12697998/bd4dd124-c791-11e5-9f39-742dd4102238.PNG)
2. Create a Menu Item of the type Single News Feed and select the Feed Datev.
   ![datev1](https://cloud.githubusercontent.com/assets/9974686/12698000/bd515c7c-c791-11e5-98a1-8129d81bbde6.PNG)
3. Open this Menu Item in the Frontend and see, that die Links to the Feeds are not correct. 
   ![datev3](https://cloud.githubusercontent.com/assets/9974686/12697999/bd506402-c791-11e5-9c48-68d192a608de.PNG)

The reason is this: DATEV adds a Space to the URI and because of this in Joomla the address is displayed not correct.
Apply my patch and see that die Links to the Feed are correct now.

Update (2016-02-04):
4. Drop my patch and go to Extensions|Modules and create a new Module of the type Feed Display with the Link to 
https://www.datev.de/web/de/rss/nachrichten-steuern-und-recht.rss and call it Test. Apply it to position debug and show it on all pages. 
![feed](https://cloud.githubusercontent.com/assets/9974686/12812899/fd4d53c0-cb34-11e5-8d00-7432ee129f63.PNG)
1. Go to the front page and see, that there are no links shown in the Module.
2. Apply my patch and see in the front end, that no the links are correct!
   ![feed2](https://cloud.githubusercontent.com/assets/9974686/12812985/8c01312c-cb35-11e5-91bf-17cb4f065b7a.PNG)
