### PR TITLE
Avoid search tools flickering

### DIFF
--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -29,6 +29,7 @@ $formSelector = !empty($data['options']['formSelector']) ? $data['options']['for
 // Load search tools
 JHtml::_('searchtools.form', $formSelector, $data['options']);
 
+$filtersClass = $data['view']->activeFilters ? ' visible-desktop visible-tablet' : '';
 ?>
 <div class="js-stools clearfix">
 	<div class="clearfix">
@@ -40,7 +41,7 @@ JHtml::_('searchtools.form', $formSelector, $data['options']);
 		</div>
 	</div>
 	<!-- Filters div -->
-	<div class="js-stools-container-filters hidden-phone clearfix">
+	<div class="js-stools-container-filters hidden-phone clearfix<?php echo $filtersClass; ?>">
 		<?php echo JLayoutHelper::render('joomla.searchtools.default.filters', $data); ?>
 	</div>
 </div>

--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -29,7 +29,7 @@ $formSelector = !empty($data['options']['formSelector']) ? $data['options']['for
 // Load search tools
 JHtml::_('searchtools.form', $formSelector, $data['options']);
 
-$filtersClass = $data['view']->activeFilters ? ' visible-desktop visible-tablet' : '';
+$filtersClass = $data['view']->activeFilters ? ' js-stools-container-filters-visible' : '';
 ?>
 <div class="js-stools clearfix">
 	<div class="clearfix">

--- a/media/jui/css/jquery.searchtools.css
+++ b/media/jui/css/jquery.searchtools.css
@@ -36,6 +36,9 @@ html[dir=rtl] .js-stools .chzn-container {
 .js-stools .js-stools-container-filters .chzn-container.active .chzn-single{
 	border: 2px solid #2384D3;
 }
+.js-stools .js-stools-container-filters-visible {
+	display: inline-block;
+}
 .js-stools .chzn-container-single .chzn-single span {
 	overflow: visible;
 }


### PR DESCRIPTION
#### Description

When you have a searchtools filter already selected and them you select another filter (or other option in the same filter), the pages reloads and there is a flickering of the searchtools (starts as hidden and them appears again).

This PR solves that by showing the searchtools filter bar with css (not waiting for js domready or onload) in the cases that there are active filters.
###### Before PR (click to open gif on new window - note there is flickering on filter changed)

![before-pr](https://cloud.githubusercontent.com/assets/9630530/13081898/73bc9cec-d4c6-11e5-835f-ef7d8c22d9d6.gif)
###### After PR (click to open gif on new window - note there is NO flickering on filter changed)

![after-pr](https://cloud.githubusercontent.com/assets/9630530/13081917/880d43fe-d4c6-11e5-9ceb-09de2a8444cf.gif)
#### How to test
1. Install latest staging.
2. Go to a view with a lot of filters (e.g. modules, content, menus, etc)
3. Select a filter. Now selected another filter. You will see the flickering (starts as hidden and them appears again).
4. Apply this patch
5. Do the same as 2 and 3. No flickering now.

Test with several browsers (mobile / non mobile).
Test in several views (frontend / administrator).

Note: I don't know for sure if flickering is the right english word for this, if not please correct me.

Update: uploaded animated gif with screen capture to show what i mean.
