### PR TITLE
Fix broken https initialisation in the Google library

### DIFF
--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -43,7 +43,7 @@ abstract class JGoogleEmbed
 	public function __construct(Registry $options = null, JUri $uri = null)
 	{
 		$this->options = $options ? $options : new Registry;
-		$this->uri = $uri ? $uri : new JUri;
+		$this->uri = $uri ? $uri : JUri::getInstance();
 	}
 
 	/**


### PR DESCRIPTION
If you try to load a google map in https environment, the scheme check fails
#### Summary of Changes

Changed new JUri to JUri::getInstance()
#### Testing Instructions

Build the following script in Joomla!:

``` php
$maps = $google->embed('maps');
$maps->setCenter('Here you should enter a valid address');
$maps->setAutoload();
$maps->setZoom(9);

$maps->echoHeader();
$maps->echoBody();
```

Now call this script with an https request => The map will not be displayed, with http only, it works

=> Apply patch => try again
