### PR TITLE
SEF system plugin performance improvements

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -31,7 +31,7 @@ class PlgSystemSef extends JPlugin
 	 *
 	 * @since   3.6
 	 */
-	public function onBeforeRender()
+	public function onAfterDispatch()
 	{
 		$doc = $this->app->getDocument();
 

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -104,7 +104,7 @@ class PlgSystemSef extends JPlugin
 			$this->checkBuffer($buffer);
 		}
 
-		// Replace all unknown protocals in onmouseover and onmouseout attributes.
+		// Replace all unknown protocols in onmouseover and onmouseout attributes.
 		$attributes = array('onmouseover=', 'onmouseout=');
 		foreach ($attributes as $attribute)
 		{
@@ -124,7 +124,7 @@ class PlgSystemSef extends JPlugin
 			$this->checkBuffer($buffer);
 		}
 
-		// Replace all unknown protocals in OBJECT param tag.
+		// Replace all unknown protocols in OBJECT param tag.
 		if (strpos($buffer, '<param') !== false)
 		{
 			// OBJECT <param name="xx", value="yy"> -- fix it only inside the <param> tag.
@@ -138,7 +138,7 @@ class PlgSystemSef extends JPlugin
 			$this->checkBuffer($buffer);
 		}
 
-		// Replace all unknown protocals in OBJECT tag.
+		// Replace all unknown protocols in OBJECT tag.
 		if (strpos($buffer, '<object') !== false)
 		{
 			$regex  = '#(<object\s+[^>]*)data\s*=\s*"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -17,33 +17,23 @@ defined('_JEXEC') or die;
 class PlgSystemSef extends JPlugin
 {
 	/**
-	 * Constructor.
+	 * Application object.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *
-	 * @since   3.6
+	 * @var    JApplicationCms
+	 * @since  3.6
 	 */
-	public function __construct(&$subject, $config)
-	{
-		parent::__construct($subject, $config);
-
-		if (!isset($this->app))
-		{
-			$this->app = JFactory::getApplication();
-		}
-	}
+	protected $app;
 
 	/**
 	 * Add the canonical uri to the head.
 	 *
 	 * @return  void
 	 *
-	 * @since   3.0
+	 * @since   3.6
 	 */
-	public function onAfterRoute()
+	public function onBeforeRender()
 	{
-		$doc = JFactory::getDocument();
+		$doc = $this->app->getDocument();
 
 		if (!$this->app->isSite() || $doc->getType() !== 'html')
 		{


### PR DESCRIPTION
#### Description

This PR does some performance improvements to the SEF system plugin.
###### Before PR

![sef-before-pr](https://cloud.githubusercontent.com/assets/9630530/12867434/817dfaee-cce5-11e5-81df-f031bf21d136.png)
###### After PR

![sef-after-pr](https://cloud.githubusercontent.com/assets/9630530/12867436/8b3021ac-cce5-11e5-9399-7aac1a5f8914.png)
#### How to test
1. Enable SEF in global config and enable SEF system plugin
2. Create some content with links, images, objects, etc. (see code to see what this plugin replaces)
3. Apply this patch
4. Check if all links and references (ex: images) are using the SEF uri as before.

For checking the performance improvements:
- Enable debug global configuration option and debug system plugin.
- Temporary replace code in line https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/event/dispatcher.php#L160 for:

``` php
JDEBUG && $this->_observers[$key] == 'PlgSystemSef' ? JProfiler::getInstance('Application')->mark('- ' . $this->_observers[$key] . '->' . $event . ' started.') : null;
$value = $this->_observers[$key]->update($args);
JDEBUG && $this->_observers[$key] == 'PlgSystemSef' ? JProfiler::getInstance('Application')->mark('- <strong>' . $this->_observers[$key] . '->' . $event . ' Ended!</strong>') : null;
```
- Check the profile information in the debug console before and after PR

Notes:
- The more code a page has, the more time the `onAfterRender` event of the SEF plugin will take. So test this in category blog views and other pages with lot of content.
- It would be good to test in ready to production sites, i.e., with real content.
#### Observations

Suggestions, code reviews and improvements are welcomed.
