### PR TITLE
Set pdomysql driver also to non strict sql mode

### DIFF
--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -147,6 +147,9 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 
 		$this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+		// Set sql_mode to non_strict mode
+		$this->connection->query("SET @@SESSION.sql_mode = '';");
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -629,17 +629,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 			"REPLACE INTO `jos_dbtest` SET `id` = 5, `title` = 'testTitle', `start_date` = '2014-08-17 00:00:00', `description` = 'testDescription'"
 		);
 
-		$this->assertThat(
-			(bool) self::$driver->execute(),
-			$this->isTrue(),
-			__LINE__
-		);
-
-		$this->assertThat(
-			self::$driver->insertid(),
-			$this->equalTo(5),
-			__LINE__
-		);
+		$this->assertInstanceOf('PDOStatement', self::$driver->execute());
 
 	}
 


### PR DESCRIPTION
#### Summary of Changes

Sets the pdomysql driver to use mysql non strict mode to have the same behavior that mysql and mysqli drivers.
#### Testing Instructions

Use a mysql 5.6.6+ db server (or emulate the strict sql mode in pdomysql driver).
1. Set mysql driver mode to "PDO (Mysql)"  in global configuration
2. Go to Extensions -> Install languages - Find Languages. You'll get an sql strict mode error.
3. Apply the patch
4. Repeat step 2. You will not get a sql mode strict error.

@wilsonge: when solved the install language and find updates strict problems, i think you can merge this.
#### Note:

To emulate strict mode before the patch (like is default in mysql 5.6.29), go to https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/database/driver/pdomysql.php#L149

And add this line after

``` php
$this->connection->query("SET @@SESSION.sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION';");
```
