### PR TITLE
No need to utf8 encode statuses which are already utf8 encoded (issue #9043)

### DIFF
--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -176,7 +176,15 @@ class JTwitterStatuses extends JTwitterObject
 		$path = '/statuses/update.json';
 
 		// Set POST data.
-		$data = array('status' => utf8_encode($status));
+		//No need to utf8 encode statuses which are already utf8 encoded
+		if(mb_detect_encoding($status,'UTF-8', true)=='UTF-8')
+                    {
+                    	$data = array('status' => $status);
+                    }
+                else 
+                    {
+                    	$data = array('status' => utf8_encode($status));
+                    }
 
 		// Check if in_reply_to_status_id is specified.
 		if ($in_reply_to_status_id)

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -177,7 +177,7 @@ class JTwitterStatuses extends JTwitterObject
 
 		// Set POST data.
 		// No need to utf8 encode statuses which are already utf8 encoded
-		if(utf8_is_valid($status))
+		if (utf8_is_valid($status))
 		{
 			$data = array('status' => $status);
 		}
@@ -517,9 +517,9 @@ class JTwitterStatuses extends JTwitterObject
 	{
 		// Set the API request path.
 		$path = '/statuses/update_with_media.json';
-		
+
 		// If the status is not UTF-8 encode it
-		if(!utf8_is_valid($status))
+		if (!utf8_is_valid($status))
 		{
 			utf8_encode($status);
 		}

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -8,7 +8,6 @@
  */
 
 defined('JPATH_PLATFORM') or die();
-jimport('phputf8.utils.validation');
 
 /**
  * Twitter API Statuses class for the Joomla Platform.

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -178,13 +178,13 @@ class JTwitterStatuses extends JTwitterObject
 		// Set POST data.
 		// No need to utf8 encode statuses which are already utf8 encoded
 		if(utf8_is_valid($status))
-        	{
-        		$data = array('status' => $status);
-        	}
-        	else
-                {
-        		$data = array('status' => utf8_encode($status));
-        	}
+		{
+			$data = array('status' => $status);
+		}
+		else
+		{
+			$data = array('status' => utf8_encode($status));
+		}
 
 		// Check if in_reply_to_status_id is specified.
 		if ($in_reply_to_status_id)
@@ -519,10 +519,10 @@ class JTwitterStatuses extends JTwitterObject
 		$path = '/statuses/update_with_media.json';
 		
 		// If the status is not UTF-8 encode it
-                if(!utf8_is_valid($status))
-        	{
-                	utf8_encode($status);
-        	}
+		if(!utf8_is_valid($status))
+		{
+			utf8_encode($status);
+		}
 
 		// Set POST data.
 		$data = array(

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -8,6 +8,7 @@
  */
 
 defined('JPATH_PLATFORM') or die();
+jimport('phputf8.utils.validation');
 
 /**
  * Twitter API Statuses class for the Joomla Platform.
@@ -176,15 +177,15 @@ class JTwitterStatuses extends JTwitterObject
 		$path = '/statuses/update.json';
 
 		// Set POST data.
-		//No need to utf8 encode statuses which are already utf8 encoded
-		if(mb_detect_encoding($status,'UTF-8', true)=='UTF-8')
-                    {
-                    	$data = array('status' => $status);
-                    }
-                else 
-                    {
-                    	$data = array('status' => utf8_encode($status));
-                    }
+		// No need to utf8 encode statuses which are already utf8 encoded
+		if(utf8_is_valid($status))
+        	{
+        		$data = array('status' => $status);
+        	}
+        	else
+                {
+        		$data = array('status' => utf8_encode($status));
+        	}
 
 		// Check if in_reply_to_status_id is specified.
 		if ($in_reply_to_status_id)
@@ -517,10 +518,16 @@ class JTwitterStatuses extends JTwitterObject
 	{
 		// Set the API request path.
 		$path = '/statuses/update_with_media.json';
+		
+		// If the status is not UTF-8 encode it
+                if(!utf8_is_valid($status))
+        	{
+                	utf8_encode($status);
+        	}
 
 		// Set POST data.
 		$data = array(
-			'status' => utf8_encode($status),
+			'status' => $status,
 			'media[]' => "@{$media}"
 		);
 


### PR DESCRIPTION
It has to detect the status encoding at first, if it is already utf8 encoded, then send it as it is without anymore encoding.
