### PR TITLE
Make JDatabaseDriver::splitSql() handle comments and remove trimSql functions

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1756,25 +1756,22 @@ class JoomlaInstallerScript
 			{
 				foreach ($queries2 as $query2)
 				{
-					if ($trimmedQuery = $this->trimQuery($query2))
+					// Downgrade the query if utf8mb4 isn't supported
+					if (!$utf8mb4Support)
 					{
-						// Downgrade the query if utf8mb4 isn't supported
-						if (!$utf8mb4Support)
-						{
-							$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
-						}
+						$query2 = $this->convertUtf8mb4QueryToUtf8($query2);
+					}
 
-						try
-						{
-							$db->setQuery($trimmedQuery)->execute();
-						}
-						catch (Exception $e)
-						{
-							$converted = 0;
+					try
+					{
+						$db->setQuery($query2)->execute();
+					}
+					catch (Exception $e)
+					{
+						$converted = 0;
 
-							// Still render the error message from the Exception object
-							JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-						}
+						// Still render the error message from the Exception object
+						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 					}
 				}
 			}
@@ -1864,36 +1861,5 @@ class JoomlaInstallerScript
 
 		// Replace utf8mb4 with utf8
 		return str_replace('utf8mb4', 'utf8', $query);
-	}
-
-	/**
-	 * Trim comment and blank lines out of a query string
-	 *
-	 * @param   string  $query  query string to be trimmed
-	 *
-	 * @return  string  String with leading comment lines removed
-	 *
-	 * @since   3.5
-	 */
-	private function trimQuery($query)
-	{
-		$query = trim($query);
-
-		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
-		{
-			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
-
-			if ($position = strpos($query, $endChars))
-			{
-				$query = trim(substr($query, $position + strlen($endChars)));
-			}
-			else
-			{
-				// If no newline, the rest of the file is a comment, so return an empty string.
-				return '';
-			}
-		}
-
-		return trim($query);
 	}
 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1770,8 +1770,8 @@ class JoomlaInstallerScript
 					{
 						$converted = 0;
 
-						// Still render the error message from the Exception object
-						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+						// Show an error message telling to check database problems
+						JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
 					}
 				}
 			}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1770,11 +1770,18 @@ class JoomlaInstallerScript
 					{
 						$converted = 0;
 
-						// Show an error message telling to check database problems
-						JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
+						// Still render the error message from the Exception object
+						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 					}
 				}
 			}
+		}
+
+		// Show if there was some error
+		if ($converted == 0)
+		{
+			// Show an error message telling to check database problems
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
 		}
 
 		// Set flag in database if the update is done.

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -342,19 +342,16 @@ class InstallerModelDatabase extends InstallerModel
 			{
 				foreach ($queries2 as $query2)
 				{
-					if ($trimmedQuery = $this->trimQuery($query2))
+					try
 					{
-						try
-						{
-							$db->setQuery($db->convertUtf8mb4QueryToUtf8($trimmedQuery))->execute();
-						}
-						catch (Exception $e)
-						{
-							$converted = 0;
+						$db->setQuery($db->convertUtf8mb4QueryToUtf8($query2))->execute();
+					}
+					catch (Exception $e)
+					{
+						$converted = 0;
 
-							// Still render the error message from the Exception object
-							JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-						}
+						// Still render the error message from the Exception object
+						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 					}
 				}
 			}
@@ -420,36 +417,5 @@ class InstallerModelDatabase extends InstallerModel
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
 				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
 		}
-	}
-
-	/**
-	 * Trim comment and blank lines out of a query string
-	 *
-	 * @param   string  $query  query string to be trimmed
-	 *
-	 * @return  string  String with leading comment lines removed
-	 *
-	 * @since   3.5
-	 */
-	private function trimQuery($query)
-	{
-		$query = trim($query);
-
-		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
-		{
-			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
-
-			if ($position = strpos($query, $endChars))
-			{
-				$query = trim(substr($query, $position + strlen($endChars)));
-			}
-			else
-			{
-				// If no newline, the rest of the file is a comment, so return an empty string.
-				return '';
-			}
-		}
-
-		return trim($query);
 	}
 }

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -870,25 +870,22 @@ class JInstaller extends JAdapter
 		// Process each query in the $queries array (children of $tagName).
 		foreach ($queries as $query)
 		{
-			if ($trimmedQuery = $this->trimQuery($query->data()))
+			// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
+			if ($doUtf8mb4ToUtf8)
 			{
-				// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-				if ($doUtf8mb4ToUtf8)
-				{
-					$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
-				}
-
-				$db->setQuery($trimmedQuery);
-
-				if (!$db->execute())
-				{
-					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
-
-					return false;
-				}
-
-				$update_count++;
+				$query = $this->convertUtf8mb4QueryToUtf8($query);
 			}
+
+			$db->setQuery($query);
+
+			if (!$db->execute())
+			{
+				JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
+
+				return false;
+			}
+
+			$update_count++;
 		}
 
 		return $update_count;
@@ -974,25 +971,22 @@ class JInstaller extends JAdapter
 				// Process each query in the $queries array (split out of sql file).
 				foreach ($queries as $query)
 				{
-					if ($trimmedQuery = $this->trimQuery($query))
+					// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
+					if ($doUtf8mb4ToUtf8)
 					{
-						// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-						if ($doUtf8mb4ToUtf8)
-						{
-							$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
-						}
-
-						$db->setQuery($trimmedQuery);
-
-						if (!$db->execute())
-						{
-							JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
-
-							return false;
-						}
-
-						$update_count++;
+						$query = $this->convertUtf8mb4QueryToUtf8($query);
 					}
+
+					$db->setQuery($query);
+
+					if (!$db->execute())
+					{
+						JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
+
+						return false;
+					}
+
+					$update_count++;
 				}
 			}
 		}
@@ -1175,31 +1169,28 @@ class JInstaller extends JAdapter
 							// Process each query in the $queries array (split out of sql file).
 							foreach ($queries as $query)
 							{
-								if ($trimmedQuery = $this->trimQuery($query))
+								// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
+								if ($doUtf8mb4ToUtf8)
 								{
-									// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-									if ($doUtf8mb4ToUtf8)
-									{
-										$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
-									}
-
-									$db->setQuery($trimmedQuery);
-
-									if (!$db->execute())
-									{
-										JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
-
-										return false;
-									}
-									else
-									{
-										$queryString = (string) $trimmedQuery;
-										$queryString = str_replace(array("\r", "\n"), array('', ' '), substr($queryString, 0, 80));
-										JLog::add(JText::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), JLog::INFO, 'Update');
-									}
-
-									$update_count++;
+									$query = $this->convertUtf8mb4QueryToUtf8($query);
 								}
+
+								$db->setQuery($query);
+
+								if (!$db->execute())
+								{
+									JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
+
+									return false;
+								}
+								else
+								{
+									$queryString = (string) $query;
+									$queryString = str_replace(array("\r", "\n"), array('', ' '), substr($queryString, 0, 80));
+									JLog::add(JText::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), JLog::INFO, 'Update');
+								}
+
+								$update_count++;
 							}
 						}
 					}
@@ -2484,36 +2475,5 @@ class JInstaller extends JAdapter
 
 		// Replace utf8mb4 with utf8
 		return str_replace('utf8mb4', 'utf8', $query);
-	}
-
-	/**
-	 * Trim comment and blank lines out of a query string
-	 *
-	 * @param   string  $query  query string to be trimmed
-	 *
-	 * @return  string  String with leading comment lines removed
-	 *
-	 * @since   3.5
-	 */
-	private function trimQuery($query)
-	{
-		$query = trim($query);
-
-		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
-		{
-			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
-
-			if ($position = strpos($query, $endChars))
-			{
-				$query = trim(substr($query, $position + strlen($endChars)));
-			}
-			else
-			{
-				// If no newline, the rest of the file is a comment, so return an empty string.
-				return '';
-			}
-		}
-
-		return trim($query);
 	}
 }

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -278,47 +278,13 @@ class JSchemaChangeset
 
 			foreach ($queries as $query)
 			{
-				if ($trimmedQuery = $this->trimQuery($query))
-				{
-					$fileQueries = new stdClass;
-					$fileQueries->file = $file;
-					$fileQueries->updateQuery = $trimmedQuery;
-					$result[] = $fileQueries;
-				}
+				$fileQueries = new stdClass;
+				$fileQueries->file = $file;
+				$fileQueries->updateQuery = $query;
+				$result[] = $fileQueries;
 			}
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Trim comment and blank lines out of a query string
-	 *
-	 * @param   string  $query  query string to be trimmed
-	 *
-	 * @return  string  String with leading comment lines removed
-	 *
-	 * @since   3.1
-	 */
-	private function trimQuery($query)
-	{
-		$query = trim($query);
-
-		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
-		{
-			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
-
-			if ($position = strpos($query, $endChars))
-			{
-				$query = trim(substr($query, $position + strlen($endChars)));
-			}
-			else
-			{
-				// If no newline, the rest of the file is a comment, so return an empty string.
-				return '';
-			}
-		}
-
-		return trim($query);
 	}
 }

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -360,8 +360,8 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			$testEnd = substr($sql, $i, $lenEndString);
 
 			if ($current == '"' || $current == "'" || $current2 == '--' || $current2 == '/*'
-			|| ($current == '#' && $current3 != '#__')
-			|| ($comment && $testEnd == $endString))
+				|| ($current == '#' && $current3 != '#__')
+				|| ($comment && $testEnd == $endString))
 			{
 				// Check if quoted with previous backslash
 				$n = 2;


### PR DESCRIPTION
#### Summary of Changes

This pull request makes JDatabaseDriver::splitSql() strip off comments beginning with "--" or "#" until the end of line and c style comments "/\* ... */" (also inline and multi-line) from the sql statements, trim the query and not return empty queries.

For the c style comments there are exceptions for mysql specials, which will not be stripped off, see [http://dev.mysql.com/doc/refman/5.7/en/comments.html](http://dev.mysql.com/doc/refman/5.7/en/comments.html).

At the moment those specials are allowed regardless of the database kind, but if this is desired I can with a later PR make overrides for the mysql drivers and remove these specials then from base driver here.

In addition this PR removes the local functions trimQuery() and their usage whereever they were recently added to work around the missing handling of comments (except single line "#") of JDatabaseDriver::splitSql().

The handling of comments in sql statements retrieved from sql files (e.g. for schema updates or extensions) is not correct in current staging because it does not respect if comment characters appear in quoted text (and so not are comments). This PR corrects also this.
#### Testing Instructions
##### Overview, preconditions

Because the changed splitSql function and the replacement of the local workarounds (trimSql functions) has impact on any kind of installation action, there are several tests necessary to make sure that all still works well:
1. New installation of Joomla!
2. Updating Joomla! with Joomla! Update component
3. Running Database Schema updates
4. Installing extensions which include sql scripts for updating database
5. Parsing a test sql script with all handled kinds of comments

All tests should be done for all supported kinds of databases, and in case of mysql databases also old without and new with utf8mb4 support.

Hint on utf8mb4 support of mysql: It is NOT supported, if database server version is lower than 5.5.3, or if mysqlnd client used with a version lower than 5.0.9, or if other database client used with a version lower than 5.5.3.
##### Test 1: New installation of Joomla!

Perform a new installation of Joomla! using the latest staging + this PR as installation source.

You can find it here: [https://github.com/richard67/joomla-cms/archive/correct-split-sql-in-db-driver.zip](https://github.com/richard67/joomla-cms/archive/correct-split-sql-in-db-driver.zip).

Verify that all worked well and all Joomla! database tables have been created, and the database is shown as updated and having no problems in "Extensions -> Manager -> Database":
- Database is up to date
- 93 changes checked
- 145 changes skipped
##### Test 2: Updating Joomla! with Joomla! Update component

Before you update, make an export of your database so you can later use it in Test 3.

Set "Custom URL" as test channel in the update component's options and enter following as custom URL:
- For updating a 3.x <= 3.4.8: [http://test5.richard-fath.de/list_test1.xml](http://test5.richard-fath.de/list_test1.xml)
- For updating a 2.5: [http://test5.richard-fath.de/list_test1_j25.xml](http://test5.richard-fath.de/list_test1_j25.xml)

Start the update and wait until it has finished.

Verify that all worked well and the database is shown as updated and having no problems in "Extensions -> Manager -> Database":
- Database is up to date
- 93 changes checked
- 145 changes skipped
##### Test 3: Running Database Schema updates

After having made the previous Test 2, delete all database tables with and restored the old pre-update database using the export file made at the beginning of Test 2.

Goto "Extensions -> Manager -> Database" and verify that updated according to the version you have saved the old data from are shown as to be done, and also the utf8mb4 or utf8 conversion is shown as to be done as the last open problem.

Click the "Fix" button.

Result:
- Database is up to date
- 93 changes checked
- 145 changes skipped
##### Test 4: Installing extensions which include sql scripts for updating database

With either the new installed 3.5.0 latest staging + this patch from Test 1 or the updated one from Test 2, verify that installing extensions works still well.

An example with an sql script containing a hashtag comment and a column with default value '#fff' can be found here: [http://test5.richard-fath.de/sampleerror.zip](http://test5.richard-fath.de/sampleerror.zip). This file was once provided with issue #9251 and installs a table `#__bla` (replace `#__` by your db prefix) if all goes well. If you use this example, check after installation that column `bla` of this new table has a default value of '#fff', so the '#' has not been stripped off by the splitSql function.
##### Test 5: Parsing the test sql script.

If you have no 3.5.0 latest staging + this patch available from the previous tests 1 and 2, apply this patch on latest staging or a 3.5.0 RC.

Download following test script and store it on a location on your server which is accessibly for Joomla!:
- For mysql: [http://test5.richard-fath.de/test_pr9369_mysql.sql](http://test5.richard-fath.de/test_pr9369_mysql.sql)
- For postgresql: [http://test5.richard-fath.de/test_pr9369_postgresql.sql](http://test5.richard-fath.de/test_pr9369_postgresql.sql)
- For sqlsrv/sqlazure: [http://test5.richard-fath.de/test_pr9369_sqlazure.sql](http://test5.richard-fath.de/test_pr9369_sqlazure.sql)

Add following code snippet below the body tag in the index.php of your site template (e.g. protostar).

> <?php
> $buffer = file_get_contents('/FULL_PATH_TO_THE_FOLDER_WITH_THE_TEST_SQL_SCRIPT/test_pr9369_mysql.sql');
> $statements = JDatabaseDriver::splitSql($buffer);
> foreach ($statements as $statement)
> {
>     echo $statement . '<br />';
> }
> echo '<br />';
> ?>

Replace the path by the path where you stored the test sql script, and in case of non-mysql db, change db type in the file name.

Now go to your site and verify that the sql statements have been correctly extracted from the sql script, removing all comments "--" and "#" for complete lines and for parts until line end.

The output should look as follows on mysql and similar on the other databases:

> ALTER TABLE `#__test_table_1` ADD COLUMN `header1` smallint(3) NOT NULL DEFAULT 1;
> ALTER TABLE `#__test_table_2` ADD COLUMN `header2` smallint(3) NOT NULL DEFAULT 2;
> ALTER TABLE `#__test_table_3` ADD COLUMN `header3` smallint(3) NOT NULL DEFAULT 3;
> ALTER TABLE `#__test_table_4` ADD COLUMN `header4` smallint(3) NOT NULL DEFAULT 4;
> ALTER TABLE `#__test_table_5` ADD COLUMN `header5` smallint(3) NOT NULL DEFAULT 5;
> ALTER TABLE /*! test special 1 */ `#__test_table_6` ADD COLUMN `header6` smallint(3) NOT NULL DEFAULT 6;
> ALTER TABLE /*\+ test special 2 */ `#__test_table_7` ADD COLUMN `header7` smallint(3) NOT NULL DEFAULT 7;
> CREATE TABLE IF NOT EXISTS `#__test_table_8` ( `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Primary Key', `name` varchar(50) NOT NULL COMMENT 'The unique name for the asset.', `title` varchar(100) NOT NULL COMMENT 'The descriptive title for the asset.', `rules` varchar(5120) NOT NULL COMMENT 'JSON encoded access control.', PRIMARY KEY (`id`), UNIQUE KEY `idx_asset_name` (`name`) KEY `idx_lft_rgt` (`lft`,`rgt`), KEY `idx_parent_id` (`parent_id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
> UPDATE `#__test_table_9` SET `textcol9` = 'Single quoted text "x" \n # dada /* no comment */ -- yeah ';
> UPDATE `#__test_table_10` SET `textcol10` = "Double quoted text 'x' \n # dada /* no comment */ -- yeah ";

Names should be properly quoted (not shown properly here because name quotes are used here as markup).

You will see in my sql that I did not end the file with a new line and the last statement not with a semicolon.

This is compatible to the old behavior.

You can play around with adding the semicolon or the newline or both, the statements shown by the test should still be the same (all end with a semicolon).

You can also use the test sql script and the code snippet on an unpatched 3.5.0 RC or staging and see that the output of queries shows a mess which will very likely cause SQL syntax errors.
