### PR TITLE
Use language item instead of hardcoded string

### DIFF
--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -232,7 +232,7 @@ abstract class JHtmlGrid
 	 *
 	 * @since   1.5
 	 */
-	public static function state($filter_state = '*', $published = 'JPUBLISHED', $unpublished = 'JPUBLISHED', $archived = null, $trashed = null)
+	public static function state($filter_state = '*', $published = 'JPUBLISHED', $unpublished = 'JUNPUBLISHED', $archived = null, $trashed = null)
 	{
 		$state = array('' => '- ' . JText::_('JLIB_HTML_SELECT_STATE') . ' -', 'P' => JText::_($published), 'U' => JText::_($unpublished));
 

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -232,7 +232,7 @@ abstract class JHtmlGrid
 	 *
 	 * @since   1.5
 	 */
-	public static function state($filter_state = '*', $published = 'Published', $unpublished = 'Unpublished', $archived = null, $trashed = null)
+	public static function state($filter_state = '*', $published = 'JPUBLISHED', $unpublished = 'JPUBLISHED', $archived = null, $trashed = null)
 	{
 		$state = array('' => '- ' . JText::_('JLIB_HTML_SELECT_STATE') . ' -', 'P' => JText::_($published), 'U' => JText::_($unpublished));
 


### PR DESCRIPTION
This is just a small PR which change the text of state dropdown (generated by **JHtmlGrid::state** method) from a text to a language item

We have language items JPUBLISHED, JUNPUBLISHED and I think we should use it instead of Published and Unpublished string at the moment. 

I found this issue while supporting a customer site. His site language is Italian but when I used JHtmlGrid::state('published'), that English text Published and Unpublished are not translated.
