### PR TITLE
Tests JLogEntry and the difference of one second

### DIFF
--- a/tests/unit/suites/libraries/joomla/log/JLogEntryTest.php
+++ b/tests/unit/suites/libraries/joomla/log/JLogEntryTest.php
@@ -50,10 +50,11 @@ class JLogEntryTest extends PHPUnit_Framework_TestCase
 		);
 
 		// Date.
-		$this->assertThat(
-			$tmp->date->toISO8601(),
-			$this->equalTo($date->toISO8601()),
-			'Line: ' . __LINE__ . '.'
+		$this->assertEquals(
+			$tmp->date->getTimestamp(),
+			$date->getTimestamp(),
+			'Line: ' . __LINE__ . '.',
+			1
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .
No issue.
#### Summary of Changes

From time to time tests fails but everything is OK.

The problem is in /tests/unit/suites/libraries/joomla/log/JLogEntryTest on line 28:

$tmp = new JLogEntry('Lorem ipsum dolor sit amet');
$date = JFactory::getDate('now');

When $tmp->date is "2016-02-22 19:00:01"
and $date is one second later "2016-02-22 19:00:02" then assertion fails.
#### Testing Instructions

Random fails.

I had situation when my pull request did not pass one php version tests.
When I used commit --amend and pushed force again then all tests passed.
