### PR TITLE
Added alias for menu items in the edit view

### DIFF
--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -78,7 +78,8 @@ class JFormFieldMenuParent extends JFormFieldList
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
-			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+			$titleAlias = '(' . JText::_('JFIELD_ALIAS_LABEL') . ': ' . $db->escape($options[$i]->alias) . ')';
+			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text . ' ' . $titleAlias;
 		}
 
 		// Merge any additional options in the XML definition.

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -39,7 +39,7 @@ class JFormFieldMenuParent extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.level')
+			->select('a.id AS value, a.title AS text, a.alias, a.level')
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -195,11 +195,11 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 					$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 					$levelPrefix = str_repeat('- ', $link->level - 1);
 					$groups[$menu->menutype][] = JHtml::_('select.option',
-								$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
-								'value',
-								'text',
-								in_array($link->type, $this->disable)
-							);
+															$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
+															'value',
+															'text',
+															in_array($link->type, $this->disable)
+														);
 				}
 			}
 		}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -154,6 +154,8 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 	{
 		$groups = array();
 
+		$db = JFactory::getDbo();
+
 		$menuType = $this->menuType;
 
 		// Get the menu items.
@@ -168,9 +170,10 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			// Build the options array.
 			foreach ($items as $link)
 			{
+				$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 				$levelPrefix = str_repeat('- ', max(0, $link->level - 1));
 				$groups[$menuType][] = JHtml::_('select.option',
-								$link->value, $levelPrefix . $link->text,
+								$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
 								'value',
 								'text',
 								in_array($link->type, $this->disable)
@@ -189,11 +192,14 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 				// Build the options array.
 				foreach ($menu->links as $link)
 				{
+					$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 					$levelPrefix = str_repeat('- ', $link->level - 1);
-					$groups[$menu->menutype][] = JHtml::_(
-						'select.option', $link->value, $levelPrefix . $link->text, 'value', 'text',
-						in_array($link->type, $this->disable)
-					);
+					$groups[$menu->menutype][] = JHtml::_('select.option',
+									       $link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
+									       'value',
+									       'text',
+									       in_array($link->type, $this->disable)
+								     );
 				}
 			}
 		}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -195,11 +195,11 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 					$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 					$levelPrefix = str_repeat('- ', $link->level - 1);
 					$groups[$menu->menutype][] = JHtml::_('select.option',
-									$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
-									'value',
-									'text',
-									in_array($link->type, $this->disable)
-								);
+								$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
+								'value',
+								'text',
+								in_array($link->type, $this->disable)
+							);
 				}
 			}
 		}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -195,11 +195,11 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 					$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 					$levelPrefix = str_repeat('- ', $link->level - 1);
 					$groups[$menu->menutype][] = JHtml::_('select.option',
-															$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
-															'value',
-															'text',
-															in_array($link->type, $this->disable)
-														);
+							$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
+							'value',
+							'text',
+							in_array($link->type, $this->disable)
+						);
 				}
 			}
 		}

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -195,11 +195,11 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 					$titleAlias = JText::sprintf('JGLOBAL_LIST_ALIAS', $db->escape($link->alias));
 					$levelPrefix = str_repeat('- ', $link->level - 1);
 					$groups[$menu->menutype][] = JHtml::_('select.option',
-									       $link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
-									       'value',
-									       'text',
-									       in_array($link->type, $this->disable)
-								     );
+									$link->value, $levelPrefix . $link->text . ' ' . $titleAlias,
+									'value',
+									'text',
+									in_array($link->type, $this->disable)
+								);
 				}
 			}
 		}


### PR DESCRIPTION
By editing of menu items there is a problem that you can't distinguish between menu items with the same title.
**Example:**
You have 2 menu items with the title "News", but they have different parents or belongs to different menus. By searching for "News" you will get 2 menu items without knowing, which menu item belongs to which parent menu item.

In order to select the right menu item, you need to write own aliases, which defines belogning to a parent menu item (See screenshots)
![image](https://cloud.githubusercontent.com/assets/4247900/12889795/ea8a11ac-ce80-11e5-8c9f-678ab6cc25a6.png)
**Joomla standard (current state):**
![image](https://cloud.githubusercontent.com/assets/4247900/12889895/67b75824-ce81-11e5-97b4-0dec9515e574.png)

**My solution:**
I added the aliases in the _Menu Item_ and _Parent Item_ dropdown field.
![image](https://cloud.githubusercontent.com/assets/4247900/12889801/f0ba5636-ce80-11e5-9ad5-38b58b4800df.png)
![image](https://cloud.githubusercontent.com/assets/4247900/12890410/dde990e6-ce83-11e5-8af7-99650b0b5330.png)

**How to test:**
1) Open some existing menu item or create a new menu item
2) Click_ Menu Item Type_ and select _Menu Item Alias_
3) Open the _Menu Item_ OR _Parent Item_ dropdown field and you will see aliases behind the titles 
