### PR TITLE
Fixed "Set ItemID" not working in Smart Search module

### DIFF
--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -47,7 +47,7 @@ class ModFinderHelper
 		// Add a field for Itemid if we need one.
 		if ($needId)
 		{
-			$id = JFactory::getApplication()->input->get('Itemid', '0', 'int');
+			$id = $paramItem ? $paramItem : JFactory::getApplication()->input->get('Itemid', '0', 'int');
 			$fields[] = '<input type="hidden" name="Itemid" value="' . $id . '" />';
 		}
 


### PR DESCRIPTION
Whatever set in that field, search results will always be displayed with the ItemID of homepage menu (When there's no menuitem of com_finder in the menu system)
