### PR TITLE
 set() returns the old value of the variable #9276 (revised)

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -525,7 +525,9 @@ class JSession implements IteratorAggregate
 			return null;
 		}
 
-		return $this->data->set($namespace . '.' . $name, $value);
+        $prev = $this->data->get($namespace . '.' . $name, null);
+        $this->data->set($namespace . '.' . $name, $value);
+        return $prev;
 	}
 
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -525,9 +525,9 @@ class JSession implements IteratorAggregate
 			return null;
 		}
 
-        $prev = $this->data->get($namespace . '.' . $name, null);
-        $this->data->set($namespace . '.' . $name, $value);
-        return $prev;
+        	$prev = $this->data->get($namespace . '.' . $name, null);
+        	$this->data->set($namespace . '.' . $name, $value);
+        	return $prev;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #8859

Testing instructions remain the same as referenced in the issue:
$session = JFactory::getSession();
$session->set('test', 1);
echo $session->set('test', 2);
