### PR TITLE
[bug] Switching message language when changing admin language

### DIFF
--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -31,12 +31,15 @@ class LanguagesControllerInstalled extends JControllerLegacy
 
 		if ($model->publish($cid))
 		{
-			// Switching to the new language for the message
-			$language = JFactory::getLanguage();
-			$newLang = JLanguage::getInstance($cid);
-			JFactory::$language = $newLang;
-			JFactory::getApplication()->loadLanguage($language = $newLang);
-			$newLang->load('com_languages', JPATH_ADMINISTRATOR);
+			// Switching to the new administrator language for the message
+			if ($model->getState('filter.client_id') == 1)
+			{
+				$language = JFactory::getLanguage();
+				$newLang = JLanguage::getInstance($cid);
+				JFactory::$language = $newLang;
+				JFactory::getApplication()->loadLanguage($language = $newLang);
+				$newLang->load('com_languages', JPATH_ADMINISTRATOR);
+			}
 
 			$msg = JText::_('COM_LANGUAGES_MSG_DEFAULT_LANGUAGE_SAVED');
 			$type = 'message';

--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -31,6 +31,13 @@ class LanguagesControllerInstalled extends JControllerLegacy
 
 		if ($model->publish($cid))
 		{
+			// Switching to the new language for the message
+			$language = JFactory::getLanguage();
+			$newLang = JLanguage::getInstance($cid);
+			JFactory::$language = $newLang;
+			JFactory::getApplication()->loadLanguage($language = $newLang);
+			$newLang->load('com_languages', JPATH_ADMINISTRATOR);
+
 			$msg = JText::_('COM_LANGUAGES_MSG_DEFAULT_LANGUAGE_SAVED');
 			$type = 'message';
 		}
@@ -64,6 +71,13 @@ class LanguagesControllerInstalled extends JControllerLegacy
 
 		if ($model->switchAdminLanguage($cid))
 		{
+			// Switching to the new language for the message
+			$language = JFactory::getLanguage();
+			$newLang = JLanguage::getInstance($cid);
+			JFactory::$language = $newLang;
+			JFactory::getApplication()->loadLanguage($language = $newLang);
+			$newLang->load('com_languages', JPATH_ADMINISTRATOR);
+
 			$msg = JText::sprintf('COM_LANGUAGES_MSG_SWITCH_ADMIN_LANGUAGE_SUCCESS', $languageName);
 			$type = 'message';
 		}


### PR DESCRIPTION
This is an old issue. Got even more obvious since was implemented in staging https://github.com/joomla/joomla-cms/pull/9126

Test instructions:
Install multiple languages.
Set your admin user to use Default language for Administration
Go to the Installed languages page.
Change the default Administration Language to another language.

Results
The success message will be displayed in the former administration language, NOT the new changed one.
I.e. if the displayed language was English (en-GB) and you set default language to French, the success message will be the en-GB one.

Same issue with the new "Switch Language" feature.

This PR loads the new Administrator Language BEFORE sending the success message.

Now we get:
when default language was en-GB and one changes Default to French:
![screen shot 2016-02-18 at 14 36 50](https://cloud.githubusercontent.com/assets/869724/13144847/3ccd89b6-d64d-11e5-8f3d-58075a93534f.png)

When using Switch ( I have updated the fr-FR.com_languages.ini file to Include the new success string)
![screen shot 2016-02-18 at 14 40 16](https://cloud.githubusercontent.com/assets/869724/13144905/95114ee6-d64d-11e5-9ea0-89bf87115216.png)

@brianteeman @richard67  @andrepereiradasilva @gwsdesk @MATsxm 
Thank you for testing
