### PR TITLE
Fix support for autoloadable model path

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -402,7 +402,7 @@ class JControllerLegacy extends JObject
 			}
 			else
 			{
-				$this->model_prefix = $this->name . 'Model';
+				$this->model_prefix = ucfirst($this->name) . 'Model';
 			}
 		}
 


### PR DESCRIPTION
Currently the "controllers", "models", "tables" etc folder names are used in many components. However we are supposed to start using singular forms "controller", "model", "table" etc so as to support autoloading of these classes.
#### Summary of Changes

The model prefix is being calculated from the controller name which is always in lowercase. This causes evaluating the model prefix as `sampleModel` instead of `SampleModel` assuming component as `com_sample`. This breaks autoload for the model.
#### Testing Instructions

Create a small empty component using "model" as folder name for models. (or rename the "models" folder) and try to get some data from the model like `$this->get('Data');` which should get the data from `SampleModelSample::getData()` and display, ideally!

I created a sample component from [component-creator.com](http://component-creator.com) and modified it for this demo. Use it if you want. See attachment below.

Open the URL: index.php?option=com_sample in your front-end.
#### Result

Without this patch: **Nothing is shown**
After this patch: **You see "Hello Joomla!"**
#### Attachment

[com_sample.zip](https://github.com/joomla/joomla-cms/files/170991/com_sample.zip)
