### PR TITLE
Improving JTableNested::delete()

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -591,18 +591,12 @@ class JTableNested extends JTable
 				->where('lft BETWEEN ' . (int) $node->lft . ' AND ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 
-			// Compress the left values.
+			// Compress the left and right values.
 			$query->clear()
 				->update($this->_tbl)
 				->set('lft = lft - ' . (int) $node->width)
-				->where('lft > ' . (int) $node->rgt);
-			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
-
-			// Compress the right values.
-			$query->clear()
-				->update($this->_tbl)
 				->set('rgt = rgt - ' . (int) $node->width)
-				->where('rgt > ' . (int) $node->rgt);
+				->where('lft > ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 		}
 		// Leave the children and move them up a level.
@@ -630,18 +624,12 @@ class JTableNested extends JTable
 				->where('parent_id = ' . (int) $node->$k);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 
-			// Shift all of the left values that are right of the node.
+			// Shift all of the left and right values that are right of the node.
 			$query->clear()
 				->update($this->_tbl)
 				->set('lft = lft - 2')
-				->where('lft > ' . (int) $node->rgt);
-			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
-
-			// Shift all of the right values that are right of the node.
-			$query->clear()
-				->update($this->_tbl)
 				->set('rgt = rgt - 2')
-				->where('rgt > ' . (int) $node->rgt);
+				->where('lft > ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 		}
 


### PR DESCRIPTION
#### Summary of Changes

This change brings a performance improvement to JTableNested::delete(). This eliminates one query per item to be deleted. If you would for example clear your trash with 200 categories, this means 200 queries less with this change. Since we are using JTableNested for the assets table, this would mean that also deleting articles would receive a performance boost.
#### Testing Instructions

YAUTPR - Yet Another Un-Testable Pull Request
You can test this PR by deleting a category for example and afterwards everything should still work. However, this actually needs a proper code review by a seasoned developer/maintainer.
