### PR TITLE
fixes issue when tag ajaxSearch for unicode characters was returning whole database of tags

### DIFF
--- a/components/com_tags/controllers/tags.php
+++ b/components/com_tags/controllers/tags.php
@@ -28,7 +28,7 @@ class TagsControllerTags extends JControllerLegacy
 
 		// Receive request data
 		$filters = array(
-			'like'      => trim($app->input->get('like', null)),
+			'like'      => trim($app->input->get('like', null, 'raw')),
 			'title'     => trim($app->input->get('title', null)),
 			'flanguage' => $app->input->get('flanguage', null),
 			'published' => $app->input->get('published', 1, 'integer'),

--- a/components/com_tags/controllers/tags.php
+++ b/components/com_tags/controllers/tags.php
@@ -28,7 +28,7 @@ class TagsControllerTags extends JControllerLegacy
 
 		// Receive request data
 		$filters = array(
-			'like'      => trim($app->input->get('like', null, 'raw')),
+			'like'      => trim($app->input->get('like', null, 'string')),
 			'title'     => trim($app->input->get('title', null)),
 			'flanguage' => $app->input->get('flanguage', null),
 			'published' => $app->input->get('published', 1, 'integer'),

--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -139,12 +139,14 @@ class JFormFieldTag extends JFormFieldList
 
 		if (empty($this->value))
 		{
-			$query->setLimit(10,0);
+			$query->setLimit(10, 0);
 		}
 		else
 		{
 			$value = implode(',', $this->value);
-			if (!empty($value)) {
+
+			if (!empty($value))
+			{
 				$query->where("a.id IN ($value)");
 			}
 		}

--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -137,6 +137,18 @@ class JFormFieldTag extends JFormFieldList
 
 		$query->order('a.lft ASC');
 
+		if (empty($this->value))
+		{
+			$query->setLimit(10,0);
+		}
+		else
+		{
+			$value = implode(',', $this->value);
+			if (!empty($value)) {
+				$query->where("a.id IN ($value)");
+			}
+		}
+
 		// Get the options.
 		$db->setQuery($query);
 


### PR DESCRIPTION
Reproduce issue:
1. add unicode character tags on article edit screen e.g. ჯონი, test, example, bla (save).
2. now write ჯონ to trigger ajax search
3. inspect XHR response

Result: you will see that response contains all terms ჯონი, test, example, bla (whole db).

This happens because, if unicode is used as tag search term `trim($app->input->get('like', null)),` returns an empty string `""`. filter->clean trips on unicode characters and strips them out completely.

Solution is to not filter input at all, set as raw - now unicode characters return matched tags and not everything from DB.

Second commit fixes issue #8074, issue is apparent on sites with a lot of tags, they are all preloaded! imagine 80K tags hogging down browser... Since we have ajaxSearch why preload everything? Lets preload sane amount and rest will be pulled as ajaxsearch is triggered.
