### PR TITLE
Add UTF8MB4 upgrade in Joomla Update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1700,7 +1700,8 @@ class JoomlaInstallerScript
 
 		// Check conversion status in database
 		$db->setQuery('SELECT ' . $db->quoteName('converted')
-			. ' FROM ' . $db->quoteName('#__utf8_conversion'));
+			. ' FROM ' . $db->quoteName('#__utf8_conversion')
+			);
 
 		try
 		{

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -37,6 +37,7 @@ class JoomlaInstallerScript
 		$this->clearRadCache();
 		$this->updateAssets();
 		$this->clearStatsCache();
+		$this->convertTablesToUtf8mb4();
 
 		// VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD
 		// LOGOUT ALL THE USERS
@@ -1659,5 +1660,180 @@ class JoomlaInstallerScript
 		}
 
 		return true;
+	}
+
+	/**
+	 * Converts the site's database tables to support UTF-8 Multibyte.
+	 *
+	 * Note that this is a modified of InstallerModelDatabase::convertTablesToUtf8mb4()
+	 * that doesn't use JDatabase functions introduced in 3.5.0 which would cause errors
+	 * when upgrading from a version before 3.5.0
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	private function convertTablesToUtf8mb4()
+	{
+		$db = JFactory::getDbo();
+
+		// This is only required for MySQL databases
+		$name = $db->getName();
+
+		if (stristr($name, 'mysql') !== false)
+		{
+			return;
+		}
+
+		// Step 1: Drop indexes later to be added again with column lengths limitations at step 2
+		$fileName1 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/mysql/utf8mb4-conversion-01.sql";
+
+		if (is_file($fileName1))
+		{
+			$fileContents1 = @file_get_contents($fileName1);
+			$queries1 = $db->splitSql($fileContents1);
+
+			if (!empty($queries1))
+			{
+				foreach ($queries1 as $query1)
+				{
+					try
+					{
+						$db->setQuery($query1)->execute();
+					}
+					catch (Exception $e)
+					{
+						// If the query fails we will go on. It just means the index to be dropped does not exist.
+					}
+				}
+			}
+		}
+
+		// Step 2: Perform the index modifications and conversions
+		$fileName2 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql";
+
+		if ($this->serverClaimsUtf8mb4Support())
+		{
+			$converted = 2;
+		}
+		else
+		{
+			$converted = 1;
+		}
+
+		if (is_file($fileName2))
+		{
+			$fileContents2 = @file_get_contents($fileName2);
+			$queries2 = $db->splitSql($fileContents2);
+
+			if (!empty($queries2))
+			{
+				foreach ($queries2 as $query2)
+				{
+					// Downgrade the query if utf8mb4 isn't supported
+					if ($converted === 1)
+					{
+						$query2 = $this->convertUtf8mb4QueryToUtf8($query2);
+					}
+
+					try
+					{
+						$db->setQuery($query2)->execute();
+					}
+					catch (Exception $e)
+					{
+						$converted = 0;
+
+						// Still render the error message from the Exception object
+						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+					}
+				}
+			}
+		}
+
+		// Set flag in database if the update is done.
+		$db->setQuery('UPDATE ' . $db->quoteName('#__utf8_conversion')
+			. ' SET ' . $db->quoteName('converted') . ' = ' . $converted . ';')->execute();
+	}
+
+	/**
+	 * Does the database server claim to have support for UTF-8 Multibyte (utf8mb4) collation?
+	 * 
+	 * This is a modified version of the function in JDatabase::serverClaimsUtf8mb4Support() - it is
+	 * duplicated here for people upgrading from a version lower than 3.5.0 through extension manager
+	 * which will still have the old database driver loaded at this point.
+	 *
+	 * @param   string  $format  The type of database connection.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5.0
+	 */
+	private function serverClaimsUtf8mb4Support($format)
+	{
+		$db = JFactory::getDbo();
+
+		switch ($format)
+		{
+			case 'mysql':
+				$client_version = mysql_get_client_info();
+				$server_version = $db->getVersion();
+				break;
+			case 'mysqli':
+				$client_version = mysqli_get_client_info();
+				$server_version = $db->getVersion();
+				break;
+			case 'pdomysql':
+				$client_version = $db->getOption(PDO::ATTR_CLIENT_VERSION);
+				$server_version = $db->getOption(PDO::ATTR_SERVER_VERSION);
+				break;
+			default:
+				$client_version = false;
+				$server_version = false;
+		}
+
+		if ($client_version && version_compare($server_version, '5.5.3', '>='))
+		{
+			if (strpos($client_version, 'mysqlnd') !== false)
+			{
+				$client_version = preg_replace('/^\D+([\d.]+).*/', '$1', $client_version);
+
+				return version_compare($client_version, '5.0.9', '>=');
+			}
+			else
+			{
+				return version_compare($client_version, '5.5.3', '>=');
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Downgrade a CREATE TABLE or ALTER TABLE query from utf8mb4 (UTF-8 Multibyte) to plain utf8. Used when the server
+	 * doesn't support UTF-8 Multibyte.
+	 *
+	 * This is a modified version of the function in JDatabase::convertUtf8mb4QueryToUtf8() - it is duplicated here for
+	 * people upgrading from a version lower than 3.5.0 through extension manager which will still have the old database
+	 * driver loaded at this point. This is missing the check for utf8mb4 in JDatabaseDriver we make this check in the
+	 * updater elsewhere.
+	 *
+	 * @param   string  $query  The query to convert
+	 *
+	 * @return  string  The converted query
+	 */
+	private function convertUtf8mb4QueryToUtf8($query)
+	{
+		// If it's not an ALTER TABLE or CREATE TABLE command there's nothing to convert
+		$beginningOfQuery = substr($query, 0, 12);
+		$beginningOfQuery = strtoupper($beginningOfQuery);
+
+		if (!in_array($beginningOfQuery, array('ALTER TABLE ', 'CREATE TABLE')))
+		{
+			return $query;
+		}
+
+		// Replace utf8mb4 with utf8
+		return str_replace('utf8mb4', 'utf8', $query);
 	}
 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1733,22 +1733,25 @@ class JoomlaInstallerScript
 			{
 				foreach ($queries2 as $query2)
 				{
-					// Downgrade the query if utf8mb4 isn't supported
-					if ($utf8mb4Support)
+					if ($trimmedQuery = $this->trimQuery($query2))
 					{
-						$query2 = $this->convertUtf8mb4QueryToUtf8($query2);
-					}
+						// Downgrade the query if utf8mb4 isn't supported
+						if ($utf8mb4Support)
+						{
+							$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
+						}
 
-					try
-					{
-						$db->setQuery($query2)->execute();
-					}
-					catch (Exception $e)
-					{
-						$converted = 0;
+						try
+						{
+							$db->setQuery($trimmedQuery)->execute();
+						}
+						catch (Exception $e)
+						{
+							$converted = 0;
 
-						// Still render the error message from the Exception object
-						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+							// Still render the error message from the Exception object
+							JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+						}
 					}
 				}
 			}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1700,7 +1700,7 @@ class JoomlaInstallerScript
 
 		// Check conversion status in database
 		$db->setQuery('SELECT ' . $db->quoteName('converted')
-			. ' FROM ' . $db->quoteName('#__utf8_conversion');
+			. ' FROM ' . $db->quoteName('#__utf8_conversion'));
 
 		try
 		{

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1759,7 +1759,7 @@ class JoomlaInstallerScript
 					if ($trimmedQuery = $this->trimQuery($query2))
 					{
 						// Downgrade the query if utf8mb4 isn't supported
-						if ($utf8mb4Support)
+						if (!$utf8mb4Support)
 						{
 							$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
 						}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1712,8 +1712,11 @@ class JoomlaInstallerScript
 		// Step 2: Perform the index modifications and conversions
 		$fileName2 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql";
 
+		$utf8mb4Support = false;
+
 		if ($this->serverClaimsUtf8mb4Support())
 		{
+			$utf8mb4Support = true;
 			$converted = 2;
 		}
 		else
@@ -1731,7 +1734,7 @@ class JoomlaInstallerScript
 				foreach ($queries2 as $query2)
 				{
 					// Downgrade the query if utf8mb4 isn't supported
-					if ($converted === 1)
+					if ($utf8mb4Support)
 					{
 						$query2 = $this->convertUtf8mb4QueryToUtf8($query2);
 					}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1714,7 +1714,7 @@ class JoomlaInstallerScript
 
 		$utf8mb4Support = false;
 
-		if ($this->serverClaimsUtf8mb4Support())
+		if ($this->serverClaimsUtf8mb4Support($name))
 		{
 			$utf8mb4Support = true;
 			$converted = 2;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1708,7 +1708,7 @@ class JoomlaInstallerScript
 		}
 		catch (Exception $e)
 		{
-			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
 
 			return;
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1704,7 +1704,7 @@ class JoomlaInstallerScript
 
 		try
 		{
-			$db->execute();
+			$convertedDB = $db->loadResult();
 		}
 		catch (Exception $e)
 		{
@@ -1712,8 +1712,6 @@ class JoomlaInstallerScript
 
 			return;
 		}
-
-		$convertedDB = $db->loadResult();
 
 		// Nothing to do, saved conversion status from DB is equal to required
 		if ($convertedDB === $converted)

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1714,7 +1714,7 @@ class JoomlaInstallerScript
 		}
 
 		// Nothing to do, saved conversion status from DB is equal to required
-		if ($convertedDB === $converted)
+		if ($convertedDB == $converted)
 		{
 			return;
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1842,4 +1842,35 @@ class JoomlaInstallerScript
 		// Replace utf8mb4 with utf8
 		return str_replace('utf8mb4', 'utf8', $query);
 	}
+
+	/**
+	 * Trim comment and blank lines out of a query string
+	 *
+	 * @param   string  $query  query string to be trimmed
+	 *
+	 * @return  string  String with leading comment lines removed
+	 *
+	 * @since   3.5
+	 */
+	private function trimQuery($query)
+	{
+		$query = trim($query);
+
+		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
+		{
+			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
+
+			if ($position = strpos($query, $endChars))
+			{
+				$query = trim(substr($query, $position + strlen($endChars)));
+			}
+			else
+			{
+				// If no newline, the rest of the file is a comment, so return an empty string.
+				return '';
+			}
+		}
+
+		return trim($query);
+	}
 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1680,7 +1680,7 @@ class JoomlaInstallerScript
 		// This is only required for MySQL databases
 		$name = $db->getName();
 
-		if (stristr($name, 'mysql') !== false)
+		if (stristr($name, 'mysql') === false)
 		{
 			return;
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1685,6 +1685,42 @@ class JoomlaInstallerScript
 			return;
 		}
 
+		// Check if utf8mb4 is supported and set required conversion status
+		$utf8mb4Support = false;
+
+		if ($this->serverClaimsUtf8mb4Support($name))
+		{
+			$utf8mb4Support = true;
+			$converted = 2;
+		}
+		else
+		{
+			$converted = 1;
+		}
+
+		// Check conversion status in database
+		$db->setQuery('SELECT ' . $db->quoteName('converted')
+			. ' FROM ' . $db->quoteName('#__utf8_conversion');
+
+		try
+		{
+			$db->execute();
+		}
+		catch (Exception $e)
+		{
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return;
+		}
+
+		$convertedDB = $db->loadResult();
+
+		// Nothing to do, saved conversion status from DB is equal to required
+		if ($convertedDB === $converted)
+		{
+			return;
+		}
+
 		// Step 1: Drop indexes later to be added again with column lengths limitations at step 2
 		$fileName1 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/mysql/utf8mb4-conversion-01.sql";
 
@@ -1711,18 +1747,6 @@ class JoomlaInstallerScript
 
 		// Step 2: Perform the index modifications and conversions
 		$fileName2 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql";
-
-		$utf8mb4Support = false;
-
-		if ($this->serverClaimsUtf8mb4Support($name))
-		{
-			$utf8mb4Support = true;
-			$converted = 2;
-		}
-		else
-		{
-			$converted = 1;
-		}
 
 		if (is_file($fileName2))
 		{

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -9,6 +9,6 @@
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
   `converted` tinyint(4) NOT NULL DEFAULT 0
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;
 
 INSERT INTO `#__utf8_conversion` (`converted`) VALUES (0);

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -1,4 +1,4 @@
-; Joomla! Project
+﻿; Joomla! Project
 ; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
@@ -153,6 +153,7 @@ JLIB_DATABASE_ERROR_CLASS_NOT_FOUND_IN_FILE="Table class %s not found in file."
 JLIB_DATABASE_ERROR_CONNECT_DATABASE="Unable to connect to the Database: %s"
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE_CONNECT="Could not connect to database."
+JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED="MySQL Database Upgrade failed. Please check the Database Fixer"
 JLIB_DATABASE_ERROR_DELETE_CATEGORY="Left-Right data inconsistency. Can't delete category."
 JLIB_DATABASE_ERROR_DELETE_FAILED="%s: :delete failed - %s"
 JLIB_DATABASE_ERROR_DELETE_ROOT_CATEGORIES="Root categories can't be deleted."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -1,4 +1,4 @@
-; Joomla! Project
+﻿; Joomla! Project
 ; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
@@ -153,6 +153,7 @@ JLIB_DATABASE_ERROR_CLASS_NOT_FOUND_IN_FILE="Table class %s not found in file."
 JLIB_DATABASE_ERROR_CONNECT_DATABASE="Unable to connect to the Database: %s"
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE_CONNECT="Could not connect to database."
+JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED="MySQL Database Upgrade failed. Please check the Database Fixer"
 JLIB_DATABASE_ERROR_DELETE_CATEGORY="Left-Right data inconsistency. Can't delete category."
 JLIB_DATABASE_ERROR_DELETE_FAILED="%s: :delete failed - %s"
 JLIB_DATABASE_ERROR_DELETE_ROOT_CATEGORIES="Root categories can't be deleted."


### PR DESCRIPTION
#### Summary of Changes

Adds the utf8mb4 conversion in the Joomla Update process (and also incidentally extension manager update)
#### Testing Instructions

Attempt to upgrade from Joomla 3.4.8 to this package [http://gwilson.org/Joomla_3.5.0-beta3-Beta-Update_Package.zip] through either Joomla Update (by setting the update stream to testing and the zip in your `tmp` folder (alternatively if you are hitting the SSL Certificate Error set the update stream to custom with the following URL: http://gwilson.org/list_test_pr9297.xml ), or the extension manager (by installing it like any regular extension). The Utf8Mb4 conversion should now take place automatically without you needing to use the database fixer tool.
