### PR TITLE
Ensure the session close method is called instead to e…

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -553,6 +553,18 @@ class JApplicationWeb extends JApplicationBase
 					$status = 303;
 				}
 
+				// Prevent browser / proxy caching for the case of 303 redirect
+				if ( $status==303 ) {
+					// HTTP 1.1
+					$this->header('Cache-Control: no-cache, no-store, must-revalidate');
+
+					// HTTP 1.0
+					$this->header('Pragma: no-cache');
+
+					// Proxies
+					$this->header('Expires: 0');
+				}
+
 				// All other cases use the more efficient HTTP header for redirection.
 				$this->header($this->responseMap[$status]);
 				$this->header('Location: ' . $url);

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -554,7 +554,7 @@ class JApplicationWeb extends JApplicationBase
 				}
 
 				// Prevent browser / proxy caching for the case of 303 redirect
-				if ( $status==303 ) {
+				if ($status == 303) {
 					// HTTP 1.1
 					$this->header('Cache-Control: no-cache, no-store, must-revalidate');
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -561,7 +561,7 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// Close the application after the redirect.
-		$this->close();
+		$this->session->close();
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -539,7 +539,7 @@ class JApplicationWeb extends JApplicationBase
 			}
 			else
 			{
-				// Check if we have a boolean for the status variable for compatability with old $move parameter
+				// Check if we have a boolean for the status variable for compatibility with old $move parameter
 				// @deprecated 4.0
 				if (is_bool($status))
 				{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -560,8 +560,11 @@ class JApplicationWeb extends JApplicationBase
 			}
 		}
 
-		// Close the application after the redirect.
+		// Close the session after the redirect to prevent session issues on slow handlers
 		$this->session->close();
+
+		// Close the application after the redirect.
+		$this->close();
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -554,7 +554,8 @@ class JApplicationWeb extends JApplicationBase
 				}
 
 				// Prevent browser / proxy caching for the case of 303 redirect
-				if ($status == 303) {
+				if ($status == 303)
+				{
 					// HTTP 1.1
 					$this->header('Cache-Control: no-cache, no-store, must-revalidate');
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -395,6 +395,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		$this->assertEquals(
 			array(
+				array('Cache-Control: no-cache, no-store, must-revalidate', true, null),
+				array('Pragma: no-cache', true, null),
+				array('Expires: 0', true, null),
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -389,7 +389,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, false);
 
@@ -429,7 +429,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, 'Test Message', 'message', false);
 
@@ -479,7 +479,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, '', 'message');
 
@@ -519,7 +519,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		// Capture the output for this test.
 		ob_start();
@@ -550,7 +550,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 			)
 		);
 
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		// Capture the output for this test.
 		ob_start();
@@ -585,7 +585,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 			)
 		);
 
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, true);
 
@@ -629,7 +629,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.request', $request);
 
 		TestReflection::setValue($this->class, 'config', $config);
-		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, false);
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -448,6 +448,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		$this->assertEquals(
 			array(
+				array('Cache-Control: no-cache, no-store, must-revalidate', true, null),
+				array('Pragma: no-cache', true, null),
+				array('Expires: 0', true, null),
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
@@ -494,6 +497,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 		// The redirect gives a 303 error code
 		$this->assertEquals(
 			array(
+				array('Cache-Control: no-cache, no-store, must-revalidate', true, null),
+				array('Pragma: no-cache', true, null),
+				array('Expires: 0', true, null),
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
@@ -636,7 +642,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		$this->class->redirect($url, false);
 
-		$this->assertEquals('Location: ' . $expected, $this->class->headers[1][0]);
+		$this->assertEquals('Location: ' . $expected, $this->class->headers[4][0]);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -208,7 +208,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// Register all the methods so that we can track if they have been fired.
 		$this->class->registerEvent('JWebDoExecute', 'JWebTestExecute-JWebDoExecute')
-			->registerEvent('onAfterRespond', 'JWebTestExecute-onAfterRespond');
+					->registerEvent('onAfterRespond', 'JWebTestExecute-onAfterRespond');
 
 		$this->class->execute();
 
@@ -237,9 +237,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// Register all the methods so that we can track if they have been fired.
 		$this->class->registerEvent('JWebDoExecute', 'JWebTestExecute-JWebDoExecute')
-			->registerEvent('onBeforeRender', 'JWebTestExecute-onBeforeRender')
-			->registerEvent('onAfterRender', 'JWebTestExecute-onAfterRender')
-			->registerEvent('onAfterRespond', 'JWebTestExecute-onAfterRespond');
+					->registerEvent('onBeforeRender', 'JWebTestExecute-onBeforeRender')
+					->registerEvent('onAfterRender', 'JWebTestExecute-onAfterRender')
+					->registerEvent('onAfterRespond', 'JWebTestExecute-onAfterRespond');
 
 		// Buffer the execution.
 		ob_start();
@@ -389,6 +389,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		$this->class->redirect($url, false);
 
@@ -428,6 +429,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		$this->class->redirect($url, 'Test Message', 'message', false);
 
@@ -477,6 +479,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		$this->class->redirect($url, '', 'message');
 
@@ -516,6 +519,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		// Capture the output for this test.
 		ob_start();
@@ -545,6 +549,8 @@ class JApplicationCmsTest extends TestCaseDatabase
 				'engine' => JApplicationWebClient::TRIDENT,
 			)
 		);
+
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		// Capture the output for this test.
 		ob_start();
@@ -578,6 +584,8 @@ class JApplicationCmsTest extends TestCaseDatabase
 				'engine' => JApplicationWebClient::GECKO,
 			)
 		);
+
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		$this->class->redirect($url, true);
 
@@ -621,6 +629,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('uri.request', $request);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', new \Joomla\Session\Session());
 
 		$this->class->redirect($url, false);
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1045,6 +1045,7 @@ class JApplicationWebTest extends TestCase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, false);
 
@@ -1078,6 +1079,7 @@ class JApplicationWebTest extends TestCase
 		$config->set('uri.base.full', $base);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		// Capture the output for this test.
 		ob_start();
@@ -1106,6 +1108,8 @@ class JApplicationWebTest extends TestCase
 				'engine' => JApplicationWebClient::TRIDENT,
 			)
 		);
+
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		// Capture the output for this test.
 		ob_start();
@@ -1137,6 +1141,8 @@ class JApplicationWebTest extends TestCase
 				'engine' => JApplicationWebClient::GECKO,
 			)
 		);
+
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, true);
 
@@ -1180,6 +1186,7 @@ class JApplicationWebTest extends TestCase
 		$config->set('uri.request', $request);
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->class->redirect($url, false);
 
@@ -1265,6 +1272,7 @@ class JApplicationWebTest extends TestCase
 		$config = new Registry(array('foo' => 'bar'));
 
 		TestReflection::setValue($this->class, 'config', $config);
+		TestReflection::setValue($this->class, 'session', $this->getMockSession());
 
 		$this->assertEquals('bar', $this->class->set('foo', 'car'));
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1051,6 +1051,9 @@ class JApplicationWebTest extends TestCase
 
 		$this->assertEquals(
 			array(
+				array('Cache-Control: no-cache, no-store, must-revalidate', true, null),
+				array('Pragma: no-cache', true, null),
+				array('Expires: 0', true, null),
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
@@ -1190,7 +1193,7 @@ class JApplicationWebTest extends TestCase
 
 		$this->class->redirect($url, false);
 
-		$this->assertEquals('Location: ' . $expected, $this->class->headers[1][0]);
+		$this->assertEquals('Location: ' . $expected, $this->class->headers[4][0]);
 	}
 
 	/**


### PR DESCRIPTION
Ensure the session close method is called instead to ensure that session_write_close() is called before redirect

Before this change we called the applications close method which was just a exit() command - the sessions close method has more specific code to base64 encode and write the session explicitly with session_write_close() - so doing this on the redirect _should_ fix any session write lag issues as per the PHP comments section and  #9013

See PHP.net http://php.net/manual/en/function.session-write-close.php comments

Its VERY VERY hard to replicate unless you have a crap webhost and slow session saving

To test, just edit some articles on the frontend - nothing should be broken.

Closes #9013
