### PR TITLE
set() returns the old value of the variable

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,7 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-			$inputvalue = strftime($format, strtotime($value));
+            $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
+            $inputvalue = $temp->format(str_replace('%','',$format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,7 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-			$temp = DateTime::createFromFormat("Y-m-d H:i:s", $value);
-			$inputvalue = $temp->format(str_replace('%', '', $format));
+			$inputvalue = strftime($format, strtotime($value));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-            $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
-            $inputvalue = $temp->format(str_replace('%','',$format));
+			$temp = DateTime::createFromFormat("Y-m-d H:i:s", $value);
+			$inputvalue = $temp->format(str_replace('%', '', $format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -527,7 +527,6 @@ class JSession implements IteratorAggregate
 
 		$prev = $this->data->get($namespace . '.' . $name, null);
 		$this->data->set($namespace . '.' . $name, $value);
-		
 		return $prev;
 	}
 

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -525,10 +525,10 @@ class JSession implements IteratorAggregate
 			return null;
 		}
 
-        $prev = $this->data->get($namespace . '.' . $name, null);
-        $this->data->set($namespace . '.' . $name, $value);
-    
-        return $prev;
+		$prev = $this->data->get($namespace . '.' . $name, null);
+		$this->data->set($namespace . '.' . $name, $value);
+		
+		return $prev;
 	}
 
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -525,7 +525,10 @@ class JSession implements IteratorAggregate
 			return null;
 		}
 
-		return $this->data->set($namespace . '.' . $name, $value);
+        $prev = $this->data->get($namespace . '.' . $name, null);
+        $this->data->set($namespace . '.' . $name, $value);
+    
+        return $prev;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #8859 

Testing instructions remain the same as referenced in the issue:
 $session = JFactory::getSession();
 $session->set('test', 1);
 echo $session->set('test', 2);
