### PR TITLE
Client/MenuType selector in Menu and Modules administrator list views (mobile xs)

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -23,6 +23,7 @@ if ($data['view'] instanceof MenusViewItems)
 		.js-stools .js-stools-menutype {
 			float: left;
 			margin-right: 10px;
+			min-width: 220px;
 		}
 		html[dir=rtl] .js-stools .js-stools-menutype {
 			float: right;

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
@@ -16,7 +16,7 @@ if ($data['view'] instanceof MenusViewItems)
 	// We will get the menutype filter & remove it from the form filters
 	$menuTypeField = $data['view']->filterForm->getField('menutype');
 ?>
-	<div class="js-stools-field-filter js-stools-menutype hidden-phone hidden-tablet">
+	<div class="js-stools-field-filter js-stools-menutype">
 		<?php echo $menuTypeField->input; ?>
 	</div>
 <?php

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
 		description="JOPTION_FILTER_CATEGORY_DESC"
-		onchange="this.form.submit();"
+		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');jQuery('#list_limit').val('25');this.form.submit();"
 	/>
 	<fields name="filter">
 		<field
@@ -19,9 +19,9 @@
 		<field
 			name="published"
 			type="status"
-			filter="*,0,1,-2"
 			label="COM_MENUS_FILTER_PUBLISHED"
 			description="COM_MENUS_FILTER_PUBLISHED_DESC"
+			filter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -45,27 +45,27 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
-        <field
-                name="level"
-                type="integer"
-                first="1"
-                last="10"
-                step="1"
-                label="JOPTION_FILTER_LEVEL"
-                languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
-        </field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			statuses="*,0,1,2,-2"
 			description="JGLOBAL_SORT_BY"
+			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
 			>
@@ -90,10 +90,10 @@
 		<field
 			name="limit"
 			type="limitbox"
-			class="input-mini"
-			default="25"
 			label="COM_MENUS_LIST_LIMIT"
 			description="COM_MENUS_LIST_LIMIT_DESC"
+			class="input-mini"
+			default="25"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
 		description="JOPTION_FILTER_CATEGORY_DESC"
-		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');jQuery('#list_limit').val('25');this.form.submit();"
+		onchange="this.form.submit();"
 	/>
 	<fields name="filter">
 		<field

--- a/administrator/components/com_modules/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_modules/layouts/joomla/searchtools/default.php
@@ -21,6 +21,7 @@ $doc->addStyleDeclaration("
 	.js-stools .js-stools-client_id {
 		float: left;
 		margin-right: 10px;
+		min-width: 220px;
 	}
 	html[dir=rtl] .js-stools .js-stools-client_id {
 		float: right;

--- a/administrator/components/com_modules/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_modules/layouts/joomla/searchtools/default/bar.php
@@ -11,19 +11,16 @@ defined('JPATH_BASE') or die;
 
 $data = $displayData;
 
-$clientIdField = $data['view']->filterForm->getField('client_id');
-JFactory::getDocument()->addScriptDeclaration(
-	"
-		jQuery.fn.clearPositionType = function(){
-			jQuery('#filter_position, #filter_module, #filter_language').val('');
-		};
-	"
-);
-
+if ($data['view'] instanceof ModulesViewModules)
+{
+	// We will get the client filter & remove it from the form filters
+	$clientIdField = $data['view']->filterForm->getField('client_id');
 ?>
-<div class="js-stools-field-filter js-stools-client_id hidden-phone hidden-tablet">
-	<?php echo $clientIdField->input; ?>
-</div>
+	<div class="js-stools-field-filter js-stools-client_id">
+		<?php echo $clientIdField->input; ?>
+	</div>
 <?php
+}
+
 // Display the main joomla layout
 echo JLayoutHelper::render('joomla.searchtools.default.bar', $data, null, array('component' => 'none'));

--- a/administrator/components/com_modules/models/forms/filter_modules.xml
+++ b/administrator/components/com_modules/models/forms/filter_modules.xml
@@ -6,7 +6,7 @@
 		name="client_id"
 		type="list"
 		label=""
-		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');jQuery('#list_limit').val('25');this.form.submit();"
+		onchange="jQuery('#filter_position, #filter_module, #filter_language').val('');this.form.submit();"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_modules/models/forms/filter_modules.xml
+++ b/administrator/components/com_modules/models/forms/filter_modules.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
+	<fieldset addfieldpath="/administrator/components/com_modules/models/fields" />
 
 	<field
 		name="client_id"
 		type="list"
 		label=""
-		onchange="jQuery.fn.clearPositionType();this.form.submit();"
-	>
+		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');jQuery('#list_limit').val('25');this.form.submit();"
+		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>
 	</field>
-
-	<fields name="filter" addfieldpath="/administrator/components/com_modules/models/fields">
-
+	<fields name="filter">
 		<field
 			name="search"
 			type="text"
@@ -20,69 +19,61 @@
 			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
-
 		<field
 			name="state"
 			type="status"
-			filter="*,-2,0,1"
 			label="JSTATUS"
+			filter="*,-2,0,1"
 			onchange="this.form.submit();"
-		>
+			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>
-
 		<field
 			name="position"
 			type="modulesposition"
 			label="COM_MODULES_FIELD_POSITION_LABEL"
 			onchange="this.form.submit();"
-		>
+			>
 			<option value="">COM_MODULES_OPTION_SELECT_POSITION</option>
 		</field>
-
 		<field
 			name="module"
 			type="ModulesModule"
 			label="COM_MODULES_OPTION_SELECT_MODULE"
 			onchange="this.form.submit();"
-		>
+			>
 			<option value="">COM_MODULES_OPTION_SELECT_MODULE</option>
 		</field>
-
 		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
 			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
-		>
+			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
 		</field>
-
 		<field
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
 			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
-		>
+			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
-
 	</fields>
-
 	<fields name="list">
-
 		<field
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			statuses="*,0,1,-2"
 			description="JGLOBAL_SORT_BY"
+			statuses="*,0,1,-2"
 			onchange="this.form.submit();"
 			default="position ASC"
-		>
+			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
@@ -103,17 +94,14 @@
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>
-
 		<field
 			name="limit"
 			type="limitbox"
-			class="input-mini"
-			default="25"
 			label="COM_MODULES_LIST_LIMIT"
 			description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
+			class="input-mini"
+			default="25"
 			onchange="this.form.submit();"
 		/>
-
 	</fields>
-
 </form>


### PR DESCRIPTION
#### Description

This PR solves https://github.com/joomla/joomla-cms/issues/9031.
#### How to test
1. Install latest staging
2. Go to com_menus items view or com_modules modules view and reduce the browser width so you be in mobile xs size.
3. How will see that the selector (client or menutype, depending on the view) disappeared
4. Apply this patch
5. Repeat 2 and 3 you will see now the selector (client or menutype, depending on the view) is there.
