### PR TITLE
Changes for JMail error handling with PHPMailer

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -17,13 +17,17 @@ defined('JPATH_PLATFORM') or die;
 class JMail extends PHPMailer
 {
 	/**
-	 * @var    array  JMail instances container.
+	 * JMail instances container.
+	 *
+	 * @var    JMail[]
 	 * @since  11.3
 	 */
 	protected static $instances = array();
 
 	/**
-	 * @var    string  Charset of the message.
+	 * Charset of the message.
+	 *
+	 * @var    string
 	 * @since  11.1
 	 */
 	public $CharSet = 'utf-8';
@@ -31,35 +35,42 @@ class JMail extends PHPMailer
 	/**
 	 * Constructor
 	 *
+	 * @param   boolean  $exceptions  Flag if Exceptions should be thrown
+	 *
 	 * @since   11.1
 	 */
-	public function __construct()
+	public function __construct($exceptions = true)
 	{
+		parent::__construct($exceptions);
+
 		// PHPMailer has an issue using the relative path for its language files
 		$this->setLanguage('joomla', __DIR__ . '/language');
 
-		// Turn on the exception handler of PHPMailer
-		parent::__construct(true);
+		// Configure a callback function to handle errors when $this->edebug() is called
+		$this->Debugoutput = function ($message, $level)
+		{
+			JLog::add(sprintf('Error in JMail API: %s', $message), JLog::ERROR, 'mail');
+		};
 	}
 
 	/**
-	 * Returns the global email object, only creating it
-	 * if it doesn't already exist.
+	 * Returns the global email object, only creating it if it doesn't already exist.
 	 *
 	 * NOTE: If you need an instance to use that does not have the global configuration
 	 * values, use an id string that is not 'Joomla'.
 	 *
-	 * @param   string  $id  The id string for the JMail instance [optional]
+	 * @param   string   $id          The id string for the JMail instance [optional]
+	 * @param   boolean  $exceptions  Flag if Exceptions should be thrown [optional]
 	 *
 	 * @return  JMail  The global JMail object
 	 *
 	 * @since   11.1
 	 */
-	public static function getInstance($id = 'Joomla')
+	public static function getInstance($id = 'Joomla', $exceptions = true)
 	{
 		if (empty(self::$instances[$id]))
 		{
-			self::$instances[$id] = new JMail;
+			self::$instances[$id] = new JMail($exceptions);
 		}
 
 		return self::$instances[$id];


### PR DESCRIPTION
#### Summary of Changes

When PHPMailer raises an error, regardless of your error handling preference, it calls the internal `edebug` function to act as a processor for errors.  A default handler is set up in JMail's constructor to log errors from the library since Joomla elects to use boolean values for errors versus Exceptions.

Next, the constructor value for PHPMailer which allows Exceptions to be enabled is now supported in JMail.  It defaults to false, same as the current behavior, but allows someone using the API to turn on Exceptions instead of boolean values.  This parameter addition propogates into JMail::getInstance() as well.
#### Testing Instructions

Trigger an error in PHPMailer.  A log statement should be added.  If Exceptions are turned on, a phpmailerException should be thrown instead of returning a boolean false.
