### PR TITLE
Add HHVM testing as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       env: RUN_PHPCS="yes" INSTALL_APCU="yes"
     - php: 7.0
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+    - php: hhvm
+      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+  allow_failures:
+    - php: hhvm
 
 services:
   - memcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - php: 7.0
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm
-      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
Replaces #6884 to allow running HHVM tests
#### Summary of Changes

Add HHVM testing as an allowed failure
#### Testing Instructions

Review Travis-ci builds. HHVM should be allowed to fail, does not change any other build.

There is a Segfault in the HHVM build, but that is a separate issue that will need to be addressed for the potential of HHVM compatibility. (Currently, it looks like the HHVM Segfault is related to PHPUnit and the Travis-ci build of HHVM) Since HHVM is added as allowed as a failure that issue should not  block consideration of this new test environment.
