### PR TITLE
Deal with opportunistic TLS change in PHPMailer 5.2.10

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -39,7 +39,7 @@ class JMail extends PHPMailer
 		$this->setLanguage('joomla', __DIR__ . '/language');
 
 		// Turn on the exception handler of PHPMailer
-		$this->exceptions = true;
+		parent::__construct(true);
 	}
 
 	/**

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -37,13 +37,6 @@ class JMail extends PHPMailer
 	{
 		// PHPMailer has an issue using the relative path for its language files
 		$this->setLanguage('joomla', __DIR__ . '/language');
-
-		/**
-		 * PHPMailer has an issue with servers with invalid certificates
-		 *
-		 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
-		 */
-		$this->SMTPAutoTLS = false;
 	}
 
 	/**
@@ -93,7 +86,32 @@ class JMail extends PHPMailer
 				}
 			}
 
-			$result = parent::send();
+			try
+			{
+				// Try sending with default settings
+				$result = parent::send();
+
+			}
+			catch (Exception $e)
+			{
+				/**
+				 * PHPMailer has an issue with servers with invalid certificates
+				 *
+				 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
+				 */
+				$this->SMTPAutoTLS = false;
+
+				try
+				{
+					// Try it again with TLS turned off
+					$result = parent::send();
+				}
+				catch (Exception $e)
+				{
+					// Keep false for B/C compatibility
+					$result = false;
+				}
+			}
 
 			if ($result == false)
 			{

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -37,6 +37,9 @@ class JMail extends PHPMailer
 	{
 		// PHPMailer has an issue using the relative path for its language files
 		$this->setLanguage('joomla', __DIR__ . '/language');
+
+		// Turn on the exception handler of PHPMailer
+		$this->exceptions = true;
 	}
 
 	/**

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -95,7 +95,7 @@ class JMail extends PHPMailer
 				$result = parent::send();
 
 			}
-			catch (Exception $e)
+			catch (phpmailerException $e)
 			{
 				/**
 				 * PHPMailer has an issue with servers with invalid certificates
@@ -109,7 +109,7 @@ class JMail extends PHPMailer
 					// Try it again with TLS turned off
 					$result = parent::send();
 				}
-				catch (Exception $e)
+				catch (phpmailerException $e)
 				{
 					// Keep false for B/C compatibility
 					$result = false;

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -37,6 +37,13 @@ class JMail extends PHPMailer
 	{
 		// PHPMailer has an issue using the relative path for its language files
 		$this->setLanguage('joomla', __DIR__ . '/language');
+
+		/**
+		 * PHPMailer has an issue with servers with invalid certificates
+		 *
+		 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
+		 */
+		$this->SMTPAutoTLS = false;
 	}
 
 	/**

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -97,22 +97,27 @@ class JMail extends PHPMailer
 			}
 			catch (phpmailerException $e)
 			{
-				/**
-				 * PHPMailer has an issue with servers with invalid certificates
-				 *
-				 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
-				 */
-				$this->SMTPAutoTLS = false;
+				$result = false;
 
-				try
+				if ($this->SMTPAutoTLS)
 				{
-					// Try it again with TLS turned off
-					$result = parent::send();
-				}
-				catch (phpmailerException $e)
-				{
-					// Keep false for B/C compatibility
-					$result = false;
+					/**
+					 * PHPMailer has an issue with servers with invalid certificates
+					 *
+					 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
+					 */
+					$this->SMTPAutoTLS = false;
+
+					try
+					{
+						// Try it again with TLS turned off
+						$result = parent::send();
+					}
+					catch (phpmailerException $e)
+					{
+						// Keep false for B/C compatibility
+						$result = false;
+					}
 				}
 			}
 


### PR DESCRIPTION
Pull Request for Issue #9373 
#### Summary of Changes

PHPMailer 5.2.10 introduced a new feature called **Opportunistic TLS**, this will see if a server advertises TLS encryption. If it does, a secure connection will be established. This is only possible if the server has been setup correctly and uses correct certificates. If the server has invalid certificates, the mail sending will fail.
#### Testing Instructions
1. Install Joomla 3.5.0 on a server which advertises TLS and has invalid certificates setup (or just a server where the mail sending / test mail button no longer works after installing 3.5.0 but worked with 3.4.8)
2. Check if mail sending fails
3. Apply the patch
4. Check if the mail sending succeeds now
