### PR TITLE
Stats plugin: Allowing more space for some languages

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8153,6 +8153,12 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+.js-pstats-data-details dd {
+	margin-left: 240px;
+}
+.js-pstats-data-details dt {
+	width: 220px;
+}
 .pull-right {
 	float: left;
 }
@@ -8940,4 +8946,7 @@ a.grid_true {
 	.view-login select {
 		width: 229px;
 	}
+}
+.js-pstats-data-details dd {
+	margin-right: 240px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8153,3 +8153,9 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+.js-pstats-data-details dd {
+	margin-left: 240px;
+}
+.js-pstats-data-details dt {
+	width: 220px;
+}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -246,3 +246,8 @@ a.grid_true {
 		}
 	}
 }
+
+/* Stats plugin */
+.js-pstats-data-details dd {
+	margin-right: 240px;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1301,3 +1301,11 @@ body.modal-open {
 	padding: 5px 10px;
 	overflow: hidden;
 }
+
+/* Stats plugin */
+.js-pstats-data-details dd {
+	margin-left: 240px;
+}
+.js-pstats-data-details dt {
+	width: 220px;
+}


### PR DESCRIPTION
Before patch, some languages may get an ellipsis:

![stats_before](https://cloud.githubusercontent.com/assets/869724/12701076/f616b118-c7fc-11e5-8739-698a6b5ad590.png)

After patch
![stats_after](https://cloud.githubusercontent.com/assets/869724/12701079/fd1b0612-c7fc-11e5-9aeb-01a32e6ae9db.png)
