### PR TITLE
Move h2 inside if statement

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -45,11 +45,11 @@ JHtml::_('behavior.caption');
 	<?php endif; ?>
 	<?php if ($params->get('show_title') || $params->get('show_author')) : ?>
 	<div class="page-header">
-		<h2 itemprop="name">
-			<?php if ($params->get('show_title')) : ?>
+		<?php if ($params->get('show_title')) : ?>
+			<h2 itemprop="name">
 				<?php echo $this->escape($this->item->title); ?>
-			<?php endif; ?>
-		</h2>
+			</h2>
+		<?php endif; ?>
 		<?php if ($this->item->state == 0) : ?>
 			<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>


### PR DESCRIPTION
Remove empty h2 tag if Show_article set to hide
## Steps to reproduce the issue

Create an single with following article properties :
show_article : hide
show_author : show
## Before PR

An empty h2 tag is added to the code rendered
## After PR

No tag present
