### PR TITLE
Added possibility to set script priority

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -446,7 +446,7 @@ class JDocument
 	 * @param   string   $type   Type of script. Defaults to 'text/javascript'
 	 * @param   boolean  $defer  Adds the defer attribute.
 	 * @param   boolean  $async  Adds the async attribute.
-	 * @param   integer  $priority  The scripts priority 
+	 * @param   int  $priority  The scripts priority
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
@@ -471,7 +471,7 @@ class JDocument
 	 * @param   string   $type     Type of script. Defaults to 'text/javascript'
 	 * @param   boolean  $defer    Adds the defer attribute.
 	 * @param   boolean  $async    [description]
-	 * @param   integer  $priority  The scripts priority 
+	 * @param   int  $priority  The scripts priority 
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -442,11 +442,11 @@ class JDocument
 	/**
 	 * Adds a linked script to the page
 	 *
-	 * @param   string   $url    URL to the linked script
-	 * @param   string   $type   Type of script. Defaults to 'text/javascript'
-	 * @param   boolean  $defer  Adds the defer attribute.
-	 * @param   boolean  $async  Adds the async attribute.
-	 * @param   int  $priority  The scripts priority
+	 * @param   string   $url       URL to the linked script
+	 * @param   string   $type      Type of script. Defaults to 'text/javascript'
+	 * @param   boolean  $defer     Adds the defer attribute.
+	 * @param   boolean  $async     Adds the async attribute.
+	 * @param   integer  $priority  The scripts priority
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
@@ -466,12 +466,12 @@ class JDocument
 	 * Adds a linked script to the page with a version to allow to flush it. Ex: myscript.js54771616b5bceae9df03c6173babf11d
 	 * If not specified Joomla! automatically handles versioning
 	 *
-	 * @param   string   $url      URL to the linked script
-	 * @param   string   $version  Version of the script
-	 * @param   string   $type     Type of script. Defaults to 'text/javascript'
-	 * @param   boolean  $defer    Adds the defer attribute.
-	 * @param   boolean  $async    [description]
-	 * @param   int  $priority  The scripts priority 
+	 * @param   string   $url       URL to the linked script
+	 * @param   string   $version   Version of the script
+	 * @param   string   $type      Type of script. Defaults to 'text/javascript'
+	 * @param   boolean  $defer     Adds the defer attribute.
+	 * @param   boolean  $async     [description]
+	 * @param   integer  $priority  The scripts priority 
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -446,16 +446,18 @@ class JDocument
 	 * @param   string   $type   Type of script. Defaults to 'text/javascript'
 	 * @param   boolean  $defer  Adds the defer attribute.
 	 * @param   boolean  $async  Adds the async attribute.
+	 * @param   integer  $priority  The scripts priority 
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
-	public function addScript($url, $type = "text/javascript", $defer = false, $async = false)
+	public function addScript($url, $type = "text/javascript", $defer = false, $async = false, $priority = 10)
 	{
 		$this->_scripts[$url]['mime'] = $type;
 		$this->_scripts[$url]['defer'] = $defer;
 		$this->_scripts[$url]['async'] = $async;
+		$this->_scripts[$url]['priority'] = $priority;
 
 		return $this;
 	}
@@ -469,12 +471,13 @@ class JDocument
 	 * @param   string   $type     Type of script. Defaults to 'text/javascript'
 	 * @param   boolean  $defer    Adds the defer attribute.
 	 * @param   boolean  $async    [description]
+	 * @param   integer  $priority  The scripts priority 
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   3.2
 	 */
-	public function addScriptVersion($url, $version = null, $type = "text/javascript", $defer = false, $async = false)
+	public function addScriptVersion($url, $version = null, $type = "text/javascript", $defer = false, $async = false, $priority = 10)
 	{
 		// Automatic version
 		if ($version === null)
@@ -487,7 +490,7 @@ class JDocument
 			$url .= '?' . $version;
 		}
 
-		return $this->addScript($url, $type, $defer, $async);
+		return $this->addScript($url, $type, $defer, $async, $priority);
 	}
 
 	/**

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -180,11 +180,6 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$document->_scripts,
 			function ($a, $b)
 			{
-				if ($a['priority'] == $b['priority'])
-				{
-					return 1;
-				}
-
 				return ($a['priority'] < $b['priority']) ? -1 : 1;
 			}
 		);

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -176,16 +176,16 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		}
 
 		// Generate script file links
-		uasort (
-			$document->_scripts, 
-			function($a, $b) 
+		uasort(
+			$document->_scripts,
+			function($a, $b)
 			{
-				if ($a['priority']  == $b['priority'])
+				if ( $a['priority']  == $b['priority'] )
 				{
 					return 1;
 				}
 
-				return ($a['priority']  < $b['priority']) ? -1 : 1;
+				return ( $a['priority']  < $b['priority'] ) ? -1 : 1;
 			}
 		);
 

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -178,14 +178,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate script file links
 		uasort(
 			$document->_scripts,
-			function($a, $b)
+			function ($a, $b)
 			{
-				if ( $a['priority']  == $b['priority'] )
+				if ($a['priority']  == $b['priority'])
 				{
 					return 1;
 				}
 
-				return ( $a['priority']  < $b['priority'] ) ? -1 : 1;
+				return ($a['priority']  < $b['priority']) ? -1 : 1;
 			}
 		);
 

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -180,12 +180,12 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$document->_scripts,
 			function ($a, $b)
 			{
-				if ($a['priority']  == $b['priority'])
+				if ($a['priority'] == $b['priority'])
 				{
 					return 1;
 				}
 
-				return ($a['priority']  < $b['priority']) ? -1 : 1;
+				return ($a['priority'] < $b['priority']) ? -1 : 1;
 			}
 		);
 

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -176,6 +176,19 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		}
 
 		// Generate script file links
+		uasort (
+			$document->_scripts, 
+			function($a, $b) 
+			{
+				if ($a['priority']  == $b['priority'])
+				{
+					return 1;
+				}
+
+				return ($a['priority']  < $b['priority']) ? -1 : 1;
+			}
+		);
+
 		foreach ($document->_scripts as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<script src="' . $strSrc . '"';


### PR DESCRIPTION
Added possibility to set script priority with $document->addScript(...);

**To test use the code bellow:**

```
$document = JFactory::getDocument();
$document->addScript('/script1.js', 'text/javascript', false, false, 1);
$document->addScript('/script2.js', 'text/javascript', false, false, 100);
print_r($document->_scripts);

$htmHeadRenderer = $document->loadRenderer('head');
echo $htmHeadRenderer->render('');
die;
``
```
