### PR TITLE
[HTTPS] joomla.org uri in version.php

### DIFF
--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -102,7 +102,7 @@ final class JVersion
 	 * @var    string
 	 * @since  3.5
 	 */
-	const URL = '<a href="http://www.joomla.org">Joomla!</a> is Free Software released under the GNU General Public License.';
+	const URL = '<a href="https://www.joomla.org">Joomla!</a> is Free Software released under the GNU General Public License.';
 
 	/**
 	 * Magic getter providing access to constants previously defined as class member vars.


### PR DESCRIPTION
#### Summary of Changes

Simple PR, just `http:` to `https:` in version.php joomla.org URI.
#### Testing Instructions

Check code difference.
