### PR TITLE
Tweak the finaliseUpgrade step for the manifest change

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -541,52 +541,42 @@ ENDDATA;
 	{
 		$installer = JInstaller::getInstance();
 
-		$installer->setPath('source', JPATH_ROOT);
-		$installer->setPath('extension_root', JPATH_ROOT);
+		$manifest = $installer->isManifest(JPATH_MANIFESTS . '/files/joomla.xml');
 
-		if (!$installer->setupInstall())
+		if ($manifest === false)
 		{
 			$installer->abort(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'));
 
 			return false;
 		}
 
+		$installer->manifest = $manifest;
+
+		$installer->setUpgrade(true);
+		$installer->setOverwrite(true);
+
 		$installer->extension = JTable::getInstance('extension');
 		$installer->extension->load(700);
+
 		$installer->setAdapter($installer->extension->type);
 
-		$manifest = $installer->getManifest();
+		$installer->setPath('manifest', JPATH_MANIFESTS . '/files/joomla.xml');
+		$installer->setPath('source', JPATH_MANIFESTS . '/files');
+		$installer->setPath('extension_root', JPATH_ROOT);
 
 		$manifestPath = JPath::clean($installer->getPath('manifest'));
-		$element = preg_replace('/\.xml/', '', basename($manifestPath));
 
 		// Run the script file.
-		$manifestScript = (string) $manifest->scriptfile;
+		JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
 
-		if ($manifestScript)
-		{
-			$manifestScriptFile = JPATH_ROOT . '/' . $manifestScript;
-
-			if (is_file($manifestScriptFile))
-			{
-				// Load the file.
-				include_once $manifestScriptFile;
-			}
-
-			$classname = 'JoomlaInstallerScript';
-
-			if (class_exists($classname))
-			{
-				$manifestClass = new $classname($this);
-			}
-		}
+		$manifestClass = new JoomlaInstallerScript;
 
 		ob_start();
 		ob_implicit_flush(false);
 
 		if ($manifestClass && method_exists($manifestClass, 'preflight'))
 		{
-			if ($manifestClass->preflight('update', $this) === false)
+			if ($manifestClass->preflight('update', $installer) === false)
 			{
 				$installer->abort(JText::_('JLIB_INSTALLER_ABORT_FILE_INSTALL_CUSTOM_INSTALL_FAILURE'));
 
@@ -622,7 +612,7 @@ ENDDATA;
 		{
 			// Install failed, roll back changes.
 			$installer->abort(
-				JText::sprintf('JLIB_INSTALLER_ABORT_FILE_ROLLBACK', JText::_('JLIB_INSTALLER_UPDATE'), $db->stderr(true))
+				JText::sprintf('JLIB_INSTALLER_ABORT_FILE_ROLLBACK', JText::_('JLIB_INSTALLER_UPDATE'), $e->getMessage())
 			);
 
 			return false;
@@ -646,7 +636,7 @@ ENDDATA;
 			{
 				// Install failed, roll back changes.
 				$installer->abort(
-					JText::sprintf('JLIB_INSTALLER_ABORT_FILE_ROLLBACK', JText::_('JLIB_INSTALLER_UPDATE'), $db->stderr(true))
+					JText::sprintf('JLIB_INSTALLER_ABORT_FILE_ROLLBACK', JText::_('JLIB_INSTALLER_UPDATE'), $row->getError())
 				);
 
 				return false;
@@ -672,7 +662,7 @@ ENDDATA;
 			if (!$row->store())
 			{
 				// Install failed, roll back changes.
-				$installer->abort(JText::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_ROLLBACK', $db->stderr(true)));
+				$installer->abort(JText::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_ROLLBACK', $row->getError()));
 
 				return false;
 			}
@@ -685,20 +675,14 @@ ENDDATA;
 			$installer->pushStep(array('type' => 'extension', 'extension_id' => $row->extension_id));
 		}
 
-		/*
-		 * Let's run the queries for the file.
-		 */
-		if ($manifest->update)
+		$result = $installer->parseSchemaUpdates($manifest->update->schemas, $row->extension_id);
+
+		if ($result === false)
 		{
-			$result = $installer->parseSchemaUpdates($manifest->update->schemas, $row->extension_id);
+			// Install failed, rollback changes.
+			$installer->abort(JText::sprintf('JLIB_INSTALLER_ABORT_FILE_UPDATE_SQL_ERROR', $db->stderr(true)));
 
-			if ($result === false)
-			{
-				// Install failed, rollback changes.
-				$installer->abort(JText::sprintf('JLIB_INSTALLER_ABORT_FILE_UPDATE_SQL_ERROR', $db->stderr(true)));
-
-				return false;
-			}
+			return false;
 		}
 
 		// Start Joomla! 1.6.
@@ -720,23 +704,10 @@ ENDDATA;
 		$msg .= ob_get_contents();
 		ob_end_clean();
 
-		// Lastly, we will copy the manifest file to its appropriate place.
-		$manifest = array();
-		$manifest['src'] = $installer->getPath('manifest');
-		$manifest['dest'] = JPATH_MANIFESTS . '/files/' . basename($installer->getPath('manifest'));
-
-		if (!$installer->copyFiles(array($manifest), true))
-		{
-			// Install failed, rollback changes.
-			$installer->abort(JText::_('JLIB_INSTALLER_ABORT_FILE_INSTALL_COPY_SETUP'));
-
-			return false;
-		}
-
 		// Clobber any possible pending updates.
 		$update = JTable::getInstance('update');
 		$uid = $update->find(
-			array('element' => $element, 'type' => 'file', 'client_id' => '0', 'folder' => '')
+			array('element' => 'joomla', 'type' => 'file', 'client_id' => '0', 'folder' => '')
 		);
 
 		if ($uid)
@@ -750,7 +721,7 @@ ENDDATA;
 
 		if ($manifestClass && method_exists($manifestClass, 'postflight'))
 		{
-			$manifestClass->postflight('update', $this);
+			$manifestClass->postflight('update', $installer);
 		}
 
 		// Append messages.


### PR DESCRIPTION
Pull Request for Issue #9402.
#### Summary of Changes

Fixes upgrade regressions introduced by #9402.  Since the manifest is no longer in the root, the `finaliseUpgrade` step needs to now look for the manifest in the manifests folder.  Also in testing, I got an error at the end of the upgrade which basically read "cannot copy manifest from administrator/manifests/files/joomla.xml to administrator/manifests/files/joomla.xml" so I dumped the step that tries to copy it (at this point we're on the new manifest anyway).
#### Testing Instructions

On a 3.4 or 3.5 install set the custom testing URL to https://www.babdev.com/updates/joomla_list.xml and run the update.
#### Caveats

I did NOT test this in a scenario where someone may have multiple files extensions installed.  That needs to be tested, and if this fails then `finaliseUpgrade()` needs more tweaks (I'm already trying to change the method to be less reliant on the lookup mechanisms and just inject the data in, stay tuned to see if it's needed).
