### PR TITLE
Admin "helpers" folder is missing from the Tags manifest - reverts 0eb3431

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.Administrator
+ * @package     Joomla.Administrator	
  * @subpackage  com_admin
  *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
@@ -1494,7 +1494,6 @@ class JoomlaInstallerScript
 			'/libraries/vendor/symfony/yaml/Symfony/Component/Yaml',
 			'/libraries/vendor/symfony/yaml/Symfony/Component',
 			'/libraries/vendor/symfony/yaml/Symfony',
-			'/administrator/components/com_tags/helpers',
 			'/libraries/joomla/document/error',
 			'/libraries/joomla/document/image',
 			'/libraries/joomla/document/json',

--- a/administrator/components/com_tags/tags.xml
+++ b/administrator/components/com_tags/tags.xml
@@ -28,6 +28,7 @@
 			<filename>config.xml</filename>
 			<filename>controller.php</filename>
 			<folder>controllers</folder>
+			<folder>helpers</folder>
 			<folder>models</folder>
 			<folder>views</folder>
 		</files>


### PR DESCRIPTION
Pull Request for Issues related to #9427 . (note, may not be full coverage of all the issues identified in #9427)
#### Summary of Changes

Admin "helpers" folder is missing from the com_tags install manifest
"helpers" Folder was being deleted, remove the delete from administrator/components/com_admin/script.php 

This completes the necessary Reverts from the 0eb3431 changes
#### Testing Instructions

from 3.4.8 Install 3.5.RC2
check if the admin administrator/components/com_tags/helpers folder is missing
update the 3.5.RC2 package with this fix
reattempt update from 3.4.8 to the modified 3.5.RC2
administrator/components/com_tags/helpers folder and files should now exist
