### PR TITLE
Can't Create User in User Manager with PDO MySQL

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -217,6 +217,12 @@ class JTableUser extends JTable
 			$this->lastvisitDate = $this->_db->getNullDate();
 		}
 
+		// Set the lastResetTime timestamp
+		if (empty($this->lastResetTime))
+		{
+			$this->lastResetTime = $this->_db->getNullDate();
+		}
+
 		// Check for existing username
 		$query = $this->_db->getQuery(true)
 			->select($this->_db->quoteName('id'))


### PR DESCRIPTION
#### Summary of Changes

Creating a user with PDO MySQL will fail because of an invalid default value for the `lastResetTime` column.
#### Testing Instructions

With the MySQL PDO database driver, in the User Manager attempt to create a new user.  Saving should fail with a SQL error because of an invalid value for the `lastResetTime` column.  With patch applied it should work.
