### PR TITLE
#9454 - Media manager, image selection with fieldid does not work on Isis

### DIFF
--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -51,7 +51,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				</div>
 			</div>
 			<div class="pull-right">
-				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>((window.parent.jInsertFieldValue) && (window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>')));<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 				<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 					// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 			</div>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -51,7 +51,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				</div>
 			</div>
 			<div class="pull-right">
-				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>((window.parent.jInsertFieldValue) && (window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>')));<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>if(window.parent.jInsertFieldValue)window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');else return true;<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 				<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 					// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 			</div>

--- a/administrator/templates/isis/html/com_media/images/default.php
+++ b/administrator/templates/isis/html/com_media/images/default.php
@@ -59,7 +59,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						</div>
 						<div class="pull-right">
-							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>((window.parent.jInsertFieldValue) && (window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>')));<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>if(window.parent.jInsertFieldValue)window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');else return true;<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 							<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 								// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 						</div>

--- a/administrator/templates/isis/html/com_media/images/default.php
+++ b/administrator/templates/isis/html/com_media/images/default.php
@@ -59,7 +59,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						</div>
 						<div class="pull-right">
-							<button class="btn btn-success button-save-selected" type="button" <?php if (!$this->state->get('field.id')):?>onclick="ImageManager.onok();window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');"<?php endif;?> data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+                            <button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 							<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 								// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 						</div>

--- a/administrator/templates/isis/html/com_media/images/default.php
+++ b/administrator/templates/isis/html/com_media/images/default.php
@@ -59,7 +59,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						</div>
 						<div class="pull-right">
-                            <button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 							<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 								// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 						</div>

--- a/administrator/templates/isis/html/com_media/images/default.php
+++ b/administrator/templates/isis/html/com_media/images/default.php
@@ -59,7 +59,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						</div>
 						<div class="pull-right">
-							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>((window.parent.jInsertFieldValue) && (window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>')));<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 							<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 								// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 						</div>

--- a/templates/protostar/html/com_media/images/default.php
+++ b/templates/protostar/html/com_media/images/default.php
@@ -59,7 +59,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						</div>
 						<div class="pull-right">
-							<button class="btn btn-success button-save-selected" type="button" <?php if (!$this->state->get('field.id')):?>onclick="ImageManager.onok();window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');"<?php endif;?> data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+							<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>if(window.parent.jInsertFieldValue)window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');else return true;<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
 							<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 								// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 						</div>


### PR DESCRIPTION
Pull Request for Issue #9454.
#### Summary of Changes

The original button from media/images fixes the issue in the case I have found.
#### Testing Instructions

Paste the following same code to generate a button to choose an image and fill the name field of a user in administrator/components/com_users/views/user/tmpl/edit.php

Before the patch, in J3.5 RC4, the image can't be inserted in the name field.

After the patch, when you select an image and Insert it, the file name replaces the user name.

```
    $idTag = 'jform_name';
    $remoteUrl = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;asset=com_users&amp;author=' . JFactory::getUser()->id . '&amp;fieldid=' . $idTag;
    $buttonId = $idTag . '_btn';

    JHtml::_('bootstrap.modal');
    $test_control[] = '<a id="' . $buttonId . '" href="#' . $idTag . '_modal" role="button" class="btn" data-toggle="modal" title="' . JText::_('JSELECT') . '">' . JText::_('JSELECT') . '</a>';
    $test_control[] = JHtmlBootstrap::renderModal(
            $idTag . '_modal',
            array(
            'url' => $remoteUrl,
            'title' => JText::_('JSELECT'),
            'height' => '600px', 'width' => '500px')
    );

    echo implode('', $test_control);

    JFactory::getDocument()->addScriptDeclaration("
    window.jInsertFieldValue = function(value, id) {jQuery('#' + id).val(value);};
    window.jModalClose = function() {jQuery('div.modal').modal('hide');};
    ");   
```
