### PR TITLE
Regression: Correct Modules ordering on drag and drop

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -93,7 +93,7 @@ if ($saveOrder)
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
 					$canChange  = $user->authorise('core.edit.state', 'com_modules.module.' . $item->id) && $canCheckin;
 				?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->position ? $item->position : JText::_('JNONE'); ?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->position ? $item->position : 'none'; ?>">
 						<td class="order nowrap center hidden-phone">
 							<?php
 							$iconClass = '';

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -93,7 +93,7 @@ if ($saveOrder)
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
 					$canChange  = $user->authorise('core.edit.state', 'com_modules.module.' . $item->id) && $canCheckin;
 				?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->ordering; ?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->position ? $item->position : JText::_('JNONE'); ?>">
 						<td class="order nowrap center hidden-phone">
 							<?php
 							$iconClass = '';


### PR DESCRIPTION
##### Description

Modules should be ordered by their order in the position, so when we order using drag and drop we should get only enabled the modules in the same position.

That is not happening right now, the enabled modules on drag are the ones with the same "ordering" indepedent of the position.
###### Before PR

![image](https://cloud.githubusercontent.com/assets/9630530/13033910/b3f1c7a0-d31e-11e5-832f-0f8ffc65cce4.png)
###### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/13033915/d52db352-d31e-11e5-9f44-8b9d87ae20ae.png)
##### How to test
1. Install latest staging
2. Create some modules in the same position
3. Try to order them within the position in the list view with drag and drop
4. Apply this PR
5. Try to order them now within the position in the list view with drag and drop
