### PR TITLE
Search tools: down caret to show, up caret to hide

### DIFF
--- a/media/jui/css/jquery.searchtools.css
+++ b/media/jui/css/jquery.searchtools.css
@@ -8,6 +8,13 @@
 .js-stools-container-bar .input-append {
 	margin-bottom: 0;
 }
+/* Use up caret to hide the search filters */
+.js-stools-container-bar .btn-primary .caret {
+	border-top: 0;
+	border-bottom: 4px solid #FFF;
+	margin-top: 7px;
+	margin-bottom: 8px;
+}
 .js-stools .btn-wrapper {
 	display: inline-block;
 	margin: 0 5px 0 0;


### PR DESCRIPTION
#### Description

Thsi is one little thing that is annoying because it doesn't behaves like the others.

When we open the search filter the caret changes color but stays a down arrow, this PR corrects that.
###### Before PR

![image](https://cloud.githubusercontent.com/assets/9630530/13160925/7f48353a-d692-11e5-9ec5-4d424f278fe2.png)
###### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/13160947/9fde69ea-d692-11e5-895a-18bf4145f5c2.png)
##### How to test
1. Use latest staging
2. Go to any backoffice view with Search Tools and press the Search Tools button. You will see the carret go white but stays down.
3. Apply patch
4. Repeat step 2. You will see the carret go white but now is up.
