### PR TITLE
$result-variable-undefined-given-default-value

### DIFF
--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -72,7 +72,7 @@ class PlgContentJoomla extends JPlugin
 
 		$default_language = JComponentHelper::getParams('com_languages')->get('administrator');
 		$debug = JFactory::getConfig()->get('debug_lang');
-
+		$result=true;
 		foreach ($users as $user_id)
 		{
 			if ($user_id != $user->id)

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -72,7 +72,7 @@ class PlgContentJoomla extends JPlugin
 
 		$default_language = JComponentHelper::getParams('com_languages')->get('administrator');
 		$debug = JFactory::getConfig()->get('debug_lang');
-		$result=true;
+		$result = true;
 		foreach ($users as $user_id)
 		{
 			if ($user_id != $user->id)


### PR DESCRIPTION
Pull Request for Issue #9253   .
#### Summary of Changes

$result redefined with a default value.
#### Testing Instructions

Enable all errors reporting in php.
Add "exit()" to the end of the onContentAfterSave() method (this is for watching the error)
In the front-end, add a menu item "propose an article".
In the front-end do log as an user which can add article.
When the article is submitted, the following error is displayed:
Notice: Undefined variable: result in /home/plambotte/Public/projets/web/joomla3dev/component-factory/plugins/content/joomla/joomla.php on line 93

After the changes the error are no longer seen.
