### PR TITLE
Add support for catching JLog messages on a unit test run

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_HTTP_STUB" value="http://localhost/joomla-cms/tests/unit/stubs/jhttp_stub.php" />
+		<const name="JOOMLA_TEST_LOGGING" value="yes" />
 	</php>
 	-->
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -117,3 +117,6 @@ JLoader::registerPrefix('Test', __DIR__ . '/core');
 
 // Register the deprecation handler
 TestHelper::registerDeprecationHandler();
+
+// Register the logger if enabled
+TestHelper::registerLogger();

--- a/tests/unit/core/helper/helper.php
+++ b/tests/unit/core/helper/helper.php
@@ -164,6 +164,21 @@ class TestHelper
 	}
 
 	/**
+	 * Adds optional logging support for the unit test run
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 */
+	public static function registerLogger()
+	{
+		if (defined('JOOMLA_TEST_LOGGING') && JOOMLA_TEST_LOGGING === 'yes')
+		{
+			JLog::addLogger(array('logger' => 'formattedtext', 'text_file' => 'unit_test.php', 'text_file_path' => JPATH_ROOT . '/logs'));
+		}
+	}
+
+	/**
 	 * Detects if the CLI output supports color codes
 	 *
 	 * This method is based on \Symfony\Bridge\PhpUnit\DeprecationErrorHandler::register()


### PR DESCRIPTION
#### Summary of Changes

Adds optional support for logging messages from `JLog` on a unit test run to the unit test suite configuration.
#### Testing Instructions
- Copy `phpunit.xml.dist` to `phpunit.xml`
- Uncomment the `<php>` section of the configuration file, you can remove every constant except for the `JOOMLA_TEST_LOGGING` value
- Run the unit test suite, with this value set to "yes" then JLog messages will log to `JPATH_ROOT/logs/unit_test.php`
