### PR TITLE
Move getCurrentLanguage() to JLanguageHelper

### DIFF
--- a/components/com_tags/models/tags.php
+++ b/components/com_tags/models/tags.php
@@ -147,7 +147,7 @@ class TagsModelTags extends JModelList
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JLanguageHelper::getCurrentLanguage();
 			}
 
 			$query->where($db->quoteName('language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -131,28 +131,14 @@ class JHelperContent
 	 *
 	 * @return  string  The language string
 	 *
-	 * @since   3.1
-	 * @note    JHelper::getCurrentLanguage is the preferred method
+	 * @since       3.1
+	 * @deprecated  4.0 Use JLanguageHelper::getCurrentLanguage() instead.
 	 */
 	public static function getCurrentLanguage($detectBrowser = true)
 	{
-		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+		JLog::add(__METHOD__ . '() is deprecated, use JLanguageHelper::getCurrentLanguage() instead.', JLog::WARNING, 'deprecated');
 
-		// No cookie - let's try to detect browser language or use site default
-		if (!$langCode)
-		{
-			if ($detectBrowser)
-			{
-				$langCode = JLanguageHelper::detectLanguage();
-			}
-			else
-			{
-				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
-			}
-		}
-
-		return $langCode;
+		return JLanguageHelper::getCurrentLanguage($detectBrowser);
 	}
 
 	/**

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -23,27 +23,14 @@ class JHelper
 	 *
 	 * @return  string  The language string
 	 *
-	 * @since   3.2
+	 * @since       3.2
+	 * @deprecated  4.0 Use JLanguageHelper::getCurrentLanguage() instead.
 	 */
 	public function getCurrentLanguage($detectBrowser = true)
 	{
-		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+		JLog::add(__METHOD__ . '() is deprecated, use JLanguageHelper::getCurrentLanguage() instead.', JLog::WARNING, 'deprecated');
 
-		// No cookie - let's try to detect browser language or use site default
-		if (!$langCode)
-		{
-			if ($detectBrowser)
-			{
-				$langCode = JLanguageHelper::detectLanguage();
-			}
-			else
-			{
-				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
-			}
-		}
-
-		return $langCode;
+		return JLanguageHelper::getCurrentLanguage($detectBrowser);
 	}
 
 	/**

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -409,7 +409,7 @@ class JHelperTags extends JHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = $this->getCurrentLanguage();
+				$language = JLanguageHelper::getCurrentLanguage();
 			}
 
 			$query->where($db->quoteName('language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');
@@ -587,7 +587,7 @@ class JHelperTags extends JHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = $this->getCurrentLanguage();
+				$language = JLanguageHelper::getCurrentLanguage();
 			}
 
 			$query->where($db->quoteName('c.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -193,21 +193,26 @@ class JLanguageHelper
 	 */
 	public static function getCurrentLanguage($detectBrowser = true)
 	{
-		$langCode = JFactory::getApplication()->input->cookie->getString(JApplicationHelper::getHash('language'));
+		static $currentLanguageCode = array();
 
-		// No cookie - let's try to detect browser language or use site default
-		if (!$langCode)
+		if (!isset($currentLanguageCode[$detectBrowser]))
 		{
-			if ($detectBrowser)
+			$currentLanguageCode[$detectBrowser] = JFactory::getApplication()->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+			// No cookie - let's try to detect browser language or use site default
+			if (!$currentLanguageCode[$detectBrowser])
 			{
-				$langCode = JLanguageHelper::detectLanguage();
-			}
-			else
-			{
-				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+				if ($detectBrowser)
+				{
+					$currentLanguageCode[$detectBrowser] = JLanguageHelper::detectLanguage();
+				}
+				else
+				{
+					$currentLanguageCode[$detectBrowser] = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+				}
 			}
 		}
 
-		return $langCode;
+		return $currentLanguageCode[$detectBrowser];
 	}
 }

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -181,4 +181,33 @@ class JLanguageHelper
 
 		return $languages[$key];
 	}
+
+	/**
+	 * Gets the current language
+	 *
+	 * @param   boolean  $detectBrowser  Flag indicating whether to use the browser language as a fallback.
+	 *
+	 * @return  string  The language string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getCurrentLanguage($detectBrowser = true)
+	{
+		$langCode = JFactory::getApplication()->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+		// No cookie - let's try to detect browser language or use site default
+		if (!$langCode)
+		{
+			if ($detectBrowser)
+			{
+				$langCode = JLanguageHelper::detectLanguage();
+			}
+			else
+			{
+				$langCode = JComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+			}
+		}
+
+		return $langCode;
+	}
 }

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -183,11 +183,11 @@ class JLanguageHelper
 	}
 
 	/**
-	 * Gets the current language
+	 * Gets the current language.
 	 *
 	 * @param   boolean  $detectBrowser  Flag indicating whether to use the browser language as a fallback.
 	 *
-	 * @return  string  The language string
+	 * @return  string  The language code.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -204,7 +204,7 @@ class JLanguageHelper
 			{
 				if ($detectBrowser)
 				{
-					$currentLanguageCode[$detectBrowser] = JLanguageHelper::detectLanguage();
+					$currentLanguageCode[$detectBrowser] = self::detectLanguage();
 				}
 				else
 				{

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -59,7 +59,7 @@ abstract class ModTagsPopularHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JLanguageHelper::getCurrentLanguage();
 			}
 
 			$query->where($db->quoteName('t.language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -105,7 +105,7 @@ abstract class ModTagssimilarHelper
 		{
 			if ($language == 'current_language')
 			{
-				$language = JHelperContent::getCurrentLanguage();
+				$language = JLanguageHelper::getCurrentLanguage();
 			}
 
 			$query->where($db->quoteName('cc.core_language') . ' IN (' . $db->quote($language) . ', ' . $db->quote('*') . ')');


### PR DESCRIPTION
##### Description

This PR moves `JHelper->getCurrentLanguage()` and `JHelperContent::getCurrentLanguage()` to `JLanguageHelper::getCurrentLanguage()`, deprecates the old methods and replaces them where they are currently being used.
##### How to test
1. Use a joomla multilanguage site and apply this patch
2. Add tags in several languages
3. Add those tags to a content
4. Go to tags component (com_tags) options and in "Item selection" -> "Language Filter" select "Current"
5. Go to frontend and check that the tags that are displayed in the content are only those in the current language and the ones with all languages
6. Check also the same behaviour for the tags in the modules (mod_tags_popular and mod_tags_similar)

In conclusion, all should work as before.

@joomdonation here you have it.

@mbabker if ok for you, IMHO this should also be done in joomla framework (language).
