### PR TITLE
Bug Fix - Correction for PR #9260 utf8mb4 / utf8 conversion for newly installed Joomla!

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -4,10 +4,7 @@
 -- message about database problem in the database schema view. 
 --
 -- The value of `converted` can be 0 (not converted yet after update),
--- 1 (converted to utf8), 2 (converted to utf8mb4) or 3 (value set on new
--- installation, will be later set to 1 or 2 by the database schema
--- manager according to utf8 support of the database before checking the
--- database)
+-- 1 (converted to utf8), or 2 (converted to utf8mb4).
 --
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -368,13 +368,11 @@ class InstallerModelDatabase extends InstallerModel
 
 		if ($db->hasUTF8mb4Support())
 		{
-			$converted = 2;
 			$creaTabSql = $creaTabSql
 				. ' DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;';
 		}
 		else
 		{
-			$converted = 1;
 			$creaTabSql = $creaTabSql
 				. ' DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;';
 		}
@@ -392,14 +390,6 @@ class InstallerModelDatabase extends InstallerModel
 				. ';')->execute();
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
 				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
-		}
-		elseif ($count == 1)
-		{
-			// Set status after new installation to converted
-			$db->setQuery('UPDATE ' . $db->quoteName('#__utf8_conversion')
-				. ' SET ' . $db->quoteName('converted')
-				. ' = ' . $converted
-				. ' WHERE ' . $db->quoteName('converted') . ' = 3;')->execute();
 		}
 		elseif ($count == 0)
 		{

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -517,6 +517,29 @@ class InstallationModelDatabase extends JModelBase
 			return false;
 		}
 
+		// Get query object for later database access
+		$query = $db->getQuery(true);
+
+		// MySQL only: Attempt to update the table #__utf8_conversion.
+		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		{
+			$query->clear()
+				->update($db->quoteName('#__utf8_conversion'))
+				->set($db->quoteName('converted') . ' = ' . ($db->hasUTF8mb4Support() ? 2 : 1));
+			$db->setQuery($query);
+
+			try
+			{
+				$db->execute();
+			}
+			catch (RuntimeException $e)
+			{
+				$app->enqueueMessage($e->getMessage(), 'notice');
+
+				return false;
+			}
+		}
+
 		// Attempt to update the table #__schema.
 		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
 
@@ -552,7 +575,7 @@ class InstallationModelDatabase extends JModelBase
 			}
 		}
 
-		$query = $db->getQuery(true)
+		$query->clear()
 			->insert($db->quoteName('#__schemas'))
 			->columns(
 				array(

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -521,7 +521,9 @@ class InstallationModelDatabase extends JModelBase
 		$query = $db->getQuery(true);
 
 		// MySQL only: Attempt to update the table #__utf8_conversion.
-		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		$serverType = $db->getServerType();
+
+		if ($serverType === 'mysql')
 		{
 			$query->clear()
 				->update($db->quoteName('#__utf8_conversion'))

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1959,10 +1959,9 @@ CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
 
 --
 -- Dumping data for table `#__utf8_conversion`
--- - the `converted`=3 means table just created with a new installation
 --
 
-INSERT INTO `#__utf8_conversion` (`converted`) VALUES (3);
+INSERT INTO `#__utf8_conversion` (`converted`) VALUES (0);
 
 --
 -- Table structure for table `#__viewlevels`

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -95,7 +95,7 @@ class JSchemaChangeset
 			$tmpSchemaChangeItem->checkQuery = 'SELECT '
 				. $this->db->quoteName('converted')
 				. ' FROM ' . $this->db->quoteName('#__utf8_conversion')
-				. ' WHERE ' . $this->db->quoteName('converted') . ' IN (' . $converted . ', 3);';
+				. ' WHERE ' . $this->db->quoteName('converted') . ' = ' . $converted;
 
 			// Set expected records from check query
 			$tmpSchemaChangeItem->checkQueryExpected = 1;


### PR DESCRIPTION
#### Summary of Changes

This PR corrects a mistake I made with PR #9260 for the utf8mb4 / utf8 conversion to detect that it runs on a newly installed Joomla! and so nothing to be converted.

With PR #9260 I decided to initialize the conversion status in database table "#__utf8_conversion" with a value of 3 and later when running the conversion to adjust that to the expected value 1 or 2, depending on utf8mb4 supoort.

But if after a new installation nobody ever goes in the backend to "Extensions -> Manage -> Database -> Fix", and Joomla! is not updasted to a newer version, the status never is set to the final value.

This PR here corrects this by setting the correct conversion status at the end of a new installation.

So the changes to deal with the value 3 from PR #9260 can be undone with this PR here,. too.

This is pre-requisite for a later PR to correct the conversion in case of update and Database -> Fix in order not to run again when it is not necessary anymore by checking the conversion status in database (which without this PR here may still be 3 when migrating to another db server and so not correctly be handeled).
#### Testing Instructions

Hint: Replace "#__" by your db prefix.
1. Perform a new installation with latest staging, the source you can find here: [https://github.com/joomla/joomla-cms/archive/staging.zip](https://github.com/joomla/joomla-cms/archive/staging.zip)
2. Before login at backend, check in your database with e.g. phpMyAdmin the value of column "converted" in table "#__utf8_conversion". Result: Value = 3.
3. Login at backend and go to 'Extensions -> Manage -> Database'. Result: No database problems shown.
4. Press the "Fix" button even if no problems shown.
5. Check again in database the value of column "converted" in table "#__utf8_conversion". Result: Value = 1 if no utf8mb4 support (collations of core tables are uft8_unicode_ci) or 2 if utf8mb4 suport (collations of core tables are uft8mb4_unicode_ci).

Now repeat steps 1 to 3 (4 and 5 are not necessary now) with the branch for this patch.

Source for it is here: [https://github.com/richard67/joomla-cms/archive/correct-utf8mb4-new-install-2.zip](https://github.com/richard67/joomla-cms/archive/correct-utf8mb4-new-install-2.zip)

Result: The final value 1 or 2 of column "converted" in table "#__utf8_conversion" is already set in step 2, step 3 shows also in this test no database problems.
