### PR TITLE
Add support for URLs with no protocol in JDocumentRenderer

### DIFF
--- a/libraries/joomla/document/renderer.php
+++ b/libraries/joomla/document/renderer.php
@@ -83,7 +83,7 @@ class JDocumentRenderer
 	protected function _relToAbs($text)
 	{
 		$base = JUri::base();
-		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
+		$text = preg_replace("/(href|src)=\"(?!http|ftp|https|mailto|data|\/\/)([^\"]*)\"/", "$1=\"$base\$2\"", $text);
 
 		return $text;
 	}


### PR DESCRIPTION
Fix for https://github.com/joomla/joomla-cms/issues/9039

Orgiinal issue description

> ## Steps to reproduce the issue
> 
> Create an article with text containing a URL with no protocol. A good example could be an embed of a dailymotion video which contains no protocol in the iframe src of the embed code. Then try to view a feed containing that article.
> ## Expected result
> 
> The expected result is that the iframe src is not modified.
> ## Actual result
> 
> Joomla tries to replace all relative links to absolute links in feeds. The function _relToAbs of JDocumentRenderer class considers incorrectly that URLs with no protocol are relative links and prepends the site's absolute URL to them.
> ## System information (as much as possible)
> 
> Checked under Joomla! 3.4.8 and 3.5 BETA 2.
> ## Additional commments
