### PR TITLE
Doc block updates

### DIFF
--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -19,7 +19,8 @@ class JFormFieldCaptcha extends JFormField
 	/**
 	 * The field type.
 	 *
-	 * @var		string
+	 * @var    string
+	 * @since  2.5
 	 */
 	protected $type = 'Captcha';
 
@@ -71,7 +72,7 @@ class JFormFieldCaptcha extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -184,7 +184,7 @@ class JFormFieldEditor extends JFormFieldTextarea
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/media.php
+++ b/libraries/cms/form/field/media.php
@@ -100,9 +100,11 @@ class JFormFieldMedia extends JFormField
 	/**
 	 * Layout to render
 	 *
-	 * @var  string
+	 * @var    string
+	 * @since  3.5
 	 */
 	protected $layout = 'joomla.form.field.media';
+
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
@@ -168,7 +170,7 @@ class JFormFieldMedia extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -117,7 +117,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/moduleposition.php
+++ b/libraries/cms/form/field/moduleposition.php
@@ -80,7 +80,7 @@ class JFormFieldModulePosition extends JFormFieldText
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/ordering.php
+++ b/libraries/cms/form/field/ordering.php
@@ -78,7 +78,7 @@ class JFormFieldOrdering extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/field/templatestyle.php
+++ b/libraries/cms/form/field/templatestyle.php
@@ -91,7 +91,7 @@ class JFormFieldTemplatestyle extends JFormFieldGroupedList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/rule/captcha.php
+++ b/libraries/cms/form/rule/captcha.php
@@ -21,7 +21,7 @@ class JFormRuleCaptcha extends JFormRule
 	/**
 	 * Method to test if the Captcha is correct.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/rule/notequals.php
+++ b/libraries/cms/form/rule/notequals.php
@@ -23,7 +23,7 @@ class JFormRuleNotequals extends JFormRule
 	 * XML needs a validate attribute of equals and a field attribute
 	 * that is equal to the field to test against.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -23,7 +23,7 @@ class JFormRulePassword extends JFormRule
 	 * XML needs a validate attribute of equals and a field attribute
 	 * that is equal to the field to test against.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -886,11 +886,14 @@ abstract class JHtmlBehavior
 	/**
 	 * Add unobtrusive JavaScript support to keep a tab state.
 	 *
-	 * Note that keeping tab state only works for inner tabs if in accordance with the following example
+	 * Note that keeping tab state only works for inner tabs if in accordance with the following example:
+	 *
+	 * ```
 	 * parent tab = permissions
 	 * child tab = permission-<identifier>
+	 * ```
 	 *
-	 * Each tab header "a" tag also should have a unique href attribute
+	 * Each tab header `<a>` tag also should have a unique href attribute
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -271,17 +271,17 @@ abstract class JHtmlBootstrap
 	 * @param   string  $selector  The ID selector for the modal.
 	 * @param   array   $params    An array of options for the modal.
 	 *                             Options for the modal can be:
-	 *                             - title     string   The modal title
-	 *                             - backdrop  mixed    A boolean select if a modal-backdrop element should be included (default = true)
-	 *                                                  The string 'static' includes a backdrop which doesn't close the modal on click.
-	 *                             - keyboard  boolean  Closes the modal when escape key is pressed (default = true)
+	 *                             - title        string   The modal title
+	 *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
+	 *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
+	 *                             - keyboard     boolean  Closes the modal when escape key is pressed (default = true)
 	 *                             - closeButton  boolean  Display modal close button (default = true)
-	 *                             - animation boolean  Fade in from the top of the page (default = true)
-	 *                             - footer    string   Optional markup for the modal footer
-	 *                             - url       string   URL of a resource to be inserted as an <iframe> inside the modal body
-	 *                             - height    string   height of the <iframe> containing the remote resource
-	 *                             - width     string   width of the <iframe> containing the remote resource
-	 * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
+	 *                             - animation    boolean  Fade in from the top of the page (default = true)
+	 *                             - footer       string   Optional markup for the modal footer
+	 *                             - url          string   URL of a resource to be inserted as an `<iframe>` inside the modal body
+	 *                             - height       string   height of the `<iframe>` containing the remote resource
+	 *                             - width        string   width of the `<iframe>` containing the remote resource
+	 * @param   string  $body      Markup for the modal body. Appended after the `<iframe>` if the url option is set
 	 *
 	 * @return  string  HTML markup for a modal
 	 *

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -84,7 +84,7 @@ abstract class JHtml
 	 *                        prefix and class are optional and can be used to load custom
 	 *                        html helpers.
 	 *
-	 * @return  mixed  JHtml::call($function, $args) or False on error
+	 * @return  mixed  Result of JHtml::call($function, $args)
 	 *
 	 * @since   1.5
 	 * @throws  InvalidArgumentException
@@ -237,13 +237,13 @@ abstract class JHtml
 	}
 
 	/**
-	 * Write a <a></a> element
+	 * Write a `<a>` element
 	 *
 	 * @param   string  $url      The relative URL to use for the href attribute
 	 * @param   string  $text     The target attribute to use
 	 * @param   array   $attribs  An associative array of attributes to add
 	 *
-	 * @return  string  <a></a> string
+	 * @return  string
 	 *
 	 * @since   1.5
 	 */
@@ -258,14 +258,14 @@ abstract class JHtml
 	}
 
 	/**
-	 * Write a <iframe></iframe> element
+	 * Write a `<iframe>` element
 	 *
 	 * @param   string  $url       The relative URL to use for the src attribute.
 	 * @param   string  $name      The target attribute to use.
 	 * @param   array   $attribs   An associative array of attributes to add.
 	 * @param   string  $noFrames  The message to display if the iframe tag is not supported.
 	 *
-	 * @return  string  <iframe></iframe> element or message if not supported.
+	 * @return  string
 	 *
 	 * @since   1.5
 	 */
@@ -550,7 +550,7 @@ abstract class JHtml
 	}
 
 	/**
-	 * Write a <img></img> element
+	 * Write a `<img>` element
 	 *
 	 * @param   string   $file      The relative or absolute URL to use for the src attribute.
 	 * @param   string   $alt       The alt text.
@@ -584,14 +584,14 @@ abstract class JHtml
 	}
 
 	/**
-	 * Write a <link rel="stylesheet" style="text/css" /> element
+	 * Write a `<link>` element to load a CSS file
 	 *
 	 * @param   string   $file            path to file
 	 * @param   array    $attribs         attributes to be added to the stylesheet
 	 * @param   boolean  $relative        path to file is relative to /media folder
 	 * @param   boolean  $path_only       return the path to the file only
 	 * @param   boolean  $detect_browser  detect browser to include specific browser css files
-	 *                                    will try to include file, file_*browser*, file_*browser*_*major*, file_*browser*_*major*_*minor*
+	 *                                    will try to include file, `file_*browser*`, `file_*browser*_*major*`, `file_*browser*_*major*_*minor*`
 	 *                                    <table>
 	 *                                       <tr><th>Navigator</th>                  <th>browser</th>	<th>major.minor</th></tr>
 	 *
@@ -614,7 +614,6 @@ abstract class JHtml
 	 *
 	 *                                       <tr><td>Firefox</td>                    <td>mozilla</td>	<td>5.0</td></tr>
 	 *                                    </table>
-	 *                                    a lot of others
 	 * @param   boolean  $detect_debug    detect debug to search for compressed files if debug is on
 	 *
 	 * @return  mixed  nothing if $path_only is false, null, path or array of path if specific css browser files were detected
@@ -655,7 +654,7 @@ abstract class JHtml
 	}
 
 	/**
-	 * Write a <script></script> element
+	 * Write a `<script>` element to load a JavaScript file
 	 *
 	 * @param   string   $file            path to file.
 	 * @param   boolean  $framework       load the JS framework.

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -31,7 +31,7 @@ abstract class JHtmlSelect
 	 * Generates a yes/no radio list.
 	 *
 	 * @param   string  $name      The value of the HTML name attribute
-	 * @param   array   $attribs   Additional HTML attributes for the <select> tag
+	 * @param   array   $attribs   Additional HTML attributes for the `<select>` tag
 	 * @param   string  $selected  The key that is selected
 	 * @param   string  $yes       Language key for Yes
 	 * @param   string  $no        Language key for no
@@ -54,7 +54,7 @@ abstract class JHtmlSelect
 	 *
 	 * @param   array    $data       An array of objects, arrays, or scalars.
 	 * @param   string   $name       The value of the HTML name attribute.
-	 * @param   mixed    $attribs    Additional HTML attributes for the <select> tag. This
+	 * @param   mixed    $attribs    Additional HTML attributes for the `<select>` tag. This
 	 *                               can be an array of attributes, or an array of options. Treated as options
 	 *                               if it is the last argument passed. Valid options are:
 	 *                               Format options, see {@see JHtml::$formatOptions}.
@@ -140,7 +140,7 @@ abstract class JHtmlSelect
 	 * @return  string  HTML for the select list
 	 *
 	 * @since       3.2
-	 * @deprecated  4.0  Just create the <datalist> directly instead
+	 * @deprecated  4.0  Just create the `<datalist>` directly instead
 	 */
 	public static function suggestionlist($data, $optKey = 'value', $optText = 'text', $idtag = null, $translate = false)
 	{
@@ -326,7 +326,7 @@ abstract class JHtmlSelect
 	 * @param   integer  $end       The end integer
 	 * @param   integer  $inc       The increment
 	 * @param   string   $name      The value of the HTML name attribute
-	 * @param   mixed    $attribs   Additional HTML attributes for the <select> tag, an array of
+	 * @param   mixed    $attribs   Additional HTML attributes for the `<select>` tag, an array of
 	 *                              attributes, or an array of options. Treated as options if it is the last
 	 *                              argument passed.
 	 * @param   mixed    $selected  The key that is selected
@@ -731,7 +731,7 @@ abstract class JHtmlSelect
 	 *
 	 * @param   array    $data       An array of objects
 	 * @param   string   $name       The value of the HTML name attribute
-	 * @param   string   $attribs    Additional HTML attributes for the <select> tag
+	 * @param   string   $attribs    Additional HTML attributes for the `<select>` tag
 	 * @param   mixed    $optKey     The key that is selected
 	 * @param   string   $optText    The name of the object variable for the option value
 	 * @param   string   $selected   The name of the object variable for the option text

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -214,7 +214,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *
@@ -780,7 +780,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	}
 
 	/**
-	 * Method to parse the queries specified in the <sql> tags
+	 * Method to parse the queries specified in the `<sql>` tags
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -112,7 +112,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
 class JInstallerAdapterFile extends JInstallerAdapter
 {
 	/**
-	 * <scriptfile> element of the extension manifest
+	 * `<scriptfile>` element of the extension manifest
 	 *
 	 * @var    object
 	 * @since  3.1
@@ -37,7 +37,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 	protected $supportsDiscoverInstall = false;
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -29,7 +29,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	protected $core = false;
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -53,7 +53,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -27,7 +27,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	protected $clientId;
 
 	/**
-	 * <scriptfile> element of the extension manifest
+	 * `<scriptfile>` element of the extension manifest
 	 *
 	 * @var    object
 	 * @since  3.1
@@ -70,7 +70,7 @@ class JInstallerAdapterModule extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -80,7 +80,7 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -19,7 +19,7 @@ jimport('joomla.filesystem.folder');
 class JInstallerAdapterPlugin extends JInstallerAdapter
 {
 	/**
-	 * <scriptfile> element of the extension manifest
+	 * `<scriptfile>` element of the extension manifest
 	 *
 	 * @var    object
 	 * @since  3.1
@@ -27,7 +27,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	protected $scriptElement = null;
 
 	/**
-	 * <files> element of the old extension manifest
+	 * `<files>` element of the old extension manifest
 	 *
 	 * @var    object
 	 * @since  3.1
@@ -66,7 +66,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -62,7 +62,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 	}
 
 	/**
-	 * Method to copy the extension's base files from the <files> tag(s) and the manifest file
+	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
 	 *

--- a/libraries/cms/schema/changeitem.php
+++ b/libraries/cms/schema/changeitem.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  * This class is used to check the site's database to see if the DDL query has been run.
  * If not, it provides the ability to fix the database by re-running the DDL query.
  * The queries are parsed from the update files in the folder
- * administrator/components/com_admin/sql/updates/<database>.
+ * `administrator/components/com_admin/sql/updates/<database>`.
  * These updates are run automatically if the site was updated using com_installer.
  * However, it is possible that the program files could be updated without udpating
  * the database (for example, if a user just copies the new files over the top of an

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -46,7 +46,7 @@ class JSchemaChangeset
 
 	/**
 	 * Constructor: builds array of $changeItems by processing the .sql files in a folder.
-	 * The folder for the Joomla core updates is administrator/components/com_admin/sql/updates/<database>.
+	 * The folder for the Joomla core updates is `administrator/components/com_admin/sql/updates/<database>`.
 	 *
 	 * @param   JDatabaseDriver  $db      The current database object
 	 * @param   string           $folder  The full path to the folder containing the update queries

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -21,7 +21,7 @@ jimport('joomla.utilities.utility');
 class JDocumentHtml extends JDocument
 {
 	/**
-	 * Array of Header <link> tags
+	 * Array of Header `<link>` tags
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -259,11 +259,11 @@ class JDocumentHtml extends JDocument
 	}
 
 	/**
-	 * Adds <link> tags to the head of the document
+	 * Adds `<link>` tags to the head of the document
 	 *
 	 * $relType defaults to 'rel' as it is the most common relation type used.
 	 * ('rev' refers to reverse relation, 'rel' indicates normal, forward relation.)
-	 * Typical tag: <link href="index.php" rel="Start">
+	 * Typical tag: `<link href="index.php" rel="Start">`
 	 *
 	 * @param   string  $href      The link that is being related.
 	 * @param   string  $relation  Relation of link.
@@ -325,7 +325,7 @@ class JDocumentHtml extends JDocument
 	/**
 	 * Returns whether the document is set up to be output as HTML5
 	 *
-	 * @return  Boolean true when HTML5 is used
+	 * @return  boolean true when HTML5 is used
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/feed/parser/atom.php
+++ b/libraries/joomla/feed/parser/atom.php
@@ -24,7 +24,7 @@ class JFeedParserAtom extends JFeedParser
 	protected $version;
 
 	/**
-	 * Method to handle the <author> element for the feed.
+	 * Method to handle the `<author>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -40,7 +40,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <contributor> element for the feed.
+	 * Method to handle the `<contributor>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -55,7 +55,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <generator> element for the feed.
+	 * Method to handle the `<generator>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -70,7 +70,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <id> element for the feed.
+	 * Method to handle the `<id>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -85,7 +85,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <link> element for the feed.
+	 * Method to handle the `<link>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -108,7 +108,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <rights> element for the feed.
+	 * Method to handle the `<rights>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -123,7 +123,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <subtitle> element for the feed.
+	 * Method to handle the `<subtitle>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -138,7 +138,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <title> element for the feed.
+	 * Method to handle the `<title>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -153,7 +153,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <updated> element for the feed.
+	 * Method to handle the `<updated>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -185,7 +185,7 @@ class JFeedParserAtom extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the feed entry element for the feed: <entry>.
+	 * Method to handle a `<entry>` element for the feed.
 	 *
 	 * @param   JFeedEntry        $entry  The JFeedEntry object being built from the parsed feed entry.
 	 * @param   SimpleXMLElement  $el     The current XML element object to handle.

--- a/libraries/joomla/feed/parser/rss.php
+++ b/libraries/joomla/feed/parser/rss.php
@@ -30,7 +30,7 @@ class JFeedParserRss extends JFeedParser
 	protected $version;
 
 	/**
-	 * Method to handle the <category> element for the feed.
+	 * Method to handle the `<category>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -49,7 +49,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <cloud> element for the feed.
+	 * Method to handle the `<cloud>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -71,7 +71,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <copyright> element for the feed.
+	 * Method to handle the `<copyright>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -86,7 +86,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <description> element for the feed.
+	 * Method to handle the `<description>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -101,7 +101,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <generator> element for the feed.
+	 * Method to handle the `<generator>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -116,7 +116,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <image> element for the feed.
+	 * Method to handle the `<image>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -146,7 +146,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <language> element for the feed.
+	 * Method to handle the `<language>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -161,7 +161,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <lastBuildDate> element for the feed.
+	 * Method to handle the `<lastBuildDate>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -176,7 +176,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <link> element for the feed.
+	 * Method to handle the `<link>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -193,7 +193,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <managingEditor> element for the feed.
+	 * Method to handle the `<managingEditor>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -208,7 +208,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <skipDays> element for the feed.
+	 * Method to handle the `<skipDays>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -232,7 +232,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <skipHours> element for the feed.
+	 * Method to handle the `<skipHours>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -256,7 +256,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <pubDate> element for the feed.
+	 * Method to handle the `<pubDate>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -271,7 +271,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <title> element for the feed.
+	 * Method to handle the `<title>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -286,7 +286,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <ttl> element for the feed.
+	 * Method to handle the `<ttl>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -301,7 +301,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the <webmaster> element for the feed.
+	 * Method to handle the `<webmaster>` element for the feed.
 	 *
 	 * @param   JFeed             $feed  The JFeed object being built from the parsed feed.
 	 * @param   SimpleXMLElement  $el    The current XML element object to handle.
@@ -348,7 +348,7 @@ class JFeedParserRss extends JFeedParser
 	}
 
 	/**
-	 * Method to handle the feed entry element for the feed: <item>.
+	 * Method to handle a `<item>` element for the feed.
 	 *
 	 * @param   JFeedEntry        $entry  The JFeedEntry object being built from the parsed feed entry.
 	 * @param   SimpleXMLElement  $el     The current XML element object to handle.

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -607,8 +607,8 @@ class JFilterInput
 	 * The options you can define are:
 	 * null_byte                   Prevent files with a null byte in their name (buffer overflow attack)
 	 * forbidden_extensions        Do not allow these strings anywhere in the file's extension
-	 * php_tag_in_content          Do not allow <?php tag in content
-	 * shorttag_in_content         Do not allow short tag <? in content
+	 * php_tag_in_content          Do not allow `<?php` tag in content
+	 * shorttag_in_content         Do not allow short tag `<?` in content
 	 * shorttag_extensions         Which file extensions to scan for short tags in content
 	 * fobidden_ext_in_content     Do not allow forbidden_extensions anywhere in content
 	 * php_ext_content_extensions  Which file extensions to scan for .php in content
@@ -1404,14 +1404,14 @@ class JFilterInput
 	}
 
 	/**
-	 * Remove CSS Expressions in the form of <property>:expression(...)
+	 * Remove CSS Expressions in the form of `<property>:expression(...)`
 	 *
 	 * @param   string  $source  The source string.
 	 *
 	 * @return  string  Filtered string
 	 *
-	 * @since      11.1
-	 * @deprecated 4.0 Use JFilterInput::stripCSSExpressions() instead
+	 * @since       11.1
+	 * @deprecated  4.0 Use JFilterInput::stripCSSExpressions() instead
 	 */
 	protected function _stripCSSExpressions($source)
 	{
@@ -1459,6 +1459,8 @@ class JFilterInput
 	 * @param   mixed  $source  The data to filter
 	 *
 	 * @return  mixed  The filtered result
+	 *
+	 * @since   3.5
 	 */
 	protected function stripUSC($source)
 	{

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -59,7 +59,7 @@ abstract class JFormField
 	protected $autofocus = false;
 
 	/**
-	 * The SimpleXMLElement object of the <field /> XML element that describes the form field.
+	 * The SimpleXMLElement object of the `<field>` XML element that describes the form field.
 	 *
 	 * @var    SimpleXMLElement
 	 * @since  11.1
@@ -539,7 +539,7 @@ abstract class JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -102,7 +102,7 @@ class JFormFieldCalendar extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -83,7 +83,7 @@ class JFormFieldCheckbox extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -117,7 +117,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
@@ -145,7 +145,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	 *
 	 * @return  array
 	 *
-	 * @since 3.5
+	 * @since   3.5
 	 */
 	protected function getLayoutData()
 	{

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -11,7 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 /**
  * Color Form Field class for the Joomla Platform.
- * This implementation is designed to be compatible with HTML5's <input type="color">
+ * This implementation is designed to be compatible with HTML5's `<input type="color">`
  *
  * @link   http://www.w3.org/TR/html-markup/input.color.html
  * @since  11.3
@@ -111,7 +111,7 @@ class JFormFieldColor extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -80,7 +80,7 @@ class JFormFieldFile extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -136,7 +136,7 @@ class JFormFieldFileList extends JFormFieldList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -125,7 +125,7 @@ class JFormFieldFolderList extends JFormFieldList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -120,7 +120,7 @@ class JFormFieldMeter extends JFormFieldNumber
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/number.php
+++ b/libraries/joomla/form/fields/number.php
@@ -100,7 +100,7 @@ class JFormFieldNumber extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -106,7 +106,7 @@ class JFormFieldPassword extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -80,7 +80,7 @@ class JFormFieldPlugins extends JFormFieldList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -100,7 +100,7 @@ class JFormFieldRules extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -110,7 +110,7 @@ class JFormFieldSQL extends JFormFieldList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -22,7 +22,6 @@ class JFormFieldText extends JFormField
 	 * The form field type.
 	 *
 	 * @var    string
-	 *
 	 * @since  11.1
 	 */
 	protected $type = 'Text';
@@ -108,7 +107,7 @@ class JFormFieldText extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -100,7 +100,7 @@ class JFormFieldTextarea extends JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -88,7 +88,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -470,9 +470,9 @@ class JForm
 	/**
 	 * Method to get the form control. This string serves as a container for all form fields. For
 	 * example, if there is a field named 'foo' and a field named 'bar' and the form control is
-	 * empty the fields will be rendered like: <input name="foo" /> and <input name="bar" />.  If
+	 * empty the fields will be rendered like: `<input name="foo" />` and `<input name="bar" />`.  If
 	 * the form control is set to 'joomla' however, the fields would be rendered like:
-	 * <input name="joomla[foo]" /> and <input name="joomla[bar]" />.
+	 * `<input name="joomla[foo]" />` and `<input name="joomla[bar]" />`.
 	 *
 	 * @return  string  The form control string.
 	 *
@@ -1565,8 +1565,7 @@ class JForm
 	}
 
 	/**
-	 * Method to get an array of <field /> elements from the form XML document which are
-	 * in a specified fieldset by name.
+	 * Method to get an array of `<field>` elements from the form XML document which are in a specified fieldset by name.
 	 *
 	 * @param   string  $name  The name of the fieldset.
 	 *
@@ -1596,8 +1595,7 @@ class JForm
 	}
 
 	/**
-	 * Method to get an array of <field /> elements from the form XML document which are
-	 * in a control group by name.
+	 * Method to get an array of `<field>` elements from the form XML document which are in a control group by name.
 	 *
 	 * @param   mixed    $group   The optional dot-separated form group path on which to find the fields.
 	 *                            Null will return all fields. False will return fields not in a group.
@@ -2151,7 +2149,7 @@ class JForm
 	}
 
 	/**
-	 * Merges new elements into a source <fields> element.
+	 * Merges new elements into a source `<fields>` element.
 	 *
 	 * @param   SimpleXMLElement  $source  The source element.
 	 * @param   SimpleXMLElement  $new     The new element to merge.

--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -24,12 +24,11 @@ class JFormHelper
 	 * Array with paths where entities(field, rule, form) can be found.
 	 *
 	 * Array's structure:
-	 * <code>
+	 *
 	 * paths:
 	 * {ENTITY_NAME}:
 	 * - /path/1
 	 * - /path/2
-	 * </code>
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -42,11 +41,9 @@ class JFormHelper
 	 * Prototypes for all fields and rules are here.
 	 *
 	 * Array's structure:
-	 * <code>
 	 * entities:
 	 * {ENTITY_NAME}:
 	 * {KEY}: {OBJECT}
-	 * </code>
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -59,7 +56,7 @@ class JFormHelper
 	 * @param   string   $type  The field type.
 	 * @param   boolean  $new   Flag to toggle whether we should get a new instance of the object.
 	 *
-	 * @return  mixed  JFormField object on success, false otherwise.
+	 * @return  JFormField|boolean  JFormField object on success, false otherwise.
 	 *
 	 * @since   11.1
 	 */
@@ -74,7 +71,7 @@ class JFormHelper
 	 * @param   string   $type  The rule type.
 	 * @param   boolean  $new   Flag to toggle whether we should get a new instance of the object.
 	 *
-	 * @return  mixed  JFormRule object on success, false otherwise.
+	 * @return  JFormRule|boolean  JFormRule object on success, false otherwise.
 	 *
 	 * @since   11.1
 	 */
@@ -128,7 +125,7 @@ class JFormHelper
 	 *
 	 * @param   string  $type  Type of a field whose class should be loaded.
 	 *
-	 * @return  mixed  Class name on success or false otherwise.
+	 * @return  string|boolean  Class name on success or false otherwise.
 	 *
 	 * @since   11.1
 	 */
@@ -143,7 +140,7 @@ class JFormHelper
 	 *
 	 * @param   string  $type  Type of a rule whose class should be loaded.
 	 *
-	 * @return  mixed  Class name on success or false otherwise.
+	 * @return  string|boolean  Class name on success or false otherwise.
 	 *
 	 * @since   11.1
 	 */
@@ -160,7 +157,7 @@ class JFormHelper
 	 * @param   string  $entity  One of the form entities (field or rule).
 	 * @param   string  $type    Type of an entity.
 	 *
-	 * @return  mixed  Class name on success or false otherwise.
+	 * @return  string|boolean  Class name on success or false otherwise.
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/form/rule.php
+++ b/libraries/joomla/form/rule.php
@@ -43,7 +43,7 @@ class JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/color.php
+++ b/libraries/joomla/form/rule/color.php
@@ -21,7 +21,7 @@ class JFormRuleColor extends JFormRule
 	/**
 	 * Method to test for a valid color in hexadecimal.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/email.php
+++ b/libraries/joomla/form/rule/email.php
@@ -30,7 +30,7 @@ class JFormRuleEmail extends JFormRule
 	/**
 	 * Method to test the email address and optionally check for uniqueness.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/equals.php
+++ b/libraries/joomla/form/rule/equals.php
@@ -23,7 +23,7 @@ class JFormRuleEquals extends JFormRule
 	 * XML needs a validate attribute of equals and a field attribute
 	 * that is equal to the field to test against.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/number.php
+++ b/libraries/joomla/form/rule/number.php
@@ -14,14 +14,14 @@ defined('JPATH_PLATFORM') or die;
  *
  * @package     Joomla.Platform
  * @subpackage  Form
- * @since       3.5.0
+ * @since       3.5
  */
 class JFormRuleNumber extends JFormRule
 {
 	/**
 	 * Method to test the range for a number value using min and max attributes.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
@@ -31,7 +31,7 @@ class JFormRuleNumber extends JFormRule
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
-	 * @since   3.5.0
+	 * @since   3.5
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{

--- a/libraries/joomla/form/rule/options.php
+++ b/libraries/joomla/form/rule/options.php
@@ -21,7 +21,7 @@ class JFormRuleOptions extends JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
@@ -54,7 +54,6 @@ class JFormRuleOptions extends JFormRule
 		else
 		{
 			// In this case value must be a string
-
 			return in_array((string) $value, $options);
 		}
 	}

--- a/libraries/joomla/form/rule/rules.php
+++ b/libraries/joomla/form/rule/rules.php
@@ -21,7 +21,7 @@ class JFormRuleRules extends JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
@@ -76,10 +76,9 @@ class JFormRuleRules extends JFormRule
 	/**
 	 * Method to get the list of possible permission action names for the form field.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the
-	 *                                      form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 *
-	 * @return  array   A list of permission action names from the form field element definition.
+	 * @return  array  A list of permission action names from the form field element definition.
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/form/rule/tel.php
+++ b/libraries/joomla/form/rule/tel.php
@@ -21,7 +21,7 @@ class JFormRuleTel extends JFormRule
 	/**
 	 * Method to test the url for a valid parts.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -21,7 +21,7 @@ class JFormRuleUrl extends JFormRule
 	/**
 	 * Method to test an external or internal url for all valid parts.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/form/rule/username.php
+++ b/libraries/joomla/form/rule/username.php
@@ -21,7 +21,7 @@ class JFormRuleUsername extends JFormRule
 	/**
 	 * Method to test the username for uniqueness.
 	 *
-	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed             $value    The form field value to validate.
 	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
 	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -28,9 +28,9 @@ class JText
 	 * Translates a string into the current language.
 	 *
 	 * Examples:
-	 * <script>alert(Joomla.JText._('<?php echo JText::_("JDEFAULT", array("script"=>true));?>'));</script>
+	 * `<script>alert(Joomla.JText._('<?php echo JText::_("JDEFAULT", array("script"=>true)); ?>'));</script>`
 	 * will generate an alert message containing 'Default'
-	 * <?php echo JText::_("JDEFAULT");?> it will generate a 'Default' string
+	 * `<?php echo JText::_("JDEFAULT"); ?>` will generate a 'Default' string
 	 *
 	 * @param   string   $string                The string to translate.
 	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
@@ -140,8 +140,8 @@ class JText
 	 * Translates a string into the current language.
 	 *
 	 * Examples:
-	 * <?php echo JText::alt("JALL","language");?> it will generate a 'All' string in English but a "Toutes" string in French
-	 * <?php echo JText::alt("JALL","module");?> it will generate a 'All' string in English but a "Tous" string in French
+	 * `<?php echo JText::alt('JALL', 'language'); ?>` will generate a 'All' string in English but a "Toutes" string in French
+	 * `<?php echo JText::alt('JALL', 'module'); ?>` will generate a 'All' string in English but a "Tous" string in French
 	 *
 	 * @param   string   $string                The string to translate.
 	 * @param   string   $alt                   The alternate option for global string
@@ -181,9 +181,9 @@ class JText
 	 * script is a boolean to indicate that the string will be push in the javascript language store.
 	 *
 	 * Examples:
-	 * <script>alert(Joomla.JText._('<?php echo JText::plural("COM_PLUGINS_N_ITEMS_UNPUBLISHED", 1, array("script"=>true));?>'));</script>
+	 * `<script>alert(Joomla.JText._('<?php echo JText::plural("COM_PLUGINS_N_ITEMS_UNPUBLISHED", 1, array("script"=>true)); ?>'));</script>`
 	 * will generate an alert message containing '1 plugin successfully disabled'
-	 * <?php echo JText::plural("COM_PLUGINS_N_ITEMS_UNPUBLISHED", 1);?> it will generate a '1 plugin successfully disabled' string
+	 * `<?php echo JText::plural('COM_PLUGINS_N_ITEMS_UNPUBLISHED', 1); ?>` will generate a '1 plugin successfully disabled' string
 	 *
 	 * @param   string   $string  The format string.
 	 * @param   integer  $n       The number of items

--- a/libraries/joomla/microdata/microdata.php
+++ b/libraries/joomla/microdata/microdata.php
@@ -686,7 +686,7 @@ class JMicrodata
 	 * In which way to display the Property:
 	 * normal -> itemprop="name"
 	 * nested -> itemprop="director" itemscope itemtype="https://schema.org/Person"
-	 * meta   -> <meta itemprop="datePublished" content="1991-05-01">
+	 * meta   -> `<meta itemprop="datePublished" content="1991-05-01">`
 	 *
 	 * @param   string  $type      The Type where to find the Property
 	 * @param   string  $property  The Property to process
@@ -769,7 +769,7 @@ class JMicrodata
 	}
 
 	/**
-	 * Return Microdata semantics in a <meta> tag with content for machines.
+	 * Return Microdata semantics in a `<meta>` tag with content for machines.
 	 *
 	 * @param   string   $content   The machine content to display
 	 * @param   string   $property  The Property
@@ -786,7 +786,7 @@ class JMicrodata
 	}
 
 	/**
-	 * Return Microdata semantics in a <span> tag.
+	 * Return Microdata semantics in a `<span>` tag.
 	 *
 	 * @param   string   $content   The human content
 	 * @param   string   $property  Optional, the human content to display
@@ -803,7 +803,7 @@ class JMicrodata
 	}
 
 	/**
-	 * Return Microdata semantics in a <div> tag.
+	 * Return Microdata semantics in a `<div>` tag.
 	 *
 	 * @param   string   $content   The human content
 	 * @param   string   $property  Optional, the human content to display

--- a/libraries/joomla/profiler/profiler.php
+++ b/libraries/joomla/profiler/profiler.php
@@ -97,12 +97,9 @@ class JProfiler
 	/**
 	 * Output a time mark
 	 *
-	 * The mark is returned as text enclosed in <div> tags
-	 * with a CSS class of 'profiler'.
-	 *
 	 * @param   string  $label  A label for the time mark
 	 *
-	 * @return  string  Mark enclosed in <div> tags
+	 * @return  string
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -25,7 +25,7 @@ class JTwitterStatuses extends JTwitterObject
 	 * @param   boolean  $entities    When set to true,  each tweet will include a node called "entities,". This node offers a variety of metadata
 	 *                                about the tweet in a discreet structure, including: user_mentions, urls, and hashtags.
 	 * @param   boolean  $my_retweet  When set to either true, t or 1, any statuses returned that have been retweeted by the authenticating user will
-	 * 								  include an additional current_user_retweet node, containing the ID of the source status for the retweet.
+	 *                                include an additional current_user_retweet node, containing the ID of the source status for the retweet.
 	 *
 	 * @return  array  The decoded JSON response
 	 *
@@ -77,7 +77,7 @@ class JTwitterStatuses extends JTwitterObject
 	 * @param   boolean  $trim_user    When set to true, each tweet returned in a timeline will include a user object including only
 	 *                                 the status author's numerical ID.
 	 * @param   boolean  $contributor  This parameter enhances the contributors element of the status response to include the screen_name of the
-	 * 								   contributor. By default only the user_id of the contributor is included.
+	 *                                 contributor. By default only the user_id of the contributor is included.
 	 *
 	 * @return  array  The decoded JSON response
 	 *
@@ -231,7 +231,7 @@ class JTwitterStatuses extends JTwitterObject
 	 * @param   boolean  $trim_user    When set to true, each tweet returned in a timeline will include a user object including only
 	 *                                 the status author's numerical ID.
 	 * @param   string   $contributor  This parameter enhances the contributors element of the status response to include the screen_name
-	 *                                  of the contributor.
+	 *                                 of the contributor.
 	 *
 	 * @return  array  The decoded JSON response
 	 *
@@ -294,14 +294,14 @@ class JTwitterStatuses extends JTwitterObject
 	 * Method to get the most recent tweets of the authenticated user that have been retweeted by others.
 	 *
 	 * @param   integer  $count          Specifies the number of tweets to try and retrieve, up to a maximum of 200.  Retweets are always included
-	 *                               	 in the count, so it is always suggested to set $include_rts to true
+	 *                                   in the count, so it is always suggested to set $include_rts to true
 	 * @param   integer  $since_id       Returns results with an ID greater than (that is, more recent than) the specified ID.
 	 * @param   boolean  $entities       When set to true,  each tweet will include a node called "entities,". This node offers a variety of metadata
-	 *                               	 about the tweet in a discreet structure, including: user_mentions, urls, and hashtags.
+	 *                                   about the tweet in a discreet structure, including: user_mentions, urls, and hashtags.
 	 * @param   boolean  $user_entities  The user entities node will be disincluded when set to false.
 	 * @param   integer  $max_id         Returns results with an ID less than (that is, older than) the specified ID.
 	 * @param   boolean  $trim_user      When set to true, each tweet returned in a timeline will include a user object including only
-	 *                               	 the status author's numerical ID.
+	 *                                   the status author's numerical ID.
 	 *
 	 * @return  array  The decoded JSON response
 	 *
@@ -358,9 +358,9 @@ class JTwitterStatuses extends JTwitterObject
 	 * @param   integer  $id             The numerical ID of the desired status.
 	 * @param   integer  $count          Specifies the number of retweets to try and retrieve, up to a maximum of 100.
 	 * @param   integer  $cursor         Causes the list of IDs to be broken into pages of no more than 100 IDs at a time.
-	 * 									 The number of IDs returned is not guaranteed to be 100 as suspended users are
-	 * 									 filtered out after connections are queried. If no cursor is provided, a value of
-	 * 									 -1 will be assumed, which is the first "page."
+	 *                                   The number of IDs returned is not guaranteed to be 100 as suspended users are
+	 *                                   filtered out after connections are queried. If no cursor is provided, a value of
+	 *                                   -1 will be assumed, which is the first "page."
 	 * @param   boolean  $stringify_ids  Set to true to return IDs as strings, false to return as integers.
 	 *
 	 * @return  array  The decoded JSON response
@@ -565,17 +565,18 @@ class JTwitterStatuses extends JTwitterObject
 	 * @param   integer  $id           The Tweet/status ID to return embed code for.
 	 * @param   string   $url          The URL of the Tweet/status to be embedded.
 	 * @param   integer  $maxwidth     The maximum width in pixels that the embed should be rendered at. This value is constrained to be
-	 * 								   between 250 and 550 pixels.
+	 *                                 between 250 and 550 pixels.
 	 * @param   boolean  $hide_media   Specifies whether the embedded Tweet should automatically expand images which were uploaded via
-	 * 								   POST statuses/update_with_media.
+	 *                                 POST statuses/update_with_media.
 	 * @param   boolean  $hide_thread  Specifies whether the embedded Tweet should automatically show the original message in the case that
-	 * 								   the embedded Tweet is a reply.
-	 * @param   boolean  $omit_script  Specifies whether the embedded Tweet HTML should include a <script> element pointing to widgets.js. In cases where
-	 * 								   a page already includes widgets.js, setting this value to true will prevent a redundant script element from being included.
+	 *                                 the embedded Tweet is a reply.
+	 * @param   boolean  $omit_script  Specifies whether the embedded Tweet HTML should include a `<script>` element pointing to widgets.js.
+	 *                                 In cases where a page already includes widgets.js, setting this value to true will prevent a redundant
+	 *                                 script element from being included.
 	 * @param   string   $align        Specifies whether the embedded Tweet should be left aligned, right aligned, or centered in the page.
-	 * 								   Valid values are left, right, center, and none.
+	 *                                 Valid values are left, right, center, and none.
 	 * @param   string   $related      A value for the TWT related parameter, as described in Web Intents. This value will be forwarded to all
-	 * 								   Web Intents calls.
+	 *                                 Web Intents calls.
 	 * @param   string   $lang         Language code for the rendered embed. This will affect the text and localization of the rendered HTML.
 	 *
 	 * @return  array  The decoded JSON response

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
 class JUpdate extends JObject
 {
 	/**
-	 * Update manifest <name> element
+	 * Update manifest `<name>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -26,7 +26,7 @@ class JUpdate extends JObject
 	protected $name;
 
 	/**
-	 * Update manifest <description> element
+	 * Update manifest `<description>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -34,7 +34,7 @@ class JUpdate extends JObject
 	protected $description;
 
 	/**
-	 * Update manifest <element> element
+	 * Update manifest `<element>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -42,7 +42,7 @@ class JUpdate extends JObject
 	protected $element;
 
 	/**
-	 * Update manifest <type> element
+	 * Update manifest `<type>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -50,7 +50,7 @@ class JUpdate extends JObject
 	protected $type;
 
 	/**
-	 * Update manifest <version> element
+	 * Update manifest `<version>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -58,7 +58,7 @@ class JUpdate extends JObject
 	protected $version;
 
 	/**
-	 * Update manifest <infourl> element
+	 * Update manifest `<infourl>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -66,7 +66,7 @@ class JUpdate extends JObject
 	protected $infourl;
 
 	/**
-	 * Update manifest <client> element
+	 * Update manifest `<client>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -74,7 +74,7 @@ class JUpdate extends JObject
 	protected $client;
 
 	/**
-	 * Update manifest <group> element
+	 * Update manifest `<group>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -82,7 +82,7 @@ class JUpdate extends JObject
 	protected $group;
 
 	/**
-	 * Update manifest <downloads> element
+	 * Update manifest `<downloads>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -90,7 +90,7 @@ class JUpdate extends JObject
 	protected $downloads;
 
 	/**
-	 * Update manifest <tags> element
+	 * Update manifest `<tags>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -98,7 +98,7 @@ class JUpdate extends JObject
 	protected $tags;
 
 	/**
-	 * Update manifest <maintainer> element
+	 * Update manifest `<maintainer>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -106,7 +106,7 @@ class JUpdate extends JObject
 	protected $maintainer;
 
 	/**
-	 * Update manifest <maintainerurl> element
+	 * Update manifest `<maintainerurl>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -114,7 +114,7 @@ class JUpdate extends JObject
 	protected $maintainerurl;
 
 	/**
-	 * Update manifest <category> element
+	 * Update manifest `<category>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -122,7 +122,7 @@ class JUpdate extends JObject
 	protected $category;
 
 	/**
-	 * Update manifest <relationships> element
+	 * Update manifest `<relationships>` element
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -130,7 +130,7 @@ class JUpdate extends JObject
 	protected $relationships;
 
 	/**
-	 * Update manifest <targetplatform> element
+	 * Update manifest `<targetplatform>` element
 	 *
 	 * @var    string
 	 * @since  11.1

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -106,14 +106,14 @@ class JViewLegacy extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param   array  $config  A named configuration array for object construction.<br />
-	 *                          name: the name (optional) of the view (defaults to the view class name suffix).<br />
-	 *                          charset: the character set to use for display<br />
-	 *                          escape: the name (optional) of the function to use for escaping strings<br />
-	 *                          base_path: the parent path (optional) of the views directory (defaults to the component folder)<br />
-	 *                          template_plath: the path (optional) of the layout directory (defaults to base_path + /views/ + view name<br />
-	 *                          helper_path: the path (optional) of the helper files (defaults to base_path + /helpers/)<br />
-	 *                          layout: the layout (optional) to use to display the view<br />
+	 * @param   array  $config  A named configuration array for object construction.
+	 *                          name: the name (optional) of the view (defaults to the view class name suffix).
+	 *                          charset: the character set to use for display
+	 *                          escape: the name (optional) of the function to use for escaping strings
+	 *                          base_path: the parent path (optional) of the views directory (defaults to the component folder)
+	 *                          template_plath: the path (optional) of the layout directory (defaults to base_path + /views/ + view name
+	 *                          helper_path: the path (optional) of the helper files (defaults to base_path + /helpers/)
+	 *                          layout: the layout (optional) to use to display the view
 	 *
 	 * @since   12.2
 	 */


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-websites/issues/220.
#### Summary of Changes

phpDocumentor uses a Markdown based parser to generate documentation and this builds the `api.joomla.org` pages.  Right now on many pages there is incorrect output due to the HTML tags in doc blocks being parsed as literal HTML instead of being formatted for output.  This PR patches a large majority of the doc blocks in the libraries folder to account for this.
#### Testing Instructions

Review it.
