### PR TITLE
Try dc:creator if author is missing in RSS feeds

### DIFF
--- a/libraries/joomla/feed/parser/rss.php
+++ b/libraries/joomla/feed/parser/rss.php
@@ -370,7 +370,13 @@ class JFeedParserRss extends JFeedParser
 		// Add the feed entry author if available.
 		$author = (string) $el->author;
 
-		if (!empty($author))
+		if (empty($author))
+		{
+			// If there is no author, try the creator in the Dublin Core namespace.
+			$dc = $el->children('http://purl.org/dc/elements/1.1/');
+			$entry->author = isset($dc->creator) ? new JFeedPerson((string) $dc->creator) : '';
+		}
+		else
 		{
 			$entry->author = $this->processPerson($author);
 		}


### PR DESCRIPTION
In feeds from WordPress blogs, the Dublin Core creator tag is used instead of the author tag.  This PR uses the Dublin Core creator tag as a fallback when the author tag is not present in a feed item.

To test, put something like the following code into a template override for the mod_feed module and point the module at a WordPress feed.

foreach ($feed as $item)
{
    echo $item->author->name;
}

You should get a string comprising all the authors of the blog posts in the feed.  You might need to check the raw feed data to see what is actually being sent by WordPress.
