### PR TITLE
Error handling adjustments (Fix #9074)

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -79,6 +79,9 @@ class JErrorPage
 
 				echo $app->toString();
 
+				$app->close(0);
+
+				// This return is needed to ensure the test suite does not trigger the non-Exception handling below
 				return;
 			}
 			catch (Exception $e)
@@ -97,7 +100,14 @@ class JErrorPage
 
 		if ($isException)
 		{
-			$message .= ': ' . $e->getMessage() . ': ' . $error->getMessage();
+			$message .= ': ';
+
+			if (isset($e))
+			{
+				$message .= $e->getMessage() . ': ';
+			}
+
+			$message .= $error->getMessage();
 		}
 
 		echo $message;

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -40,19 +40,56 @@ class PlgSystemRedirect extends JPlugin
 
 		// Set the error handler for E_ERROR to be the class handleError method.
 		JError::setErrorHandling(E_ERROR, 'callback', array('PlgSystemRedirect', 'handleError'));
-		set_exception_handler(array('PlgSystemRedirect', 'handleError'));
+		set_exception_handler(array('PlgSystemRedirect', 'handleException'));
 	}
 
 	/**
-	 * Method to handle an error condition.
+	 * Method to handle an error condition from JError.
 	 *
-	 * @param   Exception  &$error  The Exception object to be handled.
+	 * @param   JException  &$error  The JException object to be handled.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public static function handleError(&$error)
+	public static function handleError(JException &$error)
+	{
+		self::doErrorHandling($error);
+	}
+
+	/**
+	 * Method to handle an uncaught exception.
+	 *
+	 * @param   Exception|Throwable  $exception  The Exception or Throwable object to be handled.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 * @throws  InvalidArgumentException
+	 */
+	public static function handleException($exception)
+	{
+		// If this isn't a Throwable then bail out
+		if (!($exception instanceof Throwable) && !($exception instanceof Exception))
+		{
+			throw new InvalidArgumentException(
+				sprintf('The error handler requires a Exception or Throwable object, a "%s" object was given instead.', get_class($exception))
+			);
+		}
+
+		self::doErrorHandling($exception);
+	}
+
+	/**
+	 * Internal processor for all error handlers
+	 *
+	 * @param   Exception|Throwable  $error  The Exception or Throwable object to be handled.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private static function doErrorHandling($error)
 	{
 		// Get the application object.
 		$app = JFactory::getApplication();
@@ -61,7 +98,7 @@ class PlgSystemRedirect extends JPlugin
 		if ($app->isAdmin() || $error->getCode() != 404)
 		{
 			// Render the error page.
-			JError::customErrorPage($error);
+			JErrorPage::render($error);
 		}
 
 		// Get the full current URI.
@@ -72,7 +109,7 @@ class PlgSystemRedirect extends JPlugin
 		if ((strpos($current, 'mosConfig_') !== false) || (strpos($current, '=http://') !== false))
 		{
 			// Render the error page.
-			JError::customErrorPage($error);
+			JErrorPage::render($error);
 		}
 
 		// See if the current url exists in the database as a redirect.
@@ -86,7 +123,7 @@ class PlgSystemRedirect extends JPlugin
 		$link = $db->loadObject();
 
 		// If no published redirect was found try with the server-relative URL
-		if (!$link or ($link->published != 1))
+		if (!$link || ($link->published != 1))
 		{
 			$currRel = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
 			$query = $db->getQuery(true)
@@ -99,7 +136,7 @@ class PlgSystemRedirect extends JPlugin
 		}
 
 		// If a redirect exists and is published, permanently redirect.
-		if ($link and ($link->published == 1))
+		if ($link && ($link->published == 1))
 		{
 			// If no header is set use a 301 permanent redirect
 			if (!$link->header || JComponentHelper::getParams('com_redirect')->get('mode', 0) == false)
@@ -114,81 +151,75 @@ class PlgSystemRedirect extends JPlugin
 
 				$app->redirect($new_link, intval($link->header));
 			}
-			else
-			{
-				// Else rethrow the exeception with the new header and return
-				try
-				{
-					throw new RuntimeException($error->getMessage(), $link->header, $error);
-				}
-				catch (Exception $e)
-				{
-					$newError = $e;
-				}
 
-				JError::customErrorPage($newError);
-			}
+			// Else rethrow the exeception with the new header and return
+			JErrorPage::render(new RuntimeException($error->getMessage(), $link->header, $error));
 		}
-		else
+
+		try
 		{
-			try
+			$referer = $app->input->server->getString('HTTP_REFERER', '');
+			$query   = $db->getQuery(true)
+				->select($db->quoteName('id'))
+				->from($db->quoteName('#__redirect_links'))
+				->where($db->quoteName('old_url') . ' = ' . $db->quote($current));
+			$db->setQuery($query);
+			$res = $db->loadResult();
+
+			if (!$res)
 			{
-				$referer = empty($_SERVER['HTTP_REFERER']) ? '' : $_SERVER['HTTP_REFERER'];
-				$query   = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from($db->quoteName('#__redirect_links'))
-					->where($db->quoteName('old_url') . ' = ' . $db->quote($current));
-				$db->setQuery($query);
-				$res = $db->loadResult();
+				// If not, add the new url to the database but only if option is enabled
+				$params       = new Registry(JPluginHelper::getPlugin('system', 'redirect')->params);
+				$collect_urls = $params->get('collect_urls', 1);
 
-				if (!$res)
+				if ($collect_urls == true)
 				{
-					// If not, add the new url to the database but only if option is enabled
-					$params       = new Registry(JPluginHelper::getPlugin('system', 'redirect')->params);
-					$collect_urls = $params->get('collect_urls', 1);
+					$columns = array(
+						$db->quoteName('old_url'),
+						$db->quoteName('new_url'),
+						$db->quoteName('referer'),
+						$db->quoteName('comment'),
+						$db->quoteName('hits'),
+						$db->quoteName('published'),
+						$db->quoteName('created_date')
+					);
 
-					if ($collect_urls == true)
-					{
-						$columns = array(
-							$db->quoteName('old_url'),
-							$db->quoteName('new_url'),
-							$db->quoteName('referer'),
-							$db->quoteName('comment'),
-							$db->quoteName('hits'),
-							$db->quoteName('published'),
-							$db->quoteName('created_date')
-						);
-						$query->clear()
-							->insert($db->quoteName('#__redirect_links'), false)
-							->columns($columns)
-							->values(
-								$db->quote($current) . ', ' . $db->quote('') .
-								' ,' . $db->quote($referer) . ', ' . $db->quote('') . ',1,0, ' .
-								$db->quote(JFactory::getDate()->toSql())
-							);
+					$values = array(
+						$db->quote($current),
+						$db->quote(''),
+						$db->quote($referer),
+						$db->quote(''),
+						1,
+						0,
+						$db->quote(JFactory::getDate()->toSql())
+					);
 
-						$db->setQuery($query);
-						$db->execute();
-					}
-				}
-				else
-				{
-					// Existing error url, increase hit counter.
 					$query->clear()
-						->update($db->quoteName('#__redirect_links'))
-						->set($db->quoteName('hits') . ' = ' . $db->quoteName('hits') . ' + 1')
-						->where('id = ' . (int) $res);
+						->insert($db->quoteName('#__redirect_links'), false)
+						->columns($columns)
+						->values(implode(', ', $values));
+
 					$db->setQuery($query);
 					$db->execute();
 				}
 			}
-			catch (RuntimeException $exception)
+			else
 			{
-				JError::customErrorPage(new Exception(JText::_('PLG_SYSTEM_REDIRECT_ERROR_UPDATING_DATABASE'), 404));
+				// Existing error url, increase hit counter.
+				$query->clear()
+					->update($db->quoteName('#__redirect_links'))
+					->set($db->quoteName('hits') . ' = ' . $db->quoteName('hits') . ' + 1')
+					->where('id = ' . (int) $res);
+				$db->setQuery($query);
+				$db->execute();
 			}
-
-			// Render the error page.
-			JError::customErrorPage($error);
 		}
+		catch (RuntimeException $exception)
+		{
+			JErrorPage::render(new Exception(JText::_('PLG_SYSTEM_REDIRECT_ERROR_UPDATING_DATABASE'), 404, $exception));
+		}
+
+		// Render the error page.
+		JErrorPage::render($error);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #9074.
#### Summary of Changes
- `JErrorPage::render()` did not close the application correctly when rendering error pages
- The `$e` variable may not be defined in `JErrorPage::render()` when echoing a static text message instead of rendering a `JDocumentError` object
- `PlgSystemRedirect::handleError()` cannot be used as both a `JError` callback handler and a global Exception handler due to signature differences, namely passing references versus values; a new `PlgSystemRedirect::handleException()` method is added to be used as the global Exception handler and the actual error handling code is moved into a private method in the plugin
- General `JErrorPageTest` improvements
#### Testing Instructions

With the redirect plugin enabled, 404's should still be logged correctly.

To test the Exception handler pre- and post- patch, after [this line](https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/application/cms.php#L663) in JApplicationCms throw an Exception.  If running PHP 7, pre-patch you'll get this warning and an uncaught Exception:

```
Warning: Parameter 1 to PlgSystemRedirect::handleError() expected to be a reference, value given in Unknown on line 0
```

Post patch, the error page should render correctly.  PHP 5 is unaffected.
