### PR TITLE
Changing line 230 on cms.php

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -227,7 +227,7 @@ class JApplicationCms extends JApplicationWeb
 	public function enqueueMessage($msg, $type = 'message')
 	{
 		// Don't add empty messages.
-		if (!strlen($msg))
+		if (!strlen(trim($msg)))
 		{
 			return;
 		}


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Changing line 230 of cms.php to handle non-empty,  blank messages.
#### Testing Instructions

The current code, if (!strlen($msg)) still allows blank messages to be added to the messageQue.  Changing line 230 to, if (!strlen(trim($msg))) removes whitespace before checking the length, insuring that a message full just spaces won't be added,
