### PR TITLE
PostgreSQL - Error deleting article when multilanguage enabled from backend

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -790,7 +790,8 @@ abstract class JModelAdmin extends JModelForm
 							->from($db->quoteName('#__associations') . ' AS as1')
 							->join('LEFT', $db->quoteName('#__associations') . ' AS as2 ON ' . $db->quoteName('as1.key') . ' =  ' . $db->quoteName('as2.key'))
 							->where($db->quoteName('as1.context') . ' = ' . $db->quote($this->associationsContext))
-							->where($db->quoteName('as1.id') . ' = ' . (int) $pk);
+							->where($db->quoteName('as1.id') . ' = ' . (int) $pk)
+							->group($db->quoteName('as1.key'));
 
 						$db->setQuery($query);
 						$row = $db->loadAssoc();


### PR DESCRIPTION
#### Steps to reproduce the issue

Delete an article from backend with multilangage enabled
#### Expected result

Article is deleted
#### Actual result

An error has occurred.
#### System information

database: postgresql
#### Comments

added the `group by` clause as we  have a `count(*)`
