### PR TITLE
Link the link in the search results

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -58,7 +58,11 @@ if (!empty($this->query->highlight)
 	<?php endif; ?>
 	<?php if ($this->params->get('show_url', 1)) : ?>
 		<div class="small result-url<?php echo $this->pageclass_sfx; ?>">
-			<?php echo $this->baseUrl, JRoute::_($this->result->route); ?>
+		<?php
+			$link = JRoute::_($this->result->route);
+			$title = $this->baseUrl . $link;
+			echo JHtml::_('link', $link, $title);
+		?>
 		</div>
 	<?php endif; ?>
 </li>


### PR DESCRIPTION
#### Summary of Changes

The search results show a non clickable link, which confuses users
#### Testing Instructions

Create a finder menu link and search, there is a non clickable link at the bottom of every search result. Apply patch => link is clickable
