### PR TITLE
Find only the real joomla updates for your Joomla Version/php version

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -159,19 +159,19 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			$ret['latest'] = $updateObject->version;
 		}
 
-		// Fetch the full update details from the update details URL.
-		jimport('joomla.updater.update');
-		$update = new JUpdate;
-		$update->loadFromXML($updateObject->detailsurl);
-
 		// Pass the update object.
-		if ($ret['latest'] == JVERSION)
+		$ret['object'] = null;
+
+		if ($ret['latest'] != JVERSION)
 		{
-			$ret['object'] = null;
-		}
-		else
-		{
-			$ret['object'] = $update;
+			// Fetch the full update details from the update details URL.
+			jimport('joomla.updater.update');
+			$update = new JUpdate;
+			$update->loadFromXML($updateObject->detailsurl);
+			if (!is_null($update->get('downloadurl')))
+			{
+				$ret['object'] = $update;
+			}
 		}
 
 		return $ret;


### PR DESCRIPTION
#### Summary of Changes

The https://github.com/joomla/joomla-cms/issues/9392 issue itself, as commented in the issue is not a regression, but joomla update should not find joomla updates if they really doesn't exist.

This happens at least since 3.4.8 (didn't try older versions).

![image](https://cloud.githubusercontent.com/assets/9630530/13725268/b31f9056-e894-11e5-930c-62b87a70024b.png)
#### Testing Instructions
1. Used latest staging (3.5.0-rc)
2. Go to Joomla Update ... Options ... custom URL
   3 Use this URL https://raw.githubusercontent.com/andrepereiradasilva/update.joomla.org/master/www/core/teststs/list_sts.xml
3. Clear cache (Note:probably you have to clear several times.)
4. You will get an update with the error in the image above (or with blank if you have not set php error notices)
5. Apply patch
6. Go to joomla update and clear the cache (Note:probably you have to clear several times.): you will get no update.
#### Observations

After some investigation found that the JUpdate loadFromXml method (https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/updater/update.php#L409) returns always data (a JUpdate object).

Joomla updater component call this method (in https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_joomlaupdate/models/default.php#L165) for checking the updates (reading for instance the updates from this uri: https://update.joomla.org/core/teststs/extension_sts.xml).

Joomla updater doesn't check if there is really updates in the JUpdate object, only check if JUpdate object is not null (in https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_joomlaupdate/views/default/tmpl/default.php#L55).

That means that if even if you set the php minimum version to 9.9.9 in the xml Joomla will find the update and show it in the Joomla update component (but will display this error, because the update for your joomla version doesn't really exist) .

I'm not sure if this has any other consequence in the joomla update. So, besides the 2 tests, i ask also for a review of someone that fully understand the joomla update.

@mbabker i didn't want to mess with the JUpdate loadFromXml (making it return false if there is no updates for instance) because is probably used in many places and maybe with different behaviours.
Do you think this is a reasonable way to resolve this issue?
