### PR TITLE
Loading chosen for mod_languages and SmartSearch

### DIFF
--- a/components/com_finder/views/search/tmpl/default.php
+++ b/components/com_finder/views/search/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
+JHtml::_('formbehavior.chosen', 'select');
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::stylesheet('com_finder/finder.css', false, true, false);
 ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('stylesheet', 'mod_languages/template.css', array(), true);
+JHtml::_('formbehavior.chosen', 'select');
 ?>
 <div class="mod-languages<?php echo $moduleclass_sfx; ?>">
 <?php if ($headerText) : ?>


### PR DESCRIPTION
Test:
Do not publish the smart search module in frontend or any module loading chosen.
Create a Smart Search menu item.  Display the page obtained.

Also same issue when displaying a multilingual site where the setting of the language switcher is set to Use Dropdown

Before patch, the select boxes look like
![screen shot 2016-02-05 at 09 18 33](https://cloud.githubusercontent.com/assets/869724/12841141/c012b9a4-cbe9-11e5-9dd7-97bcf748083d.png)

If the smart search module had been loaded we would have got chosen Select boxes.

After patch:
![screen shot 2016-02-05 at 09 27 08](https://cloud.githubusercontent.com/assets/869724/12841251/b8d163b0-cbea-11e5-8bc4-11f2be89a3e3.png)

_Note:_ the breadcrumbs display issue should be treated separately as it exists before patch.
