### PR TITLE
Promote the use of HTTPS

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -51,7 +51,7 @@ JFactory::getDocument()->addScriptDeclaration(
 		var form = document.getElementById("adminForm");
 
 		// do field validation
-		if (form.install_url.value == "" || form.install_url.value == "http://") {
+		if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
 			alert("' . JText::_('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL', true) . '");
 		}
 		else
@@ -165,7 +165,7 @@ JFactory::getDocument()->addScriptDeclaration(
 					<div class="control-group">
 						<label for="install_url" class="control-label"><?php echo JText::_('COM_INSTALLER_INSTALL_URL'); ?></label>
 						<div class="controls">
-							<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" value="http://" />
+							<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" value="https://" />
 						</div>
 					</div>
 					<div class="form-actions">

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -49,7 +49,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		var form = document.getElementById('adminForm');
 
 		// do field validation
-		if (form.install_url.value == '' || form.install_url.value == 'http://'){
+		if (form.install_url.value == '' || form.install_url.value == 'http://' || form.install_url.value == 'https://'){
 			alert('" . JText::_('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL', true) . "');
 		}
 		else
@@ -110,7 +110,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		<fieldset class="uploadform">
 			<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_URL'); ?></legend>
 			<label for="install_url"><?php echo JText::_('COM_INSTALLER_INSTALL_URL'); ?></label>
-			<input type="text" id="install_url" name="install_url" class="input_box" size="70" value="http://" />
+			<input type="text" id="install_url" name="install_url" class="input_box" size="70" value="https://" />
 			<input type="button" class="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton4()" />
 		</fieldset>
 


### PR DESCRIPTION
#### Summary of Changes

Simple PR for in com_installer install from URL the value by default be "https://" instead of "http://"

![image](https://cloud.githubusercontent.com/assets/9630530/13723581/63037c28-e861-11e5-936c-ebda7088366a.png)
#### Testing Instructions
1. Use joomla latest staging
2. Go to Extensions install from URL. The default value is "http://". Press install, you'll get a message to enter a URL.
3. Apply this patch
4. Go to Extensions install from URL. The default value is "https://". Press install, you'll also get a message to enter a URL.
#### Observations

This, as other PR, that will come in the future is to promote the use o HTTPS across all joomla code.
