### PR TITLE
FIX #9363 Tooltips not visible in batch modal

### DIFF
--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
 
 JFactory::getDocument()->addScriptDeclaration(
 	'


### PR DESCRIPTION
Pull Request for Issue #9363 .
#### Summary of Changes

Fix tooltips not visible in batch modal, Joomla 3.5.0-RC
Set tooltip container to <code>.modal</code>
#### Testing Instructions

Select some items (articles), and click on <code>Batch</code> button and test top tooltip.
See #9363 for more details if needed (screenshot)
