### PR TITLE
Fix Component + Library installation for PDO driver with strict mode

### DIFF
--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -92,6 +92,21 @@ class BannersTableBanner extends JTable
 			$this->ordering = self::getNextOrder($this->_db->quoteName('catid') . '=' . $this->_db->quote($this->catid) . ' AND state>=0');
 		}
 
+		if (empty($this->publish_up))
+		{
+			$this->publish_up = $this->getDbo()->getNullDate();
+		}
+
+		if (empty($this->publish_down))
+		{
+			$this->publish_down = $this->getDbo()->getNullDate();
+		}
+
+		if (empty($this->modified))
+		{
+			$this->modified = $this->getDbo()->getNullDate();
+		}
+
 		return true;
 	}
 
@@ -178,19 +193,19 @@ class BannersTableBanner extends JTable
 					break;
 				case 2:
 					$date = JFactory::getDate('+1 year ' . date('Y-m-d', strtotime('now')));
-					$this->reset = $this->_db->quote($date->toSql());
+					$this->reset = $date->toSql();
 					break;
 				case 3:
 					$date = JFactory::getDate('+1 month ' . date('Y-m-d', strtotime('now')));
-					$this->reset = $this->_db->quote($date->toSql());
+					$this->reset = $date->toSql();
 					break;
 				case 4:
 					$date = JFactory::getDate('+7 day ' . date('Y-m-d', strtotime('now')));
-					$this->reset = $this->_db->quote($date->toSql());
+					$this->reset = $date->toSql();
 					break;
 				case 5:
 					$date = JFactory::getDate('+1 day ' . date('Y-m-d', strtotime('now')));
-					$this->reset = $this->_db->quote($date->toSql());
+					$this->reset = $date->toSql();
 					break;
 			}
 

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -631,6 +631,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$this->extension->client_id = 1;
 			$this->extension->params    = $this->parent->getParams();
 			$this->extension->custom_data = '';
+			$this->extension->system_data = '';
 		}
 
 		$this->extension->manifest_cache = $this->parent->generateManifestCache();

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -266,6 +266,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 
 		// Custom data
 		$this->extension->custom_data = '';
+		$this->extension->system_data = '';
 
 		// Update the manifest cache for the entry
 		$this->extension->manifest_cache = $this->parent->generateManifestCache();

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -374,6 +374,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 
 			// Custom data
 			$this->extension->custom_data    = '';
+			$this->extension->system_data    = '';
 			$this->extension->manifest_cache = $this->parent->generateManifestCache();
 
 			if (!$this->extension->store())

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -363,6 +363,7 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 
 			// Custom data
 			$this->extension->custom_data = '';
+			$this->extension->system_data = '';
 			$this->extension->params = $this->parent->getParams();
 		}
 


### PR DESCRIPTION
This fixes some of the issues described in https://github.com/joomla/joomla-cms/issues/9447 and the issue described in https://github.com/joomla/joomla-cms/issues/9455

To test try and install a component like weblinks through Extension Manager with the PDO Driver (note that you must apply https://github.com/joomla-extensions/weblinks/commit/ae8e62c1bc222e26269d9bb104e9794db96d00a5 to the weblinks 3.4.1 release for this to work). You must have strict mode enabled to replicate this problem. If you don't have MySql 5.6.6+ (and even in some other cases it's worth doing this) you can emulate the error by setting the sql_mode in pdomydriver file. For that, add, after this line https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/database/driver/pdomysql.php#L149 the following code:

```
static $sqlMode = null;
if (is_null($sqlMode))
{
    $this->connection->query("SET @@SESSION.sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION';");
    $sqlMode = true;
}
```
