### PR TITLE
Error, warning, success and info messages spacing

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -2790,6 +2790,9 @@ input[type="submit"].btn.btn-mini {
 	color: #8a6d3b;
 }
 .alert h4 {
+	margin: 0 0 .5em;
+}
+.alert p {
 	margin: 0;
 }
 .alert .close {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -2790,7 +2790,10 @@ input[type="submit"].btn.btn-mini {
 	color: #8a6d3b;
 }
 .alert h4 {
-	margin: 0;
+  margin: 0 0 .5em;
+}
+.alert p {
+  margin: 0;
 }
 .alert .close {
 	position: relative;

--- a/media/jui/less/alerts.less
+++ b/media/jui/less/alerts.less
@@ -20,6 +20,9 @@
   color: @warningText;
 }
 .alert h4 {
+  margin: 0 0 .5em;
+}
+.alert p {
   margin: 0;
 }
 

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2805,7 +2805,10 @@ input[type="submit"].btn.btn-mini {
 	color: #c09853;
 }
 .alert h4 {
-	margin: 0;
+  margin: 0 0 .5em;
+}
+.alert p {
+  margin: 0;
 }
 .alert .close {
 	position: relative;


### PR DESCRIPTION
#### Summary of Changes

This a small PR to improve the spacing in the error, warning, sucess and info messages.

Adds some space between title and message and removes extra space in the end.
##### Before PR (some examples)

![image](https://cloud.githubusercontent.com/assets/9630530/13198588/c01ba3b2-d804-11e5-995d-becb78b8073e.png)

![image](https://cloud.githubusercontent.com/assets/9630530/13198590/d996b16a-d804-11e5-91b0-ebedeec9d08e.png)
##### After PR (some examples)

![image](https://cloud.githubusercontent.com/assets/9630530/13198598/41eba108-d805-11e5-81cc-167c8a037a56.png)

![image](https://cloud.githubusercontent.com/assets/9630530/13198594/30f0b7d0-d805-11e5-9759-fe8ea3e8ad2e.png)
#### Testing Instructions
1. Use latest staging.
2. Apply patch
3. Check some messages
