### PR TITLE
Doc to support correct type hinting in IDE for JDate::modify()

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @method  JDate|bool  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object.
  * @method  JDate|bool  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object.
- * @method  JDate|bool  modify(string $modify)       Alter the timestamp of this object by incrementing/decrementing in a format accepted by strtotime().
+ * @method  JDate|bool  modify(string $modify)       Alter the timestamp of this object by incre/decre-menting in a format accepted by strtotime().
  *
  * @property-read  string   $daysinmonth   t - Number of days in the given month.
  * @property-read  string   $dayofweek     N - ISO-8601 numeric representation of the day of the week.

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @method  JDate  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object.
  * @method  JDate  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object.
- * @method  JDate  modify(string $modify)       Alter the timestamp of a JDate object by incrementing or decrementing in a format accepted by strtotime().
+ * @method  JDate  modify(string $modify)       Alter the timestamp of this object by incrementing/decrementing in a format accepted by strtotime().
  *
  * @property-read  string   $daysinmonth   t - Number of days in the given month.
  * @property-read  string   $dayofweek     N - ISO-8601 numeric representation of the day of the week.

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -13,8 +13,9 @@ defined('JPATH_PLATFORM') or die;
  * JDate is a class that stores a date and provides logic to manipulate
  * and render that date in a variety of formats.
  *
- * @method  JDate  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object
- * @method  JDate  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object
+ * @method  JDate  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object.
+ * @method  JDate  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object.
+ * @method  JDate  modify(string $modify)       Alter the timestamp of a JDate object by incrementing or decrementing in a format accepted by strtotime().
  *
  * @property-read  string   $daysinmonth   t - Number of days in the given month.
  * @property-read  string   $dayofweek     N - ISO-8601 numeric representation of the day of the week.

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -13,9 +13,9 @@ defined('JPATH_PLATFORM') or die;
  * JDate is a class that stores a date and provides logic to manipulate
  * and render that date in a variety of formats.
  *
- * @method  JDate  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object.
- * @method  JDate  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object.
- * @method  JDate  modify(string $modify)       Alter the timestamp of this object by incrementing/decrementing in a format accepted by strtotime().
+ * @method  JDate|bool  add(DateInterval $interval)  Adds an amount of days, months, years, hours, minutes and seconds to a JDate object.
+ * @method  JDate|bool  sub(DateInterval $interval)  Subtracts an amount of days, months, years, hours, minutes and seconds from a JDate object.
+ * @method  JDate|bool  modify(string $modify)       Alter the timestamp of this object by incrementing/decrementing in a format accepted by strtotime().
  *
  * @property-read  string   $daysinmonth   t - Number of days in the given month.
  * @property-read  string   $dayofweek     N - ISO-8601 numeric representation of the day of the week.


### PR DESCRIPTION
#### Summary of Changes

This method is a part of the parent class (PHP native `DateTime`) which is type-hinted to return `DateTime`. Marking return type to `JDate` when called as JDate method.
#### Testing Instructions

Only relevant for IDE (such as PHPStorm) users. Check the typehint of the return value from `JDate::modify()`. 
Without this patch it shows `DateTime`
After this patch it will show `JDate`
