### PR TITLE
Regression: Hathor installed language wrong client

### DIFF
--- a/administrator/templates/hathor/html/com_languages/installed/default.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default.php
@@ -14,11 +14,9 @@ JHtmlBehavior::core();
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 $user     = JFactory::getUser();
 $userId   = $user->get('id');
-$client   = $this->state->get('client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
-$clientId = $this->state->get('client_id', 0);
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client_id='.$clientId); ?>" method="post" id="adminForm" name="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed'); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -42,9 +40,6 @@ $clientId = $this->state->get('client_id', 0);
 				</th>
 				<th>
 					<?php echo JText::_('COM_LANGUAGES_FIELD_LANG_TAG_LABEL'); ?>
-				</th>
-				<th class="width-10">
-					<?php echo JText::_('JCLIENT'); ?>
 				</th>
 				<th class="width-5">
 					<?php echo JText::_('COM_LANGUAGES_HEADING_DEFAULT'); ?>
@@ -79,9 +74,6 @@ $clientId = $this->state->get('client_id', 0);
 				</td>
 				<td align="center">
 					<?php echo $this->escape($row->language); ?>
-				</td>
-				<td class="center">
-					<?php echo $client;?>
 				</td>
 				<td class="center">
 					<?php echo JHtml::_('jgrid.isdefault', $row->published, $i, 'installed.', !$row->published && $canChange);?>

--- a/administrator/templates/hathor/html/com_languages/installed/default.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default.php
@@ -14,8 +14,8 @@ JHtmlBehavior::core();
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 $user     = JFactory::getUser();
 $userId   = $user->get('id');
-$client   = $this->state->get('filter.client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
-$clientId = $this->state->get('filter.client_id', 0);
+$client   = $this->state->get('client_id', 0) ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
+$clientId = $this->state->get('client_id', 0);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client='.$clientId); ?>" method="post" id="adminForm" name="adminForm">

--- a/administrator/templates/hathor/html/com_languages/installed/default.php
+++ b/administrator/templates/hathor/html/com_languages/installed/default.php
@@ -18,7 +18,7 @@ $client   = $this->state->get('client_id', 0) ? JText::_('JADMINISTRATOR') : JTe
 $clientId = $this->state->get('client_id', 0);
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client='.$clientId); ?>" method="post" id="adminForm" name="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_languages&view=installed&client_id='.$clientId); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>


### PR DESCRIPTION
#9101 has changed the way to look for the client.

It now uses getState('client_id') instead of getState('filter.client_id')

This has an impact on Hathor where the location column is wrong in the installed languages column view.

Before patch
![hathor_before](https://cloud.githubusercontent.com/assets/869724/13212029/298c2cec-d93e-11e5-94fd-e48f058d39be.png)

After patch
![hathor_after](https://cloud.githubusercontent.com/assets/869724/13212035/3d6a63be-d93e-11e5-97de-87891c8a7d28.png)

@andrepereiradasilva @brianteeman @richard67 
