### PR TITLE
B/C: Adds back com_tags/helper/tags.php and mark as deprecated

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1397,7 +1397,6 @@ class JoomlaInstallerScript
 			'/libraries/vendor/symfony/yaml/Symfony/Component/Yaml/Exception/ExceptionInterface.php',
 			'/libraries/vendor/symfony/yaml/Symfony/Component/Yaml/Exception/ParseException.php',
 			'/libraries/vendor/symfony/yaml/Symfony/Component/Yaml/Exception/RuntimeException.php',
-			'/administrator/components/com_tags/helpers/tags.php',
 			'/libraries/vendor/phpmailer/phpmailer/extras/class.html2text.php',
 			'/libraries/joomla/document/error/error.php',
 			'/libraries/joomla/document/feed/feed.php',

--- a/administrator/components/com_tags/helpers/tags.php
+++ b/administrator/components/com_tags/helpers/tags.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_tags
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Tags helper.
+ *
+ * @since  3.1
+ */
+class TagsHelper extends JHelperContent
+{
+	/**
+	 * Configure the Submenu links.
+	 *
+	 * @param   string  $extension  The extension.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 * @deprecated  4.0
+	 */
+	public static function addSubmenu($extension)
+	{
+		$parts     = explode('.', $extension);
+		$component = $parts[0];
+
+		// Avoid nonsense situation.
+		if ($component == 'tags')
+		{
+			return;
+		}
+
+		// Try to find the component helper.
+		$file = JPath::clean(JPATH_ADMINISTRATOR . '/components/com_tags/helpers/tags.php');
+
+		if (file_exists($file))
+		{
+			require_once $file;
+
+			$cName = 'TagsHelper';
+
+			if (class_exists($cName))
+			{
+				if (is_callable(array($cName, 'addSubmenu')))
+				{
+					$lang = JFactory::getLanguage();
+
+					// Loading language file from administrator/language directory then administrator/components/<extension>/language
+					$lang->load($component, JPATH_BASE, null, false, true)
+					||	$lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component), null, false, true);
+				}
+			}
+		}
+	}
+}

--- a/administrator/components/com_tags/helpers/tags.php
+++ b/administrator/components/com_tags/helpers/tags.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
  * Tags helper.
  *
  * @since  3.1
+ * @deprecated  4.0
  */
 class TagsHelper extends JHelperContent
 {


### PR DESCRIPTION
Some components do not differentiate between submenu loading to override some of them.
Example: kmfastrans

This reinstate `class TagsHelper extends JHelperContent` and marks as deprecated.

@wilsonge 
Can be merged on review.
