### PR TITLE
Mod languages - no need for chosen if there is no select box (added in #9077)

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -10,7 +10,10 @@
 defined('_JEXEC') or die;
 
 JHtml::_('stylesheet', 'mod_languages/template.css', array(), true);
-JHtml::_('formbehavior.chosen', 'select');
+if ($params->get('dropdown', 1))
+{
+	JHtml::_('formbehavior.chosen', 'select');
+}
 ?>
 <div class="mod-languages<?php echo $moduleclass_sfx; ?>">
 <?php if ($headerText) : ?>


### PR DESCRIPTION
#### Description

PR https://github.com/joomla/joomla-cms/pull/9077 added chosen style in mod languages.
But it added even if there is no select box.

This corrects that
#### How to test
1. Install latest staging with Multilanguage with language switcher flags.
2. Open any page and check source code. There is a chosen css in all pages.
3. Apply PR. There is no chosen css now.
4. Chosen will still apply with mod_languages with option selector

@infograf768 please check
