### PR TITLE
ModulesViewModules::$filterForm error after session timeout #9368

### DIFF
--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -59,6 +59,20 @@ class ModulesController extends JControllerLegacy
 
 		require_once JPATH_COMPONENT . '/helpers/modules.php';
 
+		$layout = $this->input->get('layout', 'edit');
+		$id     = $this->input->getInt('id');
+
+		// Check for edit form.
+		if ($layout == 'edit' && !$this->checkEditId('com_modules.edit.module', $id))
+		{
+			// Somehow the person just went to the form - we don't allow that.
+			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
+			$this->setMessage($this->getError(), 'error');
+			$this->setRedirect(JRoute::_('index.php?option=com_modules&view=modules', false));
+
+			return false;
+		}
+
 		// Load the submenu.
 		ModulesHelper::addSubmenu($this->input->get('view', 'modules'));
 

--- a/administrator/components/com_modules/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_modules/layouts/joomla/searchtools/default.php
@@ -36,5 +36,10 @@ $doc->addStyleDeclaration("
 // Menutype filter doesn't have to activate the filter bar
 unset($data['view']->activeFilters['client_id']);
 
+$layout = JFactory::getApplication()->input->getCmd('layout');
+
 // Display the main joomla layout
-echo JLayoutHelper::render('joomla.searchtools.default', $data, null, array('component' => 'none'));
+if (($layout != 'edit'))
+{
+	echo JLayoutHelper::render('joomla.searchtools.default', $data, null, array('component' => 'none'));
+}

--- a/administrator/components/com_modules/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_modules/layouts/joomla/searchtools/default.php
@@ -36,10 +36,5 @@ $doc->addStyleDeclaration("
 // Menutype filter doesn't have to activate the filter bar
 unset($data['view']->activeFilters['client_id']);
 
-$layout = JFactory::getApplication()->input->getCmd('layout');
-
 // Display the main joomla layout
-if (($layout != 'edit'))
-{
-	echo JLayoutHelper::render('joomla.searchtools.default', $data, null, array('component' => 'none'));
-}
+echo JLayoutHelper::render('joomla.searchtools.default', $data, null, array('component' => 'none'));

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -49,10 +49,7 @@ class ModulesViewModules extends JViewLegacy
 			return false;
 		}
 
-		if ($this->getLayout() == 'default')
-		{
-			$this->addToolbar();
-		}
+		$this->addToolbar();
 
 		// Include the component HTML helpers.
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');


### PR DESCRIPTION
Pull Request for Issue ##9368
#### Steps to reproduce the issue
##### UPDATED TEST INSTRUCTIONS:

Simply copy and paste the following:
http://example.com/administrator/index.php?option=com_modules&layout=edit&id=27
Obviously changing example.com and 27 to a module ID that exists for you

Thanks @C-Lodder 
#### Expected result

The admin console should open on the modules page.
#### Actual result

Notice: Undefined property: ModulesViewModules::$filterForm in E:\wamp\www\MyWork_3_5\administrator\components\com_modules\layouts\joomla\searchtools\default\bar.php on line 17
Fatal error: Call to a member function getField() on a non-object in E:\wamp\www\MyWork_3_5\administrator\components\com_modules\layouts\joomla\searchtools\default\bar.php on line 17
#### Testing

Apply patch and redo
