### PR TITLE
Wrong column name used by schema manager for mysql

### DIFF
--- a/libraries/cms/schema/changeitem/mysql.php
+++ b/libraries/cms/schema/changeitem/mysql.php
@@ -118,9 +118,9 @@ class JSchemaChangeitemMysql extends JSchemaChangeitem
 			{
 				// Kludge to fix problem with "integer unsigned"
 				$type = $this->fixQuote($this->fixInteger($wordArray[6], $wordArray[7]));
-				$result = 'SHOW COLUMNS IN ' . $wordArray[2] . ' WHERE field = ' . $this->fixQuote($wordArray[4]) . ' AND type = ' . $type;
+				$result = 'SHOW COLUMNS IN ' . $wordArray[2] . ' WHERE field = ' . $this->fixQuote($wordArray[5]) . ' AND type = ' . $type;
 				$this->queryType = 'CHANGE_COLUMN_TYPE';
-				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[4]), $type);
+				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]), $type);
 			}
 		}
 


### PR DESCRIPTION
#### Summary of Changes

For "ALTER TABLE tablename CHANGE columnname_old columname_new ..." statements in mysql, the database schema manager builds the check query for existence of the column with the old and not the new column name.
#### Testing Instructions

Either by code review, compare with the preceeding check of "ALTER TABLE tablename MODIFY columnname" statement and check which array elements are used for building the check query and the message,

or

Add statement "ALTER TABLE #__menu CHANGE gaga_old gaga_new VARCHAR(100)" to the latest update sql script for mysqli, go in backend to "Manage -> Database" and check which column name is reported to be missing.
