### PR TITLE
Correcting regression due to the merge of #9101

### DIFF
--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -32,7 +32,7 @@ class LanguagesControllerInstalled extends JControllerLegacy
 		if ($model->publish($cid))
 		{
 			// Switching to the new administrator language for the message
-			if ($model->getState('filter.client_id') == 1)
+			if ($model->getState('client_id') == 1)
 			{
 				$language = JFactory::getLanguage();
 				$newLang = JLanguage::getInstance($cid);

--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -50,7 +50,7 @@ class LanguagesControllerInstalled extends JControllerLegacy
 			$type = 'error';
 		}
 
-		$clientId = $model->getState('filter.client_id');
+		$clientId = $model->getState('client_id');
 		$this->setredirect('index.php?option=com_languages&view=installed&client=' . $clientId, $msg, $type);
 	}
 

--- a/administrator/components/com_languages/views/installed/view.html.php
+++ b/administrator/components/com_languages/views/installed/view.html.php
@@ -104,7 +104,7 @@ class LanguagesViewInstalled extends JViewLegacy
 			$bar = JToolbar::getInstance('toolbar');
 
 			// Switch administrator language
-			if ($this->state->get('filter.client_id', 0) == 1)
+			if ($this->state->get('client_id', 0) == 1)
 			{
 				JToolbarHelper::custom('installed.switchadminlanguage', 'refresh', 'refresh', 'COM_LANGUAGES_SWITCH_ADMIN', false);
 				JToolbarHelper::divider();


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/9101 has changed the way to look for the client.
It now uses `getState('client_id')` instead of `getState('filter.client_id')`

This has broken 
https://github.com/joomla/joomla-cms/pull/9150
and
https://github.com/joomla/joomla-cms/pull/9126

@wilsonge Please merge asap
