### PR TITLE
Set mailto link for contact email based on emailcloak plugin settings

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -111,7 +111,18 @@ class ContactViewContact extends JViewLegacy
 		// Handle email cloaking
 		if ($item->email_to && $params->get('show_email'))
 		{
-			$item->email_to = JHtml::_('email.cloak', $item->email_to);
+			$mailto = true;
+
+			if (JPluginHelper::isEnabled('content', 'emailcloak'))
+			{
+				$plugin = JPluginHelper::getPlugin('content', 'emailcloak');
+
+				$pluginParams = new Joomla\Registry\Registry($plugin->params);
+
+				$mailto = (bool) $pluginParams->get('mode', true);
+			}
+
+			$item->email_to = JHtml::_('email.cloak', $item->email_to, $mailto);
 		}
 
 		if ($params->get('show_street_address') || $params->get('show_suburb') || $params->get('show_state')


### PR DESCRIPTION
#### Summary of Changes

With the proposed changes the boolean flag "$mailto" is passed to the JHtmlEmail::cloak method so the email shown in the contact view is influenced by the email cloak plugins (settings) without triggering it.
#### Why do it this way?

One could argue that this flag could / should be in com_contact itself and I agree - on the long run, surely the better option. I'm working on a PR for that, too. Regarding the current implementation: I didn't want to call the plugin directly or via JHtmlContent::prepare, since we only need the plugins mode parameter value here.
#### Test Instructions
1. **Back-end:** Create a contact. Give it a title and make sure to fill out the email address field. The contact doesn't have to be assigned to a user or a category. For easy access, create a menu item to that user.
2. **Front-end:** Verify that the email address including the mailto link is visible in the front-end. If not, please check the settings for com_contact.
3. **Back-end:** Go to the plugin section and edit the "Content - Email Cloaking" plugin. The only parameter there is the "mode" switch. Set / Change it to "Non-linkable Text".
4. **Front-end:** Refresh the page. Without the patch you will see that the email address will always have a mailto link attached to it.
5. **Front-end** / **Back-end:** Apply the patch and check again. The mailto link can now be switched on or off via the email cloak plugin.
