### PR TITLE
Not run utf8(mb4) conversion on database fix when it is not necessary

### DIFF
--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -274,6 +274,37 @@ class InstallerModelDatabase extends InstallerModel
 			return;
 		}
 
+		// Set required conversion status
+		if ($db->hasUTF8mb4Support())
+		{
+			$converted = 2;
+		}
+		else
+		{
+			$converted = 1;
+		}
+
+		// Check conversion status in database
+		$db->setQuery('SELECT ' . $db->quoteName('converted')
+			. ' FROM ' . $db->quoteName('#__utf8_conversion');
+
+		try
+		{
+			$convertedDB = $db->loadResult();
+		}
+		catch (Exception $e)
+		{
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return;
+		}
+
+		// Nothing to do, saved conversion status from DB is equal to required
+		if ($convertedDB === $converted)
+		{
+			return;
+		}
+
 		// Step 1: Drop indexes later to be added again with column lengths limitations at step 2
 		$fileName1 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/$serverType/utf8mb4-conversion-01.sql";
 
@@ -300,15 +331,6 @@ class InstallerModelDatabase extends InstallerModel
 
 		// Step 2: Perform the index modifications and conversions
 		$fileName2 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/$serverType/utf8mb4-conversion-02.sql";
-
-		if ($db->hasUTF8mb4Support())
-		{
-			$converted = 2;
-		}
-		else
-		{
-			$converted = 1;
-		}
 
 		if (is_file($fileName2))
 		{

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -286,7 +286,7 @@ class InstallerModelDatabase extends InstallerModel
 
 		// Check conversion status in database
 		$db->setQuery('SELECT ' . $db->quoteName('converted')
-			. ' FROM ' . $db->quoteName('#__utf8_conversion');
+			. ' FROM ' . $db->quoteName('#__utf8_conversion'));
 
 		try
 		{
@@ -300,7 +300,7 @@ class InstallerModelDatabase extends InstallerModel
 		}
 
 		// Nothing to do, saved conversion status from DB is equal to required
-		if ($convertedDB === $converted)
+		if ($convertedDB == $converted)
 		{
 			return;
 		}

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -286,7 +286,8 @@ class InstallerModelDatabase extends InstallerModel
 
 		// Check conversion status in database
 		$db->setQuery('SELECT ' . $db->quoteName('converted')
-			. ' FROM ' . $db->quoteName('#__utf8_conversion'));
+			. ' FROM ' . $db->quoteName('#__utf8_conversion')
+			);
 
 		try
 		{


### PR DESCRIPTION
#### Summary of Changes

Currently the conversion to utf8mb4 or utf8 (because of changing standard do unicode sorting in collations) is executed on every run of the database schema fix, i.e. every time when in "Extensions -> Manage -> Database" the "Fix" button is clicked, regardless if there is anything shown to be fixed or not and regardless if the conversionalready has been preformed with success.

This PR changes that so the conversion is only run if the saved conversion status is not equal to what is expected according to the actual utf8mb4 support, which is also the condition to show the conversio to be done as a database problem, so if nothing shown nothing will be done, and if nothing to be done nothing shown.
#### Testing Instructions

Step 1: On a latest staging, edit file "administrator/components/com_installer/models/database.php" and go to the end of function "convertTablesToUtf8mb4". You will see following code as last statement in this function:

> // Set flag in database if the update is done.
>  $db->setQuery('UPDATE ' . $db->quoteName('#__utf8_conversion')
>  . ' SET ' . $db->quoteName('converted') . ' = ' . $converted . ';')->execute();

Below this statement, means at the end of the function as last statement, add followng code:

> JFactory::getApplication()->enqueueMessage('TEST', 'info');

Step 2: Go to "Extentions -> Manage -> Database". There should be no database problems shown.

Step 3: Click the "Fix" button.

Result: At the top an blue info box appears, showing the "TEST" message.

Step 4: Important: Close this info box (x button on top right corner of the message).

Repeat steps 3 and 4 a few times.

Result: Obviously function convertTablesToUtf8mb4 is performed with every click on the "Fix" button.

Step 5: Now apply this patch by replacing the file from edited in step 1 by the same file from this patch.

I am not sure if patchtester will correctly apply the patch after the editing in step 1, but you can try. Otherwise either undo the edit before using the patchtester, or exchange this 1 file "manually".

Step 6: Edit again the file edited in step 1, and again add this "TEST" message code line.

Step 7: Go again to "Extentions -> Manage -> Database", or if still there from previous test steps, refresh the page.

Step 8: Click the "Fix" button.

Result: The blue info message "TEST" does not appear.

Step 9: Execute following statement in sql for the tested database, e.g. in phpMyAdmin:

> UPDATE `#__utf8_conversion` SET `converted`= 0;

(Replace "#__" by your db prefix.)

Step 10: Click the "Fix" button in "Extentions -> Manage -> Database".

Result: The blue info message "TEST" is shown at the top, i.e. if necessary the conversion is still performed with this patch.

At the end remove the hack for the "TEST" message if necessary from the restored file after reverting this patch.
