### PR TITLE
Do not count all table rows if start offset is 0

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -321,11 +321,14 @@ class JModelList extends JModelLegacy
 
 		$start = $this->getState('list.start');
 		$limit = $this->getState('list.limit');
-		$total = $this->getTotal();
 
-		if ($start > $total - $limit)
+		if ($start > 0)
 		{
-			$start = max(0, (int) (ceil($total / $limit) - 1) * $limit);
+			$total = $this->getTotal();
+			if ($start > $total - $limit)
+			{
+				$start = max(0, (int) (ceil($total / $limit) - 1) * $limit);
+			}
 		}
 
 		// Add the total to the internal cache.


### PR DESCRIPTION
A little speed up backend -> com_content -> articles view when you have set page 1 (means start=0).

How to test:
- enable joomla debug (list of sql queries)
- test without patch number queries
- test with patch number of queries (one count less)
