### PR TITLE
Double icon for images in the editor toolbar

### DIFF
--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -58,7 +58,7 @@ class PlgButtonImage extends JPlugin
 			$button->class = 'btn';
 			$button->link = $link;
 			$button->text = JText::_('PLG_IMAGE_BUTTON_IMAGE');
-			$button->name = 'picture';
+			$button->name = 'pictures';
 			$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
 			return $button;


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

After the plugin buttons that were at the bottom of the editor as been moved inside the editor toolbar, there are two double icons for images: one of TinyMCE and one Joomla.

This patch changes the icon of Joomla Image button, to distinguish it from the other one.
