### PR TITLE
PostgreSQL: group by Error in com_contact Categories

### DIFF
--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -63,7 +63,7 @@ class ContactHelper extends JHelperContent
 			$query->select('published AS state, count(*) AS count')
 				->from($db->qn('#__contact_details'))
 				->where('catid = ' . (int) $item->id)
-				->group('state');
+				->group('published');
 			$db->setQuery($query);
 			$contacts = $db->loadObjectList();
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

With the current staging branch and sample data installed try to access com_contact categories in the backend. You should get a SQL-group by error.
