### PR TITLE
Get tag information only when it's necessary

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -659,8 +659,11 @@ class ContentModelArticles extends JModelList
 			}
 
 			// Get the tags
-			$item->tags = new JHelperTags;
-			$item->tags->getItemTags('com_content.article', $item->id);
+			if ($item->params->get('show_tags'))
+			{
+				$item->tags = new JHelperTags;
+				$item->tags->getItemTags('com_content.article', $item->id);
+			}
 		}
 
 		return $items;


### PR DESCRIPTION
I discovered that Joomla generates lots of queries requesting article tags. Often tag queries are unnecessary when tags are not used at all on a certain page, but these queries are still retrieved.

Full description and how to test see here: #9036 
