### PR TITLE
Search filters case sensitive in sql #9242

### DIFF
--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -126,7 +126,7 @@ class InstallerModelLanguages extends JModelList
 		if (!empty($search))
 		{
 			$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-			$query->where('(name LIKE ' . $search . ')');
+			$query->where('(LOWER(name) LIKE ' . $search . ')');
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -126,7 +126,7 @@ class InstallerModelLanguages extends JModelList
 		if (!empty($search))
 		{
 			$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-			$query->where('(LOWER(name) LIKE ' . $search . ')');
+			$query->where('(LOWER(name) LIKE ' . strtolower($search) . ')');
 		}
 
 		// Add the list ordering clause.


### PR DESCRIPTION
Pull Request for Issue #9242 .
#### Steps to reproduce the issue

> Go to extensions->install languages
> Search for french
> #### Expected result
> 
> two languages are found
> #### Actual result
> 
> With Mysql you see two languages
> With PGSQL you see zero languages
#### Comment

sql is case sensitive 
