### PR TITLE
Make extension installer handle sql files for utf8mb4 or utf8

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -961,14 +961,14 @@ class JInstaller extends JAdapter
 			{
 				if (!$utf8mb4Found && $utf8Found)
 				{
-					$useCharset == 'utf8';
+					$useCharset = 'utf8';
 				}
 			}
 			else
 			{
 				if (!$utf8Found && $utf8mb4Found)
 				{
-					$useCharset == 'utf8mb4';
+					$useCharset = 'utf8mb4';
 				}
 			}
 		}
@@ -1187,14 +1187,14 @@ class JInstaller extends JAdapter
 					{
 						if (!$utf8mb4Found && $utf8Found)
 						{
-							$useCharset == 'utf8';
+							$useCharset = 'utf8';
 						}
 					}
 					else
 					{
 						if (!$utf8Found && $utf8mb4Found)
 						{
-							$useCharset == 'utf8mb4';
+							$useCharset = 'utf8mb4';
 						}
 					}
 				}

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -948,11 +948,11 @@ class JInstaller extends JAdapter
 
 					if ($fCharset == 'utf8mb4')
 					{
-						utf8mb4Found = true;
+						$utf8mb4Found = true;
 					}
 					elseif ($fCharset == 'utf8')
 					{
-						utf8Found = true;
+						$utf8Found = true;
 					}
 				}
 			}
@@ -1170,11 +1170,11 @@ class JInstaller extends JAdapter
 
 							if ($uCharset == 'utf8mb4')
 							{
-								utf8mb4Found = true;
+								$utf8mb4Found = true;
 							}
 							elseif ($uCharset == 'utf8')
 							{
-								utf8Found = true;
+								$utf8Found = true;
 							}
 						}
 					}

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -957,15 +957,20 @@ class JInstaller extends JAdapter
 				}
 			}
 
-			if ($useCharset == 'utf8' && !$utf8Found && $utf8mb4Found)
+			if ($useCharset == 'utf8mb4')
 			{
-				$useCharset == 'utf8mb4';
+				if (!$utf8mb4Found && $utf8Found)
+				{
+					$useCharset == 'utf8';
+				}
 			}
-			elseif ($useCharset == 'utf8mb4' && !$utf8mb4Found && $utf8Found)
+			else
 			{
-				$useCharset == 'utf8';
+				if (!$utf8Found && $utf8mb4Found)
+				{
+					$useCharset == 'utf8mb4';
+				}
 			}
-
 		}
 
 		$update_count = 0;
@@ -1178,15 +1183,20 @@ class JInstaller extends JAdapter
 						}
 					}
 
-					if ($useCharset == 'utf8' && !$utf8Found && $utf8mb4Found)
+					if ($useCharset == 'utf8mb4')
 					{
-						$useCharset == 'utf8mb4';
+						if (!$utf8mb4Found && $utf8Found)
+						{
+							$useCharset == 'utf8';
+						}
 					}
-					elseif ($useCharset == 'utf8mb4' && !$utf8mb4Found && $utf8Found)
+					else
 					{
-						$useCharset == 'utf8';
+						if (!$utf8Found && $utf8mb4Found)
+						{
+							$useCharset == 'utf8mb4';
+						}
 					}
-
 				}
 
 				$schemapath = '';

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -974,7 +974,6 @@ class JInstaller extends JAdapter
 		foreach ($element->children() as $file)
 		{
 			$fCharset = strtolower($file->attributes()->charset);
-			$fCharset = (strtolower($file->attributes()->charset) == 'utf8') ? 'utf8' : '';
 			$fDriver = strtolower($file->attributes()->driver);
 
 			if ($fDriver == 'mysqli' || $fDriver == 'pdomysql')

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -911,8 +911,10 @@ class JInstaller extends JAdapter
 		$queries = array();
 		$db = & $this->_db;
 		$dbDriver = strtolower($db->name);
+		$dbUtf8mb4Support = $this->serverClaimsUtf8mb4Support($dbDriver);
+		$useCharset = $dbUtf8mb4Support ? 'utf8mb4' : 'utf8';
 
-		$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
+		$doUtf8mb4ToUtf8 = !$dbUtf8mb4Support;
 
 		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 		{
@@ -922,6 +924,48 @@ class JInstaller extends JAdapter
 		if ($dbDriver != 'mysql')
 		{
 			$doUtf8mb4ToUtf8 = false;
+			$useCharset = 'utf8';
+		}
+
+		/*
+		 * For mysql related drivers check first for which of the character sets
+		 * utf8mb4 or utf8 a file is avalibale. If for both, use the appropriate one
+		 * but do query downgrade if neccesary just to be on the safer side, and if
+		 * only one of the 2 is specified, use that one, also with query downgrade.
+		 */
+		if ($dbDriver == 'mysql')
+		{
+			$utf8mb4Found = false;
+			$utf8Found = false;
+
+			foreach ($element->children() as $file1)
+			{
+				$fDriver = strtolower($file1->attributes()->driver);
+
+				if ($fDriver == 'mysql' || $fDriver == 'mysqli' || $fDriver == 'pdomysql')
+				{
+					$fCharset = strtolower($file1->attributes()->charset);
+
+					if ($fCharset == 'utf8mb4')
+					{
+						utf8mb4Found = true;
+					}
+					elseif ($fCharset == 'utf8')
+					{
+						utf8Found = true;
+					}
+				}
+			}
+
+			if ($useCharset == 'utf8' && !$utf8Found && $utf8mb4Found)
+			{
+				$useCharset == 'utf8mb4';
+			}
+			elseif ($useCharset == 'utf8mb4' && !$utf8mb4Found && $utf8Found)
+			{
+				$useCharset == 'utf8';
+			}
+
 		}
 
 		$update_count = 0;
@@ -929,6 +973,7 @@ class JInstaller extends JAdapter
 		// Get the name of the sql file to process
 		foreach ($element->children() as $file)
 		{
+			$fCharset = strtolower($file->attributes()->charset);
 			$fCharset = (strtolower($file->attributes()->charset) == 'utf8') ? 'utf8' : '';
 			$fDriver = strtolower($file->attributes()->driver);
 
@@ -937,7 +982,7 @@ class JInstaller extends JAdapter
 				$fDriver = 'mysql';
 			}
 
-			if ($fCharset == 'utf8' && $fDriver == $dbDriver)
+			if ($fCharset == $useCharset && $fDriver == $dbDriver)
 			{
 				$sqlfile = $this->getPath('extension_root') . '/' . trim($file);
 
@@ -1086,8 +1131,10 @@ class JInstaller extends JAdapter
 			if (count($schemapaths))
 			{
 				$dbDriver = strtolower($db->name);
+				$dbUtf8mb4Support = $this->serverClaimsUtf8mb4Support($dbDriver);
+				$useCharset = $dbUtf8mb4Support ? 'utf8mb4' : 'utf8';
 
-				$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
+				$doUtf8mb4ToUtf8 = !$dbUtf8mb4Support;
 
 				if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 				{
@@ -1097,6 +1144,50 @@ class JInstaller extends JAdapter
 				if ($dbDriver != 'mysql')
 				{
 					$doUtf8mb4ToUtf8 = false;
+					$useCharset = 'utf8';
+				}
+
+				/*
+				 * For mysql related drivers check first for which of the character sets
+				 * utf8mb4 or utf8 a file is avalibale. If for both, use the appropriate one
+				 * but do query downgrade if neccesary just to be on the safer side, and if
+				 * only one of the 2 is specified, use that one, also with query downgrade.
+				 */
+				if ($dbDriver == 'mysql')
+				{
+					$utf8mb4Found = false;
+					$utf8Found = false;
+
+					foreach ($schemapaths as $entry1)
+					{
+						$attrs = $entry1->attributes();
+
+						$uDriver = strtolower($attrs['type']);
+
+						if ($uDriver == 'mysql' || $uDriver == 'mysqli' || $uDriver == 'pdomysql')
+						{
+							$uCharset = isset($attrs['charset']) ? strtolower($attrs['charset']) : 'utf8';
+
+							if ($uCharset == 'utf8mb4')
+							{
+								utf8mb4Found = true;
+							}
+							elseif ($uCharset == 'utf8')
+							{
+								utf8Found = true;
+							}
+						}
+					}
+
+					if ($useCharset == 'utf8' && !$utf8Found && $utf8mb4Found)
+					{
+						$useCharset == 'utf8mb4';
+					}
+					elseif ($useCharset == 'utf8mb4' && !$utf8mb4Found && $utf8Found)
+					{
+						$useCharset == 'utf8';
+					}
+
 				}
 
 				$schemapath = '';
@@ -1113,7 +1204,9 @@ class JInstaller extends JAdapter
 						$uDriver = 'mysql';
 					}
 
-					if ($uDriver == $dbDriver)
+					$uCharset = isset($attrs['charset']) ? strtolower($attrs['charset']) : 'utf8';
+
+					if ($uCharset == $useCharset && $uDriver == $dbDriver)
 					{
 						$schemapath = $entry;
 						break;


### PR DESCRIPTION
#### Summary of Changes

Currently the extension installer accepts for installation and uninstallation sql scripts specified in extensions manifest xml files only the value 'utf8' for the "charset" attribute, and for update sql scripts the "charset" attribute is not used.

Beginning with 3.5.0 Joomla! will support utf8mb4. SQL create table and alter table statements containing "utf8mb4" can be downgraded to "utf8" by the new database driver, so Extension Installers can provide scripts for utf8mb4 only if they want to be installable only on 3.5.0 or later.

But if the same extenions shall be installable also on a pre-3.5.0, it either has to stay with utf8 (no mb4) or provide 2 package versions, one for pre-3.5.0 and one for 3.5.0 and later.

This PR here extends handling of the "charset" atribute for installation and uninstallation sql scripts and adds handling of this atribute for update sql scripts specified in the manifest xml file in following way:

If for mysql related drivers only one file is specified for one of the charsets "utf8mb4" and "utf8", this file will be used, if necessary with query downgrade.

Otherwise, if both files are specified, it will use the one suitable to actual utf8mb4 support by the server and client api combination.

To be on the safer side and also backwards compatible with extensions which already have changed their sql scripts to utf8mb4 but not have changed yet their charset attibute's value to 'utf8mb4' because this will only be supported after this PR here is merged, the qury will be downgraded also if necessary.

So with this PR, extenions developers have the choice to stay with utf8 and provide scripts for utf8 only, or change to utf8mb4 and provide only 1 set of script for this character set, which will not work on pre-3.5.0 with database not supporting utf8mb4, or provide scripts for both, so on a pre-3.5.0 where files with charset attributes different to utf8 were ignored the utf8 scripts will run.

From the schema update scripts, a pre-3.5.0 Joomla! uses the first schema path which can be found for the right servertype, without any charset info. So if the schema path for utf8 is specified as first in the xml manifest, it will also work for non-utf8 databases on a pre-3.5.0.

**Conclusion:** With this PR being implemented, extensions can use the regular mechanisms to be installable/uninstallable/updateable on any Joomla! version and apply only the scrips fot the particular charset for mysql server type, as long as for update schema paths the one for utf8 is specified as 1st, and can also use their schema updates to perform the utf8mb4 conversion.
#### Testing Instructions
##### Test 1: Test new functionality with latest staging + this patch

Apply this patch to a latest staging and then download following packages and install them with Extension Manager "Upload & install package":
- [test_package_utf8-mb4_utf8_v1.0.0.zip](http://test5.richard-fath.de/test_package_utf8-mb4_utf8_v1.0.0.zip)
- [test_package_utf8-mb4_v1.0.0.zip](http://test5.richard-fath.de/test_package_utf8-mb4_v1.0.0.zip)
- [test_package_utf8_v1.0.0.zip](http://test5.richard-fath.de/test_package_utf8_v1.0.0.zip)

Result: All 3 packages can be installed without error.

Now check with phpMyAdmin that each extension has created a table with name = db prefix + extension name:
- `#__test_package_utf8-mb4_utf8`
- `#__test_package_utf8-mb4`
- `#__test_package_utf8`

Verify that these tables all have 1 column `col1` with "..._unicode_ci" and `col2` with "..._bin".

Depending on utf8mb4 support of the database servers, the charset of the table and the columns is as follows:
- `#__test_package_utf8-mb4_utf8`: Either utf8mb4 or utf8
- `#__test_package_utf8-mb4`: Either utf8mb4 or utf8
- `#__test_package_utf8`: utf8

The tables do all not contain any records.

Now install the update packages for these three packages:
- [test_package_utf8-mb4_utf8_v1.0.1.zip](http://test5.richard-fath.de/test_package_utf8-mb4_utf8_v1.0.1.zip)
- [test_package_utf8-mb4_v1.0.1.zip](http://test5.richard-fath.de/test_package_utf8-mb4_v1.0.1.zip)
- [test_package_utf8_v1.0.1.zip](http://test5.richard-fath.de/test_package_utf8_v1.0.1.zip)

Result: All 3 packages can be updated without error.

Now check with phpMyAdmin that in each extension's table, a record has been inserted with following values:
- `#__test_package_utf8-mb4_utf8`: `col1`= '#002', `col2`= '#ffd' if no utf8mb4 support, `col1`= '#001', `col2`= '#ffe' if utf8mb4 support.
- `#__test_package_utf8-mb4`: `col1`= '#001', `col2`= '#ffe'
- `#__test_package_utf8`: `col1`= '#001', `col2`= '#ffe'

(values of col 1 have 2 zeros between the hashtag and the last digit but GitHub comments somehow eat them here).

Now uninstall the 3 packages.

Result: All 3 packages can be uninstalled without error.

Now check with phpMyAdmin that the 3 tables have been deleted.

Result: The 3 tables have been deleted.
##### Test 2: Test backwards compatibility of the packages with (unpatched) Joomla! pre-3.5.0-beta1, e.g. 3.4.8

Hint: Please do not use such an old version like 3.2.7 for this test, because they have a bug with handling extensions not having had any schema update in their previous versions and so no version number could be found in the `#__schemas` table. This could be fixed by updating my test packages with some dummy sql script, but better use a 3.4.8 for testing to save me from this work now.

Install versions 1.0.0 of the 3 packages used with Test 1.

Result:
- test_package_utf8-mb4_utf8_v1.0.0.zip: Success.
- test_package_utf8-mb4_v1.0.0.zip: Success.
- test_package_utf8_v1.0.0.zip: Success.

Now check with phpMyAdmin that for the 3 extensions the tables have been or not been created as follows:
- test_package_utf8-mb4_utf8_v1.0.0.zip: Table created.
- test_package_utf8-mb4_v1.0.0.zip: Table not created because the 1 sql for charset "utf8mb4" from the xml is ignored.
- test_package_utf8_v1.0.0.zip: Table created.

Result: Package with 1 sql for charset "utf8mb4" only is not compatible with Joomla! pre-3.5.0.

Hint: If you would change the charset in the xml to "utf8", it would cause SQL error "Unknown character set utf8mb4" on a database without utf8mb4 support.

Check the character sets and collations of the 2 tables which have been created:

Result: The 2 tables have utf8 character sets and collations.

Now update the 2 packages for which the table has been created to version 1.0.1.

Result: The 2 packages can be updated without error.

Now check with phpMyAdmin that in each extension's table, a record has been inserted with following values:
- `#__test_package_utf8-mb4_utf8`: `col1`= '#002', `col2`= '#ffd' if no utf8mb4 support, `col1`= '#001', `col2`= '#ffe' if utf8mb4 support.
- `#__test_package_utf8`: `col1`= '#001', `col2`= '#ffe'

Now uninstall all 3 packages.

Result: Success, no errors, tables deleted.

**Conclusion:**
- A package which shall continue to work with utf8 only on any Joomla! version can be made like example package "test_package_utf8_v1.0.0.zip".
- A package made like example package "test_package_utf8-mb4_v1.0.0.zip" is good for both utf8mb4 and utf8 but only on Joomla! 3.5.0 (if this PR gets merged) and later.
- A package made like example package "test_package_utf8-mb4_utf8_v1.0.0.zip" will work with both utf8mb4 and utf8 and both pre-3.5.0 and 3.5.0+.
