### PR TITLE
com_modules correct ordering wrap, and titles in mobile xs view

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -46,10 +46,10 @@ if ($saveOrder)
 			<table class="table table-striped" id="moduleList">
 				<thead>
 					<tr>
-						<th width="1%" class="hidden-phone">
+						<th width="1%" class="nowrap center hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', '', 'ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
 						</th>
-						<th width="1%" class="hidden-phone">
+						<th width="1%" class="nowrap center">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
 						<th width="1%" class="nowrap center" style="min-width:55px">


### PR DESCRIPTION
#### Description

This simple PR corrects some issues in com_modules modules view.
The issues corrected are:
- the line wrap when ordering by ordering.
- The checkbox column is missing the title in mobile xs view.
###### Before PR

![com_modules-before-pr](https://cloud.githubusercontent.com/assets/9630530/13196954/ada22ad6-d7d6-11e5-9de8-56e783b43a77.png)
![com_modules-before-pr-xs](https://cloud.githubusercontent.com/assets/9630530/13196955/b24383d2-d7d6-11e5-878b-7ee151ae2a79.png)
###### After PR

![com_modules-after-pr](https://cloud.githubusercontent.com/assets/9630530/13196956/bbd8e798-d7d6-11e5-9887-5e6ab25bb0ab.png)
![com_modules-after-pr-xs](https://cloud.githubusercontent.com/assets/9630530/13196957/bfe39464-d7d6-11e5-9c7f-041463ab4da4.png)
#### How to test
1. Use joomla latest staging
2. Go to com_modules and click on ordering order. You will see the line wrapping in the column title.
3. Now reduce the browser width until you get to mobile size. You will see the checkbox column disapperead.
4. Apply this patch.
5. Repeat 2. and 3. and should all be fine now
