### PR TITLE
Fix session reset for updates from 3.4.8.

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1613,7 +1613,12 @@ class JoomlaInstallerScript
 		 * The session may have not been started yet (e.g. CLI-based Joomla! update scripts). Let's make sure we do
 		 * have a valid session.
 		 */
-		JFactory::getSession()->restart();
+		$session = JFactory::getSession();
+
+		if (!$session->isActive())
+		{
+			$session->restart();
+		}
 
 		// If $_SESSION['__default'] is no longer set we do not have a migrated session, therefore we can quit.
 		if (!isset($_SESSION['__default']))
@@ -1631,7 +1636,7 @@ class JoomlaInstallerScript
 				case 'pdomysql':
 				case 'mysql':
 				case 'mysqli':
-					$db->truncateTable($db->qn('#__session'));
+					$db->truncateTable('#__session');
 					break;
 
 				// Non-MySQL databases, use a simple DELETE FROM query


### PR DESCRIPTION
Pull Request for Issue #9014 .

Credits for this PR to @zero-24 who investigated this issue and proposed this fix!
#### Summary of Changes
- Change 1: Restart the session only, if we have no active session.
- Change 2: Inside the "truncateTable" function, the table name is quoted already, so we don't need to quote the argument, which would lead to a double quoted table name and thus to a MySQL error.
#### Testing Instructions

An update package including this change (modified version of the beta 2 package) can be found [here](http://www.zweiiconkram.de/upload/Joomla_3.5.0-beta2-Beta-Update_Package.zip). Please note that the only change included in this package is the one from this PR. So you might encounter other issues which were already fixed since the release of beta2.

Please test this update package (or an own one including these changes) for the following cases:
1. Update from 3.4.5 or older versions.
   - Expected behavior: You should be logged out, because the session in the old format from 3.4.5 or older has to be deleted and a new session in the new, safer format has to be started.
2. Update from 3.4.8
   - Expected behavior: You should **not** be logged out, because you already have a session in the new format.
3. Update from beta2
   - Expected behavior: Same as for 3.4.8.

@nikosdion As the first change of this PR will mostly affect updates via Akeeba CLI, could you please check if this introduces any issues?
