### PR TITLE
Regression: Parse error in Smart Search on PHP 5.3.x (Correcting #9561)

### DIFF
--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -109,7 +109,8 @@ abstract class JHtmlFilter
 			return null;
 		}
 
-		$html .= JHtml::_('bootstrap.startAccordion', 'accordion', array('parent' => true, 'active' => 'accordion-' . array_keys($branches)[0])
+		$branch_keys = array_keys($branches);
+		$html .= JHtml::_('bootstrap.startAccordion', 'accordion', array('parent' => true, 'active' => 'accordion-' . $branch_keys[0])
 		);
 
 		// Load plug-in language files.


### PR DESCRIPTION
On php 5.3.x a Smartsearch menu item throws a parsing error (see #9561)
Thanks @khanhlh for creating the issue and the solution.

@wilsonge 
This is a blocker
