### PR TITLE
Align isis sidebar with grid

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7341,12 +7341,19 @@ h6 {
 	font-size: 12px;
 	line-height: 14px;
 }
+.sidebar-nav .nav-list {
+	padding-left: 25px;
+	padding-right: 25px;
+}
 .sidebar-nav .nav-list > li > a {
 	color: #555;
+	padding: 3px 25px;
+	margin-left: -25px;
+	margin-right: -25px;
 }
 .sidebar-nav .nav-list > li.active > a {
 	color: #fff;
-	margin-right: -16px;
+	margin-right: -26px;
 }
 .quick-icons .nav li + .nav-header {
 	margin-top: 12px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7341,12 +7341,19 @@ h6 {
 	font-size: 12px;
 	line-height: 14px;
 }
+.sidebar-nav .nav-list {
+	padding-left: 25px;
+	padding-right: 25px;
+}
 .sidebar-nav .nav-list > li > a {
 	color: #555;
+	padding: 3px 25px;
+	margin-left: -25px;
+	margin-right: -25px;
 }
 .sidebar-nav .nav-list > li.active > a {
 	color: #fff;
-	margin-right: -16px;
+	margin-right: -26px;
 }
 .quick-icons .nav li + .nav-header {
 	margin-top: 12px;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -449,13 +449,21 @@ h6 {
 }
 
 /* Sidebar */
+.sidebar-nav .nav-list {
+	padding-left: 25px;
+	padding-right: 25px;
+}
+
 .sidebar-nav .nav-list > li > a {
 	color: #555;
+	padding: 3px 25px;
+	margin-left: -25px;
+	margin-right: -25px;
 }
 
 .sidebar-nav .nav-list > li.active > a {
 	color: #fff;
-	margin-right: -16px;
+	margin-right: -26px;
 }
 /* Quick-icons */
 .quick-icons .nav li + .nav-header {


### PR DESCRIPTION
#### Summary of Changes

This simple PR is just to align the isis sidebar with the invisible grid lines.
###### Before PR

![before-pr](https://cloud.githubusercontent.com/assets/9630530/13375681/05079e7e-dd9e-11e5-9f05-467d9d5a9986.png)
###### After PR

![after-pr](https://cloud.githubusercontent.com/assets/9630530/13375682/09699166-dd9e-11e5-9947-f4c29f542c4a.png)
#### Testing Instructions
1. Use latest staging and apply patch
2. Refresh browser cache (Ctrl+F5)
3. Go to any view with sidebar and check the align as the images above
