### PR TITLE
Static method JURI/current changed to JURI/getInstance

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -158,7 +158,7 @@ final class JApplicationSite extends JApplicationCms
 
 				if ($router->getMode() == JROUTER_MODE_SEF)
 				{
-					$document->setBase(htmlspecialchars(JUri::current()));
+					$document->setBase(htmlspecialchars(JUri::getInstance()));
 				}
 
 				// Get the template

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-                        $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
-                        $inputvalue = $temp->format(str_replace('%','',$format));
+                       $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
+                       $inputvalue = $temp->format(str_replace('%','',$format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,7 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-			$inputvalue = strftime($format, strtotime($value));
+            $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
+            $inputvalue = $temp->format(str_replace('%','',$format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-			$temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
-			$inputvalue = $temp->format(str_replace('%','',$format));
+			$temp = DateTime::createFromFormat("Y-m-d H:i:s", $value);
+			$inputvalue = $temp->format(str_replace('%', '', $format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-                       $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
-                       $inputvalue = $temp->format(str_replace('%','',$format));
+			$temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
+			$inputvalue = $temp->format(str_replace('%','',$format));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,7 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-			$temp = DateTime::createFromFormat("Y-m-d H:i:s", $value);
-			$inputvalue = $temp->format(str_replace('%', '', $format));
+			$inputvalue = strftime($format, strtotime($value));
 			date_default_timezone_set($tz);
 		}
 		else

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -979,8 +979,8 @@ abstract class JHtml
 		{
 			$tz = date_default_timezone_get();
 			date_default_timezone_set('UTC');
-            $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
-            $inputvalue = $temp->format(str_replace('%','',$format));
+                        $temp = DateTime::createFromFormat("Y-m-d H:i:s",$value);
+                        $inputvalue = $temp->format(str_replace('%','',$format));
 			date_default_timezone_set($tz);
 		}
 		else


### PR DESCRIPTION
**Summary of Changes**
The 'current()' static method had to be changed as it returned the current request URI without the query parts or params. getInstance() does work for the situation.

**Testing Instructions**
Replace the static method in the codebase. Try editing any module and also set some parameters in dropdown menu's as well as in the text boxes. Now clicking on 'Back to top' link does not redirect to the home page as stated in the issue  #9321 .
