### PR TITLE
[com_cache] allow to select client in hathor

### DIFF
--- a/administrator/templates/hathor/html/com_cache/cache/default.php
+++ b/administrator/templates/hathor/html/com_cache/cache/default.php
@@ -25,11 +25,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<fieldset id="filter-bar">
 		<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-select fltrt">
-			<label class="selectlabel" for="filter_client_id">
+			<label class="selectlabel" for="client_id">
 				<?php echo JText::_('COM_CACHE_SELECT_CLIENT'); ?>
 			</label>
-			<select name="filter_client_id" id="filter_client_id">
-				<?php echo JHtml::_('select.options', CacheHelper::getClientOptions(), 'value', 'text', $this->state->get('clientId'));?>
+			<select name="client_id" id="client_id">
+				<?php echo JHtml::_('select.options', CacheHelper::getClientOptions(), 'value', 'text', $this->state->get('client_id'));?>
 			</select>
 
 			<button type="submit" id="filter-go">


### PR DESCRIPTION
#### Summary of Changes

After the recent changes in com_cache, in hathor is not possible to select the client (site, admin) to clean the cache. This PR corrects that.
#### Testing Instructions
1. Use latest staging
2. Change the admin template to hathor and go to com_cache (Settings -> Clear cache).
3. Try to clean the admin cache. You can't because you can't change to admin.
4. Apply this PR
5. Repeat step 3. Now you can select the Administrator and clean the cache.
