### PR TITLE
Remove some absolute paths from sysinfo download

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -100,6 +100,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'Server Root',
 			'session.name',
 			'session.save_path',
+			'upload_tmp_dir',
 			'User/Group',
 		),
 		'other' => array(

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -72,6 +72,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'Cookie',
 			'DOCUMENT_ROOT',
 			'extension_dir',
+			'error_log',
 			'Host',
 			'HTTP_COOKIE',
 			'HTTP_HOST',


### PR DESCRIPTION
Pull Request for Issue  #9252
#### Summary of Changes

The following values in the downloaded sysinfo text are obfuscated for the following (correctly): 

log_path: xxxxxx
tmp_path: xxxxxx

The absolute path is still available in the information downloaded from the PHP information 
# Example

```
    error_log
    =============
    Local Value: /Applications/MAMP/logs/php_error.log
    Master Value: /Applications/MAMP/logs/php_error.log

    upload_tmp_dir
    =============
    Local Value: /Applications/MAMP/tmp/php
    Master Value: /Applications/MAMP/tmp/php<hr /><sub>This comment was created with the <a href="https://github.com/joomla/jissues">J!Tracker Application</a> at <a href="https://issues.joomla.org/tracker/joomla-cms/9252">issues.joomla.org/joomla-cms/9252</a>.</sub>
```

Note that the absolute path being shown in the folder permissions will be solved in another PR
