### PR TITLE
Fixing missing parameter usage.

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -25,7 +25,8 @@ if ($params->get('dropdown', 1))
 	<select class="inputbox" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
 		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo $language->link; ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
-		<?php echo $language->title_native; ?></option>
+			<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+		</option>
 	<?php endforeach; ?>
 	</select>
 	</form>


### PR DESCRIPTION
Pull Request for Issue #9224 .
#### Summary of Changes

Fixed missing parameter.
#### Testing Instructions

Just add `mod_languages` module. Select **Use Dropdown** and deselect **Languages Full Names**. Then go to front and look at `mod_languages` select field.
