### PR TITLE
Fix for issue #9423 : Change collation of languages.lang_code column

### DIFF
--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
@@ -112,12 +112,14 @@ ALTER TABLE `#__viewlevels` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_uni
 
 --
 -- Step 2.4: Set collation to utf8mb4_bin for formerly utf8_bin collated columns
+-- and for the lang_code column of the languages table
 --
 
 ALTER TABLE `#__banners` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__categories` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__contact_details` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__content` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__languages` MODIFY `lang_code` char(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
 ALTER TABLE `#__menu` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'The SEF alias of the menu item.';
 ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__tags` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1179,7 +1179,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_types` (
 
 CREATE TABLE IF NOT EXISTS `#__languages` (
   `lang_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `lang_code` char(7) NOT NULL,
+  `lang_code` char(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `title` varchar(50) NOT NULL,
   `title_native` varchar(50) NOT NULL,
   `sef` varchar(50) NOT NULL,


### PR DESCRIPTION
Pull Request for parts of issue #9423 .
#### Summary of Changes

This pull request changes the collation of column lang_code in the languages table `#__languages` from utf8mb4_unicode_ci (or utf8_unicode_ci) to utf8mb4_bin or utf8_bin to avoid errors with impossible implicit character set conversion on joining other tables' columns.

Since this is the most likely use case for joins making problems, it should solve issue #9423 mostly.

In discussions there was reported that this worked for all extensions and character set and collations combinations tested there.
#### Testing Instructions

To apply this PR it is not sufficient to apply the patch with patchtester only, it is in addition necessary to change collation of the lang_code column of the languages table. This can be done by forcing the utf8(mb4) conversion to run, which makes also this conversion.

The conversion run can be forced by issuing following SQL statement in phpmyadmin:

> UPDATE `#__utf8_conversion` SET `converted`= 0;

(replace "#__" by your db prefix).

Then goto Extensions -> Manage -> Update and see that the conversion has to be done being reported as open problem.

Use the "Fix" button to run the conversion.

If I did not make any mistake in the conversion sql script, this should not cause any errors. Please check also this.

Then use following sql statement to test a join query:

> SELECT c.*, a.name AS asset_name, l.title AS language_title, u.name AS user_name FROM `#__categories` AS c LEFT JOIN `#__assets` AS a ON a.id = c.asset_id LEFT JOIN `#__languages` AS l ON l.lang_code = c.language LEFT JOIN `#__users` AS u ON u.id = c.created_user_id;

On unpatched 3.5.0 RC 3 this will break with an sql error about invalid implicit character set or collation conversions, with this patch applied and the conversion run it will succeed.

You can try different combinations of collations by modifying character set and collation of column `language`in the `#__categories` table and then doing the above query again.

Also test on a not utf8mb4 capable database that the database fix for doing the conversion works there, too.
