### PR TITLE
User Profile - remove redundant event trigger onContentPrepareData

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -20,6 +20,13 @@ use Joomla\Utilities\ArrayHelper;
 class UsersModelUser extends JModelAdmin
 {
 	/**
+	 * An item.
+	 *
+	 * @var    array
+	 */
+	protected $_item = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
@@ -70,24 +77,27 @@ class UsersModelUser extends JModelAdmin
 	 */
 	public function getItem($pk = null)
 	{
-		$result = parent::getItem($pk);
+		$pk = (!empty($pk)) ? $pk : (int) $this->getState('user.id');
 
-		$context = 'com_users.user';
+		if ($this->_item === null)
+		{
+			$this->_item = array();
+		}
 
-		$result->tags = new JHelperTags;
-		$result->tags->getTagIds($result->id, $context);
+		if (!isset($this->_item[$pk]))
+		{
+			$result = parent::getItem($pk);
 
-		// Get the dispatcher and load the content plugins.
-		$dispatcher = JEventDispatcher::getInstance();
-		JPluginHelper::importPlugin('content');
+			if ($result)
+			{
+				$result->tags = new JHelperTags;
+				$result->tags->getTagIds($result->id, 'com_users.user');
+			}
 
-		// Load the user plugins for backward compatibility (v3.3.3 and earlier).
-		JPluginHelper::importPlugin('user');
+			$this->_item[$pk] = $result;
+		}
 
-		// Trigger the data preparation event.
-		$dispatcher->trigger('onContentPrepareData', array($context, $result));
-
-		return $result;
+		return $this->_item[$pk];
 	}
 
 	/**
@@ -161,9 +171,7 @@ class UsersModelUser extends JModelAdmin
 			$data = $this->getItem();
 		}
 
-		JPluginHelper::importPlugin('user');
-
-		$this->preprocessData('com_users.profile', $data);
+		$this->preprocessData('com_users.profile', $data, 'user');
 
 		return $data;
 	}
@@ -950,7 +958,7 @@ class UsersModelUser extends JModelAdmin
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->qn('#__users'))
-			->where($db->qn('id') . ' = ' . $db->q($user_id));
+			->where($db->qn('id') . ' = ' . (int) $user_id);
 		$db->setQuery($query);
 		$item = $db->loadObject();
 

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -150,20 +150,6 @@ class UsersModelProfile extends JModelForm
 
 			$registry           = new Registry($this->data->params);
 			$this->data->params = $registry->toArray();
-
-			// Get the dispatcher and load the users plugins.
-			$dispatcher = JEventDispatcher::getInstance();
-			JPluginHelper::importPlugin('user');
-
-			// Trigger the data preparation event.
-			$results = $dispatcher->trigger('onContentPrepareData', array('com_users.profile', $this->data));
-
-			// Check for errors encountered while preparing the data.
-			if (count($results) && in_array(false, $results, true))
-			{
-				$this->setError($dispatcher->getError());
-				$this->data = false;
-			}
 		}
 
 		return $this->data;
@@ -194,10 +180,10 @@ class UsersModelProfile extends JModelForm
 
 		// Check for username compliance and parameter set
 		$isUsernameCompliant = true;
+		$username = $loadData ? $form->getValue('username') : $this->loadFormData()->username;
 
-		if ($this->loadFormData()->username)
+		if ($username)
 		{
-			$username = $this->loadFormData()->username;
 			$isUsernameCompliant  = !(preg_match('#[<>"\'%;()&\\\\]|\\.\\./#', $username) || strlen(utf8_decode($username)) < 2
 				|| trim($username) != $username);
 		}
@@ -242,7 +228,7 @@ class UsersModelProfile extends JModelForm
 	{
 		$data = $this->getData();
 
-		$this->preprocessData('com_users.profile', $data);
+		$this->preprocessData('com_users.profile', $data, 'user');
 
 		return $data;
 	}


### PR DESCRIPTION
Explanation per files:
- components/com_users/models/profile.php
  
  Do not call more than once $this->loadFormData() which call `getItem()` and `preprecessData()` each time. `getItem()` should not trigger `onContentPrepareData`. The events should be triggered in `preprocessData()` only.

- administrator/components/com_users/models/user.php
    `getItem()` is call twice in legacy view:
  
  view::get('Item'); 
  view::get('form'); 
  
  so cache it and do not run twice the same code (2 sql queries twice = 4 queries)
  
  Replace `->where($db->qn('id') . ' = ' . $db->q($user_id));`
  to `->where($db->qn('id') . ' = ' . (int) $user_id);` which will be the same as in Juser class. 
  This is for mysql  which can cache the query if it has the same text.

#### Summary of Changes
- Do not trigger `onContentPrepareData` more than once.
- Reduce sql queries.

#### Testing Instructions 1

1) Download and Install the latest Joomla 3 with sample data.
2) Install com_patchtester.zip
3) Enable plugin "User - Profile"
4) Add a few lines in /plugins/user/profile/profile.php.

At the top of method `onContentPrepareData` line ~ 61:

``` php
echo "<p><b>onContentPrepareData<b> was run with context $context from<br><code>";
array_walk(debug_backtrace(false),create_function('$a,$b','echo "{$a[\'function\']}()(".$a[\'file\'].":{$a[\'line\']}); ";'));
echo "</code></p>";
```

and at the top if method `onContentPrepareForm` line ~ 233:

``` php
echo "<p><b>onContentPrepareForm<b> was run from<br><code>";
array_walk(debug_backtrace(false),create_function('$a,$b','echo "{$a[\'function\']}()(".$a[\'file\'].":{$a[\'line\']}); ";'));
echo "</code></p>";
```

This way we can see how many times that methods is run. 

**This PR reduce calls method onContentPrepareData.**

5) Login and go to profile view /index.php?option=com_users&view=profile
You should see:
![user1](https://cloud.githubusercontent.com/assets/9054379/17341996/86449788-58f7-11e6-917e-903f9487a2b4.jpg)

6) Go to edit profile:
![user2](https://cloud.githubusercontent.com/assets/9054379/17342034/a4d427c2-58f7-11e6-810e-f0f4c8bed2c4.jpg)

7) Edit file `/libraries/legacy/controller/legacy.php` and comment line 947 as:

``` php
            //$app->redirect($this->redirect);
```

8) Save your profile and you see:
![user3](https://cloud.githubusercontent.com/assets/9054379/17342177/3b9d9d28-58f8-11e6-9e71-5843a270d64d.jpg)

9) Uncomment line from point 7)

10) Back to  backend to `/administrator/index.php?option=com_patchtester`
Search for 9325 or "User Profile - remove redundant event trigger onContentPrepareData"
Then apply that patch.

11) Go to profile view /index.php?option=com_users&view=profile
You should see now:
![user4](https://cloud.githubusercontent.com/assets/9054379/17342345/1e9acdd0-58f9-11e6-80cc-dd7f45b2f475.jpg)

12) Go to edit profile and you should see:
![user5](https://cloud.githubusercontent.com/assets/9054379/17342410/6940d50a-58f9-11e6-8a5c-670392d81ff2.jpg)

13) Comment line from point 7)

14) Save your profile
![user6](https://cloud.githubusercontent.com/assets/9054379/17342462/ac7cc8e2-58f9-11e6-96b0-94407df46bc4.jpg)
