### PR TITLE
Make installer handle comments and utf8mb4 downgrade in sql queries from files

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.4.0-2014-09-16.sql
@@ -3,4 +3,4 @@ ALTER TABLE `#__redirect_links` ADD COLUMN `header` smallint(3) NOT NULL DEFAULT
 -- The following statement has to be disabled because it conflicts with
 -- a later change added with Joomla! 3.5.0 for long URLs in this table
 --
---ALTER TABLE `#__redirect_links` MODIFY `new_url` varchar(255);
+-- ALTER TABLE `#__redirect_links` MODIFY `new_url` varchar(255);

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -9,6 +9,6 @@
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
   `converted` tinyint(4) NOT NULL DEFAULT 0
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `#__utf8_conversion` (`converted`) VALUES (0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.4.0-2014-09-16.sql
@@ -3,4 +3,4 @@ ALTER TABLE "#__redirect_links" ADD COLUMN "header" INTEGER DEFAULT 301 NOT NULL
 -- The following statement has to be disabled because it conflicts with
 -- a later change added with Joomla! 3.5.0 for long URLs in this table
 --
---ALTER TABLE "#__redirect_links" ALTER COLUMN "new_url" DROP NOT NULL;
+-- ALTER TABLE "#__redirect_links" ALTER COLUMN "new_url" DROP NOT NULL;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.4.0-2014-09-16.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.4.0-2014-09-16.sql
@@ -3,4 +3,4 @@ ALTER TABLE [#__redirect_links] ADD [header] [smallint] NOT NULL DEFAULT 301;
 -- The following statement has to be disabled because it conflicts with
 -- a later change added with Joomla! 3.5.0 for long URLs in this table
 --
---ALTER TABLE [#__redirect_links] ALTER COLUMN [new_url] [nvarchar](255) NULL;
+-- ALTER TABLE [#__redirect_links] ALTER COLUMN [new_url] [nvarchar](255) NULL;


### PR DESCRIPTION
Pull Request for Issue #9331 , but not only for this.
#### Summary of Changes

This PR makes libraries/cms/installer/installer.php handle correctly comment lines and query downgrade from utf8mb4 to utf8 in sql statements read from schema update files or other sql files.

Because the database driver in use may still be the old one, it has local implementations of functions for this purpose, same as it was done by @wilsonge in his PR #9297 for administrator/components/com_admin/script.php.

**This PR does not solve the problem that after update with Extension Installer, the utf8(mb4) conversion is not done and has to be done using the database "Fix" button.**
#### Testing Instructions

**Update to Beta 5** using one of the following custom URLs for the **Joomla! Update component**, depending on the version to be updated:
- 3.x to 3.5.0-beta5: [https://downloads.joomla.org/updates/cms/test/list_test.xml](https://downloads.joomla.org/updates/cms/test/list_test.xml)
- 2.5.x to 3.5.0-beta5: [https://downloads.joomla.org/updates/cms/test/list_test_25to3x.xml](https://downloads.joomla.org/updates/cms/test/list_test_25to3x.xml)

After successful update, check in log/joomla_update.php the log entry containing the text "update   Ran query from file 3.5.0-2016-02-26". It shows the start of an sql statement beginning with comment lines as follows:

> Query text: -- -- Create a table for UTF-8 Multibyte (utf8mb4) conversion for MySQL in -- or.

Now check "Extensions -> Manage -> Database". It should look as follows:

> Database table structure is up to date. 
> 
> Database schema version (in #__schemas): 3.5.0-2016-03-01.
> Update version (in #__extensions): 3.5.0-beta5.
> Database driver: mysqli.
> 93 database changes were checked successfully.
> 145 database changes did not alter table structure and were skipped.

In case of a MySQL database server not supporting utf8mb4, no SQL error message about invalid character set was shown.

Now repeat the same procedure with following custom URLs for **updating to Beta 5 + this PR with Joomla! Update component**:
- 3.x to 3.5.0-beta5 + this PR: [http://test5.richard-fath.de/list_test1.xml](http://test5.richard-fath.de/list_test1.xml)
- 2.5.x to 3.5.0-beta5 + this PR: [http://test5.richard-fath.de/list_test1_j25.xml](http://test5.richard-fath.de/list_test1_j25.xml)

**Result:**

The logged sql query start with text "Ran query from file 3.5.0-2016-02-26" looks now like following, comment lines have been removed

> Query text: CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (   `converted` tinyint(4) NOT N.

Database structure is up do date as shown for test with unpatched Beta 5.

In case of a MySQL database server not supporting utf8mb4, no SQL error message about invalid character set was shown.

Now test **update to Beta 5 + this PR using the Extension installer**.

The patched package you can find here: [http://test5.richard-fath.de/Joomla_3.5.0-beta5-Beta-Update_Package_test1.zip](http://test5.richard-fath.de/Joomla_3.5.0-beta5-Beta-Update_Package_test1.zip)

After successful update, go to "Extensions -> Manage -> Database".

**Result:**

The utf8mb4 or utf8 conversion is shown as to be done.

Use the "Fix" button to perform the conversion.

**Result:**

Database is up to date as shown above for the tests before.

**Hint on utf8mb4 support: It is NOT supported, if**

database server version is lower than 5.5.3,

or if mysqlnd client, this has a version lower than 5.0.9,

or other database client has version lower than 5.5.3.
