### PR TITLE
Fix JUri::isInternal error

### DIFF
--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -258,19 +258,122 @@ class JUri extends Uri
 	 *
 	 * @param   string  $url  The URL to check.
 	 *
-	 * @return  boolean  True if Internal.
+	 * @return  boolean  True  if Internal.
 	 *
 	 * @since   11.1
 	 */
 	public static function isInternal($url)
 	{
-		$uri = static::getInstance($url);
+		$uri  = static::getInstance($url);
 		$base = $uri->toString(array('scheme', 'host', 'port', 'path'));
 		$host = $uri->toString(array('scheme', 'host', 'port'));
 
+		if (empty($host))
+		{
+			$app = JFactory::getApplication();
+
+			// Decode URL to convert percent-encoding to unicode so that strings match when routing.
+			$path = urldecode($uri->getPath());
+
+			// Remove base path from url, in case site is in sub-folder
+			$basePath = static::base(true);
+			if ($basePath && JString::strpos($path, $basePath) === 0)
+			{
+				$path = str_replace($basePath, '', $path);
+			}
+
+			$path = trim($path, '/');
+
+			if (empty($path) || JString::strpos($path, 'index.php') === 0)
+			{
+				return true;
+			}
+
+			if ($app->get('sef'))
+			{
+				// Remove language code if it is available in URL
+				$languages = JLanguageHelper::getLanguages('sef');
+				$parts     = explode('/', $path);
+				$sef       = $parts[0];
+
+				if (isset($languages[$sef]))
+				{
+					$path     = str_replace($sef . '/', '', $path);
+					$lang_tag = $languages[$sef]->lang_code;
+				}
+
+				// Remove the suffix
+				if ($app->get('sef_suffix'))
+				{
+					if ($suffix = pathinfo($path, PATHINFO_EXTENSION))
+					{
+						$path = str_replace('.' . $suffix, '', $path);
+					}
+				}
+
+				// Validate and remove index.php from URL in case "Use URL Rewriting" set to Yes
+				if (!$app->get('sef_rewrite'))
+				{
+					// Url needs to start with index.php to be considered as valid URL
+					if (strpos($path, 'index.php') === false)
+					{
+						return false;
+					}
+
+					if ($path == 'index.php')
+					{
+						$path = '';
+					}
+					else
+					{
+						$path = str_replace('index.php/', '', $path);
+					}
+				}
+
+				if (empty($path))
+				{
+					return true;
+				}
+
+				$segments = explode('/', $path);
+
+				if (count($segments) > 1 && $segments[0] == 'component')
+				{
+					$option = 'com_' . $segments[1];
+					if (JComponentHelper::isEnabled($option))
+					{
+						return true;
+					}
+				}
+				else
+				{
+					$isMultilingual = JLanguageMultilang::isEnabled();
+
+					$items           = $app->getMenu()->getMenu();
+					$route = JString::strtolower($path);
+
+					foreach ($items as $item)
+					{
+						if ($item->route && JString::strpos($route . '/', $item->route . '/') === 0 && $item->type != 'menulink')
+						{
+							// Usual method for non-multilingual site.
+							if (!$isMultilingual)
+							{
+								return true;
+							}
+							// Multilingual site.
+							elseif ($item->language == '*' || $item->language == $lang_tag)
+							{
+								return true;
+							}
+						}
+					}
+				}
+			}
+		}
+
 		// @see JURITest
-		if (empty($host) && strpos($uri->path, 'index.php') === 0
-			|| !empty($host) && preg_match('#' . preg_quote(static::base(), '#') . '#', $base)
+		if (!empty($host) && preg_match('#' . preg_quote(static::base(), '#') . '#', $base)
 			|| !empty($host) && $host === static::getInstance(static::base())->host && strpos($uri->path, 'index.php') !== false
 			|| !empty($host) && $base === $host && preg_match('#' . preg_quote($base, '#') . '#', static::base()))
 		{

--- a/tests/unit/suites/libraries/joomla/uri/JURITest.php
+++ b/tests/unit/suites/libraries/joomla/uri/JURITest.php
@@ -15,7 +15,7 @@
  * @subpackage  Uri
  * @since       11.1
  */
-class JUriTest extends PHPUnit_Framework_TestCase
+class JUriTest extends TestCase
 {
 	/**
 	 * @var    JUri
@@ -862,6 +862,8 @@ class JUriTest extends PHPUnit_Framework_TestCase
 		$_SERVER['SCRIPT_NAME'] = '/joomla/index.php';
 		$_SERVER['PHP_SELF'] = '/joomla/index.php';
 		$_SERVER['REQUEST_URI'] = '/joomla/index.php?var=value 10';
+
+		JFactory::$application = $this->getMockCmsApp();
 
 		$this->object = new JUri;
 	}


### PR DESCRIPTION
## Summary

In Joomla 3.4.6, we made some changes to JUri::isInternal method to improve security. Unfortunately, these changes also break Joomla Login Redirect feature. We can see this issue on both Joomla core and third party extensions.

See https://github.com/joomla/joomla-cms/issues/8689 for the report and https://github.com/joomla/joomla-cms/pull/8698/files for the changes we have to make in Joomla core if we could not fix this error

This PR attempts to solve that issue. All should work the same as before except that relative urls should now be validated properly.
## Testing instructions

Create a menu item to link to Login Form of users component. In the menu parameter, enter any the url you want into Login Redirect parameter. When the url is valid, you should be redirected to that URL after logging in. If the URL is invalid, you should be redirected to user profile page.
