### PR TITLE
[Bug fix] Correct issue 9292 syntax error in joomla.sql for PostrgeSQL

### DIFF
--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1465,7 +1465,7 @@ CREATE TABLE "#__redirect_links" (
   "created_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "modified_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "header" INTEGER DEFAULT 301 NOT NULL,
-  PRIMARY KEY ("id"),
+  PRIMARY KEY ("id")
 );
 CREATE INDEX "#__redirect_links_idx_old_url" ON "#__redirect_links" ("old_url");
 CREATE INDEX "#__redirect_links_idx_link_modifed" ON "#__redirect_links" ("modified_date");

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1464,7 +1464,7 @@ CREATE TABLE "#__redirect_links" (
   "published" smallint NOT NULL,
   "created_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "modified_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
-  "header" INTEGER DEFAULT 301 NOT NULL,
+  "header" integer DEFAULT 301 NOT NULL,
   PRIMARY KEY ("id")
 );
 CREATE INDEX "#__redirect_links_idx_old_url" ON "#__redirect_links" ("old_url");


### PR DESCRIPTION
Pull Request for Issue #9292  .
#### Summary of Changes

This PR corrects a silly syntax error in the installation sql script joomla.sql for PostgreSQL I've made with my PR #9269 .

When removing the unique key definition at the end of the create table, I forgot to remove also the comma (shame).
#### Testing Instructions

Only relevant for PostgreSQL database users.

Do a new installation either with Joomla! 3.5.0 Beta 3 or current staging, but before you start, replace the file installation/sql/postgresql/joomla.sql by the one from this PR.

Result: The syntax error described in issue #9292 does not happen anymore, and the table for the redirect links is created.

If no other errors, installation should succeed, otherwise if new erros let me know here.

If all OK, please mark your test result in the issue tracker for this PR.
