### PR TITLE
Filter input remove - do not run cleanTags twice

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -691,10 +691,12 @@ class JFilterInput
 	protected function remove($source)
 	{
 		// Iteration provides nested tag protection
-		while ($source != ($result = $this->cleanTags($source)))
+		do
 		{
-			$source = $result;
+			$temp = $source;
+			$source = $this->cleanTags($source);
 		}
+		while ($temp != $source);
 
 		return $source;
 	}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -690,13 +690,10 @@ class JFilterInput
 	 */
 	protected function remove($source)
 	{
-		$loopCounter = 0;
-
 		// Iteration provides nested tag protection
-		while ($source != $this->_cleanTags($source))
+		while ($source != ($result = $this->cleanTags($source)))
 		{
-			$source = $this->_cleanTags($source);
-			$loopCounter++;
+			$source = $result;
 		}
 
 		return $source;


### PR DESCRIPTION
Speed up $input->remove() function, replace deprecated stuff.
