### PR TITLE
Adding index.php to administrator base href (solves #9289)

### DIFF
--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -28,7 +28,7 @@ if ($params->get('show_viewsite', 1))
 if ($params->get('show_viewadmin', 0))
 {
 	$output[] = '<div class="btn-group viewsite">'
-		. '<a href="' . JURI::base() . '" target="_blank">'
+		. '<a href="' . JURI::base() . 'index.php" target="_blank">'
 		. '<span class="icon-out-2"></span> ' . JText::_('MOD_STATUS_FIELD_LINK_VIEWADMIN_LABEL')
 		. '</a>'
 		. '</div>'

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -183,7 +183,7 @@ $doc->addScriptDeclaration(
 				</a>
 			<?php endif; ?>
 
-			<a class="admin-logo <?php echo ($hidden ? 'disabled' : ''); ?>" <?php echo ($hidden ? '' : 'href="' . $this->baseurl . '"'); ?>><span class="icon-joomla"></span></a>
+			<a class="admin-logo <?php echo ($hidden ? 'disabled' : ''); ?>" <?php echo ($hidden ? '' : 'href="' . $this->baseurl . '/index.php"'); ?>><span class="icon-joomla"></span></a>
 
 			<a class="brand hidden-desktop hidden-tablet" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('TPL_ISIS_PREVIEW', $sitename); ?>" target="_blank"><?php echo JHtml::_('string.truncate', $sitename, 14, false, false); ?>
 				<span class="icon-out-2 small"></span></a>


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/9289
This PR normalises href links to administrator base by adding index.php where necessary.
For Isis top left Joomla icon
For Show Admin in status bar.
![screen shot 2016-03-03 at 10 11 35](https://cloud.githubusercontent.com/assets/869724/13489627/6af90ec4-e128-11e5-8216-6d642de0a1bd.png)
