### PR TITLE
Regression: joomla update notification

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -63,9 +63,6 @@ class InstallerModelUpdate extends JModelList
 		$this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
 		$this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
 
-		// Extension id is a special filter case to check updates for extension id, also could use filter[search]=eid:XX
-		$this->setState('filter.extension_id', $this->getUserStateFromRequest($this->context . '.filter.extension_id', 'filter_extension_id', null, 'int'));
-
 		$app = JFactory::getApplication();
 		$this->setState('message', $app->getUserState('com_installer.message'));
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));


### PR DESCRIPTION
#### Summary of Changes

This PR solves a regression where when you activate the update plugin you receive e-mail with updates for non joomla core extensions.
The change this PR does is to remove a line added before, and with that solving the problem.
#### Testing Instructions
1. Use latest staging.
2. Configure joomla to send mails.
3. Install some extension with updates (i used com_localize 4.0.13-dev). https://github.com/joomla-projects/com_localise/releases/download/4.0.13-dev/com_localise-4.0.13-dev.zip
4. Enable update notification system plugin.
5. Logout your admin session.
6. Refresh the page several times in the admin login view.
7. You should receive a mail there is a joomla update when there isn't. If not you can force it on next refresh by changing this line (https://github.com/joomla/joomla-cms/blob/staging/plugins/system/updatenotification/updatenotification.php#L49) with `$last = 0;`
8. Apply patch.
9. Logout and repeat the same process. Check you don't receive e-mails update e-mails now.

@infograf768 This is similar with the one you have before. Can you test?
