### PR TITLE
Update spinner on joomlaupdate

### DIFF
--- a/media/media/css/mediamanager.css
+++ b/media/media/css/mediamanager.css
@@ -164,9 +164,9 @@ div#media-noimages {
 }
 
 .spinner-img {
-	background: url(../../jui/images/ajax-loader.gif) no-repeat;
-	width: 24px;
-	height: 24px;
+	background: url(../../jui/images/ajax-loader.gif) center no-repeat;
+	width: 66px;
+	height: 66px;
 	margin: 0 auto;
 }
 

--- a/media/media/css/mediamanager.css
+++ b/media/media/css/mediamanager.css
@@ -151,6 +151,7 @@ div#media-noimages {
 
 .spinner {
 	position: absolute;
+	left: 50%;
 	opacity: 0.9;
 	filter: alpha(opacity=90);
 	-ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=90);
@@ -163,7 +164,7 @@ div#media-noimages {
 }
 
 .spinner-img {
-	background: url(../../system/images/modal/spinner.gif) no-repeat;
+	background: url(../../jui/images/ajax-loader.gif) no-repeat;
 	width: 24px;
 	height: 24px;
 	margin: 0 auto;


### PR DESCRIPTION
1) Before this the spinner was loaded left before the text, so you couldn't see the text. (IE) 
2) Updating the spinner icon to the nicer ajax-loader.gif
### How to test

Install Joomla 3.4.7 apply this patch.
Update to 3.4.8

or

Install staging build, then go to /administrator/index.php?option=com_joomlaupdate&task=update.install (ignore the error)
### Results

Loading the spinner in the center of the screen and see the new icon spinner
