### PR TITLE
FIX "Hide Sidebar" tooltip when already hidden

### DIFF
--- a/layouts/joomla/sidebars/toggle.php
+++ b/layouts/joomla/sidebars/toggle.php
@@ -16,7 +16,6 @@ JText::script('JTOGGLE_SHOW_SIDEBAR');
 <div
 	id="j-toggle-sidebar-button"
 	class="j-toggle-sidebar-button hidden-phone hasTooltip"
-	title="<?php echo JHtml::tooltipText('JTOGGLE_HIDE_SIDEBAR'); ?>"
 	type="button"
 	onclick="toggleSidebar(false); return false;"
 	>


### PR DESCRIPTION
Fix the "Hide Sidebar" tooltip text, after changing page with sidebar already hidden.
#### Summary of Changes

Remove default title attribute (JHtml::tooltipText('JTOGGLE_HIDE_SIDEBAR')) in Toggle layout, as set by template.js
#### Testing Instructions
- Go to Articles (or any admin page where there's the collapsible sidebar).
- Hide the Sidebar (see the tip is now show)
- Go to Categories (or any admin page where there's the collapsible sidebar)
- Sidebar is still closed (expected behavior!) but if you mouseover the sidebar icon, the tooltip text is wrong (see the tip is now hide, but should be Show)
#### Current behavior

Tooltip text is "Hide the sidebar" (but the sidebar is hidden!)
#### Expected behavior

Tooltip text is "Show the sidebar" when sidebar is hidden
#### After Patch

After this patch, it's fixed, and tooltip text is as expected.
