### PR TITLE
Solves 9326: clean beta 4 install without pre-created database doesn't work

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -854,6 +854,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		if ($utf)
 		{
 			$charset = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
+			$collation = $charset . '_unicode_ci';
 
 			return 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' CHARACTER SET `' . $charset . '` COLLATE `' . $collation . '`';
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9326 .
#### Summary of Changes

Solves https://github.com/joomla/joomla-cms/issues/9326
#### Testing Instructions
1. Use beta 4 or latest staging and proceed with clean joomla install
2. Do step 1 of install
3. Check code difference in this PR and change that file (/libraries/joomla/database/driver.php) before executing step 2 (database) of install.
4. On step 2 of install enter a new database (don't use one that already exists). before this change it wouldn't work, after this change it will work.
