### PR TITLE
Fix index lengths errors on new installation with PDO driver in strict mode

### DIFF
--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-01.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-01.sql
@@ -12,9 +12,17 @@
 -- The file for step 2 will the be processed with reporting exceptions.
 --
 
+ALTER TABLE `#__banners` DROP KEY `idx_metakey_prefix`;
+ALTER TABLE `#__banner_clients` DROP KEY `idx_metakey_prefix`;
+ALTER TABLE `#__categories` DROP KEY `idx_path`;
 ALTER TABLE `#__categories` DROP KEY `idx_alias`;
+ALTER TABLE `#__content_types` DROP KEY `idx_alias`;
+ALTER TABLE `#__finder_links` DROP KEY `idx_title`;
 ALTER TABLE `#__menu` DROP KEY `idx_alias`;
 ALTER TABLE `#__menu` DROP KEY `idx_client_id_parent_id_alias_language`;
 ALTER TABLE `#__redirect_links` DROP KEY `idx_old_url`;
+ALTER TABLE `#__tags` DROP KEY `idx_path`;
 ALTER TABLE `#__tags` DROP KEY `idx_alias`;
 ALTER TABLE `#__ucm_content` DROP KEY `idx_alias`;
+ALTER TABLE `#__ucm_content` DROP KEY `idx_title`;
+ALTER TABLE `#__ucm_content` DROP KEY `idx_content_type`;

--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
@@ -15,24 +15,39 @@
 -- Step 2.1: Limit indexes to first 100 so their max allowed lengths would not get exceeded with utf8mb4
 --
 
+ALTER TABLE `#__banners` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
+ALTER TABLE `#__banner_clients` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
+ALTER TABLE `#__categories` ADD KEY `idx_path` (`path`(100));
 ALTER TABLE `#__categories` ADD KEY `idx_alias` (`alias`(100));
+ALTER TABLE `#__content_types` ADD KEY `idx_alias` (`type_alias`(100));
+ALTER TABLE `#__finder_links` ADD KEY `idx_title` (`title`(100));
 ALTER TABLE `#__menu` ADD KEY `idx_alias` (`alias`(100));
 ALTER TABLE `#__menu` ADD UNIQUE `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(100),`language`);
 ALTER TABLE `#__redirect_links` ADD KEY `idx_old_url` (`old_url`(100));
+ALTER TABLE `#__tags` ADD KEY `idx_path` (`path`(100));
 ALTER TABLE `#__tags` ADD KEY `idx_alias` (`alias`(100));
 ALTER TABLE `#__ucm_content` ADD KEY `idx_alias` (`core_alias`(100));
+ALTER TABLE `#__ucm_content` ADD KEY `idx_title` (`core_title`(100));
+ALTER TABLE `#__ucm_content` ADD KEY `idx_content_type` (`core_type_alias`(100));
 
 --
 -- Step 2.2: Enlarge columns to avoid data loss on later conversion to utf8mb4
 --
 
 ALTER TABLE `#__banners` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__banners` MODIFY `metakey_prefix` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__categories` MODIFY `path` varchar(400) NOT NULL DEFAULT '';
 ALTER TABLE `#__categories` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__content_types` MODIFY `type_alias` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_links` MODIFY `title` varchar(400) DEFAULT NULL;
 ALTER TABLE `#__contact_details` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
 ALTER TABLE `#__content` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
 ALTER TABLE `#__menu` MODIFY `alias` varchar(400) NOT NULL COMMENT 'The SEF alias of the menu item.';
 ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__tags` MODIFY `path` varchar(400) NOT NULL DEFAULT '';
 ALTER TABLE `#__tags` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__ucm_content` MODIFY `core_type_alias` varchar(400) NOT NULL DEFAULT '' COMMENT 'FK to the content types table';
+ALTER TABLE `#__ucm_content` MODIFY `core_title` varchar(400) NOT NULL;
 ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(400) NOT NULL DEFAULT '';
 
 --

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -122,7 +122,7 @@ CREATE TABLE IF NOT EXISTS `#__banners` (
   `metakey` text NOT NULL,
   `params` text NOT NULL,
   `own_prefix` tinyint(1) NOT NULL DEFAULT 0,
-  `metakey_prefix` varchar(255) NOT NULL DEFAULT '',
+  `metakey_prefix` varchar(400) NOT NULL DEFAULT '',
   `purchase_type` tinyint(4) NOT NULL DEFAULT -1,
   `track_clicks` tinyint(4) NOT NULL DEFAULT -1,
   `track_impressions` tinyint(4) NOT NULL DEFAULT -1,
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS `#__banners` (
   PRIMARY KEY (`id`),
   KEY `idx_state` (`state`),
   KEY `idx_own_prefix` (`own_prefix`),
-  KEY `idx_metakey_prefix` (`metakey_prefix`),
+  KEY `idx_metakey_prefix` (`metakey_prefix`(100)),
   KEY `idx_banner_catid` (`catid`),
   KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
@@ -163,13 +163,13 @@ CREATE TABLE IF NOT EXISTS `#__banner_clients` (
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `metakey` text NOT NULL,
   `own_prefix` tinyint(4) NOT NULL DEFAULT 0,
-  `metakey_prefix` varchar(255) NOT NULL DEFAULT '',
+  `metakey_prefix` varchar(400) NOT NULL DEFAULT '',
   `purchase_type` tinyint(4) NOT NULL DEFAULT -1,
   `track_clicks` tinyint(4) NOT NULL DEFAULT -1,
   `track_impressions` tinyint(4) NOT NULL DEFAULT -1,
   PRIMARY KEY (`id`),
   KEY `idx_own_prefix` (`own_prefix`),
-  KEY `idx_metakey_prefix` (`metakey_prefix`)
+  KEY `idx_metakey_prefix` (`metakey_prefix`(100))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -202,7 +202,7 @@ CREATE TABLE IF NOT EXISTS `#__categories` (
   `lft` int(11) NOT NULL DEFAULT 0,
   `rgt` int(11) NOT NULL DEFAULT 0,
   `level` int(10) unsigned NOT NULL DEFAULT 0,
-  `path` varchar(255) NOT NULL DEFAULT '',
+  `path` varchar(400) NOT NULL DEFAULT '',
   `extension` varchar(50) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL,
   `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
@@ -227,7 +227,7 @@ CREATE TABLE IF NOT EXISTS `#__categories` (
   KEY `cat_idx` (`extension`,`published`,`access`),
   KEY `idx_access` (`access`),
   KEY `idx_checkout` (`checked_out`),
-  KEY `idx_path` (`path`),
+  KEY `idx_path` (`path`(100)),
   KEY `idx_left_right` (`lft`,`rgt`),
   KEY `idx_alias` (`alias`(100)),
   KEY `idx_language` (`language`)
@@ -389,14 +389,14 @@ CREATE TABLE IF NOT EXISTS `#__content_rating` (
 CREATE TABLE IF NOT EXISTS `#__content_types` (
   `type_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type_title` varchar(255) NOT NULL DEFAULT '',
-  `type_alias` varchar(255) NOT NULL DEFAULT '',
+  `type_alias` varchar(400) NOT NULL DEFAULT '',
   `table` varchar(255) NOT NULL DEFAULT '',
   `rules` text NOT NULL,
   `field_mappings` text NOT NULL,
   `router` varchar(255) NOT NULL DEFAULT '',
   `content_history_options` varchar(5120) COMMENT 'JSON string for com_contenthistory options',
   PRIMARY KEY (`type_id`),
-  KEY `idx_alias` (`type_alias`)
+  KEY `idx_alias` (`type_alias`(100))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=10000;
 
 --
@@ -653,7 +653,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `url` varchar(255) NOT NULL,
   `route` varchar(255) NOT NULL,
-  `title` varchar(255) DEFAULT NULL,
+  `title` varchar(400) DEFAULT NULL,
   `description` varchar(255) DEFAULT NULL,
   `indexdate` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `md5sum` varchar(32) DEFAULT NULL,
@@ -671,7 +671,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `object` mediumblob NOT NULL,
   PRIMARY KEY (`link_id`),
   KEY `idx_type` (`type_id`),
-  KEY `idx_title` (`title`),
+  KEY `idx_title` (`title`(100)),
   KEY `idx_md5` (`md5sum`),
   KEY `idx_url` (`url`(75)),
   KEY `idx_published_list` (`published`,`state`,`access`,`publish_start_date`,`publish_end_date`,`list_price`),
@@ -1575,7 +1575,7 @@ CREATE TABLE IF NOT EXISTS `#__tags` (
   `lft` int(11) NOT NULL DEFAULT 0,
   `rgt` int(11) NOT NULL DEFAULT 0,
   `level` int(10) unsigned NOT NULL DEFAULT 0,
-  `path` varchar(255) NOT NULL DEFAULT '',
+  `path` varchar(400) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL,
   `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
@@ -1604,7 +1604,7 @@ CREATE TABLE IF NOT EXISTS `#__tags` (
   KEY `tag_idx` (`published`,`access`),
   KEY `idx_access` (`access`),
   KEY `idx_checkout` (`checked_out`),
-  KEY `idx_path` (`path`),
+  KEY `idx_path` (`path`(100)),
   KEY `idx_left_right` (`lft`,`rgt`),
   KEY `idx_alias` (`alias`(100)),
   KEY `idx_language` (`language`)
@@ -1670,8 +1670,8 @@ CREATE TABLE IF NOT EXISTS `#__ucm_base` (
 
 CREATE TABLE IF NOT EXISTS `#__ucm_content` (
   `core_content_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `core_type_alias` varchar(255) NOT NULL DEFAULT '' COMMENT 'FK to the content types table',
-  `core_title` varchar(255) NOT NULL,
+  `core_type_alias` varchar(400) NOT NULL DEFAULT '' COMMENT 'FK to the content types table',
+  `core_title` varchar(400) NOT NULL,
   `core_alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `core_body` mediumtext NOT NULL,
   `core_state` tinyint(1) NOT NULL DEFAULT 0,
@@ -1706,10 +1706,10 @@ CREATE TABLE IF NOT EXISTS `#__ucm_content` (
   KEY `idx_access` (`core_access`),
   KEY `idx_alias` (`core_alias`(100)),
   KEY `idx_language` (`core_language`),
-  KEY `idx_title` (`core_title`),
+  KEY `idx_title` (`core_title`(100)),
   KEY `idx_modified_time` (`core_modified_time`),
   KEY `idx_created_time` (`core_created_time`),
-  KEY `idx_content_type` (`core_type_alias`),
+  KEY `idx_content_type` (`core_type_alias`(100)),
   KEY `idx_core_modified_user_id` (`core_modified_user_id`),
   KEY `idx_core_checked_out_user_id` (`core_checked_out_user_id`),
   KEY `idx_core_created_user_id` (`core_created_user_id`),
@@ -1853,7 +1853,7 @@ INSERT INTO `#__usergroups` (`id`, `parent_id`, `lft`, `rgt`, `title`) VALUES
 
 CREATE TABLE IF NOT EXISTS `#__users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL DEFAULT '',
+  `name` varchar(400) NOT NULL DEFAULT '',
   `username` varchar(150) NOT NULL DEFAULT '',
   `email` varchar(100) NOT NULL DEFAULT '',
   `password` varchar(100) NOT NULL DEFAULT '',
@@ -1869,7 +1869,7 @@ CREATE TABLE IF NOT EXISTS `#__users` (
   `otep` varchar(1000) NOT NULL DEFAULT '' COMMENT 'One time emergency passwords',
   `requireReset` tinyint(4) NOT NULL DEFAULT 0 COMMENT 'Require user to reset password on next login',
   PRIMARY KEY (`id`),
-  KEY `idx_name` (`name`),
+  KEY `idx_name` (`name`(100)),
   KEY `idx_block` (`block`),
   KEY `username` (`username`),
   KEY `email` (`email`)
@@ -1883,7 +1883,7 @@ CREATE TABLE IF NOT EXISTS `#__users` (
 
 CREATE TABLE IF NOT EXISTS `#__user_keys` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `user_id` varchar(255) NOT NULL,
+  `user_id` varchar(400) NOT NULL,
   `token` varchar(255) NOT NULL,
   `series` varchar(191) NOT NULL,
   `invalid` tinyint(4) NOT NULL,
@@ -1893,7 +1893,7 @@ CREATE TABLE IF NOT EXISTS `#__user_keys` (
   UNIQUE KEY `series` (`series`),
   UNIQUE KEY `series_2` (`series`),
   UNIQUE KEY `series_3` (`series`),
-  KEY `user_id` (`user_id`)
+  KEY `user_id` (`user_id`(100))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Pull Request for Issue #9465 .
#### Summary of Changes

It seems there were some index and column modifications forgotten for the utf8mb4 conversion, which fail on create table then when pdomysql (or mysql in general, any driver) is in strict mode but not failed without strict mode.
#### Testing Instructions

**Test 1:** Check if a new installation works without running into the errors described in issue #9465, chosing the PDO driver for mysql on installation and using the branch of this patch as installation source: [https://github.com/richard67/joomla-cms/archive/utf8mb4-forgotten-column-changes-1.zip](https://github.com/richard67/joomla-cms/archive/utf8mb4-forgotten-column-changes-1.zip).

To enforce strict mode, hack the pdomysql.php as described in PR #9461 before starting the installation.

**Test 2:** Test also if the utf8(mb4) conversion still works on the Joomla! just installed with Test 1 before. To enforce the conversion to be performed again, enter following SQL statement in phpMyAdmin:

> UPDATE `#__utf8_conversion` SET `converted` = 0;

(replace `#__` by your db prefix).

Then go to "Extensions -> Manage -> Update".

You should see the conversion to be done reported as open problem.

Click the "Fix" button.

Result: The conversion is performed without errors, after this database is up to date without problems.
