### PR TITLE
Useless Max Level filtering for articles

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -57,28 +57,15 @@
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
-        <field
-                name="author_id"
-                type="author"
-                label="COM_CONTENT_FILTER_AUTHOR"
-                description="COM_CONTENT_FILTER_AUTHOR_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_AUTHOR</option>
-        </field>
-        <field
-                name="level"
-                type="integer"
-                first="1"
-                last="10"
-                step="1"
-                label="JOPTION_FILTER_LEVEL"
-                languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
-        </field>
+		<field
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			description="COM_CONTENT_FILTER_AUTHOR_DESC"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_AUTHOR</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -57,28 +57,15 @@
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
-        <field
-                name="author_id"
-                type="author"
-                label="COM_CONTENT_FILTER_AUTHOR"
-                description="COM_CONTENT_FILTER_AUTHOR_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_AUTHOR</option>
-        </field>
-        <field
-                name="level"
-                type="integer"
-                first="1"
-                last="10"
-                step="1"
-                label="JOPTION_FILTER_LEVEL"
-                languages="*"
-                description="JOPTION_FILTER_LEVEL_DESC"
-                onchange="this.form.submit();"
-                >
-            <option value="">JOPTION_SELECT_MAX_LEVELS</option>
-        </field>
+		<field
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			description="COM_CONTENT_FILTER_AUTHOR_DESC"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_AUTHOR</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
There must have been a wrong copy/paste...
Articles and Featured articles can't be filtered by Max Levels.
Before patch
![screen shot 2016-02-24 at 07 58 21](https://cloud.githubusercontent.com/assets/869724/13277898/742010d6-dacc-11e5-85fa-e4bc7a3c263c.png)

After patch:
![screen shot 2016-02-24 at 07 56 21](https://cloud.githubusercontent.com/assets/869724/13277863/30cbc974-dacc-11e5-981e-fe8259919063.png)

Also corrected spaces to tabs.
