### PR TITLE
Fix php notice in extension discover view

### DIFF
--- a/administrator/components/com_installer/controllers/discover.php
+++ b/administrator/components/com_installer/controllers/discover.php
@@ -27,7 +27,7 @@ class InstallerControllerDiscover extends JControllerLegacy
 	{
 		$model = $this->getModel('discover');
 		$model->discover();
-		$this->setRedirect(JRoute::_('index.php?option=com_installer&view=discover', false), $model->_message);
+		$this->setRedirect(JRoute::_('index.php?option=com_installer&view=discover', false));
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9480.
#### Summary of Changes

The extension discover view is throwing a php notice.

> PHP message: PHP Notice: Undefined property: InstallerModelDiscover::$_message in /path/to/joomla-staging/administrator/components/com_installer/controllers/discover.php on line 30
#### Testing Instructions
1. Have php error_reporting set to E_ALL and display_errors set to on
2. Use latest staging
3. Go to Extension -> Manage -> Discover
4. You will get the a php notice
5. Apply this patch
6. Repeat step 2. you will get no notice.
