### PR TITLE
pgpool-II bug with standard_conforming_strings

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -129,7 +129,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			$dsn .= "host={$this->options['host']} ";
 		}
 
-		$dsn .= "dbname={$this->options['database']} user={$this->options['user']} password={$this->options['password']}";
+		$dsn .= "dbname={$this->options['database']} user={$this->options['user']} password={$this->options['password']} options='-c standard_conforming_strings=off'";
 
 		// Attempt to connect to the server.
 		if (!($this->connection = @pg_connect($dsn)))


### PR DESCRIPTION
Pull Request for Issue 8476.
#### Summary of Changes

If you use postgres as db backend for joomla, and there is a pgpool istance in the middle, you will have to deal with this bug:
http://www.sraoss.jp/pipermail/pgpool-general/2013-August/002124.html
#### Testing Instructions
