### PR TITLE
Canonical link should be absolute even if no domain is specified in SEF plugin

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -41,9 +41,9 @@ class PlgSystemSef extends JPlugin
 		}
 
 		$uri     = JUri::getInstance();
-		$domain  = $this->params->get('domain');
+		$domain  = $this->params->get('domain', false);
 
-		if ($domain === false || $domain === '')
+		if (!$domain)
 		{
 			$domain = $uri->toString(array('scheme', 'host', 'port'));
 		}


### PR DESCRIPTION
This Pull Request is related to issues #9333 and #9556.
#### Summary of Changes

As per @ggppdk's comment on #9333, canonical generated by SEF plugin is a generic canonical for Joomla!. It is used not only when a canonical domain is specified in SEF plugin params. Therefore, it should be made absolute even if no domain is specified.
#### Testing Instructions
1. With no domain set in SEF plugin, go to a non-canonical page on Joomla where canonical URL is generated by SEF plugin.
2. Check canonical URL of the page, it is relative (does not include domain).
3. Apply patch.
4. Canonical URL should now be absolute (includes domain).

Note: This doesn't fix canonical URL behavior fully, only makes URLs absolute as per Google's recommendation: https://support.google.com/webmasters/answer/139066?hl=en
