### PR TITLE
Support for multiple ReCaptcha2 instances

### DIFF
--- a/media/plg_captcha_recaptcha/js/recaptcha.js
+++ b/media/plg_captcha_recaptcha/js/recaptcha.js
@@ -1,0 +1,20 @@
+/**
+ * @package		Joomla.JavaScript
+ * @copyright	Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+window.JoomlaInitReCaptcha2 = function() {
+	'use strict';
+
+	var items = document.getElementsByClassName('g-recaptcha'), item, options;
+	for (var i = 0, l = items.length; i < l; i++) {
+		item = items[i];
+		options = item.dataset ? item.dataset : {
+			sitekey: item.getAttribute('data-sitekey'),
+			theme:   item.getAttribute('data-theme'),
+			size:    item.getAttribute('data-size')
+		};
+		grecaptcha.render(item, options);
+	}
+}

--- a/media/plg_captcha_recaptcha/js/recaptcha.min.js
+++ b/media/plg_captcha_recaptcha/js/recaptcha.min.js
@@ -1,0 +1,1 @@
+window.JoomlaInitReCaptcha2=function(){"use strict";var e=document.getElementsByClassName("g-recaptcha"),t,n;for(var r=0,i=e.length;r<i;r++)t=e[r],n=t.dataset?t.dataset:{sitekey:t.getAttribute("data-sitekey"),theme:t.getAttribute("data-theme"),size:t.getAttribute("data-size")},grecaptcha.render(t,n)};

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -52,15 +52,16 @@ class PlgCaptchaRecaptcha extends JPlugin
 			$theme	= $this->params->get('theme', 'clean');
 			$file	= 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
 
+			JHtml::_('script', $file);
 			JFactory::getDocument()->addScriptDeclaration('jQuery( document ).ready(function()
 				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $this->_getLanguage() . 'tabindex: 0});});');
 		}
 		else
 		{
-			$file	= 'https://www.google.com/recaptcha/api.js?hl=' . JFactory::getLanguage()->getTag();
+			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
+			JHtml::_('script', $file);
+			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.js', false, true);
 		}
-
-		JHtml::_('script', $file);
 
 		return true;
 	}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -60,7 +60,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
 			JHtml::_('script', $file);
-			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.js', false, true);
+			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
 		}
 
 		return true;


### PR DESCRIPTION
Here is alternative version of that pull request #8867

**test**
Enable Captcha for the contact form.
Then add in the Contact description:

``` html
<div class="g-recaptcha" data-sitekey="ENTER_HERE_SITEKEY" 
  data-theme="light" data-size="compact"></div>
```

In result you should be able to see 2 captcha on the page. One under the form and second in the contact description.
