### PR TITLE
Correcting Plugins Select Status

### DIFF
--- a/administrator/components/com_plugins/models/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/models/forms/filter_plugins.xml
@@ -12,7 +12,6 @@
 		<field
 			name="enabled"
 			type="plugin_status"
-			filter="*,0,1"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_plugins/models/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/models/forms/filter_plugins.xml
@@ -1,73 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-    <fieldset addfieldpath="/administrator/components/com_plugins/models/fields" />
+	<fieldset addfieldpath="/administrator/components/com_plugins/models/fields" />
 
-    <fields name="filter">
-        <field
-                name="search"
-                type="text"
-                hint="JSEARCH_FILTER"
-                />
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			hint="JSEARCH_FILTER"
+		/>
 
-        <field
-                name="enabled"
-                type="status"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_PUBLISHED</option>
-        </field>
+		<field
+			name="enabled"
+			type="plugin_status"
+			filter="*,0,1"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
 
-        <field
-                name="folder"
-                type="plugintype"
-                onchange="this.form.submit();"
-                >
-            <option value="">COM_PLUGINS_OPTION_FOLDER</option>
-        </field>
+		<field
+			name="folder"
+			type="plugintype"
+			onchange="this.form.submit();"
+		>
+			<option value="">COM_PLUGINS_OPTION_FOLDER</option>
+		</field>
 
-        <field
-                name="access"
-                type="accesslevel"
-                label="JOPTION_FILTER_ACCESS"
-                description="JOPTION_FILTER_ACCESS_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_ACCESS</option>
-        </field>
-    </fields>
+		<field
+			name="access"
+			type="accesslevel"
+			label="JOPTION_FILTER_ACCESS"
+			description="JOPTION_FILTER_ACCESS_DESC"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_ACCESS</option>
+		</field>
+	</fields>
 
-    <fields name="list">
-        <field
-                name="fullordering"
-                type="list"
-                label="JGLOBAL_SORT_BY"
-                description="JGLOBAL_SORT_BY"
-                onchange="this.form.submit();"
-                default="folder ASC"
-        >
-            <option value="">JGLOBAL_SORT_BY</option>
-            <option value="ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-            <option value="ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
-            <option value="enabled ASC">JSTATUS_ASC</option>
-            <option value="enabled DESC">JSTATUS_DESC</option>
-            <option value="name ASC">JGLOBAL_TITLE_ASC</option>
-            <option value="name DESC">JGLOBAL_TITLE_DESC</option>
-            <option value="folder ASC">COM_PLUGINS_HEADING_FOLDER_ASC</option>
-            <option value="folder DESC">COM_PLUGINS_HEADING_FOLDER_DESC</option>
-            <option value="element ASC">COM_PLUGINS_HEADING_ELEMENT_ASC</option>
-            <option value="element DESC">COM_PLUGINS_HEADING_ELEMENT_DESC</option>
-            <option value="access ASC">JGRID_HEADING_ACCESS_ASC</option>
-            <option value="access DESC">JGRID_HEADING_ACCESS_DESC</option>
-            <option value="extension_id ASC">JGRID_HEADING_ID_ASC</option>
-            <option value="extension_id DESC">JGRID_HEADING_ID_DESC</option>
-        </field>
+	<fields name="list">
+		<field
+			name="fullordering"
+			type="list"
+			label="JGLOBAL_SORT_BY"
+			description="JGLOBAL_SORT_BY"
+			onchange="this.form.submit();"
+			default="folder ASC"
+		>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="enabled ASC">JSTATUS_ASC</option>
+			<option value="enabled DESC">JSTATUS_DESC</option>
+			<option value="name ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="folder ASC">COM_PLUGINS_HEADING_FOLDER_ASC</option>
+			<option value="folder DESC">COM_PLUGINS_HEADING_FOLDER_DESC</option>
+			<option value="element ASC">COM_PLUGINS_HEADING_ELEMENT_ASC</option>
+			<option value="element DESC">COM_PLUGINS_HEADING_ELEMENT_DESC</option>
+			<option value="access ASC">JGRID_HEADING_ACCESS_ASC</option>
+			<option value="access DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option value="extension_id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="extension_id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
 
-        <field
-                name="limit"
-                type="limitbox"
-                class="input-mini"
-                default="25"
-                onchange="this.form.submit();"
-                />
-    </fields>
+		<field
+			name="limit"
+			type="limitbox"
+			class="input-mini"
+			default="25"
+			onchange="this.form.submit();"
+		/>
+	</fields>
 </form>

--- a/libraries/cms/form/field/plugin_status.php
+++ b/libraries/cms/form/field/plugin_status.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+JFormHelper::loadFieldClass('predefinedlist');
+
+/**
+ * Form Field to load a list of states
+ *
+ * @since  3.5
+ */
+class JFormFieldPlugin_Status extends JFormFieldPredefinedList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  3.5
+	 */
+	public $type = 'Plugin_Status';
+
+	/**
+	 * Available statuses
+	 *
+	 * @var  array
+	 * @since  3.5
+	 */
+	protected $predefinedOptions = array(
+		'0'  => 'JDISABLED',
+		'1'  => 'JENABLED',
+		'*'  => 'JALL'
+	);
+}

--- a/libraries/cms/form/field/plugin_status.php
+++ b/libraries/cms/form/field/plugin_status.php
@@ -34,7 +34,6 @@ class JFormFieldPlugin_Status extends JFormFieldPredefinedList
 	 */
 	protected $predefinedOptions = array(
 		'0'  => 'JDISABLED',
-		'1'  => 'JENABLED',
-		'*'  => 'JALL'
+		'1'  => 'JENABLED'
 	);
 }


### PR DESCRIPTION
This PR corrects the Select Status list for plugins.

Trashed and Archived should not be displayed.
Also as we use Disabled and Enabled for plugins, this PR adds a new field "plugin_status" with the correct String constants.

After patching you should get:

![screen shot 2016-02-11 at 10 40 47](https://cloud.githubusercontent.com/assets/869724/12973356/1222d50a-d0ac-11e5-87f1-3572cba5fbbc.png)
