### PR TITLE
Removing unused <authorEmail> and <authorUrl> tags

### DIFF
--- a/installation/language/af-ZA/af-ZA.xml
+++ b/installation/language/af-ZA/af-ZA.xml
@@ -4,8 +4,6 @@
   <version>3.5.0.1</version>
   <creationDate>2016.02.02</creationDate>
   <author>Joomla4Africa Project</author>
-  <authorEmail>admin@joomla.org</authorEmail>
-  <authorUrl>www.joomla.org</authorUrl>
   <copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
   <license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
   <description>3.5 Joomla Afrikaanse Taalpaket</description>

--- a/installation/language/cy-GB/cy-GB.xml
+++ b/installation/language/cy-GB/cy-GB.xml
@@ -4,8 +4,6 @@
 	<version>3.3.0.1</version>
 	<creationDate>2014-05-07</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>cy-GB site language</description>

--- a/installation/language/da-DK/da-DK.xml
+++ b/installation/language/da-DK/da-DK.xml
@@ -6,7 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>August 2015</creationDate>
 	<author>Danish Translation project</author>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/el-GR/el-GR.xml
+++ b/installation/language/el-GR/el-GR.xml
@@ -6,8 +6,6 @@
 	<version>3.4.2</version>
 	<creationDate>2015-06-13</creationDate>
 	<author>Greek translation team : joomla.gr</author>
-	<authorEmail>joomla@joomla.gr</authorEmail>
-	<authorUrl>http://www.joomla.gr</authorUrl>
 	<copyright>Copyright (C) 2005 - 2013 joomla.gr και Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License έκδοση 2 ή νεότερη· δες LICENSE.txt</license>
 	<description>Greek language pack for Joomla! 3.4.2 installation - Ελληνική μετάφραση για την εγκατάσταση του Joomla! 3.4.2</description>

--- a/installation/language/en-AU/en-AU.xml
+++ b/installation/language/en-AU/en-AU.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>January 2016</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/en-CA/en-CA.xml
+++ b/installation/language/en-CA/en-CA.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>January 2016</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>August 2015</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/en-US/en-US.xml
+++ b/installation/language/en-US/en-US.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>January 2016</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/eo-XX/eo-XX.xml
+++ b/installation/language/eo-XX/eo-XX.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>Aŭgusto 2015</creationDate>
 	<author>EsperantoSverige, Svedio</author>
-	<authorEmail>tradukoj@esperantosverige.se</authorEmail>
-	<authorUrl>esperantosverige.se</authorUrl>
 	<copyright>Kopirajto (C) 2005 - 2016 Open Source Matters. Ĉiuj rajtoj rezervitaj.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/et-EE/et-EE.xml
+++ b/installation/language/et-EE/et-EE.xml
@@ -6,7 +6,6 @@
 	<version>3.4.0</version>
 	<creationDate>2012-09-22</creationDate>
 	<author>Joomla! Project</author>
-	<authorUrl>eraser.ee</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>Joomla! 3.0 paigaldusprotsessi eesti keele tõlge</description>

--- a/installation/language/he-IL/he-IL.xml
+++ b/installation/language/he-IL/he-IL.xml
@@ -6,7 +6,6 @@
 	<version>3.2.0</version>
 	<creationDate>September 2010</creationDate>
 	<author>Joomla Israeli Community</author>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>Hebrew language pack for Joomla! 3.0 Installation</description>

--- a/installation/language/id-ID/id-ID.xml
+++ b/installation/language/id-ID/id-ID.xml
@@ -6,7 +6,6 @@
 	<version>3.2.0</version>
 	<creationDate>January 2013</creationDate>
 	<author>Tim Hanacaraka Joomla Indonesia</author>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/km-KH/km-KH.xml
+++ b/installation/language/km-KH/km-KH.xml
@@ -4,8 +4,6 @@
 	<version>3.5.0</version>
 	<creationDate>August 2015</creationDate>
 	<author>Khmer Translation Team</author>
-	<authorEmail>info@km-kh.org</authorEmail>
-	<authorUrl>www.km-kh.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/pt-BR/pt-BR.xml
+++ b/installation/language/pt-BR/pt-BR.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>2016-01-20</creationDate>
 	<author>Equipe de Tradução Português Brasileiro</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005-2015 Open Source Matters. Todos os direitos reservados.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>

--- a/installation/language/sk-SK/sk-SK.xml
+++ b/installation/language/sk-SK/sk-SK.xml
@@ -6,7 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>August 2015</creationDate>
 	<author>Joomla! Project</author>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>Slovak language file for Joomla! 3.x installation</description>

--- a/installation/language/sl-SI/sl-SI.xml
+++ b/installation/language/sl-SI/sl-SI.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>2016-01-22</creationDate>
 	<author></author>
-	<authorEmail></authorEmail>
-	<authorUrl></authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. Vse pravice pridržane.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<description>sl-SI jezik namestitve</description>

--- a/installation/language/zh-CN/zh-CN.xml
+++ b/installation/language/zh-CN/zh-CN.xml
@@ -6,7 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>2015.3.15</creationDate>
 	<author>Joomla! Project</author>
-	<authorEmail>admin@joomla.org</authorEmail>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>This Chinese Simplified language for the installation of Joomla 3.x.</description>

--- a/installation/language/zh-TW/zh-TW.xml
+++ b/installation/language/zh-TW/zh-TW.xml
@@ -6,8 +6,6 @@
 	<version>3.5.0</version>
 	<creationDate>January 2016</creationDate>
 	<author>Joomla! Taiwan</author>
-	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description></description>


### PR DESCRIPTION
Currently, we have in some of our installation language XML files the two tags `authorEmail` and `authorUrl`. However they are not used anywhere. There is also a rule to not translate them.
To be consistent, I suggest to remove them from all files as they serve no purpose anyway and only confuse translators.

@infograf768 Can you verify?
