### PR TITLE
Update temlate CSS

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7831,8 +7831,9 @@ td.nowrap.has-context {
 }
 .item-associations li {
 	list-style: none;
-	display: inline-block;
+	display: table-cell;
 	margin: 0 0 3px 0;
+	padding-right: 5px;
 }
 .item-associations li a {
 	color: #ffffff;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1040,8 +1040,9 @@ td.nowrap.has-context {
 
 .item-associations li {
 	list-style: none;
-	display: inline-block;
+	display: table-cell;
 	margin: 0 0 3px 0;
+	padding-right: 5px;
 }
 
 .item-associations li a {


### PR DESCRIPTION
Pull Request for Issue # 9449 (https://github.com/joomla/joomla-cms/pull/9449/commits/dc1cca1c29d2bdfea3c9c25eeaf0eb699c278d39)
## The language icons will be displayed in a column as now, but in the line that saves space, allowing you to display much more items on the screen.

The same in Russian:
Значки языков, будут отображаться не в столбик как сейчас, а в строку, что СУЩЕСТВЕННО экономит пространство, позволяя отобразить намного больше пунктов на экране.

![015](https://cloud.githubusercontent.com/assets/4268737/13824519/089a776a-ebb7-11e5-913e-6644ad2416dc.jpg)
