### PR TITLE
[com_content]  Boost sql query by skipping join to #__content_frontage if not needed

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -213,8 +213,22 @@ class ContentModelArticles extends JModelList
 
 		$query->from('#__content AS a');
 
-		// Join over the frontpage articles.
-		if ($this->context != 'com_content.featured')
+		$params = $this->getState('params');
+		$orderby_sec = $params->get('orderby_sec');
+
+		// Join over the frontpage articles if required.
+		if ($this->getState('filter.frontpage'))
+		{
+			if ($orderby_sec == 'front')
+			{
+				$query->join('INNER', '#__content_frontpage AS fp ON fp.content_id = a.id');
+			}
+			else
+			{
+				$query->where('a.featured = 1');
+			}
+		}
+		elseif ($orderby_sec == 'front')
 		{
 			$query->join('LEFT', '#__content_frontpage AS fp ON fp.content_id = a.id');
 		}
@@ -481,8 +495,6 @@ class ContentModelArticles extends JModelList
 		}
 
 		// Process the filter for list views with user-entered filters
-		$params = $this->getState('params');
-
 		if ((is_object($params)) && ($params->get('filter_field') != 'hide') && ($filter = $this->getState('list.filter')))
 		{
 			// Clean filter variable

--- a/components/com_content/models/featured.php
+++ b/components/com_content/models/featured.php
@@ -134,12 +134,6 @@ class ContentModelFeatured extends ContentModelArticles
 		// Create a new query object.
 		$query = parent::getListQuery();
 
-		// Filter by frontpage.
-		if ($this->getState('filter.frontpage'))
-		{
-			$query->join('INNER', '#__content_frontpage AS fp ON fp.content_id = a.id');
-		}
-
 		// Filter by categories
 		$featuredCategories = $this->getState('filter.frontpage.categories');
 


### PR DESCRIPTION
Sql query generated by components/com_content/models/articles.php is usually heavy,
I propose to skip sql join to #__content_frontpage table if it is not used on category view or archive view.
