### PR TITLE
Add text mimetype for system information text download.

### DIFF
--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -33,6 +33,7 @@ class AdminViewSysinfo extends JViewLegacy
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
+		header("Content-Type: text/plain");
 		header('Content-Description: File Transfer');
 		header('Content-Disposition: attachment; filename="systeminfo-' . date("c") . '.txt"');
 		header('Cache-Control: must-revalidate');

--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -33,7 +33,7 @@ class AdminViewSysinfo extends JViewLegacy
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
-		header("Content-Type: text/html; charset=utf-8");
+		header("Content-Type: text/plain; charset=utf-8");
 		header('Content-Description: File Transfer');
 		header('Content-Disposition: attachment; filename="systeminfo-' . date("c") . '.txt"');
 		header('Cache-Control: must-revalidate');

--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -33,7 +33,7 @@ class AdminViewSysinfo extends JViewLegacy
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
-		header("Content-Type: text/plain; charset=utf-8");
+		header('Content-Type: text/plain; charset=utf-8');
 		header('Content-Description: File Transfer');
 		header('Content-Disposition: attachment; filename="systeminfo-' . date("c") . '.txt"');
 		header('Cache-Control: must-revalidate');

--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -33,7 +33,7 @@ class AdminViewSysinfo extends JViewLegacy
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
-		header("Content-Type: text/plain");
+		header("Content-Type: text/html; charset=utf-8");
 		header('Content-Description: File Transfer');
 		header('Content-Disposition: attachment; filename="systeminfo-' . date("c") . '.txt"');
 		header('Cache-Control: must-revalidate');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9470
#### Summary of Changes

Add text mimetype for system information text download.
#### Testing Instructions

Download system information in text, and check if in http header the content type is text/plain
