### PR TITLE
Fix autoloader issue using Prefix mechanism

### DIFF
--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -59,9 +59,6 @@ JLoader::setup();
 
 JLoader::registerPrefix('J', JPATH_PLATFORM . '/legacy');
 
-// Import the Joomla Factory.
-JLoader::import('joomla.factory');
-
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/language/text.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -49,9 +49,6 @@ if (!class_exists('JLoader'))
 // Setup the autoloaders.
 JLoader::setup();
 
-// Import the base Joomla Platform libraries.
-JLoader::import('joomla.factory');
-
 // Check if the JsonSerializable interface exists already
 if (!interface_exists('JsonSerializable'))
 {

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -602,8 +602,8 @@ abstract class JLoader
 			// Backwards compatibility patch
 
 			// If there is only one part we want to duplicate that part for generating the path.
-			if($partsCount === 1){
-
+			if($partsCount === 1)
+			{
 				// Generate the path based on the class name parts.
 				$path = $base . '/' . implode('/', array_map('strtolower', array($parts[0], $parts[0]))) . '.php';
 

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -586,9 +586,7 @@ abstract class JLoader
 	{
 		// Split the class name into parts separated by camelCase.
 		$parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
-
-		// If there is only one part we want to duplicate that part for generating the path.
-		$parts = (count($parts) === 1) ? array($parts[0], $parts[0]) : $parts;
+		$partsCount = count($parts);
 
 		foreach ($lookup as $base)
 		{
@@ -599,6 +597,21 @@ abstract class JLoader
 			if (file_exists($path))
 			{
 				return include $path;
+			}
+
+			// Backwards compatibility patch
+
+			// If there is only one part we want to duplicate that part for generating the path.
+			if($partsCount === 1){
+
+				// Generate the path based on the class name parts.
+				$path = $base . '/' . implode('/', array_map('strtolower', array($parts[0], $parts[0]))) . '.php';
+
+				// Load the file if it exists.
+				if (file_exists($path))
+				{
+					return include $path;
+				}
 			}
 		}
 

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -602,7 +602,7 @@ abstract class JLoader
 			// Backwards compatibility patch
 
 			// If there is only one part we want to duplicate that part for generating the path.
-			if($partsCount === 1)
+			if ($partsCount === 1)
 			{
 				// Generate the path based on the class name parts.
 				$path = $base . '/' . implode('/', array_map('strtolower', array($parts[0], $parts[0]))) . '.php';

--- a/tests/unit/stubs/loader/patch.php
+++ b/tests/unit/stubs/loader/patch.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaPatch
+{
+}

--- a/tests/unit/stubs/loader/patch/tester.php
+++ b/tests/unit/stubs/loader/patch/tester.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaPatchTester
+{
+}

--- a/tests/unit/stubs/loader/tester/tester.php
+++ b/tests/unit/stubs/loader/tester/tester.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JoomlaTester
+{
+}

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -220,6 +220,23 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the JLoader::load method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadForSinglePart()
+	{
+		JLoader::registerPrefix('Joomla', JPATH_TEST_STUBS . '/loader', true);
+
+		$this->assertTrue(class_exists('JoomlaPatch'), 'Tests that a class with a single part is loaded in the base path.');
+		$this->assertTrue(class_exists('JoomlaPatchTester'), 'Tests that a class with multiple parts is loaded from the correct path.');
+		$this->assertTrue(class_exists('JoomlaTester'), 'Tests that a class with a single part is loaded from a folder (legacy behavior).');
+		$this->assertFalse(class_exists('JoomlaNotPresent'), 'Tests that a non-existing class is not found.');
+	}
+
+	/**
 	 * Tests if JLoader::applyAliasFor runs automatically when loading a class by its real name
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for Issue #9523
#### Summary of Changes

Before this pull request, if the class that Joomla was trying to load only contains a capital word except  the prefix, the autoloader method duplicates that word, so it forces to have a folder on the root of the path where the prefix is pointing to. Now it tries to search on the root the path a PHP file called the same as the capital word on lowercase, if it does not find it, it works as before, making this patch backwards compatible.
#### Testing Instructions

In order to test this patch, you need to use a component that has a class on the root of the folder and register a prefix on that folder, for example, com_test and the class would be called TestClass and it will be implemented on class.php. In order to test backwards compatibility, you can put that class on a folder call **class** inside of com_test folder.
