### PR TITLE
Correct utf8mb4 / utf8 conversion for newly installed Joomla!

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -3,12 +3,7 @@
 -- order to check if the conversion has been performed and if not show a
 -- message about database problem in the database schema view. 
 --
--- Note: This table is created with charset utf8 and collation utf8_unicode_ci
--- so it will not cause an exception on upgrading a pre-3.5.0 with a database
--- not supporting utf8mb4, but all create table statements in future have to
--- use charset utf8mb4 and collation utf8mb4_unicode_ci.
---
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
   `converted` tinyint(4) NOT NULL DEFAULT 0
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -3,7 +3,15 @@
 -- order to check if the conversion has been performed and if not show a
 -- message about database problem in the database schema view. 
 --
+-- The value of `converted` can be 0 (not converted yet after update),
+-- 1 (converted to utf8), 2 (converted to utf8mb4) or 3 (value set on new
+-- installation, will be later set to 1 or 2 by the database schema
+-- manager according to utf8 support of the database before checking the
+-- database)
+--
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
   `converted` tinyint(4) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO `#__utf8_conversion` (`converted`) VALUES (0);

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -362,9 +362,22 @@ class InstallerModelDatabase extends InstallerModel
 			return;
 		}
 
-		$db->setQuery('CREATE TABLE IF NOT EXISTS ' . $db->quoteName('#__utf8_conversion')
+		$creaTabSql = 'CREATE TABLE IF NOT EXISTS ' . $db->quoteName('#__utf8_conversion')
 			. ' (' . $db->quoteName('converted') . ' tinyint(4) NOT NULL DEFAULT 0'
-			. ') ENGINE=InnoDB DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;')->execute();
+			. ') ENGINE=InnoDB';
+
+		if ($db->hasUTF8mb4Support())
+		{
+			$creaTabSql = $creaTabSql
+				. ' DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;';
+		}
+		else
+		{
+			$creaTabSql = $creaTabSql
+				. ' DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;';
+		}
+
+		$db->setQuery($creaTabSql)->execute();
 
 		$db->setQuery('SELECT COUNT(*) FROM ' . $db->quoteName('#__utf8_conversion') . ';');
 

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -368,11 +368,13 @@ class InstallerModelDatabase extends InstallerModel
 
 		if ($db->hasUTF8mb4Support())
 		{
+			$converted = 2;
 			$creaTabSql = $creaTabSql
 				. ' DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;';
 		}
 		else
 		{
+			$converted = 1;
 			$creaTabSql = $creaTabSql
 				. ' DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;';
 		}
@@ -385,15 +387,25 @@ class InstallerModelDatabase extends InstallerModel
 
 		if ($count > 1)
 		{
+			// Table messed up somehow, clear it
 			$db->setQuery('DELETE FROM ' . $db->quoteName('#__utf8_conversion')
 				. ';')->execute();
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
-				. ' (' . $db->quoteName('converted') . ') ' . ' VALUES (0);')->execute();
+				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
+		}
+		elseif ($count == 1)
+		{
+			// Set status after new installation to converted
+			$db->setQuery('UPDATE ' . $db->quoteName('#__utf8_conversion')
+				. ' SET ' . $db->quoteName('converted')
+				. ' = ' . $converted
+				. ' WHERE ' . $db->quoteName('converted') . ' = 3;')->execute();
 		}
 		elseif ($count == 0)
 		{
+			// Record missing somehow, fix this
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
-				. ' (' . $db->quoteName('converted') . ') ' . ' VALUES (0);')->execute();
+				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
 		}
 	}
 

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1949,7 +1949,13 @@ CREATE TABLE IF NOT EXISTS `#__user_usergroup_map` (
   PRIMARY KEY (`user_id`,`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
--- --------------------------------------------------------
+--
+-- Table structure for table `#__utf8_conversion`
+--
+
+CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
+  `converted` tinyint(4) NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Table structure for table `#__viewlevels`

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1958,6 +1958,13 @@ CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --
+-- Dumping data for table `#__utf8_conversion`
+-- - the `converted`=3 means table just created with a new installation
+--
+
+INSERT INTO `#__utf8_conversion` (`converted`) VALUES (3);
+
+--
 -- Table structure for table `#__viewlevels`
 --
 

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -95,7 +95,7 @@ class JSchemaChangeset
 			$tmpSchemaChangeItem->checkQuery = 'SELECT '
 				. $this->db->quoteName('converted')
 				. ' FROM ' . $this->db->quoteName('#__utf8_conversion')
-				. ' WHERE ' . $this->db->quoteName('converted') . ' = ' . $converted . ';';
+				. ' WHERE ' . $this->db->quoteName('converted') . ' IN (' . $converted . ', 3);';
 
 			// Set expected records from check query
 			$tmpSchemaChangeItem->checkQueryExpected = 1;


### PR DESCRIPTION
Pull Request for new issue.
#### Summary of Changes

Add missing creation of table #__utf8_conversion to joomla.sql and correct the utf8(mb4) conversion
detection by the database schema manager by handling newly installed Joomla!.

Shame I have forgotten that when making my corrections for utf8(mb4) conversion.
#### Testing Instructions
1. Installa fresh Joomla! 3.5.0 Beta 3
2. Login to the administrator area (backend)
3. Go to "Extensions -> Manage -> Database"
4. **Expected result**: All should be OK and up to date. **Actual result**: 2 Database Problems Found. 1.Table "#__utf8_conversion" does not exist. (From file 3.5.0-2016-02-26.sql.), and 2. "The Joomla! Core database tables have not been converted yet to UTF-8 Multibyte (utf8mb4)". Click on "Fix" button solves this.
5. Repeat steps 1 to 3 with staging + patch of this PR applied. **Result**: All OK, no problems reported.

A zip with staging + this patch can be found here: [https://github.com/richard67/joomla-cms/archive/correct-joomla-sql-1.zip](https://github.com/richard67/joomla-cms/archive/correct-joomla-sql-1.zip)
#### Additional test

Beside this problem, this PR also fixes the creation of the table mentioned above in the database schema manager and in the update sql so it is created with utf8mb4 or utf8 collation, depending on the actual system.

This can be tested by updaing a clean 3.4.8 to a 3.5.0. Beta 3 patched by the changes from this PR here and see if it works the same as with (unpatched) 3.5.0 Beta 3. You can find a patched update package for this test at http://test5.richard-fath.de/Joomla_3.5.0-beta3-Beta-Update_Package_test1.zip.
