### PR TITLE
Apply btn-group-yesno class for memcached options

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -97,7 +97,7 @@
 		<field
 			name="memcached_persist"
 			type="radio"
-			class="btn-group"
+			class="btn-group btn-group-yesno"
 			default="1"
 			label="COM_CONFIG_FIELD_MEMCACHE_PERSISTENT_LABEL"
 			description="COM_CONFIG_FIELD_MEMCACHE_PERSISTENT_DESC"
@@ -110,7 +110,7 @@
 		<field
 			name="memcached_compress"
 			type="radio"
-			class="btn-group"
+			class="btn-group btn-group-yesno"
 			default="0"
 			label="COM_CONFIG_FIELD_MEMCACHE_COMPRESSION_LABEL"
 			description="COM_CONFIG_FIELD_MEMCACHE_COMPRESSION_DESC"


### PR DESCRIPTION
#### Summary of Changes

Simple PR that adds the missing class `btn-group-yesno` to the Yes/No Options for the caching option  `memcached`
#### Testing Instructions

first Options.
- see the code and notice that this only adds the missing class

seccond option
- Install a Webseite with memcached cachehandler.
- set memcached as cachehandler.
  see:
  ![memcached_bevor](https://cloud.githubusercontent.com/assets/2596554/13731062/db168638-e960-11e5-80d4-893ff1d5bbd3.png)

-apply the patch
see:
![memcached_fixed](https://cloud.githubusercontent.com/assets/2596554/13731065/e2080d0e-e960-11e5-9c0c-8cae66f879c2.png)
