### PR TITLE
Remove obsolete whitespace and minor refactoring in mod_menu layouts

### DIFF
--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -9,17 +9,20 @@
 
 defined('_JEXEC') or die;
 
-$title = $item->anchor_title ? 'title="' . $item->anchor_title . '" ' : '';
+$title = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
+$anchor_css = $item->anchor_css ? $item->anchor_css : '';
+
+$linktype = $item->title;
 
 if ($item->menu_image)
 {
-	$item->params->get('menu_text', 1) ?
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" /><span class="image-title">' . $item->title . '</span> ' :
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" />';
+	$linktype = JHtml::_('image', $item->menu_image, $item->title);
+
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
 }
-else
-{
-	$linktype = $item->title;
-}
+
 ?>
-<span class="nav-header <?php echo $item->anchor_css; ?>" <?php echo $title; ?>><?php echo $linktype; ?></span>
+<span class="nav-header<?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -25,4 +25,4 @@ if ($item->menu_image)
 }
 
 ?>
-<span class="nav-header<?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>
+<span class="nav-header <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -25,4 +25,4 @@ if ($item->menu_image)
 }
 
 ?>
-<span class="separator<?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>
+<span class="separator <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -9,21 +9,20 @@
 
 defined('_JEXEC') or die;
 
-// Note. It is important to remove spaces between elements.
-$class = $item->anchor_css ? ' ' . $item->anchor_css : '';
-$title = $item->anchor_title ? ' title="' . $item->anchor_title . '" ' : '';
+$title = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
+$anchor_css = $item->anchor_css ? $item->anchor_css : '';
+
+$linktype = $item->title;
+
 if ($item->menu_image)
-	{
-		$item->params->get('menu_text', 1) ?
-		$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" /><span class="image-title">' . $item->title . '</span> ' :
-		$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" />';
-}
-else
 {
-	$linktype = $item->title;
+	$linktype = JHtml::_('image', $item->menu_image, $item->title);
+
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
 }
 
 ?>
-<span class="separator<?php echo $class;?>"<?php echo $title; ?>>
-	<?php echo $linktype; ?>
-</span>
+<span class="separator<?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>


### PR DESCRIPTION
While this PR doen't really fix an issue with the current implementation it aims to add minor improvements to the layout.

Speaking of which
- removing obsolete whitespace
- using JHtml::image so that in theory if one overrides that method e.g. via a plugin the menu item image will be affected as well
- getting rid of the else block

**Test Instructions**
- Create a menu item of the type *System Links - Menu Heading" in a menu of your choice.
- Give it a descriptive title e.g. _Shenanigans_
- Inspect the sites HTML Markup for that link within your prefered browser.

Before the patch you should see something like (Protostar Template without overrides):
`<span class="nav-header" >Shenanigans</span>`

After the patch it should read:
`<span class="nav-header">Shenanigans</span>`

To really make sure that everything works as before, one could play arround with different options from that menu item e.g. Link Title Attribute, Link CSS Style, Link Image or Add Menu Title.

Given that a comment in the default_separator.php file reads:
"Note. It is important to remove spaces between elements"

I figured now might be a good idea to change that layout as well. So, instead of the class attribute "nav-header" one would expect "separator".

Edit: I've added the whitespace between the css class and the suffix to keep this PR b/c (thx @bembelimen)

It seems that the method of how to handle suffixes needs to be re-evaluated in general. Maybe in a different PR.
