### PR TITLE
[imp] Saving 'mailto:utf8' mails in text in idn format

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -300,7 +300,17 @@ class JComponentHelper
 		}
 
 		// Punyencoding email addresses
-		$text = JFilterInput::getInstance()->clean($text, 'IDNMAIL');
+		$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^."?]+\.+[^."?]+("|\?))/';
+
+		if (preg_match_all($pattern, $text, $matches))
+		{
+			foreach ($matches[0] as $match)
+			{
+				$match  = str_replace('"', '', $match);
+				$match  = str_replace('?', '', $match);
+				$text   = str_replace($match, JStringPunycode::emailToPunycode($match), $text);
+			}
+		}
 
 		return $text;
 	}

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -300,7 +300,7 @@ class JComponentHelper
 		}
 
 		// Punyencoding email addresses
-		$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^."?]+\.+[^."?]+("|\?))/';
+		$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^"?]+\.+[^."?]+("|\?))/';
 
 		if (preg_match_all($pattern, $text, $matches))
 		{

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -299,6 +299,8 @@ class JComponentHelper
 			$text = $filter->clean($text, 'html');
 		}
 
+		$text = JFilterInput::getInstance()->clean($text, 'IDNMAIL');
+
 		return $text;
 	}
 

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -299,6 +299,7 @@ class JComponentHelper
 			$text = $filter->clean($text, 'html');
 		}
 
+		// Punyencoding email addresses
 		$text = JFilterInput::getInstance()->clean($text, 'IDNMAIL');
 
 		return $text;

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -133,6 +133,9 @@ class JComponentHelper
 	 */
 	public static function filterText($text)
 	{
+		// Punyencoding utf8 email addresses
+		$text = JFilterInput::getInstance()->emailToPunycode($text);
+
 		// Filter settings
 		$config     = static::getParams('com_config');
 		$user       = JFactory::getUser();
@@ -297,19 +300,6 @@ class JComponentHelper
 			}
 
 			$text = $filter->clean($text, 'html');
-		}
-
-		// Punyencoding email addresses
-		$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^"?]+\.+[^."?]+("|\?))/';
-
-		if (preg_match_all($pattern, $text, $matches))
-		{
-			foreach ($matches[0] as $match)
-			{
-				$match  = str_replace('"', '', $match);
-				$match  = str_replace('?', '', $match);
-				$text   = str_replace($match, JStringPunycode::emailToPunycode($match), $text);
-			}
 		}
 
 		return $text;

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -287,6 +287,20 @@ class JFilterInput
 				$result = (string) $this->_remove((string) $source);
 				break;
 
+			case 'IDNMAIL':
+				$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^."?]+\.+[^."?]+("|\?))/';
+
+				if (preg_match_all($pattern, (string) $source, $matches))
+				{
+					foreach ($matches[0] as $match)
+					{
+						$match  = (string) str_replace('"', '', $match);
+						$match  = (string) str_replace('?', '', $match);
+						$result = (string) str_replace($match, JStringPunycode::emailToPunycode($match), $source);
+					}
+				}
+				break;
+
 			case 'ARRAY':
 				$result = (array) $source;
 				break;

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -213,6 +213,7 @@ class JFilterInput
 	 *                           BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not case sensitive),
 	 *                           STRING:    A fully decoded and sanitised string (default),
 	 *                           HTML:      A sanitised string,
+	 *                           IDNMAIL    Punyencodes UTF8 email addresses
 	 *                           ARRAY:     An array,
 	 *                           PATH:      A sanitised file path,
 	 *                           TRIM:      A string trimmed from normal, non-breaking and multibyte spaces

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -347,6 +347,31 @@ class JFilterInput
 	}
 
 	/**
+	 * Function to punyencode utf8 mail when saving content
+	 *
+	 * @param   string  $text  The strings to encode
+	 *
+	 * @return  string  The punyencoded mail
+	 *
+	 * @since   3.5
+	 */
+	public function emailToPunycode($text)
+	{
+		$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^"?]+\.+[^."?]+("|\?))/';
+
+		if (preg_match_all($pattern, $text, $matches))
+		{
+			foreach ($matches[0] as $match)
+			{
+				$match  = (string) str_replace(array('?', '"'), '', $match);
+				$text   = (string) str_replace($match, JStringPunycode::emailToPunycode($match), $text);
+			}
+		}
+
+		return $text;
+	}
+
+	/**
 	 * Function to determine if contents of an attribute are safe
 	 *
 	 * @param   array  $attrSubSet  A 2 element array for attribute's name, value

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -213,7 +213,6 @@ class JFilterInput
 	 *                           BASE64:    A string containing A-Z, 0-9, forward slashes, plus or equals (not case sensitive),
 	 *                           STRING:    A fully decoded and sanitised string (default),
 	 *                           HTML:      A sanitised string,
-	 *                           IDNMAIL    Punyencodes UTF8 email addresses
 	 *                           ARRAY:     An array,
 	 *                           PATH:      A sanitised file path,
 	 *                           TRIM:      A string trimmed from normal, non-breaking and multibyte spaces
@@ -286,20 +285,6 @@ class JFilterInput
 
 			case 'HTML':
 				$result = (string) $this->_remove((string) $source);
-				break;
-
-			case 'IDNMAIL':
-				$pattern = '/(("mailto:)+[\w\.\-\+]+\@[^."?]+\.+[^."?]+("|\?))/';
-
-				if (preg_match_all($pattern, (string) $source, $matches))
-				{
-					foreach ($matches[0] as $match)
-					{
-						$match  = (string) str_replace('"', '', $match);
-						$match  = (string) str_replace('?', '', $match);
-						$result = (string) str_replace($match, JStringPunycode::emailToPunycode($match), $source);
-					}
-				}
 				break;
 
 			case 'ARRAY':


### PR DESCRIPTION
See https://issues.joomla.org/tracker/joomla-cms/8881

The issue is that a mailto: UTF8-mail entered in an editor will 
1. not work
2. will not be cloaked

Test 

```
<p>UTF8 mail<a href="mailto:joomlatest@джумла-тест.рф"> joomlatest@джумла-тест.рф</a></p>
<p><a href="mailto:email@example.org?subject=джумла">джумлаsomething</a></p>
```

This PR will NOT take care of a mail entered in the editor pure, i.e.:
`<p>joomlatest@джумла-тест.рф</p>`
It needs a mailto to work correctly.

A mailto can be formatted with an ? to add a subject or else, or finish with a ".
The PR takes care of this 2 possibilities

@brianteeman
@Hoffi1
@alikon
