### PR TITLE
Fix self-registration when autoregistering password

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -322,7 +322,8 @@ class PlgUserJoomla extends JPlugin
 		$instance->set('id', 0);
 		$instance->set('name', $user['fullname']);
 		$instance->set('username', $user['username']);
-		$instance->set('password_clear', $user['password_clear']);
+		$instance->set('password_clear', $user['password']);
+		$instance->set('password', JUserHelper::hashPassword($user['password']));
 
 		// Result should contain an email (check).
 		$instance->set('email', $user['email']);


### PR DESCRIPTION
If you try and create an account through the user profiles you will find that whatever password you set in the `$response` variable in your authentication plugin, then the password is autogenerated. This is for two reasons:

1) The variable user (which is just a typehinted array instance of `JAuthenticationResponse`) doesn't contain a `password_clear` property ever),

2) In `JUser` if you are going to set a password will use the `password` property `password_clear` is just there to access a property for things like emails when resetting a password. So we set the `password_clear` and `password` property (just like in method `UsesrModelReset::processResetComplete()`).

This patch therefore means that if you choose not to enter a password property into the `$response` object of your authentication plugin then it will just be auto-generated still. If you choose to set it then it will use that password rather than the Joomla generated password.
