### PR TITLE
Fix error unable to load renderer class if request params include format  html

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -133,8 +133,10 @@ class PlgContentLoadmodule extends JPlugin
 	{
 		self::$modules[$position] = '';
 		$document = JFactory::getDocument();
+		$defaultType = $document->_type;
 		$document->_type = 'html';
 		$renderer = $document->loadRenderer('module');
+		$document->_type = $defaultType;
 		$modules  = JModuleHelper::getModules($position);
 		$params   = array('style' => $style);
 		ob_start();

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -133,6 +133,7 @@ class PlgContentLoadmodule extends JPlugin
 	{
 		self::$modules[$position] = '';
 		$document = JFactory::getDocument();
+		$document->_type = 'html';
 		$renderer = $document->loadRenderer('module');
 		$modules  = JModuleHelper::getModules($position);
 		$params   = array('style' => $style);


### PR DESCRIPTION
**Summary of Changes**
Add the $_type = "html" before get renderer class to make sure no error "Unable to load renderer class" if url request the return format != html
**Testing Instructions**
I got the error when developing a plugin for calling from com_ajax
