### PR TITLE
Install Languages duplicated in potsgres #9188

### DIFF
--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -185,18 +185,18 @@ class JUpdater extends JAdapter
 						$uid = $update
 							->find(
 							array(
-								'element' => strtolower($current_update->get('element')), 'type' => strtolower($current_update->get('type')),
-								'client_id' => strtolower($current_update->get('client_id')),
-								'folder' => strtolower($current_update->get('folder'))
+								'element' => $current_update->get('element'), 'type' => $current_update->get('type'),
+								'client_id' => $current_update->get('client_id'),
+								'folder' => $current_update->get('folder')
 							)
 						);
 
 						$eid = $extension
 							->find(
 							array(
-								'element' => strtolower($current_update->get('element')), 'type' => strtolower($current_update->get('type')),
-								'client_id' => strtolower($current_update->get('client_id')),
-								'folder' => strtolower($current_update->get('folder'))
+								'element' => $current_update->get('element'), 'type' => $current_update->get('type'),
+								'client_id' => $current_update->get('client_id'),
+								'folder' => $current_update->get('folder')
 							)
 						);
 


### PR DESCRIPTION
Pull Request for Issue #9188 .
#### Steps to reproduce the issue

>  Install Joomla staging on a postrgresl database
>  Go to extensions install languages
> Observe number of languages displayed
> Click on find languages
> #### Expected result
> 
> The list of available languages should not change
> #### Actual result
> 
> Every language is repeated in the list
#### Comment

in sql `"pkg_de-DE"` is not like `strtolower("pkg_de-DE")`
