### PR TITLE
Ensure com_content models are in lookup path

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_SITE . '/components/com_content/helpers/route.php';
+JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 
 /**
  * Helper for mod_related_items
@@ -25,7 +25,7 @@ abstract class ModRelatedItemsHelper
 	 *
 	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
-	 * @return array
+	 * @return  array
 	 */
 	public static function getList(&$params)
 	{
@@ -37,7 +37,15 @@ abstract class ModRelatedItemsHelper
 		$maximum = (int) $params->get('maximum', 5);
 
 		// Get an instance of the generic articles model
+		JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_content/models');
 		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+
+		if ($articles === false)
+		{
+			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+
+			return array();
+		}
 
 		// Set application parameters in model
 		$appParams = $app->getParams();
@@ -71,7 +79,7 @@ abstract class ModRelatedItemsHelper
 			{
 				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-				return;
+				return array();
 			}
 
 			// Explode the meta keys on a comma
@@ -144,6 +152,7 @@ abstract class ModRelatedItemsHelper
 				}
 
 				$db->setQuery($query, 0, $maximum);
+
 				try
 				{
 					$temp = $db->loadObjectList();
@@ -152,7 +161,7 @@ abstract class ModRelatedItemsHelper
 				{
 					JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-					return;
+					return array();
 				}
 
 				if (count($temp))


### PR DESCRIPTION
Pull Request for Issue http://forum.joomla.org/viewtopic.php?f=710&t=913801&sid=d3a6b0d7e369a88213a0687721a77233
#### Summary of Changes

The related items module uses com_content to find items but does not ensure the com_content models are in the lookup path or validate the `$articles` assignment is a model object.  This is corrected.  As well, all returns in error conditions now match the documented return type of array.
#### Testing Instructions

Ensure the related items module functions as designed (sorry, I've never used it so couldn't tell you how it works, but from the code alone and knowing how Joomla doesn't autoload components it's easy to see how this would break on a non-com_content page).
