### PR TITLE
Layout of Options in Menu Item of type Featured Article

### DIFF
--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -126,7 +126,11 @@
 </fieldset>
 
 <fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field name="show_title" type="list"
+
+			<field
+				name="show_title"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_TITLE_DESC"
 				label="JGLOBAL_SHOW_TITLE_LABEL"
 			>
@@ -136,7 +140,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_titles" type="list"
+			<field
+				name="link_titles"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_LINKED_TITLES_DESC"
 				label="JGLOBAL_LINKED_TITLES_LABEL"
 			>
@@ -146,7 +153,10 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field name="show_intro" type="list"
+			<field
+				name="show_intro"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_INTRO_DESC"
 				label="JGLOBAL_SHOW_INTRO_LABEL"
 			>
@@ -158,7 +168,8 @@
 
 			<field
 				name="info_block_position"
-				type="list"
+				type="radio"
+				class="btn-group"
 				default=""
 				label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
 				description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
@@ -169,7 +180,10 @@
 				<option value="2">COM_CONTENT_FIELD_OPTION_SPLIT</option>
 			</field>
 
-			<field name="show_category" type="list"
+			<field
+				name="show_category"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_CATEGORY_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_LABEL"
 			>
@@ -179,7 +193,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_category" type="list"
+			<field
+				name="link_category"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_LINK_CATEGORY_DESC"
 				label="JGLOBAL_LINK_CATEGORY_LABEL"
 			>
@@ -189,7 +206,10 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field name="show_parent_category" type="list"
+			<field
+				name="show_parent_category"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
 				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
 			>
@@ -199,7 +219,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_parent_category" type="list"
+			<field
+				name="link_parent_category"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
 				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 			>
@@ -209,7 +232,10 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="show_author" type="list"
+			<field
+				name="show_author"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_AUTHOR_DESC"
 				label="JGLOBAL_SHOW_AUTHOR_LABEL"
 			>
@@ -219,7 +245,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="link_author" type="list"
+			<field
+				name="link_author"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_LINK_AUTHOR_DESC"
 				label="JGLOBAL_LINK_AUTHOR_LABEL"
 			>
@@ -229,7 +258,10 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field name="show_create_date" type="list"
+			<field
+				name="show_create_date"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
 				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
 			>
@@ -239,7 +271,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_modify_date" type="list"
+			<field
+				name="show_modify_date"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
 				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
 			>
@@ -249,7 +284,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_publish_date" type="list"
+			<field
+				name="show_publish_date"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
 				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
 			>
@@ -259,7 +297,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_item_navigation" type="list"
+			<field
+				name="show_item_navigation"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_NAVIGATION_DESC"
 				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
 			>
@@ -270,19 +311,22 @@
 			</field>
 
 			<field
-			name="show_vote" type="list"
-			label="JGLOBAL_SHOW_VOTE_LABEL"
-			description="JGLOBAL_SHOW_VOTE_DESC"
-		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-			<option value="0">JHIDE</option>
-			<option	value="1">JSHOW</option>
-		</field>
+				name="show_vote"
+				type="radio"
+				class="btn-group"
+				label="JGLOBAL_SHOW_VOTE_LABEL"
+				description="JGLOBAL_SHOW_VOTE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option	value="1">JSHOW</option>
+			</field>
 
 			<field
 				name="show_readmore"
-				type="list"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_READMORE_DESC"
 				label="JGLOBAL_SHOW_READMORE_LABEL"
 			>
@@ -293,7 +337,8 @@
 
 			<field
 				name="show_readmore_title"
-				type="list"
+				type="radio"
+				class="btn-group"
 				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
 				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
 			>
@@ -302,7 +347,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_icons" type="list"
+			<field
+				name="show_icons"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_ICONS_DESC"
 				label="JGLOBAL_SHOW_ICONS_LABEL"
 			>
@@ -312,7 +360,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_print_icon" type="list"
+			<field
+				name="show_print_icon"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
 				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 			>
@@ -322,7 +373,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_email_icon" type="list"
+			<field
+				name="show_email_icon"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
 				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
 			>
@@ -332,7 +386,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_hits" type="list"
+			<field
+				name="show_hits"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_HITS_DESC"
 				label="JGLOBAL_SHOW_HITS_LABEL"
 			>
@@ -342,8 +399,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_tags"
-				type="list"
+			<field
+				name="show_tags"
+				type="radio"
+				class="btn-group"
 				description="COM_CONTENT_FIELD_SHOW_TAGS_DESC"
 				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
 			>
@@ -352,7 +411,10 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="show_noauth" type="list"
+			<field
+				name="show_noauth"
+				type="radio"
+				class="btn-group"
 				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
 				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
 			>


### PR DESCRIPTION
This PR makes the **layout of Options** in **Menu Item type Featured Articles** consistent with  **Menu Item type Single Article**.

IMHO the Options of the Menu Item type "Single Article" (with their colored radio options) look very clear and it's easy to spot all the different settings. The Featured Articles works with drop-down options and is more difficult to see al the settings.

**One possible issue with this PR: on Mobile Phones the extra "Use Article Settings" might push the most right option "Show" off the screen**. Can we change the language label "Use Article Settings" to "Use Article", just like we have "Use Global" (and not "Use Global Settings") ?
# Testing Instructions

Use Joomla with Test English (GB) sample data.
## Before the PR

Go to Menus > All Front End Views
Open Menu Item "Single Article (Alias: single-article)" and check [Options]
All options are immediately visible. Clicking on different options will show that they have different colors.

![options-menuitem-singlearticle](https://cloud.githubusercontent.com/assets/1217850/13172408/2d970fde-d6f8-11e5-85f5-b37988f9273f.png)

Go to Menus > All Front End Views
Open Menu Item "Featured Articles (Alias: featured-articles)" and check [Options]
All options look the same with drop-down boxes.

![options-menuitem-featuredarticles](https://cloud.githubusercontent.com/assets/1217850/13172406/2d9344ee-d6f8-11e5-9a70-a9c2f9691599.png)
## After the PR

Go to Menus > All Front End Views
Open Menu Item "Featured Articles (Alias: featured-articles)" and check [Options]
All options are immediately visible. Clicking on different options will show that they have different colors.

![options-menuitem-featuredarticles-after](https://cloud.githubusercontent.com/assets/1217850/13172407/2d94a10e-d6f8-11e5-95fc-c22418e4e932.png)
