### PR TITLE
Module Popular Tags is not working properly #9351

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -73,17 +73,6 @@ abstract class ModTagsPopularHelper
 		$query->join('INNER', $db->quoteName('#__tags', 't') . ' ON ' . $db->quoteName('tag_id') . ' = t.id')
 		->join('INNER', $db->qn('#__ucm_content', 'c') . ' ON ' . $db->qn('m.core_content_id') . ' = ' . $db->qn('c.core_content_id'));
 
-		if ($order_value == 'rand()')
-		{
-			$query->order($query->Rand());
-		}
-		else
-		{
-			$order_value     = $db->quoteName($order_value);
-			$order_direction = $params->get('order_direction', 1) ? 'DESC' : 'ASC';
-			$query->order($order_value . ' ' . $order_direction);
-		}
-
 		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));
 
 		// Only return tags connected to published articles
@@ -92,6 +81,40 @@ abstract class ModTagsPopularHelper
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $db->quote($nowDate) . ')')
 			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate
 				. ' OR  ' . $db->quoteName('c.core_publish_down') . ' >= ' . $db->quote($nowDate) . ')');
+
+		// Set query depending on order_value param
+		if ($order_value == 'rand()')
+		{
+			$query->order($query->Rand());
+		}
+		else
+		{
+			$order_value     = $db->quoteName($order_value);
+			$order_direction = $params->get('order_direction', 1) ? 'DESC' : 'ASC';
+
+			if ($params->get('order_value', 'title') == 'title')
+			{
+				$query->setLimit($maximum);
+				$query->order('count DESC');
+				$equery = $db->getQuery(true)
+				->select(
+					array(
+						'a.tag_id',
+						'a.count',
+						'a.title',
+						'a.access',
+						'a.alias')
+						)
+				->from('(' . (string) $query . ') AS a')
+				->order('a.title' . ' ' . $order_direction);
+				$query = $equery;
+			}
+			else
+			{
+				$query->order($order_value . ' ' . $order_direction);
+			}
+		}
+
 		$db->setQuery($query, 0, $maximum);
 
 		try

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -97,16 +97,18 @@ abstract class ModTagsPopularHelper
 				$query->setLimit($maximum);
 				$query->order('count DESC');
 				$equery = $db->getQuery(true)
-				->select(
-					array(
-						'a.tag_id',
-						'a.count',
-						'a.title',
-						'a.access',
-						'a.alias')
+					->select(
+						array(
+							'a.tag_id',
+							'a.count',
+							'a.title',
+							'a.access',
+							'a.alias',
 						)
-				->from('(' . (string) $query . ') AS a')
-				->order('a.title' . ' ' . $order_direction);
+					)
+					->from('(' . (string) $query . ') AS a')
+					->order('a.title' . ' ' . $order_direction);
+
 				$query = $equery;
 			}
 			else


### PR DESCRIPTION
Pull Request for Issue #9351  .
#### Summary of Changes

`queryA = current query`
`if order = title`
`select a.tag_id, a.count, a.title, a.access, a.alias from (queryA) A order by a.title DESC`
#### Testing Instructions

settings: order = title

https://github.com/joomla/joomla-cms/issues/9351#issuecomment-194477650

example:

> tag | count
> fauna | 5
> flora | 4
> nature | 2
> oceans | 30
> 
> In module we want to see 3 most popular item, sorting by title.
> 
> Expecting:
> fauna, flora, oceans ("slice" 3 most popular, and then sort by the title)
> 
> Actual Result:
> 
> fauna, flora, nature (sort by title, and then slice 3). MOST POPULAR TAG ON THE SITE "OCEANS" NOT SHOWING!
