### PR TITLE
Avoid search tools flickering

### DIFF
--- a/libraries/cms/html/searchtools.php
+++ b/libraries/cms/html/searchtools.php
@@ -79,6 +79,13 @@ abstract class JHtmlSearchtools
 			$options = static::optionsToRegistry($options);
 
 			$doc = JFactory::getDocument();
+
+			// Avoid flickering of searchtools if filters already selected.
+			if ($options->get('filterButton') === null && $options->get('filtersHidden') !== 1)
+			{
+				$doc->addStyleDeclaration('.js-stools-container-filters { display: block; }');
+			}
+
 			$script = "
 				(function($){
 					$(document).ready(function() {


### PR DESCRIPTION
#### Description

When you have a searchtools filter already selected and them you select another filter (or other option in the same filter), the pages reloads and there is a flickering of the searchtools (starts as hidden and them appears again).

This PR solves that by hidden the searchtools filter bar with css is the cases that is already open, before the javascript is loaded.
#### How to test
1. Install latest staging.
2. Go to a view with a lot of filters (e.g. modules, content, menus, etc)
3. Select a filter. Now selected another filter. You will see the flickering (starts as hidden and them appears again).
4. Apply this patch
5. Do the same as 2 and 3. No flickering now.
6. Test with several browsers.

Note: I don't know for sure if flickering is the right english word for this, if not please correct me.

**Update**: Don't test yet, discovered some issues.
