### PR TITLE
Blue buttons in stats message too

### DIFF
--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -31,8 +31,8 @@ extract($displayData);
 	?>
 	<p><?php echo JText::_('PLG_SYSTEM_STATS_MSG_ALLOW_SENDING_DATA'); ?></p>
 	<p class="actions">
-		<a href="#" class="btn btn-default js-pstats-btn-allow-always"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></a>
-		<a href="#" class="btn btn-default js-pstats-btn-allow-once"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></a>
-		<a href="#" class="btn btn-default js-pstats-btn-allow-never"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></a>
+		<a href="#" class="btn btn-primary js-pstats-btn-allow-always"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></a>
+		<a href="#" class="btn btn-primary js-pstats-btn-allow-once"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></a>
+		<a href="#" class="btn btn-primary js-pstats-btn-allow-never"><?php echo JText::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></a>
 	</p>
 </div>


### PR DESCRIPTION
#### Summary of Changes

This is simple PR to just normalize the button style in the backend message.
Just a css class change as you can see in the code.
###### Before PR

![before-pr](https://cloud.githubusercontent.com/assets/9630530/13361022/264d75ee-dcb4-11e5-9ce2-21173e88d1c4.png)
###### After PR

![after-pr](https://cloud.githubusercontent.com/assets/9630530/13361031/2a036d7e-dcb4-11e5-9a31-11d6f07b0d76.png)
#### Testing Instructions
1. Use latest staging and apply this PR
2. Reset the id from the stats plugin.
3. Go to control panel and check the button style in the stats message.
