### PR TITLE
Missing class ul tag

### DIFF
--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -15,7 +15,6 @@ defined('_JEXEC') or die;
 <?php if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>
 <?php else : ?>
-
 	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $item) : ?>
 	<li><?php $route = new TagsHelperRoute; ?>

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 <?php if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>
 <?php else : ?>
-	<ul>
+	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $item) : ?>
 	<li><?php $route = new TagsHelperRoute; ?>
 		<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -15,6 +15,7 @@ defined('_JEXEC') or die;
 <?php if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>
 <?php else : ?>
+
 	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $item) : ?>
 	<li><?php $route = new TagsHelperRoute; ?>

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <div class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 <?php if ($list) : ?>
 
-	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
+	<ul class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $i => $item) : ?>
 		<li>
 			<?php $item->route = new JHelperRoute; ?>

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 <?php JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php'); ?>
 <div class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 <?php if ($list) : ?>
-
 	<ul class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $i => $item) : ?>
 		<li>

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 <?php JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php'); ?>
 <div class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 <?php if ($list) : ?>
+
 	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $i => $item) : ?>
 		<li>

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 <?php JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php'); ?>
 <div class="tagssimilar<?php echo $moduleclass_sfx; ?>">
 <?php if ($list) : ?>
-	<ul>
+	<ul class="tagspopular<?php echo $moduleclass_sfx; ?>">
 	<?php foreach ($list as $i => $item) : ?>
 		<li>
 			<?php $item->route = new JHelperRoute; ?>


### PR DESCRIPTION
Pull Request for Issue #8945  .

#### Summary of Changes
Introduced a new class in the `<ul>` tag of file mod_tags_popular and mod_tags_similar files.
#### Testing Instructions
The tag was a simple `<ul>` tag 
Now its: `<ul class="tagspopular">`