### PR TITLE
There are no updates if a download url is not found

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
@@ -52,7 +52,7 @@ JHtml::script('com_joomlaupdate/default.js', false, true, false);
 
 <form action="index.php" method="post" id="adminForm">
 
-<?php if (is_null($this->updateInfo['object'])) : ?>
+<?php if (is_null($this->updateInfo['object']) || is_null($this->updateInfo['object']->get('downloadurl'))) : ?>
 
 <fieldset>
 	<legend>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9392.
#### Summary of Changes

The https://github.com/joomla/joomla-cms/issues/9392 issue itself, as commented in the issue is not a regression, but joomla update should not find joomla updates if there is no download url.

![image](https://cloud.githubusercontent.com/assets/9630530/13725268/b31f9056-e894-11e5-930c-62b87a70024b.png)
#### Testing Instructions
1. Clean install of this joomla version https://developer.joomla.org/cms-packages/Joomla_3.5.0-beta6-dev-Beta-Full_Package.zip
2. After install go to joomla update
3. In the options switch the core update URL to "Test"
4. You will get an update with the error in the image above
5. Apply patch
6. Go to joomla update and clear the cache: you will get no update.
#### Observations

I'm not sure if this has any other consequence in the joomla update.
So, besides the 2 tests, i ask also for a review of someone that fully understand the joomla update.

@mbabker what do you think?
