### PR TITLE
[com_content] articles view (modal) - Implement searchtools

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -78,10 +78,18 @@ class ContentModelArticles extends JModelList
 	{
 		$app = JFactory::getApplication();
 
+		$forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+
 		// Adjust the context to support modal layouts.
 		if ($layout = $app->input->get('layout'))
 		{
 			$this->context .= '.' . $layout;
+		}
+
+		// Adjust the context to support forced languages.
+		if ($forcedLanguage)
+		{
+			$this->context .= '.' . $forcedLanguage;
 		}
 
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
@@ -112,8 +120,6 @@ class ContentModelArticles extends JModelList
 		parent::populateState($ordering, $direction);
 
 		// Force a language
-		$forcedLanguage = $app->input->get('forcedLanguage');
-
 		if (!empty($forcedLanguage))
 		{
 			$this->setState('filter.language', $forcedLanguage);

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -130,5 +130,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="boxchecked" value="0" />
+	<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -19,6 +19,7 @@ if ($app->isSite())
 require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 
@@ -26,93 +27,53 @@ $function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1');?>"
-      method="post" name="adminForm" id="adminForm" class="form-inline">
-	<fieldset class="filter">
-		<div class="btn-toolbar">
-			<div class="btn-group">
-				<label for="filter_search">
-					<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
-				</label>
-			</div>
-			<div class="btn-group">
-				<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" />
-			</div>
-			<div class="btn-group">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom">
-					<span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();">
-					<span class="icon-remove"></span><?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?></button>
-			</div>
-		</div>
-		<hr class="hr-condensed" />
-		<div class="filters">
-			<select name="filter_access" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
-			</select>
-
-			<select name="filter_published" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
-			</select>
-
-			<?php if ($this->state->get('filter.forcedLanguage')) : ?>
-			<select name="filter_category_id" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content', array('filter.language' => array('*', $this->state->get('filter.forcedLanguage')))), 'value', 'text', $this->state->get('filter.category_id'));?>
-			</select>
-			<input type="hidden" name="forcedLanguage" value="<?php echo $this->escape($this->state->get('filter.forcedLanguage')); ?>" />
-			<input type="hidden" name="filter_language" value="<?php echo $this->escape($this->state->get('filter.language')); ?>" />
-			<?php else : ?>
-			<select name="filter_category_id" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_content'), 'value', 'text', $this->state->get('filter.category_id'));?>
-			</select>
-			<select name="filter_language" class="input-medium" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
-			</select>
-			<?php endif; ?>
-		</div>
-	</fieldset>
-
+<div style="padding-top: 25px;"></div>
+<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
+	<div class="alert alert-no-items">
+		<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+	</div>
 	<?php else : ?>
 		<table class="table table-striped table-condensed">
 			<thead>
 				<tr>
-					<th class="title">
-						<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="center nowrap">
-						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="center nowrap">
-						<?php echo JHtml::_('grid.sort', 'JCATEGORY', 'a.catid', $listDirn, $listOrder); ?>
-					</th>
-					<th width="10%" class="center nowrap">
-						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-					</th>
-					<th width="5%" class="center nowrap">
-						<?php echo JHtml::_('grid.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
-					</th>
 					<th width="1%" class="center nowrap">
-						<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+						<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
+					</th>
+					<th class="title">
+						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+					</th>
+					<th width="10%" class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+					</th>
+					<th width="15%" class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+					</th>
+					<th width="5%" class="nowrap hidden-phone">
+						<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
+					</th>
+					<th width="1%" class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>
 			</thead>
 			<tfoot>
 				<tr>
-					<td colspan="15">
+					<td colspan="6">
 						<?php echo $this->pagination->getListFooter(); ?>
 					</td>
 				</tr>
 			</tfoot>
 			<tbody>
+			<?php
+			$iconStates = array(
+				-2 => 'icon-trash',
+				0 => 'icon-unpublish',
+				1 => 'icon-publish',
+				2 => 'icon-archive',
+			);
+			?>
 			<?php foreach ($this->items as $i => $item) : ?>
 				<?php if ($item->language && JLanguageMultilang::isEnabled())
 				{
@@ -135,27 +96,30 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				}
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
-					<td>
-						<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-							<?php echo $this->escape($item->title); ?></a>
-					</td>
 					<td class="center">
+						<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
+					</td>
+					<td>
+						<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<?php echo $this->escape($item->title); ?></a>
+						<div class="small">
+							<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+						</div>
+					</td>
+					<td class="small hidden-phone">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
-					<td class="center">
-						<?php echo $this->escape($item->category_title); ?>
-					</td>
-					<td class="center">
-						<?php if ($item->language == '*'):?>
+					<td class="small hidden-phone">
+						<?php if ($item->language == '*'): ?>
 							<?php echo JText::alt('JALL', 'language'); ?>
 						<?php else:?>
 							<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 						<?php endif;?>
 					</td>
-					<td class="center nowrap">
+					<td class="nowrap small hidden-phone">
 						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 					</td>
-					<td class="center">
+					<td>
 						<?php echo (int) $item->id; ?>
 					</td>
 				</tr>
@@ -164,11 +128,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		</table>
 	<?php endif; ?>
 
-	<div>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
-		<?php echo JHtml::_('form.token'); ?>
-	</div>
+	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="boxchecked" value="0" />
+	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -72,6 +72,28 @@ class ContentViewArticles extends JViewLegacy
 			$this->addToolbar();
 			$this->sidebar = JHtmlSidebar::render();
 		}
+		else
+		{
+			// Remove some filters that are not needed in articles list modal view.
+			$this->filterForm->removeField('author_id', 'filter');
+			$this->filterForm->removeField('level', 'filter');
+			$this->filterForm->removeField('tag', 'filter');
+
+			// In article associations modal we need to remove language filter if forcing a language.
+			// We also need to change the category filter to show show categories with All or the forced language.
+			if ($forcedLanguage = JFactory::getApplication()->input->get('forcedLanguage', '', 'CMD'))
+			{
+				// If the language is forced we can't allow to select the language, so transform the language selector filter into an hidden field.
+				$languageXml = new SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
+				$this->filterForm->setField($languageXml, 'filter', true);
+
+				// Also, unset the active language filter so the search tools is not open by default with this filter.
+				unset($this->activeFilters['language']);
+
+				// One last changes needed is to change the category filter to just show categories with All language or with the forced language.
+				$this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
+			}
+		}
 
 		parent::display($tpl);
 	}

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -74,11 +74,6 @@ class ContentViewArticles extends JViewLegacy
 		}
 		else
 		{
-			// Remove some filters that are not needed in articles list modal view.
-			$this->filterForm->removeField('author_id', 'filter');
-			$this->filterForm->removeField('level', 'filter');
-			$this->filterForm->removeField('tag', 'filter');
-
 			// In article associations modal we need to remove language filter if forcing a language.
 			// We also need to change the category filter to show show categories with All or the forced language.
 			if ($forcedLanguage = JFactory::getApplication()->input->get('forcedLanguage', '', 'CMD'))

--- a/libraries/legacy/form/field/category.php
+++ b/libraries/legacy/form/field/category.php
@@ -42,18 +42,31 @@ class JFormFieldCategory extends JFormFieldList
 		$options = array();
 		$extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $this->element['scope'];
 		$published = (string) $this->element['published'];
+		$language  = (string) $this->element['language'];
 
 		// Load the category options for a given extension.
 		if (!empty($extension))
 		{
 			// Filter over published state or not depending upon if it is present.
+			$filters = array();
 			if ($published)
 			{
-				$options = JHtml::_('category.options', $extension, array('filter.published' => explode(',', $published)));
+				$filters['filter.published'] =  explode(',', $published);
+			}
+
+			// Filter over language depending upon if it is present.
+			if ($language)
+			{
+				$filters['filter.language'] =  explode(',', $language);
+			}
+
+			if ($filters === array())
+			{
+				$options = JHtml::_('category.options', $extension);
 			}
 			else
 			{
-				$options = JHtml::_('category.options', $extension);
+				$options = JHtml::_('category.options', $extension, $filters);
 			}
 
 			// Verify permissions.  If the action attribute is set, then we scan the options.

--- a/libraries/legacy/form/field/category.php
+++ b/libraries/legacy/form/field/category.php
@@ -51,13 +51,13 @@ class JFormFieldCategory extends JFormFieldList
 			$filters = array();
 			if ($published)
 			{
-				$filters['filter.published'] =  explode(',', $published);
+				$filters['filter.published'] = explode(',', $published);
 			}
 
 			// Filter over language depending upon if it is present.
 			if ($language)
 			{
-				$filters['filter.language'] =  explode(',', $language);
+				$filters['filter.language'] = explode(',', $language);
 			}
 
 			if ($filters === array())


### PR DESCRIPTION
#### Summary of Changes

This PR adds JLayout searchtools to com_content articles modal view.
Also adds the status column, moves the category to below the article title and makes some minor visual changes to be more synchronized with the non modal view.
###### Before PR

![before-pr](https://cloud.githubusercontent.com/assets/9630530/13225504/0b9ef7a4-d985-11e5-8bac-6b6b615e9625.png)
###### After PR

![after-pr](https://cloud.githubusercontent.com/assets/9630530/13225508/0f3704d8-d985-11e5-8b94-c300e12e3ba0.png)
#### Testing Instructions
1. Use latest staging
2. In the backend edit any article and press "+Article" button on the editor, how will see a modal window with the old filter.  Note: you can also create a "Single article" menu item type and select the article there.
3. Apply this patch
4. Repeat 2. and you'll see the new searchtools
5. Now test search, ordering, filter, etc. Also select an article. In other words, test if everything works fine.

That i know of, correct me if i'm wrong, this view is used in:
1. "+Article" button in any editor (frontend and backend) -> all articles
2. Menu item "Single Article", "Select" button -> all articles
3. When language associations are enabled. Article "Associations" tab -> articles filtered by language

All this views should be tested.
#### Observations

That i know of, this is the first searchtools implemented on a modal view, so suggestions and improvements are welcomed.
