### PR TITLE
Add class deafult to homepage menu item

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -188,7 +188,7 @@ class ModMenuHelper
 	{
 		$menu = JFactory::getApplication()->getMenu();
 
-		return $menu->getActive() ? $menu->getActive() : self::getDefault(&$params);
+		return $menu->getActive() ? $menu->getActive() : self::getDefault();
 	}
 
 	/**

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -187,18 +187,28 @@ class ModMenuHelper
 	public static function getActive(&$params)
 	{
 		$menu = JFactory::getApplication()->getMenu();
+
+		return $menu->getActive() ? $menu->getActive() : self::getDefault(&$params);
+	}
+
+	/**
+	* Get default menu item (homepage) for current language.
+	*
+	* @return  object
+	*/
+	public static function getDefault()
+	{
+		$menu = JFactory::getApplication()->getMenu();
 		$lang = JFactory::getLanguage();
 
 		// Look for the home menu
 		if (JLanguageMultilang::isEnabled())
 		{
-			$home = $menu->getDefault($lang->getTag());
+			return $menu->getDefault($lang->getTag());
 		}
 		else
 		{
-			$home  = $menu->getDefault();
+			return $menu->getDefault();
 		}
-
-		return $menu->getActive() ? $menu->getActive() : $home;
 	}
 }

--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -12,13 +12,15 @@ defined('_JEXEC') or die;
 // Include the syndicate functions only once
 require_once __DIR__ . '/helper.php';
 
-$list      = ModMenuHelper::getList($params);
-$base      = ModMenuHelper::getBase($params);
-$active    = ModMenuHelper::getActive($params);
-$active_id = $active->id;
-$path      = $base->tree;
-$showAll   = $params->get('showAllChildren');
-$class_sfx = htmlspecialchars($params->get('class_sfx'));
+$list       = ModMenuHelper::getList($params);
+$base       = ModMenuHelper::getBase($params);
+$active     = ModMenuHelper::getActive($params);
+$default    = ModMenuHelper::getDefault();
+$active_id  = $active->id;
+$default_id = $default->id;
+$path       = $base->tree;
+$showAll    = $params->get('showAllChildren');
+$class_sfx  = htmlspecialchars($params->get('class_sfx'));
 
 if (count($list))
 {

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -26,6 +26,11 @@ foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;
 
+	if ($item->id == $default_id)
+	{
+		$class .= ' default';
+	}
+
 	if (($item->id == $active_id) OR ($item->type == 'alias' AND $item->params->get('aliasoptions') == $active_id))
 	{
 		$class .= ' current';


### PR DESCRIPTION
That should be right from the start. Many themes are displaying default menu item differently or disables at all.
#### Summary of Changes

This adds a **default** class for a homepage/default menu item in current language.
#### Testing Instructions

Just check if menu item containing item marked as default/homepage has class **default**.
