### PR TITLE
W3C compliance improvement for com_installer

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -105,6 +105,8 @@ JFactory::getDocument()->addStyleDeclaration(
 	'
 );
 
+?>
+
 <div id="installer-install" class="clearfix">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -84,10 +84,11 @@ JFactory::getDocument()->addScriptDeclaration(
 	});
 	'
 );
-?>
-<style type="text/css">
+
+JFactory::getDocument()->addStyleDeclaration(
+	'
 	#loading {
-		background: rgba(255, 255, 255, .8) url('<?php echo JHtml::_('image', 'jui/ajax-loader.gif', '', null, true, true); ?>') 50% 15% no-repeat;
+		background: rgba(255, 255, 255, .8) url(\'' . JHtml::_('image', 'jui/ajax-loader.gif', '', null, true, true) . '\') 50% 15% no-repeat;
 		position: fixed;
 		opacity: 0.8;
 		-ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity = 80);
@@ -101,7 +102,8 @@ JFactory::getDocument()->addScriptDeclaration(
 		line-height: 2em;
 		color:#333333;
 	}
-</style>
+	'
+);
 
 <div id="installer-install" class="clearfix">
 	<?php if (!empty( $this->sidebar)) : ?>


### PR DESCRIPTION
Pull Request for Issue # .
W3C compliance error with com_installer. Testing the page /administrator/index.php?option=com_installer with https://validator.w3.org produces "Error : Error: Element style not allowed as child of element div in this context" (From line 431, column 11; to line 431)
#### Summary of Changes

Use JFactory::getDocument()->addStyleDeclaration() to add the css, instead of adding ccs into the page content with <style type="text/css"> ...</style>
#### Testing Instructions

Re-test the page with https://validator.w3.org
