### PR TITLE
Avoid ignore SQL statement after comments starting by #

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -380,7 +380,8 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 			if (($current == ';' && !$open) || $i == $end - 1)
 			{
-				$queries[] = substr($sql, $start, ($i - $start + 1));
+				$query = substr($sql, $start, ($i - $start + 1));
+				$queries[] = preg_replace('/#(?!__)[\s\S]+?[\n\r]/', '', $query);
 				$start = $i + 1;
 			}
 		}


### PR DESCRIPTION
### Description

When you try to install a component with some comments starting by # in SQL files, the following statement is ignored. This PR solves the issue #9008 by deleting all the comments starting by #
### How to test
1. Install latest staging.
2. Get a component package ready to install.
3. Unzip the component and edit administrator/sql/install.mysql.utf8.sql file by adding some comments starting by #
4. Zip your component again and then install. The component is installed ok, but the following SQL statements to comments will be omited and may cause some errors in your component. 
5. Uninstall the component.
6. Apply this patch.
7. Repeat steps 2 to 4.
8. Now the installer is working right.
