### PR TITLE
Let's fix the Update from 2.5 to 3.5 with a method both supports

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1615,7 +1615,12 @@ class JoomlaInstallerScript
 		 */
 		$session = JFactory::getSession();
 
-		if (!$session->isActive())
+		/**
+		 * Restarting the Session require a new login for the current user so lets check if we have a active session
+		 * and only if not restart it.
+		 * For B/C reasons we need to use getState as isActive is not available in 2.5
+		 */
+		if ($session->getState() !== 'active')
 		{
 			$session->restart();
 		}


### PR DESCRIPTION
Pull Request for follow up Issue #9230.
#### Summary of Changes

Now we use a function that also support Updating from 2.5.x to 3.5
#### Testing Instructions
- Install 2.5.28 (https://github.com/joomla/joomla-cms/releases/download/2.5.28/Joomla_2.5.28-Stable-Full_Package.zip)
- Try to update and install to 3.5beta2 with this package: http://www.jah-tz.de/downloads/download.php?file=Joomla_3.5.0-beta2-fixed.zip&folder=media/joomla/
- you got logged out as you have a old session
- Login again and make sure you have a beta2
#### Expected result

Update works (without any error message) but you got logged out
#### Notes

Please note that the only change included in my package is the one from this PR and #9230 . So you might encounter other issues which were already fixed since the release of beta2.

@wilsonge @tecpromotion @Harmageddon can you check if that works for you too? Thanks.
