### PR TITLE
Fixed regression of loader spindle during extension installation

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -75,18 +75,12 @@ JFactory::getDocument()->addScriptDeclaration(
 	jQuery(document).ready(function($) {
 		var outerDiv = $("#installer-install");
 
-		$(\'<div id="loading"></div>\')
-		.css("background", \'rgba(255, 255, 255, .8) url("../media/jui/img/ajax-loader.gif") 50% 15% no-repeat\')
+		$("#loading")
 		.css("top", outerDiv.position().top - $(window).scrollTop())
 		.css("left", outerDiv.position().left - $(window).scrollLeft())
 		.css("width", outerDiv.width())
 		.css("height", outerDiv.height())
-		.css("position", "fixed")
-		.css("opacity", "0.80")
-		.css("-ms-filter", "progid:DXImageTransform.Microsoft.Alpha(Opacity = 80)")
-		.css("filter", "alpha(opacity = 80)")
 		.css("display", "none")
-		.appendTo(outerDiv);
 	});
 	'
 );
@@ -98,6 +92,8 @@ JFactory::getDocument()->addScriptDeclaration(
 		opacity: 0.8;
 		-ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity = 80);
 		filter: alpha(opacity = 80);
+		margin: -10px -50px 0 -50px;
+		overflow: hidden;
 	}
 
 	.j-jed-message {


### PR DESCRIPTION
This regression got introduced with commit 87db28b in PR #7235

Instructions for testers:
1. Checkout master or Joomla 3.5 beta 2, try installing an extension through upload or by web: See that there is no Joomla spindle during upload and install.
2. Try this branch and do same: See that there is a Joomla spindle like was the case in Joomla 3.4.3 and before.
