### PR TITLE
Add Microdata to popular articles - hard coded values

### DIFF
--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 ?>
 <ul class="mostread<?php echo $moduleclass_sfx; ?>">
 <?php foreach ($list as $item) : ?>
-	<li itemscope itemtype="https://schema.org/Article>
+	<li itemscope itemtype="https://schema.org/Article">
 		<a href="<?php echo $item->link; ?>" itemprop="url">
 			<span itemprop="name">
 				<?php echo $item->title; ?>

--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -11,9 +11,12 @@ defined('_JEXEC') or die;
 ?>
 <ul class="mostread<?php echo $moduleclass_sfx; ?>">
 <?php foreach ($list as $item) : ?>
-	<li>
-		<a href="<?php echo $item->link; ?>">
-			<?php echo $item->title; ?></a>
+	<li itemscope itemtype="https://schema.org/Article>
+		<a href="<?php echo $item->link; ?>" itemprop="url">
+			<span itemprop="name">
+				<?php echo $item->title; ?>
+			</span>
+		</a>
 	</li>
 <?php endforeach; ?>
 </ul>


### PR DESCRIPTION
Pull Request to Add Microdata to popular articles.
#### Summary of Changes

Adds hard coded Microdata to popular articles following the format established in the latest articles module
#### Testing Instructions
1. Add patch
   https://docs.joomla.org/Testing_Joomla!_patches
2. Add a popular articles module to a view
3. Check that microdata values are applied using a microdata validation tool such as
   https://developers.google.com/structured-data/testing-tool/
#### Additional Comments

With the JMicrodata PR's #8934 and #8933 in review, this PR is proposed to add the hard coded Microdata values so that schema.org markup can be added in the short term. 

The does not replace #8934, nor is it an alternative.  This PR is just a solution to put in place the missing Microdata values while the change to use the JMicrodata library is in Review.
