### PR TITLE
Fixes for APC when using APCu, APCu B/C break, enable more cache tests

### DIFF
--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -54,7 +54,8 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			$name = $key['info'];
+			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+			$name = isset($key['info']) ? $key['info'] : $key['key'];
 			$namearr = explode('-', $name);
 
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
@@ -135,9 +136,12 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+
+			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
-				apc_delete($key['info']);
+				apc_delete($internalKey);
 			}
 		}
 
@@ -159,9 +163,12 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-'))
+			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+
+			if (strpos($internalKey, $secret . '-cache-'))
 			{
-				apc_fetch($key['info']);
+				apc_fetch($internalKey);
 			}
 		}
 	}

--- a/libraries/joomla/cache/storage/apcu.php
+++ b/libraries/joomla/cache/storage/apcu.php
@@ -54,7 +54,8 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			$name = $key['info'];
+			// The internal key name changed with APCu 4.0.7 from key to info
+			$name = isset($key['info']) ? $key['info'] : $key['key'];
 			$namearr = explode('-', $name);
 
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
@@ -141,9 +142,12 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			// The internal key name changed with APCu 4.0.7 from key to info
+			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+
+			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
-				apcu_delete($key['info']);
+				apcu_delete($internalKey);
 			}
 		}
 
@@ -165,9 +169,12 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['info'], $secret . '-cache-'))
+			// The internal key name changed with APCu 4.0.7 from key to info
+			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+
+			if (strpos($internalKey, $secret . '-cache-'))
 			{
-				apcu_fetch($key['info']);
+				apcu_fetch($internalKey);
 			}
 		}
 

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMainTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMainTest.php
@@ -70,7 +70,11 @@ class JCacheStorageMainTest extends TestCase
 
 			foreach ($names as $name)
 			{
-				$ret["$name adapter"] = array($name);
+				// Make sure the adapter is not in our blacklist; this means the adapter cannot be tested or there is an internal failure
+				if (!in_array($name, array('redis')))
+				{
+					$ret["$name adapter"] = array($name);
+				}
 			}
 		}
 
@@ -88,8 +92,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheHit($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID';
 		$group = '_testing';
 		$data = 'testData';
@@ -117,8 +119,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheMiss($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID2423423';
 		$group = '_testing';
 		$data = 'testData';
@@ -143,8 +143,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheTimeout($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID';
 		$group = '_testing';
 		$data = 'testData';
@@ -175,8 +173,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheRemove($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID';
 		$group = '_testing';
 		$data = 'testData';
@@ -210,8 +206,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheClearGroup($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID';
 		$group = '_testing';
 		$data = 'testData';
@@ -244,8 +238,6 @@ class JCacheStorageMainTest extends TestCase
 	 */
 	public function testCacheClearNotGroup($store)
 	{
-		$this->checkStore($store);
-
 		$id = 'randomTestID';
 		$group = '_testing';
 		$data = 'testData';
@@ -264,22 +256,5 @@ class JCacheStorageMainTest extends TestCase
 		$new = $cache->get($id, $group);
 		$this->assertSame($new, $data, 'Expected: ' . $data . ' Actual: ' . ((string) $new));
 		unset($cache);
-	}
-
-	/**
-	 * Checks if a store is supported for testing
-	 *
-	 * @param   string  $store  The store.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.4
-	 */
-	private function checkStore($store)
-	{
-		if (in_array($store, array('apc', 'eaccelerator', 'memcached', 'redis', 'xcache')))
-		{
-			$this->markTestSkipped('This storage adapter does not test properly from CLI or is not yet configured for testing.');
-		}
 	}
 }


### PR DESCRIPTION
#### Summary of Changes

Addresses potential issues in the APC & APCu cache drivers when different APCu versions are in use (and depending on PHP configuration this can affect the APC driver even though all fixes are related to the APCu extension).
#### Testing Instructions

I only hit this by fixing various unit test issues that caused many adapters to not be tested, I don't have user level instructions for this.  I can tell you though that if you apply only the patch for the unit test file and run the cache tests if you have the right APCu version installed you can trigger the "undefined index" errors that this fixes.
